### PR TITLE
[omp2] Fix workpool item handling after fresh-agent spawn failure

### DIFF
--- a/crates/driver/src/subagent/workpool_scheduler.rs
+++ b/crates/driver/src/subagent/workpool_scheduler.rs
@@ -1298,7 +1298,13 @@ impl PoolActor {
 			});
 			state.workers.len() - 1
 		};
-		self.persist("workpool.worker.spawned").await?;
+		if let Err(error) = self.persist("workpool.worker.spawned").await {
+			if let Some(worker) = self.state.lock().workers.pop() {
+				worker.handle.cancel.cancel();
+				self.retired.push((worker.handle.finished, worker.handle.abort));
+			}
+			return Err(error);
+		}
 		Ok(worker)
 	}
 
@@ -1537,7 +1543,6 @@ impl PoolActor {
 				Ok(worker) => self.dispatch(worker, vec![item], false).await,
 				Err(_) => {
 					self.state.lock().items[item].state = ItemState::Failed;
-					break;
 				},
 			}
 		}

--- a/crates/driver/src/subagent/workpool_scheduler.rs
+++ b/crates/driver/src/subagent/workpool_scheduler.rs
@@ -643,6 +643,7 @@ impl SchedulerRegistry {
 			state: Arc::clone(&state),
 			commands: command_rx,
 			events: flume::unbounded(),
+			retry_admission: Vec::new(),
 			cancel: cancel.clone(),
 			retired: Vec::new(),
 			parent: self.parent.clone(),
@@ -972,6 +973,11 @@ where
 	}
 }
 
+/// Idle delay before re-driving items held by transient admission
+/// backpressure; long enough for the owner JobBoard to commit a settled
+/// worker and release its global concurrency slot.
+const ADMISSION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+
 struct PoolActor {
 	owner:        Str,
 	name:         Str,
@@ -986,9 +992,12 @@ struct PoolActor {
 	state:        Arc<Mutex<Snapshot>>,
 	commands:     flume::Receiver<Command>,
 	events:       (flume::Sender<WorkerEvent>, flume::Receiver<WorkerEvent>),
-	cancel:       CancellationToken,
-	retired:      Vec<(flume::Receiver<()>, tokio::task::AbortHandle)>,
-	parent:       SessionMutator,
+	/// Item indices rejected by transient admission backpressure and awaiting
+	/// a delayed re-drive after the owner's global slot is released.
+	retry_admission: Vec<usize>,
+	cancel:          CancellationToken,
+	retired:         Vec<(flume::Receiver<()>, tokio::task::AbortHandle)>,
+	parent:          SessionMutator,
 }
 
 impl PoolActor {
@@ -1111,6 +1120,14 @@ impl PoolActor {
 					Ok(command) => self.command(command).await,
 					Err(_) => return self.finish(true).await,
 				},
+				// Fires only after the actor has idled through the delay, so
+				// pending settlements and commands always drain first.
+				() = tokio::time::sleep(ADMISSION_RETRY_DELAY), if !self.retry_admission.is_empty() => {
+					let retry = std::mem::take(&mut self.retry_admission);
+					for item in retry {
+						self.schedule(item).await;
+					}
+				},
 			}
 		}
 	}
@@ -1211,7 +1228,11 @@ impl PoolActor {
 		if self.state.lock().workers.len() < limit {
 			match self.spawn_worker().await {
 				Ok(worker) => self.dispatch(worker, vec![item], false).await,
-				Err(_) => self.state.lock().items[item].state = ItemState::Failed,
+				Err(error) => {
+					if !self.item_stays_queued(item, &error) {
+						self.state.lock().items[item].state = ItemState::Failed;
+					}
+				},
 			}
 			return;
 		}
@@ -1303,9 +1324,30 @@ impl PoolActor {
 				worker.handle.cancel.cancel();
 				self.retired.push((worker.handle.finished, worker.handle.abort));
 			}
+			// A durable-state write failure is pool-terminal, not a per-item
+			// spawn failure: cancel so finish(true) reports the pool
+			// cancelled instead of completing against a stale snapshot.
+			self.cancel.cancel();
 			return Err(error);
 		}
 		Ok(worker)
+	}
+
+	/// Whether a spawn failure leaves the item queued instead of failed: a
+	/// cancelled pool defers its queue to `finish(true)`, and transient
+	/// global-capacity backpressure in a fresh pool re-drives only the
+	/// rejected item.
+	fn item_stays_queued(&mut self, item: usize, error: &WorkpoolSchedulerError) -> bool {
+		if self.cancel.is_cancelled() {
+			return true;
+		}
+		if self.fresh_agents && is_concurrency_backpressure(error) {
+			if !self.retry_admission.contains(&item) {
+				self.retry_admission.push(item);
+			}
+			return true;
+		}
+		false
 	}
 
 	async fn dispatch(&mut self, worker: usize, items: Vec<usize>, follow_up: bool) {
@@ -1541,7 +1583,10 @@ impl PoolActor {
 			};
 			match self.spawn_worker().await {
 				Ok(worker) => self.dispatch(worker, vec![item], false).await,
-				Err(_) => {
+				Err(error) => {
+					if self.item_stays_queued(item, &error) {
+						break;
+					}
 					self.state.lock().items[item].state = ItemState::Failed;
 				},
 			}
@@ -1684,6 +1729,18 @@ impl PoolActor {
 			}
 		}
 	}
+}
+
+/// A `SpawnError::Concurrency` rejection is transient global-capacity
+/// backpressure, not a terminal spawn failure: the owner's JobBoard still
+/// counts a settled-but-uncommitted worker, and the slot frees as soon as
+/// the board polls it.
+fn is_concurrency_backpressure(error: &WorkpoolSchedulerError) -> bool {
+	matches!(
+		error,
+		WorkpoolSchedulerError::WorkerSpawn { source, .. }
+			if matches!(source.as_ref(), SpawnError::Concurrency { .. })
+	)
 }
 
 fn context_load(worker: &Worker) -> f64 {

--- a/crates/driver/src/subagent/workpool_scheduler.rs
+++ b/crates/driver/src/subagent/workpool_scheduler.rs
@@ -14,7 +14,7 @@ use std::{
 use async_trait::async_trait;
 use omp_agent::{JobBoard, JobSettlement};
 pub use omp_agent::jobs::WORKPOOL_STATE;
-use omp_core::{FastHashMap, Str, sf};
+use omp_core::{FastHashMap, SparseSet, Str, sf};
 use omp_dom::{Handle, KnownTag, Op, PropId, PropKey, Tag, Txn, Value};
 use omp_journal::blob::BlobStore;
 use omp_session::{Session, components::jobs};
@@ -644,6 +644,7 @@ impl SchedulerRegistry {
 			commands: command_rx,
 			events: flume::unbounded(),
 			retry_admission: Vec::new(),
+			retry_admission_seen: SparseSet::new(),
 			cancel: cancel.clone(),
 			retired: Vec::new(),
 			parent: self.parent.clone(),
@@ -994,7 +995,9 @@ struct PoolActor {
 	events:       (flume::Sender<WorkerEvent>, flume::Receiver<WorkerEvent>),
 	/// Item indices rejected by transient admission backpressure and awaiting
 	/// a delayed re-drive after the owner's global slot is released.
-	retry_admission: Vec<usize>,
+	retry_admission:      Vec<usize>,
+	/// Membership mirror for constant-time retry deduplication.
+	retry_admission_seen: SparseSet<usize>,
 	cancel:          CancellationToken,
 	retired:         Vec<(flume::Receiver<()>, tokio::task::AbortHandle)>,
 	parent:          SessionMutator,
@@ -1124,6 +1127,7 @@ impl PoolActor {
 				// pending settlements and commands always drain first.
 				() = tokio::time::sleep(ADMISSION_RETRY_DELAY), if !self.retry_admission.is_empty() => {
 					let retry = std::mem::take(&mut self.retry_admission);
+					self.retry_admission_seen.clear();
 					for item in retry {
 						self.schedule(item).await;
 					}
@@ -1342,7 +1346,7 @@ impl PoolActor {
 			return true;
 		}
 		if self.fresh_agents && is_concurrency_backpressure(error) {
-			if !self.retry_admission.contains(&item) {
+			if self.retry_admission_seen.insert(item) {
 				self.retry_admission.push(item);
 			}
 			return true;

--- a/crates/driver/tests/workpool_scheduler.rs
+++ b/crates/driver/tests/workpool_scheduler.rs
@@ -49,14 +49,15 @@ impl WorkpoolPolicy for Policy {
 }
 
 struct Launcher {
-	sessions:  Arc<SessionRegistry>,
-	snapshot:  Arc<RwLock<omp_dom::Snapshot>>,
-	main:      Str,
-	spawned:   AtomicUsize,
-	active:    Arc<AtomicUsize>,
-	maximum:   Arc<AtomicUsize>,
-	die_once:  Arc<AtomicBool>,
-	forwarded: Arc<RwLock<Option<Arc<omp_tools::eval::EvalToolRoster>>>>,
+	sessions:   Arc<SessionRegistry>,
+	snapshot:   Arc<RwLock<omp_dom::Snapshot>>,
+	main:       Str,
+	spawned:    AtomicUsize,
+	active:     Arc<AtomicUsize>,
+	maximum:    Arc<AtomicUsize>,
+	die_once:   Arc<AtomicBool>,
+	fail_after: AtomicUsize,
+	forwarded:  Arc<RwLock<Option<Arc<omp_tools::eval::EvalToolRoster>>>>,
 }
 
 #[async_trait]
@@ -66,7 +67,15 @@ impl WorkpoolLauncher for Launcher {
 		request: WorkerSpawn,
 		events: flume::Sender<WorkerEvent>,
 	) -> Result<WorkerHandle, WorkpoolSchedulerError> {
-		self.spawned.fetch_add(1, Ordering::Relaxed);
+		let spawned = self.spawned.fetch_add(1, Ordering::Relaxed) + 1;
+		if spawned > self.fail_after.load(Ordering::Relaxed) {
+			return Err(WorkpoolSchedulerError::WorkerSpawn {
+				id:     request.id,
+				source: Arc::new(omp_driver::subagent::spawn::SpawnError::Concurrency {
+					maximum: 1,
+				}),
+			});
+		}
 		*self.forwarded.write() = request.eval_tools.clone();
 		let (batches, batch_rx) = flume::unbounded::<WorkerBatch>();
 		let cancel = CancellationToken::new();
@@ -199,6 +208,7 @@ fn harness(limit: usize, fresh: bool, die_once: bool) -> Harness {
 		active: Arc::new(AtomicUsize::new(0)),
 		maximum: Arc::new(AtomicUsize::new(0)),
 		die_once: Arc::new(AtomicBool::new(die_once)),
+		fail_after: AtomicUsize::new(usize::MAX),
 		forwarded: Arc::new(RwLock::new(None)),
 	});
 	let parent = Arc::new(Mutex::new(parent));
@@ -530,6 +540,29 @@ async fn fresh_policy_honors_concurrency_and_uses_one_worker_per_item() {
 		.expect("wait fresh aggregate")
 		.expect("fresh aggregate");
 	assert_eq!(settled.status, "completed");
+}
+
+#[tokio::test]
+async fn fresh_spawn_failure_fails_every_remaining_queued_item_and_closes() {
+	let harness = harness(1, true, false);
+	harness.launcher.fail_after.store(1, Ordering::Relaxed);
+	let pool = harness
+		.registry
+		.create(WorkpoolCreate { name: sf!("stranded"), agent: sf!("task"), context: None })
+		.expect("create pool");
+	pool
+		.push(vec![sf!("a"), sf!("b"), sf!("c")])
+		.await
+		.expect("push");
+	wait_pending(&pool, 0).await;
+	wait_closed(&pool).await;
+	wait_finished(&harness.jobs, "stranded").await;
+	let status = pool.status();
+	assert_eq!(status.items.completed, 1);
+	assert_eq!(status.items.failed, 2);
+	assert_eq!(status.items.queued, 0);
+	assert_eq!(status.items.running, 0);
+	assert!(status.closed);
 }
 
 #[tokio::test]

--- a/crates/driver/tests/workpool_scheduler.rs
+++ b/crates/driver/tests/workpool_scheduler.rs
@@ -57,6 +57,11 @@ struct Launcher {
 	maximum:    Arc<AtomicUsize>,
 	die_once:   Arc<AtomicBool>,
 	fail_after: AtomicUsize,
+	/// Transiently rejects this many spawns with `SpawnError::Concurrency`.
+	fail_next:  AtomicUsize,
+	/// Parks spawn calls at or beyond this ordinal so tests can cancel
+	/// mid-admission.
+	spawn_delay_from: AtomicUsize,
 	forwarded:  Arc<RwLock<Option<Arc<omp_tools::eval::EvalToolRoster>>>>,
 }
 
@@ -68,11 +73,23 @@ impl WorkpoolLauncher for Launcher {
 		events: flume::Sender<WorkerEvent>,
 	) -> Result<WorkerHandle, WorkpoolSchedulerError> {
 		let spawned = self.spawned.fetch_add(1, Ordering::Relaxed) + 1;
-		if spawned > self.fail_after.load(Ordering::Relaxed) {
+		if spawned >= self.spawn_delay_from.load(Ordering::Relaxed) {
+			tokio::time::sleep(Duration::from_millis(500)).await;
+		}
+		if self.fail_next.load(Ordering::Relaxed) > 0 {
+			self.fail_next.fetch_sub(1, Ordering::Relaxed);
 			return Err(WorkpoolSchedulerError::WorkerSpawn {
 				id:     request.id,
 				source: Arc::new(omp_driver::subagent::spawn::SpawnError::Concurrency {
 					maximum: 1,
+				}),
+			});
+		}
+		if spawned > self.fail_after.load(Ordering::Relaxed) {
+			return Err(WorkpoolSchedulerError::WorkerSpawn {
+				id:     request.id,
+				source: Arc::new(omp_driver::subagent::spawn::SpawnError::Denied {
+					reason: Str::new_static("injected spawn failure"),
 				}),
 			});
 		}
@@ -209,6 +226,8 @@ fn harness(limit: usize, fresh: bool, die_once: bool) -> Harness {
 		maximum: Arc::new(AtomicUsize::new(0)),
 		die_once: Arc::new(AtomicBool::new(die_once)),
 		fail_after: AtomicUsize::new(usize::MAX),
+		fail_next: AtomicUsize::new(0),
+		spawn_delay_from: AtomicUsize::new(usize::MAX),
 		forwarded: Arc::new(RwLock::new(None)),
 	});
 	let parent = Arc::new(Mutex::new(parent));
@@ -563,6 +582,71 @@ async fn fresh_spawn_failure_fails_every_remaining_queued_item_and_closes() {
 	assert_eq!(status.items.queued, 0);
 	assert_eq!(status.items.running, 0);
 	assert!(status.closed);
+}
+
+#[tokio::test]
+async fn fresh_concurrency_rejection_retries_queued_items_until_capacity_frees() {
+	let harness = harness(1, true, false);
+	harness.launcher.fail_next.store(2, Ordering::Relaxed);
+	let pool = harness
+		.registry
+		.create(WorkpoolCreate { name: sf!("backpressure"), agent: sf!("task"), context: None })
+		.expect("create pool");
+	pool
+		.push(vec![sf!("a"), sf!("b")])
+		.await
+		.expect("push");
+	wait_pending(&pool, 0).await;
+	wait_closed(&pool).await;
+	wait_finished(&harness.jobs, "backpressure").await;
+	let status = pool.status();
+	assert_eq!(status.items.completed, 2);
+	assert_eq!(status.items.failed, 0);
+	assert_eq!(status.items.queued, 0);
+	assert!(
+		harness.launcher.spawned.load(Ordering::Relaxed) > 2,
+		"transient rejections were retried instead of failing items"
+	);
+}
+
+#[tokio::test]
+async fn fresh_cancel_during_slot_fill_reports_cancelled_not_completed() {
+	let harness = harness(1, true, false);
+	harness.launcher.spawn_delay_from.store(2, Ordering::Relaxed);
+	let pool = harness
+		.registry
+		.create(WorkpoolCreate { name: sf!("drain"), agent: sf!("task"), context: None })
+		.expect("create pool");
+	pool
+		.push(vec![sf!("a"), sf!("b")])
+		.await
+		.expect("push");
+	for _ in 0..200 {
+		if harness.launcher.spawned.load(Ordering::Relaxed) >= 2 {
+			break;
+		}
+		tokio::time::sleep(Duration::from_millis(5)).await;
+	}
+	assert_eq!(
+		harness.launcher.spawned.load(Ordering::Relaxed),
+		2,
+		"second spawn is parked mid-admission"
+	);
+	harness.registry.release_owner();
+	wait_finished(&harness.jobs, "drain").await;
+	let mut parent = harness.parent.lock().await;
+	let settled = harness
+		.jobs
+		.wait(&mut parent, Some(&[sf!("drain")]))
+		.await
+		.expect("wait aggregate")
+		.expect("aggregate job");
+	drop(parent);
+	assert_eq!(settled.status, "cancelled");
+	let status = pool.status();
+	assert_eq!(status.items.completed, 1);
+	assert_eq!(status.items.cancelled, 1);
+	assert_eq!(status.items.failed, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
With `freshAgents` enabled, `fill_fresh_slots` stopped after the first worker spawn error. Remaining items stayed `Queued` with no live workers, so the aggregate job never settled.

**Trigger:** create a workpool with `freshAgents`, push multiple items, and have a later spawn fail (concurrency cap, composition error, persist failure). The first leftover item is marked failed; the rest hang forever.

**Fix:** keep draining the queue on spawn failure (same as `schedule()`), and drop a worker whose persist fails so it cannot pin a concurrency slot.

Adds `fresh_spawn_failure_fails_every_remaining_queued_item_and_closes` in `crates/driver/tests/workpool_scheduler.rs`.