### PR TITLE
fix(coding-agent): align artifact byte-budget assertion

### DIFF
--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -968,7 +968,7 @@ describe("Coding Agent Tools", () => {
 				path: "artifact://7:3-4",
 			});
 
-			expect(getTextOutput(result)).toContain("[Showing lines 2-2 of 4 (50.0KB limit). Use :3 to continue]");
+			expect(getTextOutput(result)).toContain("[Showing lines 2-2 of 4 (50.0KB limit)]");
 		});
 
 		it("should spill oversized read output to an artifact", async () => {


### PR DESCRIPTION
## Repro

On current `main`, `bun test packages/coding-agent/test/tools.test.ts -t "artifact byte budget"` fails because the test expects `[Showing lines 2-2 of 4 (50.0KB limit). Use :3 to continue]`, while the read tool emits the oversized-line notice and footer without the looping continuation selector.

## Cause

`packages/coding-agent/test/tools.test.ts` retained the continuation-hint assertion introduced by #10767 after #10798 changed oversized selected-line reads to suppress that hint and direct callers to a raw single-line selector. The dedicated regression coverage in `packages/coding-agent/test/tools/read-artifact-large.test.ts` already enforces the new no-loop behavior.

## Fix

- Keep the ranged-read byte-budget coverage while removing its obsolete expectation that the footer includes `Use :3 to continue`.

## Verification

`bun test packages/coding-agent/test/tools.test.ts -t "artifact byte budget"` passes (1 test); `bun test packages/coding-agent/test/tools/read-artifact-large.test.ts` passes (11 tests); the pre-publish `bun check` gate passes.

Fixes #10818