### PR TITLE
fix(pi-shell): widen jobspec pipeline stop deadline to 30s

### DIFF
--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -2840,8 +2840,12 @@ mod tests {
 		let (mut session, params) = kill_test_context().await;
 		let source_info = SourceInfo::from("pi-natives:test");
 
+		// A safety net, not a latency assertion: the healthy path stops in well
+		// under 300ms, but nextest full-suite parallelism can starve the pipeline
+		// long enough to trip a tight deadline. Bound a real hang generously so
+		// scheduler contention never fails the test (issue #10820).
 		time::timeout(
-			Duration::from_secs(5),
+			Duration::from_secs(30),
 			session.shell.run_string(command, &source_info, &params),
 		)
 		.await


### PR DESCRIPTION
## Repro
Running the full `pi-shell` suite under nextest parallelism (`cargo nextest run -p pi-shell` in a loop) trips `shell::tests::kill_builtin_signals_every_process_in_a_jobspec_pipeline` in roughly 1 of 4-5 full-suite runs with `pipeline did not stop: Elapsed(())` at `crates/pi-shell/src/shell.rs`. Single-test and small-filter runs stay green (the healthy path stops in ~0.15s), so the failure only surfaces under full-suite scheduler contention.

## Cause
The test wrapped `session.shell.run_string(...)` for a self-STOPping `sh -c ... | sh -c ...` pipeline in a `time::timeout(Duration::from_secs(5), ...)`. That deadline is a safety net to bound a hang, not a latency assertion — but under nextest full-suite parallel load the scheduler can starve the pipeline long enough to exceed 5s before both stages reach the stopped state, tripping the timeout non-deterministically. The other timeouts in the test are downstream of `run_string` returning; the scripts write their ready files before `kill -STOP $$`, so once the job is stopped those waits are already satisfied.

## Fix
- Raise the `run_string` stop deadline from 5s to 30s in `kill_builtin_signals_every_process_in_a_jobspec_pipeline` (`crates/pi-shell/src/shell.rs`), matching the 30s safety net used by the backpressure test elsewhere in the file.
- Add a comment documenting that the deadline bounds a real hang and is not a latency assertion, so scheduler contention never fails the test while a genuine stop regression still fails fast.

## Verification
- `cargo nextest run -p pi-shell -E 'test(kill_builtin_signals_every_process_in_a_jobspec_pipeline)'` → 1 passed (0.150s).
- `cargo nextest run -p pi-shell` → 870 passed, 1 skipped.

Fixes #10820