### PR TITLE
fix(pi-natives): make oauth_callback session probe hermetic in tests

### DIFF
--- a/crates/pi-natives/src/oauth_callback/mod.rs
+++ b/crates/pi-natives/src/oauth_callback/mod.rs
@@ -794,8 +794,7 @@ fn session_supported(env: &BTreeMap<String, String>) -> bool {
 			|| env
 				.get("WSL_INTEROP")
 				.is_some_and(|value| !value.is_empty())
-			|| fs::read_to_string("/proc/sys/kernel/osrelease")
-				.is_ok_and(|release| release.to_ascii_lowercase().contains("microsoft"))
+			|| wsl_kernel_detected()
 		{
 			return false;
 		}
@@ -814,6 +813,22 @@ fn session_supported(env: &BTreeMap<String, String>) -> bool {
 		return false;
 	}
 	true
+}
+
+/// Detects a WSL kernel by inspecting `/proc/sys/kernel/osrelease`.
+///
+/// This is a host probe that the hermetic unit tests cannot control, so it is
+/// stubbed to `false` under `#[cfg(test)]`; tests exercise WSL rejection through
+/// the `WSL_DISTRO_NAME` / `WSL_INTEROP` env keys they own instead.
+#[cfg(all(target_os = "linux", not(test)))]
+fn wsl_kernel_detected() -> bool {
+	fs::read_to_string("/proc/sys/kernel/osrelease")
+		.is_ok_and(|release| release.to_ascii_lowercase().contains("microsoft"))
+}
+
+#[cfg(all(target_os = "linux", test))]
+fn wsl_kernel_detected() -> bool {
+	false
 }
 
 fn napi_error(error: impl std::fmt::Display) -> Error {

--- a/crates/pi-natives/src/oauth_callback/tests.rs
+++ b/crates/pi-natives/src/oauth_callback/tests.rs
@@ -133,6 +133,20 @@ fn remote_start_is_unsupported_without_creating_storage() {
 	fs::remove_dir_all(home).unwrap();
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn wsl_env_is_unsupported_without_creating_storage() {
+	let _serial = TEST_SERIAL.lock();
+	let home = temp_home("wsl");
+	let core = core(home.clone(), environment(&[("WSL_DISTRO_NAME", "Ubuntu")]));
+	assert!(matches!(
+		start_blocking(&core, CancelToken::default()).unwrap(),
+		StartOutcome::Unsupported
+	));
+	assert!(!home.join(".omp").exists());
+	fs::remove_dir_all(home).unwrap();
+}
+
 #[test]
 fn prepare_failure_releases_lease_and_removes_private_artifacts() {
 	let _serial = TEST_SERIAL.lock();


### PR DESCRIPTION
## Repro
On WSL2 (`6.6.87.2-microsoft-standard-WSL2`), `cargo nextest run -p pi-natives oauth_callback` fails 5 tests 100% deterministically: `prepare_failure_releases_lease_and_removes_private_artifacts`, `activation_failure_restores_even_after_mutating_os_state`, `uncertain_restore_retains_journal_and_ownership`, `stale_journal_is_recovered_before_successor_activation`, `lease_excludes_competing_receivers_in_same_process` — each panics with `test environment must be supported` at `crates/pi-natives/src/oauth_callback/tests.rs:111`. On native Linux the suite is green; I confirmed the mechanism by temporarily pointing the probe at a fake `osrelease` containing `microsoft`, which reproduced exactly those 5 failures.

## Cause
`session_supported()` (`crates/pi-natives/src/oauth_callback/mod.rs`) read the real `/proc/sys/kernel/osrelease` to detect WSL, ORed into the WSL rejection branch. The in-memory test `Core` env (only `DISPLAY=:test`) cannot control that host file, so on a WSL2 kernel the probe returned `microsoft`, forcing the `Unsupported` early-return and making the `active()` helper panic. Host leakage broke test hermeticity; native-Linux CI never saw it.

## Fix
- Extract the `/proc/sys/kernel/osrelease` probe into a `wsl_kernel_detected()` seam.
- Compile the real `/proc` reader only under `#[cfg(all(target_os = "linux", not(test)))]`; under `#[cfg(test)]` it returns `false`, so tests depend solely on the env map they own. Production WSL detection via `/proc` is unchanged.
- Add `wsl_env_is_unsupported_without_creating_storage`, mirroring the SSH test, to keep the env-based WSL rejection contract (`WSL_DISTRO_NAME`/`WSL_INTEROP`) covered hermetically.

## Verification
`cargo nextest run -p pi-natives oauth_callback` → `21 tests run: 21 passed, 276 skipped` (5 formerly-failing now pass, plus the new regression test). `cargo build -p pi-natives` clean. Fixes #10819