### PR TITLE
test(eval): assert final agent status instead of exact onStatus count

### DIFF
--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -792,22 +792,29 @@ describe("agent() through eval runtimes", () => {
 
 		expect(result.exitCode).toBe(0);
 
+		// runEvalWait emits the current progress snapshot at wait-start, on its
+		// 1s interval, and at wait-end, so the number of op:"agent" events is a
+		// timing-dependent race (was flaky on CI under parallel load, #10821).
+		// The contract that matters is that the LAST delivered snapshot is the
+		// completed, enriched one — not that exactly one is delivered.
 		const agentEvents = events.filter(event => event.op === "agent");
-		expect(agentEvents).toHaveLength(1);
+		expect(agentEvents.length).toBeGreaterThanOrEqual(1);
 
-		const completed = agentEvents[0];
-		expect(completed.status).toBe("completed");
-		expect(completed.toolCount).toBe(7);
-		expect(completed.cost).toBeCloseTo(0.06);
-		expect(completed.contextTokens).toBe(8000);
-		expect(completed.taskPreview).toBe("investigate");
-		expect(typeof completed.id).toBe("string");
+		const completed = agentEvents.at(-1);
+		expect(completed?.status).toBe("completed");
+		expect(completed?.toolCount).toBe(7);
+		expect(completed?.cost).toBeCloseTo(0.06);
+		expect(completed?.contextTokens).toBe(8000);
+		expect(completed?.taskPreview).toBe("investigate");
+		expect(typeof completed?.id).toBe("string");
 
-		// The same final snapshot is retained in the executor's display outputs.
+		// The same final snapshot is retained as the last executor display output.
 		const displayAgentEvents = result.displayOutputs.filter(
 			(output): output is Extract<typeof output, { type: "status" }> => output.type === "status",
 		);
-		expect(displayAgentEvents).toHaveLength(1);
+		expect(displayAgentEvents.length).toBeGreaterThanOrEqual(1);
+		expect(displayAgentEvents.at(-1)?.event.status).toBe("completed");
+		expect(displayAgentEvents.at(-1)?.event.toolCount).toBe(7);
 	});
 
 	it("pauses the idle watchdog while a quiet agent() runs past the budget", async () => {


### PR DESCRIPTION
## Repro
The eval-runtime test `agent() through eval runtimes > streams the latest enriched agent progress through onStatus before the cell finishes` (`packages/coding-agent/test/eval/agent-bridge-policy.test.ts`) asserted `expect(agentEvents).toHaveLength(1)`. It failed intermittently on CI under singleton-bucket parallel load (`Test coding-agent singleton/global-state (TS)` — runs 33876279457, 33865956535) with `Expected length: 1 / Received length: 2`. Reproduced deterministically by inserting a 50ms delay between `agent(...)` and `handle.wait()` in the JS cell (standing in for CI load), which yields `agentEvents count: 2 ["completed", "completed"]`.

## Cause
`runEvalWait` in `packages/coding-agent/src/eval/handle-bridge.ts` calls `emitProgress` at wait-start (line 192), on a 1s interval (line 194), and at wait-end (line 203). Each emit reads `job.latestDetails.progress` and delivers an `op:"agent"` status event. Whether the wait-start emit fires is a microtask race between the mocked `runSubprocess` reporting progress and `runEvalWait`'s initial emit. When the job has already reported progress before `wait()` begins, both the start and end emits fire, so two events arrive. Emit-at-start-plus-end is intentional live-progress behavior; exactly-once delivery was never a designed contract, so the exact-count assertion was over-specified and timing-dependent.

## Fix
- Replace `expect(agentEvents).toHaveLength(1)` with `expect(agentEvents.length).toBeGreaterThanOrEqual(1)` and assert the enriched fields on `agentEvents.at(-1)` (the completed snapshot) instead of `agentEvents[0]`.
- Apply the same last-event check to the retained display outputs: assert `>= 1` status outputs and that the last one carries `status: "completed"` with `toolCount: 7`.
- Add a comment explaining the emit points and why the count is a race.

## Verification
`bun test test/eval/agent-bridge-policy.test.ts` → 40 pass / 0 fail. Confirmed the new assertions pass both the fast single-event path and a probe that forces the 2-event race (50ms delay before `wait()`). Fixes #10821