### PR TITLE
docs(examples): first-class PII redaction extension pattern

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -746,3 +746,21 @@ Use the right surface:
 - **Custom-tools** (`src/extensibility/custom-tools/*`): tool-focused modules; when loaded alongside extensions they are adapted and still pass through extension interception wrappers.
 
 If you need one package that owns policy, tools, command UX, and rendering together, use extensions.
+
+## Privacy middleware (PII)
+
+Built-in `secrets.enabled` obfuscates credentials before provider I/O. For NER-style PII (names, emails, phones, addresses) use an extension on:
+
+- `tool_result` — scrub tool output entering the transcript
+- `context` — rewrite `AgentMessage[]` before the model call
+- `before_provider_request` — last-mile provider payload replacement
+
+See `packages/coding-agent/examples/extensions/pii-redact.ts` for a zero-dep pattern, or install the local ProgramAsWeights plugin:
+
+```bash
+omp plugin link /path/to/pii/integrations/omp
+# https://github.com/kvnloo/pii
+```
+
+Do not fold NER models into core secrets.yml unless productizing a unified pipeline (Discord first).
+

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+
 ### Added
 
+- Added an example PII redaction extension (`examples/extensions/pii-redact.ts`) documenting `tool_result` / `context` / `before_provider_request` privacy middleware, complementary to `secrets.enabled` ([#10829](https://github.com/can1357/oh-my-pi/pull/10829)).
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
 - `/loop` accepts `--until '<cmd>'` / `--while '<cmd>'` to gate each iteration on a shell command's exit status, so a loop can stop on real project state instead of only a count or duration. ([#10858](https://github.com/can1357/oh-my-pi/pull/10858) by [@andyhite](https://github.com/andyhite))
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -23,6 +23,14 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 | `confirm-destructive.ts` | Confirms before destructive session actions (clear, switch, branch)          |
 | `dirty-repo-guard.ts`    | Prevents session changes with uncommitted git changes                        |
 
+### Privacy
+
+| Extension         | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `pii-redact.ts`   | Scrub emails/phones/SSNs on `tool_result` + `context` (+ optional PAW CLI)  |
+
+Full local NER plugin (ProgramAsWeights): https://github.com/kvnloo/pii/tree/main/integrations/omp
+
 ### Custom Tools
 
 | Extension     | Description                                                                   |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -27,7 +27,7 @@ cp permission-gate.ts ~/.omp/agent/extensions/
 
 | Extension         | Description                                                                 |
 | ----------------- | --------------------------------------------------------------------------- |
-| `pii-redact.ts`   | Scrub emails/phones/SSNs on `tool_result` + `context` (+ optional PAW CLI)  |
+| `pii-redact.ts`   | Scrub emails/phones/SSNs on `tool_result`/`context`/`before_provider_request` (+ optional PAW CLI) |
 
 Full local NER plugin (ProgramAsWeights): https://github.com/kvnloo/pii/tree/main/integrations/omp
 

--- a/packages/coding-agent/examples/extensions/pii-redact.ts
+++ b/packages/coding-agent/examples/extensions/pii-redact.ts
@@ -1,0 +1,125 @@
+/**
+ * PII redaction extension (pattern + lightweight fallback)
+ *
+ * Demonstrates first-class privacy middleware on the extension event bus:
+ *   - tool_result              — scrub tool output before it re-enters context
+ *   - context                  — rewrite AgentMessage[] before the LLM call
+ *   - before_provider_request  — last-mile provider payload scrub
+ *
+ * This example ships a small regex fallback so it runs with zero deps.
+ * For production NER (names, addresses, multilingual PII) point
+ * PAW_PII_CMD at the local ProgramAsWeights CLI from:
+ *   https://github.com/kvnloo/pii  (integrations/omp package: omp-paw-pii)
+ *
+ * Complements built-in secrets.enabled (credentials) — does not replace it.
+ *
+ * Usage:
+ *   omp -e packages/coding-agent/examples/extensions/pii-redact.ts
+ *   # or: omp plugin link /path/to/pii/integrations/omp
+ */
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE = /\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g;
+const SSN = /\b\d{3}-\d{2}-\d{4}\b/g;
+
+function regexRedact(text: string, placeholder: string): string {
+	return text.replace(EMAIL, placeholder).replace(PHONE, placeholder).replace(SSN, placeholder);
+}
+
+function collectText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	const parts: string[] = [];
+	for (const part of content) {
+		if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+			if (typeof part.text === "string") parts.push(part.text);
+		}
+	}
+	return parts.join("\n");
+}
+
+function mapText(content: unknown, redacted: string): unknown {
+	if (typeof content === "string") return redacted;
+	if (!Array.isArray(content)) return content;
+	let replaced = false;
+	return content.map((part) => {
+		if (part && typeof part === "object" && "type" in part && part.type === "text") {
+			if (!replaced) {
+				replaced = true;
+				return { ...part, text: redacted };
+			}
+			return { ...part, text: "" };
+		}
+		return part;
+	});
+}
+
+async function redactText(pi: ExtensionAPI, text: string, placeholder: string): Promise<string> {
+	const cmd = process.env.PAW_PII_CMD;
+	if (cmd) {
+		const result = await pi.exec(cmd, ["redact", "--text", text, "--placeholder", placeholder], {});
+		if (result.code === 0 && result.stdout) {
+			return result.stdout.replace(/\n$/, "");
+		}
+		pi.logger?.warn?.("PAW_PII_CMD failed; falling back to regex", {
+			code: result.code,
+			stderr: result.stderr,
+		});
+	}
+	return regexRedact(text, placeholder);
+}
+
+export default function piiRedactExtension(pi: ExtensionAPI) {
+	pi.setLabel("PII Redaction (example)");
+	const placeholder = process.env.PAW_PII_PLACEHOLDER || "[PII]";
+	let enabled = process.env.PAW_PII_DISABLE !== "1";
+
+	pi.registerCommand("pii", {
+		description: "Toggle example PII redaction middleware",
+		handler: async (_args, ctx) => {
+			enabled = !enabled;
+			ctx.ui.notify(enabled ? "PII redaction on" : "PII redaction off", "info");
+		},
+	});
+
+	pi.on("tool_result", async (event) => {
+		if (!enabled || event.isError) return;
+		const blob = collectText(event.content);
+		if (blob.length < 3) return;
+		const redacted = await redactText(pi, blob, placeholder);
+		if (redacted === blob) return;
+		return { content: mapText(event.content, redacted) };
+	});
+
+	pi.on("context", async (event) => {
+		if (!enabled || !Array.isArray(event.messages)) return;
+		const messages = [];
+		for (const message of event.messages) {
+			if (!message || typeof message !== "object") {
+				messages.push(message);
+				continue;
+			}
+			const next = { ...message };
+			if ("content" in next) {
+				const blob = collectText(next.content);
+				if (blob) {
+					const redacted = await redactText(pi, blob, placeholder);
+					next.content = mapText(next.content, redacted);
+				}
+			}
+			messages.push(next);
+		}
+		return { messages };
+	});
+
+	pi.on("before_provider_request", async (event) => {
+		if (!enabled || event.payload == null) return;
+		if (typeof event.payload === "string") {
+			return await redactText(pi, event.payload, placeholder);
+		}
+		// Opaque provider bodies: best-effort JSON string walk is left to the
+		// full omp-paw-pii plugin. Keep the example focused on message content.
+		return undefined;
+	});
+}

--- a/packages/coding-agent/examples/extensions/pii-redact.ts
+++ b/packages/coding-agent/examples/extensions/pii-redact.ts
@@ -2,9 +2,9 @@
  * PII redaction extension (pattern + lightweight fallback)
  *
  * Demonstrates first-class privacy middleware on the extension event bus:
- *   - tool_result              — scrub tool output before it re-enters context
+ *   - tool_result              — scrub tool output (success and error) before it re-enters context
  *   - context                  — rewrite AgentMessage[] before the LLM call
- *   - before_provider_request  — last-mile provider payload scrub
+ *   - before_provider_request  — last-mile provider payload scrub (strings + structured objects)
  *
  * This example ships a small regex fallback so it runs with zero deps.
  * For production NER (names, addresses, multilingual PII) point
@@ -23,51 +23,86 @@ const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const PHONE = /\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g;
 const SSN = /\b\d{3}-\d{2}-\d{4}\b/g;
 
-function regexRedact(text: string, placeholder: string): string {
+/** Keep PAW well under the extension handler timeout (30s). */
+const PAW_TIMEOUT_MS = 5_000;
+
+export function regexRedact(text: string, placeholder: string): string {
 	return text.replace(EMAIL, placeholder).replace(PHONE, placeholder).replace(SSN, placeholder);
 }
 
-function collectText(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return "";
-	const parts: string[] = [];
-	for (const part of content) {
-		if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
-			if (typeof part.text === "string") parts.push(part.text);
-		}
-	}
-	return parts.join("\n");
+/** Build argv for the linked paw-pii CLI (`--placeholder` is a root option). */
+export function buildPawArgs(text: string, placeholder: string): string[] {
+	return ["--placeholder", placeholder, "redact", "--text", text];
 }
 
-function mapText(content: unknown, redacted: string): unknown {
-	if (typeof content === "string") return redacted;
+/**
+ * Preserve multimodal block order: redact each text block in place without
+ * joining/moving content across non-text parts.
+ */
+export function mapTextBlocks(content: unknown, redact: (text: string) => string): unknown {
+	if (typeof content === "string") return redact(content);
 	if (!Array.isArray(content)) return content;
-	let replaced = false;
-	return content.map((part) => {
-		if (part && typeof part === "object" && "type" in part && part.type === "text") {
-			if (!replaced) {
-				replaced = true;
-				return { ...part, text: redacted };
+	return content.map(part => {
+		if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+			if (typeof part.text === "string") {
+				return { ...part, text: redact(part.text) };
 			}
-			return { ...part, text: "" };
 		}
 		return part;
 	});
 }
 
-async function redactText(pi: ExtensionAPI, text: string, placeholder: string): Promise<string> {
+/** Shape-preserving walk of provider request objects; redacts every string leaf. */
+export function redactStructuredPayload(value: unknown, placeholder: string, seen = new WeakSet<object>()): unknown {
+	if (typeof value === "string") return regexRedact(value, placeholder);
+	if (value == null || typeof value !== "object") return value;
+	if (seen.has(value)) return value;
+	seen.add(value);
+	if (Array.isArray(value)) {
+		return value.map(item => redactStructuredPayload(item, placeholder, seen));
+	}
+	const out: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+		out[key] = redactStructuredPayload(child, placeholder, seen);
+	}
+	return out;
+}
+
+export async function redactText(pi: ExtensionAPI, text: string, placeholder: string): Promise<string> {
 	const cmd = process.env.PAW_PII_CMD;
-	if (cmd) {
-		const result = await pi.exec(cmd, ["redact", "--text", text, "--placeholder", placeholder], {});
+	if (!cmd) return regexRedact(text, placeholder);
+	try {
+		const result = await pi.exec(cmd, buildPawArgs(text, placeholder), { timeout: PAW_TIMEOUT_MS });
 		if (result.code === 0 && result.stdout) {
 			return result.stdout.replace(/\n$/, "");
 		}
+		// Do not log stderr/stdout — detectors may echo the protected input.
 		pi.logger?.warn?.("PAW_PII_CMD failed; falling back to regex", {
 			code: result.code,
-			stderr: result.stderr,
+			killed: result.killed,
 		});
+	} catch {
+		pi.logger?.warn?.("PAW_PII_CMD failed to spawn; falling back to regex");
 	}
 	return regexRedact(text, placeholder);
+}
+
+async function redactContent(pi: ExtensionAPI, content: unknown, placeholder: string): Promise<unknown> {
+	if (typeof content === "string") {
+		return await redactText(pi, content, placeholder);
+	}
+	if (!Array.isArray(content)) return content;
+	const next = [];
+	for (const part of content) {
+		if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+			if (typeof part.text === "string") {
+				next.push({ ...part, text: await redactText(pi, part.text, placeholder) });
+				continue;
+			}
+		}
+		next.push(part);
+	}
+	return next;
 }
 
 export default function piiRedactExtension(pi: ExtensionAPI) {
@@ -83,16 +118,15 @@ export default function piiRedactExtension(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.on("tool_result", async (event) => {
-		if (!enabled || event.isError) return;
-		const blob = collectText(event.content);
-		if (blob.length < 3) return;
-		const redacted = await redactText(pi, blob, placeholder);
-		if (redacted === blob) return;
-		return { content: mapText(event.content, redacted) };
+	pi.on("tool_result", async event => {
+		if (!enabled) return;
+		// Error results are model-visible and persisted; scrub them too.
+		const redacted = await redactContent(pi, event.content, placeholder);
+		if (redacted === event.content) return;
+		return { content: redacted };
 	});
 
-	pi.on("context", async (event) => {
+	pi.on("context", async event => {
 		if (!enabled || !Array.isArray(event.messages)) return;
 		const messages = [];
 		for (const message of event.messages) {
@@ -102,24 +136,21 @@ export default function piiRedactExtension(pi: ExtensionAPI) {
 			}
 			const next = { ...message };
 			if ("content" in next) {
-				const blob = collectText(next.content);
-				if (blob) {
-					const redacted = await redactText(pi, blob, placeholder);
-					next.content = mapText(next.content, redacted);
-				}
+				next.content = await redactContent(pi, next.content, placeholder);
 			}
 			messages.push(next);
 		}
 		return { messages };
 	});
 
-	pi.on("before_provider_request", async (event) => {
+	pi.on("before_provider_request", async event => {
 		if (!enabled || event.payload == null) return;
 		if (typeof event.payload === "string") {
 			return await redactText(pi, event.payload, placeholder);
 		}
-		// Opaque provider bodies: best-effort JSON string walk is left to the
-		// full omp-paw-pii plugin. Keep the example focused on message content.
+		if (typeof event.payload === "object") {
+			return redactStructuredPayload(event.payload, placeholder);
+		}
 		return undefined;
 	});
 }

--- a/packages/coding-agent/examples/extensions/pii-redact.ts
+++ b/packages/coding-agent/examples/extensions/pii-redact.ts
@@ -18,6 +18,9 @@
  *   # or: omp plugin link /path/to/pii/integrations/omp
  */
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+
+type ToolResultContent = (TextContent | ImageContent)[];
 
 const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const PHONE = /\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g;
@@ -87,16 +90,35 @@ export async function redactText(pi: ExtensionAPI, text: string, placeholder: st
 	return regexRedact(text, placeholder);
 }
 
-async function redactContent(pi: ExtensionAPI, content: unknown, placeholder: string): Promise<unknown> {
+async function redactToolResultContent(
+	pi: ExtensionAPI,
+	content: ToolResultContent,
+	placeholder: string,
+): Promise<ToolResultContent> {
+	const next: ToolResultContent = [];
+	for (const part of content) {
+		if (part && typeof part === "object" && part.type === "text" && typeof part.text === "string") {
+			next.push({ ...part, text: await redactText(pi, part.text, placeholder) });
+			continue;
+		}
+		next.push(part);
+	}
+	return next;
+}
+
+async function redactMessageContent(pi: ExtensionAPI, content: unknown, placeholder: string): Promise<unknown> {
 	if (typeof content === "string") {
 		return await redactText(pi, content, placeholder);
 	}
 	if (!Array.isArray(content)) return content;
-	const next = [];
+	const next: unknown[] = [];
 	for (const part of content) {
 		if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
-			if (typeof part.text === "string") {
-				next.push({ ...part, text: await redactText(pi, part.text, placeholder) });
+			if (typeof (part as { text?: unknown }).text === "string") {
+				next.push({
+					...(part as object),
+					text: await redactText(pi, (part as { text: string }).text, placeholder),
+				});
 				continue;
 			}
 		}
@@ -121,7 +143,7 @@ export default function piiRedactExtension(pi: ExtensionAPI) {
 	pi.on("tool_result", async event => {
 		if (!enabled) return;
 		// Error results are model-visible and persisted; scrub them too.
-		const redacted = await redactContent(pi, event.content, placeholder);
+		const redacted = await redactToolResultContent(pi, event.content, placeholder);
 		if (redacted === event.content) return;
 		return { content: redacted };
 	});
@@ -134,11 +156,12 @@ export default function piiRedactExtension(pi: ExtensionAPI) {
 				messages.push(message);
 				continue;
 			}
-			const next = { ...message };
-			if ("content" in next) {
-				next.content = await redactContent(pi, next.content, placeholder);
+			if (!("content" in message)) {
+				messages.push(message);
+				continue;
 			}
-			messages.push(next);
+			const content = await redactMessageContent(pi, (message as { content?: unknown }).content, placeholder);
+			messages.push({ ...message, content } as typeof message);
 		}
 		return { messages };
 	});

--- a/packages/coding-agent/test/pii-redact-example.test.ts
+++ b/packages/coding-agent/test/pii-redact-example.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Behavioral coverage for the pii-redact example extension.
+ * Proves error-result scrubbing, multimodal block order, PAW fail-open
+ * fallback, and structured provider payload redaction.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { ExtensionRuntime, loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import piiRedactExtension, {
+	buildPawArgs,
+	mapTextBlocks,
+	redactStructuredPayload,
+	redactText,
+	regexRedact,
+} from "../examples/extensions/pii-redact.ts";
+
+const EXAMPLE_PATH = path.resolve(import.meta.dir, "../examples/extensions/pii-redact.ts");
+const PLACEHOLDER = "[PII]";
+
+describe("pii-redact example helpers", () => {
+	it("buildPawArgs puts --placeholder before the redact subcommand", () => {
+		expect(buildPawArgs("hi", PLACEHOLDER)).toEqual(["--placeholder", PLACEHOLDER, "redact", "--text", "hi"]);
+	});
+
+	it("regexRedact scrubs email/phone/ssn", () => {
+		const input = "mail a@b.co phone 555-123-4567 ssn 123-45-6789";
+		expect(regexRedact(input, PLACEHOLDER)).toBe(`mail ${PLACEHOLDER} phone ${PLACEHOLDER} ssn ${PLACEHOLDER}`);
+	});
+
+	it("mapTextBlocks preserves multimodal block order", () => {
+		const content = [
+			{ type: "text", text: "before a@b.co" },
+			{ type: "image", url: "img://1" },
+			{ type: "text", text: "after 555-123-4567" },
+		];
+		const mapped = mapTextBlocks(content, text => regexRedact(text, PLACEHOLDER)) as Array<Record<string, unknown>>;
+		expect(mapped).toEqual([
+			{ type: "text", text: `before ${PLACEHOLDER}` },
+			{ type: "image", url: "img://1" },
+			{ type: "text", text: `after ${PLACEHOLDER}` },
+		]);
+	});
+
+	it("redactStructuredPayload walks provider request objects", () => {
+		const payload = {
+			model: "gpt",
+			input: [{ role: "user", content: "reach me at secret@example.com" }],
+			tools: [{ name: "bash", arguments: { cmd: "echo 123-45-6789" } }],
+		};
+		expect(redactStructuredPayload(payload, PLACEHOLDER)).toEqual({
+			model: "gpt",
+			input: [{ role: "user", content: `reach me at ${PLACEHOLDER}` }],
+			tools: [{ name: "bash", arguments: { cmd: `echo ${PLACEHOLDER}` } }],
+		});
+	});
+
+	it("redactText falls back to regex when PAW exec throws", async () => {
+		const previous = process.env.PAW_PII_CMD;
+		process.env.PAW_PII_CMD = "missing-paw-binary-that-does-not-exist";
+		const warn = vi.fn();
+		const pi = {
+			exec: async () => {
+				throw new Error("spawn ENOENT");
+			},
+			logger: { warn },
+		} as unknown as ExtensionAPI;
+		try {
+			const out = await redactText(pi, "write a@b.co", PLACEHOLDER);
+			expect(out).toBe(`write ${PLACEHOLDER}`);
+			expect(warn).toHaveBeenCalled();
+			const first = warn.mock.calls[0]?.[1];
+			expect(first).toBeUndefined();
+		} finally {
+			if (previous === undefined) delete process.env.PAW_PII_CMD;
+			else process.env.PAW_PII_CMD = previous;
+		}
+	});
+
+	it("redactText falls back without logging detector stderr", async () => {
+		const previous = process.env.PAW_PII_CMD;
+		process.env.PAW_PII_CMD = "paw-pii";
+		const warn = vi.fn();
+		const pi = {
+			exec: async () => ({
+				code: 2,
+				stdout: "",
+				stderr: "ECHOED_SECRET a@b.co",
+				killed: false,
+			}),
+			logger: { warn },
+		} as unknown as ExtensionAPI;
+		try {
+			const out = await redactText(pi, "ssn 123-45-6789", PLACEHOLDER);
+			expect(out).toBe(`ssn ${PLACEHOLDER}`);
+			expect(JSON.stringify(warn.mock.calls)).not.toContain("ECHOED_SECRET");
+			expect(JSON.stringify(warn.mock.calls)).not.toContain("a@b.co");
+			expect(warn.mock.calls[0]?.[1]).toEqual({ code: 2, killed: false });
+		} finally {
+			if (previous === undefined) delete process.env.PAW_PII_CMD;
+			else process.env.PAW_PII_CMD = previous;
+		}
+	});
+});
+
+describe("pii-redact example extension events", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	afterEach(() => {
+		authStorage?.close();
+		tempDir?.removeSync();
+		delete process.env.PAW_PII_DISABLE;
+	});
+
+	async function loadExampleRunner() {
+		tempDir = TempDir.createSync("@pii-redact-ex-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+		const extensionsDir = path.join(tempDir.path(), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const dest = path.join(extensionsDir, "pii-redact.ts");
+		fs.copyFileSync(EXAMPLE_PATH, dest);
+		const result = await loadExtensions([dest], tempDir.path());
+		expect(result.errors).toEqual([]);
+		const sessionManager = SessionManager.inMemory();
+		return new ExtensionRunner(result.extensions, result.runtime, tempDir.path(), sessionManager, modelRegistry);
+	}
+
+	it("scrubs failed tool_result content", async () => {
+		const runner = await loadExampleRunner();
+		const replaced = await runner.emitToolResult({
+			type: "tool_result",
+			toolName: "bash",
+			toolCallId: "c1",
+			input: { command: "cat secrets" },
+			content: [{ type: "text", text: "Permission denied for a@b.co" }],
+			details: undefined,
+			isError: true,
+		});
+		expect(replaced?.content).toEqual([{ type: "text", text: `Permission denied for ${PLACEHOLDER}` }]);
+	});
+
+	it("keeps text/image/text order on context rewrite", async () => {
+		const runner = await loadExampleRunner();
+		const messages = await runner.emitContext([
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "see a@b.co" },
+					{ type: "image", mimeType: "image/png", data: "abc" },
+					{ type: "text", text: "then 555-123-4567" },
+				],
+				timestamp: Date.now(),
+			} as never,
+		]);
+		const content = (messages[0] as { content: unknown[] }).content;
+		expect(content[0]).toEqual({ type: "text", text: `see ${PLACEHOLDER}` });
+		expect(content[1]).toMatchObject({ type: "image" });
+		expect(content[2]).toEqual({ type: "text", text: `then ${PLACEHOLDER}` });
+	});
+
+	it("redacts structured before_provider_request payloads", async () => {
+		const runner = await loadExampleRunner();
+		const payload = await runner.emitBeforeProviderRequest({
+			messages: [{ role: "user", content: "call secret@example.com" }],
+			system: "never leak 123-45-6789",
+		});
+		expect(payload).toEqual({
+			messages: [{ role: "user", content: `call ${PLACEHOLDER}` }],
+			system: `never leak ${PLACEHOLDER}`,
+		});
+	});
+
+	it("registers via default export factory", () => {
+		const commands: string[] = [];
+		const handlers: string[] = [];
+		const pi = {
+			setLabel: () => {},
+			registerCommand: (name: string) => {
+				commands.push(name);
+			},
+			on: (event: string) => {
+				handlers.push(event);
+			},
+		} as unknown as ExtensionAPI;
+		piiRedactExtension(pi);
+		expect(commands).toContain("pii");
+		expect(handlers).toEqual(["tool_result", "context", "before_provider_request"]);
+	});
+});

--- a/packages/coding-agent/test/pii-redact-example.test.ts
+++ b/packages/coding-agent/test/pii-redact-example.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
-import { ExtensionRuntime, loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -19,7 +19,7 @@ import piiRedactExtension, {
 	redactStructuredPayload,
 	redactText,
 	regexRedact,
-} from "../examples/extensions/pii-redact.ts";
+} from "../examples/extensions/pii-redact";
 
 const EXAMPLE_PATH = path.resolve(import.meta.dir, "../examples/extensions/pii-redact.ts");
 const PLACEHOLDER = "[PII]";


### PR DESCRIPTION
## Summary

Closes the docs/example half of #10828.

- Adds `packages/coding-agent/examples/extensions/pii-redact.ts` — middleware on `tool_result` / `context` / `before_provider_request` with a zero-dep regex fallback and optional `PAW_PII_CMD` for the local ProgramAsWeights CLI.
- Indexes it under Privacy in the examples README.
- Documents the privacy middleware pattern in `docs/extensions.md` and points at the full plugin: https://github.com/kvnloo/pii/tree/main/integrations/omp

Does **not** vendor torch/PAW into core. Complements `secrets.enabled`; does not replace it.

## Test plan

- [ ] `omp -e packages/coding-agent/examples/extensions/pii-redact.ts` loads
- [ ] `/pii` toggles notify
- [ ] Tool result containing an email is scrubbed when enabled
- [ ] Optional: `PAW_PII_CMD=paw-pii` path when the package is installed