### PR TITLE
fix(tui): cached stable status-line path classification

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
+- Reduced TUI CPU use while waiting and streaming on WSL by eliminating repeated status-line path filesystem reads ([#10826](https://github.com/can1357/oh-my-pi/issues/10826)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -134,7 +134,19 @@ interface ProjectDirClassification {
 	readonly stripped: string;
 }
 
-const PROJECT_DIR_CLASSIFICATIONS = new LRUCache<string, ProjectDirClassification>({ max: 32 });
+/**
+ * Freshness bound for cached path classifications. The status line paints
+ * many times per second, so caching collapses the per-frame `realpathSync`
+ * storm (issue #10826); the TTL lets a retargeted symlink/bind mount at the
+ * same path re-canonicalize within a few seconds instead of sticking until
+ * LRU eviction. Mirrors the short VCS-cache TTLs in `component.ts`.
+ */
+const PROJECT_DIR_CLASSIFICATION_TTL_MS = 5000;
+
+const PROJECT_DIR_CLASSIFICATIONS = new LRUCache<string, ProjectDirClassification>({
+	max: 32,
+	ttl: PROJECT_DIR_CLASSIFICATION_TTL_MS,
+});
 
 function classifyProjectDir(pwd: string): ProjectDirClassification {
 	const cached = PROJECT_DIR_CLASSIFICATIONS.get(pwd);

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { SPINNER_ADVANCE_MS, TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
@@ -127,13 +128,28 @@ const SCRATCH_ROOTS: readonly string[] = (() => {
 	return [...roots];
 })();
 
-function classifyProjectDir(pwd: string): { scratch: boolean; relative: string | null } {
+interface ProjectDirClassification {
+	readonly scratch: boolean;
+	readonly relative: string | null;
+	readonly stripped: string;
+}
+
+const PROJECT_DIR_CLASSIFICATIONS = new LRUCache<string, ProjectDirClassification>({ max: 32 });
+
+function classifyProjectDir(pwd: string): ProjectDirClassification {
+	const cached = PROJECT_DIR_CLASSIFICATIONS.get(pwd);
+	if (cached) return cached;
+
+	let classification: ProjectDirClassification | undefined;
 	for (const root of SCRATCH_ROOTS) {
 		if (pathIsWithin(root, pwd)) {
-			return { scratch: true, relative: relativePathWithinRoot(root, pwd) };
+			classification = { scratch: true, relative: relativePathWithinRoot(root, pwd), stripped: pwd };
+			break;
 		}
 	}
-	return { scratch: false, relative: null };
+	classification ??= { scratch: false, relative: null, stripped: stripDisplayRoot(pwd) };
+	PROJECT_DIR_CLASSIFICATIONS.set(pwd, classification);
+	return classification;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -408,15 +424,12 @@ const pathSegment: StatusLineSegment = {
 		}
 
 		const projectDir = ctx.activeRepo?.cwd ?? getProjectDir();
-		const { scratch, relative } = classifyProjectDir(projectDir);
+		let scratch = false;
 		let pwd = projectDir;
-
 		if (stripPrefix) {
-			if (scratch) {
-				if (relative) pwd = relative;
-			} else {
-				pwd = stripDisplayRoot(pwd);
-			}
+			const classification = classifyProjectDir(projectDir);
+			scratch = classification.scratch;
+			pwd = classification.scratch ? (classification.relative ?? projectDir) : classification.stripped;
 		}
 		const repoSuffix = ctx.activeRepo ? ` ↳ ${ctx.activeRepo.relativeRepoRoot}` : "";
 		if (opts.abbreviate !== false) {

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -278,6 +278,33 @@ describe("status line path segment", () => {
 			removeSyncWithRetries(scratchDir);
 		}
 	});
+
+	it("re-canonicalizes a reselected path once the classification TTL lapses", () => {
+		const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-ttl-"));
+		try {
+			setProjectDir(scratchDir);
+			let clock = 1_000;
+			vi.spyOn(performance, "now").mockImplementation(() => clock);
+			const realpath = vi.spyOn(fs, "realpathSync");
+
+			renderSegment("path", createPathContext());
+			const coldReads = realpath.mock.calls.length;
+			expect(coldReads).toBeGreaterThan(0);
+
+			// Still within the freshness window: cache serves without re-reading.
+			clock += 4_000;
+			renderSegment("path", createPathContext());
+			expect(realpath).toHaveBeenCalledTimes(coldReads);
+
+			// Past the TTL: reselection observes the current canonical target again.
+			clock += 2_000;
+			renderSegment("path", createPathContext());
+			expect(realpath.mock.calls.length).toBeGreaterThan(coldReads);
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(scratchDir);
+		}
+	});
 });
 
 describe("status line path segment in a linked worktree", () => {

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -261,6 +261,23 @@ describe("status line path segment", () => {
 			removeSyncWithRetries(parentDir);
 		}
 	});
+	it("does not repeat canonical filesystem reads for an unchanged project directory", () => {
+		const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-cache-"));
+		try {
+			setProjectDir(scratchDir);
+			const realpath = vi.spyOn(fs, "realpathSync");
+
+			renderSegment("path", createPathContext());
+			const coldReads = realpath.mock.calls.length;
+			expect(coldReads).toBeGreaterThan(0);
+
+			renderSegment("path", createPathContext());
+			expect(realpath).toHaveBeenCalledTimes(coldReads);
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(scratchDir);
+		}
+	});
 });
 
 describe("status line path segment in a linked worktree", () => {


### PR DESCRIPTION
## Repro
On 18.1.10, the attached idle profile records `realpathSync` in 473/955 CPU samples under the status-line path segment. `cd packages/coding-agent && bun test test/status-line-path.test.ts` reproduced the repeated work with the regression assertion: one render made six canonical filesystem reads and an unchanged second render increased the count to twelve.

## Cause
`pathSegment.render()` in `packages/coding-agent/src/modes/components/status-line/segments.ts` called `classifyProjectDir()` and `stripDisplayRoot()` on every paint. Those helpers use `pathIsWithin()` / `relativePathWithinRoot()`, which canonicalize paths through `realpathSync`; narrow-layout fitting may rerender the path segment several times in one frame, multiplying filesystem reads on WSL.

## Fix
- Cache scratch-root classification and display-prefix stripping by stable project directory in a bounded `LRUCache`.
- Skip classification entirely when prefix stripping is disabled.
- Add a regression proving that an unchanged path rerender performs no additional canonical filesystem reads.
- Document the waiting/streaming CPU reduction in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/status-line-*.test.ts` — 187 passed, 0 failed. `cd packages/coding-agent && bun check` — passed. Built and launched `packages/coding-agent/dist/omp` through a real PTY; the status line rendered the project path and branch correctly before the environment's read-only agent config ended setup.

Fixes #10826