### PR TITLE
feat(claude): add .claude/rules/*.{md,mdc} discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Load Claude Code rules from `.claude/rules/*.md` and `*.mdc` (project and opted-in `~/.claude`), sharing the same Markdown frontmatter as OMP rules.
+
 ### Fixed
 
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -5,7 +5,7 @@
  * Priority: 80 (tool-specific, below builtin but above shared standards)
  */
 import * as path from "node:path";
-import { hasFsCode, tryParseJson } from "@oh-my-pi/pi-utils";
+import { hasFsCode, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { isUserSourceEnabled } from "../capability";
 import type { ContextFile } from "../capability/context-file";
@@ -14,21 +14,25 @@ import { type ExtensionModule, extensionModuleCapability } from "../capability/e
 import { readFile } from "../capability/fs";
 import { type Hook, hookCapability } from "../capability/hook";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
+import { type Rule, ruleCapability } from "../capability/rule";
 import { type Settings, settingsCapability } from "../capability/settings";
 import { type Skill, skillCapability } from "../capability/skill";
 import { type SlashCommand, slashCommandCapability } from "../capability/slash-command";
 import { type SystemPrompt, systemPromptCapability } from "../capability/system-prompt";
 import { type CustomTool, toolCapability } from "../capability/tool";
-import type { LoadContext, LoadResult } from "../capability/types";
+import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import { resolveClaudePaths } from "../config/claude-paths";
 import { settings } from "../config/settings";
 import {
 	calculateDepth,
 	createSourceMeta,
 	discoverExtensionModulePaths,
+	discoverRuleFromMarkdown,
 	expandEnvVarsDeep,
 	getExtensionNameFromPath,
+	isAlwaysApplyGlob,
 	loadFilesFromDir,
+	parseGlobList,
 	scanSkillsFromDir,
 } from "./helpers";
 
@@ -179,6 +183,110 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 			_source: createSourceMeta(PROVIDER_ID, projectClaudeMd, "project"),
 		});
 	}
+
+	return { items, warnings };
+}
+
+// =============================================================================
+// Rules
+// =============================================================================
+
+function transformClaudeRule(
+	name: string,
+	content: string,
+	filePath: string,
+	source: SourceMeta,
+	rulesDir: string,
+): Rule | null {
+	const { frontmatter } = parseFrontmatter(content, { source: filePath });
+
+	// Name rules by their path relative to the rules dir so nested files with a
+	// shared basename stay distinct (flat files keep their basename). The `/`
+	// separators are preserved: a filename component can never contain `/`, so
+	// this is collision-free, and the rule:// resolver reads the full host+path.
+	const ruleName = path
+		.relative(rulesDir, filePath)
+		.split(path.sep)
+		.join("/")
+		.replace(/\.(md|mdc)$/, "");
+
+	const rule = discoverRuleFromMarkdown(name, content, filePath, source, { ruleName });
+	if (!rule) return null;
+
+	const paths = parseGlobList(frontmatter.paths);
+
+	// A file already carrying OMP scoping (globs, alwaysApply, or a TTSR
+	// condition) expresses its own semantics; leave it untouched so shared
+	// OMP-authored files are never overlaid with Claude `paths` normalization.
+	// `frontmatter.alwaysApply` presence (not its parsed boolean) distinguishes
+	// an explicit `alwaysApply: false` from an omitted field.
+	const hasOmpScoping =
+		rule.globs !== undefined ||
+		frontmatter.alwaysApply !== undefined ||
+		(rule.condition?.length ?? 0) > 0 ||
+		(rule.astCondition?.length ?? 0) > 0;
+
+	if (paths === undefined) {
+		// A pathless Claude rule applies unconditionally.
+		if (!hasOmpScoping) rule.alwaysApply = true;
+		return rule;
+	}
+
+	if (hasOmpScoping) return rule;
+
+	// Claude `paths` scoping maps onto OMP `globs`; catch-all globs mean every
+	// file, equivalent to always-apply (mirrors the GitHub `applyTo` provider).
+	if (paths.some(isAlwaysApplyGlob)) {
+		return { ...rule, alwaysApply: true, globs: undefined };
+	}
+
+	const description = rule.description ?? describeClaudeRule(paths);
+	return { ...rule, alwaysApply: false, globs: paths, description };
+}
+
+function describeClaudeRule(globs: string[]): string {
+	return `Claude rules for ${globs.join(", ")}`;
+}
+
+async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
+	const items: Rule[] = [];
+	const warnings: string[] = [];
+
+	const userBase = getUserClaude(ctx);
+	const userRulesDir = userBase ? path.join(userBase, "rules") : null;
+
+	// Project `.claude/rules` is cwd-scoped. When cwd is the user's home, it
+	// aliases ~/.claude/rules — skip it so a disabled Claude user source is not
+	// reloaded (and re-labeled) as "project" config (mirrors loadSkills skipping
+	// $HOME in its ancestor walk).
+	const projectRulesDir = ctx.cwd === ctx.home ? null : path.join(getProjectClaude(ctx), "rules");
+
+	const [projectResult, userResult] = await Promise.all([
+		projectRulesDir
+			? loadFilesFromDir<Rule>(ctx, projectRulesDir, PROVIDER_ID, "project", {
+					extensions: ["md", "mdc"],
+					recursive: true,
+					transform: (name, content, filePath, source) =>
+						transformClaudeRule(name, content, filePath, source, projectRulesDir),
+				})
+			: Promise.resolve({ items: [] as Rule[], warnings: [] as string[] }),
+		userRulesDir
+			? loadFilesFromDir<Rule>(ctx, userRulesDir, PROVIDER_ID, "user", {
+					extensions: ["md", "mdc"],
+					recursive: true,
+					transform: (name, content, filePath, source) =>
+						transformClaudeRule(name, content, filePath, source, userRulesDir),
+				})
+			: Promise.resolve({ items: [] as Rule[], warnings: [] as string[] }),
+	]);
+
+	// Project elements first so a same-named project rule wins the name-keyed
+	// dedup over a user rule (Claude Code: project rules override user rules).
+	items.push(...projectResult.items);
+	if (projectResult.warnings) warnings.push(...projectResult.warnings);
+
+	items.push(...userResult.items);
+	if (userResult.warnings) warnings.push(...userResult.warnings);
 
 	return { items, warnings };
 }
@@ -559,6 +667,14 @@ registerProvider<ContextFile>(contextFileCapability.id, {
 	description: "Load CLAUDE.md files from .claude/ directories",
 	priority: PRIORITY,
 	load: loadContextFiles,
+});
+
+registerProvider<Rule>(ruleCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load rules from .claude/rules/*.md and *.mdc",
+	priority: PRIORITY,
+	load: loadRules,
 });
 
 registerProvider<Skill>(skillCapability.id, {

--- a/packages/coding-agent/src/discovery/github.ts
+++ b/packages/coding-agent/src/discovery/github.ts
@@ -31,8 +31,10 @@ import {
 	calculateDepth,
 	createSourceMeta,
 	getProjectPath,
+	isAlwaysApplyGlob,
 	loadFilesFromDir,
 	parseCSV,
+	parseGlobList,
 	resolveCopilotHome,
 	scanSkillsFromDir,
 } from "./helpers";
@@ -201,7 +203,7 @@ function transformInstructionRule(
 	}
 
 	const { frontmatter } = parseFrontmatter(content, { source: filePath });
-	const applyToGlobs = normalizeApplyToGlobs(frontmatter.applyTo);
+	const applyToGlobs = parseGlobList(frontmatter.applyTo, { splitCommas: true });
 	if (!applyToGlobs) {
 		warnings.push(`Missing applyTo in ${filePath}; loaded without GitHub glob scoping.`);
 	}
@@ -216,19 +218,6 @@ function transformInstructionRule(
 
 	const description = rule.description ?? describeInstructionRule(applyToGlobs);
 	return { ...rule, alwaysApply: false, globs: applyToGlobs, description };
-}
-
-function normalizeApplyToGlobs(value: unknown): string[] | undefined {
-	// GitHub documents applyTo as a single comma-separated string (e.g.
-	// "**/*.ts,**/*.tsx"); also tolerate a YAML array of such strings.
-	const raw = Array.isArray(value) ? value : [value];
-	const globs = raw.flatMap(item => (typeof item === "string" ? parseCSV(item) : []));
-	return globs.length > 0 ? globs : undefined;
-}
-
-function isAlwaysApplyGlob(glob: string): boolean {
-	// GitHub treats "*", "**", and "**/*" as matching every file.
-	return glob === "*" || glob === "**" || glob === "**/*";
 }
 
 function describeInstructionRule(globs: string[] | undefined): string {

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -204,6 +204,46 @@ export function parseArrayOrCSV(value: unknown): string[] | undefined {
 	return undefined;
 }
 
+/**
+ * Parse a rule-scoping glob list that differs by provider.
+ *
+ * With `splitCommas: true` (GitHub `applyTo`), a scalar is comma-split and so
+ * is each array element — the historical `applyTo` contract is a
+ * comma-separated string, with a YAML array merely tolerated.
+ *
+ * With `splitCommas: false` (default, Claude `paths`), every value is an
+ * atomic glob: array elements are trimmed and preserved verbatim, and a scalar
+ * is a single glob, so a comma inside an element (a brace pattern or a
+ * filename) is never treated as a separator.
+ */
+export function parseGlobList(
+	value: unknown,
+	options: { splitCommas?: boolean } = {},
+): string[] | undefined {
+	if (Array.isArray(value)) {
+		const strings = value.filter((item): item is string => typeof item === "string");
+		const globs = options.splitCommas
+			? strings.flatMap(item => parseCSV(item))
+			: strings.map(item => item.trim()).filter(Boolean);
+		return globs.length > 0 ? globs : undefined;
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (!trimmed) return undefined;
+		return options.splitCommas ? parseCSV(trimmed) : [trimmed];
+	}
+	return undefined;
+}
+
+/**
+ * Whether a rule glob matches every path (the catch-all `*`, `**`, and
+ * double-star-slash-star globs), so the rule is always-apply rather than
+ * conditionally scoped.
+ */
+export function isAlwaysApplyGlob(glob: string): boolean {
+	return glob === "*" || glob === "**" || glob === "**/*";
+}
+
 interface RuleMarkdownOptions {
 	ruleName?: string;
 	stripNamePattern?: RegExp;

--- a/packages/coding-agent/src/internal-urls/rule-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/rule-protocol.ts
@@ -14,7 +14,11 @@ export class RuleProtocolHandler implements ProtocolHandler {
 	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const rules = context?.rules ?? getActiveRules();
 
-		const ruleName = url.rawHost || url.hostname;
+		// Reconstruct host + path so nested rule names (whose directory separators
+		// surface as URL path segments) resolve — e.g. rule://frontend/style.
+		const host = url.rawHost || url.hostname;
+		const pathname = url.rawPathname ?? url.pathname;
+		const ruleName = host && pathname && pathname !== "/" ? `${host}${pathname}` : host;
 		if (!ruleName) {
 			throw new Error("rule:// URL requires a rule name: rule://<name>");
 		}

--- a/packages/coding-agent/test/discovery/claude-rules.test.ts
+++ b/packages/coding-agent/test/discovery/claude-rules.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetCapabilityForTests } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { type Rule, ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import { bucketRules } from "@oh-my-pi/pi-coding-agent/capability/rule-buckets";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings, loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { TtsrManager } from "@oh-my-pi/pi-coding-agent/export/ttsr";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+describe("Claude Code rules discovery", () => {
+	let root = "";
+	let home = "";
+	let project = "";
+	let originalHome: string | undefined;
+	let originalClaudeConfigDir: string | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		resetCapabilityForTests();
+		clearFsCache();
+		originalHome = process.env.HOME;
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-claude-rules-"));
+		home = path.join(root, "home");
+		project = path.join(root, "project");
+		process.env.HOME = home;
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		await fs.mkdir(path.join(project, ".git"), { recursive: true });
+		const settings = await Settings.init({ inMemory: true, cwd: project });
+		initializeWithSettings(settings);
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		resetCapabilityForTests();
+		clearFsCache();
+		vi.restoreAllMocks();
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+		else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		await removeWithRetries(root);
+	});
+
+	async function writeRuleFile(base: string, relPath: string, content: string): Promise<void> {
+		const filePath = path.join(base, ".claude", "rules", relPath);
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, content);
+	}
+
+	async function loadClaudeRules(cwd: string): Promise<Rule[]> {
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd, providers: ["claude"] });
+		return result.items;
+	}
+
+	test("discovers project .claude/rules markdown with MDC-style frontmatter", async () => {
+		await writeRuleFile(
+			project,
+			"conventions.md",
+			'---\ndescription: "Project coding conventions"\nalwaysApply: true\n---\nAlways format with tabs.\n',
+		);
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "conventions");
+
+		expect(rule).toBeDefined();
+		expect(rule?.description).toBe("Project coding conventions");
+		expect(rule?.alwaysApply).toBe(true);
+		expect(rule?.content).toContain("Always format with tabs.");
+		expect(rule?._source.provider).toBe("claude");
+		expect(rule?._source.level).toBe("project");
+	});
+
+	test("discovers .mdc rule files alongside .md", async () => {
+		await writeRuleFile(project, "security.mdc", '---\ndescription: Security review checklist\n---\nNever log credentials.\n');
+
+		const rules = await loadClaudeRules(project);
+		expect(rules.map(r => r.name)).toContain("security");
+	});
+
+	test("loads user ~/.claude/rules at the user level", async () => {
+		await writeRuleFile(home, "global.md", "---\ndescription: Global rules\n---\nBe concise.\n");
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "global");
+
+		expect(rule).toBeDefined();
+		expect(rule?.description).toBe("Global rules");
+		expect(rule?._source.level).toBe("user");
+	});
+
+	test("treats a plain pathless Claude rule as always-applicable", async () => {
+		await writeRuleFile(project, "plain.md", "Always be concise.\n");
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "plain");
+
+		expect(rule?.alwaysApply).toBe(true);
+
+		const { alwaysApplyRules } = bucketRules(rules, new TtsrManager());
+		expect(alwaysApplyRules.map(r => r.name)).toContain("plain");
+	});
+
+	test("maps Claude paths frontmatter to globs and buckets the rule into the rulebook", async () => {
+		await writeRuleFile(project, "typescript.md", '---\npaths: ["**/*.ts", "**/*.tsx"]\n---\nUse strict TypeScript.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "typescript");
+
+		expect(rule?.globs).toEqual(["**/*.ts", "**/*.tsx"]);
+		expect(rule?.alwaysApply).toBe(false);
+		expect(rule?.description).toBeDefined();
+
+		const { rulebookRules, alwaysApplyRules } = bucketRules(rules, new TtsrManager());
+		expect(rulebookRules.map(r => r.name)).toContain("typescript");
+		expect(alwaysApplyRules.map(r => r.name)).not.toContain("typescript");
+	});
+
+	test("preserves OMP globs scoping on a shared file instead of forcing always-apply", async () => {
+		await writeRuleFile(project, "shared.md", '---\ndescription: Shared scoped rule\nglobs: ["**/*.rs"]\n---\nRust rule.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "shared");
+
+		expect(rule?.globs).toEqual(["**/*.rs"]);
+		expect(rule?.alwaysApply).toBe(false);
+	});
+
+	test("does not overwrite OMP alwaysApply when Claude paths are also present", async () => {
+		await writeRuleFile(project, "both.md", '---\nalwaysApply: true\npaths: ["**/*.ts"]\n---\nAlways rule.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "both");
+
+		expect(rule?.alwaysApply).toBe(true);
+		expect(rule?.globs).toBeUndefined();
+	});
+
+	test("does not promote an explicit alwaysApply:false on a shared rule", async () => {
+		await writeRuleFile(project, "opt.md", '---\ndescription: Opt-in rule\nalwaysApply: false\n---\nBody.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "opt");
+
+		expect(rule?.alwaysApply).toBe(false);
+
+		const { alwaysApplyRules } = bucketRules(rules, new TtsrManager());
+		expect(alwaysApplyRules.map(r => r.name)).not.toContain("opt");
+	});
+
+	test("leaves alwaysApply:false plus Claude paths untouched (OMP scoping wins)", async () => {
+		await writeRuleFile(project, "mixed.md", '---\nalwaysApply: false\npaths: ["**/*.ts"]\n---\nBody.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "mixed");
+
+		expect(rule?.alwaysApply).toBe(false);
+		expect(rule?.globs).toBeUndefined();
+	});
+
+	test("preserves array glob elements with commas and brace patterns verbatim", async () => {
+		await writeRuleFile(project, "sites.md", '---\npaths: ["docs/foo,bar.md", "**.{ts,tsx}"]\n---\nBody.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "sites");
+
+		expect(rule?.globs).toEqual(["docs/foo,bar.md", "**.{ts,tsx}"]);
+	});
+
+	test("treats a scalar Claude path as a single atomic glob", async () => {
+		await writeRuleFile(project, "scalar.md", '---\npaths: "**/*.{ts,tsx}"\n---\nBody.\n');
+
+		const rules = await loadClaudeRules(project);
+		const rule = rules.find(r => r.name === "scalar");
+
+		expect(rule?.globs).toEqual(["**/*.{ts,tsx}"]);
+	});
+
+	test("discovers rules organized in nested subdirectories with a relative name", async () => {
+		await writeRuleFile(project, "frontend/react.md", "Use function components.\n");
+
+		const rules = await loadClaudeRules(project);
+		expect(rules.map(r => r.name)).toContain("frontend/react");
+	});
+
+	test("keeps nested same-basename rules distinct instead of dropping one", async () => {
+		await writeRuleFile(project, "frontend/style.md", "Frontend style.\n");
+		await writeRuleFile(project, "backend/style.md", "Backend style.\n");
+
+		const rules = await loadClaudeRules(project);
+		expect(rules.map(r => r.name).sort()).toEqual(["backend/style", "frontend/style"]);
+	});
+
+	test("lets a project rule override a same-named user rule", async () => {
+		await writeRuleFile(project, "security.md", "Project security rule.\n");
+		await writeRuleFile(home, "security.md", "User security rule.\n");
+
+		const rules = await loadClaudeRules(project);
+		const survivors = rules.filter(r => r.name === "security");
+
+		expect(survivors).toHaveLength(1);
+		expect(survivors[0]?._source.level).toBe("project");
+		expect(survivors[0]?.content).toContain("Project security rule.");
+	});
+
+	test("does not load ~/.claude/rules as project config when running from home", async () => {
+		await writeRuleFile(home, "secret.md", "Secret home rule.\n");
+
+		// No `providers` filter: `claude` is a foreign, non-opted-in user source,
+		// and the cwd home scan must not alias ~/.claude/rules back in as project.
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: home });
+
+		expect(result.items.filter(r => r._source.provider === "claude")).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/discovery/github-copilot.test.ts
+++ b/packages/coding-agent/test/discovery/github-copilot.test.ts
@@ -184,6 +184,19 @@ describe("github discovery — Copilot user-global surface", () => {
 		expect(all?.globs).toBeUndefined();
 	});
 
+	test("splits comma-separated applyTo values inside a YAML array (#2731)", async () => {
+		write(
+			path.join(cwd, ".github", "instructions", "multi.instructions.md"),
+			"---\napplyTo: ['**/*.ts,**/*.tsx', '**/*.md']\n---\nMulti body\n",
+		);
+
+		const result = await loadCapability<Rule>("rules", { cwd, providers: ["github"] });
+
+		const multi = result.items.find(rule => rule.name === "multi");
+		expect(multi?.alwaysApply).toBe(false);
+		expect(multi?.globs).toEqual(["**/*.ts", "**/*.tsx", "**/*.md"]);
+	});
+
 	test("disabled github provider suppresses copilot instructions and instruction-file rules (#2731)", async () => {
 		write(path.join(cwd, ".github", "copilot-instructions.md"), "project guidance");
 		write(

--- a/packages/coding-agent/test/internal-urls/rule-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/rule-protocol.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import { resetActiveRulesForTests, setActiveRules } from "@oh-my-pi/pi-coding-agent/capability/rule";
-import type { InternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/types";
+import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
 import { RuleProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/rule-protocol";
+import type { InternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/types";
 
 function makeRule(name: string, content: string): Rule {
 	return {
@@ -46,6 +47,13 @@ describe("RuleProtocolHandler", () => {
 
 		const resource = await new RuleProtocolHandler().resolve(ruleUrl("legacy"));
 		expect(resource.content.trim()).toBe("legacy body");
+	});
+
+	it("resolves a nested rule name from its host plus path", async () => {
+		setActiveRules([makeRule("frontend/style", "nested body")]);
+
+		const resource = await new RuleProtocolHandler().resolve(parseInternalUrl("rule://frontend/style"));
+		expect(resource.content.trim()).toBe("nested body");
 	});
 
 	it("completes against the caller's scoped rule set instead of the global snapshot", async () => {


### PR DESCRIPTION
Claude Code keeps project memory in `.claude/rules`, but OMP's Claude provider never wired the `rules` capability, so those files stayed invisible — sharing them across harnesses meant symlinks or copied files that drift.

Those rule files already use the same Markdown frontmatter OMP parses (description, globs, alwaysApply, enabled), so loading `.claude/rules/*.{md,mdc}` directly gives one directory serving both harnesses. `.mdc` is accepted alongside `.md` for Cursor-format files already sitting there.