### PR TITLE
fix(telemetry): isolate OTLP metrics by process

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OTLP metrics from concurrent processes now use distinct service instance IDs without exposing unbounded agent IDs ([#10840](https://github.com/can1357/oh-my-pi/issues/10840)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/telemetry-export-otlp.ts
+++ b/packages/coding-agent/src/telemetry-export-otlp.ts
@@ -49,6 +49,7 @@ import type { TelemetrySignalConfig } from "./telemetry-export";
 const FLUSH_INTERVAL_MS = 30_000;
 
 const SERVICE_NAME = "oh-my-pi";
+const SERVICE_INSTANCE_ID = crypto.randomUUID();
 
 type OtelLogLevel = "none" | logger.LogLevel;
 
@@ -118,9 +119,10 @@ export async function registerProviders(signalConfig: TelemetrySignalConfig): Pr
 	// OTEL_SERVICE_NAME; merged last so both take precedence over the fallback
 	// service.name — with OTEL_SERVICE_NAME still winning service.name inside the
 	// detector itself.
-	const resource = resourceFromAttributes({ "service.name": SERVICE_NAME }).merge(
-		detectResources({ detectors: [envDetector] }),
-	);
+	const resource = resourceFromAttributes({
+		"service.name": SERVICE_NAME,
+		"service.instance.id": SERVICE_INSTANCE_ID,
+	}).merge(detectResources({ detectors: [envDetector] }));
 
 	if (signalConfig.trace) {
 		const exporter = new OTLPTraceExporter();
@@ -233,7 +235,6 @@ class AgentMetricRecorder {
 			"gen_ai.provider.name": event.provider,
 			"gen_ai.request.model": event.model,
 			"gen_ai.response.service_tier": event.serviceTier,
-			"pi.gen_ai.agent.id": event.agent?.id,
 			"pi.gen_ai.agent.name": event.agent?.name,
 		});
 

--- a/packages/coding-agent/test/otel-resource-probe.ts
+++ b/packages/coding-agent/test/otel-resource-probe.ts
@@ -6,8 +6,8 @@
  * Stands up a loopback OTLP/proto receiver, sets OTEL_SERVICE_NAME plus
  * OTEL_RESOURCE_ATTRIBUTES (including a service.name that must lose to
  * OTEL_SERVICE_NAME), exports a span, and inspects the captured protobuf
- * payload. Exits 0 only when the resource carries the OTEL_RESOURCE_ATTRIBUTES
- * entries and service.name resolves to OTEL_SERVICE_NAME.
+ * payload. Exits 0 only when the resource carries a generated instance ID,
+ * the configured resource attributes, and the OTEL_SERVICE_NAME override.
  */
 
 import {
@@ -58,7 +58,9 @@ const has = (s: string) => payload.includes(s);
 const merged = has("deployment.environment") && has("staging") && has("tenant.id") && has("acme");
 // OTEL_SERVICE_NAME must win over the service.name in OTEL_RESOURCE_ATTRIBUTES.
 const precedence = has("svc-probe") && !has("should-lose");
+const instanceId =
+	has("service.instance.id") && /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i.test(payload);
 
-console.log(merged && precedence ? "PROBE: RECEIVED" : "PROBE: NO_EXPORT");
-console.log("merged:", merged, "precedence:", precedence);
-process.exit(merged && precedence ? 0 : 1);
+console.log(merged && precedence && instanceId ? "PROBE: RECEIVED" : "PROBE: NO_EXPORT");
+console.log("merged:", merged, "precedence:", precedence, "instanceId:", instanceId);
+process.exit(merged && precedence && instanceId ? 0 : 1);

--- a/packages/coding-agent/test/otel-signals-probe.ts
+++ b/packages/coding-agent/test/otel-signals-probe.ts
@@ -146,7 +146,7 @@ logger.error("probe error", { code: "probe" });
 // Metric instruments via the agent telemetry hooks.
 const usage: ChatUsageEvent = {
 	span: undefined as never,
-	agent: { id: "main", name: "Main" },
+	agent: { id: "probe-unbounded-agent-id", name: "Main" },
 	conversationId: "probe-session",
 	stepNumber: 0,
 	model: "claude-haiku-4-5",
@@ -201,6 +201,13 @@ await flushTelemetryExport();
 assertSingleMetricPoint("pi.omp.agent.chat.calls");
 assertSingleMetricPoint("pi.omp.agent.tool.calls");
 assertSingleMetricPoint("pi.omp.agent.tool.duration");
+const metricPayloadText = metricPayloads.map(payload => new TextDecoder().decode(payload)).join("\n");
+if (metricPayloadText.includes("pi.gen_ai.agent.id") || metricPayloadText.includes("probe-unbounded-agent-id")) {
+	throw new Error("gen_ai.client.token.usage leaked the unbounded agent ID metric attribute");
+}
+if (!metricPayloadText.includes("pi.gen_ai.agent.name") || !metricPayloadText.includes("Main")) {
+	throw new Error("gen_ai.client.token.usage dropped the bounded agent name metric attribute");
+}
 await server.stop(true);
 
 const ok = seen.has("logs") && seen.has("metrics");


### PR DESCRIPTION
## Repro
A loopback OTLP/protobuf receiver recorded one chat-usage metric from the current exporter. Running `bun /tmp/otel-metric-repro.ts` produced `service.instance.id=false`, `pi.gen_ai.agent.id=true`, and `spawn-unique-repro=true`, proving both the colliding resource identity and the unbounded metric label.

## Cause
`registerProviders()` in `packages/coding-agent/src/telemetry-export-otlp.ts` built one shared resource from only the fallback `service.name` and environment detector, so concurrent processes emitted cumulative metrics into the same resource series. `AgentMetricRecorder.recordChatUsage()` also copied each spawn-unique agent ID into metric attributes.

## Fix
- Add one UUID `service.instance.id` per exporter process while preserving `OTEL_RESOURCE_ATTRIBUTES` override precedence.
- Remove `pi.gen_ai.agent.id` from chat-usage metrics while retaining bounded `pi.gen_ai.agent.name`; trace agent identity remains unchanged.
- Extend the OTLP resource and signal probes to reject missing instance identity and leaked agent IDs.
- Document the user-visible telemetry correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/telemetry-export.test.ts` passed: 7 tests, 0 failures. `bun run --cwd packages/coding-agent check` passed lint, formatting, and type checks. The original loopback repro after the fix reports `service.instance.id=true`, `pi.gen_ai.agent.id=false`, and `spawn-unique-repro=false`.

Fixes #10840