### PR TITLE
feat(copy): keep selector open on enter for sequential block copying

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Updated `/copy` to keep the fullscreen transcript selector open after copying with `Enter`, adding localized `✓ copied!` feedback and exiting on explicit `Esc` or `q`.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -109,8 +109,8 @@ export class CopySelectorComponent implements Component {
 	#blockCache = new Map<string, CopyBlock[]>();
 	/** Click targets of the last render, keyed by composed-column line index. */
 	#controls = new Map<number, ControlRegion[]>();
-	#copiedBlock?: { turnId: string; blockIndex: number };
-	#copiedTurnId?: string;
+	#copiedBlocks = new Set<string>();
+	#copiedTurns = new Set<string>();
 	constructor(
 		entries: SessionMessageEntry[],
 		private readonly deps: CopySelectorDeps,
@@ -224,7 +224,7 @@ export class CopySelectorComponent implements Component {
 				const block = this.#blocks[this.#blockSelected];
 				if (block) {
 					if (this.deps.onPick(block.content, block.label)) {
-						this.#copiedBlock = { turnId: target.turnId, blockIndex: this.#blockSelected };
+						this.#copiedBlocks.add(`${target.turnId}:${this.#blockSelected}`);
 					}
 					this.deps.requestRender();
 				}
@@ -232,7 +232,7 @@ export class CopySelectorComponent implements Component {
 			}
 			const item = targetCopy(target, this.#blocksFor(target));
 			if (this.deps.onPick(item.content, item.label)) {
-				this.#copiedTurnId = target.turnId;
+				this.#copiedTurns.add(target.turnId);
 			}
 			this.deps.requestRender();
 			return;
@@ -268,7 +268,7 @@ export class CopySelectorComponent implements Component {
 		if (this.deps.onPick(block.content, block.label)) {
 			const target = this.#targets[this.#selected];
 			if (target) {
-				this.#copiedBlock = { turnId: target.turnId, blockIndex: hit.blockIndex };
+				this.#copiedBlocks.add(`${target.turnId}:${hit.blockIndex}`);
 			}
 		}
 		this.deps.requestRender();
@@ -368,11 +368,8 @@ export class CopySelectorComponent implements Component {
 		output.push(...this.#scrollView.render(width));
 		const selectedBlock = this.#blocks?.[this.#blockSelected];
 		const openHint = selectedBlock?.href && this.deps.onOpen ? "  o open" : "";
-		const isTurnCopied = target ? this.#copiedTurnId === target.turnId : false;
-		const isBlockCopied =
-			target && this.#copiedBlock
-				? this.#copiedBlock.turnId === target.turnId && this.#copiedBlock.blockIndex === this.#blockSelected
-				: false;
+		const isTurnCopied = target ? this.#copiedTurns.has(target.turnId) : false;
+		const isBlockCopied = target ? this.#copiedBlocks.has(`${target.turnId}:${this.#blockSelected}`) : false;
 		const hint = this.#blocks
 			? isBlockCopied
 				? `${theme.fg("success", theme.bold("✓ Copied!"))}  ${theme.fg("dim", `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  enter copy  ←/esc back  q exit${openHint}`)}`
@@ -407,10 +404,7 @@ export class CopySelectorComponent implements Component {
 			}
 			const selected = index === this.#blockSelected;
 			const captionColor: ThemeColor = selected ? OUTLINE_COLOR : "dim";
-			const isThisBlockCopied =
-				turnId && this.#copiedBlock
-					? this.#copiedBlock.turnId === turnId && this.#copiedBlock.blockIndex === index
-					: false;
+			const isThisBlockCopied = Boolean(turnId && this.#copiedBlocks.has(`${turnId}:${index}`));
 			const controls: Array<{ action: ControlRegion["action"]; text: string }> = [
 				{
 					action: "copy",

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -109,7 +109,8 @@ export class CopySelectorComponent implements Component {
 	#blockCache = new Map<string, CopyBlock[]>();
 	/** Click targets of the last render, keyed by composed-column line index. */
 	#controls = new Map<number, ControlRegion[]>();
-
+	#copiedBlock?: { turnId: string; blockIndex: number };
+	#copiedTurnId?: string;
 	constructor(
 		entries: SessionMessageEntry[],
 		private readonly deps: CopySelectorDeps,
@@ -177,6 +178,10 @@ export class CopySelectorComponent implements Component {
 			else this.deps.onCancel();
 			return;
 		}
+		if (data === "q" || data === "Q") {
+			this.deps.onCancel();
+			return;
+		}
 		if (matchesAppToolsExpand(data)) {
 			this.#expanded = !this.#expanded;
 			this.#builder.setExpanded(this.#expanded);
@@ -213,15 +218,21 @@ export class CopySelectorComponent implements Component {
 			return;
 		}
 		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
-			if (this.#blocks) {
-				const block = this.#blocks[this.#blockSelected];
-				if (block) this.deps.onPick(block.content, block.label);
-				return;
-			}
 			const target = this.#targets[this.#selected];
 			if (!target) return;
+			if (this.#blocks) {
+				const block = this.#blocks[this.#blockSelected];
+				if (block) {
+					this.#copiedBlock = { turnId: target.turnId, blockIndex: this.#blockSelected };
+					this.deps.onPick(block.content, block.label);
+					this.deps.requestRender();
+				}
+				return;
+			}
 			const item = targetCopy(target, this.#blocksFor(target));
+			this.#copiedTurnId = target.turnId;
 			this.deps.onPick(item.content, item.label);
+			this.deps.requestRender();
 			return;
 		}
 		// Page/home/end/shift+arrow scrolling without moving the selection.
@@ -252,7 +263,12 @@ export class CopySelectorComponent implements Component {
 			if (block.href && this.deps.onOpen) this.deps.onOpen(block.href, block.label);
 			return;
 		}
+		const target = this.#targets[this.#selected];
+		if (target) {
+			this.#copiedBlock = { turnId: target.turnId, blockIndex: hit.blockIndex };
+		}
 		this.deps.onPick(block.content, block.label);
+		this.deps.requestRender();
 	}
 
 	#moveVertical(delta: -1 | 1): void {
@@ -298,7 +314,6 @@ export class CopySelectorComponent implements Component {
 			else if (below < this.#targets.length) this.#selected = below;
 			this.#blocks = undefined;
 		}
-
 		const target = this.#targets[this.#selected];
 		const blocks = target ? this.#blocksFor(target) : [];
 		let composed: ComposedColumn;
@@ -306,7 +321,7 @@ export class CopySelectorComponent implements Component {
 		if (this.#blocks && target) {
 			// Descended: the turn's rendered region is replaced by its block stack.
 			const before = composeOutlineColumn(childRows, 0, target.start, [], -1, contentWidth, undefined);
-			const stack = this.#composeBlocks(this.#blocks, contentWidth, before.lines.length);
+			const stack = this.#composeBlocks(this.#blocks, contentWidth, before.lines.length, target.turnId);
 			const after = composeOutlineColumn(childRows, target.end, children.length, [], -1, contentWidth, undefined);
 			composed = {
 				lines: [...before.lines, ...stack.lines, ...after.lines],
@@ -345,16 +360,25 @@ export class CopySelectorComponent implements Component {
 		const output: string[] = [];
 		output.push(...this.#border.render(width));
 		output.push(
-			` ${theme.cmd.copy} ${theme.bold("Copy")}${theme.sep.dot}${theme.fg("dim", "pick what to put on the clipboard")}`,
+			` ${theme.cmd.copy} ${theme.bold("Copy")}${theme.sep.dot}${theme.fg("dim", "pick what to put on clipboard  (esc/q to exit)")}`,
 		);
 		output.push(...this.#border.render(width));
 		output.push(...this.#scrollView.render(width));
 		const selectedBlock = this.#blocks?.[this.#blockSelected];
 		const openHint = selectedBlock?.href && this.deps.onOpen ? "  o open" : "";
+		const isTurnCopied = target ? this.#copiedTurnId === target.turnId : false;
+		const isBlockCopied =
+			target && this.#copiedBlock
+				? this.#copiedBlock.turnId === target.turnId && this.#copiedBlock.blockIndex === this.#blockSelected
+				: false;
 		const hint = this.#blocks
-			? `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  ←/esc back  enter copy${openHint}  click ${theme.cmd.copy}/${theme.cmd.share}`
-			: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  ctrl+o expand  esc close`;
-		output.push(` ${theme.fg("dim", hint)}`);
+			? isBlockCopied
+				? `${theme.fg("success", theme.bold("✓ Copied!"))}  ${theme.fg("dim", `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  enter copy  ←/esc back  q exit${openHint}`)}`
+				: `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  ←/esc back  enter copy  q exit${openHint}`
+			: isTurnCopied
+				? `${theme.fg("success", theme.bold("✓ Copied turn!"))}  ${theme.fg("dim", `↑/↓ step  enter copy  esc/q exit`)}`
+				: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  esc/q exit`;
+		output.push(` ${hint}`);
 		output.push(...this.#border.render(width));
 		return output;
 	}
@@ -365,7 +389,7 @@ export class CopySelectorComponent implements Component {
 	 * are recorded in `#controls` under the composed line index
 	 * (`lineOffset` + local index) so {@link #click} can resolve a mouse hit.
 	 */
-	#composeBlocks(blocks: CopyBlock[], columnWidth: number, lineOffset: number): ComposedColumn {
+	#composeBlocks(blocks: CopyBlock[], columnWidth: number, lineOffset: number, turnId?: string): ComposedColumn {
 		const inner = Math.max(10, columnWidth - 4);
 		const lines: string[] = [];
 		let selStart = -1;
@@ -381,8 +405,15 @@ export class CopySelectorComponent implements Component {
 			}
 			const selected = index === this.#blockSelected;
 			const captionColor: ThemeColor = selected ? OUTLINE_COLOR : "dim";
+			const isThisBlockCopied =
+				turnId && this.#copiedBlock
+					? this.#copiedBlock.turnId === turnId && this.#copiedBlock.blockIndex === index
+					: false;
 			const controls: Array<{ action: ControlRegion["action"]; text: string }> = [
-				{ action: "copy", text: `${theme.cmd.copy} copy` },
+				{
+					action: "copy",
+					text: isThisBlockCopied ? `${theme.fg("success", "✓ copied!")}` : `${theme.cmd.copy} copy`,
+				},
 			];
 			if (block.href && this.deps.onOpen) controls.push({ action: "open", text: `${theme.cmd.share} open` });
 			const controlsWidth = controls.reduce((sum, control) => sum + visibleWidth(control.text) + 2, 0);

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -58,8 +58,8 @@ export interface CopySelectorDeps {
 	proseOnlyThinking?: () => boolean;
 	linkTargets?: ReadonlyMap<string, string>;
 	requestRender: () => void;
-	/** The outlined content was chosen — copy it. `label` feeds the status line. */
-	onPick: (content: string, label: string) => void;
+	/** The outlined content was chosen — copy it. Returns true if accepted. */
+	onPick: (content: string, label: string) => boolean;
 	/** `o` on a link block — open `href` with the system opener. Absent: `o` is ignored. */
 	onOpen?: (href: string, label: string) => void;
 	onCancel: () => void;
@@ -223,15 +223,17 @@ export class CopySelectorComponent implements Component {
 			if (this.#blocks) {
 				const block = this.#blocks[this.#blockSelected];
 				if (block) {
-					this.#copiedBlock = { turnId: target.turnId, blockIndex: this.#blockSelected };
-					this.deps.onPick(block.content, block.label);
+					if (this.deps.onPick(block.content, block.label)) {
+						this.#copiedBlock = { turnId: target.turnId, blockIndex: this.#blockSelected };
+					}
 					this.deps.requestRender();
 				}
 				return;
 			}
 			const item = targetCopy(target, this.#blocksFor(target));
-			this.#copiedTurnId = target.turnId;
-			this.deps.onPick(item.content, item.label);
+			if (this.deps.onPick(item.content, item.label)) {
+				this.#copiedTurnId = target.turnId;
+			}
 			this.deps.requestRender();
 			return;
 		}
@@ -263,11 +265,12 @@ export class CopySelectorComponent implements Component {
 			if (block.href && this.deps.onOpen) this.deps.onOpen(block.href, block.label);
 			return;
 		}
-		const target = this.#targets[this.#selected];
-		if (target) {
-			this.#copiedBlock = { turnId: target.turnId, blockIndex: hit.blockIndex };
+		if (this.deps.onPick(block.content, block.label)) {
+			const target = this.#targets[this.#selected];
+			if (target) {
+				this.#copiedBlock = { turnId: target.turnId, blockIndex: hit.blockIndex };
+			}
 		}
-		this.deps.onPick(block.content, block.label);
 		this.deps.requestRender();
 	}
 
@@ -359,9 +362,8 @@ export class CopySelectorComponent implements Component {
 
 		const output: string[] = [];
 		output.push(...this.#border.render(width));
-		output.push(
-			` ${theme.cmd.copy} ${theme.bold("Copy")}${theme.sep.dot}${theme.fg("dim", "pick what to put on clipboard  (esc/q to exit)")}`,
-		);
+		const headerText = `${theme.cmd.copy} ${theme.bold("Copy")}${theme.sep.dot}${theme.fg("dim", "pick what to put on clipboard  (esc/q to exit)")}`;
+		output.push(` ${truncateToWidth(headerText, Math.max(1, width - 2))}`);
 		output.push(...this.#border.render(width));
 		output.push(...this.#scrollView.render(width));
 		const selectedBlock = this.#blocks?.[this.#blockSelected];
@@ -378,7 +380,7 @@ export class CopySelectorComponent implements Component {
 			: isTurnCopied
 				? `${theme.fg("success", theme.bold("✓ Copied turn!"))}  ${theme.fg("dim", `↑/↓ step  enter copy  esc/q exit`)}`
 				: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  esc/q exit`;
-		output.push(` ${hint}`);
+		output.push(` ${truncateToWidth(hint, Math.max(1, width - 2))}`);
 		output.push(...this.#border.render(width));
 		return output;
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1411,10 +1411,12 @@ export class SelectorController {
 			return;
 		}
 
+		let lastCopied: string | undefined;
 		const done = () => {
 			overlayHandle?.hide();
 			selector?.dispose();
 			this.focusActiveEditorArea();
+			if (lastCopied) this.ctx.showStatus(`Copied ${lastCopied} to clipboard`);
 			this.ctx.ui.requestRender();
 		};
 		const selector = new CopySelectorComponent(entries, {
@@ -1428,16 +1430,15 @@ export class SelectorController {
 			linkTargets: getAssistantMessageLinkTargets(this.ctx),
 			requestRender: () => this.ctx.ui.requestRender(),
 			onPick: (content, label) => {
-				done();
 				if (!content.trim()) {
 					this.ctx.showStatus("Nothing to copy in that item");
 					return;
 				}
+				lastCopied = label;
 				void copyToClipboard(content);
-				this.ctx.showStatus(`Copied ${label} to clipboard`);
+				this.ctx.ui.requestRender();
 			},
 			onOpen: (href, label) => {
-				done();
 				openPath(href);
 				this.ctx.showStatus(`Opening ${label}: ${href}`);
 			},

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1412,6 +1412,7 @@ export class SelectorController {
 		}
 
 		let lastCopied: string | undefined;
+		let copyQueue: Promise<void> = Promise.resolve();
 		const done = () => {
 			overlayHandle?.hide();
 			selector?.dispose();
@@ -1432,11 +1433,16 @@ export class SelectorController {
 			onPick: (content, label) => {
 				if (!content.trim()) {
 					this.ctx.showStatus("Nothing to copy in that item");
-					return;
+					return false;
 				}
 				lastCopied = label;
-				void copyToClipboard(content);
+				copyQueue = copyQueue
+					.then(async () => {
+						await copyToClipboard(content);
+					})
+					.catch(() => {});
 				this.ctx.ui.requestRender();
+				return true;
 			},
 			onOpen: (href, label) => {
 				openPath(href);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -136,6 +136,7 @@ export class SelectorController {
 	}
 
 	#defaultRoleMutationTail = Promise.resolve();
+	#copyQueue = Promise.resolve();
 
 	async #acquireDefaultRoleMutation(): Promise<() => void> {
 		const previous = this.#defaultRoleMutationTail;
@@ -1412,7 +1413,6 @@ export class SelectorController {
 		}
 
 		let lastCopied: string | undefined;
-		let copyQueue: Promise<void> = Promise.resolve();
 		const done = () => {
 			overlayHandle?.hide();
 			selector?.dispose();
@@ -1436,7 +1436,7 @@ export class SelectorController {
 					return false;
 				}
 				lastCopied = label;
-				copyQueue = copyQueue
+				this.#copyQueue = this.#copyQueue
 					.then(async () => {
 						await copyToClipboard(content);
 					})

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -15,11 +15,11 @@ import type { SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/sess
 import { setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
 
 const UP = "\x1b[A";
+const DOWN = "\x1b[B";
 const LEFT = "\x1b[D";
 const RIGHT = "\x1b[C";
 const ENTER = "\r";
 const ESC = "\x1b";
-
 const CODE = "const answer = 42;\nconsole.log(answer);";
 const LINK = "https://github.com/can1357/oh-my-pi/pull/10503";
 const ASSISTANT_TEXT = `Here is the fix:\n\`\`\`ts\n${CODE}\n\`\`\`\nDone. See [the PR](${LINK}).`;
@@ -72,7 +72,10 @@ function makeSelector(
 		ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
 		cwd: "/tmp",
 		requestRender: () => {},
-		onPick: (content, label) => picks.push({ content, label }),
+		onPick: (content, label) => {
+			picks.push({ content, label });
+			return true;
+		},
 		onOpen: opens ? (href, label) => opens.push({ href, label }) : undefined,
 		onCancel,
 	});
@@ -304,5 +307,50 @@ describe("CopySelectorComponent", () => {
 		const boxed = lines.filter(line => line.startsWith("┆")).join("\n");
 		expect(boxed).toContain("const answer = 42;");
 		expect(boxed).not.toContain("bun test");
+	});
+
+	it("keeps picker open on Enter for sequential block copies, exits on q or Esc", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const onCancel = vi.fn();
+		const selector = makeSelector(picks, onCancel);
+		selector.render(100);
+
+		selector.handleInput(RIGHT);
+		// Copy first block (code)
+		selector.handleInput(ENTER);
+		expect(picks).toHaveLength(1);
+		expect(picks[0]).toEqual({ content: CODE, label: "ts code" });
+		expect(onCancel).not.toHaveBeenCalled();
+
+		// Navigate down and copy third block (bash command)
+		selector.handleInput(DOWN);
+		selector.handleInput(DOWN);
+		selector.handleInput(ENTER);
+		expect(picks).toHaveLength(2);
+		expect(picks[1]).toEqual({ content: "bun test", label: "bash command" });
+		expect(onCancel).not.toHaveBeenCalled();
+
+		// Exit explicitly via q
+		selector.handleInput("q");
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		selector.dispose();
+	});
+
+	it("does not mark block or turn as copied when onPick rejects payload", () => {
+		const onCancel = vi.fn();
+		const selector = new CopySelectorComponent(makeEntries(), {
+			ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
+			cwd: "/tmp",
+			requestRender: () => {},
+			onPick: () => false,
+			onCancel,
+		});
+		selector.render(100);
+		selector.handleInput(RIGHT);
+		selector.handleInput(ENTER);
+		const frame = selector.render(100).join("\n");
+		expect(frame).not.toContain("✓ copied!");
+		expect(frame).not.toContain("✓ Copied!");
+		selector.dispose();
 	});
 });

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -309,33 +309,6 @@ describe("CopySelectorComponent", () => {
 		expect(boxed).not.toContain("bun test");
 	});
 
-	it("keeps picker open on Enter for sequential block copies, exits on q or Esc", () => {
-		const picks: Array<{ content: string; label: string }> = [];
-		const onCancel = vi.fn();
-		const selector = makeSelector(picks, onCancel);
-		selector.render(100);
-
-		selector.handleInput(RIGHT);
-		// Copy first block (code)
-		selector.handleInput(ENTER);
-		expect(picks).toHaveLength(1);
-		expect(picks[0]).toEqual({ content: CODE, label: "ts code" });
-		expect(onCancel).not.toHaveBeenCalled();
-
-		// Navigate down and copy third block (bash command)
-		selector.handleInput(DOWN);
-		selector.handleInput(DOWN);
-		selector.handleInput(ENTER);
-		expect(picks).toHaveLength(2);
-		expect(picks[1]).toEqual({ content: "bun test", label: "bash command" });
-		expect(onCancel).not.toHaveBeenCalled();
-
-		// Exit explicitly via q
-		selector.handleInput("q");
-		expect(onCancel).toHaveBeenCalledTimes(1);
-		selector.dispose();
-	});
-
 	it("preserves all copied block markers when copying multiple blocks sequentially", () => {
 		const picks: Array<{ content: string; label: string }> = [];
 		const selector = makeSelector(picks);
@@ -364,9 +337,16 @@ describe("CopySelectorComponent", () => {
 			onCancel,
 		});
 		selector.render(100);
+
+		// Attempt turn-level copy without descending
+		selector.handleInput(ENTER);
+		let frame = selector.render(100).join("\n");
+		expect(frame).not.toContain("✓ Copied turn!");
+
+		// Attempt block-level copy after descending
 		selector.handleInput(RIGHT);
 		selector.handleInput(ENTER);
-		const frame = selector.render(100).join("\n");
+		frame = selector.render(100).join("\n");
 		expect(frame).not.toContain("✓ copied!");
 		expect(frame).not.toContain("✓ Copied!");
 		selector.dispose();

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -336,6 +336,24 @@ describe("CopySelectorComponent", () => {
 		selector.dispose();
 	});
 
+	it("preserves all copied block markers when copying multiple blocks sequentially", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const selector = makeSelector(picks);
+		selector.render(100);
+
+		selector.handleInput(RIGHT);
+		selector.handleInput(ENTER); // copy block 1
+
+		selector.handleInput(DOWN);
+		selector.handleInput(DOWN);
+		selector.handleInput(ENTER); // copy block 3
+
+		const frame = selector.render(100).join("\n");
+		const copiedCount = (frame.match(/✓ copied!/g) ?? []).length;
+		expect(copiedCount).toBe(2);
+		selector.dispose();
+	});
+
 	it("does not mark block or turn as copied when onPick rejects payload", () => {
 		const onCancel = vi.fn();
 		const selector = new CopySelectorComponent(makeEntries(), {

--- a/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CopySelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/copy-selector";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+beforeEach(async () => {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	setKeybindings(KeybindingsManager.inMemory());
+});
+
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
+	resetSettingsForTest();
+	vi.restoreAllMocks();
+});
+const RIGHT = "\x1b[C";
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+
+describe("SelectorController.showCopySelector overlay lifecycle", () => {
+	it("keeps the overlay mounted across sequential Enter copies until explicit exit", () => {
+		const hide = vi.fn();
+		let mountedSelector: CopySelectorComponent | undefined;
+		const showStatus = vi.fn();
+		const requestRender = vi.fn();
+
+		const entries: SessionMessageEntry[] = [
+			{
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: "2024-01-01T00:00:00Z",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "text",
+							text: "Code sample:\n```ts\nconst a = 1;\n```\nand command:\n```bash\nmake build\n```",
+						},
+					],
+					usage: {
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 15,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+				} as unknown as AgentMessage,
+			},
+		];
+
+		const editor = { id: "editor" };
+		const setFocus = vi.fn();
+		const ctx = {
+			editor,
+			editorContainer: { children: [editor], clear: vi.fn(), addChild: vi.fn() },
+			sessionManager: {
+				getBranch: () => entries,
+				getCwd: () => "/tmp",
+			},
+			session: {
+				getToolByName: vi.fn(),
+				hasBuiltInTool: vi.fn(),
+				extensionRunner: undefined,
+			},
+			viewSession: {},
+			effectiveHideThinkingBlock: false,
+			proseOnlyThinking: false,
+			showStatus,
+			ui: {
+				showOverlay: vi.fn(component => {
+					mountedSelector = component as CopySelectorComponent;
+					return { hide, setHidden: vi.fn(), isHidden: () => false };
+				}),
+				setFocus,
+				requestRender,
+			},
+		} as unknown as InteractiveModeContext;
+
+		const controller = new SelectorController(ctx);
+		controller.showCopySelector();
+
+		expect(ctx.ui.showOverlay).toHaveBeenCalledTimes(1);
+		expect(mountedSelector).toBeDefined();
+
+		const disposeSpy = vi.spyOn(mountedSelector!, "dispose");
+
+		// Descend into blocks
+		mountedSelector!.handleInput(RIGHT);
+
+		// Copy first block
+		mountedSelector!.handleInput(ENTER);
+		expect(hide).not.toHaveBeenCalled();
+		expect(disposeSpy).not.toHaveBeenCalled();
+
+		// Navigate to second block and copy
+		mountedSelector!.handleInput(DOWN);
+		mountedSelector!.handleInput(ENTER);
+		expect(hide).not.toHaveBeenCalled();
+		expect(disposeSpy).not.toHaveBeenCalled();
+
+		// Explicit exit via q
+		mountedSelector!.handleInput("q");
+		expect(hide).toHaveBeenCalledTimes(1);
+		expect(disposeSpy).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalledWith("Copied bash code to clipboard");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
@@ -7,7 +7,50 @@ import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
 import { setKeybindings } from "@oh-my-pi/pi-tui";
+
+const CODE = "const answer = 42;\nconsole.log(answer);";
+const LINK = "https://github.com/can1357/oh-my-pi/pull/10503";
+const ASSISTANT_TEXT = `Here is the fix:\n\`\`\`ts\n${CODE}\n\`\`\`\nDone. See [the PR](${LINK}).`;
+
+function entry(id: string, parentId: string | null, message: AgentMessage): SessionMessageEntry {
+	return { type: "message", id, parentId, timestamp: "2024-01-01T00:00:00Z", message };
+}
+
+function makeEntries(): SessionMessageEntry[] {
+	return [
+		entry("u1", null, { role: "user", content: "fix the logging", timestamp: 1 } as AgentMessage),
+		entry("a1", "u1", {
+			role: "assistant",
+			content: [
+				{ type: "text", text: ASSISTANT_TEXT },
+				{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "bun test" } },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: 2,
+		} as unknown as AgentMessage),
+		entry("t1", "a1", {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "bash",
+			content: [{ type: "text", text: "12 pass" }],
+			isError: false,
+			timestamp: 3,
+		} as unknown as AgentMessage),
+	];
+}
 
 beforeAll(async () => {
 	await initTheme();
@@ -23,42 +66,23 @@ afterEach(() => {
 	resetSettingsForTest();
 	vi.restoreAllMocks();
 });
+
 const RIGHT = "\x1b[C";
 const DOWN = "\x1b[B";
 const ENTER = "\r";
 
 describe("SelectorController.showCopySelector overlay lifecycle", () => {
-	it("keeps the overlay mounted across sequential Enter copies until explicit exit", () => {
+	it("keeps the overlay mounted across sequential Enter copies until explicit exit", async () => {
+		const copyDone = Promise.withResolvers<void>();
+		let callCount = 0;
+		const copySpy = vi.spyOn(clipboard, "copyToClipboard").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 2) copyDone.resolve();
+		});
 		const hide = vi.fn();
 		let mountedSelector: CopySelectorComponent | undefined;
 		const showStatus = vi.fn();
 		const requestRender = vi.fn();
-
-		const entries: SessionMessageEntry[] = [
-			{
-				type: "message",
-				id: "m1",
-				parentId: null,
-				timestamp: "2024-01-01T00:00:00Z",
-				message: {
-					role: "assistant",
-					content: [
-						{
-							type: "text",
-							text: "Code sample:\n```ts\nconst a = 1;\n```\nand command:\n```bash\nmake build\n```",
-						},
-					],
-					usage: {
-						input: 10,
-						output: 5,
-						cacheRead: 0,
-						cacheWrite: 0,
-						totalTokens: 15,
-						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-					},
-				} as unknown as AgentMessage,
-			},
-		];
 
 		const editor = { id: "editor" };
 		const setFocus = vi.fn();
@@ -66,7 +90,7 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 			editor,
 			editorContainer: { children: [editor], clear: vi.fn(), addChild: vi.fn() },
 			sessionManager: {
-				getBranch: () => entries,
+				getBranch: () => makeEntries(),
 				getCwd: () => "/tmp",
 			},
 			session: {
@@ -95,16 +119,19 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 		expect(mountedSelector).toBeDefined();
 
 		const disposeSpy = vi.spyOn(mountedSelector!, "dispose");
+		mountedSelector!.render(100);
 
 		// Descend into blocks
 		mountedSelector!.handleInput(RIGHT);
+		mountedSelector!.render(100);
 
-		// Copy first block
+		// Copy first block (code)
 		mountedSelector!.handleInput(ENTER);
 		expect(hide).not.toHaveBeenCalled();
 		expect(disposeSpy).not.toHaveBeenCalled();
 
-		// Navigate to second block and copy
+		// Navigate to third block (bash command) and copy
+		mountedSelector!.handleInput(DOWN);
 		mountedSelector!.handleInput(DOWN);
 		mountedSelector!.handleInput(ENTER);
 		expect(hide).not.toHaveBeenCalled();
@@ -114,6 +141,71 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 		mountedSelector!.handleInput("q");
 		expect(hide).toHaveBeenCalledTimes(1);
 		expect(disposeSpy).toHaveBeenCalledTimes(1);
-		expect(showStatus).toHaveBeenCalledWith("Copied bash code to clipboard");
+		expect(showStatus).toHaveBeenCalledWith("Copied bash command to clipboard");
+		await copyDone.promise;
+		expect(copySpy).toHaveBeenCalledTimes(2);
+		expect(copySpy).toHaveBeenNthCalledWith(1, CODE);
+		expect(copySpy).toHaveBeenNthCalledWith(2, "bun test");
+	});
+
+	it("serializes clipboard writes across selector reopenings", async () => {
+		const order: string[] = [];
+		const secondDone = Promise.withResolvers<void>();
+		let secondCount = 0;
+		vi.spyOn(clipboard, "copyToClipboard").mockImplementation(async (text: string) => {
+			order.push(text);
+			secondCount++;
+			if (secondCount === 2) secondDone.resolve();
+		});
+
+		let mountedSelector: CopySelectorComponent | undefined;
+		const editor = { id: "editor" };
+		const ctx = {
+			editor,
+			editorContainer: { children: [editor], clear: vi.fn(), addChild: vi.fn() },
+			sessionManager: {
+				getBranch: () => makeEntries(),
+				getCwd: () => "/tmp",
+			},
+			session: {
+				getToolByName: vi.fn(),
+				hasBuiltInTool: vi.fn(),
+				extensionRunner: undefined,
+			},
+			viewSession: {},
+			effectiveHideThinkingBlock: false,
+			proseOnlyThinking: false,
+			showStatus: vi.fn(),
+			ui: {
+				showOverlay: vi.fn(component => {
+					mountedSelector = component as CopySelectorComponent;
+					return { hide: vi.fn(), setHidden: vi.fn(), isHidden: () => false };
+				}),
+				setFocus: vi.fn(),
+				requestRender: vi.fn(),
+			},
+		} as unknown as InteractiveModeContext;
+
+		const controller = new SelectorController(ctx);
+
+		// First opening: copy first block and exit
+		controller.showCopySelector();
+		mountedSelector!.render(100);
+		mountedSelector!.handleInput(RIGHT);
+		mountedSelector!.render(100);
+		mountedSelector!.handleInput(ENTER);
+		mountedSelector!.handleInput("q");
+
+		// Second opening: copy third block and exit
+		controller.showCopySelector();
+		mountedSelector!.render(100);
+		mountedSelector!.handleInput(RIGHT);
+		mountedSelector!.render(100);
+		mountedSelector!.handleInput(DOWN);
+		mountedSelector!.handleInput(DOWN);
+		mountedSelector!.handleInput(ENTER);
+		mountedSelector!.handleInput("q");
+		await secondDone.promise;
+		expect(order).toEqual([CODE, "bun test"]);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-copy-overlay.test.ts
@@ -150,14 +150,19 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 
 	it("serializes clipboard writes across selector reopenings", async () => {
 		const order: string[] = [];
+		const firstCallStarted = Promise.withResolvers<void>();
+		const releaseFirstCall = Promise.withResolvers<void>();
 		const secondDone = Promise.withResolvers<void>();
-		let secondCount = 0;
+		let callCount = 0;
 		vi.spyOn(clipboard, "copyToClipboard").mockImplementation(async (text: string) => {
+			callCount++;
+			if (callCount === 1) {
+				firstCallStarted.resolve();
+				await releaseFirstCall.promise;
+			}
 			order.push(text);
-			secondCount++;
-			if (secondCount === 2) secondDone.resolve();
+			if (callCount === 2) secondDone.resolve();
 		});
-
 		let mountedSelector: CopySelectorComponent | undefined;
 		const editor = { id: "editor" };
 		const ctx = {
@@ -196,6 +201,9 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 		mountedSelector!.handleInput(ENTER);
 		mountedSelector!.handleInput("q");
 
+		// Wait for first call to start and hold it open
+		await firstCallStarted.promise;
+
 		// Second opening: copy third block and exit
 		controller.showCopySelector();
 		mountedSelector!.render(100);
@@ -205,6 +213,13 @@ describe("SelectorController.showCopySelector overlay lifecycle", () => {
 		mountedSelector!.handleInput(DOWN);
 		mountedSelector!.handleInput(ENTER);
 		mountedSelector!.handleInput("q");
+
+		// Verify second call has not completed because first call is still held open
+		expect(order).toEqual([]);
+
+		// Release first call
+		releaseFirstCall.resolve();
+
 		await secondDone.promise;
 		expect(order).toEqual([CODE, "bun test"]);
 	});


### PR DESCRIPTION
## What

Keep the `/copy` fullscreen transcript selector open after copying a code block or turn with `Enter`. Display inline `✓ copied!` feedback directly on the active block caption and footer, exiting only when explicitly requested via `Esc` (or `q`).

## Why

When an assistant response contains multiple code blocks (such as structured pull request descriptions, multi-file code examples, or segmented commands), users currently have to run `/copy`, navigate to the turn, expand the block view, copy a single block, and repeat the entire sequence from scratch for every subsequent block because `onPick` immediately closes the overlay.

This change preserves the active selector state on copy so users can copy multiple code blocks sequentially in a single pass without interruption.

## Testing

- Verified with `bun run check` inside `packages/coding-agent`: `oxlint`, `oxfmt`, and `tsgo --noEmit` pass with zero diagnostics.
- Launched `omp` locally and invoked `/copy`.
- Navigated into a turn with multiple code blocks using `Right`.
- Pressed `Enter` on block 1: confirmed clipboard received content, block caption updated to `✓ copied!`, footer highlighted success, and overlay remained interactive.
- Pressed `Down` and `Enter` on block 2: confirmed clipboard updated to block 2 without closing overlay, and block 1 retained its copied badge while footer scoped to current selection.
- Tested mouse click on block copy control: confirmed it updates selection and copies without dismissing the overlay.
- Tested mouse click and keyboard `o` on link blocks: confirmed links open via `openPath` without prematurely dismissing the overlay.
- Confirmed `Esc` / `q` cleanly exits the overlay and restores editor focus.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
