### PR TITLE
fix(acp): honor granted permission instead of re-prompting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed ACP `always-ask`/`write` approval modes leaving a granted tool call stuck `pending`: an approved permission now runs the tool instead of re-prompting through the interactive gate that ACP clients cannot answer ([#10850](https://github.com/can1357/oh-my-pi/issues/10850)).
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -253,18 +253,19 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			throw denyError(resolved, this.tool.name);
 		}
 		const pendingSafetyChecks = computerSafetyChecks(context);
-		// An xd:// device dispatch already cleared the write tool's outer gate at
-		// this tool's tier — re-prompting would double-ask for one action. The
-		// bypass only holds while the input is exactly what that outer gate
-		// approved: a handler revision here may have raised the tier, so revised
-		// input always faces the full gate. Explicit per-tool "prompt" policies
-		// and tool-demanded overrides still prompt. Provider safety checks are
-		// stronger: yolo, per-tool allow, and xdev approval never acknowledge
-		// them on the user's behalf.
+		// Outer approvals only cover the original input. An extension revision may
+		// raise the tier, so revised input always faces the full gate. `xd://`
+		// approval skips tier-only prompts; ACP approval also satisfies explicit
+		// prompts because the client answered that exact request. Denies were
+		// enforced above, and provider safety checks remain independently required.
 		const explicitPrompt = resolved.override || Object.hasOwn(userPolicies, resolved.policyKey ?? this.tool.name);
-		const xdevBypass = context?.xdevApproved === true && effectiveParams === params;
+		const originalInput = effectiveParams === params;
+		const xdevBypass = context?.xdevApproved === true && originalInput;
+		const acpBypass = context?.acpApproved === true && originalInput;
 		const approvalCheck = {
-			required: pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
+			required:
+				pendingSafetyChecks.length > 0 ||
+				(resolved.policy === "prompt" && !acpBypass && (explicitPrompt || !xdevBypass)),
 			reason: resolved.reason,
 		};
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -253,15 +253,17 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			throw denyError(resolved, this.tool.name);
 		}
 		const pendingSafetyChecks = computerSafetyChecks(context);
-		// Outer approvals only cover the original input. An extension revision may
-		// raise the tier, so revised input always faces the full gate. `xd://`
-		// approval skips tier-only prompts; ACP approval also satisfies explicit
-		// prompts because the client answered that exact request. Denies were
+		// Outer approvals only cover the original input. `xd://` approval skips
+		// tier-only prompts while the same object flows through; ACP approval also
+		// satisfies explicit prompts, but compares against a deep snapshot because
+		// handlers can mutate the original argument object in place. Denies were
 		// enforced above, and provider safety checks remain independently required.
 		const explicitPrompt = resolved.override || Object.hasOwn(userPolicies, resolved.policyKey ?? this.tool.name);
-		const originalInput = effectiveParams === params;
-		const xdevBypass = context?.xdevApproved === true && originalInput;
-		const acpBypass = context?.acpApproved === true && originalInput;
+		const xdevBypass = context?.xdevApproved === true && effectiveParams === params;
+		const acpBypass =
+			context !== undefined &&
+			Object.hasOwn(context, "acpApprovedArgs") &&
+			Bun.deepEquals(effectiveParams, context.acpApprovedArgs);
 		const approvalCheck = {
 			required:
 				pendingSafetyChecks.length > 0 ||

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -733,8 +733,8 @@ export class SessionTools {
 						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx as never);
 					}
 					// A selected or persisted ACP grant is the interactive approval
-					// for this call; prevent the inner wrapper from prompting again.
-					const approvedCtx = (ctx ? { ...ctx, xdevApproved: true } : ctx) as never;
+					// for this exact call; prevent the inner wrapper from prompting again.
+					const approvedCtx = (ctx ? { ...ctx, acpApproved: true } : ctx) as never;
 					const command =
 						target.name === "bash" && args && typeof args === "object" && !Array.isArray(args)
 							? stringProperty(args, "command")

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { Agent, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { Agent, AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { resolveDelegationBias } from "@oh-my-pi/pi-catalog/compat/delegation";
 import { isRecord, logger, prompt, stringProperty, untilAborted } from "@oh-my-pi/pi-utils";
@@ -726,11 +726,17 @@ export class SessionTools {
 					args: unknown,
 					signal: AbortSignal | undefined,
 					onUpdate: never,
-					ctx: never,
+					ctx: AgentToolContext | undefined,
 				) => {
+					// Reaching a target.execute below means this ACP-gated call is
+					// authorized (granted, persisted-allow, or no ACP prompt needed).
+					// The registry tool is an ExtensionToolWrapper whose own tier gate
+					// would otherwise re-prompt and fail closed in ACP (no interactive
+					// UI), so flag the call approved exactly like the xd:// device gate.
+					const approvedCtx = (ctx ? { ...ctx, xdevApproved: true } : ctx) as never;
 					const permissionIntent = getPermissionIntent(target.name, args);
 					if (!permissionIntent) {
-						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
+						return await target.execute(toolCallId, args as never, signal, onUpdate, approvedCtx);
 					}
 					const command =
 						target.name === "bash" && args && typeof args === "object" && !Array.isArray(args)
@@ -742,7 +748,7 @@ export class SessionTools {
 					// Short-circuit on persisted decisions.
 					const persisted = this.#acpPermissionDecisions.get(permissionIntent.cacheKey);
 					if (persisted === "allow_always") {
-						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
+						return await target.execute(toolCallId, args as never, signal, onUpdate, approvedCtx);
 					}
 					if (persisted === "reject_always") {
 						throw new ToolError(`Tool call rejected by user (preference)`);
@@ -799,7 +805,7 @@ export class SessionTools {
 					if (selectedOption.kind === "reject_once" || selectedOption.kind === "reject_always") {
 						throw new ToolError(`Tool call rejected by user (${target.name})`);
 					}
-					return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
+					return await target.execute(toolCallId, args as never, signal, onUpdate, approvedCtx);
 				};
 			},
 		}) as T;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { Agent, AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { resolveDelegationBias } from "@oh-my-pi/pi-catalog/compat/delegation";
-import { isRecord, logger, prompt, stringProperty, untilAborted } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, stringProperty, structuredCloneJSON, untilAborted } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import type { EffectiveExtensionRoots } from "../capability/types";
 import type { ModelRegistry } from "../config/model-registry";
@@ -732,9 +732,9 @@ export class SessionTools {
 					if (!permissionIntent) {
 						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx as never);
 					}
-					// A selected or persisted ACP grant is the interactive approval
-					// for this exact call; prevent the inner wrapper from prompting again.
-					const approvedCtx = (ctx ? { ...ctx, acpApproved: true } : ctx) as never;
+					// Preserve the exact arguments authorized by a selected or
+					// persisted ACP grant; inner handlers may mutate `args` in place.
+					const approvedCtx = (ctx ? { ...ctx, acpApprovedArgs: structuredCloneJSON(args) } : ctx) as never;
 					const command =
 						target.name === "bash" && args && typeof args === "object" && !Array.isArray(args)
 							? stringProperty(args, "command")

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -728,16 +728,13 @@ export class SessionTools {
 					onUpdate: never,
 					ctx: AgentToolContext | undefined,
 				) => {
-					// Reaching a target.execute below means this ACP-gated call is
-					// authorized (granted, persisted-allow, or no ACP prompt needed).
-					// The registry tool is an ExtensionToolWrapper whose own tier gate
-					// would otherwise re-prompt and fail closed in ACP (no interactive
-					// UI), so flag the call approved exactly like the xd:// device gate.
-					const approvedCtx = (ctx ? { ...ctx, xdevApproved: true } : ctx) as never;
 					const permissionIntent = getPermissionIntent(target.name, args);
 					if (!permissionIntent) {
-						return await target.execute(toolCallId, args as never, signal, onUpdate, approvedCtx);
+						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx as never);
 					}
+					// A selected or persisted ACP grant is the interactive approval
+					// for this call; prevent the inner wrapper from prompting again.
+					const approvedCtx = (ctx ? { ...ctx, xdevApproved: true } : ctx) as never;
 					const command =
 						target.name === "bash" && args && typeof args === "object" && !Array.isArray(args)
 							? stringProperty(args, "command")

--- a/packages/coding-agent/src/tools/context.ts
+++ b/packages/coding-agent/src/tools/context.ts
@@ -8,10 +8,11 @@ declare module "@oh-my-pi/pi-agent-core" {
 		hasUI?: boolean;
 		toolNames?: string[];
 		toolCall?: ToolCallContext;
-		/** Set on `xd://` device dispatches: the write tool's outer approval gate
-		 *  already resolved this call at the mounted tool's tier, so the inner
-		 *  wrapper must not re-prompt for the same action (explicit per-tool
-		 *  policies and overrides still apply). */
+		/** Set by an outer approval gate that already authorized this call at the
+		 *  mounted tool's tier, so the inner wrapper must not re-prompt for the
+		 *  same action (explicit per-tool policies and overrides still apply).
+		 *  Producers: the write tool's `xd://` device dispatch and the ACP
+		 *  permission gate (whose grant has no interactive UI to re-prompt on). */
 		xdevApproved?: boolean;
 		/** Reports the approval tier resolved after an extension rewrites an
 		 *  xd:// device call, so dispatch metadata describes the input that ran. */

--- a/packages/coding-agent/src/tools/context.ts
+++ b/packages/coding-agent/src/tools/context.ts
@@ -12,10 +12,10 @@ declare module "@oh-my-pi/pi-agent-core" {
 		 *  at the mounted tool's tier. The inner wrapper skips its tier-only
 		 *  prompt, while explicit policies and overrides still apply. */
 		xdevApproved?: boolean;
-		/** Set after an ACP client approves the exact original tool call. The
-		 *  inner wrapper skips tier and explicit prompts; deny policies, provider
-		 *  safety checks, and extension-revised inputs still require resolution. */
-		acpApproved?: boolean;
+		/** Immutable snapshot of the arguments an ACP client approved. The inner
+		 *  wrapper skips tier and explicit prompts only while the effective input
+		 *  remains equal; deny policies and provider safety checks still apply. */
+		acpApprovedArgs?: unknown;
 		/** Reports the approval tier resolved after an extension rewrites an
 		 *  xd:// device call, so dispatch metadata describes the input that ran. */
 		xdevTierResolved?(tier: "read" | "write" | "exec"): void;

--- a/packages/coding-agent/src/tools/context.ts
+++ b/packages/coding-agent/src/tools/context.ts
@@ -8,12 +8,14 @@ declare module "@oh-my-pi/pi-agent-core" {
 		hasUI?: boolean;
 		toolNames?: string[];
 		toolCall?: ToolCallContext;
-		/** Set by an outer approval gate that already authorized this call at the
-		 *  mounted tool's tier, so the inner wrapper must not re-prompt for the
-		 *  same action (explicit per-tool policies and overrides still apply).
-		 *  Producers: the write tool's `xd://` device dispatch and the ACP
-		 *  permission gate (whose grant has no interactive UI to re-prompt on). */
+		/** Set after the write tool's outer gate approves an `xd://` device call
+		 *  at the mounted tool's tier. The inner wrapper skips its tier-only
+		 *  prompt, while explicit policies and overrides still apply. */
 		xdevApproved?: boolean;
+		/** Set after an ACP client approves the exact original tool call. The
+		 *  inner wrapper skips tier and explicit prompts; deny policies, provider
+		 *  safety checks, and extension-revised inputs still require resolution. */
+		acpApproved?: boolean;
 		/** Reports the approval tier resolved after an extension rewrites an
 		 *  xd:// device call, so dispatch metadata describes the input that ran. */
 		xdevTierResolved?(tier: "read" | "write" | "exec"): void;

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -275,6 +275,26 @@ it("always-ask: granted ACP permission bypasses the inner ExtensionToolWrapper g
 	expect(bashTool.executeCalls).toBe(1);
 });
 
+it("always-ask: an ordinary edit without an ACP grant still faces the inner approval gate", async () => {
+	const editTool = makeFakeTool("edit");
+	editTool.approval = "write";
+	const wrapped = new ExtensionToolWrapper(editTool, noUiRunner()) as unknown as AgentTool;
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	session = await createSession([wrapped], bridge, { "tools.approvalMode": "always-ask" });
+
+	await session.setActiveToolsByName(["edit"]);
+	const gatedEdit = session.agent.state.tools.find(t => t.name === "edit");
+	const ctx = { settings: Settings.isolated({ "tools.approvalMode": "always-ask" }) } as never;
+
+	await expect(
+		gatedEdit!.execute("call-edit", { path: "/tmp/foo.ts" }, undefined, undefined as never, ctx),
+	).rejects.toThrow(/requires approval but no interactive UI/);
+
+	expect(permissionSpy).not.toHaveBeenCalled();
+	expect(editTool.executeCalls).toBe(0);
+});
+
 it("delete and move tools request ACP permission before executing", async () => {
 	const deleteTool = makeFakeTool("delete");
 	const moveTool = makeFakeTool("move");

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -13,6 +13,8 @@ import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream"
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type {
 	ClientBridge,
@@ -231,6 +233,43 @@ it("explicit yolo still gates tools whose per-tool policy requires a prompt", as
 	const wrappedBash = session.agent.state.tools.find(t => t.name === "bash");
 
 	await wrappedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, undefined as never);
+
+	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(bashTool.executeCalls).toBe(1);
+});
+
+/**
+ * Minimal runner for wrapping a tool exactly as an ACP session does: no
+ * interactive UI (so the inner tier gate fails closed) and no event handlers.
+ */
+function noUiRunner(): ExtensionRunner {
+	return {
+		hasHandlers: () => false,
+		consumeToolCallEmitted: () => false,
+		hasUI: () => false,
+		sessionId: "acp-permission-test",
+		runScoped<T>(fn: () => T): T {
+			return fn();
+		},
+	} as unknown as ExtensionRunner;
+}
+
+it("always-ask: granted ACP permission bypasses the inner ExtensionToolWrapper gate", async () => {
+	// In a real ACP session every registry tool is wrapped by ExtensionToolWrapper,
+	// then again by the ACP permission gate. Without the ACP grant marking the call
+	// approved, the inner wrapper re-resolves approval (bash is exec-tier, always-ask
+	// caps at read) and throws "no interactive UI", stranding the tool call pending.
+	const bashTool = makeFakeTool("bash");
+	const wrapped = new ExtensionToolWrapper(bashTool, noUiRunner()) as unknown as AgentTool;
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	session = await createSession([wrapped], bridge, { "tools.approvalMode": "always-ask" });
+
+	await session.setActiveToolsByName(["bash"]);
+	const gatedBash = session.agent.state.tools.find(t => t.name === "bash");
+	const ctx = { settings: Settings.isolated({ "tools.approvalMode": "always-ask" }) } as never;
+
+	await gatedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, ctx);
 
 	expect(permissionSpy).toHaveBeenCalledTimes(1);
 	expect(bashTool.executeCalls).toBe(1);

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -254,20 +254,23 @@ function noUiRunner(): ExtensionRunner {
 	} as unknown as ExtensionRunner;
 }
 
-it("always-ask: granted ACP permission bypasses the inner ExtensionToolWrapper gate", async () => {
+it("always-ask: an ACP grant satisfies the inner wrapper's explicit prompt policy", async () => {
 	// In a real ACP session every registry tool is wrapped by ExtensionToolWrapper,
-	// then again by the ACP permission gate. Without the ACP grant marking the call
-	// approved, the inner wrapper re-resolves approval (bash is exec-tier, always-ask
-	// caps at read) and throws "no interactive UI", stranding the tool call pending.
+	// then again by the ACP permission gate. The client has answered the explicit
+	// prompt, so the inner wrapper must not request the unavailable interactive UI.
 	const bashTool = makeFakeTool("bash");
 	const wrapped = new ExtensionToolWrapper(bashTool, noUiRunner()) as unknown as AgentTool;
 	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
 	const permissionSpy = spyOn(bridge, "requestPermission");
-	session = await createSession([wrapped], bridge, { "tools.approvalMode": "always-ask" });
+	const approvalSettings: Partial<Record<SettingPath, unknown>> = {
+		"tools.approvalMode": "always-ask",
+		"tools.approval": { bash: "prompt" },
+	};
+	session = await createSession([wrapped], bridge, approvalSettings);
 
 	await session.setActiveToolsByName(["bash"]);
 	const gatedBash = session.agent.state.tools.find(t => t.name === "bash");
-	const ctx = { settings: Settings.isolated({ "tools.approvalMode": "always-ask" }) } as never;
+	const ctx = { settings: Settings.isolated(approvalSettings) } as never;
 
 	await gatedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, ctx);
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3200,6 +3200,42 @@ describe("ExtensionRunner", () => {
 			expect(fs.existsSync(recordPath)).toBe(false); // tool never executed
 		});
 
+		it.each([
+			["without returning a replacement", false],
+			["while returning the same object", true],
+		] as const)("forfeits ACP approval after in-place input mutation %s", async (_case, returnsInput) => {
+			const recordPath = path.join(tempDir.path(), `acp-mutated-${returnsInput}.jsonl`);
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						event.input.command = "echo revised";
+						${returnsInput ? "return { input: event.input };" : ""}
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-acp-mutate.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createRecordingTool(recordPath), runner);
+			const acpContext = {
+				settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) },
+				acpApprovedArgs: { command: "echo original" },
+			} as never;
+
+			await expect(
+				wrapped.execute("acp-call-id", { command: "echo original" }, undefined, undefined, acpContext),
+			).rejects.toThrow(/requires approval but no interactive UI available/);
+			expect(fs.existsSync(recordPath)).toBe(false);
+		});
+
 		it("reports the effective tier after a tool_call handler revises xd:// input", async () => {
 			const recordPath = path.join(tempDir.path(), "xdev-effective-tier.jsonl");
 			const extCode = `

--- a/packages/coding-agent/test/tools/approval-mode.test.ts
+++ b/packages/coding-agent/test/tools/approval-mode.test.ts
@@ -228,6 +228,69 @@ describe("tools.approvalMode setting", () => {
 		).rejects.toThrow(/blocked by user policy/);
 	});
 
+	it("acpApproved satisfies explicit user and tool-override prompts", async () => {
+		const promptSettings = approvalSettings({
+			"tools.approvalMode": "always-ask",
+			"tools.approval": { bash: "prompt" },
+		});
+		const explicitResult = await bashTool().execute(
+			"acp-explicit-prompt",
+			{ command: "echo acp-explicit" },
+			undefined,
+			undefined,
+			{
+				settings: promptSettings,
+				acpApproved: true,
+			} as AgentToolContext,
+		);
+		expect(textOf(explicitResult)).toContain("acp-explicit");
+
+		const overrideSettings = approvalSettings({ "tools.approvalMode": "always-ask" });
+		const overrideResult = await bashTool().execute(
+			"acp-tool-override",
+			{ command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
+			undefined,
+			undefined,
+			{
+				settings: overrideSettings,
+				acpApproved: true,
+			} as AgentToolContext,
+		);
+		expect(textOf(overrideResult)).toContain("(no output)");
+	});
+
+	it("acpApproved does not bypass deny policies", async () => {
+		const settings = approvalSettings({ "tools.approvalMode": "always-ask" });
+		await expect(
+			bashTool().execute("acp-denied", { command: "rm -rf /tmp/never-run" }, undefined, undefined, {
+				settings,
+				acpApproved: true,
+			} as AgentToolContext),
+		).rejects.toThrow(/blocked by tool policy/);
+	});
+
+	it("acpApproved does not bypass provider safety checks", async () => {
+		const settings = approvalSettings({ "tools.approvalMode": "always-ask" });
+		await expect(
+			bashTool().execute("acp-safety", { command: "echo blocked" }, undefined, undefined, {
+				settings,
+				acpApproved: true,
+				toolCall: {
+					batchId: "safety-batch",
+					index: 0,
+					total: 1,
+					toolCalls: [],
+					providerMetadata: {
+						type: "computer",
+						providerItemId: "computer-call",
+						actions: [],
+						pendingSafetyChecks: [{ id: "safety-check" }],
+					},
+				},
+			} as AgentToolContext),
+		).rejects.toThrow(/pending provider safety checks but no interactive UI/);
+	});
+
 	it("constructs an extensionRunner unconditionally so the approval gate is always installed", async () => {
 		// Regression lock for the architectural fix: the per-tool approval gate is implemented
 		// inside `ExtensionToolWrapper`, which is only attached when `session.extensionRunner` exists.

--- a/packages/coding-agent/test/tools/approval-mode.test.ts
+++ b/packages/coding-agent/test/tools/approval-mode.test.ts
@@ -287,7 +287,7 @@ describe("tools.approvalMode setting", () => {
 						pendingSafetyChecks: [{ id: "safety-check" }],
 					},
 				},
-			} as AgentToolContext),
+			} as never),
 		).rejects.toThrow(/pending provider safety checks but no interactive UI/);
 	});
 

--- a/packages/coding-agent/test/tools/approval-mode.test.ts
+++ b/packages/coding-agent/test/tools/approval-mode.test.ts
@@ -228,7 +228,7 @@ describe("tools.approvalMode setting", () => {
 		).rejects.toThrow(/blocked by user policy/);
 	});
 
-	it("acpApproved satisfies explicit user and tool-override prompts", async () => {
+	it("ACP-approved arguments satisfy explicit user and tool-override prompts", async () => {
 		const promptSettings = approvalSettings({
 			"tools.approvalMode": "always-ask",
 			"tools.approval": { bash: "prompt" },
@@ -240,7 +240,7 @@ describe("tools.approvalMode setting", () => {
 			undefined,
 			{
 				settings: promptSettings,
-				acpApproved: true,
+				acpApprovedArgs: { command: "echo acp-explicit" },
 			} as AgentToolContext,
 		);
 		expect(textOf(explicitResult)).toContain("acp-explicit");
@@ -253,28 +253,28 @@ describe("tools.approvalMode setting", () => {
 			undefined,
 			{
 				settings: overrideSettings,
-				acpApproved: true,
+				acpApprovedArgs: { command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
 			} as AgentToolContext,
 		);
 		expect(textOf(overrideResult)).toContain("(no output)");
 	});
 
-	it("acpApproved does not bypass deny policies", async () => {
+	it("ACP-approved arguments do not bypass deny policies", async () => {
 		const settings = approvalSettings({ "tools.approvalMode": "always-ask" });
 		await expect(
 			bashTool().execute("acp-denied", { command: "rm -rf /tmp/never-run" }, undefined, undefined, {
 				settings,
-				acpApproved: true,
+				acpApprovedArgs: { command: "rm -rf /tmp/never-run" },
 			} as AgentToolContext),
 		).rejects.toThrow(/blocked by tool policy/);
 	});
 
-	it("acpApproved does not bypass provider safety checks", async () => {
+	it("ACP-approved arguments do not bypass provider safety checks", async () => {
 		const settings = approvalSettings({ "tools.approvalMode": "always-ask" });
 		await expect(
 			bashTool().execute("acp-safety", { command: "echo blocked" }, undefined, undefined, {
 				settings,
-				acpApproved: true,
+				acpApprovedArgs: { command: "echo blocked" },
 				toolCall: {
 					batchId: "safety-batch",
 					index: 0,


### PR DESCRIPTION
## Repro
With `omp acp --approval-mode always-ask`, a schema-conformant `session/request_permission` answer (`{"outcome":{"outcome":"selected","optionId":"allow_once"}}`) never runs the tool: the call stays `pending`, the model reports it cannot execute bash, and the turn ends. The same prompt works under `--approval-mode yolo`. Reproduced with a test that wraps the tool exactly as an ACP session does (`ExtensionToolWrapper` then the ACP permission gate) under `always-ask`; before the fix it throws `Tool "bash" requires approval but no interactive UI available` at `extensibility/extensions/wrapper.ts:316`, surfaced from `session/session-tools.ts:808`.

## Cause
In an ACP session every registry tool is wrapped by `ExtensionToolWrapper` (`sdk.ts`), and `SessionTools#wrapToolForAcpPermission` (`session/session-tools.ts`) wraps that again to raise `session/request_permission`. The permission response is unwrapped correctly, but on a granted outcome the ACP gate called `target.execute(...)` without signalling the inner wrapper that approval was already granted. The inner `ExtensionToolWrapper.execute` then re-resolved approval — `bash` is exec-tier, `always-ask` caps at read-tier — needed a prompt, found no interactive UI, and threw. The error went back to the model and the client's tool call was left `pending`. `yolo` worked only because both gates are bypassed. (The reporter's flattened-shape attempt failed earlier at `PERMISSION_OPTIONS_BY_ID.get(undefined)` → "unknown option ID"; the nested shape is correct.)

## Fix
- `session/session-tools.ts`: the ACP permission proxy now marks the authorized call `xdevApproved: true` on every path that reaches `target.execute` (granted, persisted `allow_always`, and no-ACP-prompt-needed), so the inner `ExtensionToolWrapper` defers to the ACP decision instead of re-prompting — the same bypass the `xd://` device gate already uses.
- `tools/context.ts`: documented the ACP permission gate as a second producer of `xdevApproved`.
- `test/agent-session-acp-permission.test.ts`: regression test wrapping the tool as a real ACP session does and asserting `allow_once` executes under `always-ask` (fails at `session-tools.ts:808` without the fix).
- `CHANGELOG.md`: Fixed entry.

## Verification
`bun test test/agent-session-acp-permission.test.ts test/acp-client-bridge.test.ts` → 32 pass. Confirmed the new test fails without the fix (throws "no interactive UI") and passes with it. Fixes #10850