### PR TITLE
fix(catalog): add GPT-6 Astra Codex pricing

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Muse Code subscriptions now resolve a compact edit-prompt variant, cutting recurring per-request tool bytes without touching other providers.
 - Added Meta's new `max` reasoning effort tier to Muse Spark 1.3 (standard) on the Meta Model API and Muse Code.
 
+### Fixed
+
+- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing and 1.05M-token context window ([#10852](https://github.com/can1357/oh-my-pi/pull/10852) by [@xiyihan0](https://github.com/xiyihan0)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,36 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:33",
+				"source": "providers/openai-codex.kdl:36",
+				"providers": [
+					"openai-codex"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra"
+					},
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra-wm"
+					}
+				],
+				"catalog": {
+					"costPatch": {
+						"input": 10,
+						"output": 50,
+						"cacheRead": 1,
+						"cacheWrite": 0
+					},
+					"serviceTierCost": {
+						"flex": 0.5,
+						"priority": 2.5
+					},
+					"contextWindowFloor": 1050000
+				}
+			},
+			{
+				"source": "providers/openai-codex.kdl:50",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10612,7 +10641,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:38",
+				"source": "providers/openai-codex.kdl:55",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10628,7 +10657,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:41",
+				"source": "providers/openai-codex.kdl:58",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10644,7 +10673,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:46",
+				"source": "providers/openai-codex.kdl:63",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10663,7 +10692,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:58",
+				"source": "providers/openai-codex.kdl:75",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10689,7 +10718,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:64",
+				"source": "providers/openai-codex.kdl:81",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10715,7 +10744,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:56",
+				"source": "providers/openai-codex.kdl:73",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10732,7 +10761,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:74",
+				"source": "providers/openai-codex.kdl:91",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10752,7 +10781,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:80",
+				"source": "providers/openai-codex.kdl:97",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10768,7 +10797,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:83",
+				"source": "providers/openai-codex.kdl:100",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10784,7 +10813,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:89",
+				"source": "providers/openai-codex.kdl:106",
 				"providers": [
 					"openai-codex"
 				],
@@ -10805,7 +10834,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:98",
+				"source": "providers/openai-codex.kdl:115",
 				"providers": [
 					"openai-codex"
 				],
@@ -10830,7 +10859,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:107",
+				"source": "providers/openai-codex.kdl:124",
 				"providers": [
 					"openai-codex"
 				],
@@ -10851,7 +10880,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:118",
+				"source": "providers/openai-codex.kdl:135",
 				"providers": [
 					"openai-codex"
 				],

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -29,6 +29,23 @@ provider "openai-codex" {
 			cache-write 15.625
 		}
 	}
+	// Codex discovery currently reports Astra's legacy 272K window and no
+	// pricing. Attribute subscription usage at the documented credit-equivalent
+	// rates, with free cache writes and without the API's >272K multiplier,
+	// while exposing the 1.05M window.
+	models "gpt-6-astra" "gpt-6-astra-wm" {
+		cost-patch {
+			input 10.0
+			output 50.0
+			cache-read 1.0
+			cache-write 0
+		}
+		service-tier-cost {
+			flex 0.5
+			priority 2.5
+		}
+		context-window-floor 1050000
+	}
 	class "openai" {
 		revision ">=5.3 <5.7" {
 			thinking-mode "effort"

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -370,8 +370,8 @@ function buildNormalizedCodexModel(
 			baseUrl,
 			reasoning: parsed.reasoning,
 			input: parsed.input,
-			// Daybreak standard API pricing is rule-owned (`providers/openai-codex.kdl`
-			// cost-patch) and corrected at build time.
+			// Codex discovery omits pricing; documented subscription credit-equivalent
+			// rates are rule-owned (`providers/openai-codex.kdl`) and applied at build time.
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			remoteCompaction: CODEX_REMOTE_COMPACTION,
 			contextWindow,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -261365,9 +261365,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
 				"cacheWrite": 0
 			},
 			"remoteCompaction": {
@@ -261375,7 +261375,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 272000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -261454,7 +261454,7 @@
 			},
 			"serviceTierCost": {
 				"flex": 0.5,
-				"priority": 2
+				"priority": 2.5
 			},
 			"applyPatchToolType": "freeform"
 		},

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -198,6 +198,51 @@ describe("Codex model discovery", () => {
 		expect(buildModel(red).cost).toEqual({ input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 });
 	});
 
+	it("normalizes plain and worker Codex GPT-6 Astra metadata", async () => {
+		const fetchFn: typeof fetch = Object.assign(
+			async () =>
+				Response.json({
+					models: [
+						{
+							slug: "gpt-6-astra-wm",
+							display_name: "GPT-6-Astra",
+							context_window: 272_000,
+							default_reasoning_level: "medium",
+							supported_reasoning_levels: ["low", "medium", "high", "xhigh", "max"],
+							input_modalities: ["text", "image"],
+							supported_in_api: true,
+						},
+					],
+				}),
+			{ preconnect() {} },
+		);
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			baseUrl: "https://codex.example/backend-api",
+			clientVersion: "0.153.0",
+			fetchFn,
+		});
+		const astra = result?.models.find(model => model.id === "gpt-6-astra");
+		const workerAstra = result?.models.find(model => model.id === "gpt-6-astra-wm");
+		if (!astra || !workerAstra) throw new Error("Expected plain and worker GPT-6 Astra routes");
+
+		for (const model of [astra, workerAstra]) {
+			// `/models` omits prices, so discovery stays neutral and the KDL
+			// catalog rule remains the single authority for billed metadata.
+			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+			expect(model.contextWindow).toBe(272_000);
+			const builtModel = buildModel(model);
+			// Codex credits keep this base rate above 272K and do not charge for
+			// cache writes; unlike the API card, there is no long-context tier.
+			expect(builtModel.cost).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 0 });
+			expect(builtModel.serviceTierCost).toEqual({ flex: 0.5, priority: 2.5 });
+			expect(builtModel).toMatchObject({
+				contextWindow: 1_050_000,
+				maxTokens: 128_000,
+			});
+		}
+	});
+
 	it("floors stale reported windows for GPT-5.6 luna/sol/terra and honors reports above the floor", async () => {
 		const fetchFn: typeof fetch = Object.assign(
 			async () =>


### PR DESCRIPTION
## What

- Apply GPT-6 Astra's documented Codex credit-equivalent rates to both the plain and `-wm` routes: $10 input, $1 cached input, $0 cache writes, and $50 output per 1M tokens.
- Keep the Codex long-context exception above 272K, set Fast mode to 2.5x, and correct the context window to 1.05M tokens.
- Add a discovery regression covering the raw zero-cost endpoint metadata and both KDL-normalized routes.

## Why

The Codex `/models` response advertises Astra without pricing and with the legacy 272K window, so OMP currently presents it as free and under-reports its context. Codex pricing is different from the API rate card: cache writes are free and Astra does not receive an additional long-context multiplier above 272K.

Official references:
- https://help.openai.com/en/articles/20001415-chatgpt-rate-card-enterprise-token-based-pricing
- https://learn.chatgpt.com/docs/pricing#credits-overview

Contributor review: 我review了这个diff,上面的更改是符合openai的官方文档的模型价格描述的。

## Testing

- `bun test packages/catalog/test/codex-discovery.test.ts` — 17 passed
- `bun --cwd packages/catalog run check`
- `bun check`
- Source CLI smoke: `bun run dev models openai-codex --json --no-extensions` reports Astra as input 10, cached input 1, cache write 0, output 50, and context window 1,050,000.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)