### PR TITLE
fix(model-resolver): resolve nested modelRoles role references

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- A custom `modelRoles` entry that references another role (e.g. `fast_worker: "@task"`) now resolves to the referenced role's model even when `retry.modelFallback` is disabled ([#10853](https://github.com/can1357/oh-my-pi/issues/10853)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1197,6 +1197,33 @@ function resolveDefaultInheritedPatterns(
 	return resolved;
 }
 
+/**
+ * Expand any configured role value that itself points at another role
+ * (`modelRoles.fast_worker = "@task"`) into that target role's concrete model
+ * patterns, recursively. Non-alias entries pass through unchanged. `visited`
+ * carries the roles already being resolved so a reference cycle terminates
+ * instead of recursing forever. This runs independently of retry
+ * model-fallback, so a role reference resolves even when `retry.modelFallback`
+ * is disabled (#10853).
+ */
+function expandRoleReferencePatterns(
+	patterns: string[],
+	settings: ModelRoleLookup | undefined,
+	visited: Set<string>,
+): string[] {
+	return patterns.flatMap(pattern => {
+		const { base } = splitThinkingSuffix(
+			pattern,
+			modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
+			MAX_THINKING_SUFFIX_OPTIONS,
+		);
+		const aliasRole = getModelRoleAlias(base, settings);
+		if (!aliasRole || visited.has(aliasRole)) return [pattern];
+		const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
+		return recursed && recursed.length > 0 ? recursed : [pattern];
+	});
+}
+
 function resolveConfiguredRolePattern(
 	value: string,
 	settings?: ModelRoleLookup,
@@ -1219,7 +1246,7 @@ function resolveConfiguredRolePattern(
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
 	const resolved = configured
-		? normalizeModelPatternList(configured)
+		? expandRoleReferencePatterns(normalizeModelPatternList(configured), settings, visited)
 		: isModelRole(role)
 			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
 			: roleDefaults;

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -905,6 +905,25 @@ describe("resolveModelRoleValue", () => {
 		expect(result.warning).toBeUndefined();
 	});
 
+	test("resolves a custom role that references another custom role (#10853)", () => {
+		// modelRoles.fast_worker = "@task" must expand through the referenced
+		// role to its concrete model at the pure resolution layer, without
+		// relying on the retry model-fallback path (which retry.modelFallback:
+		// false disables).
+		const roles: Record<string, string> = {
+			task: "openrouter/qwen/qwen3-coder:exacto",
+			fast_worker: "@task",
+		};
+		const settings = {
+			getModelRole: (role: string) => roles[role],
+		} as NonNullable<Parameters<typeof resolveModelRoleValue>[2]>["settings"];
+
+		const result = resolveModelRoleValue("@fast_worker", allModels, { settings });
+
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
+	});
+
 	test("splits direct comma fallback chains before parsing thinking selectors", () => {
 		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:off,openai/gpt-4o:off", allModels);
 


### PR DESCRIPTION
## Repro
With `modelRoles.task` set to a concrete model and `modelRoles.fast_worker: "@task"`, launching under a `--config` overlay that sets `retry.modelFallback: false` fails: `omp -p "say ok" --model @fast_worker --config worker-omp-config.yml` → `Model "@fast_worker" not found`. The referenced built-in-style role `@task` and custom roles with a direct model value both keep working under the same overlay, and both roles resolve when the overlay is absent. Reproduced at the resolution layer with `resolveModelRoleValue("@fast_worker", …)` returning `undefined` while `resolveModelRoleValue("@task", …)` resolves.

## Cause
`resolveConfiguredRolePattern` (`packages/coding-agent/src/config/model-resolver.ts`) expands a custom role's configured value verbatim: `modelRoles.fast_worker = "@task"` yields the literal pattern list `["@task"]` rather than recursing into the `task` role. Only `default`/`smol`/`slow` inheritance recursed (`resolveDefaultInheritedPatterns`). The concrete model was therefore reachable only as a side effect of the retry model-fallback resolution in `sdk.ts` (~L2414), which is gated on `retry.modelFallback`. The overlay's `retry.modelFallback: false` skips that path, so the unexpanded `@task` pattern never matches a model. This contradicts `docs/models.md:430` ("If a role points at another role, the target model still inherits normally").

## Fix
- Add `expandRoleReferencePatterns`: for each configured pattern, if it is a role alias not already on the `visited` stack, recurse through `resolveConfiguredRolePattern`; non-alias entries and cycles pass through unchanged.
- Wire it into the `configured` branch of `resolveConfiguredRolePattern` so nested role references expand independently of the retry model-fallback gate. Cycle-safe via the existing `visited` set.
- Add a `resolveModelRoleValue` regression test for a custom role referencing another custom role.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/model-resolver.test.ts` → 169 pass / 0 fail (includes the new regression test). The standalone repro that failed before the fix (`@fast_worker` → `undefined`) now resolves to the referenced model. Fixes #10853