### PR TITLE
feat(catalog): update Fire Pass models to glm-5.2-fast and kimi-k3-fast

### DIFF
--- a/packages/ai/test/firepass.live.ts
+++ b/packages/ai/test/firepass.live.ts
@@ -1,12 +1,13 @@
 /**
  * Live Fire Pass smoke. NOT part of the bun test suite — run manually:
+ *
  *   FIREPASS_API_KEY=fpk_... bun packages/ai/test/firepass.live.ts
  *
- * Validates:
- *   1. The bundled `firepass/kimi-k2.6-turbo` entry round-trips a real
- *      streaming chat completion against the Fire Pass router.
- *   2. The PR #1199 P2 fix (xhigh → max) actually clears the wire — without
- *      the mapping Fireworks 400s the request.
+ * Asserts that:
+ *   1. The provider resolves the active Fire Pass models (`glm-5.2-fast`, `kimi-k3-fast`).
+ *   2. Friendly IDs translate to their router wire endpoints (`accounts/fireworks/routers/...`).
+ *   3. Supported reasoning efforts pass through to the router.
+ *   4. Invalid efforts are rejected with 400 by the router.
  */
 
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
@@ -19,23 +20,23 @@ if (!apiKey) {
 	process.exit(2);
 }
 
-const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-console.log(`Model: ${model.provider}/${model.id} -> ${model.baseUrl}`);
-console.log(`thinking.effortMap:`, model.thinking?.effortMap ?? "(none)");
+const glmModel = getBundledModel<"openai-completions">("firepass", "glm-5.2-fast");
+const kimiModel = getBundledModel<"openai-completions">("firepass", "kimi-k3-fast");
 
-// Capture the outbound request body so we can verify the wire-id translation
-// and the reasoning_effort mapping locally before reading the network result.
+console.log(`GLM Model: ${glmModel.provider}/${glmModel.id} -> ${glmModel.baseUrl}`);
+console.log(`Kimi Model: ${kimiModel.provider}/${kimiModel.id} -> ${kimiModel.baseUrl}`);
+
 interface CapturedRequest {
 	url: string;
 	body: string | null;
 }
 
 const originalFetch = fetch;
-const captured: { value: CapturedRequest | null } = { value: null };
+const capturedRequests: CapturedRequest[] = [];
 type FetchInput = string | URL | Request;
 const fetchImpl: FetchImpl = async (input: FetchInput, init?: RequestInit) => {
 	const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-	captured.value = { url, body: typeof init?.body === "string" ? init.body : null };
+	capturedRequests.push({ url, body: typeof init?.body === "string" ? init.body : null });
 	return originalFetch(input, init);
 };
 
@@ -44,13 +45,10 @@ const context: Context = {
 	messages: [{ role: "user", content: "Say hi.", timestamp: Date.now() }],
 };
 
-async function runEffort(label: string, reasoning: "xhigh" | undefined) {
-	console.log(`\n=== ${label} ===`);
-	captured.value = null;
-	const stream = streamOpenAICompletions(model as Model<"openai-completions">, context, {
+async function runModel(targetModel: Model<"openai-completions">, label: string, reasoning: "high" | undefined) {
+	console.log(`\n=== ${label} (${targetModel.id}) ===`);
+	const stream = streamOpenAICompletions(targetModel, context, {
 		apiKey,
-		// Intentionally omit maxTokens here so we can also assert that the Kimi-family
-		// safety net (openai-completions.ts isKimi) injects the catalog default.
 		...(reasoning ? { reasoning } : {}),
 		fetch: fetchImpl,
 	});
@@ -69,14 +67,11 @@ async function runEffort(label: string, reasoning: "xhigh" | undefined) {
 		}
 	}
 
-	// Cast through the wrapper to defeat tsgo's control-flow narrowing, which assumes
-	// `captured.value` is always null because the closure-side mutation is invisible.
-	const snapshot = (captured as { value: CapturedRequest | null }).value;
+	const snapshot = capturedRequests.at(-1);
 	const parsedBody = snapshot?.body ? JSON.parse(snapshot.body) : null;
 	console.log("wire url:", snapshot?.url);
 	console.log("wire model:", parsedBody?.model);
 	console.log("wire reasoning_effort:", parsedBody?.reasoning_effort ?? "(omitted)");
-	console.log("wire max_tokens:", parsedBody?.max_tokens ?? "(omitted)");
 	console.log("text:", JSON.stringify(text.slice(0, 80)));
 	console.log("stopReason:", stopReason);
 	console.log("cost.total:", cost);
@@ -85,44 +80,42 @@ async function runEffort(label: string, reasoning: "xhigh" | undefined) {
 	return { parsedBody, stopReason, firstError };
 }
 
-const baseline = await runEffort("baseline (no reasoning effort, no maxTokens)", undefined);
-if (baseline.firstError) {
-	console.error("\nbaseline call failed — key, network, or router rejected the request");
+const glmBaseline = await runModel(glmModel, "GLM baseline", undefined);
+if (glmBaseline.firstError) {
+	console.error("\nGLM baseline call failed — key, network, or router rejected request");
 	process.exit(1);
 }
-if (baseline.parsedBody?.model !== "accounts/fireworks/routers/kimi-k2p6-turbo") {
-	console.error("\nwire model id was not translated to the router endpoint");
-	process.exit(1);
-}
-if (baseline.parsedBody?.max_tokens !== model.maxTokens) {
-	console.error(
-		`\nmax_tokens default did not fire (got ${baseline.parsedBody?.max_tokens}, expected ${model.maxTokens}); ` +
-			"isKimi detection is not matching the firepass catalog id",
-	);
+if (glmBaseline.parsedBody?.model !== "accounts/fireworks/routers/glm-5p2-fast") {
+	console.error("\nGLM wire model id was not translated to the router endpoint");
 	process.exit(1);
 }
 
-const xhigh = await runEffort("xhigh effort (Codex P2 — should pass through verbatim)", "xhigh");
-if (xhigh.firstError) {
-	console.error("\nxhigh call failed — router rejected the documented effort tier");
+const glmHigh = await runModel(glmModel, "GLM high effort", "high");
+if (glmHigh.firstError) {
+	console.error("\nGLM high effort call failed — router rejected effort tier");
 	process.exit(1);
 }
-if (xhigh.parsedBody?.reasoning_effort !== "xhigh") {
-	console.error(
-		`\nxhigh was rewritten on the wire (got ${xhigh.parsedBody?.reasoning_effort}); ` +
-			"expected verbatim passthrough — adding thinking.effortMap would silently downgrade the user",
-	);
+if (glmHigh.parsedBody?.reasoning_effort !== "high") {
+	console.error(`\nGLM high effort was not forwarded (got ${glmHigh.parsedBody?.reasoning_effort})`);
 	process.exit(1);
 }
 
-// Bonus: prove the router actually enforces an effort allowlist so callers can trust the
-// "xhigh is accepted" claim above. A clearly-invalid value MUST 400.
-console.log("\n=== negative probe: garbage_value should 400 at the router ===");
+const kimiBaseline = await runModel(kimiModel, "Kimi baseline", undefined);
+if (kimiBaseline.firstError) {
+	console.error("\nKimi baseline call failed — key, network, or router rejected request");
+	process.exit(1);
+}
+if (kimiBaseline.parsedBody?.model !== "accounts/fireworks/routers/kimi-k3-fast") {
+	console.error("\nKimi wire model id was not translated to the router endpoint");
+	process.exit(1);
+}
+
+console.log("\n=== negative probe: garbage_value should 400 at router ===");
 const negative = await fetch("https://api.fireworks.ai/inference/v1/chat/completions", {
 	method: "POST",
 	headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
 	body: JSON.stringify({
-		model: "accounts/fireworks/routers/kimi-k2p6-turbo",
+		model: "accounts/fireworks/routers/glm-5p2-fast",
 		messages: [{ role: "user", content: "ping" }],
 		max_tokens: 4,
 		reasoning_effort: "garbage_value",
@@ -132,11 +125,11 @@ const negativeBody = await negative.text();
 console.log("status:", negative.status);
 console.log("body:", negativeBody.slice(0, 300));
 if (negative.status !== 400) {
-	console.error("\nrouter accepted an unknown effort — the accepted-set assertion is unreliable");
+	console.error("\nrouter accepted unknown effort — accepted-set assertion unreliable");
 	process.exit(1);
 }
 
 console.log(
-	"\nLIVE OK — Fire Pass router translated the wire id, applied the Kimi K2 max_tokens default, " +
-		"forwarded `xhigh` verbatim, and rejected `garbage_value` with 400.",
+	"\nLIVE OK — Fire Pass routers translated wire ids for GLM 5.2 Fast and Kimi K3 Fast, " +
+		"forwarded `high` effort, and rejected `garbage_value` with 400.",
 );

--- a/packages/ai/test/firepass.test.ts
+++ b/packages/ai/test/firepass.test.ts
@@ -1,12 +1,13 @@
 /**
- * Fire Pass (Fireworks Kimi K2.6 Turbo subscription) wiring.
+ * Fire Pass (Fireworks subscription) wiring.
  *
- * Fire Pass keys (`fpk_…`) authorize only the `accounts/fireworks/routers/kimi-k2p6-turbo`
- * router and reject `/v1/models`. The bundled catalog stores a friendly public id
- * (`kimi-k2.6-turbo`) and the openai-completions provider translates it to the wire
- * form at request time.
+ * Fire Pass keys (`fpk_…`) authorize only router endpoints (e.g. `accounts/fireworks/routers/glm-5p2-fast`)
+ * and reject `/v1/models`. The bundled catalog stores friendly public ids (`glm-5.2-fast`, `kimi-k3-fast`)
+ * and the openai-completions provider translates them to router wire form at request time.
  */
 import { describe, expect, it } from "bun:test";
+import { getProviderDefinition } from "@oh-my-pi/pi-ai/registry";
+import type { OAuthController } from "@oh-my-pi/pi-ai/registry/oauth/types";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -20,20 +21,27 @@ function sseResponse(events: unknown[]): Response {
 }
 
 describe("Fire Pass provider", () => {
-	it("ships a bundled Kimi K2.6 Turbo entry on the firepass provider", () => {
-		const model = getBundledModel("firepass", "kimi-k2.6-turbo");
-		expect(model).toBeDefined();
-		expect(model.provider).toBe("firepass");
-		expect(model.api).toBe("openai-completions");
-		expect(model.baseUrl).toBe("https://api.fireworks.ai/inference/v1");
-		expect(model.reasoning).toBe(true);
+	it("ships bundled GLM 5.2 Fast and Kimi K3 Fast entries on the firepass provider", () => {
+		const glm = getBundledModel("firepass", "glm-5.2-fast");
+		expect(glm).toBeDefined();
+		expect(glm?.provider).toBe("firepass");
+		expect(glm?.contextWindow).toBe(1048576);
+		expect(glm?.reasoning).toBe(true);
+
+		const kimi = getBundledModel("firepass", "kimi-k3-fast");
+		expect(kimi).toBeDefined();
+		expect(kimi?.provider).toBe("firepass");
+		expect(kimi?.contextWindow).toBe(1048576);
+		expect(kimi?.reasoning).toBe(true);
 	});
 
-	it("translates the friendly id to the router wire id when calling chat completions", async () => {
-		const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-		const captured: { body: string | null } = { body: null };
+	it("translates glm-5.2-fast and kimi-k3-fast to router wire endpoints", async () => {
+		const glm = getBundledModel<"openai-completions">("firepass", "glm-5.2-fast");
+		const kimi = getBundledModel<"openai-completions">("firepass", "kimi-k3-fast");
+
+		const bodies: string[] = [];
 		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
-			captured.body = typeof init?.body === "string" ? init.body : null;
+			if (typeof init?.body === "string") bodies.push(init.body);
 			return sseResponse([
 				{ choices: [{ delta: { content: "ok" }, index: 0 }] },
 				{ choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
@@ -45,125 +53,47 @@ describe("Fire Pass provider", () => {
 			systemPrompt: [],
 			messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
 		};
-		const stream = streamOpenAICompletions(model as Model<"openai-completions">, context, {
+
+		for await (const _ of streamOpenAICompletions(glm as Model<"openai-completions">, context, {
 			apiKey: "fpk_test",
 			fetch: fetchMock,
-		});
-		for await (const _event of stream) {
-			/* drain */
+		})) {
 		}
 
-		expect(captured.body).not.toBeNull();
-		const parsed = JSON.parse(captured.body ?? "{}") as { model?: unknown };
-		expect(parsed.model).toBe("accounts/fireworks/routers/kimi-k2p6-turbo");
+		for await (const _ of streamOpenAICompletions(kimi as Model<"openai-completions">, context, {
+			apiKey: "fpk_test",
+			fetch: fetchMock,
+		})) {
+		}
+
+		expect(bodies.length).toBe(2);
+		expect(JSON.parse(bodies[0] ?? "{}").model).toBe("accounts/fireworks/routers/glm-5p2-fast");
+		expect(JSON.parse(bodies[1] ?? "{}").model).toBe("accounts/fireworks/routers/kimi-k3-fast");
 	});
 
-	it("forwards the catalog-exposed xhigh effort verbatim to the Fire Pass router", async () => {
-		// The Fire Pass router's own validation message enumerates the accepted
-		// reasoning_effort set as `low | medium | high | xhigh | max | none`, and
-		// `xhigh` is a distinct tier from `max` (different reasoning-token budgets
-		// for the same prompt). The bundled entry must therefore advertise xhigh
-		// without a thinking effortMap that would silently downgrade it to max —
-		// see PR #1199 discussion r3265122224 for the live API capture.
-		const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-		expect(model.thinking?.effortMap?.xhigh).toBeUndefined();
+	it("validates login against accounts/fireworks/routers/glm-5p2-fast", async () => {
+		const login = getProviderDefinition("firepass")?.login;
+		expect(login).toBeDefined();
 
-		const captured: { body: string | null } = { body: null };
+		let capturedBody: string | null = null;
 		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
-			captured.body = typeof init?.body === "string" ? init.body : null;
-			return sseResponse([
-				{ choices: [{ delta: { content: "ok" }, index: 0 }] },
-				{ choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
-				"[DONE]",
-			]);
+			capturedBody = typeof init?.body === "string" ? init.body : null;
+			return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
 		};
 
-		const context: Context = {
-			systemPrompt: [],
-			messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
-		};
-		const stream = streamOpenAICompletions(model as Model<"openai-completions">, context, {
-			apiKey: "fpk_test",
-			reasoning: "xhigh",
+		const ctrl: OAuthController = {
 			fetch: fetchMock,
-		});
-		for await (const _event of stream) {
-			/* drain */
-		}
-
-		expect(captured.body).not.toBeNull();
-		const parsed = JSON.parse(captured.body ?? "{}") as { reasoning_effort?: unknown };
-		expect(parsed.reasoning_effort).toBe("xhigh");
-	});
-
-	it("falls back to the catalog max_tokens when the caller omits it (Kimi K2 docs guidance)", async () => {
-		// https://docs.fireworks.ai/models/kimi-k2 — "always set max_tokens explicitly" because
-		// the Kimi K2 family otherwise emits very long reasoning traces. The openai-completions
-		// provider injects the catalog default via its Kimi-family safety net; the firepass
-		// catalog id (`kimi-k2.6-turbo`) and wire id (`accounts/fireworks/routers/kimi-k2p6-turbo`)
-		// must both fall under that net so users never hit the runaway path.
-		const model = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-		expect(model.maxTokens).toBeGreaterThan(0);
-
-		const captured: { body: string | null } = { body: null };
-		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
-			captured.body = typeof init?.body === "string" ? init.body : null;
-			return sseResponse([
-				{ choices: [{ delta: { content: "ok" }, index: 0 }] },
-				{ choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
-				"[DONE]",
-			]);
+			onPrompt: async () => "fpk_test",
+			onAuth: () => {},
+			onProgress: () => {},
 		};
 
-		const context: Context = {
-			systemPrompt: [],
-			messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
-		};
-		const stream = streamOpenAICompletions(model as Model<"openai-completions">, context, {
-			apiKey: "fpk_test",
-			fetch: fetchMock,
-			// Intentionally omit maxTokens — the provider must inject the catalog default.
-		});
-		for await (const _event of stream) {
-			/* drain */
-		}
-
-		expect(captured.body).not.toBeNull();
-		const parsed = JSON.parse(captured.body ?? "{}") as { max_tokens?: unknown };
-		expect(parsed.max_tokens).toBe(model.maxTokens);
-	});
-
-	it("applies the Kimi max_tokens default to canonical Fire Pass router ids", async () => {
-		const bundled = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
-		const model: Model<"openai-completions"> = {
-			...bundled,
-			id: "accounts/fireworks/routers/kimi-k2p6-turbo",
-		};
-		const captured: { body: string | null } = { body: null };
-		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
-			captured.body = typeof init?.body === "string" ? init.body : null;
-			return sseResponse([
-				{ choices: [{ delta: { content: "ok" }, index: 0 }] },
-				{ choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
-				"[DONE]",
-			]);
-		};
-
-		const context: Context = {
-			systemPrompt: [],
-			messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
-		};
-		const stream = streamOpenAICompletions(model, context, {
-			apiKey: "fpk_test",
-			fetch: fetchMock,
-		});
-		for await (const _event of stream) {
-			/* drain */
-		}
-
-		expect(captured.body).not.toBeNull();
-		const parsed = JSON.parse(captured.body ?? "{}") as { max_tokens?: unknown; model?: unknown };
-		expect(parsed.model).toBe("accounts/fireworks/routers/kimi-k2p6-turbo");
-		expect(parsed.max_tokens).toBe(model.maxTokens);
+		const result = await login!(ctrl);
+		expect(result).toBe("fpk_test");
+		expect(capturedBody).not.toBeNull();
+		expect(JSON.parse(capturedBody ?? "{}").model).toBe("accounts/fireworks/routers/glm-5p2-fast");
 	});
 });

--- a/packages/ai/test/openai-completions-progress-chunk.test.ts
+++ b/packages/ai/test/openai-completions-progress-chunk.test.ts
@@ -148,7 +148,7 @@ describe("resolveOpenAICompat stream idle timeout", () => {
 	});
 
 	it("widens Kimi K2.6 reasoning streams across OpenAI-compatible hosts", () => {
-		const bundled = getBundledModel<"openai-completions">("firepass", "kimi-k2.6-turbo");
+		const bundled = getBundledModel<"openai-completions">("fireworks", "kimi-k2.6");
 		const canonicalRouter = buildModel({
 			...bundled,
 			id: "accounts/fireworks/routers/kimi-k2p6-turbo",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -44,6 +44,7 @@ import {
 	clampFireworksKimiMaxTokens,
 	clampKimiK27CodeMaxTokens,
 	fetchWellKnownModels,
+	FIREPASS_STATIC_MODELS,
 	GMI_CLOUD_STATIC_MODELS,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
@@ -662,7 +663,12 @@ async function generateModels() {
 	if (!authoritativeCatalogProviders.has("gmi-cloud")) {
 		allModels.push(...GMI_CLOUD_STATIC_MODELS);
 	}
-	// Seed the GitLab Duo Agent fallback model so a fresh install (no credentialed
+	// Seed Fire Pass router models so the provider is usable when generation has
+	// no live key. Dedicated `fpk_...` keys only authorize router endpoints, not
+	// `/v1/models`, so dynamic discovery is never performed.
+	if (!authoritativeCatalogProviders.has("firepass")) {
+		allModels.push(...FIREPASS_STATIC_MODELS);
+	}
 	// dynamic discovery/cache yet) still surfaces the provider's default model in the
 	// built-in catalog. The descriptor deliberately has NO `catalogDiscovery`, so it is
 	// excluded from the generator's discovery loop (`isCatalogDescriptor` filter above):
@@ -729,6 +735,7 @@ async function generateModels() {
 		...authoritativeCatalogProviders,
 		...authoritativeSpecialDiscoveryProviders,
 		...modelsDevSnapshotExcludedProviders,
+		"firepass",
 	]);
 
 	// Previous-snapshot entries may carry an older ThinkingConfig vocabulary;
@@ -739,7 +746,6 @@ async function generateModels() {
 		prevModelsJson as unknown as Record<string, Record<string, Model<Api>>>,
 		previousSnapshotExcludedProviders,
 	);
-
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
 	// Previous-snapshot fallbacks can retain a retired client fingerprint. Force
 	// every bundled Copilot model onto the same identity used by live discovery.

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7996,25 +7996,37 @@
 				}
 			},
 			{
-				"source": "providers/firepass.kdl:11",
+				"source": "providers/firepass.kdl:10",
+				"class": "glm",
 				"providers": [
 					"firepass"
 				],
-				"models": [
-					{
-						"kind": "exact",
-						"value": "kimi-k2.6-turbo"
-					}
-				],
+				"priority": 1,
 				"thinking": {
+					"mode": "effort",
 					"efforts": [
+						"minimal",
 						"low",
 						"medium",
 						"high",
-						"xhigh",
 						"max"
-					],
-					"mode": "effort"
+					]
+				}
+			},
+			{
+				"source": "providers/firepass.kdl:15",
+				"class": "kimi",
+				"providers": [
+					"firepass"
+				],
+				"priority": 1,
+				"thinking": {
+					"mode": "effort",
+					"efforts": [
+						"low",
+						"high",
+						"max"
+					]
 				}
 			},
 			{
@@ -16405,7 +16417,7 @@
 			{
 				"id": "firepass",
 				"apiKeyFormat": "bearer",
-				"name": "Fire Pass (Fireworks Kimi K2.6 Turbo subscription)",
+				"name": "Fire Pass (Fireworks subscription)",
 				"login": {
 					"kind": "api-key",
 					"authUrl": "https://app.fireworks.ai/settings/users/api-keys",
@@ -16416,7 +16428,7 @@
 						"kind": "chat-completions",
 						"label": "Fire Pass",
 						"baseUrl": "https://api.fireworks.ai/inference/v1",
-						"model": "accounts/fireworks/routers/kimi-k2p6-turbo"
+						"model": "accounts/fireworks/routers/glm-5p2-fast"
 					}
 				}
 			},

--- a/packages/catalog/src/compat/rules/auth/firepass.kdl
+++ b/packages/catalog/src/compat/rules/auth/firepass.kdl
@@ -1,14 +1,13 @@
 auth "firepass" {
-	name "Fire Pass (Fireworks Kimi K2.6 Turbo subscription)"
+	name "Fire Pass (Fireworks subscription)"
 	login "api-key" {
 		// Fire Pass is a Fireworks subscription product whose dedicated `fpk_…` API
-		// keys are scoped to the `accounts/fireworks/routers/kimi-k2p6-turbo` router
-		// (Kimi K2.6 Turbo). The key does NOT authorize `/v1/models`, so validation
-		// pings the chat completions endpoint with the router id directly.
+		// keys are scoped to router endpoints. The key does NOT authorize `/v1/models`,
+		// so validation pings the chat completions endpoint with the router id directly.
 		// See https://docs.fireworks.ai/firepass.
 		auth-url "https://app.fireworks.ai/settings/users/api-keys"
 		instructions "Create a dedicated Fire Pass API key in the Fireworks dashboard"
 		prompt "Paste your Fire Pass API key" placeholder="fpk_..."
-		validate "chat-completions" label="Fire Pass" base-url="https://api.fireworks.ai/inference/v1" model="accounts/fireworks/routers/kimi-k2p6-turbo"
+		validate "chat-completions" label="Fire Pass" base-url="https://api.fireworks.ai/inference/v1" model="accounts/fireworks/routers/glm-5p2-fast"
 	}
 }

--- a/packages/catalog/src/compat/rules/providers/firepass.kdl
+++ b/packages/catalog/src/compat/rules/providers/firepass.kdl
@@ -7,9 +7,13 @@ provider "firepass" {
 	}
 	// Replaces the Fire Pass wire-model-id dispatch baseline.
 	wire-model-id-mode "firepass"
-	// residue: taxonomy ranks and exact globs do not isolate these models.
-	models "kimi-k2.6-turbo" {
-		thinking-efforts "low" "medium" "high" "xhigh" "max"
+	class "glm" priority=1 {
 		thinking-mode "effort"
+		thinking-efforts "minimal" "low" "medium" "high" "max"
+	}
+
+	class "kimi" priority=1 {
+		thinking-mode "effort"
+		thinking-efforts "low" "high" "max"
 	}
 }

--- a/packages/catalog/src/fireworks-model-id.ts
+++ b/packages/catalog/src/fireworks-model-id.ts
@@ -14,10 +14,10 @@ export function toFireworksWireModelId(modelId: string): string {
 }
 
 /**
- * Fire Pass exposes its Kimi K2.6 Turbo subscription through a dedicated router
- * endpoint at `accounts/fireworks/routers/<id>` rather than the `models/` namespace.
- * We keep a friendly public id (e.g. `kimi-k2.6-turbo`) in the catalog and translate
- * to the wire form (`accounts/fireworks/routers/kimi-k2p6-turbo`) at request time.
+ * Fire Pass exposes subscription models through dedicated router endpoints
+ * at `accounts/fireworks/routers/<id>` rather than the `models/` namespace.
+ * We keep a friendly public id (e.g. `glm-5.2-fast`, `kimi-k3-fast`) in the catalog
+ * and translate to the wire form (`accounts/fireworks/routers/glm-5p2-fast`) at request time.
  */
 export function toFirepassPublicModelId(modelId: string): string {
 	const stripped = modelId.startsWith(FIREPASS_WIRE_PREFIX) ? modelId.slice(FIREPASS_WIRE_PREFIX.length) : modelId;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -70726,41 +70726,44 @@
 		}
 	},
 	"firepass": {
-		"kimi-k2.6-turbo": {
-			"id": "kimi-k2.6-turbo",
-			"name": "Kimi K2.6 Turbo (Fire Pass)",
+		"glm-5.2-fast": {
+			"id": "glm-5.2-fast",
+			"name": "GLM 5.2 Fast (Fire Pass)",
 			"api": "openai-completions",
 			"provider": "firepass",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.1,
+				"output": 6.6,
+				"cacheRead": 0.21,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high",
-					"xhigh",
 					"max"
-				]
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
 			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k2.6"
-			},
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -70770,6 +70773,105 @@
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
 				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "firepass",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"kimi-k3-fast": {
+			"id": "kimi-k3-fast",
+			"name": "Kimi K3 Fast (Fire Pass)",
+			"api": "openai-completions",
+			"provider": "firepass",
+			"baseUrl": "https://api.fireworks.ai/inference/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.5,
+				"output": 22.5,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "kimi",
+				"family": "k3"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {
+					"minimal": "low",
+					"medium": "high",
+					"xhigh": "max",
+					"max": "max"
+				},
 				"supportsUsageInStreaming": true,
 				"alwaysSendMaxTokens": true,
 				"disableReasoningOnForcedToolChoice": true,
@@ -70802,9 +70904,8 @@
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
 				"toolSchemaFlavor": "moonshot-mfjs",
-				"streamIdleTimeoutMs": 300000,
 				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "kimi",
+				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false,
@@ -70816,8 +70917,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		}
 	},
 	"fireworks": {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -196,7 +196,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "firepass",
-		defaultModel: "kimi-k2.6-turbo",
+		defaultModel: "glm-5.2-fast",
 		envVars: ["FIREPASS_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => firepassModelManagerOptions(config),
 	},

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2432,8 +2432,39 @@ export function fireworksModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
-// 7.6 Fire Pass (Fireworks Kimi K2.6 Turbo subscription)
+// 7.6 Fire Pass (Fireworks subscription)
 // ---------------------------------------------------------------------------
+
+// Pricing and limits are the published Fire Pass router tariff
+// (https://docs.fireworks.ai/firepass), not upstream-discoverable: dedicated
+// `fpk_…` keys never authorize `/v1/models`, so this seed is the authoritative
+// source. cacheRead is 0.1x input; cacheWrite stays 0 (not billed separately).
+export const FIREPASS_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "glm-5.2-fast",
+		name: "GLM 5.2 Fast (Fire Pass)",
+		api: "openai-completions",
+		provider: "firepass",
+		baseUrl: "https://api.fireworks.ai/inference/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 2.1, output: 6.6, cacheRead: 0.21, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+	},
+	{
+		id: "kimi-k3-fast",
+		name: "Kimi K3 Fast (Fire Pass)",
+		api: "openai-completions",
+		provider: "firepass",
+		baseUrl: "https://api.fireworks.ai/inference/v1",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 4.5, output: 22.5, cacheRead: 0.45, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+	},
+];
 
 export interface FirepassModelManagerConfig {
 	apiKey?: string;
@@ -2442,8 +2473,8 @@ export interface FirepassModelManagerConfig {
 }
 
 /**
- * Fire Pass is a Fireworks subscription product that exposes a single router
- * model (Kimi K2.6 Turbo) under `accounts/fireworks/routers/kimi-k2p6-turbo`.
+ * Fire Pass is a Fireworks subscription product that exposes router models
+ * (GLM 5.2 Fast, Kimi K3 Fast) under `accounts/fireworks/routers/<id>`.
  * The dedicated `fpk_…` keys do not authorize `/v1/models`, so this manager
  * never performs dynamic discovery — the bundled catalog entry is canonical.
  * See https://docs.fireworks.ai/firepass.

--- a/packages/catalog/test/issue-1849-repro.test.ts
+++ b/packages/catalog/test/issue-1849-repro.test.ts
@@ -65,9 +65,8 @@ describe("Fireworks Kimi K2 maxTokens cap (#1849)", () => {
 		expect(clampFireworksKimiMaxTokens("glm-5.1", 65_536)).toBe(65_536);
 	});
 
-	it("ships the capped maxTokens in the bundled Fireworks/Fire Pass catalog", () => {
-		const entries: Array<["fireworks" | "firepass", string]> = [
-			["firepass", "kimi-k2.6-turbo"],
+	it("ships the capped maxTokens in the bundled Fireworks catalog", () => {
+		const entries: Array<["fireworks", string]> = [
 			["fireworks", "kimi-k2.5"],
 			["fireworks", "kimi-k2.6"],
 		];


### PR DESCRIPTION
## Summary

current codebase fails on login with firepass - model used for check is missing
updated to according to their docs
tested login on compiled version

## Why

- **Problem**: Running `/login firepass` failed with HTTP 404 (`Model not found, inaccessible, and/or not deployed`) because the login validation probe tested `accounts/fireworks/routers/kimi-k2p6-turbo`, which Fireworks has decommissioned from Fire Pass subscriptions. Additionally, the bundled catalog only offered `kimi-k2.6-turbo`.
- **Mechanism**: Fireworks Fire Pass subscription keys (`fpk_...`) only authorize `/v1/chat/completions` against active Fire Pass router models (`glm-5.2-fast` and `kimi-k3-fast`) and return 403 on `/v1/models` and 404 on the decommissioned `kimi-k2p6-turbo` router.
- **Fix**: Update the login validation probe to `accounts/fireworks/routers/glm-5p2-fast`, replace `kimi-k2.6-turbo` in the bundled catalog with `glm-5.2-fast` and `kimi-k3-fast` (defaulting to `glm-5.2-fast`), add thinking effort definitions, and recompile compatibility rules.

## Verification

- [x] Automated test updated: `packages/ai/test/firepass.test.ts`
- [x] Verified reproduction scenario:
  ```bash
  bun test packages/ai/test/firepass.test.ts packages/catalog/test/issue-1849-repro.test.ts
  ```
- [x] `bun check` passes with zero type or formatting errors
- [x] Test suite passes: `bun test packages/ai/test/firepass.test.ts`
