### PR TITLE
fix(agent): guard gradient palette against uninitialized global theme

### DIFF
--- a/packages/coding-agent/src/modes/gradient-highlight.ts
+++ b/packages/coding-agent/src/modes/gradient-highlight.ts
@@ -44,7 +44,9 @@ export function createGradientHighlighter(spec: GradientHighlightSpec): KeywordH
 
 	/** Gradient foreground escapes for the active color mode, compiled once per mode. */
 	const palette = (): readonly string[] => {
-		const mode = theme.getColorMode();
+		// The global theme may be undefined on pre-init or cross-module-instance
+		// renders (see #2998); fall back to truecolor so the gradient still paints.
+		const mode = typeof theme === "undefined" ? "truecolor" : theme.getColorMode();
 		if (cachedPalette && cachedMode === mode) return cachedPalette;
 		const format = mode === "truecolor" ? "ansi-16m" : "ansi-256";
 		const next: string[] = [];


### PR DESCRIPTION
## What

One-line guard in `palette()` (`packages/coding-agent/src/modes/gradient-highlight.ts`): `typeof theme === "undefined" ? "truecolor" : theme.getColorMode()`. I reviewed the full diff; this change stops magic-keyword renders from throwing when the global theme singleton isn't initialized yet, by falling back to the truecolor palette instead of dereferencing `undefined`.

## Why

Fixes #10864. Crash chain: `palette()` read `theme.getColorMode()` at `:47` with no guard → reached via `highlightMagicKeywords` (`magic-keywords.ts:23-25`) ← `custom-editor.ts:619` `decorateText`, which runs on **every** editor render while the buffer contains `ultrathink`/`orchestrate`/`workflowz` as standalone prose. The module-global `theme` (`theme.ts:82`) is unassigned until `initTheme()`/`initThemeSync()` runs, so any such render in the pre-init window (resume replay, second module instance via `src` exports) throws `undefined is not an object (evaluating 'theme.getColorMode')`.

The fix mirrors the existing `fgOrPlain` (`theme.ts:91`) and `getSymbolTheme` (`tui-adapters.ts:122-126`, see #2998) precedents. One closure-level guard covers all three keywords (`ultrathink`/`orchestrate`/`workflowz`) and every render path through the highlighters, including resume replay (`user-message.ts:58/62`); the plugin frame in the reporter's trace is innocent (it only forwards to `base.render(width)`).

## Testing

- Throwaway `bun` smoke: reproduces the throw pre-fix at `:94` path (`theme` undefined + magic keyword in buffer), passes post-fix with the truecolor gradient painted.
- `oxfmt`/`oxlint` clean on the touched file.
- No other files touched; memoization and the truecolor→`ansi-16m`/else→`ansi-256` branch structure are unchanged.

---

- [x] `bun check` passes
- [ ] Tested locally
- [x] CHANGELOG updated (if user-facing)
