### PR TITLE
extensions: add trustedExtensions setting and mutation-target fields

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -133,12 +133,18 @@ See [providers](./providers.md) and [models](./models.md) for model resolution.
 | --- | --- |
 | `--extension <path>`, `-e <path>` | Load an extension (repeatable). See [extensions](./extensions.md). |
 | `--hook <path>` | Load a hook/extension file (repeatable). See [hooks](./hooks.md). |
-| `--trusted-extension <abs-path>` | Load a trusted extension from an absolute path (repeatable; cannot be combined with `--extension`/`-e`/`--hook`). |
+| `--trusted-extension <abs-path>` | Load a trusted extension from an absolute path (repeatable; cannot be combined with `--extension`/`-e`/`--hook`). Exact allowlist: discovery is off, the path is canonicalized, a missing path aborts startup, and restricted subagents rebind these modules' event handlers. Overrides the `trustedExtensions` setting for this launch. |
 | `--plugin-dir <dir>` | Add a local plugin directory to discovery (repeatable). |
 | `--no-extensions` | Disable extension discovery (explicit `-e` paths still work). |
 | `--skills <globs>` | Comma-separated glob patterns to filter [skills](./skills.md) (e.g. `git-*,docker`). |
 | `--no-skills` | Disable skills discovery and loading. |
 | `--no-rules` | Disable rules discovery and loading. See [context files](./context-files.md). |
+
+Trusted extensions also have a persistent form: the `trustedExtensions` setting
+in `config.yml`. Those paths load through normal merged discovery, survive
+`--no-extensions`, abort startup when missing or broken, and keep running inside
+restricted subagents. `--trusted-extension` wins when both are set. See
+[extension loading](./extension-loading.md#trusted-extensions).
 
 #### System prompt
 

--- a/docs/extension-loading.md
+++ b/docs/extension-loading.md
@@ -63,7 +63,8 @@ After plugin extension entries, configured paths are appended and resolved.
 Configured path sources in the main session startup path (`sdk.ts`):
 
 1. CLI-provided paths (`--extension/-e`, and `--hook` is also treated as an extension path)
-2. Merged settings `extensions` array
+2. Trusted paths — `--trusted-extension`, or the `trustedExtensions` setting (see [Trusted extensions](#trusted-extensions))
+3. Merged settings `extensions` array
 
 Settings files:
 
@@ -115,6 +116,10 @@ it is not a whole-process capability-isolation switch. Skills, MCP servers,
 tools, prompts, and rules owned by other discovery subsystems retain their own
 enable/disable controls.
 
+Trusted paths are the exception: `--trusted-extension` and the
+`trustedExtensions` setting both keep loading under `--no-extensions`. See
+[Trusted extensions](#trusted-extensions).
+
 ### Disable specific extension modules
 
 `disabledExtensions` setting filters by extension id format:
@@ -150,6 +155,92 @@ disabledExtensions:
 The id carries no directory and no depth, so a `project` entry disables files of
 that name at every depth the discovery walk reaches. See
 [Context files](./context-files.md#disabling-a-single-context-file).
+
+---
+
+## Trusted extensions
+
+A trusted extension keeps running where ordinary extensions are cut off: inside
+restricted subagents (`task` children with a tool allowlist), which otherwise
+load no extension at all. This is the mechanism for mandatory policy — a gate a
+subagent cannot switch off.
+
+| Form | Discovery | Lifetime |
+| --- | --- | --- |
+| `--trusted-extension <abs-path>` (repeatable) | disabled; the listed paths are the entire extension set | that launch |
+| `trustedExtensions: [...]` in the user `config.yml` | normal merged discovery, plus these paths | every session started from that config |
+
+The flag wins. When both are present the setting is ignored for that launch, so
+a narrowed launch is always available.
+
+### Scope: user-level only
+
+The setting is read from the user-level layers alone — the active agent
+directory's `config.yml`, a `--config` overlay, and runtime overrides. A
+project settings file cannot set it. Entries in one (`<cwd>/.omp/config.yml`,
+`<cwd>/.omp/settings.json`, `.claude/settings.json`, or any other project-level
+provider) are dropped as that file loads, and the log records one warning
+naming the file and the dropped entries.
+
+Without that rule, checking out a repository would nominate a module that binds
+in every restricted subagent and that the policy it enforces cannot switch off.
+The ordinary `extensions` setting stays project-settable, because those modules
+load only in the top-level session, where a trusted handler still sees their
+tool calls.
+
+### Settings form
+
+Entries are normalized like configured `extensions` paths (tilde expansion,
+cwd-relative resolution, `local://` rejected), then required to be an existing
+file. They are added to the session's configured path list, so at top level the
+module loads through ordinary discovery and receives the full extension API —
+tools, commands, providers, everything a normal extension can register.
+
+`--no-extensions` does not drop them. A policy module the operator configured
+must survive a narrowed launch, so the settings form never turns discovery off
+and never removes itself from the load list.
+
+Name the same path discovery would find. A configured path and an
+auto-discovered path that differ only by a symlink hop are two entries to the
+de-duplicator, and the module then binds twice — the same caveat that applies to
+the ordinary `extensions` setting.
+
+### Restricted children
+
+A restricted child session receives only `trustedExtensionPaths` (never the
+parent's `Extension` instances, prepared factories, or ordinary paths) and
+rebinds each module from source through `loadTrustedExtensionHandlers`. Those
+factories run against a handler-only API: `api.on(...)` subscribes as usual and
+every registration call is a no-op, so a trusted module can observe and block
+tool calls in the child without widening its tool, command, or provider
+surface. Each child runs the factory itself, so policy state is per session.
+
+Two groups of members stay live, because they grant nothing and a handler needs
+them: `api.logger`, and the schema builders `api.typebox`, `api.arktype`,
+`api.zod`. A policy module that reports its own failure through `api.logger`
+would otherwise throw inside its own catch block. A handler throw is reported
+as `{ block: true }`, so the module's fail-open path would block every tool
+call instead.
+
+A forwarded list wins, and a restricted session created without one still
+resolves the `trustedExtensions` setting itself. "Restricted" is not
+"trusts nothing": a cold-revived parked subagent, a security scan, an agentic
+commit, and a compression pass are all created restricted with no forwarded
+list, and each must bind the operator's policy. A `--trusted-extension` launch
+has no setting to fall back on, so every session that forks or spawns from it
+forwards the resolved list explicitly.
+
+### Fail closed
+
+Ordinary extension load errors stay non-fatal notifications. Trusted paths do
+not: startup aborts when a trusted path is missing, is not a file, uses the
+`local://` scheme, fails to import, or its factory throws. The error names the
+path and the recovery — `Fix or remove the --trusted-extension path and
+restart.` for the flag, `Fix or remove the trustedExtensions setting entry and
+restart.` for the setting.
+
+A trusted module that quietly failed to load would leave the session running
+with its policy absent, which is worse than a session that refuses to start.
 
 ---
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -849,6 +849,12 @@ export interface AgentTool<
 	matcherPaths?: (args: unknown) => readonly string[] | undefined;
 
 	/**
+	 * Surface mutation targets parsed from a (possibly partial) call. Unlike
+	 * matcherPaths, this includes both sides of file moves and renames.
+	 */
+	mutationPaths?: (args: Partial<Static<TParameters>>) => readonly string[] | undefined;
+
+	/**
 	 * Per-file projection of a (potentially partial) streamed call, pairing each
 	 * touched file path with the digest of only the lines added to that file.
 	 * Path-scoped stream matchers (TTSR) evaluate each entry in isolation, so a

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
 - Added the `trustedExtensions` setting: user-level trusted extension paths load through normal discovery, survive `--no-extensions`, keep running inside restricted subagents, and abort startup when missing or broken.
+- Tool events for `write`, `edit`, `apply_patch`, `ast_edit`, and `lsp` now carry `plannedMutationPaths` in the call input and `changedPaths` in the result details, so extensions gate the paths the tools resolve instead of projecting them.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
+- Added the `trustedExtensions` setting: user-level trusted extension paths load through normal discovery, survive `--no-extensions`, keep running inside restricted subagents, and abort startup when missing or broken.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -599,6 +599,13 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	extensions: { type: "array", default: EMPTY_STRING_ARRAY },
+	/**
+	 * Extension modules that also bind their event handlers inside restricted
+	 * subagents, and whose absence fails startup. They load through ordinary
+	 * discovery too, so `--no-extensions` does not drop them. `--trusted-extension`
+	 * overrides this list for that launch. See docs/extension-loading.md.
+	 */
+	trustedExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
 	enabledModels: { type: "array", default: EMPTY_STRING_ARRAY },
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -238,6 +238,29 @@ export function dropSettingsGroupShadows(data: RawSettings, sourcePath: string, 
 	return result;
 }
 
+/**
+ * Drop `trustedExtensions` from a project settings file, naming the file and
+ * the dropped entries.
+ *
+ * A trusted extension rebinds inside every restricted subagent and its
+ * handlers cannot be blocked by the policy they enforce, so nominating one
+ * stays with the launch operator: only the user-level layers (the agent
+ * directory's `config.yml`, a `--config` overlay, a runtime override) may set
+ * it. Checking out a repository must not hand its `.omp/config.yml` — or a
+ * `.claude/settings.json` written for another tool — that authority. The
+ * ordinary `extensions` setting stays project-settable; it reaches only the
+ * top-level session, where a trusted policy handler still sees its tool calls.
+ */
+export function dropProjectTrustedExtensions(data: RawSettings, sourcePath: string): RawSettings {
+	if (!Object.hasOwn(data, "trustedExtensions")) return data;
+	const { trustedExtensions: ignored, ...kept } = data;
+	logger.warn("Settings: ignoring project-level trustedExtensions; only user-level config may nominate one", {
+		source: sourcePath,
+		entries: ignored,
+	});
+	return kept;
+}
+
 export function normalizeProviderMaxInFlightRequests(value: unknown): Record<string, number> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 	const normalized: Record<string, number> = {};
@@ -1816,6 +1839,7 @@ export class Settings {
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level === "project") {
 					merged = this.#deepMerge(merged, dropSettingsGroupShadows(item.data as RawSettings, item.path));
+					merged = dropProjectTrustedExtensions(merged, item.path);
 					if (Object.hasOwn(item.data, "shellPath")) shellPathSource = item.path;
 				}
 			}

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -9,7 +9,7 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
-import type { ToolExample } from "@oh-my-pi/pi-ai";
+import type { Static, ToolExample } from "@oh-my-pi/pi-ai";
 import {
 	EditSession,
 	editDescription,
@@ -49,7 +49,7 @@ import {
 	invalidateFsScanAfterWrite,
 } from "../tools/fs-cache-invalidation";
 import { outputMeta } from "../tools/output-meta";
-import { resolveFileWriteApprovalTier } from "../tools/path-utils";
+import { normalizeMutationPaths, resolveFileWriteApprovalTier } from "../tools/path-utils";
 import { planLocalProtocolOptions } from "../tools/plan-mode-guard";
 import { ToolError } from "../tools/tool-errors";
 import { type EditMode, normalizeEditMode, resolveEditMode } from "../utils/edit-mode";
@@ -227,8 +227,13 @@ function toPerFileResult(file: EditFileOutcome, mode: EditMode): EditToolPerFile
 	};
 }
 
-function aggregateDetails(files: readonly EditFileOutcome[], mode: EditMode): EditToolDetails | undefined {
+function aggregateDetails(files: readonly EditFileOutcome[], mode: EditMode, cwd: string): EditToolDetails | undefined {
 	if (files.length === 0) return undefined;
+	// The engine reports one outcome per file it wrote; a move names both sides.
+	const changedPaths = normalizeMutationPaths(
+		files.flatMap(file => (file.moveTo ? [file.path, file.moveTo] : [file.path])),
+		cwd,
+	);
 	const perFileResults = files.map(file => toPerFileResult(file, mode));
 	if (perFileResults.length === 1) {
 		const [file] = perFileResults;
@@ -243,6 +248,7 @@ function aggregateDetails(files: readonly EditFileOutcome[], mode: EditMode): Ed
 			oldText: file.oldText,
 			newText: file.newText,
 			snapshotsPruned: file.snapshotsPruned,
+			changedPaths,
 			meta: file.meta,
 		};
 	}
@@ -252,6 +258,7 @@ function aggregateDetails(files: readonly EditFileOutcome[], mode: EditMode): Ed
 			.filter(Boolean)
 			.join("\n"),
 		firstChangedLine: perFileResults.find(file => file.firstChangedLine !== undefined)?.firstChangedLine,
+		changedPaths,
 		perFileResults: capPerFileSnapshots(perFileResults),
 	};
 }
@@ -398,6 +405,15 @@ export class EditTool implements AgentTool<TInput> {
 		return entries.length > 0 ? entries : undefined;
 	}
 
+	mutationPaths(args: Partial<Static<TInput>>): readonly string[] | undefined {
+		const inspection = this.#inspect(args);
+		const paths = [
+			...inspection.paths,
+			...inspection.fileOps.flatMap(fileOp => (fileOp.to ? [fileOp.path, fileOp.to] : [fileOp.path])),
+		];
+		return paths.length > 0 ? paths : undefined;
+	}
+
 	openArgStream(init: AgentToolArgStreamInit): AgentToolArgStream {
 		const existing = this.#sessions.get(init.toolCallId);
 		if (existing) existing.close();
@@ -466,7 +482,7 @@ export class EditTool implements AgentTool<TInput> {
 			return { content: [{ type: "text", text: outcome.text }], isError: true };
 		}
 
-		const details = aggregateDetails(outcome.files, this.mode);
+		const details = aggregateDetails(outcome.files, this.mode, this.session.cwd);
 		const result: AgentToolResult<EditToolDetails, TInput> = {
 			content: [{ type: "text", text: outcome.text }],
 			...(details ? { details } : {}),

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -112,6 +112,8 @@ export interface EditToolDetails {
 	snapshotsPruned?: boolean;
 	/** Pre-move source path; set only when the edit moved/renamed the file. The header renders `sourcePath → path`. */
 	sourcePath?: string;
+	/** Absolute normalized targets the edit engine wrote; a move names both sides. */
+	changedPaths?: string[];
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -10,7 +10,11 @@ export {
 	ExtensionRuntimeNotInitializedError,
 	loadExtensionFromFactory,
 	loadExtensions,
+	loadTrustedExtensionHandlers,
+	resolveTrustedExtensionPath,
+	TRUSTED_EXTENSION_RECOVERY,
 } from "./loader";
+export type { TrustedExtensionSource } from "./loader";
 export * from "./runner";
 // Type guards
 export * from "./types";

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -1,7 +1,7 @@
 /**
  * Extension loader - loads TypeScript extension modules using native Bun import.
  */
-import type * as fs1 from "node:fs";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
@@ -401,12 +401,46 @@ async function importExtensionModule(extensionPath: string, cwd: string): Promis
 	}
 }
 
+/**
+ * Bind a trusted extension to a restricted session without granting its
+ * registration or runtime API. Only event subscriptions remain live.
+ */
+const handlerOnlyNoop = (): undefined => undefined;
+
+function handlerOnlyExtensionApi(api: ExtensionAPI): ExtensionAPI {
+	const subscribe = api.on.bind(api);
+	return new Proxy(api, {
+		get(target, property) {
+			// The logger and the schema builders grant a handler nothing and a
+			// handler needs them: stubbing `api.logger` makes an ordinary
+			// `api.logger.warn(...)` inside a policy module's own catch block
+			// throw, and the runner reports a handler throw as `{ block: true }`
+			// — so a module that meant to fail open blocks every tool call.
+			switch (property) {
+				case "on":
+					return subscribe;
+				case "logger":
+					return target.logger;
+				case "typebox":
+					return target.typebox;
+				case "arktype":
+					return target.arktype;
+				case "zod":
+					return target.zod;
+				default:
+					return handlerOnlyNoop;
+			}
+		},
+	});
+}
+
 async function bindExtension(
 	extensionPath: string,
 	imported: PreparedExtension,
 	cwd: string,
 	eventBus: EventBus,
 	runtime: IExtensionRuntime,
+	handlersOnly = false,
 ): Promise<{ extension: Extension | null; error: string | null }> {
 	const factory = imported.factory;
 	if (imported.error !== null || factory === null) {
@@ -415,7 +449,9 @@ async function bindExtension(
 	try {
 		const extension = createExtension(extensionPath, imported.resolvedPath);
 		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
-		await withHostGuard(() => runExtensionFactory(factory, api, runtime));
+		await withHostGuard(() =>
+			runExtensionFactory(factory, handlersOnly ? handlerOnlyExtensionApi(api) : api, runtime),
+		);
 
 		return { extension, error: null };
 	} catch (err) {
@@ -453,11 +489,67 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	return bindPreparedExtensions(preparedExtensions, cwd, eventBus);
 }
 
+/**
+ * Load trusted extension modules for a restricted session. Factories are run
+ * for each session, but only their event subscriptions can affect that session.
+ */
+export async function loadTrustedExtensionHandlers(
+	paths: readonly string[],
+	cwd: string,
+	eventBus?: EventBus,
+): Promise<LoadExtensionsResult> {
+	const preparedExtensions = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd)));
+	return bindPreparedExtensions(preparedExtensions, cwd, eventBus, true);
+}
+
+/** Where a trusted extension path came from. Picks the operator recovery line. */
+export type TrustedExtensionSource = "cli" | "settings";
+
+/** Operator instruction appended to every trusted-extension startup failure. */
+export const TRUSTED_EXTENSION_RECOVERY = {
+	cli: "Fix or remove the --trusted-extension path and restart.",
+	settings: "Fix or remove the trustedExtensions setting entry and restart.",
+} satisfies Record<TrustedExtensionSource, string>;
+
+/**
+ * Resolve one trusted extension path and prove it is a module file that exists
+ * now. A trusted path carries policy a restricted subagent cannot switch off,
+ * so a missing or non-file entry stops startup instead of loading nothing.
+ *
+ * `cli` paths are canonicalized through `realpath`: `--trusted-extension`
+ * disables discovery, so the resolved list is the whole allowlist and
+ * retargeting a symlink after the check must not widen it. `settings` paths
+ * keep their configured spelling because they also load through ordinary
+ * discovery, which dedupes by resolved path.
+ */
+export function resolveTrustedExtensionPath(rawPath: string, cwd: string, source: TrustedExtensionSource): string {
+	const recovery = TRUSTED_EXTENSION_RECOVERY[source];
+	let expanded: string;
+	try {
+		expanded = resolvePath(rawPath, cwd);
+	} catch (error) {
+		throw new Error(`${error instanceof Error ? error.message : String(error)} ${recovery}`);
+	}
+	let candidate = expanded;
+	let stat: fsSync.Stats;
+	try {
+		if (source === "cli") candidate = fsSync.realpathSync.native(expanded);
+		stat = fsSync.statSync(candidate);
+	} catch {
+		throw new Error(`Trusted extension must be an existing module file: ${rawPath}. ${recovery}`);
+	}
+	if (!stat.isFile()) {
+		throw new Error(`Trusted extension must be a module file, not a directory: ${rawPath}. ${recovery}`);
+	}
+	return candidate;
+}
+
 /** Bind previously imported extension factories to a fresh session runtime. */
 export async function bindPreparedExtensions(
 	preparedExtensions: readonly PreparedExtension[],
 	cwd: string,
 	eventBus?: EventBus,
+	handlersOnly = false,
 ): Promise<LoadExtensionsResult> {
 	const extensions: Extension[] = [];
 	const errors: Array<{ path: string; error: string }> = [];
@@ -465,7 +557,14 @@ export async function bindPreparedExtensions(
 	const runtime = new ExtensionRuntime();
 
 	for (const prepared of preparedExtensions) {
-		const { extension, error } = await bindExtension(prepared.path, prepared, cwd, resolvedEventBus, runtime);
+		const { extension, error } = await bindExtension(
+			prepared.path,
+			prepared,
+			cwd,
+			resolvedEventBus,
+			runtime,
+			handlersOnly,
+		);
 
 		if (error) {
 			errors.push({ path: prepared.path, error });
@@ -581,7 +680,7 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 	}
 
 	// Otherwise, discover extensions from directory contents
-	let entries: fs1.Dirent[];
+	let entries: fsSync.Dirent[];
 	try {
 		entries = await fs.readdir(dir, { withFileTypes: true });
 	} catch (err) {
@@ -612,7 +711,7 @@ async function discoverHooksInPackageRoot(root: string): Promise<string[]> {
 	const hooks: string[] = [];
 	for (const hookType of ["pre", "post"]) {
 		const hookDir = path.join(root, "hooks", hookType);
-		let entries: fs1.Dirent[];
+		let entries: fsSync.Dirent[];
 		try {
 			entries = await fs.readdir(hookDir, { withFileTypes: true });
 		} catch (err) {
@@ -718,7 +817,7 @@ export async function discoverExtensionPaths(
 	for (const configuredPath of configuredPaths) {
 		const resolved = resolvePath(configuredPath, cwd);
 
-		let stat: fs1.Stats | null = null;
+		let stat: fsSync.Stats | null = null;
 		try {
 			stat = await fs.stat(resolved);
 		} catch (err) {

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -21,7 +21,7 @@ import {
 } from "../../tools/approval";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { withFileMutationSession } from "../../tools/file-write-fallback";
-import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
+import { normalizeToolEventInputForTool, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
 import type { ExtensionRunner } from "./runner";
 import type { RegisteredTool, ToolCallEventResult } from "./types";
@@ -215,9 +215,10 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 						type: "tool_call",
 						toolName: this.tool.name,
 						toolCallId,
-						input: normalizeToolEventInput(
-							this.tool.name,
+						input: normalizeToolEventInputForTool(
+							this.tool,
 							resolveToolEventInput(this.tool, toolEventArgs(params, context)),
+							this.runner.cwd,
 						),
 					},
 					signal,
@@ -374,9 +375,10 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				type: "tool_result",
 				toolName: this.tool.name,
 				toolCallId,
-				input: normalizeToolEventInput(
-					this.tool.name,
+				input: normalizeToolEventInputForTool(
+					this.tool,
 					resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
+					this.runner.cwd,
 				),
 				content: result.content,
 				details: result.details,

--- a/packages/coding-agent/src/extensibility/hooks/runner.ts
+++ b/packages/coding-agent/src/extensibility/hooks/runner.ts
@@ -68,6 +68,10 @@ export class HookRunner {
 		this.#hasUI = false;
 	}
 
+	getCwd(): string {
+		return this.cwd;
+	}
+
 	/**
 	 * Initialize HookRunner with all required context.
 	 * Modes call this once the agent session is fully set up.

--- a/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
@@ -3,7 +3,7 @@
  */
 import type { AgentTool, AgentToolContext, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Static, TSchema } from "@oh-my-pi/pi-ai";
-import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
+import { normalizeToolEventInputForTool, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
 import type { HookRunner } from "./runner";
 import type { ToolCallEventResult, ToolResultEventResult } from "./types";
@@ -49,9 +49,10 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_call",
 					toolName: this.tool.name,
 					toolCallId,
-					input: normalizeToolEventInput(
-						this.tool.name,
+					input: normalizeToolEventInputForTool(
+						this.tool,
 						resolveToolEventInput(this.tool, params as Record<string, unknown>),
+						this.hookRunner.getCwd(),
 					),
 				})) as ToolCallEventResult | undefined;
 
@@ -84,9 +85,10 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_result",
 					toolName: this.tool.name,
 					toolCallId,
-					input: normalizeToolEventInput(
-						this.tool.name,
+					input: normalizeToolEventInputForTool(
+						this.tool,
 						resolveToolEventInput(this.tool, effectiveParams as Record<string, unknown>),
+						this.hookRunner.getCwd(),
 					),
 					content: result.content,
 					details: result.details,
@@ -110,9 +112,10 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_result",
 					toolName: this.tool.name,
 					toolCallId,
-					input: normalizeToolEventInput(
-						this.tool.name,
+					input: normalizeToolEventInputForTool(
+						this.tool,
 						resolveToolEventInput(this.tool, effectiveParams as Record<string, unknown>),
+						this.hookRunner.getCwd(),
 					),
 					content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
 					details: undefined,

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -1,34 +1,47 @@
+import { type } from "@oh-my-pi/omptype";
 import { HL_FILE_PREFIX, HL_FILE_SUFFIX } from "../tools/hashline-format";
+import { normalizeMutationPaths } from "../tools/path-utils";
 
 const LEGACY_HASHLINE_FILE_PREFIX = "¶";
 const HASHLINE_FILE_TAG_RE = /#[0-9a-fA-F]{4}$/u;
+const nonEmptyString = type("string > 0");
 
+/**
+ * A tool call's arguments as extensions and hooks observe them: the tool's own
+ * fields plus the path projection this module derives. Field values come from
+ * the model, so nothing here is trusted until a boundary parses it — the
+ * omptype guards below and each tool's own schema are those boundaries.
+ */
+export interface ToolEventInput extends Record<string, unknown> {}
+
+/** The tool surface this module reads: its name, its edit-payload resolver, and its mutation-target parser. */
 interface ToolEventInputResolver {
 	name: string;
 	resolveEventInput?: (input: string) => string;
+	/** A method, not a property, so a tool can declare its own parameter type. */
+	mutationPaths?(args: ToolEventInput): readonly string[] | undefined;
 }
 
+/** Tools whose calls write files, and therefore carry `plannedMutationPaths`. */
+const MUTATING_TOOL_NAMES = { ast_edit: true, edit: true, lsp: true, write: true } satisfies Record<string, true>;
+
 /** Resolves mode-specific textual tool input before extension/hook event normalization. */
-export function resolveToolEventInput(
-	tool: ToolEventInputResolver,
-	input: Record<string, unknown>,
-): Record<string, unknown> {
-	if (tool.name !== "edit" || typeof tool.resolveEventInput !== "function") return input;
+export function resolveToolEventInput(tool: ToolEventInputResolver, input: ToolEventInput): ToolEventInput {
+	if (tool.name !== "edit" || tool.resolveEventInput === undefined) return input;
 	let resolved = input;
 	for (const key of ["input", "_input"] as const) {
 		const value = stringField(resolved, key);
 		if (value === undefined) continue;
 		const nextValue = tool.resolveEventInput(value);
 		if (nextValue === value) continue;
-		if (resolved === input) resolved = { ...input };
-		resolved[key] = nextValue;
+		resolved = Object.assign({}, resolved, { [key]: nextValue });
 	}
 	return resolved;
 }
 
-function stringField(input: Record<string, unknown>, key: string): string | undefined {
-	const value = input[key];
-	return typeof value === "string" && value.length > 0 ? value : undefined;
+function stringField(input: ToolEventInput, key: string): string | undefined {
+	const value = nonEmptyString(Object.getOwnPropertyDescriptor(input, key)?.value);
+	return value instanceof type.errors ? undefined : value;
 }
 
 function normalizeHashlineHeaderPath(body: string): string | undefined {
@@ -67,8 +80,8 @@ function extractHashlinePaths(input: string): string[] {
 }
 
 /** Adds derived compatibility fields to tool event input without changing tool execution parameters. */
-export function normalizeToolEventInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
-	if (toolName !== "edit" || stringField(input, "path")) return input;
+export function normalizeToolEventInput(toolName: string, input: ToolEventInput): ToolEventInput {
+	if (toolName !== "edit" || stringField(input, "path") !== undefined) return input;
 
 	// Hashline edit mode: the only authoritative target list is the parsed
 	// `[PATH#TAG]` (or legacy `¶PATH#TAG`) headers inside the patch.
@@ -78,14 +91,44 @@ export function normalizeToolEventInput(toolName: string, input: Record<string, 
 	if (rawInput !== undefined) {
 		const hashlinePaths = extractHashlinePaths(rawInput);
 		if (hashlinePaths.length === 0) return input;
-		if (hashlinePaths.length === 1) return { ...input, path: hashlinePaths[0], paths: hashlinePaths };
-		return { ...input, paths: hashlinePaths };
+		return hashlinePaths.length === 1
+			? Object.assign({}, input, { path: hashlinePaths[0], paths: hashlinePaths })
+			: Object.assign({}, input, { paths: hashlinePaths });
 	}
 
 	// Replace/patch modes: `path` is the real parameter; some hosts forward
 	// it as `_path` after schema normalization, so propagate it for gates.
 	const directPath = stringField(input, "_path");
-	if (directPath) return { ...input, path: directPath };
+	return directPath === undefined ? input : Object.assign({}, input, { path: directPath });
+}
 
-	return input;
+/** The tool's own parsed targets, or `undefined` when its parser could not name them. */
+function parsedMutationPaths(tool: ToolEventInputResolver, input: ToolEventInput): readonly string[] {
+	try {
+		return tool.mutationPaths?.(input) ?? [];
+	} catch {
+		// A payload the parser rejects names no target; `[]` reports absence below.
+		return [];
+	}
+}
+
+/**
+ * Add the parser-derived mutation-target contract to an extension event input.
+ *
+ * `plannedMutationPaths` is attached only when the tool named at least one
+ * filesystem target. An empty list would assert that the call writes nothing,
+ * and every empty case here means the opposite — the parser could not tell
+ * (device URL, unparsable payload, whole-tree scope), so a gate must keep
+ * using its own bookkeeping.
+ */
+export function normalizeToolEventInputForTool(
+	tool: ToolEventInputResolver,
+	input: ToolEventInput,
+	cwd: string,
+): ToolEventInput {
+	const normalized = normalizeToolEventInput(tool.name, input);
+	if (!Object.hasOwn(MUTATING_TOOL_NAMES, tool.name)) return normalized;
+	const planned = normalizeMutationPaths(parsedMutationPaths(tool, normalized), cwd);
+	if (planned.length === 0) return normalized;
+	return Object.assign({}, normalized, { plannedMutationPaths: planned });
 }

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { isEnoent, logger, postmortem, ptree, stableStringifyJson, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../jsonrpc/message-framing";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
-import { applyWorkspaceEdit, type ExecutedWorkspaceChange } from "./edits";
+import { applyWorkspaceEdit, type ExecutedWorkspaceChange, type WorkspaceEditResult } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
 import { connectSharedLspTransport } from "./mux/daemon";
 import type {
@@ -595,15 +595,15 @@ async function reconcileExecutedChanges(
  * when the edit fails partway the already-executed prefix is still reconciled before the
  * error propagates so mutated files never keep stale overlays.
  */
-export async function applyWorkspaceEditWithLsp(
+export async function applyWorkspaceEditWithLspResult(
 	edit: WorkspaceEdit,
 	cwd: string,
 	signal?: AbortSignal,
-): Promise<string[]> {
+): Promise<WorkspaceEditResult> {
 	const executed: ExecutedWorkspaceChange[] = [];
-	let applied: string[];
+	let result: WorkspaceEditResult;
 	try {
-		({ applied } = await applyWorkspaceEdit(edit, cwd, change => executed.push(change)));
+		result = await applyWorkspaceEdit(edit, cwd, change => executed.push(change));
 	} catch (err) {
 		// Best-effort: overlays for the mutated prefix must not stay stale, but
 		// reconciliation problems must not mask the original apply failure.
@@ -617,7 +617,15 @@ export async function applyWorkspaceEditWithLsp(
 		throw err;
 	}
 	await reconcileExecutedChanges(executed, cwd, signal);
-	return applied;
+	return result;
+}
+
+export async function applyWorkspaceEditWithLsp(
+	edit: WorkspaceEdit,
+	cwd: string,
+	signal?: AbortSignal,
+): Promise<string[]> {
+	return (await applyWorkspaceEditWithLspResult(edit, cwd, signal)).applied;
 }
 
 interface DynamicCapabilityRegistration {

--- a/packages/coding-agent/src/lsp/edits.ts
+++ b/packages/coding-agent/src/lsp/edits.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEexist, isEnoent, logger } from "@oh-my-pi/pi-utils";
-import { formatPathRelativeToCwd } from "../tools/path-utils";
+import { formatPathRelativeToCwd, normalizeMutationPaths } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 import type {
 	CreateFile,
@@ -289,6 +289,38 @@ function planDocumentChanges(documentChanges: NonNullable<WorkspaceEdit["documen
 	return ops;
 }
 
+function mutationPathsForWorkspaceOps(ops: readonly WorkspaceEditOp[], cwd: string): string[] {
+	const paths: string[] = [];
+	for (const op of ops) {
+		if (op.kind === "rename") paths.push(uriToFile(op.oldUri), uriToFile(op.newUri));
+		else if (op.kind === "text") {
+			if (op.edits.length > 0) paths.push(uriToFile(op.uri));
+		} else paths.push(uriToFile(op.uri));
+	}
+	return normalizeMutationPaths(paths, cwd);
+}
+
+function mutationPathsForExecutedChanges(changes: readonly ExecutedWorkspaceChange[], cwd: string): string[] {
+	const paths: string[] = [];
+	for (const change of changes) {
+		if (change.kind === "rename") paths.push(uriToFile(change.oldUri), uriToFile(change.newUri));
+		else paths.push(uriToFile(change.uri));
+	}
+	return normalizeMutationPaths(paths, cwd);
+}
+
+/** Return the normalized filesystem targets declared by a workspace edit without applying it. */
+export function plannedWorkspaceEditPaths(edit: WorkspaceEdit, cwd: string): string[] {
+	if (edit.documentChanges) return mutationPathsForWorkspaceOps(planDocumentChanges(edit.documentChanges), cwd);
+	if (!edit.changes) return [];
+	return normalizeMutationPaths(
+		Object.entries(edit.changes)
+			.filter(([, textEdits]) => textEdits.length > 0)
+			.map(([uri]) => uriToFile(uri)),
+		cwd,
+	);
+}
+
 /** One filesystem mutation actually performed by {@link applyWorkspaceEdit}. */
 export type ExecutedWorkspaceChange =
 	| { kind: "edit"; uri: string }
@@ -301,6 +333,10 @@ export interface WorkspaceEditResult {
 	applied: string[];
 	/** Ops that mutated the filesystem — skipped `ignoreIfExists`/`ignoreIfNotExists` ops are excluded. */
 	executed: ExecutedWorkspaceChange[];
+	/** Absolute normalized targets declared by the workspace-edit parser. */
+	plannedMutationPaths: string[];
+	/** Absolute normalized targets whose operations actually ran. */
+	changedPaths: string[];
 }
 
 /**
@@ -320,6 +356,7 @@ export async function applyWorkspaceEdit(
 ): Promise<WorkspaceEditResult> {
 	const applied: string[] = [];
 	const executed: ExecutedWorkspaceChange[] = [];
+	let plannedMutationPaths: string[] = [];
 	const record = (change: ExecutedWorkspaceChange) => {
 		executed.push(change);
 		onExecuted?.(change);
@@ -327,6 +364,7 @@ export async function applyWorkspaceEdit(
 
 	if (edit.documentChanges) {
 		const ops = planDocumentChanges(edit.documentChanges);
+		plannedMutationPaths = mutationPathsForWorkspaceOps(ops, cwd);
 		for (const op of ops) {
 			if (op.kind === "text") sortAndValidateTextEdits(op.edits);
 		}
@@ -435,6 +473,12 @@ export async function applyWorkspaceEdit(
 	} else if (edit.changes) {
 		// Legacy changes-map path: validate every file's edits before writing any.
 		const changes = edit.changes;
+		plannedMutationPaths = normalizeMutationPaths(
+			Object.entries(changes)
+				.filter(([, textEdits]) => textEdits.length > 0)
+				.map(([uri]) => uriToFile(uri)),
+			cwd,
+		);
 		for (const uri in changes) {
 			sortAndValidateTextEdits(changes[uri]);
 		}
@@ -448,5 +492,5 @@ export async function applyWorkspaceEdit(
 		}
 	}
 
-	return { applied, executed };
+	return { applied, executed, plannedMutationPaths, changedPaths: mutationPathsForExecutedChanges(executed, cwd) };
 }

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -1,3 +1,4 @@
+import { type } from "@oh-my-pi/omptype";
 import * as fs from "node:fs";
 import path from "node:path";
 import type {
@@ -12,12 +13,12 @@ import { type Theme, theme } from "../modes/theme/theme";
 import lspDescription from "../prompts/tools/lsp.md" with { type: "text" };
 import type { ToolSession } from "../tools";
 import { truncateForPrompt } from "../tools/approval";
-import { formatPathRelativeToCwd, resolveToCwd } from "../tools/path-utils";
+import { formatPathRelativeToCwd, normalizeMutationPaths, resolveToCwd } from "../tools/path-utils";
 import { replaceTabs, shortenPath } from "../tools/render-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "../tools/tool-errors";
 import { clampTimeout } from "../tools/tool-timeouts";
 import {
-	applyWorkspaceEditWithLsp,
+	applyWorkspaceEditWithLspResult,
 	clearInitializationFailure,
 	ensureFileOpen,
 	getActiveClients,
@@ -51,9 +52,11 @@ import {
 import {
 	applyEditsThenRename,
 	flattenWorkspaceTextEdits,
+	plannedWorkspaceEditPaths,
 	type RenameReferenceEdit,
 	rangesOverlap,
 	sortAndValidateTextEdits,
+	type WorkspaceEditResult,
 } from "./edits";
 import { detectLspmux } from "./lspmux";
 import {
@@ -174,6 +177,19 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		const action = typeof rawAction === "string" ? rawAction.toLowerCase() : "";
 		return LSP_READONLY_ACTIONS.has(action) ? "read" : "write";
 	};
+	mutationPaths(args: Partial<LspParams>): readonly string[] | undefined {
+		const params = lspSchema(args);
+		if (params instanceof type.errors || LSP_READONLY_ACTIONS.has(params.action)) return undefined;
+		// A preview leaves the workspace alone, and `code_actions` only writes
+		// when it is asked to apply one. Reporting a target for either would
+		// make a gate treat a look-only call as a mutation.
+		if (params.apply === false || (params.action === "code_actions" && params.apply !== true)) return undefined;
+		if (params.action === "rename_file") {
+			const paths = [params.file, params.new_name].filter((value): value is string => value !== undefined);
+			return paths.length > 0 ? paths : undefined;
+		}
+		return params.file === undefined ? undefined : [params.file];
+	}
 	readonly formatApprovalDetails = (args: unknown): string[] => {
 		const params = args as Partial<LspParams>;
 		const lines = [`Action: ${typeof params.action === "string" ? params.action : "(missing)"}`];
@@ -205,6 +221,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<LspToolDetails>> {
 		const { action, file, line, symbol, query, new_name, apply, timeout } = params;
+		let mutationDetails: Pick<LspToolDetails, "plannedMutationPaths" | "changedPaths"> | undefined;
 		if (this.session.lspReadOnly && !LSP_READONLY_ACTIONS.has(action)) {
 			throw new ToolError(`LSP action ${action} is disabled in this read-only session`);
 		}
@@ -465,26 +482,22 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		}
 
 		if (action === "rename_file") {
+			// Every guard below returns before a single file moves. The explicit
+			// empty report is what keeps a mutation gate from grading files this
+			// call never touched.
+			const unmoved = (text: string): AgentToolResult<LspToolDetails> => ({
+				content: [{ type: "text", text }],
+				details: { action, success: false, request: params, changedPaths: [] },
+			});
 			if (!file || !new_name) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: "Error: rename_file requires both `file` (source path) and `new_name` (destination path)",
-						},
-					],
-					details: { action, success: false, request: params },
-				};
+				return unmoved("Error: rename_file requires both `file` (source path) and `new_name` (destination path)");
 			}
 
 			const source = resolveToCwd(file, this.session.cwd);
 			const dest = resolveToCwd(new_name, this.session.cwd);
 
 			if (source === dest) {
-				return {
-					content: [{ type: "text", text: "Error: source and destination paths are identical" }],
-					details: { action, success: false, request: params },
-				};
+				return unmoved("Error: source and destination paths are identical");
 			}
 
 			let sourceStat: fs.Stats;
@@ -495,65 +508,36 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				// missing path sends the caller hunting the wrong problem — and
 				// silently invites them to recreate a file that is already there.
 				const relSource = formatRenameStatPath(source, this.session.cwd);
-				return {
-					content: [
-						{
-							type: "text",
-							text: isEnoent(err)
-								? `Error: source path does not exist: ${relSource}`
-								: `Error: cannot read source path ${relSource}: ${formatRenameStatError(err)}`,
-						},
-					],
-					details: { action, success: false, request: params },
-				};
+				return unmoved(
+					isEnoent(err)
+						? `Error: source path does not exist: ${relSource}`
+						: `Error: cannot read source path ${relSource}: ${formatRenameStatError(err)}`,
+				);
 			}
 
 			try {
 				await fs.promises.lstat(dest);
-				return {
-					content: [
-						{
-							type: "text",
-							text: `Error: destination already exists: ${formatRenameStatPath(dest, this.session.cwd)}`,
-						},
-					],
-					details: { action, success: false, request: params },
-				};
+				return unmoved(`Error: destination already exists: ${formatRenameStatPath(dest, this.session.cwd)}`);
 			} catch (err) {
 				// ENOENT is the success case: the destination is free. Any other
 				// failure means we never established that, so renaming onto it
 				// could clobber a file we simply could not see.
 				if (!isEnoent(err)) {
-					return {
-						content: [
-							{
-								type: "text",
-								text: `Error: cannot read destination path ${formatRenameStatPath(dest, this.session.cwd)}: ${formatRenameStatError(err)}`,
-							},
-						],
-						details: { action, success: false, request: params },
-					};
+					return unmoved(
+						`Error: cannot read destination path ${formatRenameStatPath(dest, this.session.cwd)}: ${formatRenameStatError(err)}`,
+					);
 				}
 			}
 
 			const enumerated = await enumerateRenamePairs(source, dest);
 			if (enumerated.exceeded) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: `Error: directory contains more than ${MAX_RENAME_PAIRS} files; rename in smaller batches to keep LSP edits accurate`,
-						},
-					],
-					details: { action, success: false, request: params },
-				};
+				return unmoved(
+					`Error: directory contains more than ${MAX_RENAME_PAIRS} files; rename in smaller batches to keep LSP edits accurate`,
+				);
 			}
 			const { pairs } = enumerated;
 			if (pairs.length === 0) {
-				return {
-					content: [{ type: "text", text: "Error: no files to rename" }],
-					details: { action, success: false, request: params },
-				};
+				return unmoved("Error: no files to rename");
 			}
 
 			const lspParams = { files: pairs };
@@ -664,6 +648,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						serverName: Array.from(respondingServers).join(", "),
 						success: true,
 						request: params,
+						// A preview moves nothing; report what an apply would touch.
+						plannedMutationPaths: normalizeMutationPaths(
+							[
+								...perServerEdits.flatMap(entry => plannedWorkspaceEditPaths(entry.edit, this.session.cwd)),
+								...pairs.flatMap(pair => [uriToFile(pair.oldUri), uriToFile(pair.newUri)]),
+							],
+							this.session.cwd,
+						),
+						changedPaths: [],
 					},
 				};
 			}
@@ -684,6 +677,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						serverName: Array.from(respondingServers).join(", "),
 						success: false,
 						request: params,
+						changedPaths: [],
 					},
 				};
 			}
@@ -779,6 +773,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			// the reference edits back so the source, destination, and every
 			// reference file are left unchanged.
 			await applyEditsThenRename(referenceEdits, source, dest);
+			// Same execution source as the write: the coalesced reference edits
+			// that were applied, plus every path the move actually renamed.
+			const renamedPaths = normalizeMutationPaths(
+				[
+					...referenceEdits.map(referenceEdit => referenceEdit.filePath),
+					...pairs.flatMap(pair => [uriToFile(pair.oldUri), uriToFile(pair.newUri)]),
+				],
+				this.session.cwd,
+			);
 			summary.push(`  Renamed ${sourceLabel} → ${destLabel}`);
 
 			for (const [serverName, serverConfig] of servers) {
@@ -813,6 +816,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					serverName: Array.from(respondingServers).join(", "),
 					success: true,
 					request: params,
+					changedPaths: renamedPaths,
 				},
 			};
 		}
@@ -1390,10 +1394,14 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 							break;
 						}
 
+						let workspaceEditResult: WorkspaceEditResult | undefined;
 						const appliedAction = await applyCodeAction(selectedAction, {
 							resolveCodeAction: async actionItem =>
 								(await sendRequest(client, "codeAction/resolve", actionItem, signal)) as CodeAction,
-							applyWorkspaceEdit: async edit => applyWorkspaceEditWithLsp(edit, this.session.cwd, signal),
+							applyWorkspaceEdit: async edit => {
+								workspaceEditResult = await applyWorkspaceEditWithLspResult(edit, this.session.cwd, signal);
+								return workspaceEditResult.applied;
+							},
 							executeCommand: async commandItem => {
 								await sendRequest(
 									client,
@@ -1406,6 +1414,12 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 								);
 							},
 						});
+						if (workspaceEditResult) {
+							mutationDetails = {
+								plannedMutationPaths: workspaceEditResult.plannedMutationPaths,
+								changedPaths: workspaceEditResult.changedPaths,
+							};
+						}
 
 						if (!appliedAction) {
 							output = `Action "${selectedAction.title}" has no workspace edit or command to apply`;
@@ -1489,10 +1503,18 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 					} else {
 						const shouldApply = apply !== false;
 						if (shouldApply) {
-							const applied = await applyWorkspaceEditWithLsp(result, this.session.cwd, signal);
-							output = `Applied rename:\n${applied.map(a => `  ${a}`).join("\n")}`;
+							const applied = await applyWorkspaceEditWithLspResult(result, this.session.cwd, signal);
+							mutationDetails = {
+								plannedMutationPaths: applied.plannedMutationPaths,
+								changedPaths: applied.changedPaths,
+							};
+							output = `Applied rename:\n${applied.applied.map(a => `  ${a}`).join("\n")}`;
 						} else {
 							const preview = formatWorkspaceEdit(result, this.session.cwd);
+							mutationDetails = {
+								plannedMutationPaths: plannedWorkspaceEditPaths(result, this.session.cwd),
+								changedPaths: [],
+							};
 							output = `Rename preview:\n${preview.map(p => `  ${p}`).join("\n")}`;
 						}
 					}
@@ -1510,7 +1532,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 
 			return {
 				content: [{ type: "text", text: output }],
-				details: { serverName, action, success: true, request: params },
+				details: { serverName, action, success: true, request: params, ...mutationDetails },
 				...(useless ? { useless: true } : {}),
 			};
 		} catch (err) {
@@ -1530,7 +1552,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			const errorMessage = err instanceof Error ? err.message : String(err);
 			return {
 				content: [{ type: "text", text: `LSP error: ${errorMessage}` }],
-				details: { serverName, action, success: false, request: params },
+				details: { serverName, action, success: false, request: params, ...mutationDetails },
 			};
 		}
 	}

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -28,6 +28,8 @@ export interface LspToolDetails {
 	action: string;
 	success: boolean;
 	request?: LspParams;
+	plannedMutationPaths?: string[];
+	changedPaths?: string[];
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -55,7 +55,11 @@ import {
 } from "./discovery/helpers";
 import { injectOmpExtensionCliRoots } from "./discovery/omp-extension-roots";
 import { formatExtensionLoadNotifications } from "./extensibility/extensions/load-errors";
-import { loadExtensions } from "./extensibility/extensions/loader";
+import {
+	loadExtensions,
+	resolveTrustedExtensionPath,
+	TRUSTED_EXTENSION_RECOVERY,
+} from "./extensibility/extensions/loader";
 import { ExtensionRunner } from "./extensibility/extensions/runner";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import { scheduleMarketplaceAutoUpdate } from "./extensibility/plugins/marketplace-auto-update";
@@ -85,6 +89,7 @@ import {
 	createAgentSession,
 	discoverAuthStorage,
 	loadSessionExtensions,
+	resolveConfiguredTrustedExtensionPaths,
 } from "./sdk";
 import type { AgentSession } from "./session/agent-session";
 import { describeAuthBrokerStartupError } from "./session/auth-broker-config";
@@ -384,23 +389,19 @@ export interface AcpSessionFactoryOptions {
 	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
 }
 
+/**
+ * Re-check and load the `--trusted-extension` allowlist for one ACP session.
+ * The paths were already proven at startup; an ACP host opens a session per
+ * workspace long after that, so the file must still be there now.
+ */
 async function loadTrustedSessionExtensions(
 	options: Pick<CreateAgentSessionOptions, "additionalExtensionPaths">,
 	cwd: string,
 	eventBus: EventBus,
 ) {
-	const paths = options.additionalExtensionPaths ?? [];
-	for (const trustedPath of paths) {
-		let stat: fsSync.Stats;
-		try {
-			stat = fsSync.statSync(trustedPath);
-		} catch {
-			throw new Error(`Trusted extension must be an existing module file: ${trustedPath}`);
-		}
-		if (!stat.isFile()) {
-			throw new Error(`Trusted extension must be a module file, not a directory: ${trustedPath}`);
-		}
-	}
+	const paths = (options.additionalExtensionPaths ?? []).map(trustedPath =>
+		resolveTrustedExtensionPath(trustedPath, cwd, "cli"),
+	);
 	return loadExtensions(paths, cwd, eventBus);
 }
 
@@ -433,7 +434,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 				: undefined;
 		if (trustedExtensions && trustedExtensions.errors.length > 0) {
 			throw new Error(
-				`Trusted extension failed to load: ${trustedExtensions.errors.map(item => item.error).join("; ")}`,
+				`Trusted extension failed to load: ${trustedExtensions.errors.map(item => item.error).join("; ")}. ${TRUSTED_EXTENSION_RECOVERY.cli}`,
 			);
 		}
 		const { session: nextSession, setToolUIContext } = await args.createSession({
@@ -1351,29 +1352,31 @@ export async function buildSessionOptions(
 		options.rules = [];
 	}
 
-	// Trusted extension paths are an exact allowlist for extension modules.
+	// `--trusted-extension` is an exact allowlist: discovery off, and every
+	// loaded module is trusted. The `trustedExtensions` setting is the
+	// persistent form and loads inside normal merged discovery instead. The flag
+	// wins when both are present, so a launch can always narrow the surface.
+	const trustedCwd = options.cwd ?? getProjectDir();
 	if (parsed.trustedExtensions && parsed.trustedExtensions.length > 0) {
-		const trustedPaths = parsed.trustedExtensions.map(trustedPath => {
-			let resolvedPath: string;
-			let stat: fsSync.Stats;
-			try {
-				resolvedPath = fsSync.realpathSync.native(trustedPath);
-				stat = fsSync.statSync(resolvedPath);
-			} catch {
-				throw new Error(`Trusted extension must be an existing module file: ${trustedPath}`);
-			}
-			if (!stat.isFile()) {
-				throw new Error(`Trusted extension must be a module file, not a directory: ${trustedPath}`);
-			}
-			return resolvedPath;
-		});
+		const trustedPaths = parsed.trustedExtensions.map(trustedPath =>
+			resolveTrustedExtensionPath(trustedPath, trustedCwd, "cli"),
+		);
 		options.disableExtensionDiscovery = true;
 		options.additionalExtensionPaths = trustedPaths;
+		options.trustedExtensionPaths = trustedPaths;
 	} else {
-		// Additional extension paths from CLI
+		// Configured trusted modules load through discovery like any other
+		// extension AND are marked trusted, so restricted subagents rebind their
+		// handlers. `--no-extensions` does not drop them: a mandatory policy
+		// module the operator configured must survive a narrowed launch.
+		const configuredTrustedPaths = resolveConfiguredTrustedExtensionPaths(activeSettings, trustedCwd);
 		const cliExtensionPaths = [...(parsed.extensions ?? []), ...(parsed.hooks ?? [])];
-		if (cliExtensionPaths.length > 0) {
-			options.additionalExtensionPaths = cliExtensionPaths;
+		const additionalPaths = [...new Set([...cliExtensionPaths, ...configuredTrustedPaths])];
+		if (additionalPaths.length > 0) {
+			options.additionalExtensionPaths = additionalPaths;
+		}
+		if (configuredTrustedPaths.length > 0) {
+			options.trustedExtensionPaths = configuredTrustedPaths;
 		}
 
 		if (parsed.noExtensions) {
@@ -1903,10 +1906,23 @@ export async function runRootCommand(
 			};
 			const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
 			normalizeContinueSessionArgs(initialArgs, rawArgs);
-			if ((parsedArgs.trustedExtensions?.length ?? 0) > 0 && extensionsResult.errors.length > 0) {
-				throw new Error(
-					`Trusted extension failed to load: ${extensionsResult.errors.map(item => item.error).join("; ")}`,
-				);
+			// Flag mode: every loaded module is trusted, so any error is fatal.
+			// Settings mode: only the configured trusted paths are fatal; ordinary
+			// extension failures stay warnings below.
+			if (parsedArgs.trustedExtensions?.length) {
+				if (extensionsResult.errors.length > 0) {
+					throw new Error(
+						`Trusted extension failed to load: ${extensionsResult.errors.map(item => item.error).join("; ")}. ${TRUSTED_EXTENSION_RECOVERY.cli}`,
+					);
+				}
+			} else if (sessionOptions.trustedExtensionPaths?.length) {
+				const trusted = new Set(sessionOptions.trustedExtensionPaths);
+				const failures = extensionsResult.errors.filter(item => trusted.has(item.path));
+				if (failures.length > 0) {
+					throw new Error(
+						`Trusted extension failed to load: ${failures.map(item => `${item.path}: ${item.error}`).join("; ")}. ${TRUSTED_EXTENSION_RECOVERY.settings}`,
+					);
+				}
 			}
 			for (const message of formatExtensionLoadNotifications(extensionsResult.errors)) {
 				if (isInteractive) {

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -167,6 +167,12 @@ export class TanCommandController {
 								? parentPreparedExtensions
 								: undefined,
 							preloadedExtensionPaths: parentExtensionPaths?.length ? [...parentExtensionPaths] : undefined,
+							// The parent's resolved trusted list is what "trusted" means for
+							// the whole session tree. A `--trusted-extension` launch carries
+							// it nowhere else (no setting to fall back on), so without this
+							// forward every restricted subagent the tan spawns binds no
+							// policy — same forward structured-subagent.ts makes.
+							trustedExtensionPaths: session.trustedExtensionPaths,
 							extensionRoots: () => parentExtensionRoots,
 							localProtocolOptions,
 						});

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -113,9 +113,12 @@ import {
 	type LoadExtensionsResult,
 	loadExtensionFromFactory,
 	loadExtensions,
+	loadTrustedExtensionHandlers,
 	type PreparedExtension,
 	type RegisteredTool,
+	resolveTrustedExtensionPath,
 	type ToolDefinition,
+	TRUSTED_EXTENSION_RECOVERY,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
 import {
@@ -458,6 +461,14 @@ export interface CreateAgentSessionOptions {
 	extensions?: ExtensionFactory[];
 	/** Additional extension paths to load (merged with discovery). */
 	additionalExtensionPaths?: string[];
+	/**
+	 * Trusted extension paths: `--trusted-extension` (exact allowlist, discovery
+	 * off) or the `trustedExtensions` setting (merged with normal discovery).
+	 * Restricted children bind only these modules, and only their event handlers.
+	 * Omitted on a top-level session means "read the setting"; a restricted child
+	 * takes the parent's resolved list verbatim.
+	 */
+	trustedExtensionPaths?: readonly string[];
 	/** Disable extension discovery (explicit paths still load). */
 	disableExtensionDiscovery?: boolean;
 	/**
@@ -759,6 +770,21 @@ export async function discoverExtensions(cwd?: string): Promise<LoadExtensionsRe
 	const resolvedCwd = cwd ?? getProjectDir();
 
 	return discoverAndLoadExtensions([], resolvedCwd);
+}
+
+/**
+ * Trusted extension paths from the persistent `trustedExtensions` setting,
+ * each proven to be an existing module file. Every entry must ALSO reach
+ * `additionalExtensionPaths`: unlike `--trusted-extension`, the settings form
+ * loads through ordinary merged discovery and only marks those paths trusted,
+ * so restricted subagents rebind their handlers.
+ *
+ * Throws when an entry is missing or is not a file. A policy module that
+ * silently fails to load is worse than a session that refuses to start.
+ */
+export function resolveConfiguredTrustedExtensionPaths(settings: Settings, cwd: string): string[] {
+	const configured = settings.get("trustedExtensions") ?? [];
+	return configured.map(entry => resolveTrustedExtensionPath(entry, cwd, "settings"));
 }
 
 /**
@@ -1993,17 +2019,44 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (event.type === "connecting" && event.serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event);
 		};
+		// One source decides what "trusted" means for a whole session tree: a
+		// parent that resolved the list forwards it and the child never re-reads
+		// config. A restricted session created without one is not therefore
+		// untrusted-by-default — a cold revive, a security scan, an agentic
+		// commit, and a compression pass all create restricted sessions with no
+		// forwarded list, and each must still bind the operator's policy — so the
+		// setting is the fallback at every level.
+		const trustedExtensionPaths =
+			options.trustedExtensionPaths ?? resolveConfiguredTrustedExtensionPaths(settings, cwd);
+		// Settings-form trusted modules load through ordinary discovery as well,
+		// so they keep their full extension API at top level. A CLI
+		// `--trusted-extension` run already carries them in additionalExtensionPaths.
+		const extensionDiscoveryOptions =
+			trustedExtensionPaths.length > 0
+				? {
+						...options,
+						additionalExtensionPaths: [
+							...new Set([...(options.additionalExtensionPaths ?? []), ...trustedExtensionPaths]),
+						],
+					}
+				: options;
 		// Provider, never a stored value: inherited child policy remains linked to
 		// the owning session, while top-level sessions materialize their own live
 		// settings on every discovery call.
-		const buildSessionExtensionRoots =
-			options.extensionRoots ??
-			((): EffectiveExtensionRoots => ({
-				explicit: options.additionalExtensionPaths ?? [],
-				mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
-				configured: settings.get("extensions") ?? [],
-				configuredLevel: settings.extensionsSourceLevel(),
-			}));
+		const buildSessionExtensionRoots = restrictToolNames
+			? (): EffectiveExtensionRoots => ({
+					explicit: [],
+					mode: "explicit-only",
+					configured: [],
+					configuredLevel: settings.extensionsSourceLevel(),
+				})
+			: (options.extensionRoots ??
+				((): EffectiveExtensionRoots => ({
+					explicit: options.additionalExtensionPaths ?? [],
+					mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
+					configured: settings.get("extensions") ?? [],
+					configuredLevel: settings.extensionsSourceLevel(),
+				})));
 		const mcpDiscoverOptions = {
 			onStatus: onMCPStatus,
 			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
@@ -2154,7 +2207,25 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// the flag and pre-resolved the result already reflects that choice.
 		let extensionPaths: string[];
 		let extensionsResult: LoadExtensionsResult;
-		if (restrictToolNames) {
+		if (restrictToolNames && trustedExtensionPaths.length > 0) {
+			// Restricted children rebind trusted handlers from source paths. Never
+			// reuse parent Extension instances or prepared factories: each factory
+			// owns session-local policy state.
+			extensionPaths = [];
+			extensionsResult = await logger.time(
+				"loadTrustedExtensionHandlers",
+				loadTrustedExtensionHandlers,
+				trustedExtensionPaths,
+				cwd,
+				eventBus,
+			);
+			if (extensionsResult.errors.length > 0) {
+				const failures = extensionsResult.errors.map(({ path, error }) => `${path}: ${error}`).join("; ");
+				throw new Error(
+					`Trusted extension handlers failed to load for this restricted session: ${failures}. Fix or remove the trusted extension entry and restart.`,
+				);
+			}
+		} else if (restrictToolNames) {
 			// Allocate a session runtime without evaluating caller-provided extension
 			// instances, paths, or factories.
 			extensionPaths = [];
@@ -2189,16 +2260,29 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			}
 		} else {
 			extensionPaths = await logger.time("discoverSessionExtensionPaths", () =>
-				discoverSessionExtensionPaths(options, cwd, settings),
+				discoverSessionExtensionPaths(extensionDiscoveryOptions, cwd, settings),
 			);
 			extensionsResult = await logger.time("loadExtensions", loadExtensions, extensionPaths, cwd, eventBus);
 			for (const { path, error } of extensionsResult.errors) {
 				logger.error("Failed to load extension", { path, error });
 			}
 		}
-		// Forward the source-path list (NOT the loaded instances) so subagents
-		// rebuild their own session-scoped extensions.
+		// A configured trusted module that fails to load must stop startup:
+		// ordinary extension errors stay non-fatal notifications, but a policy
+		// module that silently went missing would leave the session unguarded.
+		if (!restrictToolNames && trustedExtensionPaths.length > 0) {
+			const trusted = new Set(trustedExtensionPaths);
+			const failures = extensionsResult.errors.filter(item => trusted.has(item.path));
+			if (failures.length > 0) {
+				throw new Error(
+					`Trusted extension failed to load: ${failures.map(item => `${item.path}: ${item.error}`).join("; ")}. ${TRUSTED_EXTENSION_RECOVERY.settings}`,
+				);
+			}
+		}
+		// Forward ordinary source paths separately from trusted handler paths so
+		// restricted descendants cannot rebind full extension capabilities.
 		toolSession.extensionPaths = extensionPaths;
+		toolSession.trustedExtensionPaths = trustedExtensionPaths;
 		toolSession.effectiveExtensionRoots = buildSessionExtensionRoots;
 
 		// Inline source ids must remain stable when caller factories are rebound in
@@ -2233,7 +2317,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				}
 			}
 		}
-		toolSession.preparedExtensions = extensionsResult.preparedExtensions;
+		toolSession.preparedExtensions = restrictToolNames ? [] : extensionsResult.preparedExtensions;
 
 		// Process provider registrations queued during extension loading.
 		// This must happen before the runner is created so that models registered by
@@ -2244,12 +2328,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			for (const sourceId of new Set(activeExtensionSources)) {
 				modelRegistry.clearSourceRegistrations(sourceId);
 			}
-		}
-		if (extensionsResult.runtime.pendingProviderRegistrations.length > 0) {
-			for (const { name, config, sourceId } of extensionsResult.runtime.pendingProviderRegistrations) {
-				modelRegistry.registerProvider(name, config, sourceId);
+			if (extensionsResult.runtime.pendingProviderRegistrations.length > 0) {
+				for (const { name, config, sourceId } of extensionsResult.runtime.pendingProviderRegistrations) {
+					modelRegistry.registerProvider(name, config, sourceId);
+				}
+				extensionsResult.runtime.pendingProviderRegistrations = [];
 			}
-			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
 		// Hydrate cached runtime (extension) provider catalogs before model
 		// resolution. Dynamic-only providers have no synchronous registration side
@@ -3731,8 +3815,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			sessionManager,
 			settings,
 			additionalExtensionPaths: options.additionalExtensionPaths,
+			trustedExtensionPaths,
 			extensionRoots: buildSessionExtensionRoots,
-			preparedExtensions: extensionsResult.preparedExtensions,
+			preparedExtensions: restrictToolNames ? [] : extensionsResult.preparedExtensions,
 			extensionPaths,
 			disableExtensionDiscovery: options.disableExtensionDiscovery,
 			autoApprove: options.autoApprove,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -148,6 +148,8 @@ export interface AgentSessionConfig {
 	 * subagent forward) — keeps the child from building an empty extension set.
 	 */
 	extensionPaths?: readonly string[];
+	/** Trusted extension source paths forwarded only to restricted child sessions. */
+	trustedExtensionPaths?: readonly string[];
 	/** Raw SDK `additionalExtensionPaths`; used when no inherited root provider exists. */
 	additionalExtensionPaths?: readonly string[];
 	/** Mirror of `disableExtensionDiscovery`; used when no inherited root provider exists. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -149,7 +149,7 @@ import type { CompactOptions, ContextUsage } from "../extensibility/extensions/t
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
-import { normalizeToolEventInput, resolveToolEventInput } from "../extensibility/tool-event-input";
+import { normalizeToolEventInputForTool, resolveToolEventInput } from "../extensibility/tool-event-input";
 import { GoalRuntime } from "../goals/runtime";
 import type { GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
@@ -549,12 +549,19 @@ export class AgentSession {
 		return this.#preparedExtensions;
 	}
 
-	/** Source paths of the parent's loaded extensions; forwarded to `/tan` forks as the prepared-extension fallback. */
+	/** Source paths of the parent's loaded extensions; forwarded to /tan forks as the prepared-extension fallback. */
 	readonly #extensionPaths: readonly string[] | undefined;
 
 	/** Source paths of loaded extensions, forwarded to child sessions when prepared factories are unavailable. */
 	get extensionPaths(): readonly string[] | undefined {
 		return this.#extensionPaths;
+	}
+
+	/** Paths supplied through --trusted-extension, forwarded only to restricted children. */
+	readonly #trustedExtensionPaths: readonly string[] | undefined;
+
+	get trustedExtensionPaths(): readonly string[] | undefined {
+		return this.#trustedExtensionPaths;
 	}
 
 	#powerAssertion: PowerAssertion | undefined;
@@ -1163,6 +1170,7 @@ export class AgentSession {
 			}));
 		this.#preparedExtensions = config.preparedExtensions;
 		this.#extensionPaths = config.extensionPaths;
+		this.#trustedExtensionPaths = config.trustedExtensionPaths;
 		this.#codexResetCoordinator = config.codexResetCoordinator ?? defaultCodexAutoRedeemCoordinator;
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,
@@ -3883,7 +3891,11 @@ export class AgentSession {
 				type: "tool_call",
 				toolName: ctx.tool.name,
 				toolCallId: ctx.toolCall.id,
-				input: normalizeToolEventInput(ctx.tool.name, resolveToolEventInput(ctx.tool, eventArgs)),
+				input: normalizeToolEventInputForTool(
+					ctx.tool,
+					resolveToolEventInput(ctx.tool, eventArgs),
+					this.sessionManager.getCwd(),
+				),
 			},
 			signal,
 		);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -502,6 +502,12 @@ export interface ExecutorOptions {
 	/** Parent-imported extension factories rebound to the child runtime. */
 	preloadedPreparedExtensions?: readonly PreparedExtension[];
 	/**
+	 * Parent's trusted extension source paths. A restricted child rebinds these
+	 * modules' event handlers even though it takes no ordinary extension, so
+	 * mandatory policy still runs inside the narrowed session.
+	 */
+	trustedExtensionPaths?: readonly string[];
+	/**
 	 * Parent's discovered custom-tool source paths. Forwarded to skip the
 	 * `.omp/tools/` FS scan in the subagent; the subagent then re-binds each
 	 * tool against its own `CustomToolAPI` (cwd, exec, pushPendingAction, UI).
@@ -3355,6 +3361,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				workspaceTree: options.workspaceTree,
 				rules: options.rules,
 				extensionRoots: options.extensionRoots,
+				// A restricted child takes no ordinary extension, so the trusted list
+				// is the only path by which mandatory policy reaches it. An
+				// unrestricted child already rebinds the parent's full extension set.
+				trustedExtensionPaths: restrictToolNames ? options.trustedExtensionPaths : undefined,
 				preloadedExtensionPaths: restrictToolNames ? [] : options.preloadedExtensionPaths,
 				preloadedPreparedExtensions: restrictToolNames ? [] : options.preloadedPreparedExtensions,
 				preloadedCustomToolPaths: restrictToolNames ? [] : options.preloadedCustomToolPaths,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -463,6 +463,7 @@ function buildExecutorOptions(
 		// recursive sub-discovery; preloaded paths only avoid re-scanning/reusing
 		// parent-bound extension instances while constructing the child.
 		extensionRoots: session.effectiveExtensionRoots?.bind(session),
+		trustedExtensionPaths: restrictToolNames ? session.trustedExtensionPaths : undefined,
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedPreparedExtensions: restrictToolNames ? [] : session.preparedExtensions,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -27,7 +27,7 @@ import { parseReadUrlTarget } from "./fetch";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
 import { classifyGroupedLines, formatGroupedFiles, groupLineIndicesByBlank } from "./grouped-file-output";
 import type { OutputMeta } from "./output-meta";
-import { isInternalUrlPath, resolveToolSearchScope } from "./path-utils";
+import { isInternalUrlPath, normalizeMutationPaths, resolveToolSearchScope } from "./path-utils";
 import {
 	appendParseErrorsBulletList,
 	capParseErrors,
@@ -172,7 +172,11 @@ export interface AstEditToolDetails {
 	/** Session cwd at edit time. Display header paths are cwd-relative, so the
 	 * renderer resolves them against this; `searchPath` is the scope target. */
 	cwd?: string;
+	plannedMutationPaths?: string[];
+	changedPaths?: string[];
 }
+
+const astEditMutationSchema = type({ "paths?": "string[]" });
 
 type AstEditSchemaInfer = typeof astEditSchema.infer;
 
@@ -184,6 +188,10 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 			: [];
 		return paths.length > 0 && paths.every(path => isInternalUrlPath(path)) ? "read" : "write";
 	};
+	mutationPaths(args: Partial<AstEditSchemaInfer>): readonly string[] | undefined {
+		const params = astEditMutationSchema(args);
+		return params instanceof type.errors || params.paths === undefined ? undefined : params.paths;
+	}
 	readonly formatApprovalDetails = (args: unknown): string[] => {
 		const params = args as Partial<AstEditSchemaInfer>;
 		const lines: string[] = [];
@@ -332,6 +340,10 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				changesByFile.get(relativePath)!.push(change);
 			}
 
+			const previewPaths = normalizeMutationPaths(
+				fileList.map(filePath => path.resolve(this.session.cwd, filePath)),
+				this.session.cwd,
+			);
 			const baseDetails: AstEditToolDetails = {
 				totalReplacements: result.totalReplacements,
 				filesTouched: result.filesTouched,
@@ -343,6 +355,10 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				searchPath: resolvedSearchPath,
 				cwd: this.session.cwd,
 				files: fileList,
+				// This run is a dry run: the files are candidates, not changes. The
+				// write happens when a staged proposal is applied through
+				// `xd://resolve`, which reports `changedPaths` from the apply pass.
+				...(result.applied ? { changedPaths: previewPaths } : { plannedMutationPaths: previewPaths }),
 				fileReplacements: [],
 			};
 
@@ -500,6 +516,12 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 								: {}),
 							scopePath,
 							files: appliedFileList,
+							// The apply pass wrote these; the staged preview already published
+							// its candidate list.
+							changedPaths: normalizeMutationPaths(
+								appliedFileList.map(filePath => path.resolve(this.session.cwd, filePath)),
+								this.session.cwd,
+							),
 							fileReplacements: appliedFileReplacements,
 						};
 						const stalePreview =

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -203,6 +203,8 @@ export interface ToolSession {
 	 * (`<inline-N>`) are NOT included — those are session-local.
 	 */
 	extensionPaths?: string[];
+	/** Paths supplied through --trusted-extension, forwarded only to restricted children. */
+	trustedExtensionPaths?: readonly string[];
 	/** Imported extension factories safe to rebind in child sessions. */
 	preparedExtensions?: PreparedExtension[];
 	/**

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -22,6 +22,43 @@ const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 export function isFilesystemSourcePath(value: string): boolean {
 	return path.posix.isAbsolute(value) || path.win32.isAbsolute(value);
 }
+
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const FILE_URL_RE = /^file:\/\//i;
+
+/**
+ * Normalize a mutation target without resolving symlinks or requiring it to
+ * exist. Returns `undefined` for anything that is not a filesystem target:
+ * internal URLs (`xd://`, `local://`, `conflict://`) name no file on disk.
+ *
+ * Resolution goes through {@link resolveToCwd} — the same call the mutating
+ * tools make via `resolvePlanPath` — so the reported target is the path the
+ * tool actually opens, `@/`, stray-`:`, drive-alias and `file://` shorthands
+ * included. The extra `path.normalize` collapses `.`/`..` so a gate matching
+ * on the reported path cannot be walked out of its own prefix.
+ */
+export function normalizeMutationPath(value: string, cwd: string): string | undefined {
+	if (value.length === 0 || (URL_SCHEME_RE.test(value) && !FILE_URL_RE.test(value))) return undefined;
+	try {
+		return path.normalize(resolveToCwd(value, cwd));
+	} catch {
+		return undefined;
+	}
+}
+
+/** Normalize, de-duplicate, and preserve the parser's target order. */
+export function normalizeMutationPaths(values: readonly string[], cwd: string): string[] {
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const value of values) {
+		const target = normalizeMutationPath(value, cwd);
+		if (target !== undefined && !seen.has(target)) {
+			seen.add(target);
+			normalized.push(target);
+		}
+	}
+	return normalized;
+}
 // A single line-range chunk: `N`, `N-M`, `N+K`, or open-ended `N-`. `..` is
 // accepted everywhere `-` is, as a forgiving alias for Rust/Python-style ranges
 // (e.g. `2724..2727` == `2724-2727`, `2724..` == `2724-`); it is normalized to

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -35,6 +35,7 @@ import writeDeviceOnlyDescription from "../prompts/tools/write-device-only.md" w
 import type { ToolSession } from "../sdk";
 import { fileHyperlink, framedBlock, renderStatusLine } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
+import { normalizeMutationPaths } from "./path-utils";
 import { routeWriteThroughBridge } from "./acp-bridge";
 import { resolveToolTier, truncateForPrompt } from "./approval";
 import { assertEditableFile } from "./auto-generated-guard";
@@ -308,6 +309,8 @@ const writeSchema = type({
 	content: type("string").describe("file content"),
 });
 
+const writeMutationSchema = type({ "path?": "string" });
+
 export type WriteToolInput = typeof writeSchema.infer;
 
 /** Details returned by the write tool for TUI rendering */
@@ -321,6 +324,29 @@ export interface WriteToolDetails {
 	resolvedPath?: string;
 	/** Set when the write dispatched an `xd://` tool device; drives renderer delegation. */
 	xdev?: XdevDispatch;
+	/** Absolute normalized targets this write changed. Absent when the branch cannot name them. */
+	changedPaths?: string[];
+}
+
+/** A device dispatch's inner tool result, which reports its own changed targets. */
+const deviceMutationReport = type({ "changedPaths?": "string[]" });
+
+/** A resolve/reject dispatch nests the applied tool's result under `sourceResultDetails`. */
+const resolveMutationReport = type({ "sourceResultDetails?": deviceMutationReport });
+
+/**
+ * Report the file a completed write changed. Every branch that touches the
+ * filesystem already records it as `resolvedPath`, so this reads the executor's
+ * own record rather than re-deriving a target from the request. Branches that
+ * name no path of their own (device dispatches, multi-file conflict
+ * resolution) set `changedPaths` themselves and are left untouched.
+ */
+function withChangedPaths(result: AgentToolResult<WriteToolDetails>, cwd: string): AgentToolResult<WriteToolDetails> {
+	const details = result.details;
+	if (details === undefined || details.changedPaths !== undefined || details.resolvedPath === undefined) {
+		return result;
+	}
+	return { ...result, details: { ...details, changedPaths: normalizeMutationPaths([details.resolvedPath], cwd) } };
 }
 
 /**
@@ -567,6 +593,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		const content = typeof params.content === "string" ? params.content : "";
 		return [`Path: ${truncateForPrompt(targetPath)}`, `Content:\n${truncateForPrompt(content)}`];
 	};
+	mutationPaths(args: Partial<WriteParams>): readonly string[] | undefined {
+		const params = writeMutationSchema(args);
+		if (params instanceof type.errors || params.path === undefined) return undefined;
+		return [peelWriteUrlSelector(unwrapHashlineHeaderPath(params.path))];
+	}
 	readonly label = "Write";
 	get description(): string {
 		const deviceOnly = this.session.deviceOnlyWrite === true && this.session.pendingFullWriteDescription !== true;
@@ -980,7 +1011,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			byFile.set(entry.absolutePath, bucket);
 		}
 
-		const succeededFiles: { displayPath: string; count: number; header?: string }[] = [];
+		const succeededFiles: { path: string; displayPath: string; count: number; header?: string }[] = [];
 		const failedFiles: { displayPath: string; count: number; error: string }[] = [];
 		let totalResolvedIds = 0;
 		let totalEchoTrimmed = 0;
@@ -1047,7 +1078,12 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			for (const entry of resolvedEntries) history.invalidate(entry.id);
 			for (const entry of staleEntries) history.invalidate(entry.id);
 			const header = maybeWriteSnapshotHeader(this.session, absolutePath, text);
-			succeededFiles.push({ displayPath: sample.displayPath, count: resolvedEntries.length, header });
+			succeededFiles.push({
+				path: absolutePath,
+				displayPath: sample.displayPath,
+				count: resolvedEntries.length,
+				header,
+			});
 			totalResolvedIds += resolvedEntries.length;
 		}
 
@@ -1098,7 +1134,12 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		}
 		return {
 			content: [{ type: "text", text: resultText }],
-			details: {},
+			details: {
+				changedPaths: normalizeMutationPaths(
+					succeededFiles.map(file => file.path),
+					this.session.cwd,
+				),
+			},
 			isError: failedFiles.length > 0 ? true : undefined,
 		};
 	}
@@ -1135,7 +1176,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				"This `write` tool is limited to the xd:// device transport: call it with path `xd://<tool>` and the device's JSON arguments in `content` (`read xd://` lists mounted devices). Active plan mode additionally permits local:// sandbox drafts. Filesystem writes are not available elsewhere.",
 			);
 		}
-		return untilAborted(signal, async () => {
+		const result: AgentToolResult<WriteToolDetails> = await untilAborted(signal, async () => {
 			// Strip hashline display prefixes ([PATH#HASH] + LINE:) if the model copied them from read output
 			const { text: cleanContent, stripped } = stripWriteContent(this.session, content);
 			const internalRouter = InternalUrlRouter.instance();
@@ -1169,9 +1210,14 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 								}
 								if (name && isResolutionDeviceName(name)) {
 									const { result, xdev } = await dispatchResolutionDevice(this.session, name, deviceContent);
+									// The device writes nothing itself; the applied tool's own
+									// result names what changed.
+									const applied = resolveMutationReport(result.details);
+									const changedPaths =
+										applied instanceof type.errors ? undefined : applied.sourceResultDetails?.changedPaths;
 									xdResult = {
 										content: result.content,
-										details: { xdev },
+										details: changedPaths === undefined ? { xdev } : { xdev, changedPaths },
 										isError: result.isError,
 										useless: result.useless,
 									};
@@ -1196,9 +1242,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 									// inner tool does not prompt a second time.
 									context ? { ...context, xdevApproved: true } : undefined,
 								);
+								// A dispatched tool writes through its own executor, so its
+								// result is the authority on what changed.
+								const inner = deviceMutationReport(result.details);
+								const changedPaths = inner instanceof type.errors ? undefined : inner.changedPaths;
 								xdResult = {
 									content: result.content,
-									details: { xdev: dispatch },
+									details: changedPaths === undefined ? { xdev: dispatch } : { xdev: dispatch, changedPaths },
 									isError: result.isError,
 									useless: result.useless,
 								};
@@ -1362,6 +1412,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				},
 			};
 		});
+		return withChangedPaths(result, this.session.cwd);
 	}
 }
 

--- a/packages/coding-agent/test/mutation-target-contract.test.ts
+++ b/packages/coding-agent/test/mutation-target-contract.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The mutation-target contract a policy gate consumes: `plannedMutationPaths`
+ * on a tool_call event and `changedPaths` on a tool_result's details. Each test
+ * observes the contract through the surface the gate reads, never through an
+ * internal helper.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
+import { normalizeToolEventInputForTool } from "@oh-my-pi/pi-coding-agent/extensibility/tool-event-input";
+import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
+import { applyWorkspaceEdit } from "@oh-my-pi/pi-coding-agent/lsp/edits";
+import { fileToUri } from "@oh-my-pi/pi-coding-agent/lsp/utils";
+import { ToolChoiceQueue } from "@oh-my-pi/pi-coding-agent/session/tool-choice-queue";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { AstEditTool } from "@oh-my-pi/pi-coding-agent/tools/ast-edit";
+import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+/** A resolve dispatch's result nests the applied tool's own details. */
+const resolveResult = type({
+	details: { "sourceResultDetails?": { "applied?": "boolean", "changedPaths?": "string[]" } },
+});
+
+function makeSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		enableLsp: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => null,
+		getSessionId: () => null,
+		getPlanModeState: () => undefined,
+		settings: Settings.isolated(),
+		...overrides,
+	};
+}
+
+let tempDir: string;
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+});
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mutation-contract-"));
+});
+
+afterEach(async () => {
+	await removeWithRetries(tempDir);
+});
+
+describe("tool_call plannedMutationPaths", () => {
+	it("reports both sides of an apply-patch move", () => {
+		const tool = new EditTool(makeSession(tempDir), "apply_patch");
+		const input = [
+			"*** Begin Patch",
+			"*** Update File: src/old.ts",
+			"*** Move to: src/new.ts",
+			"@@",
+			"-const a = 1;",
+			"+const a = 2;",
+			"*** End Patch",
+			"",
+		].join("\n");
+
+		const event = normalizeToolEventInputForTool(tool, { input }, tempDir);
+
+		expect(event.plannedMutationPaths).toEqual([path.join(tempDir, "src/old.ts"), path.join(tempDir, "src/new.ts")]);
+	});
+
+	it("normalizes a bracketed hashline header to an absolute target", () => {
+		const tool = new EditTool(makeSession(tempDir), "hashline");
+		const input = "[packages/app/src/thing.ts#A1B2]\nPUT 3.=3:\n+const x = 2;\n";
+
+		const event = normalizeToolEventInputForTool(tool, { input }, tempDir);
+
+		expect(event.plannedMutationPaths).toEqual([path.join(tempDir, "packages/app/src/thing.ts")]);
+	});
+
+	it("omits the projection for a device write, which names no file", () => {
+		const event = normalizeToolEventInputForTool(
+			new WriteTool(makeSession(tempDir)),
+			{ path: "xd://resolve", content: "apply the staged proposal" },
+			tempDir,
+		);
+
+		// An empty list would claim the call writes nothing and stand down the
+		// gate's own bookkeeping for the staged proposal this write applies.
+		expect(event.plannedMutationPaths).toBeUndefined();
+	});
+
+	it("reports both sides of an lsp rename_file before it runs", () => {
+		const event = normalizeToolEventInputForTool(
+			new LspTool(makeSession(tempDir)),
+			{ action: "rename_file", file: "src/old.ts", new_name: "src/new.ts" },
+			tempDir,
+		);
+
+		expect(event.plannedMutationPaths).toEqual([path.join(tempDir, "src/old.ts"), path.join(tempDir, "src/new.ts")]);
+	});
+
+	it("omits the projection for a read-only lsp action", () => {
+		const event = normalizeToolEventInputForTool(
+			new LspTool(makeSession(tempDir)),
+			{ action: "diagnostics", file: "packages/app/test/thing.test.ts" },
+			tempDir,
+		);
+
+		// Naming a target here would make a gate treat reading diagnostics on a
+		// test file as a mutation of it.
+		expect(event.plannedMutationPaths).toBeUndefined();
+	});
+
+	it.skipIf(process.platform === "win32")("projects the drive-letter target the write then creates", async () => {
+		const input = { path: "C:/tmp/x.ts", content: "drive\n" };
+		const tool = new WriteTool(makeSession(tempDir));
+
+		const event = normalizeToolEventInputForTool(tool, input, tempDir);
+		const result = await tool.execute("drive", input);
+
+		// A `path.win32` branch taken off Windows projected `C:/tmp/x.ts`
+		// verbatim: not absolute, and not the file the write goes on to create,
+		// so a gate matching absolute rules sees neither.
+		const written = path.join(tempDir, "C:", "tmp", "x.ts");
+		expect(event.plannedMutationPaths).toEqual([written]);
+		expect(result.details?.changedPaths).toEqual([written]);
+	});
+});
+
+describe("tool_result changedPaths", () => {
+	it("reports every file a multi-file edit wrote", async () => {
+		await Bun.write(path.join(tempDir, "one.txt"), "one\n");
+		await Bun.write(path.join(tempDir, "two.txt"), "two\n");
+		const input = [
+			"*** Begin Patch",
+			"*** Update File: one.txt",
+			"@@",
+			"-one",
+			"+uno",
+			"*** Update File: two.txt",
+			"@@",
+			"-two",
+			"+dos",
+			"*** End Patch",
+			"",
+		].join("\n");
+
+		const result = await new EditTool(makeSession(tempDir), "apply_patch").execute("multi", { input });
+
+		expect(result.isError).not.toBe(true);
+		expect(result.details?.changedPaths).toEqual([path.join(tempDir, "one.txt"), path.join(tempDir, "two.txt")]);
+	});
+
+	it("reports the source and destination of an apply-patch move", async () => {
+		await Bun.write(path.join(tempDir, "move.txt"), "move me\n");
+		const input = [
+			"*** Begin Patch",
+			"*** Update File: move.txt",
+			"*** Move to: moved.txt",
+			"@@",
+			"-move me",
+			"+moved",
+			"*** End Patch",
+			"",
+		].join("\n");
+
+		const result = await new EditTool(makeSession(tempDir), "apply_patch").execute("move", { input });
+
+		expect(result.isError).not.toBe(true);
+		expect(result.details?.changedPaths).toEqual([path.join(tempDir, "move.txt"), path.join(tempDir, "moved.txt")]);
+	});
+
+	it("reports the path of a write whose content is unchanged", async () => {
+		const target = path.join(tempDir, "same.txt");
+		const content = "identical\n";
+		await Bun.write(target, content);
+
+		const result = await new WriteTool(makeSession(tempDir)).execute("same", { path: target, content });
+
+		expect(result.details?.changedPaths).toEqual([target]);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"reports the single file a backslash-bearing relative path writes",
+		async () => {
+			// POSIX has no separator here: `a\b.txt` is one filename. Reporting
+			// `<cwd>/a/b.txt` names a file the write never touched and leaves the
+			// one it did touch unnamed.
+			const result = await new WriteTool(makeSession(tempDir)).execute("backslash", {
+				path: "a\\b.txt",
+				content: "backslash\n",
+			});
+
+			expect(result.details?.changedPaths).toEqual([path.join(tempDir, "a\\b.txt")]);
+			expect(await Bun.file(path.join(tempDir, "a\\b.txt")).exists()).toBe(true);
+			expect(await Bun.file(path.join(tempDir, "a", "b.txt")).exists()).toBe(false);
+		},
+	);
+
+	it("separates ast_edit candidates from the files its apply pass wrote", async () => {
+		const target = path.join(tempDir, "legacy.ts");
+		await Bun.write(target, "legacyWrap(x, value)\n");
+		await Bun.write(path.join(tempDir, "other.ts"), "const y = 1;\n");
+		const queue = new ToolChoiceQueue();
+		const session = makeSession(tempDir, {
+			getToolChoiceQueue: () => queue,
+			buildToolChoice: () => ({ type: "tool" as const, name: "resolve" }),
+			steer: () => {},
+		});
+
+		const staged = await new AstEditTool(session).execute("stage", {
+			ops: [{ pat: "legacyWrap($A, $B)", out: "modernWrap($A, $B)" }],
+			paths: [tempDir],
+		});
+
+		// Staging writes nothing: the candidates are planned, not changed.
+		expect(staged.details?.applied).toBe(false);
+		expect(staged.details?.changedPaths).toBeUndefined();
+		expect(staged.details?.plannedMutationPaths).toEqual([target]);
+
+		const applied = await queue.peekPendingInvoker()!({ action: "apply", reason: "apply the staged rewrite" });
+		const report = resolveResult.assert(applied).details.sourceResultDetails;
+
+		expect(report?.applied).toBe(true);
+		expect(report?.changedPaths).toEqual([target]);
+	});
+
+	it("reports both sides of an lsp rename_file", async () => {
+		const source = path.join(tempDir, "notes.txt");
+		const dest = path.join(tempDir, "renamed.txt");
+		await Bun.write(source, "notes\n");
+
+		const result = await new LspTool(makeSession(tempDir)).execute("rename", {
+			action: "rename_file",
+			file: source,
+			new_name: dest,
+		});
+
+		expect(result.details?.success).toBe(true);
+		expect(result.details?.changedPaths).toEqual([source, dest]);
+	});
+
+	it("reports import-rewritten files alongside a renamed file", async () => {
+		const source = path.join(tempDir, "moved.ts");
+		const dest = path.join(tempDir, "renamed.ts");
+		const reference = path.join(tempDir, "ref.ts");
+		await Bun.write(source, "export const x = 1;\n");
+		await Bun.write(reference, 'import { x } from "./moved";\n');
+
+		const result = await applyWorkspaceEdit(
+			{
+				documentChanges: [
+					{
+						textDocument: { uri: fileToUri(reference), version: null },
+						edits: [
+							{
+								range: { start: { line: 0, character: 19 }, end: { line: 0, character: 26 } },
+								newText: "./renamed",
+							},
+						],
+					},
+					{ kind: "rename", oldUri: fileToUri(source), newUri: fileToUri(dest) },
+				],
+			},
+			tempDir,
+		);
+
+		// Membership, not order: the planner runs resource ops before trailing
+		// text edits, and a gate only cares which files the edit touched.
+		expect([...result.changedPaths].sort()).toEqual([dest, reference, source].sort());
+		expect(await Bun.file(reference).text()).toBe('import { x } from "./renamed";\n');
+	});
+});

--- a/packages/coding-agent/test/trusted-extension-settings.test.ts
+++ b/packages/coding-agent/test/trusted-extension-settings.test.ts
@@ -1,0 +1,400 @@
+/**
+ * The `trustedExtensions` setting is the persistent form of
+ * `--trusted-extension`: modules that keep running inside restricted subagents
+ * and whose absence stops startup. These tests pin the three properties that
+ * make it load-bearing — it survives `--no-extensions`, it fails closed, and a
+ * restricted child rebinds its handlers while ordinary extensions stay out.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	type CreateAgentSessionOptions,
+	createAgentSession,
+	discoverSessionExtensionPaths,
+	resolveConfiguredTrustedExtensionPaths,
+} from "@oh-my-pi/pi-coding-agent/sdk";
+import { buildSessionOptions } from "@oh-my-pi/pi-coding-agent/main";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+const SETTINGS_RECOVERY = "Fix or remove the trustedExtensions setting entry and restart.";
+
+let tempDir: string;
+let authStorage: AuthStorage;
+const openSessions: Array<{ dispose: () => Promise<void> }> = [];
+
+beforeAll(() => {
+	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `omp-trusted-extension-${Snowflake.next()}-`));
+	authStorage = createInMemoryAuthStorage();
+});
+
+afterEach(async () => {
+	for (const session of openSessions.splice(0)) await session.dispose();
+});
+
+afterAll(() => {
+	authStorage.close();
+	removeSyncWithRetries(tempDir);
+});
+
+declare global {
+	/** Lifecycle log the probe modules append to, keyed by each probe's own key. */
+	var __ompTrustedProbeLog: Record<string, string[]> | undefined;
+}
+
+/**
+ * Extension module that appends every lifecycle step it observes to a
+ * globalThis-keyed log, so a test can tell factory binding from handler
+ * dispatch and one module's activity from another's.
+ */
+function writeProbeModule(name: string, key: string, block: boolean): string {
+	const modulePath = path.join(tempDir, name);
+	fs.writeFileSync(
+		modulePath,
+		[
+			"declare global { var __ompTrustedProbeLog: Record<string, string[]> | undefined; }",
+			`const KEY = ${JSON.stringify(key)};`,
+			"const record = entry => {",
+			"	const logs = (globalThis.__ompTrustedProbeLog ??= {});",
+			"	(logs[KEY] ??= []).push(entry);",
+			"};",
+			"export default function (api) {",
+			'	record("factory");',
+			'	api.on("tool_call", () => {',
+			'		record("tool_call");',
+			`		return ${block ? '{ block: true, reason: "policy denied" }' : "undefined"};`,
+			"	});",
+			'	api.on("tool_result", () => {',
+			'		record("tool_result");',
+			"		return undefined;",
+			"	});",
+			"}",
+			"",
+		].join("\n"),
+	);
+	return modulePath;
+}
+
+/**
+ * Handler-only module shaped like the deployed policy gates: the handler
+ * catches its own failure, reports it through `api.logger`, and allows the
+ * call. The log call is the point — a stubbed `api.logger` turns that catch
+ * block into a throw, and the runner turns a handler throw into a block.
+ */
+function writeLoggingProbeModule(name: string, key: string): string {
+	const modulePath = path.join(tempDir, name);
+	fs.writeFileSync(
+		modulePath,
+		[
+			"export default function (api) {",
+			'	api.on("tool_call", () => {',
+			"		try {",
+			'			throw new Error("policy backend unavailable");',
+			"		} catch (error) {",
+			`			api.logger.warn("policy failed open", { key: ${JSON.stringify(key)}, error });`,
+			"			return undefined;",
+			"		}",
+			"	});",
+			"}",
+			"",
+		].join("\n"),
+	);
+	return modulePath;
+}
+
+function probeLog(key: string): string[] {
+	return globalThis.__ompTrustedProbeLog?.[key] ?? [];
+}
+
+function resetProbeLog(key: string): void {
+	(globalThis.__ompTrustedProbeLog ??= {})[key] = [];
+}
+
+function sessionOptions(overrides: Partial<CreateAgentSessionOptions>): CreateAgentSessionOptions {
+	return {
+		cwd: tempDir,
+		agentDir: tempDir,
+		authStorage,
+		modelRegistry: new ModelRegistry(authStorage, path.join(tempDir, "models.json")),
+		sessionManager: SessionManager.inMemory(tempDir),
+		// Ambient discovery would pull the developer's own ~/.omp extensions into
+		// the assertions; the trusted list must reach the loader without it.
+		disableExtensionDiscovery: true,
+		skills: [],
+		rules: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		preloadedCustomToolPaths: [],
+		toolNames: ["read"],
+		enableMCP: false,
+		enableLsp: false,
+		skipPythonPreflight: true,
+		...overrides,
+	};
+}
+
+describe("trustedExtensions setting", () => {
+	it("loads the configured module at top level and rebinds its handlers in a restricted child", async () => {
+		const trustedKey = `__omp_trusted_probe_${Snowflake.next()}`;
+		const ordinaryKey = `__omp_ordinary_probe_${Snowflake.next()}`;
+		const trustedPath = writeProbeModule("policy-probe.ts", trustedKey, true);
+		const ordinaryPath = writeProbeModule("ordinary-probe.ts", ordinaryKey, false);
+		resetProbeLog(trustedKey);
+		resetProbeLog(ordinaryKey);
+
+		const parent = await createAgentSession(
+			sessionOptions({
+				settings: Settings.isolated({ trustedExtensions: [trustedPath] }),
+				additionalExtensionPaths: [ordinaryPath],
+			}),
+		);
+		openSessions.push(parent.session);
+
+		expect(probeLog(trustedKey)).toEqual(["factory"]);
+		expect(probeLog(ordinaryKey)).toEqual(["factory"]);
+		expect(parent.session.trustedExtensionPaths).toEqual([trustedPath]);
+
+		resetProbeLog(trustedKey);
+		resetProbeLog(ordinaryKey);
+		// The child reads no settings: it must trust exactly what the parent
+		// forwarded, and drop the ordinary path even though it is handed one.
+		const child = await createAgentSession(
+			sessionOptions({
+				settings: Settings.isolated(),
+				restrictToolNames: true,
+				trustedExtensionPaths: parent.session.trustedExtensionPaths,
+				additionalExtensionPaths: [ordinaryPath],
+			}),
+		);
+		openSessions.push(child.session);
+
+		expect(probeLog(trustedKey)).toEqual(["factory"]);
+		expect(probeLog(ordinaryKey)).toEqual([]);
+
+		const blocked = await child.session.extensionRunner?.emitToolCall({
+			type: "tool_call",
+			toolName: "write",
+			toolCallId: "trusted-child-call",
+			input: { path: path.join(tempDir, "blocked.txt") },
+		});
+		expect(blocked).toEqual({ block: true, reason: "policy denied" });
+
+		await child.session.extensionRunner?.emitToolResult({
+			type: "tool_result",
+			toolName: "write",
+			toolCallId: "trusted-child-call",
+			input: { path: path.join(tempDir, "blocked.txt") },
+			content: [{ type: "text", text: "wrote" }],
+			isError: false,
+			details: undefined,
+		});
+
+		expect(probeLog(trustedKey)).toEqual(["factory", "tool_call", "tool_result"]);
+		expect(probeLog(ordinaryKey)).toEqual([]);
+	});
+
+	it("binds the configured trusted module in a restricted session that was forwarded no list", async () => {
+		const probeKey = `__omp_unforwarded_probe_${Snowflake.next()}`;
+		const trustedPath = writeProbeModule("unforwarded-policy.ts", probeKey, true);
+		resetProbeLog(probeKey);
+
+		// A cold revive, a security scan, an agentic commit, and a compression
+		// pass each create a restricted session with no forwarded trusted list.
+		// Treating that as "trusts nothing" runs them with the policy absent.
+		const restricted = await createAgentSession(
+			sessionOptions({
+				settings: Settings.isolated({ trustedExtensions: [trustedPath] }),
+				restrictToolNames: true,
+			}),
+		);
+		openSessions.push(restricted.session);
+
+		expect(probeLog(probeKey)).toEqual(["factory"]);
+		const blocked = await restricted.session.extensionRunner?.emitToolCall({
+			type: "tool_call",
+			toolName: "write",
+			toolCallId: "unforwarded-call",
+			input: { path: path.join(tempDir, "blocked.txt") },
+		});
+		expect(blocked).toEqual({ block: true, reason: "policy denied" });
+	});
+
+	it("refuses to start a restricted session whose configured trusted module is missing", async () => {
+		const missingPath = path.join(tempDir, "absent-restricted-policy.ts");
+
+		await expect(
+			createAgentSession(
+				sessionOptions({
+					settings: Settings.isolated({ trustedExtensions: [missingPath] }),
+					restrictToolNames: true,
+				}),
+			),
+		).rejects.toThrow(`Trusted extension must be an existing module file: ${missingPath}. ${SETTINGS_RECOVERY}`);
+	});
+
+	it("refuses to start a restricted session whose configured trusted factory throws", async () => {
+		const throwingPath = path.join(tempDir, "restricted-throwing-policy.ts");
+		fs.writeFileSync(throwingPath, 'export default function () {\n\tthrow new Error("policy boot failed");\n}\n');
+
+		await expect(
+			createAgentSession(
+				sessionOptions({
+					settings: Settings.isolated({ trustedExtensions: [throwingPath] }),
+					restrictToolNames: true,
+				}),
+			),
+		).rejects.toThrow(
+			`Trusted extension handlers failed to load for this restricted session: ${throwingPath}: Failed to load extension: policy boot failed.`,
+		);
+	});
+
+	it("keeps api.logger live in a handler-only session so a module's own catch block allows the call", async () => {
+		const probeKey = `__omp_logging_probe_${Snowflake.next()}`;
+		const trustedPath = writeLoggingProbeModule("logging-policy.ts", probeKey);
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const restricted = await createAgentSession(
+				sessionOptions({
+					settings: Settings.isolated({ trustedExtensions: [trustedPath] }),
+					restrictToolNames: true,
+				}),
+			);
+			openSessions.push(restricted.session);
+
+			const decision = await restricted.session.extensionRunner?.emitToolCall({
+				type: "tool_call",
+				toolName: "write",
+				toolCallId: "logging-call",
+				input: { path: path.join(tempDir, "allowed.txt") },
+			});
+
+			// A stubbed `api.logger` makes the handler throw instead, and the
+			// runner converts a handler throw into `{ block: true }` — so every
+			// tool call in the session dies on the policy's own error path.
+			expect(decision).toBeUndefined();
+			expect(warn).toHaveBeenCalledWith("policy failed open", expect.objectContaining({ key: probeKey }));
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("fails startup when a configured trusted extension is missing", async () => {
+		const missingPath = path.join(tempDir, "absent-policy.ts");
+		const settings = Settings.isolated({ trustedExtensions: [missingPath] });
+
+		await expect(
+			buildSessionOptions(
+				parseArgs([]),
+				[],
+				SessionManager.inMemory(tempDir),
+				new ModelRegistry(authStorage, path.join(tempDir, "models.json")),
+				settings,
+			),
+		).rejects.toThrow(`Trusted extension must be an existing module file: ${missingPath}. ${SETTINGS_RECOVERY}`);
+	});
+
+	it("fails startup closed when a configured trusted extension factory throws", async () => {
+		const throwingPath = path.join(tempDir, "throwing-policy.ts");
+		fs.writeFileSync(throwingPath, 'export default function () {\n\tthrow new Error("policy boot failed");\n}\n');
+
+		await expect(
+			createAgentSession(sessionOptions({ settings: Settings.isolated({ trustedExtensions: [throwingPath] }) })),
+		).rejects.toThrow(`${throwingPath}: Failed to load extension: policy boot failed. ${SETTINGS_RECOVERY}`);
+	});
+
+	it("prefers --trusted-extension over the trustedExtensions setting", async () => {
+		const flagPath = writeProbeModule("flag-policy.ts", `__omp_flag_probe_${Snowflake.next()}`, true);
+		const settingPath = writeProbeModule("setting-policy.ts", `__omp_setting_probe_${Snowflake.next()}`, true);
+		const canonicalFlagPath = fs.realpathSync.native(flagPath);
+
+		const options = await buildSessionOptions(
+			parseArgs(["--trusted-extension", flagPath]),
+			[],
+			SessionManager.inMemory(tempDir),
+			new ModelRegistry(authStorage, path.join(tempDir, "models.json")),
+			Settings.isolated({ trustedExtensions: [settingPath] }),
+		);
+
+		expect(options.trustedExtensionPaths).toEqual([canonicalFlagPath]);
+		expect(options.additionalExtensionPaths).toEqual([canonicalFlagPath]);
+		expect(options.disableExtensionDiscovery).toBe(true);
+	});
+
+	it("keeps configured trusted extensions loading under --no-extensions, down to a restricted child", async () => {
+		const probeKey = `__omp_flagoff_probe_${Snowflake.next()}`;
+		const trustedPath = writeProbeModule("no-extensions-policy.ts", probeKey, true);
+		const settings = Settings.isolated({ trustedExtensions: [trustedPath] });
+
+		const options = await buildSessionOptions(
+			parseArgs(["--no-extensions"]),
+			[],
+			SessionManager.inMemory(tempDir),
+			new ModelRegistry(authStorage, path.join(tempDir, "models.json")),
+			settings,
+		);
+
+		expect(options.disableExtensionDiscovery).toBe(true);
+		expect(options.trustedExtensionPaths).toEqual([trustedPath]);
+		expect(options.additionalExtensionPaths).toContain(trustedPath);
+		expect(await discoverSessionExtensionPaths(options, tempDir, settings)).toEqual([trustedPath]);
+
+		resetProbeLog(probeKey);
+		const parent = await createAgentSession(sessionOptions({ ...options, cwd: tempDir, settings }));
+		openSessions.push(parent.session);
+		expect(probeLog(probeKey)).toEqual(["factory"]);
+
+		resetProbeLog(probeKey);
+		const child = await createAgentSession(
+			sessionOptions({
+				...options,
+				cwd: tempDir,
+				settings,
+				restrictToolNames: true,
+				trustedExtensionPaths: parent.session.trustedExtensionPaths,
+			}),
+		);
+		openSessions.push(child.session);
+
+		const blocked = await child.session.extensionRunner?.emitToolCall({
+			type: "tool_call",
+			toolName: "write",
+			toolCallId: "no-extensions-child-call",
+			input: { path: path.join(tempDir, "blocked.txt") },
+		});
+		expect(blocked).toEqual({ block: true, reason: "policy denied" });
+		expect(probeLog(probeKey)).toEqual(["factory", "tool_call"]);
+	});
+
+	it("ignores a project-level trustedExtensions entry and honors the user-level one", async () => {
+		const userPath = writeProbeModule("user-scope-policy.ts", `__omp_user_scope_${Snowflake.next()}`, true);
+		const projectPath = writeProbeModule("project-scope-policy.ts", `__omp_project_scope_${Snowflake.next()}`, true);
+		const projectDir = path.join(tempDir, "scoped-project");
+		const agentDir = path.join(tempDir, "scoped-agent");
+		const projectConfig = path.join(projectDir, ".omp", "config.yml");
+		await Bun.write(projectConfig, `trustedExtensions:\n  - ${projectPath}\n`);
+		await Bun.write(path.join(agentDir, "config.yml"), `trustedExtensions:\n  - ${userPath}\n`);
+
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const settings = await Settings.loadReadOnly({ cwd: projectDir, agentDir });
+
+			// A checked-out repository cannot nominate a module that binds in every
+			// restricted subagent; the launch operator's own config still can.
+			expect(resolveConfiguredTrustedExtensionPaths(settings, projectDir)).toEqual([userPath]);
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("project-level trustedExtensions"), {
+				source: projectConfig,
+				entries: [projectPath],
+			});
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
a restricted task child loads no extension, so a policy gate installed in the parent was gone in every subagent, and the only way to keep it was repeating --trusted-extension on each launch. an extension that gates file edits also had to guess the target path from tool arguments, and that guess drifted from what write, edit, ast_edit, and lsp rename touched.

this adds a trustedExtensions setting in the user config. those paths load in every session, restricted children included. a project-level entry is dropped with a logged warning, and a missing or broken entry aborts startup instead of running without the gate. a restricted session created without a forwarded list (cold revive, the security coordinator, the commit agent) falls back to the setting, and the /tan fork forwards the parent's list.

write, edit, apply_patch, ast_edit, and lsp rename now attach plannedMutationPaths to the tool_call input and changedPaths to the tool_result details, only for filesystem targets, resolved with the same resolveToCwd the tools use. a gating extension reads those fields instead of parsing arguments.

verified on this branch after rebasing onto main: bun check passes, the two new suites pass (23 cases, including a probe named in trustedExtensions blocking a write at top level and inside a restricted child), and the extension, loader, edit, lsp, and hook suites pass (389 cases). from a scratch HOME, a missing trustedExtensions entry stopped startup with "Trusted extension must be an existing module file" plus the recovery text in the log, and a project .omp/config.yml entry was dropped with "ignoring project-level trustedExtensions" logged. launched with --trusted-extension, a /tan fork kept the probe and a restricted grandchild's write was blocked. the test gate I run locally consumes these fields.

opening as a draft since this spans packages/agent and packages/coding-agent; splitting the setting and the mutation-target fields into two PRs is fine if that reads easier.
