### PR TITLE
fix(catalog): cap vercel muse-spark-1.3-contributor output tokens

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Capped the Vercel AI Gateway `meta/muse-spark-1.3-contributor` output budget to 131072 tokens so requests no longer fail with HTTP 400 ([#10705](https://github.com/can1357/oh-my-pi/issues/10705)).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -12887,6 +12887,27 @@
 				}
 			},
 			{
+				"source": "providers/vercel-ai-gateway.kdl:79",
+				"providers": [
+					"vercel-ai-gateway"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "meta/muse-spark-1.2-contributor"
+					},
+					{
+						"kind": "exact",
+						"value": "meta/muse-spark-1.3-contributor"
+					}
+				],
+				"catalog": {
+					"limitsPatch": {
+						"maxTokens": 131072
+					}
+				}
+			},
+			{
 				"source": "providers/vllm.kdl:4",
 				"class": "qwen",
 				"providers": [

--- a/packages/catalog/src/compat/rules/providers/vercel-ai-gateway.kdl
+++ b/packages/catalog/src/compat/rules/providers/vercel-ai-gateway.kdl
@@ -70,4 +70,15 @@ provider "vercel-ai-gateway" {
 	models "openai/gpt-5.1-codex-mini" {
 		thinking-efforts "medium" "high"
 	}
+	// Vercel reports context_window and max_tokens both as 1_048_576 for the
+	// Meta Muse Spark contributor SKUs, but the upstream Meta deployment 400s
+	// when max_tokens plus any prompt exceeds that shared window. Cap output to
+	// OMP's first-party Meta ceiling; the context window stays as reported.
+	// #9115 capped 1.2-contributor in TS; 1.3-contributor regressed the same
+	// way (#10705), so both live here now.
+	models "meta/muse-spark-1.2-contributor" "meta/muse-spark-1.3-contributor" {
+		limits-patch {
+			max-tokens 131072
+		}
+	}
 }

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -349758,7 +349758,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 131072,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3711,12 +3711,6 @@ export function vercelAiGatewayModelManagerOptions(
 				): ModelSpec<"anthropic-messages"> => {
 					const pricing = entry.pricing as Record<string, unknown> | undefined;
 					const tags = Array.isArray(entry.tags) ? (entry.tags as string[]) : [];
-					const reportedMaxTokens = typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens;
-					const modelId = typeof entry.id === "string" ? entry.id : defaults.id;
-					const maxTokens =
-						modelId === "meta/muse-spark-1.2-contributor" && typeof reportedMaxTokens === "number"
-							? Math.min(reportedMaxTokens, 131_072)
-							: reportedMaxTokens;
 
 					return {
 						...defaults,
@@ -3731,7 +3725,7 @@ export function vercelAiGatewayModelManagerOptions(
 						},
 						contextWindow:
 							typeof entry.context_window === "number" ? entry.context_window : defaults.contextWindow,
-						maxTokens,
+						maxTokens: typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens,
 					};
 				},
 				fetch: config?.fetch,

--- a/packages/catalog/test/vercel-ai-gateway-provider.test.ts
+++ b/packages/catalog/test/vercel-ai-gateway-provider.test.ts
@@ -1,27 +1,35 @@
 import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { vercelAiGatewayModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 
 describe("Vercel AI Gateway provider", () => {
-	test("caps meta/muse-spark-1.2-contributor output allowance to 131072 while preserving context window", async () => {
-		// Vercel currently reports both context_window and max_tokens as 1M for the
-		// contributor model, which makes Anthropic messages requests fail with 400
-		// when prompt + max_tokens exceeds the shared context window. The mapper
-		// must cap the output allowance while leaving the context window intact.
-		const contributorId = "meta/muse-spark-1.2-contributor";
+	test("caps Meta Muse Spark contributor output allowance to 131072 while preserving context window", async () => {
+		// Vercel reports both context_window and max_tokens as 1M for the Muse Spark
+		// contributor SKUs, which makes Anthropic messages requests 400 when prompt +
+		// max_tokens exceeds the shared context window. The `limits-patch` rule in
+		// providers/vercel-ai-gateway.kdl must cap the output allowance for both the
+		// 1.2 and 1.3 contributor ids (#9115, #10705) while leaving the context
+		// window — and the non-contributor SKUs — untouched.
+		const contributor12 = "meta/muse-spark-1.2-contributor";
+		const contributor13 = "meta/muse-spark-1.3-contributor";
+		const plain13 = "meta/muse-spark-1.3";
 		const controlId = "anthropic/claude-sonnet-4-5-20250929";
+		const oneMegModel = (id: string, owner: string) => ({
+			id,
+			object: "model",
+			owned_by: owner,
+			tags: ["tool-use", "reasoning", "vision"],
+			context_window: 1_048_576,
+			max_tokens: 1_048_576,
+			pricing: { input: 0.0000001, output: 0.0000002 },
+		});
 		const fetchMock = (async () =>
 			Response.json({
 				object: "list",
 				data: [
-					{
-						id: contributorId,
-						object: "model",
-						owned_by: "meta",
-						tags: ["tool-use", "reasoning", "vision"],
-						context_window: 1_048_576,
-						max_tokens: 1_048_576,
-						pricing: { input: 0.0000001, output: 0.0000002 },
-					},
+					oneMegModel(contributor12, "meta"),
+					oneMegModel(contributor13, "meta"),
+					oneMegModel(plain13, "meta"),
 					{
 						id: controlId,
 						object: "model",
@@ -35,14 +43,24 @@ describe("Vercel AI Gateway provider", () => {
 			})) as unknown as typeof fetch;
 
 		const options = vercelAiGatewayModelManagerOptions({ fetch: fetchMock });
-		const models = await options.fetchDynamicModels?.();
-		expect(models).not.toBeNull();
-		const byId = new Map((models ?? []).map(model => [model.id, model]));
+		const specs = await options.fetchDynamicModels?.();
+		expect(specs).not.toBeNull();
+		// The model manager rebuilds every discovered spec via `buildModel`, which is
+		// where the KDL limits-patch is applied — assert the built contract, not the
+		// raw discovery spec.
+		const byId = new Map((specs ?? []).map(spec => [spec.id, buildModel(spec)]));
 
-		const contributor = byId.get(contributorId);
-		expect(contributor).toBeDefined();
-		expect(contributor?.contextWindow).toBe(1_048_576);
-		expect(contributor?.maxTokens).toBe(131_072);
+		for (const id of [contributor12, contributor13]) {
+			const model = byId.get(id);
+			expect(model).toBeDefined();
+			expect(model?.contextWindow).toBe(1_048_576);
+			expect(model?.maxTokens).toBe(131_072);
+		}
+
+		// The non-contributor SKU is out of scope and must keep its reported budget.
+		const plain = byId.get(plain13);
+		expect(plain).toBeDefined();
+		expect(plain?.maxTokens).toBe(1_048_576);
 
 		const control = byId.get(controlId);
 		expect(control).toBeDefined();


### PR DESCRIPTION
## What

Caps the Vercel AI Gateway `meta/muse-spark-1.3-contributor` output budget to 131072 tokens via a `limits-patch` rule in `providers/vercel-ai-gateway.kdl` covering both contributor SKUs (`1.2` + `1.3`), and removes the one-off `1.2-contributor` hardcoded cap from the Vercel discovery mapper in `openai-compat.ts` so the mapper reports upstream values and KDL owns the policy. Regenerates `rules.json` (`bun run gen:compat`), updates the bundled `models.json` `1.3-contributor` row (`1048576` → `131072`, context window unchanged), and rewrites the provider test to assert the built-model contract.

## Why

Fixes #10705. Vercel reports both `context_window` and `max_tokens` as 1048576 for the Meta Muse Spark contributor SKUs; omp copied that allowance into Anthropic Messages requests, so any non-empty prompt pushed prompt + requested output past the shared window and the gateway returned HTTP 400 (reproduced: 400 at 1048576, 200 at 65536). #9115 capped `1.2-contributor` with a hardcoded id check in TS; `1.3-contributor` slipped through uncapped the same way.

Relation to #10706: same approach, rebased onto current `main` (`5964a0f`). No code changes vs #10706's head beyond rebase regeneration. #10706's 2 CI failures were proven unrelated pre-existing flakes from its run logs (run `33774832169`): `packages/utils/test/incoming-json.test.ts:439` perf budget (`Expected: < 2000`, `Received: 2008.35`) and `packages/coding-agent/test/mcp-http-transport.test.ts:50` 500ms event guard (`resumed notification stayed pending past 500ms`) — the catalog suite was green (`✓ packages/catalog`) in the same run. Its `CONFLICTING` state was also computed against a stale base and the head auto-merges into current `main` cleanly.

## Testing

Scoped suites, all green (21 tests pass):
- `vercel-ai-gateway-provider.test.ts` — asserts `buildModel` output for both contributor ids (`contextWindow` 1048576, `maxTokens` 131072), the non-contributor `meta/muse-spark-1.3` SKU untouched at 1048576, plus the control model
- catalog compat-compile drift gate, parity, and conformance suites
- `check:types` and `oxlint`/`oxfmt` clean

Full-workspace runs were not used as signal: the two failures seen on #10706 are the pre-existing timing flakes above, unrelated to this change.

> Honesty note: the `models.json` 1.3-contributor row value is mirrored from #10706's generator output because `gen:models` requires the `pi_natives` binary, which is absent in this environment. The capped value is proven by the passing `buildModel` assertion in the provider test; a maintainer `bun run gen:models` should show an empty diff for this row.

---

- [x] `bun check` passes (scoped: `check:types` + `oxlint`/`oxfmt` clean; see note above on full-workspace flakes)
- [x] Tested locally (scoped provider + catalog suites, 21 pass)
- [x] CHANGELOG updated (if user-facing)