### PR TITLE
fix(coding-agent): support extended context for GPT-6 Astra

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Muse Code subscriptions now resolve a compact edit-prompt variant, cutting recurring per-request tool bytes without touching other providers.
 - Added Meta's new `max` reasoning effort tier to Muse Spark 1.3 (standard) on the Meta Model API and Muse Code.
 
+### Fixed
+
+- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10872](https://github.com/can1357/oh-my-pi/pull/10872) by [@fzlzjerry](https://github.com/fzlzjerry)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -277,6 +277,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"limits-patch": { key: "limitsPatch", set: "catalog", shape: "object" },
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
 	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
+	"max-context-window": { key: "maxContextWindow", set: "catalog", shape: "scalar" },
 	"requires-cursor-tool-schema-projection": {
 		key: "requiresCursorToolSchemaProjection",
 		set: "catalog",

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -8,6 +8,11 @@ import { resolveModelPolicy } from "./resolve";
  * at catalog composition time so frozen bundled rows need no runtime mutation.
  */
 export function resolveMaxContextWindow(model: Model): number | undefined {
-	const maximum = model.maxContextWindow ?? resolveModelPolicy(toModelSpec(model)).catalog.maxContextWindow;
-	return typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0 ? maximum : undefined;
+	const maximum = model.maxContextWindow;
+	if (typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0) {
+		return maximum;
+	}
+
+	const fallback = resolveModelPolicy(toModelSpec(model)).catalog.maxContextWindow;
+	return typeof fallback === "number" && Number.isFinite(fallback) && fallback > 0 ? fallback : undefined;
 }

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -1,0 +1,13 @@
+import { toModelSpec } from "../provider-models/bundled-references";
+import type { Model } from "../types";
+import { resolveModelPolicy } from "./resolve";
+
+/**
+ * Maximum prompt window for extended context. Live discovery takes precedence
+ * over rule-owned fallbacks for older bundled or cached model metadata. Resolve
+ * at catalog composition time so frozen bundled rows need no runtime mutation.
+ */
+export function resolveMaxContextWindow(model: Model): number | undefined {
+	const maximum = model.maxContextWindow ?? resolveModelPolicy(toModelSpec(model)).catalog.maxContextWindow;
+	return typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0 ? maximum : undefined;
+}

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10874,6 +10874,21 @@
 				}
 			},
 			{
+				"source": "providers/openai-codex.kdl:124",
+				"providers": [
+					"openai-codex"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra"
+					}
+				],
+				"catalog": {
+					"maxContextWindow": 872000
+				}
+			},
+			{
 				"source": "providers/openai-codex.kdl:3",
 				"providers": [
 					"openai-codex"

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -118,4 +118,10 @@ provider "openai-codex" {
 	models "gpt-5.6-luna" "gpt-5.6-sol" "gpt-5.6-terra" {
 		context-window-floor 1000000
 	}
+	// Residue: Astra's Codex registry advertises a 272000 default prompt window
+	// and max_context_window=872000 (client 0.153.1, 2026-09-04). Older bundled
+	// and cached catalogs omit the maximum; live discovery takes precedence.
+	models "gpt-6-astra" {
+		max-context-window 872000
+	}
 }

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -61,6 +61,7 @@ const codexModelEntrySchema = type({
 	"id?": "unknown",
 	"display_name?": "unknown",
 	"context_window?": "unknown",
+	"max_context_window?": "unknown",
 	"default_reasoning_level?": "unknown",
 	"supported_reasoning_levels?": "unknown",
 	"input_modalities?": "unknown",
@@ -289,6 +290,7 @@ interface ParsedCodexModelEntry {
 	slug: string;
 	name: string;
 	contextWindow: number | null;
+	maxContextWindow: number | null;
 	reasoning: boolean;
 	input: ("text" | "image")[];
 	preferWebsockets: boolean;
@@ -318,6 +320,7 @@ function parseCodexModelEntry(entry: unknown): ParsedCodexModelEntry | null {
 		slug,
 		name: toNonEmptyString(payload.display_name) ?? slug,
 		contextWindow: toPositiveInt(payload.context_window),
+		maxContextWindow: toPositiveInt(payload.max_context_window),
 		reasoning: supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels),
 		input: normalizeInputModalities(payload.input_modalities),
 		preferWebsockets: toBoolean(payload.prefer_websockets) === true,
@@ -375,6 +378,7 @@ function buildNormalizedCodexModel(
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			remoteCompaction: CODEX_REMOTE_COMPACTION,
 			contextWindow,
+			...(parsed.maxContextWindow !== null ? { maxContextWindow: parsed.maxContextWindow } : {}),
 			maxTokens,
 			...(parsed.preferWebsockets ? { preferWebsockets: true } : {}),
 			...(parsed.useResponsesLite ? { useResponsesLite: true } : {}),

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1121,6 +1121,8 @@ export interface Model<TApi extends Api = Api> {
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;
+	/** Optional larger prompt window available when extended context is enabled. */
+	maxContextWindow?: number;
 	maxTokens: number | null;
 	/**
 	 * When `true`, providers MUST omit `max_output_tokens` (Responses) /

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -14,6 +14,24 @@ import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import { resolveProviderModelReference } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 
 describe("Codex model discovery", () => {
+	it("normalizes optional maximum context windows separately from the default window", async () => {
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			fetchFn: async () =>
+				Response.json({
+					models: [
+						{ slug: "gpt-6-astra", context_window: 272_000, max_context_window: 872_000 },
+						{ slug: "gpt-5.5", context_window: 272_000 },
+						{ slug: "invalid-maximum", context_window: 64_000, max_context_window: -1 },
+					],
+				}),
+		});
+		const astra = result?.models.find(model => model.id === "gpt-6-astra");
+		expect(astra).toMatchObject({ contextWindow: 272_000, maxContextWindow: 872_000 });
+		expect(result?.models.find(model => model.id === "gpt-5.5")).not.toHaveProperty("maxContextWindow");
+		expect(result?.models.find(model => model.id === "invalid-maximum")).not.toHaveProperty("maxContextWindow");
+	});
+
 	it("marks discovered models for provider-native V2 compaction", async () => {
 		let capturedHeaders: Headers | undefined;
 		const fetchFn: typeof fetch = Object.assign(

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
+import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+
+function bundledAstra() {
+	const astra = getBundledModels("openai-codex").find(model => model.id === "gpt-6-astra");
+	if (!astra) throw new Error("Expected bundled Astra model");
+	return astra;
+}
+
+test("uses the policy fallback when a model maximum is not finite", () => {
+	const astra = bundledAstra();
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(872_000);
+});
+
+test("uses the policy fallback when cached maxima are non-positive", () => {
+	const now = 1_000_000;
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-context-window-"));
+	const dbPath = path.join(tempDir, "models.db");
+	try {
+		writeModelCache("openai-codex", now, [{ ...bundledAstra(), maxContextWindow: 0 }], true, "", dbPath);
+		const cachedSpec = readModelCache("openai-codex", 1_000, () => now, dbPath)?.models.find(
+			model => model.id === "gpt-6-astra",
+		);
+		if (!cachedSpec) throw new Error("Expected cached Astra model");
+
+		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(872_000);
+	} finally {
+		removeSyncWithRetries(tempDir);
+	}
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Fixed `/extended-context` leaving GPT-6 Astra at 272K instead of enabling its 872K prompt window ([#10872](https://github.com/can1357/oh-my-pi/pull/10872) by [@fzlzjerry](https://github.com/fzlzjerry)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -17,6 +17,7 @@ import type {
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { collapseBuiltVariants } from "@oh-my-pi/pi-catalog/compat/collapse";
+import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
 import { applyCatalogMetrics, CatalogMetricsIndex } from "@oh-my-pi/pi-catalog/identity/metrics";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import {
@@ -2127,6 +2128,12 @@ export class ModelRegistry {
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
 		const extendedContext = isExtendedContextEnabledFromSettings(this.#settings);
 		return models.map(model => {
+			if (extendedContext) {
+				const maximum = resolveMaxContextWindow(model);
+				if (maximum !== undefined && model.contextWindow !== null && maximum > model.contextWindow) {
+					model = applyModelOverride(model, { contextWindow: maximum });
+				}
+			}
 			// Extended context off: cap models with a premium long-context price
 			// tier (e.g. GPT-5.6 bills 2x input above 272K) at the standard-pricing
 			// threshold so compaction fires before a request crosses into the tier.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2513,9 +2513,9 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	// Premium long-context tiers (OpenAI GPT-5.6 bills 2x input / 1.5x output
-	// above 272K input tokens). Off caps affected models at the threshold so
-	// compaction kicks in before any request crosses into premium billing.
+	// Opt in to advertised maximum context windows and premium long-context
+	// tiers. Off preserves default windows and caps premium models before
+	// requests cross into their higher pricing tier.
 	extendedContext: {
 		type: "boolean",
 		default: false,
@@ -2524,7 +2524,7 @@ export const SETTINGS_SCHEMA = {
 			group: "General",
 			label: "Extended Context",
 			description:
-				"Use premium long-context windows on models that bill extra past a threshold (e.g. GPT-5.6 1M charges 2x input above 272K); off caps them at the standard-pricing window",
+				"Use larger context windows where supported; may incur premium pricing. Off keeps default or standard-pricing windows",
 		},
 	},
 

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -539,12 +539,12 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "extended-context",
 		icon: "expand",
-		description: "Toggle premium long-context windows",
+		description: "Toggle extended context windows",
 		acpDescription: "Toggle extended context",
 		acpInputHint: "[on|off|status]",
 		subcommands: [
-			{ name: "on", description: "Enable premium long-context windows" },
-			{ name: "off", description: "Use standard-pricing context windows" },
+			{ name: "on", description: "Enable larger context windows" },
+			{ name: "off", description: "Use default or standard-pricing context windows" },
 			{ name: "status", description: "Show extended context status" },
 		],
 		allowArgs: true,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1711,6 +1711,64 @@ describe("ModelRegistry", () => {
 		});
 	});
 	describe("extended context", () => {
+		test("toggles bundled Astra between its default and maximum windows without discovery", async () => {
+			const testSettings = Settings.isolated();
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(872_000);
+			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", false);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
+		});
+
+		test("preserves an explicit Astra context override when extended context is enabled", () => {
+			writeRawModelsJson({
+				"openai-codex": { modelOverrides: { "gpt-6-astra": { contextWindow: 400_000 } } },
+			});
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+				settings: Settings.isolated({ extendedContext: true }),
+			});
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(400_000);
+		});
+
+		test("restores a discovered maximum from cache ahead of the Astra fallback on each toggle", async () => {
+			const testSettings = Settings.isolated();
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			const astra = registry.find("openai-codex", "gpt-6-astra");
+			const legacy = registry.find("openai-codex", "gpt-5.5");
+			if (!astra || !legacy) throw new Error("Expected bundled Codex models");
+			writeModelCache(
+				"openai-codex",
+				Date.now(),
+				[
+					{ ...astra, maxContextWindow: 640_000 },
+					{ ...legacy, maxContextWindow: 128_000 },
+				],
+				true,
+				"",
+				path.join(tempDir, "models.db"),
+			);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(640_000);
+			// An advertised maximum smaller than the current window cannot shrink it.
+			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", false);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(640_000);
+		});
+
 		test("off caps billable premium models without shrinking subscription estimates", async () => {
 			await Settings.init({ inMemory: true, overrides: { extendedContext: false } });
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);


### PR DESCRIPTION
## What

Fix `/extended-context` for `openai-codex/gpt-6-astra`: enabling it selects the 872,000-token prompt window, and disabling it restores the 272,000-token default.

Preserve Codex discovery's `max_context_window` separately from the default window. A provider-scoped KDL fallback supplies Astra's maximum for older bundled and cached metadata. Discovered maxima take precedence over that fallback, and explicit user context-window overrides still win. Update the setting and command descriptions to cover models without a published premium-pricing tier.

## Why

The existing switch could remove a premium-pricing cap but could not expand Astra's default window: discovery discarded its advertised maximum, and the bundled Astra entry stayed at 272,000. Codex model metadata fetched on 2026-09-04 with client 0.153.1 reports `context_window: 272000` and `max_context_window: 872000`.

## Testing

- Exercised the actual source CLI in RPC mode with a fresh temporary configuration and Astra selected. `get_state` initially reported 272,000; `/extended-context on`, `off`, then `on` produced 872,000 → 272,000 → 872,000 in the same session. This verifies CLI context budgeting; no oversized provider request was sent.
- Five focused model-registry tests passed, covering the bundled fallback, repeated toggles with cached discovery, user overrides, and existing premium-context behavior: `bun test packages/coding-agent/test/model-registry.test.ts --test-name-pattern 'extended context'`.
- All 36 tests passed in `packages/catalog/test/codex-discovery.test.ts`, `packages/catalog/test/compat-compile.test.ts`, and `packages/catalog/test/long-context-pricing.test.ts`.
- `bun check` passed in both `packages/catalog` and `packages/coding-agent`.
- Regenerated `rules.json` with `bun run gen:compat`; the committed-rules consistency check passes.

---

- [x] Package-local `bun check` passes (`catalog` and `coding-agent`)
- [x] Tested locally, including the actual CLI command path
- [x] CHANGELOG updated
