### PR TITLE
fix(tools): advertise mirrored artifact in column-cap truncation notice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- The per-line column-cap truncation notice now points to the full-output artifact (`Read artifact://<id> for full output`) when the raw stream was mirrored, matching the tail-truncation notice ([#10877](https://github.com/can1357/oh-my-pi/issues/10877)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -75,7 +75,7 @@ export interface LimitsMeta {
 	matchLimit?: { reached: number; suggestion: number };
 	resultLimit?: { reached: number; suggestion: number };
 	headLimit?: { reached: number; suggestion: number };
-	columnTruncated?: { maxColumn: number };
+	columnTruncated?: { maxColumn: number; artifactId?: string };
 }
 
 /**
@@ -236,7 +236,7 @@ export class OutputMetaBuilder {
 		// notice rather than a "Showing lines X-Y … limit" range. This runs even
 		// when the output is otherwise complete (`truncated === false`).
 		if (summary.columnMax != null && summary.columnMax > 0 && (summary.columnTruncatedLines ?? 0) > 0) {
-			this.columnTruncated(summary.columnMax);
+			this.columnTruncated(summary.columnMax, summary.artifactId);
 		}
 		if (!summary.truncated) return this;
 
@@ -381,10 +381,16 @@ export class OutputMetaBuilder {
 		return this;
 	}
 
-	/** Add column truncation notice. No-op if maxColumn <= 0. */
-	columnTruncated(maxColumn: number): this {
+	/**
+	 * Add column truncation notice. No-op if maxColumn <= 0.
+	 *
+	 * When `artifactId` is supplied the sink mirrored the raw, uncapped stream
+	 * into that artifact; the rendered notice then advertises it as a recovery
+	 * pointer (see {@link formatOutputNotice}), matching the tail-truncation notice.
+	 */
+	columnTruncated(maxColumn: number, artifactId?: string): this {
 		if (maxColumn <= 0) return this;
-		this.#meta.limits = { ...this.#meta.limits, columnTruncated: { maxColumn } };
+		this.#meta.limits = { ...this.#meta.limits, columnTruncated: { maxColumn, artifactId } };
 		return this;
 	}
 
@@ -577,7 +583,12 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 		parts.push(`${l.reached} results limit reached. Use limit=${l.suggestion} for more`);
 	}
 	if (meta.limits?.columnTruncated) {
-		parts.push(`Some lines truncated to ${meta.limits.columnTruncated.maxColumn} chars`);
+		const c = meta.limits.columnTruncated;
+		let columnNotice = `Some lines truncated to ${c.maxColumn} chars`;
+		if (c.artifactId != null) {
+			columnNotice += `. ${formatFullOutputReference(c.artifactId)}`;
+		}
+		parts.push(columnNotice);
 	}
 
 	// Diagnostics

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -827,6 +827,32 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 		expect(notice).not.toContain("artifact://");
 	});
 
+	test("column-cap notice advertises the mirrored artifact when one exists", async () => {
+		// Regression for #10877: when the per-line cap drops bytes and the raw
+		// stream was mirrored into an output artifact, the notice must point at
+		// that artifact — matching the tail-truncation notice's recovery pointer.
+		const summary = {
+			output: "a\nb\nc\n" + "x".repeat(8) + "…\nd",
+			truncated: false,
+			totalLines: 5,
+			totalBytes: 100,
+			outputLines: 5,
+			outputBytes: 20,
+			columnTruncatedLines: 1,
+			columnDroppedBytes: 42,
+			columnMax: 8,
+			artifactId: "77",
+		};
+
+		const meta = outputMeta().truncationFromSummary(summary, { direction: "tail" }).get();
+		expect(meta?.truncation).toBeUndefined();
+		expect(meta?.limits?.columnTruncated).toEqual({ maxColumn: 8, artifactId: "77" });
+
+		const notice = formatOutputNotice(meta);
+		expect(notice).toContain("Some lines truncated to 8 chars");
+		expect(notice).toContain("Read artifact://77 for full output");
+	});
+
 	test("persists per-line state across chunk boundaries", async () => {
 		const sink = new OutputSink({ maxColumns: 4, spillThreshold: 1000 });
 		await sink.push("ab"); // 2 bytes into the current line


### PR DESCRIPTION
## Repro
When the per-line column cap (`tools.outputMaxColumns`) drops bytes and the raw stream is mirrored into an output artifact, the consumer-facing notice omits any pointer to that artifact — a display cut looks like unrecoverable loss even though the full output sits one lookup away. Reproduced with a unit test against the plumbing:

```
bun test packages/coding-agent/test/streaming-output.test.ts -t "advertises the mirrored artifact"
```

A summary with `columnMax: 8`, `columnTruncatedLines: 1`, `artifactId: "77"` yields `meta.limits.columnTruncated === { maxColumn: 8 }` (the id is dropped), so `formatOutputNotice` renders `Some lines truncated to 8 chars` with no recovery pointer.

## Cause
`OutputMetaBuilder.truncationFromSummary` (`packages/coding-agent/src/tools/output-meta.ts`) recorded only `{ maxColumn }` via `columnTruncated(summary.columnMax)` on the pure column-cap path and then returned early (`if (!summary.truncated) return this`), so `summary.artifactId` never reached the metadata. `formatOutputNotice`'s `columnTruncated` branch therefore had no artifact to render — unlike the sibling `formatTailTruncationNotice`, which appends `. Full output: <path>`.

## Fix
- `LimitsMeta.columnTruncated` gains an optional `artifactId`.
- `OutputMetaBuilder.columnTruncated(maxColumn, artifactId?)` stores it; `truncationFromSummary` passes `summary.artifactId`.
- `formatOutputNotice` appends `. Read artifact://<id> for full output` (the same `formatFullOutputReference` pointer the middle/tail truncation branches already use) when the artifact is present; the notice is unchanged when no artifact was allocated.

## Verification
`bun test packages/coding-agent/test/streaming-output.test.ts packages/coding-agent/test/tools/eval-streaming-output.test.ts packages/coding-agent/test/tools/strip-output-notice.test.ts packages/coding-agent/test/mcp-render-status.test.ts` — 78 pass, 0 fail. New regression test asserts the pointer appears when `artifactId` is present; the existing #4735 test (no artifact allocated) still asserts no pointer. `bun check` passed via the pre-publish gate.

Fixes #10877