### PR TITLE
test(release): sync native-core file list with VCS entrypoints

### DIFF
--- a/scripts/ci-release-publish.test.ts
+++ b/scripts/ci-release-publish.test.ts
@@ -69,6 +69,8 @@ describe("published legal payloads", () => {
 				"native/desktop-adapter.d.ts",
 				"native/loader-state.js",
 				"native/loader-state.d.ts",
+				"native/vcs.js",
+				"native/vcs.d.ts",
 				"native/embedded-addon.js",
 				"README.md",
 				"LICENSE",


### PR DESCRIPTION
## Repro
`bun test scripts/ci-release-publish.test.ts` fails 1/6. The "lists every legal file explicitly in the native core package" case asserts an exact `manifest.files` array that omits `native/vcs.js` and `native/vcs.d.ts`, while `prepareNativeCorePackage()` copies both into the published package.

## Cause
Commit 80832ea (natives vcs binding after the pi-vcs migration) added `native/vcs.js`/`native/vcs.d.ts` to the file list in `prepareNativeCorePackage()` (`scripts/ci-release-publish.ts:309-310`) and the `./vcs` export in `packages/natives/package.json`, but the exact-list contract assertion in `scripts/ci-release-publish.test.ts` was not updated, so the received list carries two extra entries the expected array lacks.

## Fix
- Insert `native/vcs.js` and `native/vcs.d.ts` into the expected array in `scripts/ci-release-publish.test.ts`, positioned between `native/loader-state.d.ts` and `native/embedded-addon.js` to match the order produced by `prepareNativeCorePackage()`.

## Verification
`bun test scripts/ci-release-publish.test.ts` → 6 pass, 0 fail. Test-contract synchronization only; no production, export, dependency, or release-workflow change.

Fixes #10878