### PR TITLE
docs: fix README hashline package link to deleted directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,6 @@ For architecture and contribution guidelines, see [packages/coding-agent/DEVELOP
 | **[@oh-my-pi/omptype](packages/omptype)**                                     | ArkType-compatible schema validation with lazy JIT compilation              |
 | **[@oh-my-pi/pi-utils](packages/utils)**                                      | Shared utilities (logging, streams, dirs/env/process helpers)               |
 | **[@oh-my-pi/pi-wire](packages/wire)**                                        | Shared collab live-session protocol types and relay constants               |
-| **[@oh-my-pi/hashline](packages/hashline)**                                   | Line-anchored patch language and applier behind the `edit` tool             |
 | **[@oh-my-pi/pi-mnemopi](packages/mnemopi)**                                  | Local SQLite memory engine for Oh My Pi agents                              |
 | **[@oh-my-pi/snapcompact](packages/snapcompact)**                             | Bitmap-frame context compression package and SQuAD eval suite               |
 | **[@oh-my-pi/browser-relay](packages/browser-relay)**                         | Chrome extension that lets the Eval browser API drive your existing tabs    |
@@ -663,6 +662,7 @@ For architecture and contribution guidelines, see [packages/coding-agent/DEVELOP
 | **[pi-iso](crates/pi-iso)**                        | Task isolation backend resolver: APFS clones, btrfs/zfs reflinks, overlayfs, projfs, rcopy          |
 | **[pi-voice](crates/pi-voice)**                    | Audio capture/playback, Opus codecs, and live WebRTC streaming primitives                           |
 | **[pi-walker](crates/pi-walker)**                  | Parallel ignore-aware filesystem walker with the scan cache shared by grep, glob, and workspace     |
+| **[pi-edit](crates/pi-edit)**                      | Edit engine behind the `edit` tool: line-anchored patch/hashline modes, streaming previews, atomic apply |
 | **[brush-core](crates/vendor/brush-core)**         | Vendored fork of [brush-shell](https://github.com/reubeno/brush) for embedded bash execution        |
 | **[pi-builtins](crates/pi-builtins)**              | Bash builtins (cd, echo, test, printf, read, export, …) plus 67 in-process command-line utilities |
 


### PR DESCRIPTION
## Repro
The root README Monorepo Packages table renders a row `**[@oh-my-pi/hashline](packages/hashline)**`. Following that link (README.md:649) opens a 404: `packages/hashline` was removed during the native Rust edit migration. Confirmed with `git ls-files packages/hashline` (0 tracked files) while `crates/pi-edit` — the current edit engine — is present and unlisted in the Rust Crates table.

## Cause
`README.md` still advertised `@oh-my-pi/hashline` as a JavaScript package under `packages/hashline`. That package no longer exists; hashline is now one mode (`EditMode::Hashline`) of the `crates/pi-edit` engine crate (`crates/pi-edit/src/lib.rs`), which the Rust Crates table never picked up.

## Fix
- Remove the stale `@oh-my-pi/hashline` → `packages/hashline` row from the Monorepo Packages table.
- Add a `pi-edit` → `crates/pi-edit` row to the Rust Crates table describing the edit engine (line-anchored patch/hashline modes, streaming previews, atomic apply).

## Verification
Grepped `README.md` for `hashline`/`packages/hashline`: the only remaining match is the `edit` tool description (line 265), not a path link. Confirmed the new link target `crates/pi-edit` is a tracked directory. Docs-only change; pre-publish `bun run fix` + `bun check` gate ran clean on push.

Fixes #10880