### PR TITLE
fix(robomp): load work-items fixture from URL

### DIFF
--- a/python/robomp/web/src/work-items.contract.test.ts
+++ b/python/robomp/web/src/work-items.contract.test.ts
@@ -4,7 +4,7 @@ import type { StatusResponse } from "./types";
 
 // Read from test/fixtures/status-contract.json relative to src/
 const status = await Bun.file(
-  new URL("../test/fixtures/status-contract.json", import.meta.url).pathname
+  new URL("../test/fixtures/status-contract.json", import.meta.url)
 ).json() as StatusResponse;
 
 describe("buildWorkItems contract validation", () => {


### PR DESCRIPTION
## Repro
On Windows, `bun test --cwd=python/robomp/web src/work-items.contract.test.ts` resolves the fixture URL's `.pathname` to `/D:/repo/.../status-contract.json`, then fails with `ENOENT`; a focused `bun -e` probe confirmed that a `file:///D:/...` URL produces that non-native pathname.

## Cause
The top-level fixture load in `python/robomp/web/src/work-items.contract.test.ts` discarded the file URL before calling `Bun.file()`, forcing Bun's string overload to interpret a slash-prefixed Windows drive path.

## Fix
- Pass the fixture `URL` directly to `Bun.file()` so Bun performs platform-native file URL handling.

## Verification
`bun test --cwd=python/robomp/web src/work-items.contract.test.ts` passed with 1 test and 20 assertions. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #10879