### PR TITLE
fix(tools): label column-truncation notice with the enforced unit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- The per-line column-truncation notice now names the unit it enforces — `bytes` for streamed bash/eval output, `chars` for `read`/`grep` — instead of always claiming `chars`, which overstated visible content for multibyte text ([#10888](https://github.com/can1357/oh-my-pi/issues/10888)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -43,7 +43,7 @@ export interface OutputSummary {
 	columnDroppedBytes?: number;
 	/** Number of distinct lines that hit the per-line column cap. */
 	columnTruncatedLines?: number;
-	/** Configured per-line column cap in effect (chars), when > 0. */
+	/** Configured per-line column cap in effect (UTF-8 bytes), when > 0. */
 	columnMax?: number;
 	/** Artifact ID for internal URL access (artifact://<id>) when truncated */
 	artifactId?: string;

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -8,7 +8,7 @@ import { sanitizeWithOptionalSixelPassthrough } from "../utils/sixel";
 
 export const DEFAULT_MAX_LINES = 3000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
-export const DEFAULT_MAX_COLUMN = 512; // Max chars per grep match line
+export const DEFAULT_MAX_COLUMN = 512; // Max UTF-8 bytes per grep match line
 
 /**
  * Default artifact-on-disk cap for {@link OutputSink}.
@@ -274,6 +274,21 @@ export function truncateLine(
 ): { text: string; wasTruncated: boolean } {
 	if (line.length <= maxChars) return { text: line, wasTruncated: false };
 	return { text: materializeString(`${line.slice(0, maxChars)}…`), wasTruncated: true };
+}
+
+/**
+ * Truncate a single line to a UTF-8 byte budget, appending '…' if truncated.
+ * Mirrors the native grep `truncate_line` (reserves 3 bytes for the marker and
+ * cuts on a char boundary) so JS-side virtual-resource matches truncate in the
+ * same unit as on-disk matches from the Rust searcher.
+ */
+export function truncateLineBytes(
+	line: string,
+	maxBytes: number = DEFAULT_MAX_COLUMN,
+): { text: string; wasTruncated: boolean } {
+	if (Buffer.byteLength(line, "utf-8") <= maxBytes) return { text: line, wasTruncated: false };
+	const head = truncateHeadBytes(line, Math.max(0, maxBytes - 3)).text;
+	return { text: materializeString(`${head}…`), wasTruncated: true };
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -27,7 +27,12 @@ import { InternalUrlRouter } from "../internal-urls/router";
 import type { InternalResource, ResolveContext } from "../internal-urls/types";
 import type { Theme } from "../modes/theme/theme";
 import grepDescription from "../prompts/tools/grep.md" with { type: "text" };
-import { DEFAULT_MAX_COLUMN, type TruncationResult, truncateHead, truncateLine } from "../session/streaming-output";
+import {
+	DEFAULT_MAX_COLUMN,
+	type TruncationResult,
+	truncateHead,
+	truncateLineBytes,
+} from "../session/streaming-output";
 import { sessionDelegationBias } from "../task/prompt-policy";
 import { isScoutSpawnable } from "../task/spawn-policy";
 import {
@@ -548,7 +553,7 @@ async function nativeChunkedLineIndexes(
 }
 
 function makeContextLine(lines: readonly string[], lineIndex: number): { lineNumber: number; line: string } {
-	const { text } = truncateLine(lines[lineIndex] ?? "", DEFAULT_MAX_COLUMN);
+	const { text } = truncateLineBytes(lines[lineIndex] ?? "", DEFAULT_MAX_COLUMN);
 	return { lineNumber: lineIndex + 1, line: text };
 }
 
@@ -562,7 +567,7 @@ function makeVirtualMatch(
 	nextMatchLine: number,
 ): GrepMatch {
 	const lineNumber = lineIndex + 1;
-	const { text, wasTruncated } = truncateLine(lines[lineIndex] ?? "", DEFAULT_MAX_COLUMN);
+	const { text, wasTruncated } = truncateLineBytes(lines[lineIndex] ?? "", DEFAULT_MAX_COLUMN);
 	const match: GrepMatch = {
 		path: resource.path,
 		lineNumber,
@@ -1611,7 +1616,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 				if (linesTruncated) details.linesTruncated = true;
 				const resultBuilder = toolResult(details)
 					.text(output)
-					.limits({ columnMax: linesTruncated ? DEFAULT_MAX_COLUMN : undefined });
+					.limits({ columnMax: linesTruncated ? DEFAULT_MAX_COLUMN : undefined, columnUnit: "bytes" });
 				if (truncation.truncated) {
 					resultBuilder.truncation(truncation, { direction: "head" });
 				}

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -75,7 +75,8 @@ export interface LimitsMeta {
 	matchLimit?: { reached: number; suggestion: number };
 	resultLimit?: { reached: number; suggestion: number };
 	headLimit?: { reached: number; suggestion: number };
-	columnTruncated?: { maxColumn: number; unit: "bytes" | "chars" };
+	/** `unit` may be absent in sessions persisted before it was recorded. */
+	columnTruncated?: { maxColumn: number; unit?: "bytes" | "chars" };
 }
 
 /**
@@ -589,7 +590,11 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 	}
 	if (meta.limits?.columnTruncated) {
 		const c = meta.limits.columnTruncated;
-		parts.push(`Some lines truncated to ${c.maxColumn} ${c.unit}`);
+		// Sessions persisted before the unit field carry only `maxColumn`; those
+		// notices always read "chars", so default missing units to it. Otherwise
+		// a resumed legacy session renders "… 768 undefined" and stripOutputNotice
+		// stops matching the persisted "… 768 chars" text.
+		parts.push(`Some lines truncated to ${c.maxColumn} ${c.unit ?? "chars"}`);
 	}
 
 	// Diagnostics

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -79,6 +79,15 @@ export interface LimitsMeta {
 	columnTruncated?: { maxColumn: number; unit?: "bytes" | "chars" };
 }
 
+/** Input for {@link OutputMetaBuilder.limits}. `columnUnit` defaults to `chars`. */
+export interface LimitsInput {
+	matchLimit?: number;
+	resultLimit?: number;
+	headLimit?: number;
+	columnMax?: number;
+	columnUnit?: "bytes" | "chars";
+}
+
 /**
  * Structured metadata for tool outputs.
  */
@@ -353,13 +362,7 @@ export class OutputMetaBuilder {
 	}
 
 	/** Add limit notices in one call. */
-	limits(limits: {
-		matchLimit?: number;
-		resultLimit?: number;
-		headLimit?: number;
-		columnMax?: number;
-		columnUnit?: "bytes" | "chars";
-	}): this {
+	limits(limits: LimitsInput): this {
 		if (limits.matchLimit !== undefined) {
 			this.matchLimit(limits.matchLimit);
 		}

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -75,7 +75,7 @@ export interface LimitsMeta {
 	matchLimit?: { reached: number; suggestion: number };
 	resultLimit?: { reached: number; suggestion: number };
 	headLimit?: { reached: number; suggestion: number };
-	columnTruncated?: { maxColumn: number };
+	columnTruncated?: { maxColumn: number; unit: "bytes" | "chars" };
 }
 
 /**
@@ -234,9 +234,10 @@ export class OutputMetaBuilder {
 		// A per-line column cap only trims individual lines (with a `…` marker);
 		// it is not a window/byte truncation, so surface it as its own limit
 		// notice rather than a "Showing lines X-Y … limit" range. This runs even
-		// when the output is otherwise complete (`truncated === false`).
+		// when the output is otherwise complete (`truncated === false`). The sink
+		// enforces the cap in UTF-8 bytes, so the notice must say "bytes".
 		if (summary.columnMax != null && summary.columnMax > 0 && (summary.columnTruncatedLines ?? 0) > 0) {
-			this.columnTruncated(summary.columnMax);
+			this.columnTruncated(summary.columnMax, "bytes");
 		}
 		if (!summary.truncated) return this;
 
@@ -351,7 +352,13 @@ export class OutputMetaBuilder {
 	}
 
 	/** Add limit notices in one call. */
-	limits(limits: { matchLimit?: number; resultLimit?: number; headLimit?: number; columnMax?: number }): this {
+	limits(limits: {
+		matchLimit?: number;
+		resultLimit?: number;
+		headLimit?: number;
+		columnMax?: number;
+		columnUnit?: "bytes" | "chars";
+	}): this {
 		if (limits.matchLimit !== undefined) {
 			this.matchLimit(limits.matchLimit);
 		}
@@ -362,7 +369,7 @@ export class OutputMetaBuilder {
 			this.headLimit(limits.headLimit);
 		}
 		if (limits.columnMax !== undefined) {
-			this.columnTruncated(limits.columnMax);
+			this.columnTruncated(limits.columnMax, limits.columnUnit);
 		}
 		return this;
 	}
@@ -381,10 +388,14 @@ export class OutputMetaBuilder {
 		return this;
 	}
 
-	/** Add column truncation notice. No-op if maxColumn <= 0. */
-	columnTruncated(maxColumn: number): this {
+	/**
+	 * Add column truncation notice. No-op if maxColumn <= 0. `unit` names the
+	 * unit the producer enforced the cap in — `"bytes"` for the streaming
+	 * sink's UTF-8 cap, `"chars"` (UTF-16 code units) for the read/grep path.
+	 */
+	columnTruncated(maxColumn: number, unit: "bytes" | "chars" = "chars"): this {
 		if (maxColumn <= 0) return this;
-		this.#meta.limits = { ...this.#meta.limits, columnTruncated: { maxColumn } };
+		this.#meta.limits = { ...this.#meta.limits, columnTruncated: { maxColumn, unit } };
 		return this;
 	}
 
@@ -577,7 +588,8 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 		parts.push(`${l.reached} results limit reached. Use limit=${l.suggestion} for more`);
 	}
 	if (meta.limits?.columnTruncated) {
-		parts.push(`Some lines truncated to ${meta.limits.columnTruncated.maxColumn} chars`);
+		const c = meta.limits.columnTruncated;
+		parts.push(`Some lines truncated to ${c.maxColumn} ${c.unit}`);
 	}
 
 	// Diagnostics

--- a/packages/coding-agent/src/tools/tool-result.ts
+++ b/packages/coding-agent/src/tools/tool-result.ts
@@ -1,7 +1,13 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import type { OutputSummary, TruncationResult } from "../session/streaming-output";
-import type { OutputMeta, TruncationOptions, TruncationSummaryOptions, TruncationTextOptions } from "./output-meta";
+import type {
+	LimitsInput,
+	OutputMeta,
+	TruncationOptions,
+	TruncationSummaryOptions,
+	TruncationTextOptions,
+} from "./output-meta";
 import { outputMeta } from "./output-meta";
 
 type ToolContent = Array<TextContent | ImageContent>;
@@ -44,7 +50,7 @@ export class ToolResultBuilder<TDetails extends DetailsWithMeta> {
 		return this;
 	}
 
-	limits(limits: { matchLimit?: number; resultLimit?: number; headLimit?: number; columnMax?: number }): this {
+	limits(limits: LimitsInput): this {
 		this.#meta.limits(limits);
 		return this;
 	}

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -818,13 +818,32 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 		const meta = outputMeta().truncationFromSummary(dumped, { direction: "tail" }).get();
 		// No window truncation → no styled TUI warning and no range/limit footer.
 		expect(meta?.truncation).toBeUndefined();
-		expect(meta?.limits?.columnTruncated).toEqual({ maxColumn: 8 });
+		expect(meta?.limits?.columnTruncated).toEqual({ maxColumn: 8, unit: "bytes" });
 
 		const notice = formatOutputNotice(meta);
-		expect(notice).toContain("Some lines truncated to 8 chars");
+		expect(notice).toContain("Some lines truncated to 8 bytes");
 		expect(notice).not.toContain("Showing lines");
 		expect(notice).not.toContain("limit");
 		expect(notice).not.toContain("artifact://");
+	});
+
+	test("multibyte line: cap counts UTF-8 bytes and the notice says bytes", async () => {
+		// Regression for #10888: a 385-char line is 770 UTF-8 bytes. A char cap of
+		// 768 would leave it untouched; the sink enforces bytes, so it trims. The
+		// notice must name the enforced unit, not "chars".
+		const sink = new OutputSink({ maxColumns: 768, spillThreshold: 100_000 });
+		await sink.push("é".repeat(385));
+		const dumped = await sink.dump();
+
+		expect(dumped.columnTruncatedLines).toBe(1);
+		// 3 bytes reserved for "…" inside the 768-byte cap → 765 bytes of room →
+		// 382 two-byte "é" (764 bytes) kept, then the ellipsis.
+		const keptAccents = (dumped.output.match(/é/g) ?? []).length;
+		expect(keptAccents).toBe(382);
+		expect(dumped.output).toContain("…");
+
+		const meta = outputMeta().truncationFromSummary(dumped, { direction: "tail" }).get();
+		expect(formatOutputNotice(meta)).toContain("Some lines truncated to 768 bytes");
 	});
 
 	test("persists per-line state across chunk boundaries", async () => {

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -16,7 +16,7 @@ import {
 	truncateTail,
 	truncateTailBytes,
 } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
-import { formatOutputNotice, outputMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { formatOutputNotice, outputMeta, stripOutputNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const createdTempDirs: string[] = [];
@@ -844,6 +844,17 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 
 		const meta = outputMeta().truncationFromSummary(dumped, { direction: "tail" }).get();
 		expect(formatOutputNotice(meta)).toContain("Some lines truncated to 768 bytes");
+	});
+
+	test("legacy metadata without a unit falls back to chars", () => {
+		// Sessions persisted before the unit field carry `{ maxColumn }` only.
+		// Resuming one must not render "768 undefined", and the reconstructed
+		// notice must still match the persisted "768 chars" text so stripping works.
+		const legacyMeta = { limits: { columnTruncated: { maxColumn: 768 } } };
+		const notice = formatOutputNotice(legacyMeta);
+		expect(notice).toContain("Some lines truncated to 768 chars");
+		expect(notice).not.toContain("undefined");
+		expect(stripOutputNotice(`body${notice}`, legacyMeta)).toBe("body");
 	});
 
 	test("persists per-line state across chunk boundaries", async () => {

--- a/packages/coding-agent/test/tools/eval-streaming-output.test.ts
+++ b/packages/coding-agent/test/tools/eval-streaming-output.test.ts
@@ -106,6 +106,6 @@ describe("EvalTool live stdout streaming", () => {
 		);
 
 		expect(result.details?.meta?.truncation).toBeUndefined();
-		expect(formatOutputNotice(result.details?.meta)).toContain("Some lines truncated to 8 chars");
+		expect(formatOutputNotice(result.details?.meta)).toContain("Some lines truncated to 8 bytes");
 	});
 });

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -16,6 +16,7 @@ import {
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import * as sshFileTransfer from "@oh-my-pi/pi-coding-agent/ssh/file-transfer";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { formatOutputNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { GlobTool } from "../../src/tools/glob";
@@ -287,6 +288,24 @@ describe("GrepTool internal URL resolution", () => {
 		const tool = new GrepTool(createSession());
 		const result = await tool.execute("big-virtual", { pattern: "(?i)NEEDLE", path: "virtual://big.md" });
 		expect(getResultText(result)).toContain("needle");
+	});
+
+	it("truncates a multibyte virtual match by UTF-8 bytes and labels the notice bytes", async () => {
+		// Regression for #10888: virtual-resource matches must truncate in the
+		// same unit as native on-disk matches (bytes), and the notice must say so.
+		// "needle " + "é"*300 is 307 chars but 607 bytes; a char cap of 512 would
+		// leave it whole, the byte cap trims it.
+		const line = `needle ${"é".repeat(300)}`;
+		registerVirtualDocs(new Map([["mb.md", `${line}\n`]]));
+		const result = await new GrepTool(createSession()).execute("mb-virtual", {
+			pattern: "needle",
+			path: "virtual://mb.md",
+		});
+		const text = getResultText(result);
+		expect(text).toContain("…");
+		expect((text.match(/é/g) ?? []).length).toBeLessThan(300);
+		expect(result.details?.meta?.limits?.columnTruncated).toEqual({ maxColumn: 512, unit: "bytes" });
+		expect(formatOutputNotice(result.details?.meta)).toContain("Some lines truncated to 512 bytes");
 	});
 
 	it("rejects a malformed selector on a selector-capable internal URL instead of widening the search", async () => {


### PR DESCRIPTION
## Repro
With `tools.outputMaxColumns=768`, feeding `"é"*385` (385 chars / 770 UTF-8 bytes) through the streaming `OutputSink` keeps 382 `é` (~767 bytes) then `…` — the cap is enforced in bytes — while the notice renders `Some lines truncated to 768 chars`, a 2x overstatement of the visible content. Repro: `bun /tmp/repro-10888.ts` driving `OutputSink({ maxColumns: 768 })`.

## Cause
The per-line column cap has two producers enforcing two units: `OutputSink.#applyColumnCap` (`packages/coding-agent/src/session/streaming-output.ts`) caps in UTF-8 bytes via `Buffer.byteLength(...,"utf-8")`, while `read`/`grep` cap via `truncateLine` in UTF-16 code units. `formatOutputNotice` (`packages/coding-agent/src/tools/output-meta.ts`) hard-coded `chars` for every consumer, so the streaming notice claimed a unit it does not enforce, contradicting the shipped docs (`docs/settings.md`, `docs/bash-tool-runtime.md`) that describe it as a byte cap.

## Fix
- `LimitsMeta.columnTruncated` now carries `unit: "bytes" | "chars"`; `OutputMetaBuilder.columnTruncated(maxColumn, unit)` defaults to `"chars"` and `limits({ columnUnit })` threads it through.
- `truncationFromSummary` (the streaming/`OutputSummary` path) passes `"bytes"`; `read`/`grep` keep the `"chars"` default, since they enforce code units.
- `formatOutputNotice` renders `Some lines truncated to N <unit>`.
- Corrected the `OutputSummary.columnMax` doc comment (UTF-8 bytes).
- Enforcement units are unchanged; this is notice/meta accuracy only. Unifying the two enforcement units is a separate design change, out of scope.

## Verification
`bun test test/streaming-output.test.ts test/tools/eval-streaming-output.test.ts` — column-cap suites pass, including a new multibyte regression (`"é"*385`) asserting the byte-based cut point and the `bytes` notice; `read`-path column tests in `test/tools.test.ts -t truncat` still assert `chars`. Fixes #10888