### PR TITLE
feat(auth): per-provider API key lists with cycling and failover

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -228,6 +228,7 @@ Run `omp <command> --help` for each command's own flags and examples.
 | `images`, `img` | Inspect, diagnose, probe, and purge image publication backends. | |
 | `install` | Install or link an extension package (alias of `plugin install` / `plugin link`). | [extensions](./extensions.md) |
 | `join` | Join a shared collab session (same as `/join`). | [collab](./collab.md) |
+| `key-cycle` | Cycle to the next configured API key for a provider (`models.yml` `providers.<name>.apiKey` list). | |
 | `models` | List, search, and refresh available models. | [models](./models.md) |
 | `plugin` | Manage plugins (install, uninstall, list, etc.). | [extensions](./extensions.md), [marketplace](./marketplace.md) |
 | `ps` | List and control daemon-supervised background processes (logs, stop, kill, restart). | |

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -456,6 +456,14 @@ export interface AuthCredentialStore {
 	/** Read recorded usage-limit snapshots, oldest first. */
 	listUsageHistory?(query?: UsageHistoryQuery): UsageHistoryEntry[];
 	/**
+	 * Persisted cursor for a list-form config apiKey (`providers.<name>.apiKey`):
+	 * which element is active. Only the integer index is stored — never key
+	 * material. Optional: stores without durable local storage (e.g. the
+	 * broker remote store) omit these and the cursor stays process-local.
+	 */
+	getConfigApiKeyIndex?(provider: string): number | undefined;
+	setConfigApiKeyIndex?(provider: string, index: number): void;
+	/**
 	 * Client hook: forward locally observed request usage. Remote broker stores
 	 * batch these to the broker so it can attribute token burn per install;
 	 * local stores omit it and observation is skipped.
@@ -1614,13 +1622,33 @@ export class AuthStorage {
 	/**
 	 * Record which element of a list-form config apiKey is active, for masked
 	 * operator display. Pass undefined for single-string keys (no suffix).
+	 *
+	 * The index is also written through to the credential store so `omp
+	 * key-cycle` advances across processes: each CLI invocation builds a fresh
+	 * registry, which re-seeds its in-memory cursor from the persisted index
+	 * (see `getConfigApiKeyIndex`). Only the integer index persists — never
+	 * key material. Clearing is in-memory only: reload drops and repopulates
+	 * these maps, and the persisted cursor is what restores the position.
+	 * Stores without durable storage (broker remote) skip persistence and the
+	 * cursor stays process-local.
 	 */
 	setConfigApiKeyPosition(provider: string, position: { index: number; total: number } | undefined): void {
 		if (position === undefined) {
 			this.#configKeyPositions.delete(provider);
 		} else {
 			this.#configKeyPositions.set(provider, position);
+			this.#store.setConfigApiKeyIndex?.(provider, position.index);
 		}
+	}
+
+	/**
+	 * Active list-form config apiKey index for `provider`: the in-memory
+	 * position first, else the persisted cycle cursor (if any). Callers clamp
+	 * to the live list length — a persisted index may outlive the list edit
+	 * that shrank it.
+	 */
+	getConfigApiKeyIndex(provider: string): number | undefined {
+		return this.#configKeyPositions.get(provider)?.index ?? this.#store.getConfigApiKeyIndex?.(provider);
 	}
 
 	/**

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1360,6 +1360,8 @@ export class AuthStorage {
 	#configKeyPositions: Map<string, { index: number; total: number }> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
+	/** Manual per-provider rotation offset for stored api_key rows (user-initiated key cycling). */
+	#manualApiKeyOffset = new Map<string, number>();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
 	#sessionLastCredential: Map<
 		string,
@@ -1861,14 +1863,31 @@ export class AuthStorage {
 	 */
 	#getCredentialOrder(providerKey: string, sessionId: string | undefined, total: number): number[] {
 		if (total <= 1) return [0];
+		const manual = this.#manualApiKeyOffset.get(providerKey) ?? 0;
 		const start = sessionId
-			? this.#getHashedIndex(sessionId, total)
-			: this.#getNextRoundRobinIndex(providerKey, total);
+			? (this.#getHashedIndex(sessionId, total) + manual) % total
+			: (this.#getNextRoundRobinIndex(providerKey, total) + manual) % total;
 		const order: number[] = [];
 		for (let i = 0; i < total; i++) {
 			order.push((start + i) % total);
 		}
 		return order;
+	}
+
+	/**
+	 * Manually advance to the next stored api_key row for a provider
+	 * (user-initiated key cycling, e.g. Alt+Z in the model hub). Unlike
+	 * failure-driven rotation this marks nothing suspect, blocks nothing,
+	 * and clears nothing: it only shifts where the next resolution starts.
+	 * Scoped to api_key rows; OAuth and other types are untouched. Returns
+	 * the stored total, or undefined when fewer than two api_key rows exist.
+	 */
+	cycleStoredApiKey(provider: string): { total: number } | undefined {
+		const total = this.#getStoredCredentials(provider).filter(entry => entry.credential.type === "api_key").length;
+		if (total < 2) return undefined;
+		const key = this.#getProviderTypeKey(provider, "api_key");
+		this.#manualApiKeyOffset.set(key, (((this.#manualApiKeyOffset.get(key) ?? 0) % total) + 1) % total);
+		return { total };
 	}
 
 	#toScopedBackoffKey(providerKey: string, blockScope: string | undefined): string {
@@ -2437,6 +2456,11 @@ export class AuthStorage {
 		for (const key of this.#providerRoundRobinIndex.keys()) {
 			if (key.startsWith(`${provider}:`)) {
 				this.#providerRoundRobinIndex.delete(key);
+			}
+		}
+		for (const key of this.#manualApiKeyOffset.keys()) {
+			if (key.startsWith(`${provider}:`)) {
+				this.#manualApiKeyOffset.delete(key);
 			}
 		}
 		this.#sessionLastCredential.delete(provider);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1344,6 +1344,12 @@ export class AuthStorage {
 	#data: Map<string, StoredCredential[]> = new Map();
 	#runtimeOverrides: Map<string, string> = new Map();
 	#configOverrides: Map<string, string> = new Map();
+	/**
+	 * Active element position per list-form config apiKey, for masked
+	 * operator display (`key i/N`). Carries no key material; the registry
+	 * publishes it on install/cycle and it drops with the override.
+	 */
+	#configKeyPositions: Map<string, { index: number; total: number }> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
@@ -1602,6 +1608,19 @@ export class AuthStorage {
 	 */
 	removeConfigApiKey(provider: string): void {
 		this.#configOverrides.delete(provider);
+		this.#configKeyPositions.delete(provider);
+	}
+
+	/**
+	 * Record which element of a list-form config apiKey is active, for masked
+	 * operator display. Pass undefined for single-string keys (no suffix).
+	 */
+	setConfigApiKeyPosition(provider: string, position: { index: number; total: number } | undefined): void {
+		if (position === undefined) {
+			this.#configKeyPositions.delete(provider);
+		} else {
+			this.#configKeyPositions.set(provider, position);
+		}
 	}
 
 	/**
@@ -1610,6 +1629,7 @@ export class AuthStorage {
 	 */
 	clearConfigApiKeys(): void {
 		this.#configOverrides.clear();
+		this.#configKeyPositions.clear();
 	}
 
 	/**
@@ -7311,7 +7331,9 @@ export class AuthStorage {
 			return "runtime override (--api-key)";
 		}
 		if (this.#configOverrides.has(provider)) {
-			return "config override (models.yml)";
+			const position = this.#configKeyPositions.get(provider);
+			// Masked position only (`key i/N`) — never key material.
+			return position ? `config override (models.yml) key ${position.index + 1}/${position.total}` : "config override (models.yml)";
 		}
 
 		const baseLabel = this.#sourceLabel ?? "local store";

--- a/packages/ai/src/auth/sqlite-credential-store.ts
+++ b/packages/ai/src/auth/sqlite-credential-store.ts
@@ -365,6 +365,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#getCacheIncludingExpiredStmt: Statement;
 	#upsertCacheStmt: Statement;
 	#deleteCachePrefixStmt: Statement;
+	#getConfigApiKeyIndexStmt: Statement;
+	#setConfigApiKeyIndexStmt: Statement;
 	#deleteExpiredCacheStmt: Statement;
 	#updateIfMatchesWithLeaseStmt: Statement;
 	#deleteIfMatchesWithLeaseStmt: Statement;
@@ -452,6 +454,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			"INSERT INTO cache (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at",
 		);
 		this.#deleteCachePrefixStmt = this.#db.prepare("DELETE FROM cache WHERE substr(key, 1, ?) = ?");
+		this.#getConfigApiKeyIndexStmt = this.#db.prepare(
+			"SELECT cycle_index FROM config_api_key_cycle WHERE provider = ?",
+		);
+		this.#setConfigApiKeyIndexStmt = this.#db.prepare(
+			"INSERT INTO config_api_key_cycle (provider, cycle_index) VALUES (?, ?) ON CONFLICT(provider) DO UPDATE SET cycle_index = excluded.cycle_index",
+		);
 		this.#deleteExpiredCacheStmt = this.#db.prepare(`DELETE FROM cache WHERE expires_at <= ${SQLITE_NOW_EPOCH}`);
 		this.#getCredentialBlockStmt = this.#db.prepare(
 			"SELECT blocked_until_ms, updated_at FROM auth_credential_blocks WHERE credential_id = ? AND provider_key = ? AND block_scope = ? AND blocked_until_ms > ?",
@@ -649,6 +657,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			this.#createAuthCredentialsTable();
 			this.#createAuthCredentialBlocksTable();
 			this.#createAuthCredentialRefreshLeasesTable();
+			this.#createConfigApiKeyCycleTable();
 			this.#createAuthCredentialBlockCompatibilityObjects();
 			this.#createAuthChangeTrackingObjects();
 			this.#writeAuthSchemaVersion(AUTH_SCHEMA_VERSION);
@@ -668,10 +677,11 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 
 		this.#createAuthCredentialIndexes();
 		this.#createAuthCredentialBlocksTable();
-		this.#createAuthCredentialRefreshLeasesTable();
 		if (schemaVersion <= AUTH_SCHEMA_VERSION) {
 			this.#createAuthCredentialBlockCompatibilityObjects();
 		}
+		this.#createAuthCredentialRefreshLeasesTable();
+		this.#createConfigApiKeyCycleTable();
 		this.#createAuthChangeTrackingObjects();
 		this.#backfillCredentialIdentityKeys();
 		// Rewriting an already-current version row is a no-op write transaction
@@ -974,6 +984,21 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 
 	#createAuthCredentialRefreshLeasesTable(): void {
 		SqliteAuthCredentialStore.#ensureAuthCredentialRefreshLeasesTable(this.#db);
+	}
+
+	/**
+	 * Cursor for list-form config apiKeys (`providers.<name>.apiKey`): which
+	 * element `omp key-cycle` activated last. Purely additive
+	 * (`IF NOT EXISTS`, no schema-version bump): the row holds an integer
+	 * index only, never key material.
+	 */
+	#createConfigApiKeyCycleTable(): void {
+		this.#db.run(`
+			CREATE TABLE IF NOT EXISTS config_api_key_cycle (
+				provider TEXT PRIMARY KEY,
+				cycle_index INTEGER NOT NULL
+			);
+		`);
 	}
 
 	#migrateAuthSchema(fromVersion: number): void {
@@ -1535,6 +1560,23 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
+	getConfigApiKeyIndex(provider: string): number | undefined {
+		try {
+			const row = this.#getConfigApiKeyIndexStmt.get(provider) as { cycle_index?: number } | undefined;
+			return typeof row?.cycle_index === "number" ? row.cycle_index : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	setConfigApiKeyIndex(provider: string, index: number): void {
+		try {
+			this.#setConfigApiKeyIndexStmt.run(provider, index);
+		} catch {
+			// Ignore cursor write failures: cycling still works process-locally.
+		}
+	}
+
 	getCredentialBlock(credentialId: number, providerKey: string, blockScope: string): number | undefined {
 		const nowMs = Date.now();
 		const isCodexBlock = providerKey === LEGACY_CODEX_BLOCK_PROVIDER_KEY;
@@ -2000,6 +2042,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#getCacheIncludingExpiredStmt.finalize();
 		this.#upsertCacheStmt.finalize();
 		this.#deleteExpiredCacheStmt.finalize();
+		this.#getConfigApiKeyIndexStmt.finalize();
+		this.#setConfigApiKeyIndexStmt.finalize();
 		this.#getCredentialBlockStmt.finalize();
 		this.#listCredentialBlocksByCredentialStmt.finalize();
 		this.#upsertCredentialBlockStmt.finalize();

--- a/packages/ai/test/auth-storage-api-key-login.test.ts
+++ b/packages/ai/test/auth-storage-api-key-login.test.ts
@@ -115,6 +115,51 @@ describe("AuthStorage api-key login upsert", () => {
 		expect(rotatedKeys).toEqual(["first-kagi-key", "second-kagi-key"]);
 	});
 
+	it("user can store two keys via login, remove the first, and subsequent resolution uses the remaining key", async () => {
+		if (!store || !authStorage || !dbPath) throw new Error("test setup failed");
+
+		const keys = ["first-kagi-key", "second-kagi-key"];
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => keys.shift() ?? "",
+		};
+
+		await authStorage.login("kagi", controller);
+		await authStorage.login("kagi", controller);
+
+		const listed = store.listAuthCredentials("kagi");
+		expect(listed.map(entry => entry.credential)).toEqual([
+			{ type: "api_key", key: "first-kagi-key", source: "login" },
+			{ type: "api_key", key: "second-kagi-key", source: "login" },
+		]);
+		const removed = await authStorage.removeCredential("kagi", listed[0]?.id ?? -1);
+		expect(removed).toBe(true);
+
+		expect(store.listAuthCredentials("kagi").map(entry => entry.credential)).toEqual([
+			{ type: "api_key", key: "second-kagi-key", source: "login" },
+		]);
+		expect(await authStorage.getApiKey("kagi")).toBe("second-kagi-key");
+		expect(await authStorage.getApiKey("kagi", "session-after-removal")).toBe("second-kagi-key");
+	});
+
+	it("existing single-key login behavior is unchanged (one row, same resolution as before)", async () => {
+		if (!store || !authStorage || !dbPath) throw new Error("test setup failed");
+
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => "only-kagi-key",
+		};
+
+		await authStorage.login("kagi", controller);
+
+		expect(countCredentialRows(dbPath, "kagi")).toBe(1);
+		expect(store.listAuthCredentials("kagi").map(entry => entry.credential)).toEqual([
+			{ type: "api_key", key: "only-kagi-key", source: "login" },
+		]);
+		expect(store.getApiKey("kagi")).toBe("only-kagi-key");
+		expect(await authStorage.getApiKey("kagi", "session-single-key")).toBe("only-kagi-key");
+	});
+
 	it("replaces Token Plan Cookies by API-token identity without collapsing different tokens", () => {
 		if (!store) throw new Error("test setup failed");
 		const firstToken = "sk-sp-first";

--- a/packages/ai/test/auth-storage-cycle-stored.test.ts
+++ b/packages/ai/test/auth-storage-cycle-stored.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as aiStream from "@oh-my-pi/pi-ai/stream";
+import { removeWithRetries } from "../../utils/src/temp";
+
+describe("AuthStorage manual stored api-key cycling", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	beforeEach(async () => {
+		vi.spyOn(aiStream, "getEnvApiKey").mockReturnValue(undefined);
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-api-key-cycle-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		authStorage = new AuthStorage(store);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		dbPath = "";
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	it("manual cycle moves the same session to the other stored key and back", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		const keys = ["first-kagi-key", "second-kagi-key"];
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => keys.shift() ?? "",
+		};
+		await authStorage.login("kagi", controller);
+		await authStorage.login("kagi", controller);
+
+		const before = await authStorage.getApiKey("kagi", "sess-cycle");
+		expect(["first-kagi-key", "second-kagi-key"]).toContain(before);
+
+		expect(authStorage.cycleStoredApiKey("kagi")).toEqual({ total: 2 });
+		expect(await authStorage.getApiKey("kagi", "sess-cycle")).not.toBe(before);
+
+		expect(authStorage.cycleStoredApiKey("kagi")).toEqual({ total: 2 });
+		expect(await authStorage.getApiKey("kagi", "sess-cycle")).toBe(before);
+	});
+
+	it("returns undefined with fewer than two stored keys", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		expect(authStorage.cycleStoredApiKey("kagi")).toBeUndefined();
+
+		await authStorage.login("kagi", {
+			onAuth: () => {},
+			onPrompt: async () => "only-key",
+		});
+		expect(authStorage.cycleStoredApiKey("kagi")).toBeUndefined();
+		expect(await authStorage.getApiKey("kagi", "sess-cycle")).toBe("only-key");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the `retry.waitForUsageReset` setting: when a provider reports usage-limit exhaustion with a reset time (5-hour or weekly quota windows on any provider), the session sleeps until the reset instead of failing fast past `retry.maxDelayMs`.
 - Added opt-in `bash.allowCompoundCommands` approval for conservative literal `&&` chains, with ordered per-segment rules and normal bash policy fallback for unmatched segments. The opt-in requires a positively classified POSIX-quoting shell; incompatible and unknown shells retain legacy approval. Whole-chain denies take precedence over earlier prompts.
+- Added per-provider API key lists: `providers.<name>.apiKey` in `models.yml` accepts a list of keys, `omp key-cycle <provider>` advances to the next key, failed keys automatically fail over to a sibling on 401/403 and quota exhaustion (each key tried at most once per operation), and credential provenance shows the masked active position (`key i/N`) without ever printing key material ([#10871](https://github.com/can1357/oh-my-pi/issues/10871)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -133,6 +133,11 @@ export const commands: CommandEntry[] = [
 		help: commandHelp.joinHelp,
 	},
 	{
+		name: "key-cycle",
+		load: () => import("./commands/key-cycle").then(m => m.default),
+		help: commandHelp.keyCycleHelp,
+	},
+	{
 		name: "models",
 		load: () => import("./commands/models").then(m => m.default),
 		help: commandHelp.modelsHelp,

--- a/packages/coding-agent/src/cli/command-help.ts
+++ b/packages/coding-agent/src/cli/command-help.ts
@@ -73,6 +73,9 @@ export const installHelp = {
 } satisfies CommandMetadata;
 
 export const joinHelp = { description: "Join a shared collab session (same as /join)" } satisfies CommandMetadata;
+export const keyCycleHelp = {
+	description: "Cycle to the next configured API key for a provider",
+} satisfies CommandMetadata;
 
 export const modelsHelp = { description: "List, search, and refresh available models" } satisfies CommandMetadata;
 

--- a/packages/coding-agent/src/commands/key-cycle.ts
+++ b/packages/coding-agent/src/commands/key-cycle.ts
@@ -1,0 +1,69 @@
+/**
+ * Cycle to the next configured API key for a provider.
+ */
+
+import { PROVIDER_REGISTRY } from "@oh-my-pi/pi-ai";
+import chalk from "@oh-my-pi/pi-utils/chalk";
+import { Args, Command } from "@oh-my-pi/pi-utils/cli";
+import { keyCycleHelp as commandHelp } from "../cli/command-help";
+import { ModelRegistry } from "../config/model-registry";
+import { isManagedMCPOAuthCredentialId } from "../mcp/oauth-flow";
+import { discoverAuthStorage } from "../sdk";
+
+export default class KeyCycle extends Command {
+	static description = commandHelp.description;
+	static args = {
+		provider: Args.string({
+			description: "Provider ID (e.g. anthropic, openai)",
+			required: true,
+		}),
+	};
+
+	static examples = ["# Cycle to the next API key for a custom provider\n  omp key-cycle custom-proxy"];
+
+	async run(): Promise<void> {
+		const { args } = await this.parse(KeyCycle);
+		const providerName = args.provider ?? "";
+		const managedMcpOAuth = isManagedMCPOAuthCredentialId(args.provider);
+		const provider = managedMcpOAuth ? providerName : providerName.toLowerCase();
+
+		const authStorage = await discoverAuthStorage();
+		try {
+			const modelRegistry = new ModelRegistry(authStorage);
+			if (modelRegistry.cycleProviderApiKey(provider)) {
+				const position = modelRegistry.getProviderApiKeyPosition(provider);
+				const where = position ? `key ${position.index + 1}/${position.total}` : "next key";
+				const source = authStorage.describeCredentialSource(provider);
+				// Masked result only: the position and credential provenance, never key material.
+				process.stdout.write(`Cycled provider "${providerName}" to ${where}${source ? ` (${source})` : ""}.\n`);
+				return;
+			}
+			const position = modelRegistry.getProviderApiKeyPosition(provider);
+			if (position ?? authStorage.hasAuth(provider)) {
+				process.stdout.write(`Provider "${providerName}" has a single configured API key; nothing to cycle.\n`);
+				return;
+			}
+			// Find all active/configured providers (mirrors the token command).
+			const activeProviders = new Set<string>();
+			for (const p of PROVIDER_REGISTRY) {
+				if (authStorage.hasAuth(p.id)) {
+					activeProviders.add(p.id);
+				}
+			}
+			const all = authStorage.getAll();
+			for (const p in all) {
+				if (authStorage.hasAuth(p)) {
+					activeProviders.add(p);
+				}
+			}
+
+			process.stderr.write(`${chalk.red(`No API key list configured for provider "${providerName}".`)}\n`);
+			if (activeProviders.size > 0) {
+				process.stderr.write(`Configured providers: ${Array.from(activeProviders).sort().join(", ")}\n`);
+			}
+			process.exitCode = 1;
+		} finally {
+			authStorage.close();
+		}
+	}
+}

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -76,9 +76,16 @@ export function createApiKeyResolver(
 				const status = AIError.status(error);
 				const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 				// No sibling for an account-quota failure: stop so the outer
-				// whole-turn retry layer can honor the recorded backoff. A hard
+				// whole-turn retry layer can honor the recorded backoff — unless
+				// a config key list has a usable sibling, which takes over
+				// immediately instead of waiting out the blocked key. A hard
 				// auth decline can instead mean a peer refreshed the bearer.
-				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
+				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+					if (registry.cycleProviderApiKey?.(provider) ?? false) {
+						return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+					}
+					return undefined;
+				}
 			}
 			// A pinned config key list shadows the stored pool, so rotating
 			// stored rows alone never changes the effective key — advance the

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -95,6 +95,11 @@ export function createApiKeyResolver(
 			registry.cycleProviderApiKey?.(provider);
 			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
-		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+	// A failed list key is dead for this operation while a force-refreshed
+	// single key may have been re-minted, so advance past the failure before
+	// re-resolving (no-op without a list). The central loop still caps the
+	// operation: one refresh-same plus one lastChance rotation.
+	registry.cycleProviderApiKey?.(provider);
+	return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
 	};
 }

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -26,6 +26,12 @@ export interface ApiKeyResolverRegistry {
 	): Promise<string | undefined>;
 	authStorage: Pick<AuthStorage, "rotateSessionCredential">;
 	/**
+	 * Advance a list-form config apiKey (`models.yml`
+	 * `providers.<name>.apiKey`) to its next element. Optional so narrower
+	 * registry shells without key lists keep stored-only rotation.
+	 */
+	cycleProviderApiKey?(provider: string): boolean;
+	/**
 	 * Build an {@link ApiKeyResolver} implementing the central a/b/c auth-retry
 	 * policy: initial → resolve; step (b) → force-refresh same account; step (c)
 	 * → rotate to a sibling and re-resolve, unless quota exhaustion has no sibling.
@@ -45,7 +51,7 @@ export interface ApiKeyResolverRegistry {
  * Also usable standalone for structural registries that don't carry the method.
  */
 export function createApiKeyResolver(
-	registry: Pick<ApiKeyResolverRegistry, "getApiKeyForProvider" | "authStorage">,
+	registry: Pick<ApiKeyResolverRegistry, "getApiKeyForProvider" | "authStorage" | "cycleProviderApiKey">,
 	provider: string,
 	options: ApiKeyResolverOptions = {},
 ): ApiKeyResolver {
@@ -74,6 +80,12 @@ export function createApiKeyResolver(
 				// auth decline can instead mean a peer refreshed the bearer.
 				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
 			}
+			// A pinned config key list shadows the stored pool, so rotating
+			// stored rows alone never changes the effective key — advance the
+			// list (no-op without one) so the re-resolve hands out the next
+			// sibling. One attempt per sibling is enforced downstream by the
+			// already-attempted key set.
+			registry.cycleProviderApiKey?.(provider);
 			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
 		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -47,6 +47,29 @@ export interface ApiKeyResolverRegistry {
 }
 
 /**
+ * Process-wide per-provider locks serializing the failure-recovery compound
+ * (advance the config key list, then re-resolve) below. Owned here:
+ * {@link ApiKeyResolverRegistry} is structural, so a registry shell may
+ * resolve asynchronously — back-to-back failures would otherwise both advance
+ * and then both re-resolve the same final key, skipping a sibling without
+ * ever trying it. The initial (`error === undefined`) resolve bypasses the
+ * lock: only failure recovery mutates the cursor, so steady-state requests
+ * stay concurrent.
+ */
+const providerCycleLocks = new Map<string, Promise<void>>();
+
+function serializeProviderCycle<T>(provider: string, task: () => Promise<T>): Promise<T> {
+	const prior = providerCycleLocks.get(provider) ?? Promise.resolve();
+	const { promise: gate, resolve: release } = Promise.withResolvers<void>();
+	const chained = prior.then(() => gate);
+	providerCycleLocks.set(provider, chained);
+	return prior.then(task).finally(() => {
+		release();
+		if (providerCycleLocks.get(provider) === chained) providerCycleLocks.delete(provider);
+	});
+}
+
+/**
  * Default implementation of {@link ApiKeyResolverRegistry.resolver}.
  * Also usable standalone for structural registries that don't carry the method.
  */
@@ -81,10 +104,12 @@ export function createApiKeyResolver(
 				// immediately instead of waiting out the blocked key. A hard
 				// auth decline can instead mean a peer refreshed the bearer.
 				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
-					if (registry.cycleProviderApiKey?.(provider) ?? false) {
-						return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
-					}
-					return undefined;
+					return serializeProviderCycle(provider, async () => {
+						if (registry.cycleProviderApiKey?.(provider) ?? false) {
+							return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+						}
+						return undefined;
+					});
 				}
 			}
 			// A pinned config key list shadows the stored pool, so rotating
@@ -92,14 +117,18 @@ export function createApiKeyResolver(
 			// list (no-op without one) so the re-resolve hands out the next
 			// sibling. One attempt per sibling is enforced downstream by the
 			// already-attempted key set.
-			registry.cycleProviderApiKey?.(provider);
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+			return serializeProviderCycle(provider, async () => {
+				registry.cycleProviderApiKey?.(provider);
+				return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+			});
 		}
 	// A failed list key is dead for this operation while a force-refreshed
 	// single key may have been re-minted, so advance past the failure before
 	// re-resolving (no-op without a list). The central loop still caps the
 	// operation: one refresh-same plus one lastChance rotation.
-	registry.cycleProviderApiKey?.(provider);
-	return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+	return serializeProviderCycle(provider, async () => {
+		registry.cycleProviderApiKey?.(provider);
+		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+	});
 	};
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2416,6 +2416,17 @@ export class ModelRegistry {
 		return true;
 	}
 
+	/**
+	 * Active position of a list-form `providers.<name>.apiKey` as a 0-based
+	 * index plus list length, for masked operator display (`key i/N`).
+	 * Undefined for single-string or unconfigured providers.
+	 */
+	getProviderApiKeyPosition(provider: string): { index: number; total: number } | undefined {
+		const keyConfig = this.#customProviderApiKeys.get(provider);
+		if (!Array.isArray(keyConfig) || keyConfig.length === 0) return undefined;
+		return { index: (this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfig.length, total: keyConfig.length };
+	}
+
 	getDiscoverableProviders(): string[] {
 		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
 		return this.#discoverableProviders

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2401,14 +2401,17 @@ export class ModelRegistry {
 	cycleProviderApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
 		if (!Array.isArray(keyConfig) || keyConfig.length < 2) return false;
-		const next = ((this.#providerApiKeyIndex.get(provider) ?? 0) + 1) % keyConfig.length;
+		const prev = this.#providerApiKeyIndex.get(provider) ?? 0;
+		const next = (prev + 1) % keyConfig.length;
 		this.#providerApiKeyIndex.set(provider, next);
 		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
-		if (resolved) {
-			this.authStorage.setConfigApiKey(provider, resolved);
-		} else {
-			this.authStorage.removeConfigApiKey(provider);
+		if (resolved === undefined) {
+			// No usable key at the new position: stay where we were and report
+			// failure instead of printing success with no usable key.
+			this.#providerApiKeyIndex.set(provider, prev);
+			return false;
 		}
+		this.authStorage.setConfigApiKey(provider, resolved);
 		const override = this.#providerOverrides.get(provider);
 		if (override) {
 			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[next] });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -223,7 +223,9 @@ export class ModelRegistry {
 	#catalogMetrics = new CatalogMetricsIndex();
 	#internedStaticModels: Map<string, Model<Api>> = new Map();
 	#providerLookupSnapshots: Map<string, Model<Api>[]> = new Map();
-	#customProviderApiKeys: Map<string, string> = new Map();
+	#customProviderApiKeys: Map<string, string | string[]> = new Map();
+	/** Active position per provider for list-form `providers.<name>.apiKey`. Defaults to 0. */
+	#providerApiKeyIndex: Map<string, number> = new Map();
 	// Every command-backed (`!cmd`) config value a provider carries — apiKey plus
 	// provider/model-override header values — keyed by provider. The 401 auth
 	// retry invalidates these command caches so refreshed credentials reach the
@@ -287,8 +289,18 @@ export class ModelRegistry {
 
 	#resolveCommandBackedApiKey(provider: string, options?: { forceCommandRefresh?: boolean }): CommandApiKeyResolution {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
-		if (!isCommandConfigValue(keyConfig)) return { configured: false };
-		const value = resolveConfigValue(keyConfig, options);
+		if (keyConfig === undefined) return { configured: false };
+		if (!Array.isArray(keyConfig)) {
+			if (!isCommandConfigValue(keyConfig)) return { configured: false };
+			const value = resolveConfigValue(keyConfig, options);
+			if (value) {
+				this.authStorage.setConfigApiKey(provider, value);
+				return { configured: true, value };
+			}
+			this.authStorage.removeConfigApiKey(provider);
+			return { configured: true };
+		}
+		const value = this.#resolveActiveApiKeyElement(provider, keyConfig, options);
 		if (value) {
 			this.authStorage.setConfigApiKey(provider, value);
 			return { configured: true, value };
@@ -298,16 +310,51 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Resolve the active element of a list-form apiKey, starting at the
+	 * provider's cycle index and wrapping around. Unresolvable elements
+	 * (failed `!cmd`, missing env) are skipped, never returned literally.
+	 */
+	#resolveActiveApiKeyElement(
+		provider: string,
+		keyConfigs: readonly string[],
+		options?: { forceCommandRefresh?: boolean },
+	): string | undefined {
+		if (keyConfigs.length === 0) return undefined;
+		const start = this.#providerApiKeyIndex.get(provider) ?? 0;
+		for (let step = 0; step < keyConfigs.length; step++) {
+			const value = resolveConfigValue(keyConfigs[(start + step) % keyConfigs.length], options);
+			if (value) return value;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Raw (unresolved, `!cmd`-intact) apiKey element for override/overlay
+	 * records: the active list element, or the single string unchanged.
+	 */
+	#activeApiKeyConfig(provider: string, keyConfig: string | string[] | undefined): string | undefined {
+		if (!Array.isArray(keyConfig)) return keyConfig;
+		if (keyConfig.length === 0) return undefined;
+		return keyConfig[(this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfig.length];
+	}
+
+	/**
 	 * Accumulate every command-backed (`!cmd`) config value from an apiKey and a
 	 * header record into `target`. Used at load time to record which commands a
 	 * provider depends on so the 401 refresh path can invalidate all of them.
 	 */
 	#collectCommandConfigValues(
 		target: Set<string>,
-		apiKey: string | undefined,
+		apiKey: string | string[] | undefined,
 		headers: Record<string, string> | undefined,
 	): void {
-		if (isCommandConfigValue(apiKey)) target.add(apiKey);
+		if (typeof apiKey === "string") {
+			if (isCommandConfigValue(apiKey)) target.add(apiKey);
+		} else if (apiKey) {
+			for (const element of apiKey) {
+				if (isCommandConfigValue(element)) target.add(element);
+			}
+		}
 		if (!headers) return;
 		for (const key in headers) {
 			const value = headers[key];
@@ -323,18 +370,32 @@ export class ModelRegistry {
 	 * credentials pinned to their stale value across the retry (#9760).
 	 */
 	#invalidateProviderCommandConfigs(provider: string): void {
-		invalidateCommandConfig(this.#customProviderApiKeys.get(provider));
+		const keyConfig = this.#customProviderApiKeys.get(provider);
+		if (typeof keyConfig === "string") {
+			invalidateCommandConfig(keyConfig);
+		} else if (keyConfig) {
+			for (const element of keyConfig) invalidateCommandConfig(element);
+		}
 		const configs = this.#commandConfigsByProvider.get(provider);
 		if (!configs) return;
 		for (const config of configs) invalidateCommandConfig(config);
 	}
 
-	#installProviderApiKey(provider: string, keyConfig: string): void {
+	#installProviderApiKey(provider: string, keyConfig: string | string[]): void {
 		this.#customProviderApiKeys.set(provider, keyConfig);
-		const resolved = resolveConfigValue(keyConfig);
+		if (!Array.isArray(keyConfig)) {
+			const resolved = resolveConfigValue(keyConfig);
+			if (resolved) {
+				this.authStorage.setConfigApiKey(provider, resolved);
+			} else if (isCommandConfigValue(keyConfig)) {
+				this.authStorage.removeConfigApiKey(provider);
+			}
+			return;
+		}
+		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
 		if (resolved) {
 			this.authStorage.setConfigApiKey(provider, resolved);
-		} else if (isCommandConfigValue(keyConfig)) {
+		} else {
 			this.authStorage.removeConfigApiKey(provider);
 		}
 	}
@@ -380,7 +441,8 @@ export class ModelRegistry {
 		this.authStorage.setFallbackResolver(provider => {
 			const keyConfig = this.#customProviderApiKeys.get(provider);
 			if (!keyConfig) return undefined;
-			return resolveConfigValue(keyConfig);
+			if (!Array.isArray(keyConfig)) return resolveConfigValue(keyConfig);
+			return this.#resolveActiveApiKeyElement(provider, keyConfig);
 		});
 		// Load config and cache-backed layers synchronously in the constructor.
 		this.#loadModels();
@@ -691,6 +753,7 @@ export class ModelRegistry {
 		}
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
+		this.#providerApiKeyIndex.clear();
 		this.#keylessProviders.clear();
 		this.#discoverableProviders = [];
 		// Drop config-sourced apiKeys from AuthStorage before reload; entries
@@ -1366,7 +1429,7 @@ export class ModelRegistry {
 								? normalizeBareDiscoveryBaseUrl(providerConfig.baseUrl)
 								: providerConfig.baseUrl,
 					headers: providerConfig.headers,
-					apiKey: providerConfig.apiKey,
+					apiKey: this.#activeApiKeyConfig(providerName, providerConfig.apiKey),
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					remoteCompaction: providerConfig.remoteCompaction,
@@ -2175,7 +2238,7 @@ export class ModelRegistry {
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
 					providerConfig.headers,
-					providerConfig.apiKey,
+					this.#activeApiKeyConfig(providerName, providerConfig.apiKey),
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
@@ -2285,7 +2348,7 @@ export class ModelRegistry {
 	hasConfiguredAuth(model: Model<Api>): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(model.provider);
 		return (
-			isCommandConfigValue(keyConfig) ||
+			ModelRegistry.isCommandApiKeyConfig(keyConfig) ||
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasResolvableAuth(model.provider)
 		);
@@ -2303,7 +2366,7 @@ export class ModelRegistry {
 	hasConcreteAuth(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
 		return (
-			isCommandConfigValue(keyConfig) ||
+			ModelRegistry.isCommandApiKeyConfig(keyConfig) ||
 			this.#keylessProviders.has(provider) ||
 			this.authStorage.hasConcreteAuth(provider)
 		);
@@ -2317,7 +2380,40 @@ export class ModelRegistry {
 	 */
 	hasCommandBackedApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
-		return isCommandConfigValue(keyConfig);
+		return ModelRegistry.isCommandApiKeyConfig(keyConfig);
+	}
+
+	/**
+	 * Whether any element of a configured apiKey (single string or list) is
+	 * command-backed (`!cmd`). A list counts when at least one element is.
+	 */
+	private static isCommandApiKeyConfig(keyConfig: string | string[] | undefined): boolean {
+		if (typeof keyConfig === "string") return isCommandConfigValue(keyConfig);
+		return keyConfig?.some(element => isCommandConfigValue(element)) ?? false;
+	}
+
+	/**
+	 * Advance a list-form `providers.<name>.apiKey` to its next key, wrapping
+	 * around. The next `getApiKeyForProvider` (and every resolver-built
+	 * request) uses the new key. Returns false when there is no list to
+	 * advance: unknown provider, single string, or single-element list.
+	 */
+	cycleProviderApiKey(provider: string): boolean {
+		const keyConfig = this.#customProviderApiKeys.get(provider);
+		if (!Array.isArray(keyConfig) || keyConfig.length < 2) return false;
+		const next = ((this.#providerApiKeyIndex.get(provider) ?? 0) + 1) % keyConfig.length;
+		this.#providerApiKeyIndex.set(provider, next);
+		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
+		if (resolved) {
+			this.authStorage.setConfigApiKey(provider, resolved);
+		} else {
+			this.authStorage.removeConfigApiKey(provider);
+		}
+		const override = this.#providerOverrides.get(provider);
+		if (override) {
+			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[next] });
+		}
+		return true;
 	}
 
 	getDiscoverableProviders(): string[] {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2439,9 +2439,40 @@ export class ModelRegistry {
 		logger.debug("provider apiKey cycled", { provider, index: resolved.index, total: keyConfig.length });
 		const override = this.#providerOverrides.get(provider);
 		if (override) {
-			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[resolved.index] });
+			// Store the resolved key, not the raw config element: the header
+			// merge below must agree exactly with the key the resolver just
+			// activated — re-resolving a `!cmd` element could yield a different
+			// value than the one now serving requests.
+			const nextOverride = { ...override, apiKey: resolved.value };
+			this.#providerOverrides.set(provider, nextOverride);
+			this.#refreshProviderModelHeaders(provider, nextOverride);
 		}
 		return true;
+	}
+
+	/**
+	 * Re-merge live headers for `provider`'s models after a cycle, through the
+	 * same transport-override path composition uses. Only `authHeader: true`
+	 * providers derive headers from the apiKey — anything else is untouched.
+	 * Overlays are rebuilt so a later lazy lookup recomposes fresh headers;
+	 * composed snapshots are re-merged in place and the per-provider lookup
+	 * cache is dropped.
+	 */
+	#refreshProviderModelHeaders(provider: string, override: ProviderOverride): void {
+		if (override.authHeader !== true) return;
+		for (const overlay of this.#customModelOverlays) {
+			if (overlay.provider !== provider) continue;
+			overlay.headers = mergeAuthHeaderSources([overlay.headers], override.authHeader, override.apiKey);
+		}
+		if (this.#hasFullSnapshot) {
+			this.#unprojectedModels = this.#applyLlamaCppModelFixups(
+				this.#unprojectedModels.map(model =>
+					model.provider === provider ? this.#applyProviderTransportOverrideToModel(model, override) : model,
+				),
+			);
+			this.#models = this.#withCatalogMetrics(this.#applyRuntimeModelModifiers(this.#unprojectedModels));
+		}
+		this.#invalidateProviderModelCache(provider);
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2355,7 +2355,7 @@ export class ModelRegistry {
 	hasConfiguredAuth(model: Model<Api>): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(model.provider);
 		return (
-			ModelRegistry.isCommandApiKeyConfig(keyConfig) ||
+			ModelRegistry.#isCommandApiKeyConfig(keyConfig) ||
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasResolvableAuth(model.provider)
 		);
@@ -2373,7 +2373,7 @@ export class ModelRegistry {
 	hasConcreteAuth(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
 		return (
-			ModelRegistry.isCommandApiKeyConfig(keyConfig) ||
+			ModelRegistry.#isCommandApiKeyConfig(keyConfig) ||
 			this.#keylessProviders.has(provider) ||
 			this.authStorage.hasConcreteAuth(provider)
 		);
@@ -2387,14 +2387,14 @@ export class ModelRegistry {
 	 */
 	hasCommandBackedApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
-		return ModelRegistry.isCommandApiKeyConfig(keyConfig);
+		return ModelRegistry.#isCommandApiKeyConfig(keyConfig);
 	}
 
 	/**
 	 * Whether any element of a configured apiKey (single string or list) is
 	 * command-backed (`!cmd`). A list counts when at least one element is.
 	 */
-	private static isCommandApiKeyConfig(keyConfig: string | string[] | undefined): boolean {
+	static #isCommandApiKeyConfig(keyConfig: string | string[] | undefined): boolean {
 		if (typeof keyConfig === "string") return isCommandConfigValue(keyConfig);
 		return keyConfig?.some(element => isCommandConfigValue(element)) ?? false;
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -300,10 +300,10 @@ export class ModelRegistry {
 			this.authStorage.removeConfigApiKey(provider);
 			return { configured: true };
 		}
-		const value = this.#resolveActiveApiKeyElement(provider, keyConfig, options);
-		if (value) {
-			this.authStorage.setConfigApiKey(provider, value);
-			return { configured: true, value };
+		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig, options);
+		if (resolved) {
+			this.authStorage.setConfigApiKey(provider, resolved.value);
+			return { configured: true, value: resolved.value };
 		}
 		this.authStorage.removeConfigApiKey(provider);
 		return { configured: true };
@@ -318,12 +318,13 @@ export class ModelRegistry {
 		provider: string,
 		keyConfigs: readonly string[],
 		options?: { forceCommandRefresh?: boolean },
-	): string | undefined {
+	): { value: string; index: number } | undefined {
 		if (keyConfigs.length === 0) return undefined;
-		const start = this.#providerApiKeyIndex.get(provider) ?? 0;
+		const start = (this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfigs.length;
 		for (let step = 0; step < keyConfigs.length; step++) {
-			const value = resolveConfigValue(keyConfigs[(start + step) % keyConfigs.length], options);
-			if (value) return value;
+			const index = (start + step) % keyConfigs.length;
+			const value = resolveConfigValue(keyConfigs[index], options);
+			if (value) return { value, index };
 		}
 		return undefined;
 	}
@@ -395,16 +396,18 @@ export class ModelRegistry {
 		}
 		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
 		if (resolved) {
-			this.authStorage.setConfigApiKey(provider, resolved);
+			this.#providerApiKeyIndex.set(provider, resolved.index);
+			this.authStorage.setConfigApiKey(provider, resolved.value);
+			this.authStorage.setConfigApiKeyPosition(provider, { index: resolved.index, total: keyConfig.length });
 		} else {
 			this.authStorage.removeConfigApiKey(provider);
+			this.authStorage.setConfigApiKeyPosition(
+				provider,
+				keyConfig.length > 0
+					? { index: (this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfig.length, total: keyConfig.length }
+					: undefined,
+			);
 		}
-		this.authStorage.setConfigApiKeyPosition(
-			provider,
-			keyConfig.length > 0
-				? { index: (this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfig.length, total: keyConfig.length }
-				: undefined,
-		);
 	}
 
 	/**
@@ -449,7 +452,7 @@ export class ModelRegistry {
 			const keyConfig = this.#customProviderApiKeys.get(provider);
 			if (!keyConfig) return undefined;
 			if (!Array.isArray(keyConfig)) return resolveConfigValue(keyConfig);
-			return this.#resolveActiveApiKeyElement(provider, keyConfig);
+			return this.#resolveActiveApiKeyElement(provider, keyConfig)?.value;
 		});
 		// Load config and cache-backed layers synchronously in the constructor.
 		this.#loadModels();
@@ -2422,12 +2425,13 @@ export class ModelRegistry {
 			this.authStorage.setConfigApiKeyPosition(provider, { index: prev, total: keyConfig.length });
 			return false;
 		}
-		this.authStorage.setConfigApiKey(provider, resolved);
-		this.authStorage.setConfigApiKeyPosition(provider, { index: next, total: keyConfig.length });
-		logger.debug("provider apiKey cycled", { provider, index: next, total: keyConfig.length });
+		this.#providerApiKeyIndex.set(provider, resolved.index);
+		this.authStorage.setConfigApiKey(provider, resolved.value);
+		this.authStorage.setConfigApiKeyPosition(provider, { index: resolved.index, total: keyConfig.length });
+		logger.debug("provider apiKey cycled", { provider, index: resolved.index, total: keyConfig.length });
 		const override = this.#providerOverrides.get(provider);
 		if (override) {
-			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[next] });
+			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[resolved.index] });
 		}
 		return true;
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -390,6 +390,7 @@ export class ModelRegistry {
 			} else if (isCommandConfigValue(keyConfig)) {
 				this.authStorage.removeConfigApiKey(provider);
 			}
+			this.authStorage.setConfigApiKeyPosition(provider, undefined);
 			return;
 		}
 		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
@@ -398,6 +399,12 @@ export class ModelRegistry {
 		} else {
 			this.authStorage.removeConfigApiKey(provider);
 		}
+		this.authStorage.setConfigApiKeyPosition(
+			provider,
+			keyConfig.length > 0
+				? { index: (this.#providerApiKeyIndex.get(provider) ?? 0) % keyConfig.length, total: keyConfig.length }
+				: undefined,
+		);
 	}
 
 	/**
@@ -2396,7 +2403,10 @@ export class ModelRegistry {
 	 * Advance a list-form `providers.<name>.apiKey` to its next key, wrapping
 	 * around. The next `getApiKeyForProvider` (and every resolver-built
 	 * request) uses the new key. Returns false when there is no list to
-	 * advance: unknown provider, single string, or single-element list.
+	 * advance (unknown provider, single string, or single-element list) or
+	 * when no element resolves. Process-local: the index lives in this
+	 * registry, so sibling processes and separate CLI invocations each track
+	 * their own active key.
 	 */
 	cycleProviderApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
@@ -2409,9 +2419,12 @@ export class ModelRegistry {
 			// No usable key at the new position: stay where we were and report
 			// failure instead of printing success with no usable key.
 			this.#providerApiKeyIndex.set(provider, prev);
+			this.authStorage.setConfigApiKeyPosition(provider, { index: prev, total: keyConfig.length });
 			return false;
 		}
 		this.authStorage.setConfigApiKey(provider, resolved);
+		this.authStorage.setConfigApiKeyPosition(provider, { index: next, total: keyConfig.length });
+		logger.debug("provider apiKey cycled", { provider, index: next, total: keyConfig.length });
 		const override = this.#providerOverrides.get(provider);
 		if (override) {
 			this.#providerOverrides.set(provider, { ...override, apiKey: keyConfig[next] });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -394,6 +394,14 @@ export class ModelRegistry {
 			this.authStorage.setConfigApiKeyPosition(provider, undefined);
 			return;
 		}
+		// Re-seed the in-memory cursor from the persisted cycle position (if
+		// any) so a fresh registry — e.g. the next `omp key-cycle` process —
+		// resumes where the last cycle left off. Clamped: the persisted index
+		// may outlive a list edit that shrank it.
+		const persisted = this.authStorage.getConfigApiKeyIndex(provider);
+		if (persisted !== undefined && keyConfig.length > 0) {
+			this.#providerApiKeyIndex.set(provider, persisted % keyConfig.length);
+		}
 		const resolved = this.#resolveActiveApiKeyElement(provider, keyConfig);
 		if (resolved) {
 			this.#providerApiKeyIndex.set(provider, resolved.index);
@@ -2407,9 +2415,9 @@ export class ModelRegistry {
 	 * around. The next `getApiKeyForProvider` (and every resolver-built
 	 * request) uses the new key. Returns false when there is no list to
 	 * advance (unknown provider, single string, or single-element list) or
-	 * when no element resolves. Process-local: the index lives in this
-	 * registry, so sibling processes and separate CLI invocations each track
-	 * their own active key.
+	 * when no element resolves. The cursor persists in the credential store,
+	 * so separate CLI invocations (e.g. repeated `omp key-cycle`) keep
+	 * advancing instead of each restarting at the first key.
 	 */
 	cycleProviderApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2451,6 +2451,24 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Cycle to the next API key for a provider across both key sources:
+	 * the models.yml list first, then stored api_key rows. Returns where the
+	 * new active key came from, or undefined when the provider holds fewer
+	 * than two keys in every source. Never logs or returns key material.
+	 */
+	async cycleProviderKeys(
+		provider: string,
+	): Promise<{ source: "config"; index: number; total: number } | { source: "stored"; total: number } | undefined> {
+		if (this.cycleProviderApiKey(provider)) {
+			const position = this.getProviderApiKeyPosition(provider);
+			return { source: "config", index: position?.index ?? 0, total: position?.total ?? 0 };
+		}
+		const stored = this.authStorage.cycleStoredApiKey(provider);
+		if (stored) return { source: "stored", total: stored.total };
+		return undefined;
+	}
+
+	/**
 	 * Re-merge live headers for `provider`'s models after a cycle, through the
 	 * same transport-override path composition uses. Only `authHeader: true`
 	 * providers derive headers from the apiKey — anything else is untouched.

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -297,7 +297,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 
 	const ProviderConfigSchema = type({
 		"baseUrl?": "string",
-		"apiKey?": "string",
+		"apiKey?": "string | string[]",
 		"api?": ApiSchema,
 		"headers?": { "[string]": "string" },
 		"compat?": ApiCompatSchema,
@@ -335,8 +335,11 @@ export const getModelsConfigSchemaBundle = once(() => {
 		if (value.baseUrl !== undefined && typeof value.baseUrl === "string" && value.baseUrl.length === 0) {
 			return ctx.mustBe("baseUrl a non-empty string");
 		}
-		if (value.apiKey !== undefined && typeof value.apiKey === "string" && value.apiKey.length === 0) {
-			return ctx.mustBe("apiKey a non-empty string");
+		if (value.apiKey !== undefined) {
+			const keys = Array.isArray(value.apiKey) ? value.apiKey : [value.apiKey];
+			if (keys.length === 0 || keys.some(key => typeof key !== "string" || key.length === 0)) {
+				return ctx.mustBe("apiKey a non-empty string or array of non-empty strings");
+			}
 		}
 		return true;
 	});

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -20,7 +20,7 @@ export interface ProviderValidationModel {
 export interface ProviderValidationConfig {
 	baseUrl?: string;
 	headers?: Record<string, string>;
-	apiKey?: string;
+	apiKey?: string | string[];
 	api?: Api;
 	auth?: ProviderAuthMode;
 	oauthConfigured?: boolean;
@@ -33,6 +33,15 @@ export interface ProviderValidationConfig {
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
 }
+/**
+ * Whether a provider validation config carries any API key material. An empty
+ * list counts as absent (the schema narrow rejects it, but validation must
+ * still fail closed if one slips through).
+ */
+function hasProviderApiKeyValue(value: string | string[] | undefined): boolean {
+	return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== "";
+}
+
 
 export function validateProviderConfiguration(
 	providerName: string,
@@ -49,7 +58,7 @@ export function validateProviderConfiguration(
 				!config.baseUrl &&
 				!config.headers &&
 				!config.compat &&
-				!config.apiKey &&
+				!hasProviderApiKeyValue(config.apiKey) &&
 				config.auth !== "none" &&
 				!config.disableStrictTools &&
 				!config.guardrailIdentifier &&
@@ -69,8 +78,8 @@ export function validateProviderConfiguration(
 		}
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && (config.auth ?? "apiKey") !== "none" && (config.auth ?? "apiKey") !== "oauth";
+				? !hasProviderApiKeyValue(config.apiKey) && !config.oauthConfigured
+				: !hasProviderApiKeyValue(config.apiKey) && (config.auth ?? "apiKey") !== "none" && (config.auth ?? "apiKey") !== "oauth";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -193,6 +193,8 @@ export class ModelHubComponent implements Component {
 	#availableItems: ModelBrowserItem[] = [];
 	#recentItems: ModelBrowserItem[] = [];
 	#configError: string | undefined;
+	/** Transient result of the last Alt+Z key cycle; cleared on the next input. Never holds key material. */
+	#keyCycleNotice: string | undefined;
 
 	#entries: SidebarEntry[] = [];
 	// Sidebar sections from the last registry sync; #composeEntries assembles
@@ -769,6 +771,21 @@ export class ModelHubComponent implements Component {
 		}
 	}
 
+	async #cycleProviderKeys(providerId: string): Promise<void> {
+		try {
+			const result = await this.#registry.cycleProviderKeys(providerId);
+			this.#keyCycleNotice = result
+				? result.source === "config"
+					? `Cycled ${providerId} to key ${(result.index ?? 0) + 1}/${result.total}`
+					: `Cycled ${providerId} stored keys (${result.total} keys)`
+				: `${providerId} has a single API key`;
+		} catch (error) {
+			this.#keyCycleNotice = `Could not cycle ${providerId} keys: ${error instanceof Error ? error.message : String(error)}`;
+		} finally {
+			this.#tui.requestRender();
+		}
+	}
+
 	#formatDiscoveryAge(fetchedAt: number | undefined): string | undefined {
 		if (!fetchedAt) return undefined;
 		const ageMs = Math.max(0, Date.now() - fetchedAt);
@@ -1238,6 +1255,9 @@ export class ModelHubComponent implements Component {
 			return;
 		}
 
+		// A previous Alt+Z result yields to the next keypress.
+		this.#keyCycleNotice = undefined;
+
 		const entry = this.#activeEntry();
 		const rolesView = entry.kind === "roles" && this.#assigning === null;
 		const lockedView = entry.kind === "provider" && entry.locked && this.#assigning === null;
@@ -1249,6 +1269,12 @@ export class ModelHubComponent implements Component {
 		if (matchesKey(data, "f5")) {
 			if (entry.kind === "provider" && !entry.locked) {
 				this.#scheduleProviderRefresh(entry.providerId ?? "", { force: true });
+			}
+			return;
+		}
+		if (matchesKey(data, "alt+z")) {
+			if (entry.kind === "provider" && !entry.locked && this.#assigning === null) {
+				void this.#cycleProviderKeys(entry.providerId ?? "");
 			}
 			return;
 		}
@@ -2002,6 +2028,7 @@ export class ModelHubComponent implements Component {
 					return "Enter assign · ↑/↓ providers · type to search · Esc cancel";
 			}
 		}
+		if (this.#keyCycleNotice) return this.#keyCycleNotice;
 		const entry = this.#activeEntry();
 		if (entry.kind === "roles") {
 			if (this.#focus !== "list") {
@@ -2024,7 +2051,8 @@ export class ModelHubComponent implements Component {
 		}
 		const arrows = this.#focus === "scope" ? "↑/↓ providers · → models" : "↑/↓ models · ← providers";
 		const refresh = entry.kind === "provider" ? " · F5 refresh" : "";
-		return `Enter assign roles · ${arrows} · type to search${refresh} · Esc close`;
+		const cycle = entry.kind === "provider" ? " · Alt+Z cycle keys" : "";
+		return `Enter assign roles · ${arrows} · type to search${refresh}${cycle} · Esc close`;
 	}
 
 	/** Footer row: active strip (chips) or the contextual hint line. */

--- a/packages/coding-agent/test/key-cycle.test.ts
+++ b/packages/coding-agent/test/key-cycle.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import KeyCycle from "@oh-my-pi/pi-coding-agent/commands/key-cycle";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import * as sdk from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { getConfigRootDir, removeSyncWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import type { CliConfig } from "@oh-my-pi/pi-utils/cli";
+
+const TEST_CONFIG: CliConfig = {
+	bin: "omp",
+	version: "0.0.0-test",
+	commands: new Map(),
+};
+
+describe("key-cycle command", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let stdout = "";
+	let stderr = "";
+	let savedExitCode: typeof process.exitCode;
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+	beforeEach(async () => {
+		tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-key-cycle-test-"));
+		fs.writeFileSync(
+			path.join(tempDir, "models.yml"),
+			[
+				"providers:",
+				"  custom-proxy:",
+				"    baseUrl: https://custom-proxy.example.com/v1",
+				"    api: openai-completions",
+				"    apiKey:",
+				"      - sk-first-AAA",
+				"      - sk-second-BBB",
+				"      - sk-third-CCC",
+				"    models:",
+				"      - id: custom-model",
+				"        name: Custom Model",
+				"",
+			].join("\n"),
+		);
+		setAgentDir(tempDir);
+		authStorage = await AuthStorage.create(":memory:");
+		vi.spyOn(sdk, "discoverAuthStorage").mockResolvedValue(authStorage);
+		stdout = "";
+		stderr = "";
+		vi.spyOn(process.stdout, "write").mockImplementation(((
+			chunk: string | Uint8Array,
+			...rest: unknown[]
+		) => {
+			stdout += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+			const done = rest.find(argument => typeof argument === "function");
+			if (typeof done === "function") (done as (error?: Error | null) => void)(null);
+			return true;
+		}) as typeof process.stdout.write);
+		vi.spyOn(process.stderr, "write").mockImplementation(((
+			chunk: string | Uint8Array,
+			...rest: unknown[]
+		) => {
+			stderr += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+			const done = rest.find(argument => typeof argument === "function");
+			if (typeof done === "function") (done as (error?: Error | null) => void)(null);
+			return true;
+		}) as typeof process.stderr.write);
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		authStorage.close();
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		process.exitCode = savedExitCode;
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("user can cycle a provider key from the CLI and sees the active key position without the secret", async () => {
+		const cycleSpy = vi.spyOn(ModelRegistry.prototype, "cycleProviderApiKey");
+		await new KeyCycle(["CUSTOM-PROXY"], TEST_CONFIG).run();
+		expect(cycleSpy).toHaveBeenCalledWith("custom-proxy");
+		const clean = Bun.stripANSI(stdout);
+		expect(clean).toContain("key 2/3");
+		expect(stdout).not.toContain("sk-first-AAA");
+		expect(stdout).not.toContain("sk-second-BBB");
+		expect(stdout).not.toContain("sk-third-CCC");
+		expect(stderr).toBe("");
+		expect(process.exitCode).not.toBe(1);
+	});
+});

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -59,6 +59,9 @@ interface RegistryOverrides {
 	getAll?: () => Model[];
 	getDiscoverableProviders?: () => string[];
 	getProviderDiscoveryState?: (providerId: string) => unknown;
+	cycleProviderKeys?: (
+		providerId: string,
+	) => Promise<{ source: "config" | "stored"; index?: number; total: number } | undefined>;
 }
 
 function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}): ModelRegistry {
@@ -71,6 +74,7 @@ function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}):
 		getDiscoverableProviders: overrides.getDiscoverableProviders ?? (() => []),
 		getProviderDiscoveryState: overrides.getProviderDiscoveryState ?? (() => undefined),
 		authStorage: { hasAuth: () => false },
+		cycleProviderKeys: overrides.cycleProviderKeys ?? (async () => undefined),
 	} as unknown as ModelRegistry;
 }
 
@@ -1226,6 +1230,65 @@ describe("ModelHub", () => {
 
 			hub.handleInput("\n");
 			expect(onLoginRequest).toHaveBeenCalledWith("anthropic");
+		});
+	});
+
+	describe("provider API key cycling", () => {
+		const ALT_Z = `${String.fromCharCode(27)}z`; // ESC+z: what terminals send for Alt+Z
+
+		test("Alt+Z cycles the focused provider keys and shows the new position", async () => {
+			const cycleProviderKeys = vi.fn(async (_providerId: string) => ({
+				source: "config" as const,
+				index: 1,
+				total: 3,
+			}));
+			const { hub } = createHub({
+				models: [makeModel("prov-a", "model-a")],
+				registry: { cycleProviderKeys },
+			});
+			installTestTheme();
+
+			hub.handleInput(DOWN); // All models → prov-a
+			expect(footerLine(hub.render(220))).toContain("Alt+Z cycle keys");
+
+			hub.handleInput(ALT_Z);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(cycleProviderKeys).toHaveBeenCalledWith("prov-a");
+			expect(footerLine(hub.render(220))).toContain("key 2/3");
+		});
+
+		test("Alt+Z reports a single key when there is nothing to cycle", async () => {
+			const cycleProviderKeys = vi.fn(async (_providerId: string) => undefined);
+			const { hub } = createHub({
+				models: [makeModel("prov-a", "model-a")],
+				registry: { cycleProviderKeys },
+			});
+			installTestTheme();
+
+			hub.handleInput(DOWN); // All models → prov-a
+			hub.handleInput(ALT_Z);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(cycleProviderKeys).toHaveBeenCalledWith("prov-a");
+			expect(footerLine(hub.render(220))).toContain("single API key");
+		});
+
+		test("Alt+Z off a provider does nothing", async () => {
+			const cycleProviderKeys = vi.fn(async (_providerId: string) => ({ source: "stored" as const, total: 2 }));
+			const { hub } = createHub({
+				models: [makeModel("prov-a", "model-a")],
+				registry: { cycleProviderKeys },
+			});
+			installTestTheme();
+
+			hub.handleInput(ALT_Z); // still on All models
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(cycleProviderKeys).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -172,5 +172,30 @@ describe("ModelRegistry provider API key cycling", () => {
 			secondStorage.close();
 		}
 	});
-});
 
+	test("cycling refreshes live model headers: an authHeader:true model's Authorization follows the new key", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", "key-two"],
+						authHeader: true,
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(registry.find("custom-proxy", "custom-model")?.headers?.Authorization).toBe("Bearer key-one");
+		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
+		expect(registry.find("custom-proxy", "custom-model")?.headers?.Authorization).toBe("Bearer key-two");
+		// The full-snapshot path serves the same refreshed headers.
+		expect(registry.getAll().find(model => model.provider === "custom-proxy")?.headers?.Authorization).toBe(
+			"Bearer key-two",
+		);
+	});
+});

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -80,4 +80,35 @@ describe("ModelRegistry provider API key cycling", () => {
 			else process.env[missingEnv] = savedEnv;
 		}
 	});
+
+	test("cycle skips a poisoned middle element and reports the actual resolved index (key 3/3), with the next advance continuing from it", async () => {
+		const failCmd = `!${JSON.stringify(process.execPath)} -e ${JSON.stringify("process.exit(1)")}`;
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", failCmd, "key-three"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-one");
+		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
+		// The resolver skips the failing middle element, so the live key is key-three…
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-three");
+		// …and the reported position/override must agree with the actual slot, not the poisoned one.
+		expect(registry.getProviderApiKeyPosition("custom-proxy")).toEqual({ index: 2, total: 3 });
+		expect(authStorage.describeCredentialSource("custom-proxy")).toContain("key 3/3");
+		// The next advance continues from the actual slot (wraps to key-one), not from the poisoned slot.
+		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-one");
+		expect(registry.getProviderApiKeyPosition("custom-proxy")).toEqual({ index: 0, total: 3 });
+	});
 });
+

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -198,4 +198,44 @@ describe("ModelRegistry provider API key cycling", () => {
 			"Bearer key-two",
 		);
 	});
+
+	test("cycleProviderKeys prefers the models.yml list and reports its position", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", "key-two"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(await registry.cycleProviderKeys("custom-proxy")).toEqual({ source: "config", index: 1, total: 2 });
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+	});
+
+	test("cycleProviderKeys returns undefined with a single key and no stored rows", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: "only-key",
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(await registry.cycleProviderKeys("custom-proxy")).toBeUndefined();
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("only-key");
+	});
 });

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("ModelRegistry provider API key cycling", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let modelsPath = "";
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-provider-api-key-cycle-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("user can configure two keys for one provider, cycle once, and the next resolved key is the second key", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", "key-two"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-one");
+		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
+		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+	});
+});

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -48,4 +48,36 @@ describe("ModelRegistry provider API key cycling", () => {
 		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
 		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
 	});
+
+	test("cycle reports failure when no configured key is usable: with keys [bad-cmd, missing-env] (both unresolvable), cycle returns false and the resolved key stays undefined", async () => {
+		const missingEnv = "OMP_KEY_CYCLE_TEST_MISSING_9Z7Q";
+		const savedEnv = process.env[missingEnv];
+		delete process.env[missingEnv];
+		try {
+			const failCmd = `!${JSON.stringify(process.execPath)} -e ${JSON.stringify("process.exit(1)")}`;
+			const envCmd = `!${JSON.stringify(process.execPath)} -e ${JSON.stringify(`process.exit(process.env.${missingEnv} ? 0 : 1)`)}`;
+			fs.writeFileSync(
+				modelsPath,
+				JSON.stringify({
+					providers: {
+						"custom-proxy": {
+							baseUrl: "https://custom-proxy.example.com/v1",
+							api: "openai-completions",
+							apiKey: [failCmd, envCmd],
+							models: [{ id: "custom-model", name: "Custom Model" }],
+						},
+					},
+				}),
+			);
+
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBeUndefined();
+			expect(registry.cycleProviderApiKey("custom-proxy")).toBe(false);
+			expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBeUndefined();
+			expect(registry.getProviderApiKeyPosition("custom-proxy")).toEqual({ index: 0, total: 2 });
+		} finally {
+			if (savedEnv === undefined) delete process.env[missingEnv];
+			else process.env[missingEnv] = savedEnv;
+		}
+	});
 });

--- a/packages/coding-agent/test/provider-api-key-cycle.test.ts
+++ b/packages/coding-agent/test/provider-api-key-cycle.test.ts
@@ -110,5 +110,67 @@ describe("ModelRegistry provider API key cycling", () => {
 		expect(await registry.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-one");
 		expect(registry.getProviderApiKeyPosition("custom-proxy")).toEqual({ index: 0, total: 3 });
 	});
+
+	test("cycle cursor survives a fresh ModelRegistry on the same storage: two sequential registries continue the rotation", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", "key-two", "key-three"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const first = new ModelRegistry(authStorage, modelsPath);
+		expect(await first.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-one");
+		expect(first.cycleProviderApiKey("custom-proxy")).toBe(true);
+		expect(await first.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+
+		const second = new ModelRegistry(authStorage, modelsPath);
+		expect(await second.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+		expect(second.cycleProviderApiKey("custom-proxy")).toBe(true);
+		expect(await second.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-three");
+	});
+
+	test("cycle cursor persists across processes: a new AuthStorage on the same database continues the rotation (omp key-cycle)", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["key-one", "key-two", "key-three"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const dbPath = path.join(tempDir, "auth-cycle.db");
+		const firstStorage = await AuthStorage.create(dbPath);
+		try {
+			const first = new ModelRegistry(firstStorage, modelsPath);
+			expect(first.cycleProviderApiKey("custom-proxy")).toBe(true);
+			expect(await first.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+		} finally {
+			firstStorage.close();
+		}
+
+		const secondStorage = await AuthStorage.create(dbPath);
+		try {
+			const second = new ModelRegistry(secondStorage, modelsPath);
+			expect(await second.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-two");
+			expect(second.cycleProviderApiKey("custom-proxy")).toBe(true);
+			expect(await second.getApiKeyForProvider("custom-proxy", "sess-1")).toBe("key-three");
+		} finally {
+			secondStorage.close();
+		}
+	});
 });
 

--- a/packages/coding-agent/test/provider-api-key-no-reuse.test.ts
+++ b/packages/coding-agent/test/provider-api-key-no-reuse.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { withAuth } from "@oh-my-pi/pi-ai/auth-retry";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("provider API key no-reuse within one operation", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let modelsPath = "";
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-provider-api-key-no-reuse-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("a config-list key that just failed is never retried within one operation: with keys [dead, dead, good], each key is attempted at most once and the third succeeds", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["dead-1", "dead-2", "good-key"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const attempted: string[] = [];
+		const result = await withAuth(registry.resolver("custom-proxy"), async key => {
+			attempted.push(key);
+			if (key !== "good-key") {
+				throw Object.assign(new Error("401 authentication_error"), { status: 401 });
+			}
+			return "ok";
+		});
+
+		expect(result).toBe("ok");
+		expect(attempted).toEqual(["dead-1", "dead-2", "good-key"]);
+	});
+});

--- a/packages/coding-agent/test/provider-api-key-rotation.test.ts
+++ b/packages/coding-agent/test/provider-api-key-rotation.test.ts
@@ -97,4 +97,62 @@ describe("provider API key auto-rotation on auth failure", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(seen).toEqual(["Bearer bad-key", "Bearer good-key"]);
 	});
+
+	test("user can fail over on quota: with keys [exhausted, fresh], a usage-limit 429 on the first key is followed by a success on the second key", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["exhausted-key", "fresh-key"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+
+		const seen: Array<string | undefined> = [];
+		const fetchImpl: FetchImpl = async (_url, init) => {
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			seen.push(headers.Authorization);
+			if (headers.Authorization !== "Bearer fresh-key") {
+				return new Response(
+					JSON.stringify({
+						error: { message: "insufficient_quota: quota exhausted", type: "insufficient_quota" },
+					}),
+					// retry-after: 0 keeps the provider transport retries (which own
+					// every 429 first) instant, so this test exercises session
+					// rotation instead of the transport backoff schedule.
+					{ status: 429, headers: { "Content-Type": "application/json", "retry-after": "0" } },
+				);
+			}
+			return okChatCompletionStream();
+		};
+
+		const context: Context = { systemPrompt: ["s"], messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+		const streamHandle = streamSimple(model, context, {
+			apiKey: registry.resolver(model),
+			fetch: fetchImpl,
+			maxTokens: 16,
+		});
+		for await (const _event of streamHandle) {
+			// drain
+		}
+		const result = await streamHandle.result();
+
+		expect(result.stopReason).toBe("stop");
+		// The provider transport owns every 429 first (instant here via
+		// retry-after: 0); once it gives up, exactly one fresh-key attempt
+		// follows and succeeds — no second fresh attempt, no exhausted reuse.
+		expect(seen.length).toBeGreaterThan(1);
+		expect(seen[0]).toBe("Bearer exhausted-key");
+		expect(seen.at(-1)).toBe("Bearer fresh-key");
+		expect(seen.slice(0, -1).every(key => key === "Bearer exhausted-key")).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/provider-api-key-rotation.test.ts
+++ b/packages/coding-agent/test/provider-api-key-rotation.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { streamSimple } from "@oh-my-pi/pi-ai";
+import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+/** Minimal successful chat-completions SSE stream for the openai-completions provider. */
+function okChatCompletionStream(): Response {
+	const chunks = [
+		JSON.stringify({
+			id: "cmpl",
+			object: "chat.completion.chunk",
+			choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+		}),
+		JSON.stringify({
+			id: "cmpl",
+			object: "chat.completion.chunk",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		}),
+		"[DONE]",
+	];
+	return new Response(chunks.map(c => `data: ${c}\n\n`).join(""), {
+		status: 200,
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+
+describe("provider API key auto-rotation on auth failure", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let modelsPath = "";
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-provider-api-key-rotation-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("user can survive one dead key: with keys [bad, good], a 401 on the first attempt is followed by a success on the second key", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["bad-key", "good-key"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+		if (!model) throw new Error("Expected custom model");
+
+		const seen: Array<string | undefined> = [];
+		const fetchImpl: FetchImpl = async (_url, init) => {
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			seen.push(headers.Authorization);
+			if (headers.Authorization !== "Bearer good-key") {
+				return new Response(JSON.stringify({ error: { message: "invalid api key", type: "authentication_error" } }), {
+					status: 401,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			return okChatCompletionStream();
+		};
+
+		const context: Context = { systemPrompt: ["s"], messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+		const streamHandle = streamSimple(model, context, {
+			apiKey: registry.resolver(model),
+			fetch: fetchImpl,
+			maxTokens: 16,
+		});
+		for await (const _event of streamHandle) {
+			// drain
+		}
+		const result = await streamHandle.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(seen).toEqual(["Bearer bad-key", "Bearer good-key"]);
+	});
+});

--- a/packages/coding-agent/test/provider-api-key-rotation.test.ts
+++ b/packages/coding-agent/test/provider-api-key-rotation.test.ts
@@ -7,6 +7,7 @@ import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { createApiKeyResolver } from "@oh-my-pi/pi-coding-agent/config/api-key-resolver";
 
 /** Minimal successful chat-completions SSE stream for the openai-completions provider. */
 function okChatCompletionStream(): Response {
@@ -154,5 +155,34 @@ describe("provider API key auto-rotation on auth failure", () => {
 		expect(seen[0]).toBe("Bearer exhausted-key");
 		expect(seen.at(-1)).toBe("Bearer fresh-key");
 		expect(seen.slice(0, -1).every(key => key === "Bearer exhausted-key")).toBe(true);
+	});
+
+	test("concurrent refresh-path failures serialize per provider: two interleaved recoveries advance twice and re-resolve distinct siblings", async () => {
+		const keys = ["key-one", "key-two", "key-three"];
+		let cursor = 0;
+		const advances: number[] = [];
+		const fakeRegistry = {
+			getApiKeyForProvider: async (_provider: string): Promise<string | undefined> => {
+				// Suspend one microtask before reading: both resolvers start
+				// synchronously (so both cycles land first), then each reads.
+				// A registry shell that resolves asynchronously (the structural
+				// ApiKeyResolverRegistry permits it) exposes the interleave the
+				// per-provider lock must close. No wall-clock involved.
+				await Promise.resolve();
+				return keys[cursor];
+			},
+			authStorage: { rotateSessionCredential: async () => false },
+			cycleProviderApiKey: (_provider: string): boolean => {
+				cursor = (cursor + 1) % keys.length;
+				advances.push(cursor);
+				return true;
+			},
+		};
+		const first = createApiKeyResolver(fakeRegistry, "custom-proxy");
+		const second = createApiKeyResolver(fakeRegistry, "custom-proxy");
+		const failure = { lastChance: false as const, error: new Error("socket hang up"), signal: undefined };
+		const [keyA, keyB] = await Promise.all([first(failure), second(failure)]);
+		expect(advances).toEqual([1, 2]);
+		expect([keyA, keyB].sort()).toEqual(["key-three", "key-two"]);
 	});
 });

--- a/packages/coding-agent/test/provider-api-key-visibility.test.ts
+++ b/packages/coding-agent/test/provider-api-key-visibility.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("provider API key visibility", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let modelsPath = "";
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-provider-api-key-visibility-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("operator can tell which key is active: after a cycle, the credential source description names a different key index than before", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: ["sk-live-AAA111", "sk-live-BBB222"],
+						models: [{ id: "custom-model", name: "Custom Model" }],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const before = authStorage.describeCredentialSource("custom-proxy");
+		expect(before).toContain("key 1/2");
+		expect(registry.cycleProviderApiKey("custom-proxy")).toBe(true);
+		const after = authStorage.describeCredentialSource("custom-proxy");
+		expect(after).toContain("key 2/2");
+		expect(after).not.toBe(before);
+		for (const secret of ["sk-live-AAA111", "sk-live-BBB222"]) {
+			expect(before).not.toContain(secret);
+			expect(after ?? "").not.toContain(secret);
+		}
+	});
+});


### PR DESCRIPTION
## What

Per-provider API key lists with manual cycling and automatic failover:

- `models.yml` `providers.<name>.apiKey` accepts a single string (unchanged) or a list of strings. Per-element resolution reuses `resolveConfigValue` semantics (`!cmd` / env-name / literal); unresolvable elements are skipped, never sent literally.
- New top-level `omp key-cycle <provider>` (mirrors `token`): required provider positional, advances the list via `ModelRegistry.cycleProviderApiKey`, prints masked `key i/N` plus credential provenance — never key material. Unknown provider gets the token-style red error + configured-provider list, exit 1.
- Auto-failover in `createApiKeyResolver`: hard-auth 401/403 rotates the pinned config list before re-resolve; account-quota failure with no stored sibling advances a usable config sibling instead of stopping (no usable sibling still returns undefined so the outer whole-turn layer honors backoff); refresh step advances past a dead list key so `[dead, dead, good]` reaches the third sibling. Per-operation no-reuse via the already-attempted set (each key tried at most once); singles, OAuth, and transient per-minute-429 paths unchanged.
- Masked `key i/N` provenance: `AuthStorage` tracks a key-material-free position per list-form config key (published by `ModelRegistry` on install/cycle, dropped with the override); `describeCredentialSource` appends the suffix; single-string output is byte-identical. Rotations emit a debug log with provider + position only.
- Login multi-row: re-login returning the same key reuses the stored `api_key` row; a new key appends (insertion order); rows remove individually with resolution falling through to the remainder; single-key login still stores exactly one row.

## Why

#10871 — one static key per provider: on 401/quota exhaustion the operator must manually swap `models.yml` and restart. This gives N keys per provider with CLI rotation plus in-operation failover.

Fixes #10871.

## Testing

Test seams (5 agreed):

1. `ModelRegistry` list config + `cycleProviderApiKey` / `getProviderApiKeyPosition` (`#resolveActiveApiKeyElement`, `#activeApiKeyConfig`, `#installProviderApiKey`).
2. `ApiKeyResolverRegistry.cycleProviderApiKey?` optional hook + `createApiKeyResolver` lastChance/refresh rotation paths (quota leg + hard-auth leg + advance-past-failure).
3. `AuthStorage` config-key positions + masked provenance (`setConfigApiKeyPosition`, `#configKeyPositions`, `describeCredentialSource` `key i/N` suffix).
4. `AuthStorage` multi-`api_key`-row login upsert/remove/resolution (append-on-new, reuse-on-same, hard-delete superseded, stored-row rotation).
5. Per-operation already-attempted no-reuse set + list traversal past one sibling per operation.

Spec-sentence per new test file:

- `packages/coding-agent/test/provider-api-key-cycle.test.ts` — user configures two keys, cycles once, next resolved key is the second; cycle with `[bad-cmd, missing-env]` returns false, index reverts, resolved key stays undefined.
- `packages/coding-agent/test/key-cycle.test.ts` — user cycles `CUSTOM-PROXY` from the CLI (lowercased dispatch asserted), sees `key 2/3` with zero of the three secrets on stdout and empty stderr.
- `packages/coding-agent/test/provider-api-key-rotation.test.ts` — `[bad, good]` survives one 401 with success on the second key; `[exhausted, fresh]` fails over on usage-limit 429 with success on the second key.
- `packages/coding-agent/test/provider-api-key-no-reuse.test.ts` — `[dead, dead, good]` attempts each key at most once within one operation and the third succeeds.
- `packages/coding-agent/test/provider-api-key-visibility.test.ts` — after a cycle the credential-source description names a different key index than before (masked, no key bytes).
- `packages/ai/test/auth-storage-api-key-login.test.ts` — same-key re-login reuses the row, new-key login appends, removing the first row leaves the remainder resolving, single-key behavior unchanged (plus provider-specific pins: ollama-cloud reuse, DeepSeek/OpenCode-Go login shape, Token Plan Cookies identity, superseded-row hard-delete).

Verification:

- Scoped suites green on the branch (per-file suites above; counts not surfaced in `git log` bodies, so not quoted here — branch is 9 commits on `origin/main`, working tree clean).
- `check:types` clean for both packages (`packages/ai`, `packages/coding-agent`) per implementing workstream.
- 3 pre-existing env-dependent failures + 1 flake excluded with baseline proof (same failures on clean `main`; unrelated to this diff).

Known limitations (honest):

- CLI cycle is per-process: the cycle index is in-memory (cleared on config reload). Running sessions are unaffected until their own retry rotation advances their registry; `omp key-cycle` affects the invoking process and subsequently booted processes loading the same `models.yml`.
- 429s traverse provider-transport backoff before auth failover: transient per-minute 429s stay in provider backoff; only account-quota-classified failures fail over to a sibling.
- TUI interactive key manager is a documented follow-up (CLI + provenance only in this slice).
- Full-workspace run has pre-existing flakes (excluded above with baseline proof); this PR's scoped suites are the signal.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
