### PR TITLE
fix(agent): respect spawn depth in eval guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -84,6 +84,7 @@
 ### Fixed
 
 - Fixed `todo` and other tools called through eval rejecting optional `None`/`null` arguments that direct tool calls accept.
+- Stop eval from advertising `agent()` after the session reaches its subagent recursion-depth limit.
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Stop eval from advertising `agent()` after the session reaches its subagent recursion-depth limit.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
@@ -84,7 +85,6 @@
 ### Fixed
 
 - Fixed `todo` and other tools called through eval rejecting optional `None`/`null` arguments that direct tool calls accept.
-- Stop eval from advertising `agent()` after the session reaches its subagent recursion-depth limit.
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -24,11 +24,11 @@ completion(prompt, model?="default"|"smol"|"slow", system?=None, schema?=None) �
 {{#if spawns}}agent(prompt, agent?="{{spawnDefaultAgent}}", label?=None, schema?=None, schema{{#if js}}Mode{{else}}_mode{{/if}}?="permissive", isolated?=None, apply?=None, merge?=None{{#if evalTools}}, tools?=None{{/if}}) → AgentHandle
     Spawns a background subagent and returns immediately. `agent` selects a discovered agent; omit it to use `{{spawnDefaultAgent}}`.{{#if spawnAllowedAgentsText}} Allowed agents: {{spawnAllowedAgentsText}}.{{/if}} Handle: `.id`, `.handle` ("agent://<id>"), `.status`, `.done()`, `.wait(timeout?)` → final text (parsed with `schema`), `.send(message)`, `.cancel()`, `.output()`. Unwaited results auto-deliver like async jobs. `schema` overrides agent/session schemas; `isolated` requests a worktree; `apply`/`merge` control its changes.{{#if evalTools}} `tools`: names of your @tool-defined tools the child may call.{{/if}}
 {{#if js}}    JS: ONE trailing object — agent(prompt, { agent, label, schema, schemaMode, isolated, apply, merge{{#if evalTools}}, tools{{/if}} }).{{/if}}
-wait(handles, timeout?=None, raise_errors?=True) → list
-    Barrier over agent/completion handles, results in input order. `raise_errors=False` keeps the error in its slot.{{#if js}} JS: wait(handles, { timeout, raiseErrors }).{{/if}}
 workpool(agent?=None, name?=None, context?=None{{#if evalTools}}, tools?=None{{/if}}) → WorkPool
     {{#if eagerDelegation}}Default for 2+ independent items.{{else}}Keep-alive worker pool for a batch of independent items.{{/if}} `.push(*items)`; `.status()`; `.peek()`; `.close()`. Pool name = async job id; results auto-deliver, or poll outside eval with `hub wait` and `ids:[pool.name]`. `eval.workpool.freshAgents=true` uses a new agent per item.
 {{/if}}
+wait(handles, timeout?=None, raise_errors?=True) → list
+    Barrier over agent/completion handles, results in input order. `raise_errors=False` keeps the error in its slot.{{#if js}} JS: wait(handles, { timeout, raiseErrors }).{{/if}}
 {{#if evalTools}}{{#if py}}@tool / tool(fn, name=None, description=None){{/if}}{{#if js}}tool(fn, { name?, description?, parameters? }){{/if}}
     Define a tool that runs in this kernel{{#if py}} (schema inferred from type hints){{/if}}; reference by name in `task` items' `tools`{{#if spawns}}, `agent(tools=…)`, `workpool(tools=…)`{{/if}}. `tool.defined()`, `tool.undefine(name)`.
 {{/if}}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -21,6 +21,7 @@ import evalCodeModeDescription from "../prompts/tools/eval-code-mode.md" with { 
 import { DEFAULT_MAX_BYTES, OutputSink, type OutputSummary, TailBuffer } from "../session/streaming-output";
 import { sessionDelegationBias } from "../task/prompt-policy";
 import { resolveSpawnPolicy } from "../task/spawn-policy";
+import { canSpawnAtDepth } from "../task/types";
 import { webpExclusionForModel } from "../utils/image-loading";
 import { formatDimensionNote, resizeImage } from "../utils/image-resize";
 import type { ToolSession } from ".";
@@ -280,6 +281,10 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		} else {
 			const backends = resolveEvalBackends(this.session);
 			const sessionSpawns = this.session.getSessionSpawns?.() ?? "*";
+			const depthAllowsSpawning = canSpawnAtDepth(
+				this.session.settings.get("task.maxRecursionDepth") ?? 2,
+				this.session.taskDepth ?? 0,
+			);
 			const preludeDocumentation = getEnabledEvalPreludes(this.session.getEvalPreludes?.() ?? [])
 				.map(definition => definition.documentation.trim())
 				.filter(Boolean)
@@ -287,7 +292,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 			base = getEvalToolDescription({
 				py: backends.python,
 				js: backends.js,
-				spawns: sessionSpawns,
+				spawns: depthAllowsSpawning ? sessionSpawns : false,
 				autoBackgroundEnabled: this.session.settings.get("eval.autoBackground.enabled"),
 				evalTools: this.session.settings.get("eval.tools.enabled"),
 				eagerDelegation: sessionDelegationBias(this.session) === "eager",

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -10,14 +10,18 @@ function makeSession(opts: {
 	spawns?: string | null;
 	backends?: Record<string, boolean>;
 	preludes?: () => readonly EvalPreludeDefinition[];
+	taskDepth?: number;
+	maxRecursionDepth?: number;
 }): ToolSession {
 	const settings = Settings.isolated();
 	for (const [key, value] of Object.entries(opts.backends ?? {})) settings.set(key as never, value);
+	if (opts.maxRecursionDepth !== undefined) settings.set("task.maxRecursionDepth", opts.maxRecursionDepth);
 	return {
 		cwd: "/tmp/eval-test",
 		hasUI: false,
 		getSessionFile: () => null,
 		getSessionSpawns: () => opts.spawns ?? "*",
+		taskDepth: opts.taskDepth,
 		...(opts.preludes ? { getEvalPreludes: opts.preludes } : {}),
 		settings,
 	} as unknown as ToolSession;
@@ -67,6 +71,16 @@ describe("eval tool description", () => {
 		const denied = new EvalTool(makeSession({ spawns: "" })).description;
 		expect(wildcard).toContain("agent(prompt");
 		expect(denied).not.toContain("agent(prompt");
+	});
+
+	it("omits agent() when recursion depth is exhausted", () => {
+		const belowCap = new EvalTool(makeSession({ taskDepth: 1, maxRecursionDepth: 2 })).description;
+		const atCap = new EvalTool(makeSession({ taskDepth: 2, maxRecursionDepth: 2 })).description;
+		const spawningDisabled = new EvalTool(makeSession({ taskDepth: 0, maxRecursionDepth: 0 })).description;
+
+		expect(belowCap).toContain("agent(prompt");
+		expect(atCap).not.toContain("agent(prompt");
+		expect(spawningDisabled).not.toContain("agent(prompt");
 	});
 
 	it("hides eval-defined tool guidance when eval.tools.enabled is off", () => {

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -59,11 +59,13 @@ describe("eval tool description", () => {
 		expect(text).toContain("agent(prompt");
 	});
 
-	it("omits agent() when the session forbids spawning", () => {
+	it("omits spawning helpers but keeps wait() when the session forbids spawning", () => {
 		// Subagents with spawns: undefined (resolved to "") cannot launch tasks.
-		// The prelude doc must not promise a helper that always throws.
+		// wait() remains usable with completion() handles.
 		const text = getEvalToolDescription({ py: true, js: true, spawns: false });
 		expect(text).not.toContain("agent(prompt");
+		expect(text).not.toContain("workpool(");
+		expect(text).toContain("wait(handles");
 	});
 
 	it("EvalTool description reflects spawn policy from the session", () => {
@@ -73,14 +75,17 @@ describe("eval tool description", () => {
 		expect(denied).not.toContain("agent(prompt");
 	});
 
-	it("omits agent() when recursion depth is exhausted", () => {
+	it("omits spawning helpers but keeps wait() when recursion depth is exhausted", () => {
 		const belowCap = new EvalTool(makeSession({ taskDepth: 1, maxRecursionDepth: 2 })).description;
 		const atCap = new EvalTool(makeSession({ taskDepth: 2, maxRecursionDepth: 2 })).description;
 		const spawningDisabled = new EvalTool(makeSession({ taskDepth: 0, maxRecursionDepth: 0 })).description;
 
 		expect(belowCap).toContain("agent(prompt");
-		expect(atCap).not.toContain("agent(prompt");
-		expect(spawningDisabled).not.toContain("agent(prompt");
+		for (const description of [atCap, spawningDisabled]) {
+			expect(description).not.toContain("agent(prompt");
+			expect(description).not.toContain("workpool(");
+			expect(description).toContain("wait(handles");
+		}
 	});
 
 	it("hides eval-defined tool guidance when eval.tools.enabled is off", () => {


### PR DESCRIPTION
## What

Make `EvalTool` respect the session recursion-depth limit when generating its model-facing description.

When the current task depth reaches `task.maxRecursionDepth`, the eval tool no longer advertises `agent()`. Existing spawn-policy behavior remains unchanged when the session is below the depth limit.

Regression coverage verifies:

- `agent()` remains available below the recursion limit;
- `agent()` is omitted at the recursion limit; and
- a maximum depth of zero disables the guidance at the top level.

## Why

The runtime already rejects subagent creation once the recursion limit is reached, but the eval description continued instructing the model to use `agent()`. This mismatch caused impossible delegation attempts and wasted turns.

As I am using RPC and subagent support is not two way to support what I am doing, this is a way to not confuse agents on enabled capabilities.

This is a focused extraction of the eval-specific fix related to #8231, rather than the broader capability-gating refactor in that draft PR.

## Verification

- Reproduced the previous mismatch: with `taskDepth = 2` and `task.maxRecursionDepth = 2`, `EvalTool.description` still contained `agent(prompt`.
- Confirmed the same scenario no longer advertises `agent()` after the change.
- Confirmed a session below the limit still advertises `agent()`.
- `bun test test/tools/eval-description.test.ts` — 7 passed, 0 failed.
- `bun run check` in `packages/coding-agent` — passed.
- Currently running this as a patch.

## Checklist

- [x] `bun run check` passes
- [x] Tested locally for several days and versions