### PR TITLE
fix(compaction): size threshold archives for recovery headroom

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -29,15 +29,15 @@ Both are persisted as session entries and converted back into user-context messa
 Compaction and branch summaries are first-class session entries, not plain assistant/user messages.
 
 - `CompactionEntry`
-  - `type: "compaction"`
-  - `summary`, optional `shortSummary`
-  - `firstKeptEntryId` (compaction boundary)
-  - `tokensBefore`
-  - optional `details`, `preserveData`, `fromExtension`
+   - `type: "compaction"`
+   - `summary`, optional `shortSummary`
+   - `firstKeptEntryId` (compaction boundary)
+   - `tokensBefore`
+   - optional `details`, `preserveData`, `fromExtension`
 - `BranchSummaryEntry`
-  - `type: "branch_summary"`
-  - `fromId`, `summary`
-  - optional `details`, `fromExtension`
+   - `type: "branch_summary"`
+   - `fromId`, `summary`
+   - optional `details`, `fromExtension`
 
 When context is rebuilt (`buildSessionContext`):
 
@@ -106,32 +106,33 @@ What the LLM sees:
 The automatic paths are intentionally different:
 
 - **Overflow recovery**
-  - Trigger: current-model assistant error is detected as context overflow and the error is not older than the latest compaction.
-  - The failing assistant error message is removed from active agent state before retry.
-  - Context promotion is tried first; if a configured larger model is available, the agent switches model and retries without compacting.
-  - If promotion is unavailable and compaction is enabled, automatic maintenance walks `compaction.methodOrder` with `reason: "overflow"` and `willRetry: true`; handoff is skipped because its request would reuse the overflowing input.
-  - On success, `agent.continue()` is scheduled to retry the turn.
+   - Trigger: current-model assistant error is detected as context overflow and the error is not older than the latest compaction.
+   - The failing assistant error message is removed from active agent state before retry.
+   - Context promotion is tried first; if a configured larger model is available, the agent switches model and retries without compacting.
+   - If promotion is unavailable and compaction is enabled, automatic maintenance walks `compaction.methodOrder` with `reason: "overflow"` and `willRetry: true`; handoff is skipped because its request would reuse the overflowing input.
+   - On success, `agent.continue()` is scheduled to retry the turn.
 
 - **Incomplete-output recovery**
-  - Trigger: same-model assistant message ends with `stopReason === "length"` and the message is not older than the latest compaction.
-  - The incomplete assistant message is removed from active agent state before recovery.
-  - Context promotion is tried first.
-  - If promotion is unavailable and compaction is enabled, auto maintenance walks `compaction.methodOrder` with `reason: "incomplete"` and `willRetry: true`.
-  - Unlike overflow, a reachable `handoff` preference may run because the input context is still usable.
-  - On soft-compaction success, `agent.continue()` is scheduled to retry the turn.
+   - Trigger: same-model assistant message ends with `stopReason === "length"` and the message is not older than the latest compaction.
+   - The incomplete assistant message is removed from active agent state before recovery.
+   - Context promotion is tried first.
+   - If promotion is unavailable and compaction is enabled, auto maintenance walks `compaction.methodOrder` with `reason: "incomplete"` and `willRetry: true`.
+   - Unlike overflow, a reachable `handoff` preference may run because the input context is still usable.
+   - On soft-compaction success, `agent.continue()` is scheduled to retry the turn.
 
 - **Threshold maintenance**
-  - Trigger: successful, non-error assistant message whose adjusted context tokens exceed `resolveThresholdTokens(...)`. The measured count comes from `calculateContextTokens(...)`, which subtracts provider-side orchestration tokens (billable, but never replayed into the conversation prefix) so auto-compaction and context-promotion thresholds are not inflated by them.
-  - Mid-turn maintenance also checks safe tool-loop boundaries before the next provider request when `compaction.midTurnEnabled !== false`.
-  - Tool-output pruning can reduce the measured token count before threshold comparison.
-  - Context promotion is tried before post-turn compaction.
-  - If promotion is unavailable, auto maintenance walks `compaction.methodOrder` with `reason: "threshold"` and `willRetry: false`.
-  - When `handoff` is the next runnable method, post-turn threshold maintenance normally schedules a post-prompt task that generates the handoff document and commits it as a compaction entry; pre-prompt and mid-turn checks run all methods inline to avoid racing the next turn.
-  - On success, if `compaction.autoContinue !== false`, post-turn maintenance schedules an agent-authored developer auto-continue prompt from `prompts/system/auto-continue.md`; mid-turn maintenance never schedules a separate continuation because the core loop already owns the next provider request.
+   - Trigger: successful, non-error assistant message whose adjusted context tokens exceed `resolveThresholdTokens(...)`. The measured count comes from `calculateContextTokens(...)`, which subtracts provider-side orchestration tokens (billable, but never replayed into the conversation prefix) so auto-compaction and context-promotion thresholds are not inflated by them.
+   - Mid-turn maintenance also checks safe tool-loop boundaries before the next provider request when `compaction.midTurnEnabled !== false`.
+   - Tool-output pruning can reduce the measured token count before threshold comparison.
+   - Context promotion is tried before post-turn compaction.
+   - If promotion is unavailable, auto maintenance walks `compaction.methodOrder` with `reason: "threshold"` and `willRetry: false`.
+   - Snapcompact sizes its initial frame archive against the recovery band (`0.8 × threshold`), capped by the model window minus reserve, to avoid an immediate smaller-frame rebuild. Manual compaction, overflow/incomplete retries, and idle maintenance retain their window-fit sizing.
+   - When `handoff` is the next runnable method, post-turn threshold maintenance normally schedules a post-prompt task that generates the handoff document and commits it as a compaction entry; pre-prompt and mid-turn checks run all methods inline to avoid racing the next turn.
+   - On success, if `compaction.autoContinue !== false`, post-turn maintenance schedules an agent-authored developer auto-continue prompt from `prompts/system/auto-continue.md`; mid-turn maintenance never schedules a separate continuation because the core loop already owns the next provider request.
 
 - **Idle maintenance**
-  - Trigger: `runIdleCompaction()` when not streaming or already compacting.
-  - Uses `reason: "idle"` and does not auto-continue afterward.
+   - Trigger: `runIdleCompaction()` when not streaming or already compacting.
+   - Uses `reason: "idle"` and does not auto-continue afterward.
 
 ### Shake method
 
@@ -253,8 +254,8 @@ Remote summarization modes, consulted in order (each stage falls back to the nex
 - **V2 streaming Responses compaction** (tried first, on by default via `compaction.remoteStreamingV2Enabled`): for eligible models — `shouldUseCompactionV2Streaming(...)`: `openai-responses`, `azure-openai-responses`, or `openai-codex-responses` APIs with `remoteCompaction.v2StreamingEnabled` and a resolvable Responses endpoint — compaction forwards the full conversation, including provider-native tool-call history replay, to the model's normal Responses streaming endpoint with a trailing `compaction_trigger` input item, and requires exactly one streamed `compaction` output item. The request carries session routing and prompt-cache identifiers (routing/session-id headers plus `prompt_cache_key`) and resolves the model's reasoning effort the same way a normal turn does. Replacement history is Codex-style: retained real user messages within the `compaction.v2RetainedMessageBudget` (default `64000` tokens, clamped to that ceiling) followed by the compaction item, stored in `preserveData.openaiRemoteCompaction` (version `"v2"`). Transient stream errors retry up to `V2_COMPACTION_MAX_RETRIES` (`2`) times with exponential backoff under a 3-minute timeout (`V2_COMPACTION_TIMEOUT_MS`, same as V1); user aborts are never retried.
 - **V1 native `/responses/compact`**: for OpenAI/OpenAI Codex models (`shouldUseOpenAiRemoteCompaction`), when remote compaction is enabled and V2 did not run (ineligible or failed), compaction tries the provider-native `/responses/compact` endpoint. It preserves provider replacement history in `preserveData.openaiRemoteCompaction`. A native failure surfaces its transport error instead of silently switching to generic summarization — unless `compaction.remoteEndpoint` is set, in which case summary generation falls through to that endpoint/local summarization.
 - **Custom remote endpoint**: if `compaction.remoteEndpoint` is set and remote compaction is enabled, local summary generation POSTs one of two wire formats:
-  - custom omp summarizer endpoints receive `{ systemPrompt, prompt }` and must return JSON containing at least `{ summary }`.
-  - OpenAI-compatible endpoints whose path ends in `/chat/completions` receive `{ model, messages, stream: false }`, where `messages` contains one system prompt and one user prompt. The summary is read from `choices[0].message.content`, which lets self-hosted servers such as llama.cpp and vLLM act as remote compactors without a separate summarizer shim.
+   - custom omp summarizer endpoints receive `{ systemPrompt, prompt }` and must return JSON containing at least `{ summary }`.
+   - OpenAI-compatible endpoints whose path ends in `/chat/completions` receive `{ model, messages, stream: false }`, where `messages` contains one system prompt and one user prompt. The summary is read from `choices[0].message.content`, which lets self-hosted servers such as llama.cpp and vLLM act as remote compactors without a separate summarizer shim.
 
 When a native remote compaction (V2 or V1) succeeds, local LLM summarization is skipped entirely — the durable history lives in the provider replay payload and the stored `summary` is a placeholder lead-in plus the file-operation list.
 
@@ -413,9 +414,9 @@ Post-navigation event exposing new/old leaf and optional summary entry.
 - Auto compaction can try multiple model candidates and retry transient failures; long retry delays prefer the next candidate when one is available.
 - Overflow errors are excluded from generic retry path because they are handled by context promotion/compaction.
 - If auto-compaction fails:
-  - overflow path emits `Context overflow recovery failed: ...`
-  - incomplete-output path emits `Incomplete response recovery failed: ...`
-  - threshold/idle paths emit `Auto-compaction failed: ...`
+   - overflow path emits `Context overflow recovery failed: ...`
+   - incomplete-output path emits `Incomplete response recovery failed: ...`
+   - threshold/idle paths emit `Auto-compaction failed: ...`
 - Branch summarization can be cancelled via abort signal (e.g., Escape), returning canceled/aborted navigation result.
 
 ## Settings and defaults

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed threshold-triggered snapcompact sizing to target recovery headroom on the first pass, avoiding an immediate smaller-frame rebuild.
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2404,11 +2404,10 @@ export class SessionMaintenance {
 	}
 
 	/**
-	 * Cap on snapcompact frames the post-compaction context can carry without
-	 * busting the model window. Mirrors the per-frame token charge used by the
-	 * projection ({@link snapcompact.FRAME_TOKEN_ESTIMATE}, the conservative
-	 * high-res Anthropic ceiling), so picking `maxFrames` from this helper makes
-	 * {@link #projectSnapcompactContextTokens} succeed by construction.
+	 * Cap on snapcompact frames the post-compaction context can carry within its
+	 * target budget. Normal/manual maintenance targets the model window; threshold
+	 * maintenance targets the stricter recovery band so the first archive creates
+	 * enough headroom to avoid an immediate local rescue.
 	 *
 	 * Skip vs. cap use different reserves on purpose. The **skip** decision
 	 * (return `0`) trips only when kept-recent plus non-message tokens already
@@ -2435,7 +2434,11 @@ export class SessionMaintenance {
 	 * ~402k frame-token projection always overflows any sub-1M-token window
 	 * (issue #3247).
 	 */
-	#computeSnapcompactMaxFrames(preparation: CompactionPreparation, settings: EngineCompactionSettings): number {
+	#computeSnapcompactMaxFrames(
+		preparation: CompactionPreparation,
+		settings: EngineCompactionSettings,
+		targetRecoveryBand = false,
+	): number {
 		const ctxWindow = this.#model?.contextWindow ?? 0;
 		if (ctxWindow <= 0) {
 			return Math.min(
@@ -2447,11 +2450,19 @@ export class SessionMaintenance {
 		const reserve = effectiveReserveTokens(ctxWindow, settings);
 		let baseTokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
 		baseTokens += this.#tokenizer.countMessages(preparation.recentMessages);
-		const totalBudget = ctxWindow - reserve;
-		// Skip iff there is no headroom whatsoever; a text-only archive costs
-		// far less than the cap reserve below, so any positive residual is
+		const windowBudget = ctxWindow - reserve;
+		// Threshold compaction must leave enough headroom to avoid immediately
+		// re-entering maintenance. Other callers deliberately retain the looser
+		// window-fit target: overflow/incomplete retries only need a request that
+		// fits, idle maintenance has no threshold continuation, and manual
+		// compaction must honor the full user-available window.
+		const totalBudget = targetRecoveryBand
+			? Math.min(windowBudget, Math.floor(resolveThresholdTokens(ctxWindow, settings) * COMPACTION_RECOVERY_BAND))
+			: windowBudget;
+		// Skip iff there is no window headroom whatsoever; a text-only archive
+		// costs far less than the cap reserve below, so any positive residual is
 		// worth attempting and the projection guard catches actual overflow.
-		if (baseTokens >= totalBudget) return 0;
+		if (baseTokens >= windowBudget) return 0;
 		// Cap reserve mirrors what `countMessage(summaryMessage)` will charge
 		// when frames > 0: `countTokens(summaryTemplate ‖ textHead ‖ textTail)`
 		// plus `numFrames × FRAME_TOKEN_ESTIMATE`. Resolve the shape this
@@ -2753,10 +2764,10 @@ export class SessionMaintenance {
 	/**
 	 * Frame budget for {@link #rescueSnapcompactFrameOverflow}: targets
 	 * `COMPACTION_RECOVERY_BAND × threshold` (the same band
-	 * {@link #compactionCreatedHeadroom} re-tests), not the window-fit budget
-	 * {@link #computeSnapcompactMaxFrames} sizes against — a rebuilt archive
-	 * must land back under the maintenance trigger, or the next settle
-	 * re-enters the same dead-end. Cap reserve mirrors
+	 * {@link #compactionCreatedHeadroom} re-tests), matching the threshold target
+	 * in {@link #computeSnapcompactMaxFrames}. A rebuilt archive must land back
+	 * under the maintenance trigger, or the next settle re-enters the same
+	 * dead-end. Cap reserve mirrors
 	 * #computeSnapcompactMaxFrames (text edges + summary template), and
 	 * `keptTailTokens` charges the kept entries AFTER the archive so the
 	 * budget mirrors what #compactionCreatedHeadroom will actually measure.
@@ -3389,9 +3400,9 @@ export class SessionMaintenance {
 
 			// Snapcompact runs locally first. The post-compaction context = kept-recent
 			// + a summary message carrying the imaged archive at FRAME_TOKEN_ESTIMATE
-			// per frame; #computeSnapcompactMaxFrames sizes the frame cap from the
-			// live window so we don't run snapcompact just to overflow every threshold
-			// tick. Any local blocker (unsupported snapcompact glyphs, kept-history too
+			// per frame; threshold passes size their first archive for recovery-band
+			// headroom, while non-threshold passes retain window-fit semantics. Any local
+			// blocker (unsupported snapcompact glyphs, kept-history too
 			// large, post-render overflow) advances automatic maintenance to the next
 			// configured preference instead of wedging the session (#3659). Manual
 			// `/compact snapcompact` remains local-only because its one-method override
@@ -3423,7 +3434,11 @@ export class SessionMaintenance {
 					});
 					snapcompactBlocker = `snapcompact disabled: unsupported characters for selected snapcompact font (${percent}%); trying the next preferred compaction method.`;
 				} else {
-					const maxFrames = this.#computeSnapcompactMaxFrames(preparation, effectiveSettings);
+					const maxFrames = this.#computeSnapcompactMaxFrames(
+						preparation,
+						effectiveSettings,
+						reason === "threshold",
+					);
 					if (maxFrames < 1) {
 						logger.warn("Snapcompact skipped: kept history alone exceeds the context budget", {
 							model: this.#model?.id,

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -20,7 +20,7 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import { effectiveReserveTokens, prepareCompaction } from "@oh-my-pi/pi-agent-core/compaction";
+import { effectiveReserveTokens, prepareCompaction, resolveThresholdTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -43,8 +43,8 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		modelRegistry = new ModelRegistry(authStorage);
 	});
 
-	beforeEach(() => {
-		sessionManager = SessionManager.inMemory();
+	function createHarness(turnPairs = 64): { session: AgentSession; sessionManager: SessionManager } {
+		const sessionManager = SessionManager.inMemory();
 
 		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!bundled) throw new Error("Expected bundled claude-sonnet-4-5 model");
@@ -62,11 +62,11 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		// substantial filler so prepareCompaction() splits the branch into
 		// "discard + summarize" (oldest) vs "kept-recent" (newest).
 		const filler = "the quick brown fox jumps over the lazy dog. ".repeat(64);
-		for (let i = 0; i < 64; i++) {
+		for (let i = 0; i < turnPairs; i++) {
 			sessionManager.appendMessage({
 				role: "user",
 				content: [{ type: "text", text: `turn ${i}: ${filler}` }],
-				timestamp: Date.now() - (64 - i) * 1000,
+				timestamp: Date.now() - (turnPairs - i) * 1000,
 			});
 			sessionManager.appendMessage({
 				role: "assistant",
@@ -83,23 +83,30 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 					totalTokens: 2000,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 				},
-				timestamp: Date.now() - (64 - i) * 1000 + 100,
+				timestamp: Date.now() - (turnPairs - i) * 1000 + 100,
 			});
 		}
 
-		session = new AgentSession({
-			agent,
-			sessionManager,
-			settings: Settings.isolated({
-				"compaction.methodOrder": ["snapcompact", "soft"],
-				"compaction.autoContinue": false,
-				// Force a small kept-recent window so the seeded conversation
-				// definitely splits into discard + kept and prepareCompaction()
-				// returns a non-empty preparation.
-				"compaction.keepRecentTokens": 4000,
+		return {
+			session: new AgentSession({
+				agent,
+				sessionManager,
+				settings: Settings.isolated({
+					"compaction.methodOrder": ["snapcompact", "soft"],
+					"compaction.autoContinue": false,
+					// Force a small kept-recent window so the seeded conversation
+					// definitely splits into discard + kept and prepareCompaction()
+					// returns a non-empty preparation.
+					"compaction.keepRecentTokens": 4000,
+				}),
+				modelRegistry,
 			}),
-			modelRegistry,
-		});
+			sessionManager,
+		};
+	}
+
+	beforeEach(() => {
+		({ session, sessionManager } = createHarness());
 	});
 
 	afterEach(async () => {
@@ -180,6 +187,82 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		const worstCaseEdgeTokens = Math.ceil((2 * edgeCap) / 4) + 2000;
 		const fullProjection = baseTokens + (maxFrames ?? 0) * snapcompact.FRAME_TOKEN_ESTIMATE + worstCaseEdgeTokens;
 		expect(fullProjection).toBeLessThanOrEqual(budget);
+	});
+
+	it("uses the recovery-band boundary for a threshold archive before frame rescue is needed", async () => {
+		// A manual archive preserves the old window-fit contract. Its retained
+		// history is valid for the model request but too large for a threshold
+		// maintenance continuation, which is the legacy first-pass shape that
+		// required a second local frame rescue.
+		await session.dispose();
+		({ session, sessionManager } = createHarness(128));
+		const manualHarness = createHarness(128);
+		try {
+			const model = session.model;
+			if (!model) throw new Error("Expected model");
+			const contextWindow = model.contextWindow ?? 0;
+			const thresholdTokens = 100_000;
+			session.settings.set("compaction.thresholdTokens", thresholdTokens);
+			manualHarness.session.settings.set("compaction.thresholdTokens", thresholdTokens);
+			session.settings.set("compaction.methodOrder", ["snapcompact"]);
+			manualHarness.session.settings.set("compaction.methodOrder", ["snapcompact"]);
+			session.settings.set("contextPromotion.enabled", false);
+
+			const recoveryBand = Math.floor(
+				resolveThresholdTokens(contextWindow, session.settings.getGroup("compaction")) * 0.8,
+			);
+			const windowBudget =
+				contextWindow - effectiveReserveTokens(contextWindow, session.settings.getGroup("compaction"));
+
+			await manualHarness.session.compact(undefined, { mode: "snapcompact" });
+			const manualEntry = manualHarness.sessionManager.getBranch().findLast(entry => entry.type === "compaction");
+			if (manualEntry?.type !== "compaction" || manualEntry.tokensAfter === undefined) {
+				throw new Error("Expected a window-fit manual snapcompact archive");
+			}
+			const manualArchive = snapcompact.getPreservedArchive(manualEntry.preserveData);
+			if (!manualArchive) throw new Error("Expected the manual archive to retain frames");
+			expect(manualEntry.tokensAfter).toBeLessThanOrEqual(windowBudget);
+			expect(manualEntry.tokensAfter).toBeGreaterThan(recoveryBand);
+
+			const { promise: compactionDone, resolve: finishCompaction } = Promise.withResolvers<void>();
+			session.subscribe(event => {
+				if (event.type === "auto_compaction_end") finishCompaction();
+			});
+			const thresholdAssistant = {
+				role: "assistant" as const,
+				content: [{ type: "text" as const, text: "Threshold pass." }],
+				api: "anthropic-messages" as const,
+				provider: "anthropic" as const,
+				model: "claude-sonnet-4-5",
+				stopReason: "stop" as const,
+				usage: {
+					input: 150_000,
+					output: 100,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 150_100,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: thresholdAssistant });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [thresholdAssistant] });
+			await compactionDone;
+			await session.waitForIdle();
+
+			const automaticEntries = sessionManager.getBranch().filter(entry => entry.type === "compaction");
+			expect(automaticEntries).toHaveLength(1);
+			const automaticEntry = automaticEntries[0];
+			if (!automaticEntry || automaticEntry.tokensAfter === undefined) {
+				throw new Error("Expected a persisted threshold snapcompact archive");
+			}
+			const automaticArchive = snapcompact.getPreservedArchive(automaticEntry.preserveData);
+			if (!automaticArchive) throw new Error("Expected the threshold archive to retain frames");
+			expect(automaticEntry.tokensAfter).toBeLessThanOrEqual(recoveryBand);
+			expect(automaticArchive.frames.length).toBeLessThan(manualArchive.frames.length);
+		} finally {
+			await manualHarness.session.dispose();
+		}
 	});
 
 	it("still invokes snapcompact with maxFrames=1 when residual headroom is below the summary-text reserve", async () => {


### PR DESCRIPTION
## What

Size the initial threshold-triggered snapcompact archive against the existing recovery band (`0.8 × threshold`), capped by the model window minus reserve. Manual compaction, overflow/incomplete retries, and idle maintenance keep their existing window-fit sizing.

The no-window-headroom skip decision is unchanged. Existing post-render guards and rescue remain available. Adds a regression covering the threshold boundary and updates the compaction reference and Unreleased changelog.

## Why

The first-pass frame budget previously targeted a valid model request, while the subsequent headroom check required a smaller recovery-band archive. That mismatch could render and persist an archive only to rebuild it immediately.

A metadata-only snapshot of one long-running session contains 20 initial archives plus four immediate smaller-frame rebuilds. Each pair has the same retained-history boundary and no intervening journal record:[^trace]

| Rebuild | Initial → rebuilt frames | Persisted context estimate, initial → rebuilt |
| --- | --- | --- |
| 1 | 17 → 16 | 144,353 → 139,329 |
| 2 | 17 → 14 | 151,664 → 136,592 |
| 3 | 17 → 16 | 144,305 → 139,283 |
| 4 | 17 → 16 | 144,511 → 139,487 |

This fix aligns the two sizing targets on the first pass. It is independent of the experimental notes-backed context proposal in #10893.

## Testing

- `bun test packages/coding-agent/test/agent-session-snapcompact-budget.test.ts`: the added regression fails on baseline `5964a0f764` and passes with this patch.
- Focused frame-dead-end, savings-journal, and automatic-compaction progress-guard checks passed.
- `bun run --cwd packages/coding-agent check:types` passed; changed TypeScript files passed `oxlint` and `oxfmt --check`.
- Source-loaded local maintenance smoke: 128 fixed-timestamp turn pairs, 200,000-token window, 100,000-token threshold, 4,000-token kept-recent budget, and no provider calls. One run per side, with a 60-second command timeout. Baseline `5964a0f764` produced frame counts `[17, 13]`; patch `925d0371e9` produced `[13]`. Final archive text, text edges, truncation, retained messages, and context estimate matched exactly. Both finished at 76,923 estimated context tokens.[^proof]

[^trace]: Observational correctness evidence from the existing snapcompact path. The journal does not record executable/source identity, and `tokensAfter` is a harness estimate. The proposed patch was not run in that session. Private session identifiers, task content, and raw transcripts are withheld. This is not a timing, cost, or model-quality comparison.
[^proof]: Bun loaded each source checkout directly with existing native dependencies. Native binary identity and cold/warm cache state were not recorded; no performance claim is made. Full repository `bun check` and exact-head CI are not established by these focused local checks.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
