### PR TITLE
feat(coding-agent): let task spawns specify a model role or name

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Task spawns can now override their model with the new `model` parameter (role alias like `@smol`/`@slow` or a model pattern, optionally a fallback array). Exposed to callers via the `task.enableModel` setting (off by default); agent overrides, settings overrides, and role identities are respected per the existing model-resolution precedence.
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -991,7 +991,20 @@ function modelRoleAliasPrefixLength(value: string): number | undefined {
 function getModelRoleAlias(value: string, settings?: ModelRoleLookup): string | undefined {
 	const normalized = value.trim();
 	const prefixLength = modelRoleAliasPrefixLength(normalized);
-	if (prefixLength === undefined) return undefined;
+	if (prefixLength === undefined) {
+		// Bare role names (task `model: "smol"`) are valid alongside the
+		// prefixed forms `@smol`, `pi/smol`, and `*`. Keep bare `default`
+		// special: it means "inherit the session's active model", not the
+		// `default` role chain. Explicit `provider/id` selectors are never
+		// roles; they are matched as concrete model patterns.
+		if (
+			normalized !== DEFAULT_MODEL_ROLE &&
+			(isModelRole(normalized) || settings?.getModelRole(normalized) !== undefined)
+		) {
+			return normalized;
+		}
+		return undefined;
+	}
 
 	const candidate = normalized === DEFAULT_MODEL_ROLE_ALIAS ? DEFAULT_MODEL_ROLE : normalized.slice(prefixLength);
 	if (isModelRole(candidate) || settings?.getModelRole(candidate) !== undefined) return candidate;
@@ -1009,9 +1022,10 @@ export function normalizeModelPatternList(value: string | string[] | undefined):
  * Extract the first explicit model-role alias from a raw model selection.
  *
  * This intentionally runs before role expansion so callers can retain the
- * source identity (`@smol`, `pi/slow`, or `*`) even when it resolves to a
- * concrete provider/model or inherited fallback. Bare role names and explicit
- * provider/model selectors are not role aliases.
+ * source identity (`@smol`, `pi/slow`, `*`, or the bare `smol` documented by
+ * the task `model` override) even when it resolves to a concrete
+ * provider/model or inherited fallback. Explicit provider/model selectors
+ * (`provider/id`) are not role aliases.
  */
 export function resolveExplicitModelRole(
 	value: string | string[] | undefined,
@@ -1019,8 +1033,16 @@ export function resolveExplicitModelRole(
 ): string | undefined {
 	for (const pattern of normalizeModelPatternList(value)) {
 		const prefixLength = modelRoleAliasPrefixLength(pattern);
-		if (prefixLength === undefined) continue;
-		const { base } = splitThinkingSuffix(pattern, prefixLength, MAX_THINKING_SUFFIX_OPTIONS);
+		if (prefixLength !== undefined) {
+			const { base } = splitThinkingSuffix(pattern, prefixLength, MAX_THINKING_SUFFIX_OPTIONS);
+			const role = getModelRoleAlias(base, settings);
+			if (role) return role;
+			continue;
+		}
+		// Bare role names carry no alias prefix. getModelRoleAlias recognizes a
+		// bare built-in role or configured custom role (but neither bare
+		// `default` nor an explicit `provider/id` selectors).
+		const { base } = splitThinkingSuffix(pattern, LEGACY_MODEL_ROLE_ALIAS_PREFIX.length, MAX_THINKING_SUFFIX_OPTIONS);
 		const role = getModelRoleAlias(base, settings);
 		if (role) return role;
 	}
@@ -1486,10 +1508,13 @@ export function resolveModelOverride(
  * Resolve a list of override patterns to the first matching model, with an
  * auth-aware fallback to the parent session's active model.
  *
- * If the resolved subagent model has no working credentials (provider has no
- * usable auth), and the parent's active model resolves with working auth,
- * use the parent's model instead. This prevents subagent dispatch from
- * silently routing to a provider the user can't actually call (e.g.
+ * The caller-supplied patterns are exhausted in order against their own
+ * credentials before the parent is considered, so an advertised fallback array
+ * such as `["provider-a/model", "provider-b/model"]` is honored when the first
+ * pattern matches a model whose provider lacks credentials but a later pattern
+ * is authenticated. Only when no caller pattern has working credentials does
+ * this fall back to the parent's active model. This prevents subagent dispatch
+ * from silently routing to a provider the user can't actually call (e.g.
  * `modelRoles.task` pointing at an unqualified id whose only available
  * provider variant has no configured credentials — see #985).
  *
@@ -1521,29 +1546,64 @@ export async function resolveModelOverrideWithAuthFallback(
 	authFallbackUsed: boolean;
 	warning?: string;
 }> {
-	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings);
-	if (!primary.model || !parentActiveModelPattern) {
-		return { ...primary, authFallbackUsed: false };
+	if (modelPatterns.length === 0) {
+		return { explicitThinkingLevel: false, authFallbackUsed: false };
 	}
 
-	const primaryKey = await modelRegistry.getApiKey(primary.model, sessionId);
-	if (primaryKey === kNoAuth || isAuthenticated(primaryKey)) {
-		return { ...primary, authFallbackUsed: false };
+	const availableModels = modelRegistry.getAvailable();
+	const matchPreferences = getModelMatchPreferences(settings);
+
+	// Exhaust the caller-supplied patterns in order before falling back to the
+	// parent session model. A requested fallback array such as
+	// ["provider-a/model", "provider-b/model"] must have each of its patterns
+	// tried against its own credentials, so a later authenticated pattern is
+	// used instead of jumping straight to the parent (see the task `model`
+	// override, whose patterns are ordered by caller preference).
+	let primary: ResolvedModelRoleValue | undefined;
+	let primaryWarning: string | undefined;
+	for (const pattern of modelPatterns) {
+		const result = resolveModelRoleValue(pattern, availableModels, { settings, matchPreferences });
+		if (!result.model) {
+			if (!primaryWarning && result.warning) primaryWarning = result.warning;
+			continue;
+		}
+		if (!primary) {
+			primary = result;
+			primaryWarning = result.warning;
+		}
+		if (!parentActiveModelPattern) {
+			// No parent to fall back to: take the first matching pattern unchanged,
+			// exactly as before.
+			break;
+		}
+		const key = await modelRegistry.getApiKey(result.model, sessionId);
+		if (key === kNoAuth || isAuthenticated(key)) {
+			return { ...result, authFallbackUsed: false };
+		}
 	}
 
+	if (!primary) {
+		return { explicitThinkingLevel: false, warning: primaryWarning, authFallbackUsed: false };
+	}
+	if (!parentActiveModelPattern) {
+		return { ...primary, authFallbackUsed: false, warning: primaryWarning };
+	}
+
+	// No caller pattern had working credentials: fall back to the parent's
+	// active model, which by definition has working auth.
 	const fallback = resolveModelOverride([parentActiveModelPattern], modelRegistry, settings);
 	if (!fallback.model) {
-		return { ...primary, authFallbackUsed: false };
+		return { ...primary, authFallbackUsed: false, warning: primaryWarning ?? fallback.warning };
 	}
 	if (modelsAreEqual(fallback.model, primary.model)) {
-		return { ...primary, authFallbackUsed: false };
+		return { ...primary, authFallbackUsed: false, warning: primaryWarning ?? fallback.warning };
 	}
 	const fallbackKey = await modelRegistry.getApiKey(fallback.model, sessionId);
 	if (!isAuthenticated(fallbackKey)) {
-		return { ...primary, authFallbackUsed: false };
+		return { ...primary, authFallbackUsed: false, warning: primaryWarning ?? fallback.warning };
 	}
 
-	return { ...fallback, authFallbackUsed: true, warning: primary.warning ?? fallback.warning };
+	return { ...fallback, authFallbackUsed: true, warning: primaryWarning ?? fallback.warning };
 }
 
 /**

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4952,6 +4952,17 @@ export const SETTINGS_SCHEMA = {
 				"Expose the optional effort parameter on task spawns, allowing callers to override each subagent's thinking level",
 		},
 	},
+	"task.enableModel": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			group: "Subagents",
+			label: "Per-Task Model",
+			description:
+				"Expose the optional model parameter on task spawns, allowing callers to override each subagent's model with a role alias (@smol, @slow, …) or a model pattern (provider/model-id)",
+		},
+	},
 
 	"task.maxConcurrency": {
 		type: "number",

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -29,6 +29,8 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
+{{#if modelEnabled}}  - `model`: Override the spawn's model with a role alias (`@smol`, `@slow`, …) or a model pattern (`provider/model-id`); string or array of fallback patterns. Omit to keep the agent's model.
+{{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
   - `schemaMode`: `"permissive"` (default) accepts a retry-exhausted invalid result with a warning; `"strict"` fails it.
 {{#if isolationEnabled}}
@@ -45,6 +47,8 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   NEVER pass the spawn-policy default explicitly. Only omit it after checking the available agents below.
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
+{{/if}}
+{{#if modelEnabled}}- `model`: Override the spawn's model with a role alias (`@smol`, `@slow`, …) or a model pattern (`provider/model-id`); string or array of fallback patterns. Omit to keep the agent's model.
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
 - `schemaMode`: `"permissive"` (default) accepts a retry-exhausted invalid result with a warning; `"strict"` fails it.

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -140,6 +140,7 @@ interface TaskDescriptionOptions {
 	disabledAgents: string[];
 	batchEnabled: boolean;
 	effortEnabled: boolean;
+	modelEnabled: boolean;
 	asyncEnabled: boolean;
 	ircEnabled: boolean;
 	parentSpawns: string;
@@ -175,6 +176,7 @@ function renderDescription(options: TaskDescriptionOptions): string {
 		applyIsolatedChanges: options.applyIsolatedChanges,
 		batchEnabled: options.batchEnabled,
 		effortEnabled: options.effortEnabled,
+		modelEnabled: options.modelEnabled,
 		asyncEnabled: options.asyncEnabled,
 		hasBlockingAgents: renderedAgents.some(agent => agent.blocking),
 		ircEnabled: options.ircEnabled,
@@ -279,6 +281,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
 	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
 	if ("effort" in params) item.effort = params.effort;
+	if ("model" in params) item.model = params.model;
 	if ("isolated" in params) item.isolated = params.isolated;
 	return [item];
 }
@@ -300,6 +303,7 @@ function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string
 	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
 	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
 	if ("effort" in item) spawn.effort = item.effort;
+	if ("model" in item) spawn.model = item.model;
 	if (item.isolated !== undefined) {
 		spawn.isolated = item.isolated;
 	} else if ("isolated" in params) {
@@ -594,6 +598,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			isolationEnabled,
 			batchEnabled: this.#isBatchEnabled(),
 			effortEnabled: this.session.settings.get("task.enableEffort"),
+			modelEnabled: this.session.settings.get("task.enableModel"),
 			defaultAgent,
 		});
 	}
@@ -616,6 +621,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			disabledAgents,
 			batchEnabled: this.#isBatchEnabled(),
 			effortEnabled: this.session.settings.get("task.enableEffort"),
+			modelEnabled: this.session.settings.get("task.enableModel"),
 			asyncEnabled: this.session.settings.get("async.enabled"),
 			ircEnabled: isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
 			parentSpawns: this.session.getSessionSpawns() ?? "*",
@@ -663,6 +669,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 			...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 			...(params.effort !== undefined ? { effort: params.effort } : {}),
+			...(Object.hasOwn(params, "model") ? { model: params.model } : {}),
 			...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),
 			blockedAgent: this.#blockedAgent,
 			enableLsp: (this.session.enableLsp ?? true) && this.session.settings.get("task.enableLsp"),
@@ -1432,6 +1439,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 				...(params.effort !== undefined ? { effort: params.effort } : {}),
+				...(Object.hasOwn(params, "model") ? { model: params.model } : {}),
 				// `name` is the spawn handle: keep it for id allocation when this
 				// path did not pre-reserve one. Do not treat it as a HUD description.
 				identity: { id: preAllocatedId, label: params.name },

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -139,6 +139,8 @@ export interface TaskItem {
 	task?: string;
 	/** Per-spawn thinking effort: lowest/middle/highest level the resolved model supports. Overrides the agent's default selector (e.g. `auto`). */
 	effort?: TaskEffort;
+	/** Per-spawn model override: a role alias (`@smol`, `smol`) or model pattern (`provider/model-id`). */
+	model?: string | string[];
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
 	outputSchema?: unknown;
 	/** Validation behavior for a caller-provided or inherited output schema. */
@@ -197,9 +199,11 @@ function createTaskSchema(options: {
 	batchEnabled: boolean;
 	defaultAgent: string;
 	effortEnabled: boolean;
+	modelEnabled: boolean;
 }): BaseType {
 	const agent = taskAgentSchemaRule(options.defaultAgent);
 	const effortField = options.effortEnabled ? { "effort?": effortRule } : {};
+	const modelField = options.modelEnabled ? { "model?": "string | string[]" } : {};
 	if (options.batchEnabled) {
 		if (options.isolationEnabled) {
 			const item = type.raw({
@@ -207,6 +211,7 @@ function createTaskSchema(options: {
 				agent,
 				task: "string",
 				...effortField,
+				...modelField,
 				"outputSchema?": outputSchemaInputSchema,
 				"schemaMode?": '"permissive" | "strict"',
 				"isolated?": "boolean",
@@ -223,6 +228,7 @@ function createTaskSchema(options: {
 			agent,
 			task: "string",
 			...effortField,
+			...modelField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"+": "delete",
@@ -239,6 +245,7 @@ function createTaskSchema(options: {
 			agent,
 			task: "string",
 			...effortField,
+			...modelField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"isolated?": "boolean",
@@ -250,6 +257,7 @@ function createTaskSchema(options: {
 		agent,
 		task: "string",
 		...effortField,
+		...modelField,
 		"outputSchema?": outputSchemaInputSchema,
 		"schemaMode?": '"permissive" | "strict"',
 		"+": "delete",
@@ -261,18 +269,20 @@ export function getTaskSchema(options: {
 	isolationEnabled: boolean;
 	batchEnabled: boolean;
 	effortEnabled?: boolean;
+	modelEnabled?: boolean;
 	defaultAgent?: string;
 }): TaskToolSchemaInstance {
 	const defaultAgent = options.defaultAgent ?? "task";
 	const effortEnabled = options.effortEnabled ?? false;
-	if (defaultAgent === "task" && !effortEnabled) {
+	const modelEnabled = options.modelEnabled ?? false;
+	if (defaultAgent === "task" && !effortEnabled && !modelEnabled) {
 		if (options.batchEnabled) return options.isolationEnabled ? taskSchemaBatch : taskSchemaBatchNoIsolation;
 		return options.isolationEnabled ? taskSchema : taskSchemaNoIsolation;
 	}
-	const key = `${options.isolationEnabled ? "iso" : "flat"}:${options.batchEnabled ? "batch" : "single"}:${effortEnabled ? "effort" : "default"}:${defaultAgent}`;
+	const key = `${options.isolationEnabled ? "iso" : "flat"}:${options.batchEnabled ? "batch" : "single"}:${effortEnabled ? "effort" : "default"}:${modelEnabled ? "model" : "nomodel"}:${defaultAgent}`;
 	const cached = taskSchemaCache.get(key);
 	if (cached) return cached;
-	const schema = createTaskSchema({ ...options, effortEnabled, defaultAgent });
+	const schema = createTaskSchema({ ...options, effortEnabled, modelEnabled, defaultAgent });
 	taskSchemaCache.set(key, schema);
 	return schema;
 }
@@ -294,6 +304,8 @@ export interface TaskParams {
 	effort?: TaskEffort;
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
 	outputSchema?: unknown;
+	/** Per-spawn model override (flat form): a role alias (`@smol`, `smol`) or model pattern (`provider/model-id`). */
+	model?: string | string[];
 	/** Validation behavior for a caller-provided or inherited output schema. */
 	schemaMode?: "permissive" | "strict";
 	/** Batch form (`task.batch`): one subagent per item. */

--- a/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
@@ -151,6 +151,40 @@ describe("issue #985: subagent dispatch auth fallback", () => {
 		expect(result.model?.id).toBe("shared-id");
 	});
 
+	test("uses a later authenticated caller pattern before falling back to the parent", async () => {
+		// A requested fallback array must be exhausted in caller order before the
+		// parent session model is substituted: provider-a has no auth but
+		// provider-b does, so provider-b is selected and no parent fallback
+		// occurs (see feat/task-model-param review comment on honoring an
+		// advertised model fallback array).
+		const authedSecondModel: Model<Api> = buildModel({
+			id: "claude-sonnet-4-5",
+			name: "Claude Sonnet 4.5",
+			api: "openai-completions",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 8192,
+		});
+		const registry = createMockRegistry({
+			models: [parentModel, unauthedTaskModel, authedSecondModel],
+			authedProviders: new Set(["deepseek", "anthropic"]), // opencode-zen unauthed
+		});
+
+		const result = await resolveModelOverrideWithAuthFallback(
+			["qwen3.6-plus-free", "anthropic/claude-sonnet-4-5"],
+			"deepseek/deepseek-v4-pro",
+			registry,
+		);
+
+		expect(result.authFallbackUsed).toBe(false);
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+	});
+
 	test("treats keyless providers (kNoAuth marker) as authenticated", async () => {
 		// Keyless-by-design providers (Ollama, llama.cpp, lm-studio) advertise the
 		// kNoAuth sentinel from getApiKey to signal that they do not require

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1040,6 +1040,24 @@ describe("resolveAgentModelPatterns", () => {
 		).toEqual({ patterns: ["openai/gpt-4o"], role: undefined });
 	});
 
+	test('honors a bare role name as the request model (task `model: "smol"`)', () => {
+		const settings = Settings.isolated({
+			modelRoles: { smol: "openai/gpt-4o-mini" },
+		});
+
+		// The task `model` override documents bare role aliases (`smol`), which
+		// must expand to the configured role's model AND retain the role identity
+		// so the child's inherited retry-fallback chain is keyed off `smol`
+		// rather than `default`. Previously this fell through as a literal/fuzzy
+		// pattern and used the parent session model.
+		expect(
+			resolveAgentModelSelection({
+				requestModel: "smol",
+				settings,
+			}),
+		).toEqual({ patterns: ["openai/gpt-4o-mini"], role: "smol" });
+	});
+
 	test("falls back to the active session model when @task is unset", () => {
 		const settings = Settings.isolated({
 			modelRoles: { default: "anthropic/claude-sonnet-4-5" },
@@ -1937,6 +1955,17 @@ describe("resolveExplicitModelRole", () => {
 		expect(resolveExplicitModelRole("pi/reviewer:high", settings)).toBe("reviewer");
 		expect(resolveExplicitModelRole("@reviewer:xhigh", settings)).toBe("reviewer");
 		expect(resolveExplicitModelRole("*:low", settings)).toBe("default");
+	});
+
+	test('recognizes a bare role name (task `model: "smol"`) beside prefixed aliases', () => {
+		const settings = Settings.isolated({ modelRoles: { smol: "openai/gpt-4o-mini" } });
+
+		expect(resolveExplicitModelRole("smol", settings)).toBe("smol");
+		expect(resolveExplicitModelRole("smol:high", settings)).toBe("smol");
+		// bare `default` stays "inherit the session model", not the default role,
+		// and explicit provider/model selectors are never roles.
+		expect(resolveExplicitModelRole("default", settings)).toBeUndefined();
+		expect(resolveExplicitModelRole("openai/gpt-4o", settings)).toBeUndefined();
 	});
 
 	test("does not infer a role from an explicit model selector", () => {

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -184,6 +184,28 @@ describe("task.batch schema gating", () => {
 		expect(batch.description).toContain("`effort`");
 	});
 
+	it("hides model by default and exposes it when task.enableModel is enabled", async () => {
+		mockDiscovery();
+
+		const flatSession = createSession({ settings: { "task.batch": false } });
+		const flat = await TaskTool.create(flatSession);
+		expect(getSchemaProperties(flat).model).toBeUndefined();
+		expect(flat.description).not.toContain("`model`");
+
+		flatSession.settings.override("task.enableModel", true);
+		expect(getSchemaProperties(flat).model).toBeDefined();
+		expect(flat.description).toContain("`model`");
+
+		const batchSession = createSession({ settings: { "task.batch": true } });
+		const batch = await TaskTool.create(batchSession);
+		expect(getBatchItemProperties(batch).model).toBeUndefined();
+		expect(batch.description).not.toContain("`model`");
+
+		batchSession.settings.override("task.enableModel", true);
+		expect(getBatchItemProperties(batch).model).toBeDefined();
+		expect(batch.description).toContain("`model`");
+	});
+
 	it("keeps isolation boolean-only in the batch item schema", async () => {
 		mockDiscovery();
 

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -148,6 +148,42 @@ describe("task spawn routing", () => {
 		expect(runSpy.mock.calls[0]?.[0].modelOverride).toEqual(["openai/gpt-4.1-mini"]);
 	});
 
+	it("routes a caller-requested model role into the executor's model override", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [taskAgent],
+			projectAgentsDir: null,
+		});
+		const runSpy = vi
+			.spyOn(executorModule, "runSubprocess")
+			.mockImplementation(async options => makeResult(options.id ?? "?"));
+
+		const manager = createManager();
+		// The agent's own model must be strictly lower priority than the
+		// caller's `model` param: the caller-requested role alias wins and is
+		// recorded as the spawn's role identity.
+		const tool = await TaskTool.create(
+			createSession({
+				manager,
+				settings: { modelRoles: { slow: "anthropic/claude-opus-4.7", task: "openai/gpt-4.1-mini" } },
+			}),
+		);
+
+		const result = await tool.execute("tc-model", {
+			agent: "task",
+			name: "Modeled",
+			task: "Do the thing.",
+			model: "@slow",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		expect(jobId).toBeTruthy();
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(runSpy.mock.calls[0]?.[0].modelOverride).toEqual(["anthropic/claude-opus-4.7"]);
+		expect(runSpy.mock.calls[0]?.[0].modelRole).toBe("slow");
+	});
+
 	it("bounds concurrent job bodies with the session spawn semaphore", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
 			agents: [taskAgent],

--- a/packages/coding-agent/test/task/wire-schema.test.ts
+++ b/packages/coding-agent/test/task/wire-schema.test.ts
@@ -97,6 +97,33 @@ describe("task wire schema", () => {
 		expect("role" in item).toBe(false);
 		expect(item.task).toBe("x");
 	});
+
+	it("strips model from items on the fast path (modelEnabled unset)", () => {
+		const batch = getTaskSchema({ isolationEnabled: false, batchEnabled: true });
+		const items = parsedItems(batch({ context: "ctx", tasks: [{ task: "x", model: "@smol" }] }));
+		expect("model" in items[0]!).toBe(false);
+	});
+
+	it("accepts model as string or pattern array when modelEnabled", () => {
+		const batch = getTaskSchema({ isolationEnabled: false, batchEnabled: true, modelEnabled: true });
+		const items = parsedItems(
+			batch({
+				context: "ctx",
+				tasks: [
+					{ task: "x", model: "@smol" },
+					{ task: "y", model: ["openai/gpt-5.6", "anthropic/claude-opus-4.7"] },
+				],
+			}),
+		);
+		expect(items[0]?.model).toBe("@smol");
+		expect(items[1]?.model).toEqual(["openai/gpt-5.6", "anthropic/claude-opus-4.7"]);
+	});
+
+	it("rejects a non-string model value when modelEnabled", () => {
+		const batch = getTaskSchema({ isolationEnabled: false, batchEnabled: true, modelEnabled: true });
+		const parsed = batch({ context: "ctx", tasks: [{ task: "x", model: 42 }] });
+		expect(parsed instanceof type.errors).toBe(true);
+	});
 });
 
 // Contract: `agent` and `name` shape the spawned subagent's identity and the


### PR DESCRIPTION
## Summary

Task tool calls can now override the spawned subagent's model with a `model` parameter:

- **Role alias**: `@smol`, `@slow`, `@task`, … (or bare `smol`) — expands through the configured model-role table, including chained aliases and `:level` thinking suffixes.
- **Model pattern**: `provider/model-id`, optionally as an array of fallback patterns.

The caller-requested selector takes the **highest priority** in `resolveAgentModelSelection` — above `task.agentModelOverrides` and the agent definition's `model` — and when it names a role alias, that alias is recorded as the spawn's `modelRole` so the child's inherited retry-fallback chain stays keyed off the role (the same contract the existing agent-override path follows).

## Design

Mirrors the existing `effort` precedent:

- **Wire exposure gated**: new `task.enableModel` setting (default `off`, Tasks → Subagents). When enabled, the task schema (flat and per-batch-item) gains `model?: string | string[]` and the tool description documents it.
- **Runtime plumbing ungated** (like `effort`): internal callers and stale transcripts can pass `model` regardless of the setting; it flows `resolveSpawnItems` → `spawnParamsFor` → preflight/`#runSpawn` → `StructuredSubagentRequest.model` (a path the eval bridge already uses).

## Test plan

- `test/task/wire-schema.test.ts`: `model` stripped on the fast path when the gate is off; accepted as string and pattern array when enabled; non-string values rejected.
- `test/task/task-batch.test.ts`: gating of the schema field and description for both flat and batch shapes (mirrors the effort test).
- `test/task/task-spawn.test.ts`: a spawn carrying `model: "@slow"` reaches the executor as `modelOverride: ["anthropic/claude-opus-4.7"]` with `modelRole: "slow"`, winning over both the agent's own model and `task.agentModelOverrides`.
- `bun run check` (biome + tsgo) clean; `bun test test/task/` matches the pre-existing baseline (the 45 jj/worktree-environment failures reproduce on the untouched main checkout).