### PR TITLE
fix(coding-agent): guard early toolSession access before session instantiation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
-- Guard early `toolSession` access during worker startup so evaluating tool descriptions and schemas safely defaults before session instantiation completes.
+- Guard early `toolSession` access during worker startup and seed workpool metadata in the initial inline prompt so `yield` tool contracts reflect active workpool items.
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- Guard early `toolSession` access during worker startup so evaluating tool descriptions and schemas safely defaults before session instantiation completes.
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -196,6 +196,7 @@ import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency
 import { sessionDelegationBias } from "./task/prompt-policy";
 import { isScoutSpawnable } from "./task/spawn-policy";
 import type { StructuredSubagentSchemaMode } from "./task/types";
+import type { WorkPoolYieldItem } from "./task/workpool-yield";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -568,6 +569,8 @@ export interface CreateAgentSessionOptions {
 	outputSchemaMode?: StructuredSubagentSchemaMode;
 	/** Whether to include the yield tool by default */
 	requireYieldTool?: boolean;
+	/** Active workpool item labels accepted by this subagent's yield tool. */
+	workPoolYieldItems?: readonly WorkPoolYieldItem[];
 	/** Task recursion depth (for subagent sessions). Default: 0 */
 	taskDepth?: number;
 	/** Parent Hindsight state to alias for subagent memory tools. */
@@ -1784,6 +1787,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				activeToolNames.add(name);
 			}
 		};
+		let workPoolYieldItems = options.workPoolYieldItems ? [...options.workPoolYieldItems] : [];
 		const toolSession: ToolSession = {
 			get cwd() {
 				return sessionManager.getCwd();
@@ -1877,8 +1881,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getFileMutationVersion: path => fileMutationVersions.get(path) ?? 0,
 			getTodoPhases: () => session?.getTodoPhases() ?? [],
 			setTodoPhases: phases => session?.setTodoPhases(phases),
-			getWorkPoolYieldItems: () => session?.getWorkPoolYieldItems() ?? [],
-			setWorkPoolYieldItems: items => session?.setWorkPoolYieldItems(items),
+			getWorkPoolYieldItems: () => session?.getWorkPoolYieldItems() ?? workPoolYieldItems,
+			setWorkPoolYieldItems: items => {
+				workPoolYieldItems = [...items];
+				session?.setWorkPoolYieldItems(items);
+			},
 			getCheckpointState: () => session?.getCheckpointState(),
 			setCheckpointState: state => session?.setCheckpointState(state ?? undefined),
 			getLastCompletedRewind: () => session?.getLastCompletedRewind(),
@@ -3736,6 +3743,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			extensionPaths,
 			disableExtensionDiscovery: options.disableExtensionDiscovery,
 			autoApprove: options.autoApprove,
+			workPoolYieldItems: options.workPoolYieldItems,
 			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),
 			evalKernelOwnerId,
 			// Defined only for top-level sessions (creation is gated above).

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1813,7 +1813,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			get skills() {
 				return session?.skills ?? skills;
 			},
-			refreshSkills: () => session.refreshSkills(),
+			refreshSkills: () => session?.refreshSkills(),
 			rules: allRules,
 			activeRules: [...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()],
 			eventBus,
@@ -1875,20 +1875,20 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				return next;
 			},
 			getFileMutationVersion: path => fileMutationVersions.get(path) ?? 0,
-			getTodoPhases: () => session.getTodoPhases(),
-			setTodoPhases: phases => session.setTodoPhases(phases),
+			getTodoPhases: () => session?.getTodoPhases() ?? [],
+			setTodoPhases: phases => session?.setTodoPhases(phases),
 			getWorkPoolYieldItems: () => session?.getWorkPoolYieldItems() ?? [],
-			setWorkPoolYieldItems: items => session.setWorkPoolYieldItems(items),
-			getCheckpointState: () => session.getCheckpointState(),
-			setCheckpointState: state => session.setCheckpointState(state ?? undefined),
-			getLastCompletedRewind: () => session.getLastCompletedRewind(),
-			getToolChoiceQueue: () => session.toolChoiceQueue,
+			setWorkPoolYieldItems: items => session?.setWorkPoolYieldItems(items),
+			getCheckpointState: () => session?.getCheckpointState(),
+			setCheckpointState: state => session?.setCheckpointState(state ?? undefined),
+			getLastCompletedRewind: () => session?.getLastCompletedRewind(),
+			getToolChoiceQueue: () => session?.toolChoiceQueue,
 			buildToolChoice: name => {
-				const m = session.model;
+				const m = session?.model;
 				return m ? buildNamedToolChoice(name, m) : undefined;
 			},
 			steer: msg =>
-				session.agent.steer({
+				session?.agent.steer({
 					role: "custom",
 					customType: msg.customType,
 					content: msg.content,
@@ -1897,11 +1897,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					attribution: "agent",
 					timestamp: Date.now(),
 				}),
-			peekQueueInvoker: () => session.peekQueueInvoker(),
-			peekPendingInvoker: () => session.peekPendingInvoker(),
-			clearPendingInvokers: () => session.clearPendingInvokers(),
-			peekPlanProposalHandler: () => session.peekPlanProposalHandler(),
-			setPlanProposalHandler: handler => session.setPlanProposalHandler(handler),
+			peekQueueInvoker: () => session?.peekQueueInvoker(),
+			peekPendingInvoker: () => session?.peekPendingInvoker(),
+			clearPendingInvokers: () => session?.clearPendingInvokers(),
+			peekPlanProposalHandler: () => session?.peekPlanProposalHandler(),
+			setPlanProposalHandler: handler => session?.setPlanProposalHandler(handler),
 			allocateOutputArtifact: async toolType => {
 				try {
 					return await sessionManager.allocateArtifactPath(toolType);

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -39,6 +39,7 @@ import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { XdevState } from "../tools/xdev";
 import type { CodexAutoRedeemCoordinator } from "./codex-auto-reset";
+import type { WorkPoolYieldItem } from "../task/workpool-yield";
 import type { SessionManager } from "./session-manager";
 
 /** Maximum time the interactive shutdown path waits for Mnemopi consolidation. */
@@ -323,6 +324,8 @@ export interface AgentSessionConfig {
 	disconnectOwnedMcpManager?: () => Promise<void>;
 	/** System prompt used by automatic session-title generation. */
 	titleSystemPrompt?: string;
+	/** Initial workpool items accepted by the incremental yield tool. */
+	workPoolYieldItems?: readonly WorkPoolYieldItem[];
 }
 
 /** Options for AgentSession.prompt(). */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1164,6 +1164,9 @@ export class AgentSession {
 		this.#preparedExtensions = config.preparedExtensions;
 		this.#extensionPaths = config.extensionPaths;
 		this.#codexResetCoordinator = config.codexResetCoordinator ?? defaultCodexAutoRedeemCoordinator;
+		if (config.workPoolYieldItems) {
+			this.#workPoolYieldItems = config.workPoolYieldItems.map(item => ({ ...item }));
+		}
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
@@ -7297,8 +7300,9 @@ export class AgentSession {
 	}
 
 	/** Replace the item labels before starting a pooled turn. */
-	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): void {
+	async setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
 		this.#workPoolYieldItems = items.map(item => ({ ...item }));
+		await this.refreshBaseSystemPrompt();
 	}
 
 	#buildReplanTitleContext(): string {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2827,7 +2827,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const index = options.index ?? 0;
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
-	session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;
 
@@ -3349,6 +3349,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: options.restrictToolNames,
 				requireYieldTool: true,
+				workPoolYieldItems: options.workPoolYieldItems,
 				contextFiles: options.contextFiles,
 				skills: options.skills,
 				promptTemplates: options.promptTemplates,
@@ -3506,7 +3507,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			if (filteredSubagentTools.length !== subagentToolNames.length) {
 				await awaitAbortable(session.setActiveToolsByName(filteredSubagentTools));
 			}
-			if (options.workPoolYieldItems) session.setWorkPoolYieldItems(options.workPoolYieldItems);
+			if (options.workPoolYieldItems) await session.setWorkPoolYieldItems(options.workPoolYieldItems);
 			const enabledSubagentTools = session.getEnabledToolNames();
 			// The enabled set includes the synthetic write transport injected for
 			// explicit tool lists that omitted write. `session_init.tools` is later

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -381,7 +381,7 @@ export interface ToolSession {
 	/** Active workpool items whose incremental yields complete the current turn. */
 	getWorkPoolYieldItems?: () => readonly WorkPoolYieldItem[];
 	/** Replace the active workpool item contract before a pooled turn starts. */
-	setWorkPoolYieldItems?: (items: readonly WorkPoolYieldItem[]) => void;
+	setWorkPoolYieldItems?: (items: readonly WorkPoolYieldItem[]) => Promise<void> | void;
 	/** The tool-choice queue used to force forthcoming tool invocations and carry invocation handlers. */
 	getToolChoiceQueue?(): ToolChoiceQueue;
 	/** Build a model-provider-specific ToolChoice that targets the named tool, or undefined if unsupported. */

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -67,7 +67,7 @@ describe("SDK workpool yield schema", () => {
 		expect(Reflect.get(tool.parameters, "properties")).toHaveProperty("type");
 		expect(Reflect.get(tool.parameters, "properties")).not.toHaveProperty("key");
 
-		session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+		await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
 		expect(Reflect.get(tool.parameters, "required")).toEqual(["key"]);
 		const properties = Reflect.get(tool.parameters, "properties");
 		expect(properties).toHaveProperty("key");
@@ -75,11 +75,12 @@ describe("SDK workpool yield schema", () => {
 		const activeTool = session.agent.state.tools.find(candidate => candidate.name === "yield");
 		if (!activeTool) throw new Error("Missing active yield tool");
 		expect(Reflect.get(activeTool.parameters, "required")).toEqual(["key"]);
+		expect(session.agent.state.systemPrompt.join("\n\n")).toContain("Submit ONE workpool item at a time");
 		const result = await tool.execute("yield-pool-1", { key: 1, data: { answer: 42 } });
 		expect(result.details).toMatchObject({ type: ["pool#1"], complete: true });
 	});
 
-	it("initializes a subagent session with requireYieldTool when inlineToolDescriptors is enabled", async () => {
+	it("seeds workpool metadata into initial inline prompt when workPoolYieldItems is provided at creation", async () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,
 			agentDir: registryDir,
@@ -97,8 +98,12 @@ describe("SDK workpool yield schema", () => {
 			skipPythonPreflight: true,
 			requireYieldTool: true,
 			toolNames: ["yield"],
+			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
 		});
 		sessions.push(session);
-		expect(session.getToolByName("yield")).toBeDefined();
+		const tool = session.getToolByName("yield");
+		if (!tool) throw new Error("Missing yield tool");
+		expect(Reflect.get(tool.parameters, "required")).toEqual(["key"]);
+		expect(session.agent.state.systemPrompt.join("\n\n")).toContain("Submit ONE workpool item at a time");
 	});
 });

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -78,4 +78,27 @@ describe("SDK workpool yield schema", () => {
 		const result = await tool.execute("yield-pool-1", { key: 1, data: { answer: 42 } });
 		expect(result.details).toMatchObject({ type: ["pool#1"], complete: true });
 	});
+
+	it("initializes a subagent session with requireYieldTool when inlineToolDescriptors is enabled", async () => {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ inlineToolDescriptors: "on" }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			requireYieldTool: true,
+			toolNames: ["yield"],
+		});
+		sessions.push(session);
+		expect(session.getToolByName("yield")).toBeDefined();
+	});
 });


### PR DESCRIPTION
## Summary

When initializing subagents or worker sessions (such as `task` agents or `/vibe` workers) with `requireYieldTool: true` under models that enable `inlineToolDescriptors` (e.g. Gemini), session startup crashed with:

```text
TypeError: undefined is not an object (evaluating 'session.getWorkPoolYieldItems')
    at #workPoolItems (packages/coding-agent/src/tools/yield.ts)
    at description (packages/coding-agent/src/tools/yield.ts)
    at projectSystemPromptToolMetadata (packages/coding-agent/src/system-prompt.ts)
    at rebuildSystemPrompt (packages/coding-agent/src/sdk.ts)
    at createAgentSessionScoped (packages/coding-agent/src/sdk.ts)
```

### Root Cause
1. In `createAgentSessionScoped` (`packages/coding-agent/src/sdk.ts`), `toolSession` is instantiated before `session = new AgentSession(...)`.
2. Several `toolSession` delegates (`getWorkPoolYieldItems`, `getTodoPhases`, etc.) called `session.method()` directly without optional chaining.
3. During initial system prompt assembly in `rebuildSystemPrompt`, when `inlineToolDescriptors` is active (the default for Gemini models), `projectSystemPromptToolMetadata` evaluates `tool.description` in full mode for every active tool.
4. For `YieldTool`, reading `get description()` queries `this.#session.getWorkPoolYieldItems?.()`.
5. Because `session` in the outer closure was still `undefined` while `new AgentSession(...)` was in-flight, invoking `session.getWorkPoolYieldItems()` threw an immediate TypeError within ~120-200 ms of session launch.

### Fix
- Guarded `toolSession` accessors in `packages/coding-agent/src/sdk.ts` with optional chaining (`session?.getWorkPoolYieldItems() ?? []`, `session?.getTodoPhases() ?? []`, etc.), matching sibling delegates.
- Added regression test covering `requireYieldTool: true` with `inlineToolDescriptors: "on"` in `sdk-workpool-yield-schema.test.ts`.
- Added user-facing entry in `packages/coding-agent/CHANGELOG.md` under `## [Unreleased]`.

### Verification
- `bun test packages/coding-agent/test/sdk-workpool-yield-schema.test.ts` passes (reproduced failure before fix, passes post-fix).
- `bun test packages/coding-agent/test/task/workpool.test.ts packages/coding-agent/test/tools/yield.test.ts` passes (59 tests across 3 files).
- `bun x tsc --noEmit -p packages/coding-agent` clean.
- `bun run check:tools` (oxlint + oxfmt) clean.