### PR TITLE
fix(browser): align worker and cmux capability contracts

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -43,6 +43,8 @@ await tab.close();
 
 `open` accepts `name`, `url`, `viewport`, `wait_until`, `dialogs`, `app`, and `timeout`. `timeout` is in seconds, defaults to 30, and is clamped to 1–300.
 
+For worker-backed tabs, an explicit `viewport` is applied during the first attached/spawned/CDP open; omitting it preserves a visible tab's existing layout. CMUX surfaces are terminal panes, not emulated browser viewports: `open({ viewport })` and `page.setViewport(...)` fail with the requested and actual pane dimensions rather than resizing a user pane.
+
 ### Direct tab helpers
 
 Direct helpers cross the host bridge and return real structured values:
@@ -79,6 +81,8 @@ Functions receive `{ tab, page, browser, wait, assert }` as their first argument
 The inner `tab` is the full worker helper API. In addition to the direct surface it includes handle-returning `waitFor`/`waitForSelector` and run-scoped `waitForNavigation`/`waitForResponse`. Start a navigation/response wait before the action that triggers it.
 
 Runs use the shared JavaScript runtime with ordinary Eval helpers and full Bun/Node and tool-bridge access. This is API isolation, not a security sandbox. Request interception is cleaned up at the end of each run.
+
+In worker-backed modes, the raw Puppeteer `page` and `browser` objects are available. Public `page.evaluate` and `page.evaluateHandle` execute in the page's main world, including page-defined globals and handles. Cmux instead exposes a limited compatible facade: it does not provide `evaluateHandle`, and only supports discrete `page.keyboard.press(key)` / `tab.press(key)`. Its `page.keyboard.down(key)` and `.up(key)` methods fail descriptively because CMUX cannot deliver genuine held-key input.
 
 The return value stays structured. Nonempty text emitted by inner `display(...)` calls prints in the outer Eval cell, object/image displays remain Eval output, and a run with no display text emits no placeholder.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed browser runs reading page globals through `page.evaluate` and `page.evaluateHandle`, and honored explicitly requested viewports on attached worker tabs while preserving omitted-viewport behavior.
+- Report unsupported cmux viewport emulation and held-key input with actionable errors instead of silently accepting viewport changes or exposing missing keyboard methods.
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -15,12 +15,15 @@ Drive real Chromium tabs from JavaScript or Python Eval with the global `browser
 - `tab.id(n)` / `tab.ref("e5")` return `BrowserElement` handles supporting `click`, `type`, `fill`, `press`, `hover`, `focus`, `select`, `uploadFile`, `scrollIntoView`, `boundingBox`, `isVisible`, `isHidden`, and `evaluate`. A string passed to `BrowserElement.evaluate` is a function expression invoked with the element as its first argument.
 - JavaScript `await tab.run(fnOrCode, { args?, timeout? })` runs a function or code string. Functions receive `{ tab, page, browser, wait, assert }`; cell closures are not captured. Plain data, functions, and `RegExp` values are supported in `args`.
 - Python `await tab.run(code, timeout=…)` accepts a JavaScript code string only. Direct Python helpers use the same method names; keyword arguments become a trailing JavaScript options object.
-- `tab.run` executes in an isolated JavaScript tab runtime with raw Puppeteer `page`/`browser`, ordinary Eval helpers, and full Bun/Node + tool-bridge access. It is not sandboxed.
+- `tab.run` executes in an isolated JavaScript tab runtime with ordinary Eval helpers and full Bun/Node + tool-bridge access. It is not sandboxed. Raw Puppeteer `page`/`browser` objects are available only in worker-backed modes; cmux supplies a limited compatible facade.
 - Direct helpers and `tab.run` return real structured values. Nonempty inner `display` text prints in the outer Eval cell; screenshots surface as Eval images.
 - Selectors accept CSS plus Puppeteer `aria/…`, `text/…`, `xpath/…`, and `pierce/…` query handlers.
 - Navigation and re-renders invalidate observed ids and refs. Re-observe, then act in the same cell.
 - Use `tab.select` for `<select>` elements; `tab.fill` does not support them.
 - Raw request interception lasts only for the current `tab.run`.
+- In worker-backed modes, public `page.evaluate` and `page.evaluateHandle` run in the page's main world, so they can access page-defined globals. Cmux has no `evaluateHandle`.
+- An explicit `viewport` is applied to worker-backed attached/spawned/CDP tabs; omitting it preserves a visible tab's current layout. CMUX terminal panes cannot be resized or emulated: `open({ viewport })` and `page.setViewport(...)` fail with the requested and actual pane sizes.
+- CMUX supports only discrete `page.keyboard.press(key)` / `tab.press(key)`. `page.keyboard.down(key)` and `.up(key)` fail because CMUX cannot provide genuine held-key input.
 
 Application modes:
 - `app.path`: spawn the specified browser or Electron executable.

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -288,6 +288,11 @@ async function openBrowser(
 			`URL: ${url}`,
 			title ? `Title: ${title}` : null,
 		].filter((line): line is string => typeof line === "string");
+		if (kind.kind === "cmux") {
+			lines.push(
+				`Viewport: ${tab.info.viewport.width}x${tab.info.viewport.height} (current CMUX terminal-pane surface; viewport emulation is unavailable)`,
+			);
+		}
 		return toolResult(details).text(lines.join("\n")).done();
 	} catch (error) {
 		// Caller cancellation stays a ToolAbortError; the requested timeout

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -105,6 +105,12 @@ interface ViewportOptions {
 	deviceScaleFactor?: number;
 }
 
+export function cmuxViewportUnsupportedError(requested: ViewportOptions, actual: ReadyInfo["viewport"]): ToolError {
+	return new ToolError(
+		`CMUX cannot honor requested viewport ${requested.width}x${requested.height}: this terminal-pane surface is ${actual.width}x${actual.height}. CMUX cannot resize panes or emulate a virtual viewport. Omit viewport to use the current surface dimensions.`,
+	);
+}
+
 const PAGE_SELECTOR_HELPERS = `
 const isVisible = element => {
 	const style = getComputedStyle(element);
@@ -359,11 +365,7 @@ export class CmuxTab {
 	}
 
 	async setViewport(viewport: ViewportOptions): Promise<void> {
-		this.#lastViewport = {
-			width: viewport.width,
-			height: viewport.height,
-			deviceScaleFactor: viewport.deviceScaleFactor,
-		};
+		throw cmuxViewportUnsupportedError(viewport, this.#lastViewport);
 	}
 
 	url(): string {
@@ -376,7 +378,7 @@ export class CmuxTab {
 		return this.#lastTitle;
 	}
 
-	async readyInfo(viewport: ReadyInfo["viewport"] = DEFAULT_VIEWPORT): Promise<ReadyInfo> {
+	async readyInfo(): Promise<ReadyInfo> {
 		const urlResult = (await this.#request("browser.url.get", {})) as CmuxUrlGetResult;
 		if (typeof urlResult.url === "string" && urlResult.url.length > 0) {
 			this.#lastUrl = urlResult.url;
@@ -384,7 +386,7 @@ export class CmuxTab {
 		const geometry = await this.#readGeometry().catch(() => undefined);
 		this.#lastViewport = geometry
 			? { width: geometry.innerWidth, height: geometry.innerHeight, deviceScaleFactor: geometry.dpr }
-			: viewport;
+			: DEFAULT_VIEWPORT;
 		await this.title().catch(() => "");
 		return {
 			url: this.#lastUrl,
@@ -1240,7 +1242,11 @@ class CmuxLocator {
 
 class CmuxPageFacade {
 	readonly #tab: CmuxTab;
-	readonly keyboard: { press: (key: string) => Promise<void> };
+	readonly keyboard: {
+		press: (key: string) => Promise<void>;
+		down: (key: string) => Promise<never>;
+		up: (key: string) => Promise<never>;
+	};
 	readonly mouse: {
 		wheel: (delta: { deltaX?: number; deltaY?: number }) => Promise<void>;
 		move: (x: number, y: number) => Promise<void>;
@@ -1250,7 +1256,11 @@ class CmuxPageFacade {
 
 	constructor(tab: CmuxTab) {
 		this.#tab = tab;
-		this.keyboard = { press: key => this.#tab.press(key) };
+		this.keyboard = {
+			press: key => this.#tab.press(key),
+			down: key => Promise.reject(this.#unsupportedHeldKey("down", key)),
+			up: key => Promise.reject(this.#unsupportedHeldKey("up", key)),
+		};
 		let lastPoint = { x: 0, y: 0 };
 		let dragStart: { x: number; y: number } | undefined;
 		this.mouse = {
@@ -1331,6 +1341,12 @@ class CmuxPageFacade {
 
 	async screenshot(opts: ScreenshotOptions = {}): Promise<Buffer | string> {
 		return await this.#tab.pageScreenshot(opts);
+	}
+
+	#unsupportedHeldKey(action: "down" | "up", key: string): ToolError {
+		return new ToolError(
+			`page.keyboard.${action}(${JSON.stringify(key)}) is unsupported on CMUX browser surfaces: CMUX only supports discrete key presses. Use page.keyboard.press(${JSON.stringify(key)}) or tab.press(${JSON.stringify(key)}); held-key input is unavailable.`,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -60,6 +60,7 @@ export type WorkerInitPayload =
 			browserWSEndpoint: string;
 			safeDir: string;
 			targetId: string;
+			viewport?: { width: number; height: number; deviceScaleFactor?: number };
 			dialogs?: "accept" | "dismiss";
 			url?: string;
 			waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -14,9 +14,8 @@ import type { ToolSession } from "../index";
 import { expandPath } from "../path-utils";
 import { ToolAbortError, ToolError } from "../tool-errors";
 import { pickElectronTarget, shouldPreserveConnectedBrowserFocus } from "./attach";
-import { CmuxTab, runCmuxCode } from "./cmux/cmux-tab";
+import { CmuxTab, cmuxViewportUnsupportedError, runCmuxCode } from "./cmux/cmux-tab";
 import { mapWaitUntil } from "./cmux/rpc";
-import { DEFAULT_VIEWPORT } from "./launch";
 import { closeCdpTarget, forgetSharedTarget, recordSharedTarget, type SharedTargetScope } from "./orphan-registry";
 import {
 	type BrowserHandle,
@@ -274,6 +273,9 @@ async function acquireTabImpl(
 				await releaseTab(name, { kill: false });
 			} else {
 				const reuseSteps: string[] = [];
+				if (opts.viewport && existing.backend === "cmux") {
+					throw cmuxViewportUnsupportedError(opts.viewport, existing.cmuxTab.viewport());
+				}
 				if (opts.viewport && browser.kind.kind !== "cmux") {
 					const dsf = opts.viewport.deviceScaleFactor;
 					reuseSteps.push(
@@ -456,10 +458,14 @@ async function acquireCmuxTab(
 		}
 
 		const cmuxTab = new CmuxTab({ client: browser.client, surfaceId, url: initialUrl });
+		if (opts.viewport) {
+			const actual = await cmuxTab.readyInfo();
+			throw cmuxViewportUnsupportedError(opts.viewport, actual.viewport);
+		}
 		if (attachedSurface && opts.url) {
 			await cmuxTab.goto(opts.url, { waitUntil: opts.waitUntil ?? "load", timeoutMs: opts.timeoutMs });
 		}
-		const info = await cmuxTab.readyInfo(opts.viewport ?? DEFAULT_VIEWPORT);
+		const info = await cmuxTab.readyInfo();
 		// If the caller aborted while we were opening the cmux surface, close the
 		// surface (if we own it) instead of taking a browser hold on it.
 		if (opts.signal?.aborted) {
@@ -800,6 +806,7 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 		browserWSEndpoint,
 		safeDir,
 		targetId,
+		viewport: opts.viewport,
 		dialogs: opts.dialogs,
 		url: opts.url,
 		waitUntil: opts.waitUntil,

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -558,73 +558,84 @@ function createRunPageScope(page: Page): RunPageScope {
 	const off = page.off;
 	const once = page.once;
 	const removeAllListeners = page.removeAllListeners;
-	const onDescriptor = Object.getOwnPropertyDescriptor(page, "on");
-	const offDescriptor = Object.getOwnPropertyDescriptor(page, "off");
-	const onceDescriptor = Object.getOwnPropertyDescriptor(page, "once");
-	const removeAllDescriptor = Object.getOwnPropertyDescriptor(page, "removeAllListeners");
 
-	Object.defineProperties(page, {
-		on: {
-			configurable: true,
-			value: (type: unknown, handler: unknown): Page => {
-				Reflect.apply(on, page, [type, handler]);
-				if (type === "request") requestHandlers.push(handler);
-				return page;
-			},
-		},
-		once: {
-			configurable: true,
-			value: (type: unknown, handler: unknown): Page => {
-				if (type !== "request" || typeof handler !== "function") {
-					Reflect.apply(once, page, [type, handler]);
-					return page;
-				}
-				const wrapper = (event: unknown): void => {
-					const index = requestHandlers.lastIndexOf(wrapper);
-					if (index >= 0) requestHandlers.splice(index, 1);
-					Reflect.apply(off, page, ["request", wrapper]);
-					Reflect.apply(handler, page, [event]);
+	// The patched Puppeteer runtime deliberately sends ordinary Page.evaluate()
+	// calls to its isolated realm so its own probes remain unobtrusive. That is
+	// not the public Puppeteer contract: code supplied to tab.run must see the
+	// page's globals and return handles from the page's main realm. Keep this
+	// behavior on the per-run facade rather than changing the actual Page, so
+	// worker internals retain the patched default.
+	const evaluate = (pageFunction: unknown, ...args: unknown[]): Promise<unknown> =>
+		typeof pageFunction === "string"
+			? page.mainFrame().mainRealm().evaluate(pageFunction)
+			: page
+					.mainFrame()
+					.mainRealm()
+					.evaluate(pageFunction as (...a: unknown[]) => unknown, ...args);
+	const evaluateHandle = (pageFunction: unknown, ...args: unknown[]): Promise<unknown> =>
+		typeof pageFunction === "string"
+			? page.mainFrame().mainRealm().evaluateHandle(pageFunction)
+			: page
+					.mainFrame()
+					.mainRealm()
+					.evaluateHandle(pageFunction as (...a: unknown[]) => unknown, ...args);
+
+	const runPage: Page = new Proxy(page, {
+		get(target, property) {
+			if (property === "evaluate") return evaluate as unknown as Page["evaluate"];
+			if (property === "evaluateHandle") return evaluateHandle as unknown as Page["evaluateHandle"];
+			if (property === "on") {
+				return (type: unknown, handler: unknown): Page => {
+					Reflect.apply(on, page, [type, handler]);
+					if (type === "request") requestHandlers.push(handler);
+					return runPage;
 				};
-				requestHandlers.push(wrapper);
-				Reflect.apply(on, page, [type, wrapper]);
-				return page;
-			},
-		},
-		off: {
-			configurable: true,
-			value: (type: unknown, handler?: unknown): Page => {
-				Reflect.apply(off, page, [type, handler]);
-				if (type === "request") {
-					if (handler === undefined) requestHandlers.length = 0;
-					else {
-						const index = requestHandlers.lastIndexOf(handler);
-						if (index >= 0) requestHandlers.splice(index, 1);
+			}
+			if (property === "once") {
+				return (type: unknown, handler: unknown): Page => {
+					if (type !== "request" || typeof handler !== "function") {
+						Reflect.apply(once, page, [type, handler]);
+						return runPage;
 					}
-				}
-				return page;
-			},
+					const wrapper = (event: unknown): void => {
+						const index = requestHandlers.lastIndexOf(wrapper);
+						if (index >= 0) requestHandlers.splice(index, 1);
+						Reflect.apply(off, page, ["request", wrapper]);
+						Reflect.apply(handler, page, [event]);
+					};
+					requestHandlers.push(wrapper);
+					Reflect.apply(on, page, [type, wrapper]);
+					return runPage;
+				};
+			}
+			if (property === "off") {
+				return (type: unknown, handler?: unknown): Page => {
+					Reflect.apply(off, page, [type, handler]);
+					if (type === "request") {
+						if (handler === undefined) requestHandlers.length = 0;
+						else {
+							const index = requestHandlers.lastIndexOf(handler);
+							if (index >= 0) requestHandlers.splice(index, 1);
+						}
+					}
+					return runPage;
+				};
+			}
+			if (property === "removeAllListeners") {
+				return (type?: unknown): Page => {
+					Reflect.apply(removeAllListeners, page, [type]);
+					if (type === undefined || type === "request") requestHandlers.length = 0;
+					return runPage;
+				};
+			}
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
 		},
-		removeAllListeners: {
-			configurable: true,
-			value: (type?: unknown): Page => {
-				Reflect.apply(removeAllListeners, page, [type]);
-				if (type === undefined || type === "request") requestHandlers.length = 0;
-				return page;
-			},
-		},
-	});
+	}) as Page;
 
 	return {
-		page,
+		page: runPage,
 		async cleanup() {
-			if (onDescriptor) Object.defineProperty(page, "on", onDescriptor);
-			else Reflect.deleteProperty(page, "on");
-			if (offDescriptor) Object.defineProperty(page, "off", offDescriptor);
-			else Reflect.deleteProperty(page, "off");
-			if (onceDescriptor) Object.defineProperty(page, "once", onceDescriptor);
-			else Reflect.deleteProperty(page, "once");
-			if (removeAllDescriptor) Object.defineProperty(page, "removeAllListeners", removeAllDescriptor);
-			else Reflect.deleteProperty(page, "removeAllListeners");
 			for (const handler of requestHandlers) Reflect.apply(off, page, ["request", handler]);
 			requestHandlers.length = 0;
 			try {
@@ -1102,6 +1113,7 @@ export class WorkerCore {
 				const page = await target.page();
 				if (!page) throw new ToolError(`Target ${payload.targetId} is no longer available on the attached browser`);
 				this.#page = page;
+				if (payload.viewport) await applyViewport(this.#page, payload.viewport);
 				await this.#claimRelayTarget(page);
 				this.#observeDialogs();
 				if (payload.dialogs) this.#applyDialogPolicy(payload.dialogs);

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -17,7 +17,7 @@ import {
 	normalizeConnectedCdpUrl,
 	releaseBrowser,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
-import { acquireTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { acquireTab, releaseTab, runInTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { Browser, HTTPRequest, Page, Target } from "puppeteer-core";
 import { chromiumAvailable } from "./chromium-probe";
@@ -50,6 +50,27 @@ function fakePage(options: FakePageOptions): Page {
 		title: async () => options.title,
 		evaluate: async () => options.visible === true,
 	} as unknown as Page;
+}
+
+async function readLayoutViewport(page: Page): Promise<{ width: number; height: number }> {
+	const session = await page.target().createCDPSession();
+	try {
+		const response = await session.send("Runtime.evaluate", {
+			expression: "({ width: globalThis.innerWidth, height: globalThis.innerHeight })",
+			returnByValue: true,
+		});
+		const value = response.result.value;
+		if (!value || typeof value !== "object" || !("width" in value) || !("height" in value)) {
+			throw new Error("Expected Runtime.evaluate to return layout viewport dimensions");
+		}
+		const { width, height } = value;
+		if (typeof width !== "number" || typeof height !== "number") {
+			throw new Error("Expected Runtime.evaluate to return numeric layout viewport dimensions");
+		}
+		return { width, height };
+	} finally {
+		await session.detach();
+	}
 }
 
 function fakeTarget(type: string, page: Page | null): Target {
@@ -286,6 +307,96 @@ describe("pickElectronTarget", () => {
 				expect(targetPage.url()).toBe(requested);
 			} finally {
 				if (opened) await invokeBrowser({ action: "close", name: tabName });
+			}
+		},
+		30_000,
+	);
+
+	test.skipIf(!CHROMIUM_AVAILABLE)(
+		"runs public page.evaluate and evaluateHandle in the page main world",
+		async () => {
+			const launched = sharedHeadless;
+			if (!launched || !("browser" in launched)) throw new Error("Expected a shared Puppeteer browser");
+			const endpoint = new URL(launched.browser.wsEndpoint());
+			const tabName = `attach-main-world-${process.pid}-${Math.random().toString(36).slice(2)}`;
+			const attached = await acquireBrowser(
+				{ kind: "connected", cdpUrl: `http://${endpoint.host}` },
+				{ cwd: process.cwd() },
+			);
+			let opened = false;
+			try {
+				await acquireTab(tabName, attached, { timeoutMs: 15_000 });
+				opened = true;
+				const result = await runInTab(tabName, {
+					code: `
+						await tab.evaluate(() => {
+							globalThis.__ompMainWorldProbe = { value: "page-global" };
+						});
+						const fromPage = await page.evaluate(() => globalThis.__ompMainWorldProbe.value);
+						const handle = await page.evaluateHandle(() => globalThis.__ompMainWorldProbe);
+						const fromHandle = await handle.evaluate(probe => probe.value);
+						await handle.dispose();
+						return { fromPage, fromHandle };
+					`,
+					timeoutMs: 15_000,
+					session: makeSession(),
+				});
+				expect(result.returnValue).toEqual({ fromPage: "page-global", fromHandle: "page-global" });
+			} finally {
+				if (opened) await releaseTab(tabName, { kill: false });
+				else await releaseBrowser(attached, { kill: false });
+			}
+		},
+		30_000,
+	);
+
+	test.skipIf(!CHROMIUM_AVAILABLE)(
+		"applies an explicit attached viewport without changing omitted-viewports",
+		async () => {
+			const launched = sharedHeadless;
+			if (!launched || !("browser" in launched)) throw new Error("Expected a shared Puppeteer browser");
+			const endpoint = new URL(launched.browser.wsEndpoint());
+			const targetPage = (await launched.browser.pages())[0];
+			if (!targetPage) throw new Error("Expected the launched browser to expose a page target");
+			const preservedViewport = { width: 701, height: 503, deviceScaleFactor: 1 };
+			const requestedViewport = { width: 777, height: 555, deviceScaleFactor: 1 };
+			const explicitName = `attach-viewport-explicit-${process.pid}-${Math.random().toString(36).slice(2)}`;
+			const omittedName = `attach-viewport-omitted-${process.pid}-${Math.random().toString(36).slice(2)}`;
+
+			await targetPage.setViewport(preservedViewport);
+			const explicitBrowser = await acquireBrowser(
+				{ kind: "connected", cdpUrl: `http://${endpoint.host}` },
+				{ cwd: process.cwd() },
+			);
+			let explicitOpened = false;
+			try {
+				await acquireTab(explicitName, explicitBrowser, { timeoutMs: 15_000, viewport: requestedViewport });
+				explicitOpened = true;
+				expect(await readLayoutViewport(targetPage)).toEqual({
+					width: requestedViewport.width,
+					height: requestedViewport.height,
+				});
+			} finally {
+				if (explicitOpened) await releaseTab(explicitName, { kill: false });
+				else await releaseBrowser(explicitBrowser, { kill: false });
+			}
+
+			await targetPage.setViewport(preservedViewport);
+			const omittedBrowser = await acquireBrowser(
+				{ kind: "connected", cdpUrl: `http://${endpoint.host}` },
+				{ cwd: process.cwd() },
+			);
+			let omittedOpened = false;
+			try {
+				await acquireTab(omittedName, omittedBrowser, { timeoutMs: 15_000 });
+				omittedOpened = true;
+				expect(await readLayoutViewport(targetPage)).toEqual({
+					width: preservedViewport.width,
+					height: preservedViewport.height,
+				});
+			} finally {
+				if (omittedOpened) await releaseTab(omittedName, { kill: false });
+				else await releaseBrowser(omittedBrowser, { kill: false });
 			}
 		},
 		30_000,

--- a/packages/coding-agent/test/tools/browser-cmux-release-mid-run.test.ts
+++ b/packages/coding-agent/test/tools/browser-cmux-release-mid-run.test.ts
@@ -32,7 +32,8 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
+import { GEOMETRY_SCRIPT, type CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
+import { CmuxTab } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/cmux-tab";
 import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
 import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import {
@@ -77,6 +78,72 @@ describe("browser tab-supervisor — cmux tab close mid-run (#4499)", () => {
 		} finally {
 			vi.restoreAllMocks();
 		}
+	});
+
+	it("rejects unsupported cmux viewport and held-key APIs with actionable errors", async () => {
+		const tab = new CmuxTab({
+			client: new CmuxSocketClient({ socketPath: "/tmp/unused-cmux-capability-probe.sock" }),
+			surfaceId: "capability-probe",
+		});
+
+		await expect(tab.setViewport({ width: 1440, height: 900 })).rejects.toThrow(
+			/CMUX cannot honor requested viewport 1440x900.*1365x768/,
+		);
+		await expect(tab.page.setViewport({ width: 1440, height: 900 })).rejects.toThrow(
+			/CMUX cannot honor requested viewport 1440x900/,
+		);
+		await expect(tab.page.keyboard.down("Shift")).rejects.toThrow(
+			/page\.keyboard\.down\("Shift"\) is unsupported.*page\.keyboard\.press\("Shift"\)/,
+		);
+		await expect(tab.page.keyboard.up("Shift")).rejects.toThrow(
+			/page\.keyboard\.up\("Shift"\) is unsupported.*held-key input is unavailable/,
+		);
+	});
+
+	it("closes an owned cmux split when an explicit viewport cannot be honored", async () => {
+		spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+		spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+		const closedSurfaces: string[] = [];
+		spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+			async (method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> => {
+				switch (method) {
+					case "browser.open_split":
+						return { surface_id: "surface-viewport-rejected", url: "about:blank" };
+					case "browser.eval":
+						return {
+							value:
+								params.script === GEOMETRY_SCRIPT
+									? {
+											innerWidth: 635,
+											innerHeight: 859,
+											dpr: 1,
+											scrollX: 0,
+											scrollY: 0,
+											scrollWidth: 635,
+											scrollHeight: 859,
+										}
+									: "",
+						};
+					case "surface.close":
+						closedSurfaces.push(String(params.surface_id));
+						return {};
+					default:
+						return {};
+				}
+			},
+		);
+
+		const browser = await acquireBrowser(
+			{ kind: "cmux", socketPath: "/tmp/omp-test-viewport-rejected.sock" },
+			{ cwd: "/tmp" },
+		);
+		await expect(
+			acquireTab("cmux-viewport-rejected", browser, {
+				timeoutMs: 5_000,
+				viewport: { width: 1440, height: 900 },
+			}),
+		).rejects.toThrow(/requested viewport 1440x900.*surface is 635x859/);
+		expect(closedSurfaces).toEqual(["surface-viewport-rejected"]);
 	});
 
 	it("releaseTab() during an in-flight cmux run rejects the run and never emits unhandledRejection", async () => {


### PR DESCRIPTION
## What

Align the browser tool's public evaluation, viewport, and keyboard contracts across worker and cmux backends.

- Run public `page.evaluate` and `page.evaluateHandle` in the page's main JavaScript world. Keep the underlying Puppeteer Page unchanged so internal operations retain their existing isolated-world behavior.
- Apply an explicitly requested viewport when initializing an attached worker tab. Leave omitted viewports untouched so visible windows retain their existing sizing behavior.
- Reject unsupported cmux viewport emulation and `page.keyboard.down` / `page.keyboard.up` with actionable errors. Explicit cmux open failures report requested versus actual dimensions and close a newly owned split.
- Update the browser prompt, reference documentation, and changelog to describe the backend-specific capabilities.

## Why

Observed browser runs exposed three mismatches between the advertised API and actual behavior: a requested 1440x900 viewport could remain at the cmux pane's 635x859 dimensions, `page.keyboard.down` was missing from the cmux facade, and `page.evaluate` could not read page-defined globals that direct CDP main-world evaluation could access.

These mismatches forced callers to investigate and work around backend behavior. The fix makes worker evaluation and explicit sizing behave as requested, while reporting cmux limitations rather than silently accepting unsupported operations. It does not change relay tab ownership, resize user panes, or synthesize DOM events as a substitute for held-key input.

## Testing

From `packages/coding-agent`:

- `bun run check` passed, including lint, formatting, and TypeScript checking.
- `bun test test/tools/browser-attach.test.ts test/tools/browser-cmux-release-mid-run.test.ts` passed.

A standalone runtime smoke launched isolated headless Chromium and attached through CDP. It verified that both public evaluation APIs could read a page-script-defined global, worker keyboard down/up produced the expected DOM state transitions, and the actual layout viewport was 1440x900. The resulting screenshot was inspected.

Focused regressions also verify omitted-viewport preservation, actionable cmux capability errors, and owned-split cleanup after an unsupported explicit viewport request. The cmux paths were regression-tested with the existing transport fixtures; a live cmux pane session was not exercised. The repository-wide `bun check` was not run.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
