### PR TITLE
Fix extension cache startup contention

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -9,7 +9,6 @@ import * as url from "node:url";
 import type { ParseResult, ParserPlugin } from "@babel/parser";
 import { parse as parseBabel } from "@babel/parser";
 import {
-	getDbBusyTimeoutMs,
 	getLegacyPiExtensionCacheDbPath,
 	isCompiledBinary,
 	logger,
@@ -548,6 +547,7 @@ function collectExtensionSpecifierReferences(
 const EXTENSION_PARSE_CACHE_SCHEMA_VERSION = 1;
 const EXTENSION_PARSE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const EXTENSION_PARSE_CACHE_MAX_ENTRIES = 10_000;
+const EXTENSION_PARSE_CACHE_BUSY_TIMEOUT_MS = 25;
 
 interface ExtensionSourceAnalysis {
 	readonly sourceType: "script" | "module";
@@ -592,13 +592,12 @@ function getExtensionParseCacheDb(): Database | null {
 		}
 		fs.mkdirSync(path.dirname(cachePath), { recursive: true });
 		const db = new Database(cachePath, { create: true });
-		// Install the busy handler BEFORE any lock-taking statement (incl.
-		// `PRAGMA journal_mode=WAL`, which takes an exclusive lock during WAL
-		// recovery). See #2421. WAL + synchronous=NORMAL avoids the per-entry
-		// journal create/delete + fsync churn that serialized this cache behind
-		// concurrent omp startups and blocked the event loop for ~20s (#9549).
-		db.run(`PRAGMA busy_timeout = ${getDbBusyTimeoutMs()}`);
-		db.run("PRAGMA journal_mode=WAL");
+		// This cache is optional. Never inherit session-database lock waits here:
+		// a contended parse cache must fail fast and fall back to parsing instead
+		// of freezing every interactive frame during extension startup.
+		db.run(`PRAGMA busy_timeout = ${EXTENSION_PARSE_CACHE_BUSY_TIMEOUT_MS}`);
+		const journalMode = db.query<{ journal_mode: string }, []>("PRAGMA journal_mode").get()?.journal_mode;
+		if (journalMode?.toLowerCase() !== "wal") db.run("PRAGMA journal_mode=WAL");
 		db.run("PRAGMA synchronous=NORMAL");
 		db.run(
 			"CREATE TABLE IF NOT EXISTS extension_parse_cache (cache_key TEXT PRIMARY KEY, source_type TEXT NOT NULL, [references] TEXT NOT NULL, commonjs_named_exports TEXT NOT NULL, commonjs_reexport_specifiers TEXT NOT NULL)",

--- a/packages/coding-agent/test/legacy-pi-extension-cache.test.ts
+++ b/packages/coding-agent/test/legacy-pi-extension-cache.test.ts
@@ -75,6 +75,28 @@ test("legacy extension parse cache opens in WAL mode (#9549)", async () => {
 	}
 });
 
+test("contended legacy extension parse cache fails fast instead of blocking startup", async () => {
+	const tempDir = TempDir.createSync("@legacy-pi-extension-cache-contended-");
+	tempDirs.push(tempDir);
+	const cacheRoot = tempDir.path();
+	const cachePath = path.join(cacheRoot, "omp", "cache", "legacy-pi-extension-cache.db");
+	await fs.mkdir(path.dirname(cachePath), { recursive: true });
+
+	const lockHolder = new Database(cachePath, { create: true });
+	try {
+		lockHolder.run(
+			"CREATE TABLE extension_parse_cache (cache_key TEXT PRIMARY KEY, source_type TEXT NOT NULL, [references] TEXT NOT NULL, commonjs_named_exports TEXT NOT NULL, commonjs_reexport_specifiers TEXT NOT NULL)",
+		);
+		lockHolder.run("BEGIN EXCLUSIVE");
+		const startedAt = performance.now();
+		expect((await runProbe(cacheRoot, healthProbePath)).trim()).toBe("UNAVAILABLE");
+		expect(performance.now() - startedAt).toBeLessThan(2_000);
+	} finally {
+		lockHolder.run("ROLLBACK");
+		lockHolder.close();
+	}
+});
+
 test("oversized-cache eviction keeps the parse cache usable when a concurrent process holds the WAL (#9549)", async () => {
 	const tempDir = TempDir.createSync("@legacy-pi-extension-cache-evict-");
 	tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- fail fast when optional legacy extension parse cache is locked
- avoid rewriting WAL mode when cache is already configured
- add contention regression proving startup probe returns within 2 seconds

## Root cause
The optional parse cache inherited the interactive 5-second SQLite busy timeout. A contended `PRAGMA journal_mode=WAL` therefore blocked the UI event loop during `loadExtensions`.

## Verification
- `bun test packages/coding-agent/test/legacy-pi-extension-cache.test.ts` (4 pass)
- installed 18.1.10 smoke: `loadExtensions:start` to `loadExtensions:done` without the prior 3.6–4.7 second loop block; interactive input accepted