### PR TITLE
feat(coding-agent): report catalog int/tps in omp models --json

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the `retry.waitForUsageReset` setting: when a provider reports usage-limit exhaustion with a reset time (5-hour or weekly quota windows on any provider), the session sleeps until the reset instead of failing fast past `retry.maxDelayMs`.
+- `omp models --json` now reports each model's catalog intelligence score (`int`) and estimated output speed (`tps`), the same numbers the model browser shows; both are `null` when the catalog has not scored the model.
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -12,6 +12,7 @@
  * forces the network (`online`).
  */
 import type { Api, Effort, Model } from "@oh-my-pi/pi-ai";
+import { catalogMetricsOf } from "@oh-my-pi/pi-catalog/identity/metrics";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -63,7 +64,7 @@ export function resolveModelsArgs(
 	return { action: "ls", pattern: first };
 }
 
-interface ModelJson {
+export interface ModelJson {
 	provider: string;
 	id: string;
 	selector: string;
@@ -75,6 +76,10 @@ interface ModelJson {
 	thinking: readonly Effort[] | null;
 	input: ("text" | "image")[];
 	cost: Model<Api>["cost"];
+	/** Catalog intelligence score, as shown in the model browser; null when the catalog has not scored the model. */
+	int: number | null;
+	/** Catalog-estimated output speed in tokens per second; null when unmeasured (a zero speed is not a score). */
+	tps: number | null;
 }
 
 interface ModelsJson {
@@ -103,7 +108,8 @@ function byProviderThenId(left: Model<Api>, right: Model<Api>): number {
 	return left.id.localeCompare(right.id);
 }
 
-function toModelJson(model: Model<Api>): ModelJson {
+export function toModelJson(model: Model<Api>): ModelJson {
+	const metrics = catalogMetricsOf(model);
 	return {
 		provider: model.provider,
 		id: model.id,
@@ -115,6 +121,8 @@ function toModelJson(model: Model<Api>): ModelJson {
 		thinking: model.thinking ? getSupportedEfforts(model) : null,
 		input: model.input,
 		cost: model.cost,
+		int: metrics?.int ?? null,
+		tps: metrics?.tps ?? null,
 	};
 }
 

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -64,7 +64,7 @@ export function resolveModelsArgs(
 	return { action: "ls", pattern: first };
 }
 
-export interface ModelJson {
+interface ModelJson {
 	provider: string;
 	id: string;
 	selector: string;
@@ -108,7 +108,7 @@ function byProviderThenId(left: Model<Api>, right: Model<Api>): number {
 	return left.id.localeCompare(right.id);
 }
 
-export function toModelJson(model: Model<Api>): ModelJson {
+function toModelJson(model: Model<Api>): ModelJson {
 	const metrics = catalogMetricsOf(model);
 	return {
 		provider: model.provider,

--- a/packages/coding-agent/test/models-cli-json.test.ts
+++ b/packages/coding-agent/test/models-cli-json.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { toModelJson } from "@oh-my-pi/pi-coding-agent/cli/models-cli";
+
+function bundled(provider: "anthropic", id: string): Model<Api> {
+	const model = getBundledModel(provider, id);
+	if (!model) throw new Error(`Expected bundled model ${provider}/${id}`);
+	return model;
+}
+
+describe("omp models --json catalog metrics", () => {
+	it("carries the catalog intelligence score and output speed the model browser shows", () => {
+		const model = bundled("anthropic", "claude-fable-5");
+		// Guard: the fixture must actually be scored, or the assertions below prove nothing.
+		expect(model.int).toBeGreaterThan(0);
+		expect(model.tps).toBeGreaterThan(0);
+
+		const json = toModelJson(model);
+		expect(json.int).toBe(model.int as number);
+		expect(json.tps).toBe(model.tps as number);
+	});
+
+	it("reports null for an unscored model instead of omitting the keys", () => {
+		const model = { ...bundled("anthropic", "claude-fable-5"), int: undefined, tps: undefined } as Model<Api>;
+		const json = toModelJson(model);
+		expect(json).toHaveProperty("int", null);
+		expect(json).toHaveProperty("tps", null);
+	});
+
+	it("treats a zero speed as unmeasured, matching the model browser", () => {
+		const model = { ...bundled("anthropic", "claude-fable-5"), tps: 0 } as Model<Api>;
+		expect(toModelJson(model).tps).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/models-cli-json.test.ts
+++ b/packages/coding-agent/test/models-cli-json.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "bun:test";
-import type { Api, Model } from "@oh-my-pi/pi-ai";
+/**
+ * `omp models --json` is a machine-readable output contract: rumen and other
+ * schedulers rank models by capability from it. These tests drive the listing
+ * command itself and parse the bytes it writes to stdout, so they fail if the
+ * `--json` path stops carrying the catalog metrics — not just if a helper
+ * copies a field.
+ */
+
+import { describe, expect, it, spyOn } from "bun:test";
+import { AuthStorage, type Api, type Model } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { toModelJson } from "@oh-my-pi/pi-coding-agent/cli/models-cli";
+import { runModelsListing } from "@oh-my-pi/pi-coding-agent/cli/models-cli";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+
+interface ListedModel {
+	provider: string;
+	id: string;
+	int: number | null;
+	tps: number | null;
+}
 
 function bundled(provider: "anthropic", id: string): Model<Api> {
 	const model = getBundledModel(provider, id);
@@ -9,27 +25,76 @@ function bundled(provider: "anthropic", id: string): Model<Api> {
 	return model;
 }
 
+/** Run `omp models --json` over an exact model set and parse what it printed. */
+async function listAsJson(models: Model<Api>[]): Promise<ListedModel[]> {
+	const authStorage = await AuthStorage.create(":memory:");
+	try {
+		const modelRegistry = new ModelRegistry(authStorage);
+		// The registry's own discovery is not under test; the listing's JSON
+		// rendering is, so the available set is pinned.
+		spyOn(modelRegistry, "getAvailable").mockReturnValue(models);
+
+		const captured: string[] = [];
+		const originalWrite = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			await runModelsListing({
+				modelRegistry,
+				cwd: process.cwd(),
+				action: "ls",
+				json: true,
+				disableExtensionDiscovery: true,
+			});
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		const payload = JSON.parse(captured.join("")) as { models: ListedModel[] };
+		return payload.models;
+	} finally {
+		authStorage.close();
+	}
+}
+
 describe("omp models --json catalog metrics", () => {
-	it("carries the catalog intelligence score and output speed the model browser shows", () => {
+	it("prints the catalog intelligence score and output speed the model browser shows", async () => {
 		const model = bundled("anthropic", "claude-fable-5");
-		// Guard: the fixture must actually be scored, or the assertions below prove nothing.
+		// Guard: an unscored fixture would let the assertions below pass vacuously.
 		expect(model.int).toBeGreaterThan(0);
 		expect(model.tps).toBeGreaterThan(0);
 
-		const json = toModelJson(model);
-		expect(json.int).toBe(model.int as number);
-		expect(json.tps).toBe(model.tps as number);
+		const [listed] = await listAsJson([model]);
+		expect(listed).toMatchObject({
+			provider: model.provider,
+			id: model.id,
+			int: model.int,
+			tps: model.tps,
+		});
 	});
 
-	it("reports null for an unscored model instead of omitting the keys", () => {
-		const model = { ...bundled("anthropic", "claude-fable-5"), int: undefined, tps: undefined } as Model<Api>;
-		const json = toModelJson(model);
-		expect(json).toHaveProperty("int", null);
-		expect(json).toHaveProperty("tps", null);
+	it("prints null for an unscored model instead of omitting the keys", async () => {
+		const scored = bundled("anthropic", "claude-fable-5");
+		const unscored = { ...scored, id: "unscored-fixture", int: undefined, tps: undefined } as Model<Api>;
+
+		const listed = await listAsJson([scored, unscored]);
+		const row = listed.find(entry => entry.id === "unscored-fixture");
+		// An absent key and a zero score are different facts to a consumer that
+		// reads `int` as a number, so the keys must be present and null.
+		expect(row).toHaveProperty("int", null);
+		expect(row).toHaveProperty("tps", null);
+		// Same listing, other row scored: the null is the model's own fact, not
+		// the whole `--json` path dropping the fields.
+		expect(listed.find(entry => entry.id === scored.id)?.int).toBe(scored.int as number);
 	});
 
-	it("treats a zero speed as unmeasured, matching the model browser", () => {
+	it("prints a zero output speed as unmeasured, matching the model browser", async () => {
 		const model = { ...bundled("anthropic", "claude-fable-5"), tps: 0 } as Model<Api>;
-		expect(toModelJson(model).tps).toBeNull();
+		const [listed] = await listAsJson([model]);
+		expect(listed?.tps).toBeNull();
+		// The score survives: zero speed disqualifies `tps` alone.
+		expect(listed?.int).toBe(model.int as number);
 	});
 });


### PR DESCRIPTION
The catalog scores a model's intelligence (`int`) and estimates its output speed (`tps`), and the model browser renders both. `omp models --json` dropped them, so any caller ranking models by capability has to re-derive the catalog lookup itself — matching ids across vendor dialects, which is exactly what `catalogMetricsOf` already does.

`toModelJson` now carries both through `catalogMetricsOf`, so the JSON listing and the browser read one source:

```
$ omp models --json | jq -c '.models[0] | {provider, id, int, tps}'
{"provider":"cerebras","id":"gemma-4-31b","int":29.7,"tps":35}
```

Two properties are deliberate:

- **`null`, not omitted**, when the catalog has not scored a model. An absent key and a zero score are different facts, and a consumer that reads `int` as a number needs to tell them apart.
- **A zero speed is unmeasured, not a score** — the browser's own rule, applied by `catalogMetricsOf` rather than restated here.

Measured on a real catalog (459 models, one account's providers): 233 report `int`, 208 report `tps`. `int` is fractional (`46.8`, `53`), so consumers should type it as a float.

`ModelJson` and `toModelJson` are exported so the test can assert the shape without going through the registry.

### Test

`packages/coding-agent/test/models-cli-json.test.ts` — a scored model carries both numbers, an unscored one reports `null` for both, and a model with a zero speed reports a score with `tps: null`.
