### PR TITLE
fix(task): preserve isolated worktrees across yields

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- Isolated task worktrees now survive agent yields and retain committed checkpoints until the agent is released ([#10913](https://github.com/can1357/oh-my-pi/issues/10913)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -57,14 +57,17 @@ export type PersistedSubagentReviverFactory = (ref: AgentRef) => Promise<AgentRe
 export interface AdoptOptions {
 	/** TTL before an idle agent is parked. <= 0 disables parking. */
 	idleTtlMs: number;
-	/** Recreates a live AgentSession from the ref's sessionFile. Absent => not resumable after park (e.g. isolated runs). */
+	/** Recreates a live AgentSession from the ref's sessionFile after parking. */
 	revive?: AgentReviver;
+	/** Releases resources that must survive parking but end with the agent lifecycle. */
+	onRelease?: () => Promise<void>;
 }
 
 interface AdoptedAgent {
 	ref: AgentRef;
 	idleTtlMs: number;
 	revive?: AgentReviver;
+	onRelease?: () => Promise<void>;
 	timer?: NodeJS.Timeout;
 }
 
@@ -161,7 +164,12 @@ export class AgentLifecycleManager {
 		}
 		const existing = this.#adopted.get(id);
 		clearTimeout(existing?.timer);
-		const adopted: AdoptedAgent = { ref, idleTtlMs: opts.idleTtlMs, revive: opts.revive };
+		const adopted: AdoptedAgent = {
+			ref,
+			idleTtlMs: opts.idleTtlMs,
+			revive: opts.revive,
+			onRelease: opts.onRelease,
+		};
 		this.#adopted.set(id, adopted);
 		this.#armTimer(id, adopted);
 	}
@@ -422,6 +430,7 @@ export class AgentLifecycleManager {
 		const adoptedMatches =
 			adopted && (expected === undefined || adopted.ref === expected || adopted.ref.session === expected);
 		const ref = currentMatches ? current : adoptedMatches ? adopted.ref : undefined;
+		const onRelease = adopted && adopted.ref === ref ? adopted.onRelease : undefined;
 		if (!ref) return false;
 		if (adopted?.ref === ref) {
 			clearTimeout(adopted.timer);
@@ -464,6 +473,14 @@ export class AgentLifecycleManager {
 				} catch (error) {
 					logger.warn("AgentLifecycleManager.release: session dispose failed", { id, error: String(error) });
 				}
+			}
+			try {
+				await onRelease?.();
+			} catch (error) {
+				logger.warn("AgentLifecycleManager.release: owned resource cleanup failed", {
+					id,
+					error: String(error),
+				});
 			}
 		}
 		if (!options?.tombstone) this.#registry.unregister(id, ref);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -555,6 +555,8 @@ export interface ExecutorOptions {
 	keepAlive?: boolean;
 	/** Internal ownership handoff for cleanup that outlives the visible Task result. */
 	onCleanupDeferred?: (completion: Promise<void>) => void;
+	/** Releases resources retained for a kept-alive agent when its lifecycle ends. */
+	onRelease?: () => Promise<void>;
 	/** Internal cleanup grace override for deterministic lifecycle tests. */
 	cleanupGraceMs?: number;
 }
@@ -2657,10 +2659,10 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 
 /**
  * Settle a subagent's registry lifecycle after a run: terminal teardown for
- * hard aborts, unregister for one-shot helpers, park for isolated runs, and
- * idle + lifecycle adoption for kept-alive agents. A soft-budget abort on a
- * kept-alive, revivable agent is treated as a self-inflicted stop rather than
- * a kill — the agent stays interrogable and resumable (irc wake / revival).
+ * hard aborts, unregister for one-shot helpers, and idle + lifecycle adoption
+ * for kept-alive agents. A soft-budget abort on a kept-alive, revivable agent
+ * is treated as a self-inflicted stop rather than a kill — the agent stays
+ * interrogable and resumable (IRC wake / revival).
  */
 export async function finalizeSubagentLifecycle(args: {
 	id: string;
@@ -2674,6 +2676,7 @@ export async function finalizeSubagentLifecycle(args: {
 	reviveSession: AgentReviver | null;
 	cleanupDeadlineAt?: number;
 	onCleanupDeferred?: (completion: Promise<void>) => void;
+	onRelease?: () => Promise<void>;
 }): Promise<void> {
 	const registry = AgentRegistry.global();
 	const ref = registry.get(args.id);
@@ -2704,13 +2707,19 @@ export async function finalizeSubagentLifecycle(args: {
 			});
 		}
 	};
+	const releaseOwnedResources = async (): Promise<void> => {
+		try {
+			await args.onRelease?.();
+		} catch (error) {
+			logger.warn("Subagent lifecycle resource cleanup failed", { id: args.id, error: String(error) });
+		}
+	};
 
 	// A budget abort leaves a consistent session with its transcript on disk.
 	// Manager shutdown also preserves the transcript, but disposes and unregisters
 	// the process-local session. Caller signals, wall-clock timeouts, and internal
 	// terminations are genuine kills and stay terminal.
-	const resumableAbort =
-		args.abortKind === "budget" && args.keepAlive && !args.isolated && args.reviveSession !== null;
+	const resumableAbort = args.abortKind === "budget" && args.keepAlive && args.reviveSession !== null;
 	if (args.aborted && !resumableAbort) {
 		if (ref && ownsRef) {
 			if (args.abortKind === "shutdown") {
@@ -2740,6 +2749,7 @@ export async function finalizeSubagentLifecycle(args: {
 		} else {
 			await disposeSession();
 		}
+		await releaseOwnedResources();
 		return;
 	}
 
@@ -2747,18 +2757,7 @@ export async function finalizeSubagentLifecycle(args: {
 		// One-shot helper: dispose and unregister. No IRC, no revival.
 		await disposeSession();
 		if (ref && ownsRef) registry.unregister(args.id, ref);
-		return;
-	}
-
-	if (args.isolated) {
-		// Isolated run: the worktree is merged + cleaned after the run, so
-		// the session is not resumable. Park the ref WITHOUT adopting — the
-		// transcript stays reachable (history://), but ensureLive will throw.
-		// Status must flip to "parked" before dispose so the sdk dispose
-		// wrapper skips unregister.
-		if (ref && ownsRef) registry.setStatus(args.id, "parked", ref);
-		await disposeSession();
-		if (ref && ownsRef) registry.detachSession(args.id, ref);
+		await releaseOwnedResources();
 		return;
 	}
 
@@ -2766,6 +2765,7 @@ export async function finalizeSubagentLifecycle(args: {
 	// The lifecycle manager owns idle-TTL parking + revival from here on.
 	if (!ref || !ownsRef || !registry.setStatus(args.id, "idle", ref)) {
 		await disposeSession();
+		await releaseOwnedResources();
 		return;
 	}
 	AgentLifecycleManager.global().adopt(
@@ -2773,6 +2773,7 @@ export async function finalizeSubagentLifecycle(args: {
 		{
 			idleTtlMs: args.agentIdleTtlMs,
 			revive: args.reviveSession ?? undefined,
+			onRelease: args.onRelease,
 		},
 		ref,
 	);
@@ -3443,11 +3444,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Run-state notifications precede deferrable wire-level `agent_end`,
 			// so adopted keep-alive lifecycle cannot get stuck during prompt unwind.
 			AgentRegistry.global().syncSessionStatus(id, session);
-			if (sessionFile !== null && worktree === undefined) {
+			if (sessionFile !== null) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
 				// the single-writer lock cleanly and restores the full message history
-				// (createAgentSession → agent.replaceMessages). Isolated runs are not
-				// resumable (worktree is merged + cleaned) and never get a reviver.
+				// (createAgentSession → agent.replaceMessages). Isolated runs keep their
+				// worktree for the same lifecycle, so they can use this path too.
 				reviveSession = async expectedAgentRef => {
 					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
 						suppressBreadcrumb: true,
@@ -3708,7 +3709,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const session = monitor.takeActiveSession();
 			if (session) {
 				monitor.captureSalvage(session);
-				if (options.keepAlive !== false && worktree === undefined) {
+				if (options.keepAlive !== false) {
 					installIrcWakeTurnMonitor(session);
 				}
 				await finalizeSubagentLifecycle({
@@ -3721,6 +3722,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					agentIdleTtlMs,
 					reviveSession,
 					cleanupDeadlineAt,
+					onRelease: options.onRelease,
 					onCleanupDeferred: completion => {
 						deferredSessionShutdown = completion;
 						deferCleanup(completion);

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -246,6 +246,11 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 				deferredCleanup = completion;
 				opts.baseOptions.onCleanupDeferred?.(completion);
 			},
+			// One-shot runs get `releaseBase` (never touches the worktree): their
+			// `finalizeSubagentLifecycle` calls `onRelease` before this function's
+			// post-run capture, so the handle must survive until the `finally`
+			// below cleans it up. Only kept-alive runs hand full capture+cleanup
+			// (`releaseIsolation`) to the agent lifecycle.
 			onRelease: opts.baseOptions.keepAlive === false ? releaseBase : releaseIsolation,
 		});
 		opts.onSubprocessResult?.(result);

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -10,7 +10,7 @@
  * Shape:
  *   1. {@link prepareIsolationContext} — resolve git root + capture baseline.
  *   2. {@link runIsolatedSubprocess}    — start worktree, run, capture
- *                                        branch/patch, tear worktree down.
+ *                                        changes, and transfer cleanup ownership.
  *   3. {@link mergeIsolatedChanges}     — apply captured changes back to the
  *                                        parent repo (skip when the caller
  *                                        opted out).
@@ -21,6 +21,7 @@
 import * as path from "node:path";
 import type * as natives from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
 import type { ToolSession } from "../tools";
 import { generateCommitMessage } from "../utils/commit-message-generator";
@@ -192,11 +193,22 @@ async function writeIsolationPatch(
  * the caller can still surface the subagent's output; only isolation setup
  * itself routes through {@link IsolatedRunOptions.buildFailureResult}.
  *
- * The isolation handle is always torn down in `finally`.
+ * A kept-alive subagent retains the isolation handle until its agent lifecycle
+ * is released; one-shot and failed startup paths tear it down in `finally`.
  */
 export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<SingleResult> {
 	let handle: IsolationHandle | undefined;
 	let deferredCleanup: Promise<void> | undefined;
+	let released = false;
+	const releaseIsolation = async (): Promise<void> => {
+		if (released || !handle) return;
+		released = true;
+		try {
+			await opts.baseOptions.onRelease?.();
+		} finally {
+			await cleanupIsolation(handle);
+		}
+	};
 	try {
 		const taskBaseline = structuredClone(opts.context.baseline);
 		handle = await ensureIsolation(opts.context.repoRoot, opts.agentId, opts.preferredBackend);
@@ -211,6 +223,7 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 				deferredCleanup = completion;
 				opts.baseOptions.onCleanupDeferred?.(completion);
 			},
+			onRelease: releaseIsolation,
 		});
 		opts.onSubprocessResult?.(result);
 		// A successful result cannot be captured while deferred owner jobs or
@@ -291,18 +304,14 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 	} catch (err) {
 		return rememberAgentArtifacts(opts.buildFailureResult(err));
 	} finally {
-		if (handle) {
-			const isolationHandle = handle;
+		if (handle && !(opts.baseOptions.keepAlive !== false && AgentLifecycleManager.global().has(opts.agentId))) {
 			if (deferredCleanup) {
-				trackLateCleanup(
-					deferredCleanup.then(() => cleanupIsolation(isolationHandle)),
-					{
-						agentId: opts.agentId,
-						resource: "isolation",
-					},
-				);
+				trackLateCleanup(deferredCleanup.then(releaseIsolation), {
+					agentId: opts.agentId,
+					resource: "isolation",
+				});
 			} else {
-				await cleanupIsolation(isolationHandle);
+				await releaseIsolation();
 			}
 		}
 	}

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -193,24 +193,47 @@ async function writeIsolationPatch(
  * the caller can still surface the subagent's output; only isolation setup
  * itself routes through {@link IsolatedRunOptions.buildFailureResult}.
  *
- * A kept-alive subagent retains the isolation handle until its agent lifecycle
- * is released; one-shot and failed startup paths tear it down in `finally`.
+ * On release it captures the final patch and transfers commits to a parent-repo
+ * task branch before cleanup. One-shot and failed startup paths clean up in `finally`.
  */
 export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<SingleResult> {
+	const taskBaseline = structuredClone(opts.context.baseline);
 	let handle: IsolationHandle | undefined;
 	let deferredCleanup: Promise<void> | undefined;
-	let released = false;
-	const releaseIsolation = async (): Promise<void> => {
-		if (released || !handle) return;
-		released = true;
-		try {
-			await opts.baseOptions.onRelease?.();
-		} finally {
-			await cleanupIsolation(handle);
-		}
+	let baseReleasePromise: Promise<void> | undefined;
+	let cleanupPromise: Promise<void> | undefined;
+	let releasePromise: Promise<void> | undefined;
+	const releaseBase = (): Promise<void> => {
+		baseReleasePromise ??= opts.baseOptions.onRelease?.() ?? Promise.resolve();
+		return baseReleasePromise;
+	};
+	const cleanupHandle = (): Promise<void> => {
+		cleanupPromise ??= (async () => {
+			await releaseBase();
+			if (handle) await cleanupIsolation(handle);
+		})();
+		return cleanupPromise;
+	};
+	const releaseIsolation = (): Promise<void> => {
+		releasePromise ??= (async () => {
+			if (!handle) return;
+			const patchResult = await writeIsolationPatch(handle.mergedDir, taskBaseline, opts.artifactsDir, opts.agentId);
+			const commitResult = await commitToBranch(
+				handle.mergedDir,
+				taskBaseline,
+				opts.agentId,
+				opts.description,
+				undefined,
+			);
+			AgentRegistry.global().setHistory(opts.agentId, {
+				patchPath: patchResult.patchPath,
+				branchName: commitResult?.branchName,
+			});
+			await cleanupHandle();
+		})();
+		return releasePromise;
 	};
 	try {
-		const taskBaseline = structuredClone(opts.context.baseline);
 		handle = await ensureIsolation(opts.context.repoRoot, opts.agentId, opts.preferredBackend);
 		const isolationDir = handle.mergedDir;
 		const result = await runSubprocess({
@@ -223,7 +246,7 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 				deferredCleanup = completion;
 				opts.baseOptions.onCleanupDeferred?.(completion);
 			},
-			onRelease: releaseIsolation,
+			onRelease: opts.baseOptions.keepAlive === false ? releaseBase : releaseIsolation,
 		});
 		opts.onSubprocessResult?.(result);
 		// A successful result cannot be captured while deferred owner jobs or
@@ -304,14 +327,18 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 	} catch (err) {
 		return rememberAgentArtifacts(opts.buildFailureResult(err));
 	} finally {
-		if (handle && !(opts.baseOptions.keepAlive !== false && AgentLifecycleManager.global().has(opts.agentId))) {
+		if (
+			handle &&
+			!releasePromise &&
+			!(opts.baseOptions.keepAlive !== false && AgentLifecycleManager.global().has(opts.agentId))
+		) {
 			if (deferredCleanup) {
-				trackLateCleanup(deferredCleanup.then(releaseIsolation), {
+				trackLateCleanup(deferredCleanup.then(cleanupHandle), {
 					agentId: opts.agentId,
 					resource: "isolation",
 				});
 			} else {
-				await releaseIsolation();
+				await cleanupHandle();
 			}
 		}
 	}

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -395,6 +395,25 @@ describe("AgentLifecycleManager", () => {
 		expect(registry.get("6-Sub")).toBeUndefined();
 	});
 
+	it("keeps owned resources through parking and releases them with the agent", async () => {
+		vi.useFakeTimers();
+		const stub = makeSessionStub();
+		const releaseResource = vi.fn(async () => {});
+		registerIdleSub("Owned-Sub", stub.session);
+		lifecycle.adopt("Owned-Sub", { idleTtlMs: TTL, onRelease: releaseResource });
+
+		vi.advanceTimersByTime(TTL);
+		await flushAsync();
+
+		expect(registry.get("Owned-Sub")?.status).toBe("parked");
+		expect(stub.disposeCalls()).toBe(1);
+		expect(releaseResource).not.toHaveBeenCalled();
+
+		await lifecycle.release("Owned-Sub");
+
+		expect(releaseResource).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not let one stuck adopted agent block sibling disposal", async () => {
 		const gate = deferred();
 		const stuck = makeSessionStub(() => gate.promise);

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -461,6 +461,95 @@ describe("runIsolatedSubprocess", () => {
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("captures a one-shot isolated patch before cleanup when its lifecycle releases early", async () => {
+		// One-shot runs (keepAlive === false) invoke onRelease inside
+		// finalizeSubagentLifecycle, before runIsolatedSubprocess performs its
+		// post-run patch capture. The worktree must survive that early release so
+		// capture succeeds; cleanup happens once afterwards in `finally`.
+		const isolationDir = "/repo/isolated";
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolation-oneshot-"));
+		tempRoots.push(artifactsDir);
+		const rootPatch = "diff --git a/task.txt b/task.txt\n+captured\n";
+		const baseline = {
+			root: {
+				repoRoot: "/repo",
+				headCommit: "base",
+				staged: "",
+				unstaged: "",
+				untracked: [],
+				untrackedPatch: "",
+			},
+			nested: [],
+		};
+		const order: string[] = [];
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: isolationDir,
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		const oneShotSession = {
+			prepareForHeadlessAdvisorDrain: () => {},
+			waitForAdvisorCatchup: async () => true,
+			dispose: async () => {},
+		} as unknown as AgentSession;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			AgentRegistry.global().register({
+				id: options.id,
+				displayName: options.id,
+				kind: "sub",
+				session: oneShotSession,
+				sessionFile: "/tmp/OneShotIsolation.jsonl",
+				status: "running",
+			});
+			// Eval-bridge one-shot: keepAlive false drives onRelease immediately.
+			await executorModule.finalizeSubagentLifecycle({
+				id: options.id,
+				session: oneShotSession,
+				aborted: false,
+				keepAlive: false,
+				isolated: true,
+				agentIdleTtlMs: 0,
+				reviveSession: null,
+				onRelease: options.onRelease,
+			});
+			return result({ id: options.id, exitCode: 0 });
+		});
+		const captureSpy = vi.spyOn(worktreeModule, "captureDeltaPatch").mockImplementation(async () => {
+			order.push("capture");
+			return { rootPatch, nestedPatches: [] };
+		});
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockImplementation(async () => {
+			order.push("cleanup");
+		});
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: "/repo",
+				agent: { name: "task", description: "Task agent", systemPrompt: "test", source: "bundled" },
+				task: "Do work",
+				index: 0,
+				id: "OneShotIsolation",
+				keepAlive: false,
+			},
+			context: { repoRoot: "/repo", baseline },
+			preferredBackend: undefined,
+			agentId: "OneShotIsolation",
+			mergeMode: "patch",
+			artifactsDir,
+			buildFailureResult: error => result({ exitCode: 1, error: String(error) }),
+		});
+
+		const patchPath = path.join(artifactsDir, "OneShotIsolation.patch");
+		expect(outcome.exitCode).toBe(0);
+		expect(outcome.error).toBeUndefined();
+		expect(outcome.patchPath).toBe(patchPath);
+		expect(await Bun.file(patchPath).text()).toBe(rootPatch);
+		expect(order).toEqual(["capture", "cleanup"]);
+		expect(captureSpy).toHaveBeenCalledTimes(1);
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("observes real child usage before fallible isolation cleanup", async () => {
 		const childResult = result({
 			exitCode: 1,

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
 import {
 	applyEligibleNestedPatches,
@@ -74,6 +76,7 @@ async function seedFooRepo(finalContent: string): Promise<{ repoRoot: string; pa
 describe("runIsolatedSubprocess", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
 		await Promise.all(tempRoots.splice(0).map(tempRoot => fs.rm(tempRoot, { force: true, recursive: true })));
 	});
@@ -365,6 +368,85 @@ describe("runIsolatedSubprocess", () => {
 		expect(captureSpy).toHaveBeenCalledWith("/repo/isolated", baseline);
 		await Promise.resolve();
 		await Promise.resolve();
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("retains a kept-alive isolated worktree until the agent is released", async () => {
+		const isolationDir = "/repo/isolated";
+		const rootPatch = "diff --git a/task.txt b/task.txt\n";
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: isolationDir,
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		const liveSession = {
+			prepareForHeadlessAdvisorDrain: () => {},
+			waitForAdvisorCatchup: async () => true,
+			dispose: async () => {},
+		} as unknown as AgentSession;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			AgentRegistry.global().register({
+				id: options.id,
+				displayName: options.id,
+				kind: "sub",
+				session: liveSession,
+				sessionFile: "/tmp/RetainedIsolation.jsonl",
+				status: "running",
+			});
+			await executorModule.finalizeSubagentLifecycle({
+				id: options.id,
+				session: liveSession,
+				aborted: false,
+				keepAlive: true,
+				isolated: true,
+				agentIdleTtlMs: 0,
+				reviveSession: async () => liveSession,
+				onRelease: options.onRelease,
+			});
+			return result({ id: options.id, exitCode: 0 });
+		});
+		vi.spyOn(worktreeModule, "captureDeltaPatch").mockResolvedValue({
+			rootPatch,
+			nestedPatches: [],
+		});
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: "/repo",
+				agent: { name: "task", description: "Task agent", systemPrompt: "test", source: "bundled" },
+				task: "Do work",
+				index: 0,
+				id: "RetainedIsolation",
+			},
+			context: {
+				repoRoot: "/repo",
+				baseline: {
+					root: {
+						repoRoot: "/repo",
+						headCommit: "base",
+						staged: "",
+						unstaged: "",
+						untracked: [],
+						untrackedPatch: "",
+					},
+					nested: [],
+				},
+			},
+			preferredBackend: undefined,
+			agentId: "RetainedIsolation",
+			mergeMode: "patch",
+			artifactsDir: "/artifacts",
+			buildFailureResult: error => result({ exitCode: 1, error: String(error) }),
+		});
+
+		expect(outcome.exitCode).toBe(0);
+		expect(AgentRegistry.global().get("RetainedIsolation")?.status).toBe("idle");
+		expect(cleanupSpy).not.toHaveBeenCalled();
+
+		await AgentLifecycleManager.global().release("RetainedIsolation");
+
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -371,9 +371,23 @@ describe("runIsolatedSubprocess", () => {
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("retains a kept-alive isolated worktree until the agent is released", async () => {
+	it("captures follow-up changes before releasing a kept-alive isolated worktree", async () => {
 		const isolationDir = "/repo/isolated";
-		const rootPatch = "diff --git a/task.txt b/task.txt\n";
+		const artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolation-retained-"));
+		tempRoots.push(artifactsDir);
+		const initialPatch = "diff --git a/task.txt b/task.txt\n+initial\n";
+		const finalPatch = "diff --git a/task.txt b/task.txt\n+initial\n+follow-up\n";
+		const baseline = {
+			root: {
+				repoRoot: "/repo",
+				headCommit: "base",
+				staged: "",
+				unstaged: "",
+				untracked: [],
+				untrackedPatch: "",
+			},
+			nested: [],
+		};
 		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
 			mergedDir: isolationDir,
 			backend: natives.IsoBackendKind.Rcopy,
@@ -406,8 +420,13 @@ describe("runIsolatedSubprocess", () => {
 			});
 			return result({ id: options.id, exitCode: 0 });
 		});
-		vi.spyOn(worktreeModule, "captureDeltaPatch").mockResolvedValue({
-			rootPatch,
+		const captureSpy = vi
+			.spyOn(worktreeModule, "captureDeltaPatch")
+			.mockResolvedValueOnce({ rootPatch: initialPatch, nestedPatches: [] })
+			.mockResolvedValueOnce({ rootPatch: finalPatch, nestedPatches: [] });
+		const commitSpy = vi.spyOn(worktreeModule, "commitToBranch").mockResolvedValue({
+			branchName: "omp/task/RetainedIsolation",
+			baseSha: "base",
 			nestedPatches: [],
 		});
 		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
@@ -420,33 +439,25 @@ describe("runIsolatedSubprocess", () => {
 				index: 0,
 				id: "RetainedIsolation",
 			},
-			context: {
-				repoRoot: "/repo",
-				baseline: {
-					root: {
-						repoRoot: "/repo",
-						headCommit: "base",
-						staged: "",
-						unstaged: "",
-						untracked: [],
-						untrackedPatch: "",
-					},
-					nested: [],
-				},
-			},
+			context: { repoRoot: "/repo", baseline },
 			preferredBackend: undefined,
 			agentId: "RetainedIsolation",
 			mergeMode: "patch",
-			artifactsDir: "/artifacts",
+			artifactsDir,
 			buildFailureResult: error => result({ exitCode: 1, error: String(error) }),
 		});
 
+		const patchPath = path.join(artifactsDir, "RetainedIsolation.patch");
 		expect(outcome.exitCode).toBe(0);
+		expect(await Bun.file(patchPath).text()).toBe(initialPatch);
 		expect(AgentRegistry.global().get("RetainedIsolation")?.status).toBe("idle");
 		expect(cleanupSpy).not.toHaveBeenCalled();
 
 		await AgentLifecycleManager.global().release("RetainedIsolation");
 
+		expect(captureSpy).toHaveBeenCalledTimes(2);
+		expect(await Bun.file(patchPath).text()).toBe(finalPatch);
+		expect(commitSpy).toHaveBeenCalledWith(isolationDir, baseline, "RetainedIsolation", undefined, undefined);
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Repro
A successful isolated task yield exercised by `bun test packages/coding-agent/test/task/isolation-runner.test.ts -t "captures a successful yield's patch"` called `cleanupIsolation` immediately, while `finalizeSubagentLifecycle` parked the agent without a reviver; the test passed under the old contract and confirmed the worktree teardown.

## Cause
`runIsolatedSubprocess` in `packages/coding-agent/src/task/isolation-runner.ts` unconditionally cleaned its `IsolationHandle` in `finally`, and `finalizeSubagentLifecycle` in `packages/coding-agent/src/task/executor.ts` deliberately excluded isolated sessions from keep-alive adoption and revival. A yield therefore preserved only transcript metadata, not the workspace required to continue the agent or reach its local commits.

## Fix
- Transfer each kept-alive isolation handle to `AgentLifecycleManager` after the first yield.
- Keep isolated sessions idle/parkable/revivable like other kept-alive agents.
- Release the worktree exactly once when the agent is explicitly released or the lifecycle manager shuts down.
- Cover both the isolation handoff and resource retention across idle parking.

## Verification
`bun test packages/coding-agent/test/task/isolation-runner.test.ts -t "runIsolatedSubprocess"` — 6 passed; `bun test packages/coding-agent/test/registry/agent-lifecycle.test.ts` — 33 passed; `bun check` — passed.

Fixes #10913