### PR TITLE
fix(plan-mode): inline approved plan content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
+- Approved plan content is now inlined into approve-and-execute prompts instead of forcing the executor to re-read the durable plan file ([#10923](https://github.com/can1357/oh-my-pi/issues/10923)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3869,8 +3869,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.session.clearPlanInternalAbortPending();
 		}
 
-		// Restore the execution tool set, but force-enable `read`: approved-plan
-		// prompts now require loading the durable local:// plan file before work.
+		// Restore the execution tool set, but force-enable `read` so the durable
+		// local:// plan remains available if the inline copy becomes unrecoverable.
 		const executionTools = previousPresentation.enabled.includes("read")
 			? previousPresentation.enabled
 			: [...previousPresentation.enabled, "read"];
@@ -3919,6 +3919,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.session.markPlanReferenceSent();
 		const planModePrompt = prompt.render(planModeApprovedPrompt, {
 			planFilePath: options.planFilePath,
+			planContent,
 			contextPreserved: options.preserveContext === true,
 		});
 		// Close the review overlay only now — after the async title write and plan

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -594,11 +594,10 @@ describe("InteractiveMode plan review rendering", () => {
 			title: "PLAN",
 		});
 
-		// The plan-approved prompt stays reference-only; approval must instead
-		// await the durable file mirror before dispatch so read sees the edit.
+		// The executor must receive the final approved text, including in-overlay edits.
 		const call = promptSpy.mock.calls.find(isPlanApprovedCall);
 		expect(call).toBeDefined();
-		expect(call?.[0] as string).not.toContain("edited body");
+		expect(call?.[0] as string).toContain("edited body");
 		expect(call?.[0] as string).not.toContain("original body");
 		// onPlanEdited mirrored the edit to the plan file.
 		expect(await Bun.file(resolvedPlanPath).text()).toContain("edited body");


### PR DESCRIPTION
## Repro
Approve a plan after editing it in the Plan Review overlay, then inspect the synthetic execution prompt. Before the fix, `bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts -t "approves with in-overlay edits"` failed because `<plan path="local://PLAN.md">` had an empty body instead of the edited-plan sentinel.

## Cause
`InteractiveMode.#approvePlan` in `packages/coding-agent/src/modes/interactive-mode.ts` received the final approved `planContent` but rendered `planModeApprovedPrompt` with only `planFilePath` and `contextPreserved`; Handlebars therefore replaced `{{planContent}}` with an empty string.

## Fix
- Pass the final reviewed plan content into the approval prompt render context.
- Assert that the synthetic execution message contains in-overlay edits and excludes the obsolete draft.
- Clarify that the enabled `read` tool is the recovery path and record the fix in the coding-agent changelog.

## Verification
`PI_CONFIG_FILES=/tmp/omp-10923-test-config.yml bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts` passed all 60 tests; the config only disabled Git-backed status segments because the worktree's prebuilt native addon predates `vcsDiscover`. The pre-publish `bun check` gate also passed.

Fixes #10923