### PR TITLE
fix(coding-agent): classify Codex reset windows by duration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Codex saved resets now auto-redeem when the exhausted weekly chat window is reported in the primary limit slot ([#10929](https://github.com/can1357/oh-my-pi/issues/10929)).
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/session/codex-auto-reset.ts
+++ b/packages/coding-agent/src/session/codex-auto-reset.ts
@@ -21,8 +21,8 @@
  *   retried as usage grows or a window exhausts before expiry.
  * - `blocked-account` (restore; `blocked` trigger only): a live 429 blocked
  *   the turn and no sibling credential could take over, so the pool is dry.
- *   Candidates are accounts with at least one genuinely exhausted chat window
- *   — 5h primary or weekly secondary. A banked reset clears the account's
+ *   Candidates are accounts with at least one genuinely exhausted normalized
+ *   chat window — 5h or weekly. A banked reset clears the account's
  *   chat rate limits generally, not just the weekly window: OpenAI's own
  *   client consumes one for a 5h-only block while the weekly window still has
  *   ~80% headroom (openai/codex#28525). The natural unblock is the LATEST
@@ -43,11 +43,11 @@
  * BOTH the primary (5h) and secondary (weekly) `buildUsageLimit` calls, so when
  * an account is blocked, *both* limit entries carry `status: "exhausted"`
  * regardless of which window is actually at 100%. Only `amount.usedFraction`
- * disambiguates. This module keys eligibility off exact limit ids
- * (`openai-codex:primary` / `openai-codex:secondary`) and `usedFraction`,
- * never off `status`, so the plan names the true blocking window(s) and their
- * real unblock time. Whether a short wait (e.g. a 5h-only block) is worth a
- * credit is the `minBlockedMinutes` knob's call, not hardcoded fiat.
+ * disambiguates. This module selects the base chat entries by their stable
+ * limit ids, then classifies the actual window from normalized window metadata
+ * before applying duration-specific policy. Whether a short wait (e.g. a
+ * 5h-only block) is worth a credit is the `minBlockedMinutes` knob's call,
+ * not hardcoded fiat.
  *
  * All of this is pure — no fetches, no IO. The only stateful piece is the
  * {@link CodexAutoRedeemCoordinator} container, whose read-only views are
@@ -57,6 +57,7 @@ import type {
 	OAuthAccountIdentity,
 	ResetCreditAccountStatus,
 	ResetCreditTarget,
+	UsageLimit,
 	UsageReport,
 	UsageResetCreditDetail,
 } from "@oh-my-pi/pi-ai";
@@ -210,6 +211,15 @@ function soonestCreditExpiryMs(
 	return soonest;
 }
 
+type CodexChatWindow = "5h" | "weekly";
+
+interface CodexChatWindowSnapshot {
+	window: CodexChatWindow;
+	usedFraction: number | undefined;
+	resetsAt: number | undefined;
+	plausibleMs: number;
+}
+
 interface AccountSnapshot {
 	accountKey: string;
 	target: ResetCreditTarget;
@@ -217,12 +227,41 @@ interface AccountSnapshot {
 	active: boolean;
 	/** Undefined when synthesized from live 429 evidence without a report. */
 	availableCount: number | undefined;
-	primaryUsed: number | undefined;
-	primaryResetsAt: number | undefined;
-	weeklyUsed: number | undefined;
-	weeklyResetsAt: number | undefined;
+	windows: CodexChatWindowSnapshot[];
 	limitReached: boolean;
 	creditExpiresAtMs: number | undefined;
+}
+
+function classifyChatWindow(limit: UsageLimit, fallback: CodexChatWindow): CodexChatWindow {
+	const durationMs = limit.window?.durationMs;
+	if (durationMs !== undefined && Number.isFinite(durationMs)) {
+		if (Math.abs(durationMs - 7 * 24 * 3_600_000) <= 60_000) return "weekly";
+		if (Math.abs(durationMs - 5 * 3_600_000) <= 60_000) return "5h";
+	}
+	const windowId = limit.window?.id.toLowerCase();
+	const scopeWindowId = limit.scope.windowId?.toLowerCase();
+	if (windowId === "7d" || scopeWindowId === "7d") return "weekly";
+	if (windowId === "5h" || scopeWindowId === "5h") return "5h";
+	return fallback;
+}
+
+function snapshotChatWindow(limit: UsageLimit, fallback: CodexChatWindow): CodexChatWindowSnapshot {
+	const window = classifyChatWindow(limit, fallback);
+	return {
+		window,
+		usedFraction: limit.amount.usedFraction,
+		resetsAt: limit.window?.resetsAt,
+		plausibleMs: window === "weekly" ? MAX_PLAUSIBLE_WEEKLY_REMAINING_MS : MAX_PLAUSIBLE_PRIMARY_REMAINING_MS,
+	};
+}
+
+function usedFractionForWindow(snapshot: AccountSnapshot, window: CodexChatWindow): number | undefined {
+	let fullest: number | undefined;
+	for (const entry of snapshot.windows) {
+		if (entry.window !== window || entry.usedFraction === undefined) continue;
+		if (fullest === undefined || entry.usedFraction > fullest) fullest = entry.usedFraction;
+	}
+	return fullest;
 }
 
 /**
@@ -285,6 +324,9 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 		}
 		const primary = report.limits.find(l => l.id === "openai-codex:primary");
 		const weekly = report.limits.find(l => l.id === "openai-codex:secondary");
+		const windows: CodexChatWindowSnapshot[] = [];
+		if (primary) windows.push(snapshotChatWindow(primary, "5h"));
+		if (weekly) windows.push(snapshotChatWindow(weekly, "weekly"));
 		if (isActive) activeHasSnapshot = true;
 		snapshots.push({
 			accountKey,
@@ -292,10 +334,7 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 			label: email ?? accountId ?? accountKey,
 			active: isActive,
 			availableCount: available,
-			primaryUsed: primary?.amount.usedFraction,
-			primaryResetsAt: primary?.window?.resetsAt,
-			weeklyUsed: weekly?.amount.usedFraction,
-			weeklyResetsAt: weekly?.window?.resetsAt,
+			windows,
 			limitReached: report.metadata?.limitReached === true,
 			creditExpiresAtMs: soonestCreditExpiryMs(report.resetCredits?.credits, nowMs),
 		});
@@ -333,20 +372,11 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 			// `status` (see the Decision-2 trap in the module docs). Either
 			// window qualifies: a banked reset also clears a 5h-only block
 			// (openai/codex#28525).
-			const exhausted: { window: "5h" | "weekly"; resetsAt: number | undefined; plausibleMs: number }[] = [];
-			if (snapshot.primaryUsed !== undefined && snapshot.primaryUsed >= WINDOW_EXHAUSTED_MIN_FRACTION) {
-				exhausted.push({
-					window: "5h",
-					resetsAt: snapshot.primaryResetsAt,
-					plausibleMs: MAX_PLAUSIBLE_PRIMARY_REMAINING_MS,
-				});
-			}
-			if (snapshot.weeklyUsed !== undefined && snapshot.weeklyUsed >= WINDOW_EXHAUSTED_MIN_FRACTION) {
-				exhausted.push({
-					window: "weekly",
-					resetsAt: snapshot.weeklyResetsAt,
-					plausibleMs: MAX_PLAUSIBLE_WEEKLY_REMAINING_MS,
-				});
+			const exhausted: CodexChatWindowSnapshot[] = [];
+			for (const window of snapshot.windows) {
+				if (window.usedFraction !== undefined && window.usedFraction >= WINDOW_EXHAUSTED_MIN_FRACTION) {
+					exhausted.push(window);
+				}
 			}
 			let unblockAtMs: number;
 			let blockedWindows: ("5h" | "weekly")[];
@@ -467,10 +497,7 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 						label: email ?? accountId ?? accountKey,
 						active: true,
 						availableCount: undefined,
-						primaryUsed: undefined,
-						primaryResetsAt: undefined,
-						weeklyUsed: undefined,
-						weeklyResetsAt: undefined,
+						windows: [],
 						limitReached: true,
 						creditExpiresAtMs: undefined,
 					},
@@ -488,7 +515,7 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 				attemptKey: blockedAttemptKey(best.snapshot.accountKey, best.unblockAtMs),
 				label: best.snapshot.label,
 				availableCount: best.snapshot.availableCount,
-				weeklyUsedFraction: best.snapshot.weeklyUsed,
+				weeklyUsedFraction: usedFractionForWindow(best.snapshot, "weekly"),
 				remainingMs: best.remainingMs,
 				expiresInMs:
 					best.snapshot.creditExpiresAtMs === undefined ? undefined : best.snapshot.creditExpiresAtMs - nowMs,
@@ -510,19 +537,21 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 				skip("no-expiring-credit");
 				continue;
 			}
-			// Value = the fuller of the two chat windows a redeem restores. A
-			// 5h-only exhausted account with a light week still gains real quota
-			// (openai/codex#28525); a reset on two mostly-free windows restores
+			// Value = the fullest chat window a redeem restores. A 5h-only
+			// exhausted account with a light week still gains real quota
+			// (openai/codex#28525); a reset on mostly-free windows restores
 			// ~nothing. If usage grows before the credit expires, a later sweep
 			// reconsiders.
-			const primaryUsed = snapshot.primaryUsed ?? 0;
-			const weeklyUsed = snapshot.weeklyUsed ?? 0;
-			const salvageUsedFraction = Math.max(primaryUsed, weeklyUsed);
-			if (salvageUsedFraction < SALVAGE_MIN_USED_FRACTION) {
+			let fullestWindow: CodexChatWindowSnapshot | undefined;
+			for (const window of snapshot.windows) {
+				if ((window.usedFraction ?? 0) > (fullestWindow?.usedFraction ?? 0)) fullestWindow = window;
+			}
+			const salvageUsedFraction = fullestWindow?.usedFraction ?? 0;
+			if (!fullestWindow || salvageUsedFraction < SALVAGE_MIN_USED_FRACTION) {
 				skip("window-mostly-free");
 				continue;
 			}
-			const salvageWindow: "5h" | "weekly" = primaryUsed >= weeklyUsed ? "5h" : "weekly";
+			const salvageWindow = fullestWindow.window;
 			const attemptKey = salvageAttemptKey(snapshot.accountKey, expiresAtMs);
 			if (input.attemptedKeys.has(attemptKey)) {
 				skip("already-attempted");
@@ -544,7 +573,7 @@ export function planCodexResetRedemptions(input: CodexResetPlanInput): CodexRese
 				attemptKey,
 				label: snapshot.label,
 				availableCount: snapshot.availableCount,
-				weeklyUsedFraction: snapshot.weeklyUsed,
+				weeklyUsedFraction: usedFractionForWindow(snapshot, "weekly"),
 				salvageWindow,
 				salvageUsedFraction,
 				expiresInMs: expiresAtMs - nowMs,

--- a/packages/coding-agent/test/codex-auto-reset.test.ts
+++ b/packages/coding-agent/test/codex-auto-reset.test.ts
@@ -6,9 +6,10 @@
  *
  * Two rules under test:
  * - `blocked-account` (trigger `blocked` only): eligibility comes from the
- *   exact exhausted chat windows — 5h primary and/or weekly secondary; a
- *   banked reset also clears a 5h-only block (openai/codex#28525). The
- *   natural unblock is the LATEST reset among the exhausted windows.
+ *   exact exhausted normalized chat windows — 5h and/or weekly, regardless of
+ *   which base limit slot carries them; a banked reset also clears a 5h-only
+ *   block (openai/codex#28525). The natural unblock is the LATEST reset among
+ *   the exhausted windows.
  *   Candidates span ALL accounts, active first.
  * - `expiring-credit` (any trigger): use-it-or-lose-it salvage of credits
  *   whose `expiresAt` falls inside the horizon, gated only by the window
@@ -51,6 +52,10 @@ interface AccountOpts {
 	primaryUsed?: number;
 	/** Primary `resetsAt = NOW + this`; `undefined` omits the timestamp. */
 	primaryResetInMs?: number | undefined;
+	/** Normalized primary window id; defaults to `5h`. */
+	primaryWindowId?: string;
+	/** Normalized primary window duration, when reported. */
+	primaryWindowDurationMs?: number;
 	/** `availableCount`; `undefined` omits `resetCredits` (older broker / parse failure). */
 	credits?: number | undefined;
 	/** Per-credit `expiresAt = NOW + offset` (ISO). */
@@ -69,14 +74,16 @@ function report(opts: AccountOpts = {}): UsageReport {
 	const weeklyResetInMs = "weeklyResetInMs" in opts ? opts.weeklyResetInMs : 3 * DAY;
 	const primaryResetInMs = "primaryResetInMs" in opts ? opts.primaryResetInMs : 2 * HOUR;
 	const credits = "credits" in opts ? opts.credits : 1;
+	const primaryWindowId = opts.primaryWindowId ?? "5h";
 	const limits: UsageReport["limits"] = [
 		{
 			id: "openai-codex:primary",
-			label: "5 Hour",
-			scope: { provider: "openai-codex", accountId },
+			label: primaryWindowId === "7d" ? "7 Days" : "5 Hour",
+			scope: { provider: "openai-codex", accountId, windowId: primaryWindowId },
 			window: {
-				id: "5h",
-				label: "5 Hour",
+				id: primaryWindowId,
+				label: primaryWindowId === "7d" ? "7 Days" : "5 Hour",
+				...(opts.primaryWindowDurationMs === undefined ? {} : { durationMs: opts.primaryWindowDurationMs }),
 				...(primaryResetInMs === undefined ? {} : { resetsAt: NOW + primaryResetInMs }),
 			},
 			amount: { usedFraction: opts.primaryUsed ?? 0.5, unit: "percent" },
@@ -147,6 +154,27 @@ describe("planCodexResetRedemptions: blocked-account", () => {
 				blockedWindows: ["weekly"],
 				active: true,
 			},
+		]);
+	});
+
+	it("restores a weekly block reported in the primary limit slot", () => {
+		const plan = planCodexResetRedemptions(
+			input([
+				report({
+					primaryUsed: 1,
+					primaryResetInMs: 42 * HOUR,
+					primaryWindowId: "7d",
+					primaryWindowDurationMs: 7 * DAY,
+					weeklyUsed: undefined,
+				}),
+			]),
+		);
+		expect(plan.actions).toEqual([
+			expect.objectContaining({
+				remainingMs: 42 * HOUR,
+				blockedWindows: ["weekly"],
+				weeklyUsedFraction: 1,
+			}),
 		]);
 	});
 


### PR DESCRIPTION
## Repro
An exhausted `openai-codex:primary` limit with normalized window `7d`/604800000 ms and `resetsAt = now + 42h` produced no action and `reset-implausible`; the regression fixture is exercised with `bun test packages/coding-agent/test/codex-auto-reset.test.ts`.

## Cause
`planCodexResetRedemptions` in `packages/coding-agent/src/session/codex-auto-reset.ts` treated the primary and secondary limit slots as fixed 5-hour and weekly windows. ChatGPT now places the 7-day chat window in the primary slot, so the planner applied the 6-hour plausibility ceiling to a valid weekly reset.

## Fix
- Classify each base Codex chat limit from normalized `window.durationMs`, `window.id`, or `scope.windowId`, retaining slot-based behavior only as a metadata fallback.
- Use that classification for plausibility bounds, blocked-window labels, weekly usage, and expiring-credit salvage selection.
- Cover a 7-day, 42-hour-away primary-slot window and document the user-visible fix.

## Verification
`bun test packages/coding-agent/test/codex-auto-reset.test.ts packages/coding-agent/test/codex-auto-reset-integration.test.ts` passes 66 tests. `bun check` passes. The standalone reproduction now plans one `blocked-account` action with `blockedWindows: ["weekly"]`, `weeklyUsedFraction: 1`, and no skips.

Fixes #10929