### PR TITLE
fix(catalog): prevent clinepass proxy reference leaks

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM model discovery leaking ClinePass display names and pricing into models with colliding ids ([#10932](https://github.com/can1357/oh-my-pi/issues/10932)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/catalog/scripts/compat-compiler/compile-behavior.ts
+++ b/packages/catalog/scripts/compat-compiler/compile-behavior.ts
@@ -277,6 +277,7 @@ export function compileBehavior(source: { file: string; text: string } | undefin
 		modelLimits: [],
 		excludeModels: [],
 		retiredProviders: [],
+		referenceIsolatedProviders: [],
 		planRequirements: [],
 		pricingPeers: [],
 	};
@@ -349,6 +350,13 @@ export function compileBehavior(source: { file: string; text: string } | undefin
 				const values = positionalStrings(node);
 				if (values.length === 0 || values.some(value => !value)) malformed(node);
 				behavior.retiredProviders.push(...values);
+				break;
+			}
+			case "reference-isolated-providers": {
+				ensureLeaf(node, []);
+				const values = positionalStrings(node);
+				if (values.length === 0 || values.some(value => !value)) malformed(node);
+				behavior.referenceIsolatedProviders.push(...values);
 				break;
 			}
 			default:

--- a/packages/catalog/src/compat/behavior.ts
+++ b/packages/catalog/src/compat/behavior.ts
@@ -184,6 +184,16 @@ export function isRetiredProvider(provider: string): boolean {
 	return behavior.retiredProviders.includes(provider);
 }
 
+/**
+ * Whether a provider's bundled rows may seed cross-provider bare-id enrichment
+ * references. Gateway-namespaced providers (ClinePass) are isolated so their
+ * limits, pricing, and reasoning controls never contaminate an unrelated proxy
+ * model that happens to advertise the same bare id.
+ */
+export function isBareIdReferenceProvider(provider: string): boolean {
+	return !behavior.referenceIsolatedProviders.includes(provider);
+}
+
 /** The declared subscription tier required to use a provider model id, if any. */
 export function planRequirementFor(provider: string, model: string): string | undefined {
 	const rule = behavior.planRequirements.find(candidate => candidate.provider === provider);

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -14815,6 +14815,9 @@
 			"wandb",
 			"opencode"
 		],
+		"referenceIsolatedProviders": [
+			"cline-pass"
+		],
 		"planRequirements": [
 			{
 				"provider": "openai-codex",

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -20,6 +20,12 @@ behavior {
 	// `opencode` provider in the picker.
 	retired-providers "wafer-pass" "wandb" "opencode"
 
+	// ClinePass exposes gateway-specific limits, pricing, and reasoning
+	// controls; matching them by bare model id contaminates unrelated proxy
+	// models (a LiteLLM proxy serving `glm-5.3-flash`), so its rows are barred
+	// from seeding cross-provider bare-id enrichment references (#10932).
+	reference-isolated-providers "cline-pass"
+
 	// Discovered Responses/Codex models receive these additional operations.
 	model-operations provider="openai" {
 		exact "o3"

--- a/packages/catalog/src/compat/types.ts
+++ b/packages/catalog/src/compat/types.ts
@@ -318,6 +318,7 @@ export interface CompiledBehavior {
 	planRequirements: CompiledPlanRequirement[];
 	pricingPeers: CompiledPricingPeer[];
 	retiredProviders: string[];
+	referenceIsolatedProviders: string[];
 }
 
 /**

--- a/packages/catalog/src/identity/bundled.ts
+++ b/packages/catalog/src/identity/bundled.ts
@@ -6,6 +6,7 @@
  * non-bundled reference data use the pure builder directly
  * ({@link buildModelReferenceIndex}).
  */
+import { isBareIdReferenceProvider } from "../compat/behavior";
 import { getBundledModels, getBundledProviders } from "../models";
 import type { Api, Model } from "../types";
 import { buildModelReferenceIndex, type ModelReferenceIndex } from "./reference";
@@ -13,9 +14,9 @@ import { buildModelReferenceIndex, type ModelReferenceIndex } from "./reference"
 let bundledModels: readonly Model<Api>[] | undefined;
 
 function getBundledModelList(): readonly Model<Api>[] {
-	bundledModels ??= getBundledProviders().flatMap(
-		provider => getBundledModels(provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[],
-	);
+	bundledModels ??= getBundledProviders()
+		.filter(isBareIdReferenceProvider)
+		.flatMap(provider => getBundledModels(provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[]);
 	return bundledModels;
 }
 

--- a/packages/catalog/src/provider-models/bundled-references.ts
+++ b/packages/catalog/src/provider-models/bundled-references.ts
@@ -35,6 +35,11 @@ export function createBundledReferenceMap<TApi extends Api>(
 
 type ProviderReferenceSource<TApi extends Api> = Map<string, ModelSpec<TApi>> | (() => Map<string, ModelSpec<TApi>>);
 
+/** Whether a provider's rows may enrich proxy models through bare model ids. */
+export function isBareIdReferenceProvider(provider: string): boolean {
+	return provider !== "cline-pass";
+}
+
 let globalReferences: Map<string, Model<Api>> | undefined;
 
 function getGlobalReferences(): Map<string, Model<Api>> {
@@ -45,9 +50,9 @@ function getGlobalReferences(): Map<string, Model<Api>> {
 	for (const provider of getBundledProviders()) {
 		for (const model of getBundledModels(provider as Parameters<typeof getBundledModels>[0])) {
 			const candidate = model as Model<Api>;
-			// ClinePass limits, pricing, and reasoning controls are gateway-specific;
-			// matching them by bare id would contaminate unrelated proxy models.
-			if (candidate.provider === "cline-pass" || isZeroCostXaiOAuthReference(candidate)) {
+			// Gateway-specific metadata must remain provider-local when proxy
+			// discovery resolves references by bare model id.
+			if (!isBareIdReferenceProvider(candidate.provider) || isZeroCostXaiOAuthReference(candidate)) {
 				continue;
 			}
 			const existing = references.get(candidate.id);

--- a/packages/catalog/src/provider-models/bundled-references.ts
+++ b/packages/catalog/src/provider-models/bundled-references.ts
@@ -1,3 +1,4 @@
+import { isBareIdReferenceProvider } from "../compat/behavior";
 import { isZeroCostXaiOAuthReference } from "../identity/reference";
 import { getBundledModels, getBundledProviders } from "../models";
 import type { Api, Model, ModelSpec } from "../types";
@@ -34,11 +35,6 @@ export function createBundledReferenceMap<TApi extends Api>(
 }
 
 type ProviderReferenceSource<TApi extends Api> = Map<string, ModelSpec<TApi>> | (() => Map<string, ModelSpec<TApi>>);
-
-/** Whether a provider's rows may enrich proxy models through bare model ids. */
-export function isBareIdReferenceProvider(provider: string): boolean {
-	return provider !== "cline-pass";
-}
 
 let globalReferences: Map<string, Model<Api>> | undefined;
 

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -60,10 +60,9 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 			return "cursor:default-effort-v4";
 		case "litellm": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
-			// rich-v8 invalidates rows whose `compatConfig` retained a colliding
-			// bundled model's provider-specific transport (e.g. Fireworks
-			// `wireModelIdMode`) before that leak was fixed (issue #9938).
-			return `litellm:rich-v8:${Bun.hash(baseUrl).toString(36)}`;
+			// rich-v9 invalidates rows that inherited ClinePass gateway metadata
+			// through generic models.dev bare-id enrichment (issue #10932).
+			return `litellm:rich-v9:${Bun.hash(baseUrl).toString(36)}`;
 		}
 		case "opencode-go":
 		case "opencode-zen": {

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -64,6 +64,12 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 			// through generic models.dev bare-id enrichment (issue #10932).
 			return `litellm:rich-v9:${Bun.hash(baseUrl).toString(36)}`;
 		}
+		case "gmi-cloud":
+		case "siliconflow":
+		case "siliconflow-cn":
+			// models-v1 moves rows enriched before cross-provider reference
+			// isolation out of the legacy bare-provider namespaces (#10932).
+			return `${providerId}:models-v1`;
 		case "opencode-go":
 		case "opencode-zen": {
 			// v3: gateway-first rows cached before stencil enrichment carry null

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4,6 +4,7 @@ import { toClinePassPublicModelId } from "../cline-pass-model-id";
 import {
 	apiRouteExactModelIds,
 	apiRouteFor,
+	isBareIdReferenceProvider,
 	isExcludedModel,
 	isLikelyOpenAIResponsesId,
 	modelLimitsFor,
@@ -40,12 +41,7 @@ import {
 	mergeCopilotApiHeaders,
 	parseGitHubCopilotApiKey,
 } from "../wire/github-copilot";
-import {
-	createBundledReferenceMap,
-	createReferenceResolver,
-	isBareIdReferenceProvider,
-	toModelSpec,
-} from "./bundled-references";
+import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
 import { getDefaultModelDiscoveryBaseUrl, resolveModelCacheProviderId } from "./cache-provider-id";
 import { getClinePassModelMetadata } from "./cline-pass";
 import type { ModelManagerConfig } from "./descriptor-types";

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -40,7 +40,12 @@ import {
 	mergeCopilotApiHeaders,
 	parseGitHubCopilotApiKey,
 } from "../wire/github-copilot";
-import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
+import {
+	createBundledReferenceMap,
+	createReferenceResolver,
+	isBareIdReferenceProvider,
+	toModelSpec,
+} from "./bundled-references";
 import { getDefaultModelDiscoveryBaseUrl, resolveModelCacheProviderId } from "./cache-provider-id";
 import { getClinePassModelMetadata } from "./cline-pass";
 import type { ModelManagerConfig } from "./descriptor-types";
@@ -2377,6 +2382,9 @@ function createModelsDevReferenceMap<TApi extends Api>(
 	const references = new Map<string, ModelSpec<TApi>>();
 	for (const model of models) {
 		const candidate = model as ModelSpec<TApi>;
+		if (!isBareIdReferenceProvider(candidate.provider)) {
+			continue;
+		}
 		const existing = references.get(candidate.id);
 		if (!existing) {
 			references.set(candidate.id, candidate);
@@ -5866,14 +5874,14 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
 	return {
 		providerId: "litellm",
-		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
-		// bundled model's provider-specific transport (e.g. Fireworks
-		// `wireModelIdMode`) before that leak was fixed. Earlier versions added
-		// bundled reference fallback, moved OpenAI models to Responses, continued
-		// past incomplete vision/API metadata and endpoints omitting cache
-		// pricing, stripped reseller usage suffixes, filtered placeholder rows,
-		// and mapped rich pricing. Bump the version whenever these mappers change,
-		// or warm authoritative caches keep serving pre-change rows for the full TTL.
+		// rich-v9 invalidates rows that inherited ClinePass gateway metadata
+		// through generic models.dev bare-id enrichment. Earlier versions fixed
+		// provider-specific transport leakage, added bundled reference fallback,
+		// moved OpenAI models to Responses, continued past incomplete vision/API
+		// metadata and endpoints omitting cache pricing, stripped reseller usage
+		// suffixes, filtered placeholder rows, and mapped rich pricing.
+		// Bump the version whenever these mappers change, or warm authoritative
+		// caches keep serving pre-change rows for the full TTL.
 		cacheProviderId: resolveModelCacheProviderId("litellm", { baseUrl }),
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer
@@ -6878,6 +6886,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 			return {
 				...model,
 				id,
+				name: id,
 				thinking: model.reasoning ? buildClinePassThinking(raw, model) : undefined,
 			};
 		},

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -626,6 +626,7 @@ type OpenAICompatibleModelManagerBuilderOptions<TApi extends Api> = {
 	dynamicModelsAuthoritative?: true;
 	requireApiKey?: true;
 	dropCachedModelIdsOnStaticMismatch?: readonly string[];
+	cacheProviderId?: string;
 	filterModel?: (
 		entry: OpenAICompatibleModelRecord,
 		model: ModelSpec<TApi>,
@@ -647,6 +648,7 @@ function createOpenAICompatibleModelManagerOptions<TApi extends Api>(
 	const filterModel = options.filterModel;
 	return {
 		providerId: options.providerId,
+		...(options.cacheProviderId && { cacheProviderId: options.cacheProviderId }),
 		...(options.dynamicModelsAuthoritative && { dynamicModelsAuthoritative: true }),
 		...(options.dropCachedModelIdsOnStaticMismatch && {
 			dropCachedModelIdsOnStaticMismatch: options.dropCachedModelIdsOnStaticMismatch,
@@ -1121,6 +1123,7 @@ export function gmiCloudModelManagerOptions(
 		api: "openai-completions",
 		providerId: "gmi-cloud",
 		defaultBaseUrl: GMI_CLOUD_BASE_URL,
+		cacheProviderId: resolveModelCacheProviderId("gmi-cloud"),
 		config,
 		requireApiKey: true,
 		mapModel: mapGmiCloudModel,
@@ -1955,6 +1958,7 @@ function createSiliconFlowModelManagerOptions(
 	const baseUrl = config?.baseUrl ?? defaultBaseUrl;
 	return {
 		providerId,
+		cacheProviderId: resolveModelCacheProviderId(providerId),
 		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: async () => {

--- a/packages/catalog/test/cline-pass-compat.test.ts
+++ b/packages/catalog/test/cline-pass-compat.test.ts
@@ -35,6 +35,15 @@ const CLINEPASS_MODELS_DEV_FIXTURE = {
 				limit: { context: 1_000_000, output: 384_000 },
 				cost: { input: 5, output: 10 },
 			},
+			"cline-pass/unlisted-model": {
+				id: "cline-pass/unlisted-model",
+				name: "cline-pass/unlisted-model",
+				tool_call: true,
+				reasoning: false,
+				modalities: { input: ["text"] },
+				limit: { context: 131_072, output: 8_192 },
+				cost: { input: 1, output: 2 },
+			},
 		},
 	},
 };
@@ -80,6 +89,10 @@ describe("ClinePass catalog", () => {
 			contextWindow: 1_048_576,
 			maxTokens: 1_048_576,
 		});
+	});
+
+	it("keeps uncurated model names free of the Cline wire namespace", () => {
+		expect(sourceModel("unlisted-model").name).toBe("unlisted-model");
 	});
 
 	it("maps Cline's per-model reasoning controls from the curated snapshot", () => {

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -4,6 +4,15 @@ import { getBundledModelReferenceIndex } from "../src/identity/bundled";
 import { inheritReferenceThinking, resolveModelReference } from "../src/identity/reference";
 import type { ModelSpec } from "../src/types";
 
+describe("Bundled model references", () => {
+	test("excludes providers isolated from cross-provider bare-id enrichment", () => {
+		const reference = resolveModelReference("glm-5.3-flash", getBundledModelReferenceIndex());
+
+		expect(reference).toBeDefined();
+		expect(reference?.provider).not.toBe("cline-pass");
+	});
+});
+
 describe("Portkey gateway model references", () => {
 	test("@modal ids do not fuzzy-match bundled catalog entries", () => {
 		const index = getBundledModelReferenceIndex();

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -114,6 +114,52 @@ function makeCollisionFetchMock(): FetchImpl {
 	}) as FetchImpl;
 }
 
+function makeClinePassCollisionFetchMock(): FetchImpl {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = inputUrl(input);
+		if (url === MODELS_DEV_URL) {
+			return Response.json({
+				"cline-pass": {
+					models: {
+						"cline-pass/glm-5.3-flash": {
+							id: "cline-pass/glm-5.3-flash",
+							name: "cline-pass/glm-5.3-flash",
+							tool_call: true,
+							reasoning: true,
+							limit: { context: 1_000_000, output: 131_072 },
+							cost: { input: 0.15, output: 0.5, cache_read: 0.03 },
+						},
+					},
+				},
+				zai: {
+					models: {
+						"glm-5.3-flash": {
+							id: "glm-5.3-flash",
+							name: "GLM-5.3-Flash",
+							tool_call: true,
+							reasoning: true,
+							limit: { context: 1_000_000, output: 131_072 },
+							cost: { input: 0.075, output: 0.25, cache_read: 0.015 },
+						},
+					},
+				},
+			});
+		}
+		if (url === "http://primary:4000/model_group/info") {
+			return Response.json({
+				data: [
+					{
+						model_group: "glm-5.3-flash",
+						model_name: "glm-5.3-flash",
+						litellm_params: { model: "openrouter/z-ai/glm-5.3-flash" },
+					},
+				],
+			});
+		}
+		return new Response("Not found", { status: 404 });
+	}) as FetchImpl;
+}
+
 afterEach(() => {
 	restoreLiteLLMBaseUrl();
 	vi.restoreAllMocks();
@@ -131,7 +177,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v8:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
+			`litellm:rich-v9:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -155,7 +201,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v8:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
+			`litellm:rich-v9:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -184,6 +230,28 @@ describe("LiteLLM provider discovery", () => {
 			cost: {
 				input: 1,
 				output: 2,
+			},
+		});
+	});
+
+	test("does not inherit ClinePass metadata through a colliding bare model id (#10932)", async () => {
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-litellm-test",
+			baseUrl: "http://primary:4000/v1",
+			fetch: makeClinePassCollisionFetchMock(),
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({
+			id: "glm-5.3-flash",
+			name: "GLM-5.3-Flash",
+			provider: "litellm",
+			cost: {
+				input: 0.075,
+				output: 0.25,
+				cacheRead: 0.015,
 			},
 		});
 	});

--- a/packages/catalog/test/provider-cache-id.test.ts
+++ b/packages/catalog/test/provider-cache-id.test.ts
@@ -25,6 +25,12 @@ test("lightweight cache resolver matches scoped descriptor inputs", () => {
 	}
 });
 
+test("canonical-reference consumers invalidate pre-isolation cache rows", () => {
+	for (const providerId of ["gmi-cloud", "siliconflow", "siliconflow-cn"]) {
+		expect(resolveModelCacheProviderId(providerId)).toBe(`${providerId}:models-v1`);
+	}
+});
+
 test("ollama cache scope preserves reverse-proxy path prefixes", () => {
 	const teamA = resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a/v1/" });
 	expect(teamA).toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a" }));


### PR DESCRIPTION
## Repro
A controlled models.dev response with tied ClinePass and Z.AI `glm-5.3-flash` rows, combined with LiteLLM rich metadata whose `model_name` equals the bare id, made `litellmModelManagerOptions().fetchDynamicModels()` return `cline-pass/glm-5.3-flash` and ClinePass pricing. The regression is exercised with `bun test packages/catalog/test/litellm-provider.test.ts`.

## Cause
`createModelsDevReferenceMap` in `packages/catalog/src/provider-models/openai-compat.ts` accepted ClinePass rows for generic bare-id enrichment even though `packages/catalog/src/provider-models/bundled-references.ts` excluded them from the equivalent bundled index. The ClinePass descriptor’s uncurated fallback also normalized only `id`, leaving the namespaced source `name` intact.

## Fix
- Centralize the provider-level bare-id reference guard and apply it to bundled and live models.dev references.
- Normalize uncurated ClinePass display names to the public id and bump the LiteLLM cache namespace to evict contaminated rows.
- Add regressions for LiteLLM display/pricing collisions and ClinePass fallback names, plus a catalog changelog entry.

## Verification
`bun test packages/catalog/test/litellm-provider.test.ts packages/catalog/test/cline-pass-compat.test.ts packages/catalog/test/provider-cache-id.test.ts` passes 48 tests with 0 failures. The pre-publish gate also completed `bun run fix` and `bun check`.

Fixes #10932