### PR TITLE
fix(catalog): apply DeepInfra promotional discount to model cost

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepInfra model cost reporting so promotional pricing is reflected: the `metadata.discount` fraction is now applied to input, output, and cache-read rates ([#10935](https://github.com/can1357/oh-my-pi/issues/10935)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1339,6 +1339,13 @@ function mapDeepinfraModel(
 		return null;
 	}
 	const pricing = isRecord(metadata.pricing) ? metadata.pricing : {};
+	// `metadata.discount` is a promotional fraction in [0, 1): DeepInfra bills
+	// `pricing * (1 - discount)` (verified against the site — GLM-5.2 lists
+	// input 0.75 with discount 0.35 and charges 0.4875), while `pricing.*`
+	// stays at list price. Fold it into the rate card so cost reporting matches
+	// what the user is actually billed. Values outside (0, 1) are ignored.
+	const discount = toNumber(metadata.discount);
+	const discountMultiplier = discount !== undefined && discount > 0 && discount < 1 ? 1 - discount : 1;
 	// `reasoning_effort` marks models whose effort dial is advertised. The
 	// parameter itself is validated and accepted platform-wide on DeepInfra
 	// (verified: 200 on effort-tagged, reasoning-only, and plain-chat models;
@@ -1381,9 +1388,9 @@ function mapDeepinfraModel(
 		...(thinking ? { thinking } : {}),
 		input: tags.includes("vision") || tags.includes("vlm") ? ["text", "image"] : ["text"],
 		cost: {
-			input: toPositiveNumber(pricing.input_tokens, 0),
-			output: toPositiveNumber(pricing.output_tokens, 0),
-			cacheRead: toPositiveNumber(pricing.cache_read_tokens, 0),
+			input: toPositiveNumber(pricing.input_tokens, 0) * discountMultiplier,
+			output: toPositiveNumber(pricing.output_tokens, 0) * discountMultiplier,
+			cacheRead: toPositiveNumber(pricing.cache_read_tokens, 0) * discountMultiplier,
 			cacheWrite: 0,
 		},
 		contextWindow,

--- a/packages/catalog/test/deepinfra-provider.test.ts
+++ b/packages/catalog/test/deepinfra-provider.test.ts
@@ -141,6 +141,51 @@ describe("DeepInfra built-in provider", () => {
 		expect(mapped?.maxTokens).toBe(256000);
 	});
 
+	test("applies metadata.discount to the token rate card", async () => {
+		// DeepInfra publishes `pricing.*` at list price and a separate
+		// `discount` fraction; the user is billed `pricing * (1 - discount)`.
+		// GLM-5.2 is the live example (input 0.75 @ 35% off = 0.4875), and a
+		// `discount: null` row must keep list price untouched.
+		const fetchMock = async (): Promise<Response> =>
+			Response.json({
+				object: "list",
+				data: [
+					{
+						id: "vendor/on-promo",
+						object: "model",
+						metadata: {
+							context_length: 1048576,
+							pricing: { input_tokens: 0.75, output_tokens: 2.4, cache_read_tokens: 0.14 },
+							discount: 0.35,
+							tags: ["chat", "prompt_cache", "reasoning"],
+						},
+					},
+					{
+						id: "vendor/full-price",
+						object: "model",
+						metadata: {
+							context_length: 131072,
+							pricing: { input_tokens: 0.09, output_tokens: 0.18 },
+							discount: null,
+							tags: ["chat"],
+						},
+					},
+				],
+			});
+
+		const options = deepinfraModelManagerOptions({ fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+
+		const promo = models?.find(item => item.id === "vendor/on-promo");
+		expect(promo?.cost.input).toBeCloseTo(0.4875, 10);
+		expect(promo?.cost.output).toBeCloseTo(1.56, 10);
+		expect(promo?.cost.cacheRead).toBeCloseTo(0.091, 10);
+		expect(promo?.cost.cacheWrite).toBe(0);
+
+		const fullPrice = models?.find(item => item.id === "vendor/full-price");
+		expect(fullPrice?.cost).toEqual({ input: 0.09, output: 0.18, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	test("ships no bundled row whose output cap exceeds its context window", () => {
 		// Guards the generated slice itself: the reference fallback runs again
 		// during `gen:models`, so an unclamped cap would be baked into the


### PR DESCRIPTION
## Repro
DeepInfra's `/v1/openai/models` returns per-model `metadata.pricing.*` at list price plus a sibling `metadata.discount` fraction in [0, 1); the platform bills `pricing * (1 - discount)`. `zai-org/GLM-5.2` reports `pricing {input_tokens: 0.75, output_tokens: 2.4, cache_read_tokens: 0.14}` with `discount: 0.35`, and deepinfra.com shows the effective rate as `$0.488 in / $1.56 out / $0.091 cached` ("35% off already applied"). Driving `mapDeepinfraModel` with that payload reported `{input: 0.75, output: 2.4, cacheRead: 0.14}` — full list price — so every discounted DeepInfra chat model was overpriced in the model selector and cost estimates.

## Cause
`mapDeepinfraModel` in `packages/catalog/src/provider-models/openai-compat.ts` built its `cost` block straight from `toPositiveNumber(pricing.input_tokens, 0)` etc. and never read `metadata.discount`, dropping the promotional adjustment.

## Fix
- Read `metadata.discount` via `toNumber` and derive `discountMultiplier = discount in (0, 1) ? 1 - discount : 1` (values outside the range are ignored).
- Multiply the `input`, `output`, and `cacheRead` rates by `discountMultiplier` in the `cost` block; `cacheWrite` stays 0.
- Added a regression test asserting a 35%-off row is priced at `0.4875 / 1.56 / 0.091` while a `discount: null` row keeps list price.
- Changelog entry under `packages/catalog` `[Unreleased] > Fixed`.

## Verification
`bun test test/deepinfra-provider.test.ts` (in `packages/catalog`) — 7 pass / 0 fail. Manually reran the mapper against the GLM-5.2 payload post-fix: `{input: 0.4875, output: 1.56, cacheRead: 0.091}`, matching deepinfra.com. Fixes #10935