### PR TITLE
fix(coding-agent): re-read RULES.md on /clear and /new

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -183,6 +183,7 @@ Do not edit generated files.
 
 - It is read **only** at native locations: the active user agent directory and the nearest non-empty project `.omp/` directory selected by the cwd-to-repository-root walk. If that project directory has no `RULES.md`, OMP does not fall back to a farther `.omp/RULES.md`.
 - It is loaded as an **always-apply rule**, not as a context file, so it is re-attached near the current turn and keeps its hold across long sessions.
+- It is re-discovered from disk when a session starts and on session-scoped rebuilds such as `/clear` and `/new`, so creating or editing it while OMP is running takes effect at the next reset — no restart required.
 - It is **always sticky**: frontmatter cannot make it non-sticky. If you want conditional or opt-in behavior, write a normal rule file instead (see [Skills](./skills.md)).
 - Both top-level candidates are synthesized with the rule name `RULES`, and rule deduplication is name-based. In the usual case, a user `RULES.md` shadows the project `RULES.md`; they are not concatenated. Avoid naming a regular file under `.omp/rules/` or the user `rules/` directory `RULES.md`, because native regular rules load earlier and can shadow both sticky candidates.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
+- Sticky `RULES.md` and other discovered rules are now re-read from disk on `/clear` and `/new`, so rules created or edited while omp is running take effect on the next session reset instead of only after a restart ([#10940](https://github.com/can1357/oh-my-pi/issues/10940)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/capability/rule-buckets.ts
+++ b/packages/coding-agent/src/capability/rule-buckets.ts
@@ -32,6 +32,8 @@ export interface BucketRulesOptions {
 	 * from every bucket. Omit to disable agent scoping (CLI inventory listings).
 	 */
 	agentName?: string;
+	/** Replace existing TTSR registrations before bucketing this complete rule snapshot. */
+	replaceTtsrRules?: boolean;
 }
 
 /**
@@ -51,20 +53,22 @@ export function bucketRules(
 		if (name.length > 0) disabled.add(name);
 	}
 
-	const rulebookRules: Rule[] = [];
-	const alwaysApplyRules: Rule[] = [];
-
+	const includedRules: Rule[] = [];
 	for (const rule of rules) {
 		if (disabled.has(rule.name)) continue;
 		if (!includeBuiltin && rule._source?.provider === BUILTIN_DEFAULTS_PROVIDER_ID) continue;
 		if (!ruleAppliesToAgent(rule, options.agentName)) continue;
+		includedRules.push(rule);
+	}
 
+	const replacedTtsrNames = options.replaceTtsrRules ? ttsrManager.replaceRules(includedRules) : undefined;
+	const rulebookRules: Rule[] = [];
+	const alwaysApplyRules: Rule[] = [];
+
+	for (const rule of includedRules) {
 		const hasTtsrCondition =
 			(rule.condition && rule.condition.length > 0) || (rule.astCondition && rule.astCondition.length > 0);
-		// `hasRule` first so re-bucketing against an already-populated manager (the
-		// mid-session rule re-discovery on /clear and /new) recognizes a rule it
-		// registered earlier as TTSR instead of leaking it into the rulebook bucket.
-		const isTtsrRule = hasTtsrCondition ? ttsrManager.hasRule(rule.name) || ttsrManager.addRule(rule) : false;
+		const isTtsrRule = hasTtsrCondition ? (replacedTtsrNames?.has(rule.name) ?? ttsrManager.addRule(rule)) : false;
 		if (isTtsrRule) continue;
 		if (rule.alwaysApply === true) {
 			alwaysApplyRules.push(rule);

--- a/packages/coding-agent/src/capability/rule-buckets.ts
+++ b/packages/coding-agent/src/capability/rule-buckets.ts
@@ -9,7 +9,7 @@
  *   1. disabledRules  — dropped before any bucket assignment
  *   2. builtin drop   — `builtinRules === false` drops `builtin-defaults` rules
  *   3. agents scope   — rules whose `agents` globs do not match `options.agentName` are dropped
- *   4. TTSR           — non-empty `condition`/`astCondition` that `TtsrManager.addRule` accepts
+ *   4. TTSR           — non-empty `condition`/`astCondition` the manager already tracks or newly accepts
  *   5. always         — `alwaysApply === true`
  *   6. rulebook       — has a `description`
  */
@@ -61,7 +61,10 @@ export function bucketRules(
 
 		const hasTtsrCondition =
 			(rule.condition && rule.condition.length > 0) || (rule.astCondition && rule.astCondition.length > 0);
-		const isTtsrRule = hasTtsrCondition ? ttsrManager.addRule(rule) : false;
+		// `hasRule` first so re-bucketing against an already-populated manager (the
+		// mid-session rule re-discovery on /clear and /new) recognizes a rule it
+		// registered earlier as TTSR instead of leaking it into the rulebook bucket.
+		const isTtsrRule = hasTtsrCondition ? ttsrManager.hasRule(rule.name) || ttsrManager.addRule(rule) : false;
 		if (isTtsrRule) continue;
 		if (rule.alwaysApply === true) {
 			alwaysApplyRules.push(rule);

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -568,6 +568,11 @@ export class TtsrManager {
 		return this.#rules.size > 0;
 	}
 
+	/** Whether a rule with this name is already registered for monitoring. */
+	hasRule(name: string): boolean {
+		return this.#rules.has(name);
+	}
+
 	/** All rules currently registered for TTSR monitoring, in registration order. */
 	getRules(): Rule[] {
 		return Array.from(this.#rules.values(), entry => entry.rule);

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -568,9 +568,32 @@ export class TtsrManager {
 		return this.#rules.size > 0;
 	}
 
-	/** Whether a rule with this name is already registered for monitoring. */
-	hasRule(name: string): boolean {
-		return this.#rules.has(name);
+	/**
+	 * Atomically replace monitored rules while retaining injection state for names
+	 * that remain registered.
+	 *
+	 * Returns the names accepted for TTSR monitoring so the caller can bucket
+	 * rejected conditional rules through its normal fallback path.
+	 */
+	replaceRules(rules: readonly Rule[]): Set<string> {
+		const replacement = new TtsrManager(this.#settings);
+		for (const rule of rules) {
+			replacement.addRule(rule);
+		}
+
+		const registered = new Set(replacement.#rules.keys());
+		this.#rules.clear();
+		for (const [name, entry] of replacement.#rules) {
+			this.#rules.set(name, entry);
+		}
+		this.#canMatchText = replacement.#canMatchText;
+		this.#canMatchThinking = replacement.#canMatchThinking;
+		this.resetBuffer();
+
+		for (const name of this.#injectionRecords.keys()) {
+			if (!registered.has(name)) this.#injectionRecords.delete(name);
+		}
+		return registered;
 	}
 
 	/** All rules currently registered for TTSR monitoring, in registration order. */

--- a/packages/coding-agent/src/modes/controllers/omfg-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/omfg-controller.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { CONFIG_DIR_NAME, prompt } from "@oh-my-pi/pi-utils";
+import { invalidate as invalidateCapabilityCache } from "../../capability";
 import type { Rule } from "../../capability/rule";
 import omfgUserPrompt from "../../prompts/system/omfg-user.md" with { type: "text" };
 import { shortenPath } from "../../tools/render-utils";
@@ -234,6 +235,14 @@ export class OmfgController {
 
 			request.component.setStatus("saving", `Saving ${candidate.rule.name}…`);
 			await Bun.write(target.filePath, candidate.fileContent);
+			// Drop the cached directory snapshot the discovery layer reads, so the next
+			// session-scoped rebuild's rule rediscovery observes this new file instead of
+			// a stale listing that would make `replaceTtsrRules` evict the live rule
+			// registered below (issue #10940 review). Invalidating the file clears its
+			// parent (rules dir); invalidating that dir clears its parent (the config dir)
+			// so a first-ever rule in a freshly created `.omp/rules` is still discovered.
+			invalidateCapabilityCache(target.filePath);
+			invalidateCapabilityCache(path.dirname(target.filePath));
 			if (!this.#isActiveRequest(request)) return { kind: "aborted" };
 
 			const savedRule = buildOmfgRuleForPath(

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3118,8 +3118,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				});
 				rulebookRules = buckets.rulebookRules;
 				alwaysApplyRules = buckets.alwaysApplyRules;
+				const nextActiveRules = [...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()];
+				// Refresh the session-local snapshots too: `rule://` resolution reads
+				// `toolSession.activeRules` and spawned subagents inherit `toolSession.rules`,
+				// so leaving the construction-time arrays would advertise a new `rule://<name>`
+				// the read tool rejects and hand children the stale set.
+				toolSession.rules = rulesResult.items;
+				toolSession.activeRules = nextActiveRules;
 				if (!options.parentTaskPrefix) {
-					setActiveRules([...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()]);
+					setActiveRules(nextActiveRules);
 				}
 			}
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3103,8 +3103,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// session creation, so a `RULES.md` (or any rule) created or edited while omp
 			// runs never reaches the prompt on /clear or /new until restart (issue #10940).
 			// resetCapabilities() clears the fs cache at those boundaries, so this observes
-			// the current file; reusing `ttsrManager` (bucketRules is idempotent on it)
-			// preserves TTSR registration and injection state across the rebuild.
+			// the current file. TTSR registrations are replaced from the new snapshot while
+			// injection state is retained only for rule names that remain registered.
 			if (hasSession && options.rules === undefined) {
 				const ttsrSettings = settings.getGroup("ttsr");
 				const rulesResult = await logger.time("rediscoverRules", () =>
@@ -3114,6 +3114,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					builtinRules: ttsrSettings.builtinRules,
 					disabledRules: ttsrSettings.disabledRules,
 					agentName: resolvedAgentName,
+					replaceTtsrRules: true,
 				});
 				rulebookRules = buckets.rulebookRules;
 				alwaysApplyRules = buckets.alwaysApplyRules;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1660,27 +1660,30 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	const resolvedAgentName = (options.agentName ?? agentKind).trim().toLowerCase();
 
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.
-	const { ttsrManager, rulebookRules, alwaysApplyRules, allRules } = await logger.time(
-		"discoverTtsrRules",
-		async () => {
-			const { TtsrManager } = await import("./export/ttsr");
-			const ttsrSettings = settings.getGroup("ttsr");
-			const ttsrManager = new TtsrManager(ttsrSettings);
-			const rulesResult =
-				options.rules !== undefined
-					? { items: options.rules, warnings: undefined }
-					: await loadCapability<Rule>(ruleCapability.id, { cwd });
-			const { rulebookRules, alwaysApplyRules } = bucketRules(rulesResult.items, ttsrManager, {
-				builtinRules: ttsrSettings.builtinRules,
-				disabledRules: ttsrSettings.disabledRules,
-				agentName: resolvedAgentName,
-			});
-			if (existingSession.injectedTtsrRules.length > 0) {
-				ttsrManager.restoreInjected(existingSession.injectedTtsrRules);
-			}
-			return { ttsrManager, rulebookRules, alwaysApplyRules, allRules: rulesResult.items };
-		},
-	);
+	const discovered = await logger.time("discoverTtsrRules", async () => {
+		const { TtsrManager } = await import("./export/ttsr");
+		const ttsrSettings = settings.getGroup("ttsr");
+		const ttsrManager = new TtsrManager(ttsrSettings);
+		const rulesResult =
+			options.rules !== undefined
+				? { items: options.rules, warnings: undefined }
+				: await loadCapability<Rule>(ruleCapability.id, { cwd });
+		const { rulebookRules, alwaysApplyRules } = bucketRules(rulesResult.items, ttsrManager, {
+			builtinRules: ttsrSettings.builtinRules,
+			disabledRules: ttsrSettings.disabledRules,
+			agentName: resolvedAgentName,
+		});
+		if (existingSession.injectedTtsrRules.length > 0) {
+			ttsrManager.restoreInjected(existingSession.injectedTtsrRules);
+		}
+		return { ttsrManager, rulebookRules, alwaysApplyRules, allRules: rulesResult.items };
+	});
+	const { ttsrManager, allRules } = discovered;
+	// Mutable so the mid-session prompt rebuild (on /clear and /new) can re-discover
+	// rules from disk, mirroring the context-file refresh below (issue #10940). The
+	// same `ttsrManager` is reused, so restored TTSR injection state survives.
+	let rulebookRules = discovered.rulebookRules;
+	let alwaysApplyRules = discovered.alwaysApplyRules;
 
 	// Resolve contextFiles up-front (it's needed before tool creation). The
 	// workspace tree scan is slow on large repos and we MUST NOT block startup on
@@ -3094,6 +3097,29 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				]);
 				toolSession.contextFiles = contextFiles;
 				session.setAdvisorContextPrompt(formatAdvisorContextPrompt(contextFiles));
+			}
+			// Re-discover rules from disk on every session-scoped rebuild, mirroring the
+			// context-file refresh above. The rule buckets are otherwise frozen at
+			// session creation, so a `RULES.md` (or any rule) created or edited while omp
+			// runs never reaches the prompt on /clear or /new until restart (issue #10940).
+			// resetCapabilities() clears the fs cache at those boundaries, so this observes
+			// the current file; reusing `ttsrManager` (bucketRules is idempotent on it)
+			// preserves TTSR registration and injection state across the rebuild.
+			if (hasSession && options.rules === undefined) {
+				const ttsrSettings = settings.getGroup("ttsr");
+				const rulesResult = await logger.time("rediscoverRules", () =>
+					loadCapability<Rule>(ruleCapability.id, { cwd: promptCwd }),
+				);
+				const buckets = bucketRules(rulesResult.items, ttsrManager, {
+					builtinRules: ttsrSettings.builtinRules,
+					disabledRules: ttsrSettings.disabledRules,
+					agentName: resolvedAgentName,
+				});
+				rulebookRules = buckets.rulebookRules;
+				alwaysApplyRules = buckets.alwaysApplyRules;
+				if (!options.parentTaskPrefix) {
+					setActiveRules([...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()]);
+				}
 			}
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);
 			const memoryInstructions = memoryBackend

--- a/packages/coding-agent/test/agent-session-rules-reload.test.ts
+++ b/packages/coding-agent/test/agent-session-rules-reload.test.ts
@@ -18,7 +18,7 @@ import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 function buildLocalModel(api: string): Model<Api> {
 	return buildModel({
@@ -33,6 +33,20 @@ function buildLocalModel(api: string): Model<Api> {
 		contextWindow: 4096,
 		maxTokens: 1024,
 	} as ModelSpec<Api>) as Model<Api>;
+}
+
+// User-scope `RULES.md` resolves through the process-global agent dir (getAgentDir()),
+// not the createAgentSession `agentDir` option, so a user-scope case must redirect it.
+const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+function restoreAgentDir(): void {
+	if (originalAgentDirEnv) {
+		setAgentDir(originalAgentDirEnv);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
 }
 
 async function createReloadSession(tempDir: TempDir): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
@@ -62,14 +76,17 @@ async function createReloadSession(tempDir: TempDir): Promise<{ session: AgentSe
 
 async function expectStickyRuleReload(
 	reset: (session: AgentSession) => Promise<unknown>,
-	opts: { seedInitial: boolean },
+	opts: { seedInitial: boolean; scope: "user" | "project" },
 ): Promise<void> {
 	using tempDir = TempDir.createSync("@pi-rules-reload-");
 	const marker = Bun.nanoseconds().toString(36);
 	const original = `ORIGINAL_STICKY_${marker}`;
 	const updated = `UPDATED_STICKY_${marker}`;
-	// Project-scope sticky rule: nearest `.omp/RULES.md` walking up from cwd.
-	const rulesMd = path.join(tempDir.path(), ".omp", "RULES.md");
+	// User scope: `<agentDir>/RULES.md` via the process-global getAgentDir().
+	// Project scope: nearest `.omp/RULES.md` walking up from cwd.
+	if (opts.scope === "user") setAgentDir(tempDir.path());
+	const rulesMd =
+		opts.scope === "user" ? path.join(tempDir.path(), "RULES.md") : path.join(tempDir.path(), ".omp", "RULES.md");
 	if (opts.seedInitial) {
 		await fs.mkdir(path.dirname(rulesMd), { recursive: true });
 		await fs.writeFile(rulesMd, original);
@@ -95,6 +112,7 @@ async function expectStickyRuleReload(
 	} finally {
 		await session.dispose();
 		authStorage.close();
+		if (opts.scope === "user") restoreAgentDir();
 	}
 }
 
@@ -103,16 +121,24 @@ describe("AgentSession sticky RULES.md reload on session reset", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("re-reads an edited RULES.md after resetSessionContext()", async () => {
-		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: true });
+	it("re-reads an edited project RULES.md after resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: true, scope: "project" });
 	});
 
-	it("re-reads an edited RULES.md after newSession()", async () => {
-		await expectStickyRuleReload(session => session.newSession(), { seedInitial: true });
+	it("re-reads an edited project RULES.md after newSession()", async () => {
+		await expectStickyRuleReload(session => session.newSession(), { seedInitial: true, scope: "project" });
 	});
 
-	it("picks up a RULES.md created after startup on resetSessionContext()", async () => {
-		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: false });
+	it("picks up a project RULES.md created after startup on resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: false, scope: "project" });
+	});
+
+	it("re-reads an edited user RULES.md after resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: true, scope: "user" });
+	});
+
+	it("picks up a user RULES.md created after startup on resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: false, scope: "user" });
 	});
 });
 

--- a/packages/coding-agent/test/agent-session-rules-reload.test.ts
+++ b/packages/coding-agent/test/agent-session-rules-reload.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for sticky `RULES.md` reload on in-process session reset.
+ *
+ * `RULES.md` is a sticky always-apply rule rendered into the system prompt's
+ * generic-rules section. Creating or editing it while omp runs and then
+ * resetting the context (`/clear`) or starting a new session (`/new`) MUST make
+ * the next prompt observe the current file — otherwise the rule set stays frozen
+ * at session creation until the process restarts (issue #10940).
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Api, Model, ModelSpec } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function buildLocalModel(api: string): Model<Api> {
+	return buildModel({
+		id: "rules-reload-model",
+		name: "Rules Reload Model",
+		api,
+		provider: "managed-primary",
+		baseUrl: "http://127.0.0.1:8080/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 4096,
+		maxTokens: 1024,
+	} as ModelSpec<Api>) as Model<Api>;
+}
+
+async function expectStickyRuleReload(
+	reset: (session: AgentSession) => Promise<unknown>,
+	opts: { seedInitial: boolean },
+): Promise<void> {
+	using tempDir = TempDir.createSync("@pi-rules-reload-");
+	const marker = Bun.nanoseconds().toString(36);
+	const original = `ORIGINAL_STICKY_${marker}`;
+	const updated = `UPDATED_STICKY_${marker}`;
+	// Project-scope sticky rule: nearest `.omp/RULES.md` walking up from cwd.
+	const rulesMd = path.join(tempDir.path(), ".omp", "RULES.md");
+	if (opts.seedInitial) {
+		await fs.mkdir(path.dirname(rulesMd), { recursive: true });
+		await fs.writeFile(rulesMd, original);
+	}
+
+	const api = `rules-reload-${marker}`;
+	const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+	authStorage.setRuntimeApiKey("managed-primary", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+
+	const { session } = await createAgentSession({
+		cwd: tempDir.path(),
+		agentDir: tempDir.path(),
+		sessionManager: SessionManager.inMemory(tempDir.path()),
+		authStorage,
+		modelRegistry,
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		model: buildLocalModel(api),
+		disableExtensionDiscovery: true,
+		skills: [],
+		// rules intentionally omitted so discovery runs against disk.
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		skipPythonPreflight: true,
+	});
+
+	try {
+		await session.refreshBaseSystemPrompt();
+		if (opts.seedInitial) {
+			expect(session.systemPrompt.join("\n")).toContain(original);
+		} else {
+			expect(session.systemPrompt.join("\n")).not.toContain(updated);
+		}
+
+		await fs.mkdir(path.dirname(rulesMd), { recursive: true });
+		await fs.writeFile(rulesMd, updated);
+		expect(await reset(session)).toBeTruthy();
+
+		const rebuilt = session.systemPrompt.join("\n");
+		expect(rebuilt).toContain(updated);
+		if (opts.seedInitial) expect(rebuilt).not.toContain(original);
+	} finally {
+		await session.dispose();
+		authStorage.close();
+	}
+}
+
+describe("AgentSession sticky RULES.md reload on session reset", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("re-reads an edited RULES.md after resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: true });
+	});
+
+	it("re-reads an edited RULES.md after newSession()", async () => {
+		await expectStickyRuleReload(session => session.newSession(), { seedInitial: true });
+	});
+
+	it("picks up a RULES.md created after startup on resetSessionContext()", async () => {
+		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: false });
+	});
+});

--- a/packages/coding-agent/test/agent-session-rules-reload.test.ts
+++ b/packages/coding-agent/test/agent-session-rules-reload.test.ts
@@ -35,6 +35,31 @@ function buildLocalModel(api: string): Model<Api> {
 	} as ModelSpec<Api>) as Model<Api>;
 }
 
+async function createReloadSession(tempDir: TempDir): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
+	const marker = Bun.nanoseconds().toString(36);
+	const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+	authStorage.setRuntimeApiKey("managed-primary", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+	const { session } = await createAgentSession({
+		cwd: tempDir.path(),
+		agentDir: tempDir.path(),
+		sessionManager: SessionManager.inMemory(tempDir.path()),
+		authStorage,
+		modelRegistry,
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		model: buildLocalModel(`rules-reload-${marker}`),
+		disableExtensionDiscovery: true,
+		skills: [],
+		// rules intentionally omitted so discovery runs against disk.
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		skipPythonPreflight: true,
+	});
+	return { session, authStorage };
+}
+
 async function expectStickyRuleReload(
 	reset: (session: AgentSession) => Promise<unknown>,
 	opts: { seedInitial: boolean },
@@ -50,28 +75,7 @@ async function expectStickyRuleReload(
 		await fs.writeFile(rulesMd, original);
 	}
 
-	const api = `rules-reload-${marker}`;
-	const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
-	authStorage.setRuntimeApiKey("managed-primary", "test-key");
-	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
-
-	const { session } = await createAgentSession({
-		cwd: tempDir.path(),
-		agentDir: tempDir.path(),
-		sessionManager: SessionManager.inMemory(tempDir.path()),
-		authStorage,
-		modelRegistry,
-		settings: Settings.isolated({ "compaction.enabled": false }),
-		model: buildLocalModel(api),
-		disableExtensionDiscovery: true,
-		skills: [],
-		// rules intentionally omitted so discovery runs against disk.
-		promptTemplates: [],
-		slashCommands: [],
-		enableMCP: false,
-		enableLsp: false,
-		skipPythonPreflight: true,
-	});
+	const { session, authStorage } = await createReloadSession(tempDir);
 
 	try {
 		await session.refreshBaseSystemPrompt();
@@ -109,5 +113,55 @@ describe("AgentSession sticky RULES.md reload on session reset", () => {
 
 	it("picks up a RULES.md created after startup on resetSessionContext()", async () => {
 		await expectStickyRuleReload(session => session.resetSessionContext(), { seedInitial: false });
+	});
+});
+
+describe("AgentSession session-local rule snapshot reload on session reset", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("resolves rule://<name> for a rulebook rule created after startup once the context resets", async () => {
+		using tempDir = TempDir.createSync("@pi-rules-reload-book-");
+		const marker = Bun.nanoseconds().toString(36);
+		const body = `RULEBOOK_BODY_${marker}`;
+		const ruleName = `reload-book-${marker}`;
+		// Empty `.omp/rules/` keeps the project config scope present without any rulebook rule yet.
+		const rulesDir = path.join(tempDir.path(), ".omp", "rules");
+		await fs.mkdir(rulesDir, { recursive: true });
+
+		const { session, authStorage } = await createReloadSession(tempDir);
+		const readRule = async (label: string): Promise<string> => {
+			const readTool = session.getToolByName("read");
+			expect(readTool).toBeDefined();
+			try {
+				const result = await readTool!.execute(
+					`${label}-${marker}`,
+					{ path: `rule://${ruleName}` },
+					new AbortController().signal,
+				);
+				return result.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			} catch (err) {
+				return String(err);
+			}
+		};
+
+		try {
+			await session.refreshBaseSystemPrompt();
+			// The read tool cannot resolve a rule that discovery has not seen yet.
+			expect(await readRule("before")).not.toContain(body);
+
+			await fs.writeFile(
+				path.join(rulesDir, `${ruleName}.md`),
+				`---\ndescription: reloaded rulebook rule\n---\n${body}\n`,
+			);
+			expect(await session.resetSessionContext()).toBeTruthy();
+
+			// After the reset, `toolSession.activeRules` reflects the new snapshot, so `rule://` resolves.
+			expect(await readRule("after")).toContain(body);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/capability/rule-buckets.test.ts
+++ b/packages/coding-agent/test/capability/rule-buckets.test.ts
@@ -36,6 +36,51 @@ describe("bucketRules", () => {
 		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["no-foo"]);
 	});
 
+	it("replaces an edited TTSR rule while preserving its injection state", () => {
+		const mgr = new TtsrManager({
+			enabled: true,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "after-gap",
+			repeatGap: 0,
+		});
+		const original = makeRule({ name: "guard", condition: ["OLD"], content: "old content" });
+		bucketRules([original], mgr);
+		mgr.markInjected([original]);
+
+		const updated = makeRule({ name: "guard", condition: ["NEW"], content: "new content" });
+		bucketRules([updated], mgr, { replaceTtsrRules: true });
+
+		expect(mgr.getInjectedRuleNames()).toEqual(["guard"]);
+		expect(mgr.getRules()).toEqual([updated]);
+		expect(mgr.checkDelta("OLD", { source: "text" })).toEqual([]);
+		mgr.resetBuffer();
+		expect(mgr.checkDelta("NEW", { source: "text" })).toEqual([updated]);
+	});
+
+	it("removes stale TTSR registrations and injection state after rename or deletion", () => {
+		const mgr = new TtsrManager();
+		const original = makeRule({ name: "old-guard", condition: ["OLD"] });
+		bucketRules([original], mgr);
+		mgr.markInjected([original]);
+
+		const renamed = makeRule({ name: "new-guard", condition: ["NEW"] });
+		bucketRules([renamed], mgr, { replaceTtsrRules: true });
+
+		expect(mgr.getRules()).toEqual([renamed]);
+		expect(mgr.getInjectedRuleNames()).toEqual([]);
+		expect(mgr.checkDelta("OLD", { source: "text" })).toEqual([]);
+		mgr.resetBuffer();
+		expect(mgr.checkDelta("NEW", { source: "text" })).toEqual([renamed]);
+
+		mgr.markInjected([renamed]);
+		bucketRules([], mgr, { replaceTtsrRules: true });
+
+		expect(mgr.hasRules()).toBe(false);
+		expect(mgr.getInjectedRuleNames()).toEqual([]);
+		expect(mgr.checkDelta("NEW", { source: "text" })).toEqual([]);
+	});
+
 	it("registers an ast-only rule as TTSR and excludes it from rulebook/always buckets", () => {
 		const mgr = new TtsrManager();
 		const ttsr = makeRule({ name: "no-console", astCondition: ["console.log($A)"], description: "blocks console" });

--- a/packages/coding-agent/test/modes/controllers/omfg-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/omfg-controller.test.ts
@@ -10,6 +10,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { Container, type TUI } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { clearCache, readDirEntries } from "@oh-my-pi/pi-coding-agent/capability/fs";
 
 const PROJECT_OPTION = "This project (.omp/rules)";
 
@@ -130,6 +131,7 @@ beforeAll(async () => {
 
 afterEach(async () => {
 	vi.restoreAllMocks();
+	clearCache();
 	while (tempRoots.length > 0) {
 		const root = tempRoots.pop();
 		if (root) {
@@ -172,5 +174,47 @@ describe("OmfgController", () => {
 		expect(signal?.aborted).toBe(true);
 		expect(controller.hasActiveRequest()).toBe(false);
 		expect(await Bun.file(path.join(harness.projectDir, ".omp", "rules", "ts-no-any.md")).exists()).toBe(false);
+	});
+
+	it("invalidates the discovery cache after saving so rediscovery observes the new rule", async () => {
+		clearCache();
+		const runEphemeralTurn = vi.fn<RunEphemeralTurn>(async () => ({
+			replyText: JSON.stringify({
+				name: "ts-no-any",
+				description: "No any in TS edits",
+				condition: ": any",
+				scope: ["tool:edit(*.ts)", "tool:write(*.ts)"],
+				body: "Use `unknown` instead.",
+			}),
+			assistantMessage: createAssistantMessage([{ type: "text", text: "done" }]),
+		}));
+		const harness = await createHarness({
+			runEphemeralTurn,
+			messages: createMatchingMessages(),
+			selectorChoice: PROJECT_OPTION,
+		});
+		const rulesDir = path.join(harness.projectDir, ".omp", "rules");
+
+		// Warm the discovery cache with the pre-save (absent) directory snapshot, the
+		// state the mid-session rule rediscovery would read on the next prompt rebuild.
+		expect(await readDirEntries(rulesDir)).toHaveLength(0);
+
+		// #registerLive() calls ttsrManager.addRule right after the write + cache
+		// invalidation, so resolving on it awaits the real save signal (no timers).
+		const registered = Promise.withResolvers<void>();
+		harness.ttsrAddRule.mockImplementation(() => {
+			registered.resolve();
+			return true;
+		});
+
+		await new OmfgController(harness.ctx).start("stop using any");
+		await registered.promise;
+
+		const savedRuleFile = path.join(rulesDir, "ts-no-any.md");
+		expect(await Bun.file(savedRuleFile).exists()).toBe(true);
+		expect(harness.ttsrAddRule).toHaveBeenCalled();
+		// Without the post-write invalidation the cache would still serve the empty
+		// snapshot, and `replaceTtsrRules` would evict the freshly registered rule.
+		expect((await readDirEntries(rulesDir)).map(entry => entry.name)).toContain("ts-no-any.md");
 	});
 });


### PR DESCRIPTION
## Repro
With no `RULES.md` present, start omp; while it runs, create a sticky `RULES.md` (e.g. `~/.omp/agent/RULES.md` or project `.omp/RULES.md`); run `/clear` (or `/new`). The rule never reaches the model until omp is restarted. The same staleness applies to editing an existing `RULES.md`. Reproduced with `bun test packages/coding-agent/test/agent-session-rules-reload.test.ts`: a project `.omp/RULES.md` present at session creation renders into the base system prompt, but after editing/creating it and calling `resetSessionContext()` (`/clear`) or `newSession()` (`/new`) the rebuilt prompt still lacks the new content.

## Cause
`/clear` (`AgentSession.resetSessionContext`) and `/new` (`#runNewSessionFlow`) already call `resetCapabilities()` — which fully clears the `capability/fs.ts` content+dir cache — and then `refreshBaseSystemPrompt()`. That is why edited `AGENTS.md` context files are picked up (issue #9273 / PR #9275): the `rebuildSystemPrompt` closure in `sdk.ts` re-runs `discoverContextFiles` on every session-scoped rebuild. The rule pipeline was missed: `rulebookRules`/`alwaysApplyRules` (where a sticky `RULES.md` lands) are computed once by `discoverTtsrRules` at session creation and captured as `const` in the closure, so they stay frozen for the process lifetime while context files refresh correctly.

## Fix
- `sdk.ts`: make `rulebookRules`/`alwaysApplyRules` mutable and re-discover + re-bucket rules inside `rebuildSystemPrompt` whenever a session is present and rules were not SDK-supplied, mirroring the existing context-file refresh. The same `TtsrManager` is reused so restored TTSR registration/injection state survives; `setActiveRules` is refreshed for top-level sessions so `rule://` stays consistent.
- `capability/rule-buckets.ts`: `bucketRules` now treats a TTSR rule the manager already tracks as TTSR (`hasRule` before `addRule`), making re-bucketing on an already-populated manager idempotent instead of leaking such rules into the rulebook bucket.
- `export/ttsr.ts`: add `TtsrManager.hasRule(name)`.
- Regression test `agent-session-rules-reload.test.ts` covering `/clear`, `/new`, and the create-after-startup case.

## Verification
`bun test packages/coding-agent/test/agent-session-rules-reload.test.ts` — 3/3 pass (failed before the fix). Also green: `capability/rule-buckets.test.ts`, `discovery/builtin-rules-md.test.ts`, `agent-session-context-file-reload.test.ts`, `agent-session-tool-rebuild-skip.test.ts`, `ttsr-inline-flags-scope.test.ts`, `cli/ttsr-cli.test.ts` (91 tests). `bun check` passes. Fixes #10940