### PR TITLE
fix(task): expose native job IDs in progress

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the `retry.waitForUsageReset` setting: when a provider reports usage-limit exhaustion with a reset time (5-hour or weekly quota windows on any provider), the session sleeps until the reset instead of failing fast past `retry.maxDelayMs`.
 - Added opt-in `bash.allowCompoundCommands` approval for conservative literal `&&` chains, with ordered per-segment rules and normal bash policy fallback for unmatched segments. The opt-in requires a positively classified POSIX-quoting shell; incompatible and unknown shells retain legacy approval. Whole-chain denies take precedence over earlier prompts.
+- Expose the collision-resolved native manager job ID as `AgentProgress.jobId`, preserving `id` as the child agent identity for exact per-dispatch correlation.
 
 ### Fixed
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -932,6 +932,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						if (failed) failedCount += 1;
 					},
 				});
+				spawn.progress.jobId = jobId;
 				if (started.length === 0) primaryJobId = jobId;
 				started.push({ agentId: spawn.agentId, jobId });
 			} catch (error) {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -417,6 +417,8 @@ export interface YieldItem {
 export interface AgentProgress {
 	index: number;
 	id: string;
+	/** Actual async manager job id; differs from `id` when registration resolves a collision. */
+	jobId?: string;
 	agent: string;
 	agentSource: AgentSource;
 	status: "pending" | "running" | "completed" | "failed" | "aborted";

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -392,6 +392,10 @@ describe("task.batch spawning", () => {
 		expect(text).toContain("- `Alpha`");
 		expect(text).toContain("- `Beta`");
 		expect(result.details?.progress?.map(progress => progress.id)).toEqual(["Alpha", "Beta"]);
+		expect(result.details?.progress?.map(({ id, jobId }) => ({ id, jobId }))).toEqual([
+			{ id: "Alpha", jobId: "Alpha" },
+			{ id: "Beta", jobId: "Beta" },
+		]);
 		expect(result.details?.async?.state).toBe("running");
 
 		const alphaJob = manager.getJob("Alpha");
@@ -414,6 +418,34 @@ describe("task.batch spawning", () => {
 		expect(byId.get("Beta")?.outputSchemaMode).toBe("permissive");
 		expect(seen.map(spawn => spawn.assignment).sort()).toEqual(["Do A.", "Do B."]);
 		for (const spawn of seen) expect(spawn.parentAgentId).toBe("ParentA");
+	});
+
+	it("binds identical task text to independent jobs by dispatch identity", async () => {
+		mockDiscovery();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => makeResult(options.id ?? "?"));
+
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({ manager, settings: { "async.enabled": true, "task.batch": true } }),
+		);
+		const result = await tool.execute("tc-identical", {
+			context: "Shared context.",
+			tasks: [
+				{ name: "SameAlpha", task: "Run the same assignment." },
+				{ name: "SameBeta", task: "Run the same assignment." },
+			],
+		} as TaskParams);
+
+		expect(result.details?.progress?.map(({ id, jobId, assignment }) => ({ id, jobId, assignment }))).toEqual([
+			{ id: "SameAlpha", jobId: "SameAlpha", assignment: "Run the same assignment." },
+			{ id: "SameBeta", jobId: "SameBeta", assignment: "Run the same assignment." },
+		]);
+		const alphaJob = manager.getJob("SameAlpha");
+		const betaJob = manager.getJob("SameBeta");
+		expect(alphaJob).toBeDefined();
+		expect(betaJob).toBeDefined();
+		expect(alphaJob).not.toBe(betaJob);
+		await Promise.all([alphaJob!.promise, betaJob!.promise]);
 	});
 
 	it("routes each mixed-agent item through its selected definition while preserving caller overrides", async () => {

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -96,6 +96,19 @@ describe("task progress rendering", () => {
 		expect(rawRow0).toBe(rawRow1);
 	});
 
+	it("does not render the async manager job id", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const options: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		const legacy = runningProgress({ id: "Foo", description: "Build it" });
+		const bound = { ...legacy, jobId: "Foo-2" };
+		const render = (progress: AgentProgress): readonly string[] =>
+			taskToolRenderer
+				.renderResult({ content: [{ type: "text", text: "" }], details: detailsFor(progress) }, options, theme)
+				.render(120);
+
+		expect(render(bound)).toEqual(render(legacy));
+	});
+
 	// Regression: the ⟨agent⟩ type badge must survive past the streaming call
 	// preview — it stays on live progress rows and on finished result rows, and
 	// the generic `task` worker stays bare.

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -20,7 +20,7 @@ import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
-import type { AgentDefinition, SingleResult, TaskParams } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, SingleResult, TaskParams, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
 const taskAgent: AgentDefinition = {
@@ -122,11 +122,19 @@ describe("task spawn routing", () => {
 			createSession({ manager, settings: { "task.agentModelOverrides": { task: "openai/gpt-4.1-mini" } } }),
 		);
 
-		const result = await tool.execute("tc-spawn", {
-			agent: "task",
-			name: "Spawnling",
-			task: "Do the thing.",
-		} as TaskParams);
+		const updates: TaskToolDetails[] = [];
+		const result = await tool.execute(
+			"tc-spawn",
+			{
+				agent: "task",
+				name: "Spawnling",
+				task: "Do the thing.",
+			} as TaskParams,
+			undefined,
+			update => {
+				if (update.details) updates.push(update.details);
+			},
+		);
 
 		// Tool returned while the job body is still gated on the deferred.
 		const text = getFirstText(result);
@@ -134,12 +142,24 @@ describe("task spawn routing", () => {
 		const jobId = result.details?.async?.jobId;
 		expect(jobId).toBeTruthy();
 		expect(text).toContain(`job \`${jobId}\``);
+		expect(result.details?.progress).toMatchObject([{ id: "Spawnling", jobId }]);
+		// Existing consumers that key progress by dispatch id continue to see
+		// the original shape; the manager id is additive.
+		expect(result.details?.progress?.map(({ id, status }) => ({ id, status }))).toEqual([
+			{ id: "Spawnling", status: expect.stringMatching(/pending|running/) },
+		]);
 		const job = manager.getJob(jobId!);
 		expect(job?.status).toBe("running");
 		expect(job?.resultText).toBeUndefined();
 
 		gate.resolve();
 		await job!.promise;
+		expect(updates.length).toBeGreaterThan(0);
+		for (const update of updates) {
+			const spawn = update.progress?.find(progress => progress.id === "Spawnling");
+			if (spawn) expect(spawn.jobId).toBe(jobId);
+		}
+		expect(updates.at(-1)?.progress).toMatchObject([{ id: "Spawnling", jobId, status: "completed" }]);
 
 		expect(job!.status).toBe("completed");
 		expect(job!.resultText).toContain("Spawnling is now idle");
@@ -283,6 +303,7 @@ describe("task spawn routing", () => {
 
 		const jobId = result.details?.async?.jobId;
 		expect(jobId).toBe("Foo-2");
+		expect(result.details?.progress).toMatchObject([{ id: "Foo", jobId: "Foo-2" }]);
 		const job = manager.getJob(jobId!);
 		await job!.promise;
 


### PR DESCRIPTION
## Contract and scope

Expose optional AgentProgress.jobId as the exact manager-returned ID; progress.id remains the child agent ID. Production changes remain one documented field and one post-registration assignment. Head is ddce3599c63b5ff7100e07d62a76ab8ecec912cb after the changelog-only review follow-up; production patch remains b974caedb54f41b25b353e749285c4bd84651bdf.

Both PRs remain separate; no rebase or production semantic change. Original fork points: #10928 5964a0f7649275bcde818f20073193fd032451f2; #10948 be6cb8217cd4c1dafcc86793ae5d809ea4d7396a. Both merge cleanly into the tested current main.

## Exact current-main combined proof

- Main: `feba7f113fd041542afac0f44c0d3529b81c50a6`.
- Local integration: `e874b613654fd493b2bcb45c832e68f8d1a9a23e`. Reproduce by cherry-picking original delivery 874fe1f20bc5f906812ff52c0a6a5698a59c191e, dispatch b974caedb54f41b25b353e749285c4bd84651bdf, then proof-only follow-up 26e02fc02b2eab374aedf04bc931dc8f4a6555e9 and changelog-only follow-up ddce3599c63b5ff7100e07d62a76ab8ecec912cb.
- **97/97 tests, 417 assertions** across task spawn, batch, progress rendering, blocking split, async manager, and async delivery.
- Collision binding, identical work, distinct IDs, real completed/failed delivery, eviction reconstruction, spoof resistance, and existing consumers pass.
- Coding-agent typecheck and changed-TypeScript-file oxlint/oxfmt pass. Package formatting scripts do not include Markdown; the added changelog line follows its existing style.
- Paired dispatch and delivery model-facing bytes equal the unpatched main.
- Actual combined native host through unchanged Brain factory/Python persistence passes: exact binding, wrong-agent and unknown-job rejection, restart recovery, mixed hub/async dedup, and immutable receipts. Worker executor stubbed; zero provider calls.

## Cancellation boundary — corrected evidence

The native manager suppresses automatic delivery after cancellation. A real manager probe confirms completed/failed callbacks and **no cancelled callback**. This is existing policy, not changed by either patch. The former fabricated cancelled-row test proved formatting only and has been removed from lifecycle coverage. **Automatic cancelled delivery is not claimed PASS.** Supporting it would need a separately authorized policy change; these additive patches do not implement one.

## Upstream qualification

Ready for review. Workflow runs reporting `action_required` with zero jobs are approval-pending, not failed CI. Approval and maintainer review requested in comments; formal reviewer assignment is denied by fork-author permissions. No claim of clean upstream CI or released capability. Historical Windows full-suite timeouts are not patch-failure evidence.
