### PR TITLE
fix(eval): validate bridged tool arguments before execution

### DIFF
--- a/packages/agent/test/yield.test.ts
+++ b/packages/agent/test/yield.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { ExponentialYield, YieldGate } from "@oh-my-pi/pi-agent-core/utils/yield";
+import { YieldGate } from "@oh-my-pi/pi-agent-core/utils/yield";
 
 const YIELD_INTERVAL_MS = 50;
 
@@ -65,33 +65,34 @@ describe("YieldGate.yieldIfDue", () => {
 });
 
 describe("ExponentialYield.race", () => {
-	it("returns the racer's value as soon as it settles", async () => {
-		const ey = new ExponentialYield({ minMs: 5_000, maxMs: 10_000 });
-		const racer = Bun.sleep(10).then(() => "done");
-		const start = performance.now();
-		const out = await ey.race([racer]);
-		const elapsed = performance.now() - start;
-		expect(out).toBe("done");
-		// The 5s yield must not have delayed us: settle within a comfy margin.
-		expect(elapsed).toBeLessThan(500);
-	});
-
 	it("cancels the losing sleep so it does not keep the loop alive", async () => {
-		// If the losing Bun.sleep weren't cancelled, this test would block for
-		// the full minMs after the racer wins, since the prior implementation
-		// kept fresh timers ticking. We pick a minMs far larger than the racer
-		// delay and assert we return well before it.
-		const ey = new ExponentialYield({ minMs: 2_000, maxMs: 2_000 });
-		const racer = Bun.sleep(20).then(() => 42);
-		const start = performance.now();
-		const out = await ey.race([racer]);
-		const elapsed = performance.now() - start;
-		expect(out).toBe(42);
-		expect(elapsed).toBeLessThan(500);
-
-		// After race resolves, ensure the AbortController-driven cancel really
-		// unblocked the underlying timer: a short follow-up sleep should not
-		// be perturbed by residual pending timers. (Sanity: this returns.)
-		await Bun.sleep(30);
-	});
+		// A child process makes event-loop liveness observable without measuring
+		// how quickly a loaded CI worker schedules a short racer. If race() leaves
+		// its losing timer behind, the child cannot exit before the watchdog.
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`
+					import { ExponentialYield } from "./src/utils/yield.ts";
+					const ey = new ExponentialYield({ minMs: 60_000, maxMs: 60_000 });
+					const out = await ey.race([Promise.resolve(42)]);
+					if (out !== 42) process.exit(1);
+				`,
+			],
+			{
+				cwd: import.meta.dir + "/..",
+				stdin: "ignore",
+				stdout: "ignore",
+				stderr: "inherit",
+			},
+		);
+		const watchdog = setTimeout(() => child.kill(), 10_000);
+		try {
+			expect(await child.exited).toBe(0);
+		} finally {
+			clearTimeout(watchdog);
+			child.kill();
+		}
+	}, 15_000);
 });

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -204,17 +204,21 @@ function requiresOnlyPropertyPresence(schema: unknown, key: string, root: unknow
 /** Whether any same-instance schema declaration or constraint owns this property name. */
 export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 	const root = schema;
-	const visited = new WeakSet<object>();
-	const visit = (node: unknown): boolean => {
+	const visited = new WeakMap<object, number>();
+	const visit = (node: unknown, context: "positive" | "negative" | "predicate" = "positive"): boolean => {
 		if (!isJsonObject(node)) return false;
-		if (visited.has(node)) return false;
-		visited.add(node);
+		const contextBit = context === "positive" ? 1 : context === "negative" ? 2 : 4;
+		const previousContexts = visited.get(node) ?? 0;
+		if (previousContexts & contextBit) return false;
+		visited.set(node, previousContexts | contextBit);
 		if (isJsonObject(node.const) && Object.hasOwn(node.const, key)) return true;
 		if (Array.isArray(node.enum) && node.enum.some(value => isJsonObject(value) && Object.hasOwn(value, key))) {
 			return true;
 		}
 		const properties = node.properties;
-		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
+		if (isJsonObject(properties) && Object.hasOwn(properties, key)) {
+			return properties[key] !== false || context !== "positive";
+		}
 		const required = node.required;
 		if (Array.isArray(required) && required.includes(key)) return true;
 		if (
@@ -237,18 +241,24 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		if (isJsonObject(node.additionalProperties)) return true;
 		for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
 			const branches = node[keyword];
-			if (Array.isArray(branches) && branches.some(visit)) return true;
+			if (Array.isArray(branches) && branches.some(branch => visit(branch, context))) return true;
 		}
-		for (const keyword of ["if", "then", "else"] as const) {
-			if (visit(node[keyword])) return true;
+		if (visit(node.if, "predicate")) return true;
+		for (const keyword of ["then", "else"] as const) {
+			if (visit(node[keyword], context)) return true;
 		}
 		// `not: { required: [key] }` forbids the name rather than declaring data.
 		// Negated value constraints still own their inputs and must be validated.
-		if (!requiresOnlyPropertyPresence(node.not, key, root) && visit(node.not)) return true;
+		if (
+			(context !== "positive" || !requiresOnlyPropertyPresence(node.not, key, root)) &&
+			visit(node.not, context === "predicate" ? "predicate" : context === "positive" ? "negative" : "positive")
+		) {
+			return true;
+		}
 		const dependentSchemas = node.dependentSchemas;
 		if (isJsonObject(dependentSchemas)) {
 			if (Object.hasOwn(dependentSchemas, key)) return true;
-			if (Object.values(dependentSchemas).some(visit)) return true;
+			if (Object.values(dependentSchemas).some(dependency => visit(dependency, context))) return true;
 		}
 		const dependentRequired = node.dependentRequired;
 		if (isJsonObject(dependentRequired)) {
@@ -262,12 +272,12 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 			if (Object.hasOwn(dependencies, key)) return true;
 			for (const dependency of Object.values(dependencies)) {
 				if (Array.isArray(dependency) && dependency.includes(key)) return true;
-				if (visit(dependency)) return true;
+				if (visit(dependency, context)) return true;
 			}
 		}
 		if (typeof node.$ref === "string") {
 			const resolved = resolveLocalRef(root, node.$ref);
-			if (resolved !== undefined && visit(resolved)) return true;
+			if (resolved !== undefined && visit(resolved, context)) return true;
 		}
 		return false;
 	};

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -196,8 +196,8 @@ function requiresOnlyPropertyPresence(schema: unknown, key: string, root: unknow
 	return (
 		(schema.type === undefined || schema.type === "object") &&
 		Array.isArray(schema.required) &&
-		schema.required.length === 1 &&
-		schema.required[0] === key
+		schema.required.includes(key) &&
+		schema.required.every(entry => typeof entry === "string")
 	);
 }
 

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -181,6 +181,10 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		if (!isJsonObject(node)) return false;
 		if (visited.has(node)) return false;
 		visited.add(node);
+		if (isJsonObject(node.const) && Object.hasOwn(node.const, key)) return true;
+		if (Array.isArray(node.enum) && node.enum.some(value => isJsonObject(value) && Object.hasOwn(value, key))) {
+			return true;
+		}
 		const properties = node.properties;
 		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
 		const required = node.required;

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -173,6 +173,29 @@ function resolveLocalRef(root: unknown, ref: string): unknown | undefined {
 	return current;
 }
 
+/** Return whether a schema node or same-instance composed/ref branch declares a property. */
+export function schemaDefinesProperty(schema: unknown, key: string): boolean {
+	const root = schema;
+	const visited = new WeakSet<object>();
+	const visit = (node: unknown): boolean => {
+		if (!isJsonObject(node)) return false;
+		if (visited.has(node)) return false;
+		visited.add(node);
+		const properties = node.properties;
+		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
+		for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
+			const branches = node[keyword];
+			if (Array.isArray(branches) && branches.some(visit)) return true;
+		}
+		if (typeof node.$ref === "string") {
+			const resolved = resolveLocalRef(root, node.$ref);
+			if (resolved !== undefined && visit(resolved)) return true;
+		}
+		return false;
+	};
+	return visit(schema);
+}
+
 /** Resolve a `#/path/to/node` pointer against the root schema. Returns `undefined` for external/unsupported refs. */
 
 function isRequiredSet(value: unknown): value is string[] {

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -173,6 +173,34 @@ function resolveLocalRef(root: unknown, ref: string): unknown | undefined {
 	return current;
 }
 
+/** A presence-only constraint, as distinct from restrictions on a property's value. */
+function requiresOnlyPropertyPresence(schema: unknown, key: string, root: unknown, depth = 0): boolean {
+	if (!isJsonObject(schema) || depth >= MAX_REF_DEPTH) return false;
+	for (const keyword of Object.keys(schema)) {
+		switch (keyword) {
+			case "required":
+			case "type":
+			case "$ref":
+			case "description":
+			case "title":
+			case "$comment":
+				break;
+			default:
+				return false;
+		}
+	}
+	if ("$ref" in schema) {
+		if (typeof schema.$ref !== "string" || schema.required !== undefined || schema.type !== undefined) return false;
+		return requiresOnlyPropertyPresence(resolveLocalRef(root, schema.$ref), key, root, depth + 1);
+	}
+	return (
+		(schema.type === undefined || schema.type === "object") &&
+		Array.isArray(schema.required) &&
+		schema.required.length === 1 &&
+		schema.required[0] === key
+	);
+}
+
 /** Whether any same-instance schema declaration or constraint owns this property name. */
 export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 	const root = schema;
@@ -211,9 +239,12 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 			const branches = node[keyword];
 			if (Array.isArray(branches) && branches.some(visit)) return true;
 		}
-		for (const keyword of ["if", "then", "else", "not"] as const) {
+		for (const keyword of ["if", "then", "else"] as const) {
 			if (visit(node[keyword])) return true;
 		}
+		// `not: { required: [key] }` forbids the name rather than declaring data.
+		// Negated value constraints still own their inputs and must be validated.
+		if (!requiresOnlyPropertyPresence(node.not, key, root) && visit(node.not)) return true;
 		const dependentSchemas = node.dependentSchemas;
 		if (isJsonObject(dependentSchemas)) {
 			if (Object.hasOwn(dependentSchemas, key)) return true;

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -208,6 +208,21 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 			if (Object.hasOwn(dependentSchemas, key)) return true;
 			if (Object.values(dependentSchemas).some(visit)) return true;
 		}
+		const dependentRequired = node.dependentRequired;
+		if (isJsonObject(dependentRequired)) {
+			if (Object.hasOwn(dependentRequired, key)) return true;
+			for (const dependencies of Object.values(dependentRequired)) {
+				if (Array.isArray(dependencies) && dependencies.includes(key)) return true;
+			}
+		}
+		const dependencies = node.dependencies;
+		if (isJsonObject(dependencies)) {
+			if (Object.hasOwn(dependencies, key)) return true;
+			for (const dependency of Object.values(dependencies)) {
+				if (Array.isArray(dependency) && dependency.includes(key)) return true;
+				if (visit(dependency)) return true;
+			}
+		}
 		if (typeof node.$ref === "string") {
 			const resolved = resolveLocalRef(root, node.$ref);
 			if (resolved !== undefined && visit(resolved)) return true;

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -185,7 +185,11 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
 		const required = node.required;
 		if (Array.isArray(required) && required.includes(key)) return true;
-		if (node.propertyNames !== undefined && validateSchemaValueInRoot(node.propertyNames, key, root).success) {
+		if (
+			node.propertyNames !== undefined &&
+			node.additionalProperties !== false &&
+			validateSchemaValueInRoot(node.propertyNames, key, root).success
+		) {
 			return true;
 		}
 		const patternProperties = node.patternProperties;

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -185,6 +185,9 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
 		const required = node.required;
 		if (Array.isArray(required) && required.includes(key)) return true;
+		if (node.propertyNames !== undefined && validateSchemaValueInRoot(node.propertyNames, key, root).success) {
+			return true;
+		}
 		const patternProperties = node.patternProperties;
 		if (isJsonObject(patternProperties)) {
 			for (const pattern of Object.keys(patternProperties)) {
@@ -674,16 +677,20 @@ function validateNumberKeywords(
 	return valid;
 }
 
-export function validateJsonSchemaValue(schema: unknown, value: unknown): JsonSchemaValidationResult {
+function validateSchemaValueInRoot(schema: unknown, value: unknown, root: unknown): JsonSchemaValidationResult {
 	const issues: JsonSchemaValidationIssue[] = [];
 	const success = validateSchemaNode(
 		schema,
 		value,
 		[],
-		{ root: schema, seenPairs: new Set(), objectIds: new WeakMap(), nextObjectId: { value: 0 }, refDepth: 0 },
+		{ root, seenPairs: new Set(), objectIds: new WeakMap(), nextObjectId: { value: 0 }, refDepth: 0 },
 		issues,
 	);
 	return { success, issues };
+}
+
+export function validateJsonSchemaValue(schema: unknown, value: unknown): JsonSchemaValidationResult {
+	return validateSchemaValueInRoot(schema, value, schema);
 }
 
 export function isJsonSchemaValueValid(schema: unknown, value: unknown): boolean {

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -230,14 +230,17 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		}
 		const patternProperties = node.patternProperties;
 		if (isJsonObject(patternProperties)) {
-			for (const pattern of Object.keys(patternProperties)) {
+			for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
 				try {
-					if (new RegExp(pattern).test(key)) return true;
+					if (new RegExp(pattern).test(key)) {
+						if (patternSchema !== false) return true;
+					}
 				} catch {
 					// Invalid patterns are rejected by validation and cannot declare ownership.
 				}
 			}
 		}
+		if (isJsonObject(node.unevaluatedProperties)) return true;
 		if (isJsonObject(node.additionalProperties)) return true;
 		for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
 			const branches = node[keyword];

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -173,7 +173,7 @@ function resolveLocalRef(root: unknown, ref: string): unknown | undefined {
 	return current;
 }
 
-/** Return whether a schema node or same-instance composed/ref branch declares a property. */
+/** Whether any same-instance schema declaration or constraint owns this property name. */
 export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 	const root = schema;
 	const visited = new WeakSet<object>();
@@ -183,6 +183,19 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 		visited.add(node);
 		const properties = node.properties;
 		if (isJsonObject(properties) && Object.hasOwn(properties, key)) return true;
+		const required = node.required;
+		if (Array.isArray(required) && required.includes(key)) return true;
+		const patternProperties = node.patternProperties;
+		if (isJsonObject(patternProperties)) {
+			for (const pattern of Object.keys(patternProperties)) {
+				try {
+					if (new RegExp(pattern).test(key)) return true;
+				} catch {
+					// Invalid patterns are rejected by validation and cannot declare ownership.
+				}
+			}
+		}
+		if (isJsonObject(node.additionalProperties)) return true;
 		for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
 			const branches = node[keyword];
 			if (Array.isArray(branches) && branches.some(visit)) return true;
@@ -191,7 +204,10 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 			if (visit(node[keyword])) return true;
 		}
 		const dependentSchemas = node.dependentSchemas;
-		if (isJsonObject(dependentSchemas) && Object.values(dependentSchemas).some(visit)) return true;
+		if (isJsonObject(dependentSchemas)) {
+			if (Object.hasOwn(dependentSchemas, key)) return true;
+			if (Object.values(dependentSchemas).some(visit)) return true;
+		}
 		if (typeof node.$ref === "string") {
 			const resolved = resolveLocalRef(root, node.$ref);
 			if (resolved !== undefined && visit(resolved)) return true;

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -187,6 +187,11 @@ export function schemaDefinesProperty(schema: unknown, key: string): boolean {
 			const branches = node[keyword];
 			if (Array.isArray(branches) && branches.some(visit)) return true;
 		}
+		for (const keyword of ["if", "then", "else", "not"] as const) {
+			if (visit(node[keyword])) return true;
+		}
+		const dependentSchemas = node.dependentSchemas;
+		if (isJsonObject(dependentSchemas) && Object.values(dependentSchemas).some(visit)) return true;
 		if (typeof node.$ref === "string") {
 			const resolved = resolveLocalRef(root, node.$ref);
 			if (resolved !== undefined && visit(resolved)) return true;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `todo` and other tools called through eval rejecting optional `None`/`null` arguments that direct tool calls accept.
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -1,4 +1,5 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { validateToolArguments } from "@oh-my-pi/pi-ai";
 import { isRecord } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import type { ToolSession } from "../../tools";
@@ -201,8 +202,39 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 		throw new ToolError(`\`${name}\` cannot run through the eval bridge; call the direct \`${name}\` tool.`);
 	}
 	const tool = getTool(options.session, name);
-	const normalizedArgs = normalizeArgs(args);
 	const toolCallId = `js-${name}-${crypto.randomUUID()}`;
+	const suppliedIntent = isRecord(args) ? args[INTENT_FIELD] : undefined;
+	const validationArgs = isRecord(args) ? { ...args } : args;
+	if (isRecord(validationArgs)) delete validationArgs[INTENT_FIELD];
+	let validatedArgs: unknown;
+	try {
+		validatedArgs = validateToolArguments(tool, {
+			type: "toolCall",
+			id: toolCallId,
+			name,
+			arguments: validationArgs as Record<string, unknown>,
+		});
+	} catch (error) {
+		if (!tool.lenientArgValidation) {
+			options.emitStatus?.({
+				op: name,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		}
+		if (isRecord(validationArgs)) {
+			const fallback = { ...validationArgs };
+			delete fallback.__parseError;
+			delete fallback.__rawJson;
+			validatedArgs = fallback;
+		} else {
+			validatedArgs = validationArgs;
+		}
+	}
+	if (isRecord(validatedArgs) && suppliedIntent !== undefined) {
+		validatedArgs[INTENT_FIELD] = suppliedIntent;
+	}
+	const normalizedArgs = normalizeArgs(validatedArgs);
 	try {
 		const result = await tool.execute(
 			toolCallId,

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -1,9 +1,10 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { validateToolArguments } from "@oh-my-pi/pi-ai";
+import { toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
 import { isRecord } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import type { ToolSession } from "../../tools";
 import { ToolError } from "../../tools/tool-errors";
+import { schemaDeclaresIntentField } from "../../utils/tool-schema";
 import { invokeEvalPrelude } from "../preludes";
 import { EVAL_AGENT_BRIDGE_NAME, type EvalAgentHandleResult, runEvalAgent } from "../agent-bridge";
 import { EVAL_BUDGET_BRIDGE_NAME, type EvalBudgetResult, runEvalBudget } from "../budget-bridge";
@@ -56,10 +57,10 @@ function getTool(session: ToolSession, name: string): AgentTool {
 	return tool;
 }
 
-function normalizeArgs(args: unknown): unknown {
+function normalizeArgs(args: unknown, injectIntent = true): unknown {
 	if (!isRecord(args)) return args;
 	const record = { ...args };
-	if (record[INTENT_FIELD] === undefined) {
+	if (injectIntent && record[INTENT_FIELD] === undefined) {
 		record[INTENT_FIELD] = "js prelude";
 	}
 	return record;
@@ -203,9 +204,10 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 	}
 	const tool = getTool(options.session, name);
 	const toolCallId = `js-${name}-${crypto.randomUUID()}`;
+	const intentIsDeclared = schemaDeclaresIntentField(toolWireSchema(tool));
 	const suppliedIntent = isRecord(args) ? args[INTENT_FIELD] : undefined;
 	const validationArgs = isRecord(args) ? { ...args } : args;
-	if (isRecord(validationArgs)) delete validationArgs[INTENT_FIELD];
+	if (isRecord(validationArgs) && !intentIsDeclared) delete validationArgs[INTENT_FIELD];
 	let validatedArgs: unknown;
 	try {
 		validatedArgs = validateToolArguments(tool, {
@@ -231,10 +233,10 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 			validatedArgs = validationArgs;
 		}
 	}
-	if (isRecord(validatedArgs) && suppliedIntent !== undefined) {
+	if (isRecord(validatedArgs) && !intentIsDeclared && suppliedIntent !== undefined) {
 		validatedArgs[INTENT_FIELD] = suppliedIntent;
 	}
-	const normalizedArgs = normalizeArgs(validatedArgs);
+	const normalizedArgs = normalizeArgs(validatedArgs, !intentIsDeclared);
 	try {
 		const result = await tool.execute(
 			toolCallId,

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -27,6 +27,7 @@ interface ToolBridgeOptions {
 	session: ToolSession;
 	signal?: AbortSignal;
 	emitStatus?: (event: JsStatusEvent) => void;
+	defaultIntent?: string;
 }
 
 type ToolValue =
@@ -57,11 +58,11 @@ function getTool(session: ToolSession, name: string): AgentTool {
 	return tool;
 }
 
-function normalizeArgs(args: unknown, injectIntent = true): unknown {
+function normalizeArgs(args: unknown, defaultIntent?: string): unknown {
 	if (!isRecord(args)) return args;
 	const record = { ...args };
-	if (injectIntent && record[INTENT_FIELD] === undefined) {
-		record[INTENT_FIELD] = "js prelude";
+	if (defaultIntent !== undefined && !(INTENT_FIELD in record)) {
+		record[INTENT_FIELD] = defaultIntent;
 	}
 	return record;
 }
@@ -236,7 +237,10 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 	if (isRecord(validatedArgs) && !intentIsDeclared && suppliedIntent !== undefined) {
 		validatedArgs[INTENT_FIELD] = suppliedIntent;
 	}
-	const normalizedArgs = normalizeArgs(validatedArgs, !intentIsDeclared);
+	const normalizedArgs = normalizeArgs(
+		validatedArgs,
+		!intentIsDeclared ? (options.defaultIntent ?? "js prelude") : undefined,
+	);
 	try {
 		const result = await tool.execute(
 			toolCallId,

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -205,6 +205,8 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 	}
 	const tool = getTool(options.session, name);
 	const toolCallId = `js-${name}-${crypto.randomUUID()}`;
+	// A schema-owned name stays tool data across alternatives. Deleting an
+	// invalid value to make another branch match could select a different operation.
 	const intentIsDeclared = schemaDeclaresIntentField(toolWireSchema(tool));
 	const suppliedIntent = isRecord(args) ? args[INTENT_FIELD] : undefined;
 	const validationArgs = isRecord(args) ? { ...args } : args;

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -7,7 +7,6 @@ if "__omp_prelude_loaded__" not in globals():
     import asyncio, collections.abc, inspect, os, json, math, re, types, typing
     from urllib.parse import unquote
 
-    INTENT_FIELD = "i"
 
     # __omp_display is injected by runner.py before the prelude executes; it
     # mirrors IPython's display() semantics with the same MIME bundle output.
@@ -473,8 +472,6 @@ if "__omp_prelude_loaded__" not in globals():
                     f"tool.{self._name}(...) expects a dict of arguments (got {type(args).__name__})"
                 )
             merged.update(kwargs)
-            if INTENT_FIELD not in merged:
-                merged[INTENT_FIELD] = "py prelude"
             value = await asyncio.to_thread(_bridge_call, self._name, merged)
             return _surface_bridged_tool_images(value)
 

--- a/packages/coding-agent/src/eval/py/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/py/tool-bridge.ts
@@ -81,6 +81,7 @@ async function callSessionToolPromptOnAbort(name: string, args: unknown, entry: 
 		session: entry.toolSession,
 		signal: entry.signal,
 		emitStatus: entry.emitStatus,
+		defaultIntent: "py prelude",
 	});
 	const signal = entry.shieldedSignal ?? entry.signal;
 	if (!signal) return await call;

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -20,6 +20,7 @@ import type { Theme } from "../modes/theme/theme";
 import type { OutputMeta } from "../tools/output-meta";
 import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
+import { schemaDeclaresIntentField } from "../utils/tool-schema";
 import { callTool } from "./client";
 import { formatMCPToolFailure, MCPTransportError } from "./errors";
 import { renderMCPCall, renderMCPResult } from "./render";
@@ -114,12 +115,12 @@ function omitUnusedOptionalArgs(args: MCPToolArgs, inputSchema: MCPToolDefinitio
  * carries `i`. The MCP boundary is the authoritative guard so callers don't
  * have to pre-strip.
  *
- * Leaves `i` in place when the server's own `inputSchema.properties` declares
- * it, so a server that legitimately uses `i` as a parameter is unaffected.
+ * Leaves `i` in place when the server's own input schema declares or
+ * constrains it, so legitimate tool data is not discarded at forwarding.
  */
 function stripHarnessIntent(args: MCPToolArgs, inputSchema: MCPToolDefinition["inputSchema"]): MCPToolArgs {
 	if (!Object.hasOwn(args, INTENT_FIELD)) return args;
-	if (inputSchema.properties && Object.hasOwn(inputSchema.properties, INTENT_FIELD)) return args;
+	if (schemaDeclaresIntentField(inputSchema)) return args;
 	const { [INTENT_FIELD]: _intent, ...rest } = args;
 	return rest;
 }

--- a/packages/coding-agent/src/task/eval-tools.ts
+++ b/packages/coding-agent/src/task/eval-tools.ts
@@ -9,6 +9,7 @@ import type { EvalToolDescriptor, EvalToolInvokeResult } from "../eval/types";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { ToolSession } from "../tools";
 import { ToolError } from "../tools/tool-errors";
+import { schemaDeclaresIntentField } from "../utils/tool-schema";
 
 interface EvalToolQueryResult {
 	tools: EvalToolDescriptor[];
@@ -118,8 +119,7 @@ function stripHarnessIntent(
 	parameters: Record<string, unknown>,
 ): Record<string, unknown> {
 	if (!Object.hasOwn(params, INTENT_FIELD)) return params;
-	const properties = parameters.properties;
-	if (isUnknownRecord(properties) && Object.hasOwn(properties, INTENT_FIELD)) return params;
+	if (schemaDeclaresIntentField(parameters)) return params;
 	const { [INTENT_FIELD]: _intent, ...args } = params;
 	return args;
 }

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -33,6 +33,7 @@ import type { AgentToolContext, AgentToolResult, AgentToolUpdateCallback, ToolLo
 import { type Tool as AiTool, jsonSchemaToTypeScript, toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
 import { type Component, Container, Text } from "@oh-my-pi/pi-tui";
 import { parseStreamingJson } from "@oh-my-pi/pi-utils";
+import { schemaDeclaresIntentField } from "../utils/tool-schema";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { stripXdUrlPrefix, XD_URL_PREFIX } from "../internal-urls/xd-protocol";
 import { parseMCPToolName } from "../mcp/tool-bridge";
@@ -112,13 +113,6 @@ let rendererLookup: ((name: string) => ToolRenderer | undefined) | undefined;
 /** Wire the wrapped-renderer lookup. Called once by `renderers.ts`. */
 export function setXdevRendererLookup(lookup: (name: string) => ToolRenderer | undefined): void {
 	rendererLookup = lookup;
-}
-
-/** Whether a wire JSON schema declares a top-level `i` (intent) property. */
-function schemaDeclaresIntentField(schema: unknown): boolean {
-	if (!schema || typeof schema !== "object" || !("properties" in schema)) return false;
-	const props = schema.properties;
-	return !!props && typeof props === "object" && "i" in props;
 }
 
 function renderDocs(inst: Tool, heading = "#", descriptionCap?: number): string {

--- a/packages/coding-agent/src/utils/tool-schema.ts
+++ b/packages/coding-agent/src/utils/tool-schema.ts
@@ -1,0 +1,7 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+
+/** Whether a wire schema owns `i` as a tool parameter rather than harness intent. */
+export function schemaDeclaresIntentField(schema: unknown): boolean {
+	return isRecord(schema) && isRecord(schema.properties) && Object.hasOwn(schema.properties, INTENT_FIELD);
+}

--- a/packages/coding-agent/src/utils/tool-schema.ts
+++ b/packages/coding-agent/src/utils/tool-schema.ts
@@ -1,7 +1,7 @@
-import { isRecord } from "@oh-my-pi/pi-utils";
+import { schemaDefinesProperty } from "@oh-my-pi/pi-ai/utils/schema";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 /** Whether a wire schema owns `i` as a tool parameter rather than harness intent. */
 export function schemaDeclaresIntentField(schema: unknown): boolean {
-	return isRecord(schema) && isRecord(schema.properties) && Object.hasOwn(schema.properties, INTENT_FIELD);
+	return schemaDefinesProperty(schema, INTENT_FIELD);
 }

--- a/packages/coding-agent/test/blob-exposure-tunnels.test.ts
+++ b/packages/coding-agent/test/blob-exposure-tunnels.test.ts
@@ -36,20 +36,42 @@ function exposure(kind: ExposureConfig["kind"], overrides: Partial<ExposureConfi
 	} as ExposureConfig;
 }
 
+function shellLiteral(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 function prepareFake(output: string, options: { exitCode?: number; restartOnce?: boolean } = {}): FakeInvocation {
 	const suffix = String(invocationSequence++);
-	const argsFile = path.join(fakeBinDir, `args-${suffix}.json`);
-	const runsFile = path.join(fakeBinDir, `runs-${suffix}.txt`);
-	const signalsFile = path.join(fakeBinDir, `signals-${suffix}.txt`);
-	process.env.OMP_FAKE_TUNNEL_ARGS = argsFile;
-	process.env.OMP_FAKE_TUNNEL_RUNS = runsFile;
-	process.env.OMP_FAKE_TUNNEL_SIGNALS = signalsFile;
-	process.env.OMP_FAKE_TUNNEL_OUTPUT = output;
-	if (options.exitCode === undefined) delete process.env.OMP_FAKE_TUNNEL_EXIT_CODE;
-	else process.env.OMP_FAKE_TUNNEL_EXIT_CODE = String(options.exitCode);
-	const restartMarker = options.restartOnce ? path.join(fakeBinDir, `restart-${suffix}.txt`) : undefined;
-	if (restartMarker === undefined) delete process.env.OMP_FAKE_TUNNEL_RESTART_MARKER;
-	else process.env.OMP_FAKE_TUNNEL_RESTART_MARKER = restartMarker;
+	const invocationDir = path.join(fakeBinDir, suffix);
+	fs.mkdirSync(invocationDir);
+	const argsFile = path.join(invocationDir, "args.txt");
+	const runsFile = path.join(invocationDir, "runs.txt");
+	const signalsFile = path.join(invocationDir, "signals.txt");
+	const restartMarker = options.restartOnce ? path.join(invocationDir, "restart.txt") : undefined;
+	const target = path.join(invocationDir, "fake-tunnel");
+	fs.writeFileSync(
+		target,
+		`#!/bin/sh\n` +
+		`: > ${shellLiteral(argsFile)}\n` +
+		`for arg do printf '%s\\n' "$arg" >> ${shellLiteral(argsFile)}; done\n` +
+		`printf 'run\\n' >> ${shellLiteral(runsFile)}\n` +
+		`trap 'printf "SIGINT\\n" >> ${shellLiteral(signalsFile)}; exit 0' INT\n` +
+		`trap 'printf "SIGTERM\\n" >> ${shellLiteral(signalsFile)}; exit 0' TERM\n` +
+		`printf '%s\\n' ${shellLiteral(output)}\n` +
+		(restartMarker
+			? `if [ ! -e ${shellLiteral(restartMarker)} ]; then\n` +
+			`  printf 'first\\n' > ${shellLiteral(restartMarker)}\n` +
+			`  exit 23\n` +
+			`fi\n` +
+			`printf 'restarted\\n' >> ${shellLiteral(restartMarker)}\n`
+			: "") +
+		(options.exitCode === undefined ? `while :; do /bin/sleep 1; done\n` : `exit ${options.exitCode}\n`),
+	);
+	fs.chmodSync(target, 0o755);
+	for (const name of ["ssh", "devtunnel", "zrok", "bore", "cloudflared"]) {
+		fs.symlinkSync(target, path.join(invocationDir, name));
+	}
+	process.env.PATH = invocationDir;
 	return { argsFile, runsFile, signalsFile, restartMarker };
 }
 
@@ -97,31 +119,6 @@ async function stopAndObserve(exposure: ActiveExposure, invocation: FakeInvocati
 
 beforeAll(() => {
 	fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-blob-tunnels-"));
-	const target = path.join(fakeBinDir, "fake-tunnel");
-	fs.writeFileSync(
-		target,
-		`#!/bin/sh\n` +
-			`: > "$OMP_FAKE_TUNNEL_ARGS"\n` +
-			`for arg do printf '%s\\n' "$arg" >> "$OMP_FAKE_TUNNEL_ARGS"; done\n` +
-			`printf 'run\\n' >> "$OMP_FAKE_TUNNEL_RUNS"\n` +
-			`trap 'printf "SIGINT\\n" >> "$OMP_FAKE_TUNNEL_SIGNALS"; exit 0' INT\n` +
-			`trap 'printf "SIGTERM\\n" >> "$OMP_FAKE_TUNNEL_SIGNALS"; exit 0' TERM\n` +
-			`if [ -n "$OMP_FAKE_TUNNEL_OUTPUT" ]; then printf '%s\\n' "$OMP_FAKE_TUNNEL_OUTPUT"; fi\n` +
-			`if [ -n "$OMP_FAKE_TUNNEL_RESTART_MARKER" ]; then\n` +
-			`  if [ ! -e "$OMP_FAKE_TUNNEL_RESTART_MARKER" ]; then\n` +
-			`    printf 'first\\n' > "$OMP_FAKE_TUNNEL_RESTART_MARKER"\n` +
-			`    exit 23\n` +
-			`  fi\n` +
-			`  printf 'restarted\\n' >> "$OMP_FAKE_TUNNEL_RESTART_MARKER"\n` +
-			`fi\n` +
-			`if [ -n "$OMP_FAKE_TUNNEL_EXIT_CODE" ]; then exit "$OMP_FAKE_TUNNEL_EXIT_CODE"; fi\n` +
-			`while :; do /bin/sleep 1; done\n`,
-	);
-	fs.chmodSync(target, 0o755);
-	for (const name of ["ssh", "devtunnel", "zrok", "bore", "cloudflared"]) {
-		fs.symlinkSync(target, path.join(fakeBinDir, name));
-	}
-	process.env.PATH = fakeBinDir;
 });
 
 afterAll(async () => {
@@ -129,12 +126,6 @@ afterAll(async () => {
 	await Promise.all(activeExposures.map(active => active.exited));
 	if (originalPath === undefined) delete process.env.PATH;
 	else process.env.PATH = originalPath;
-	delete process.env.OMP_FAKE_TUNNEL_ARGS;
-	delete process.env.OMP_FAKE_TUNNEL_RUNS;
-	delete process.env.OMP_FAKE_TUNNEL_SIGNALS;
-	delete process.env.OMP_FAKE_TUNNEL_OUTPUT;
-	delete process.env.OMP_FAKE_TUNNEL_EXIT_CODE;
-	delete process.env.OMP_FAKE_TUNNEL_RESTART_MARKER;
 	fs.rmSync(fakeBinDir, { recursive: true, force: true });
 });
 

--- a/packages/coding-agent/test/blob-exposure-tunnels.test.ts
+++ b/packages/coding-agent/test/blob-exposure-tunnels.test.ts
@@ -52,20 +52,20 @@ function prepareFake(output: string, options: { exitCode?: number; restartOnce?:
 	fs.writeFileSync(
 		target,
 		`#!/bin/sh\n` +
-		`: > ${shellLiteral(argsFile)}\n` +
-		`for arg do printf '%s\\n' "$arg" >> ${shellLiteral(argsFile)}; done\n` +
-		`printf 'run\\n' >> ${shellLiteral(runsFile)}\n` +
-		`trap 'printf "SIGINT\\n" >> ${shellLiteral(signalsFile)}; exit 0' INT\n` +
-		`trap 'printf "SIGTERM\\n" >> ${shellLiteral(signalsFile)}; exit 0' TERM\n` +
-		`printf '%s\\n' ${shellLiteral(output)}\n` +
-		(restartMarker
-			? `if [ ! -e ${shellLiteral(restartMarker)} ]; then\n` +
-			`  printf 'first\\n' > ${shellLiteral(restartMarker)}\n` +
-			`  exit 23\n` +
-			`fi\n` +
-			`printf 'restarted\\n' >> ${shellLiteral(restartMarker)}\n`
-			: "") +
-		(options.exitCode === undefined ? `while :; do /bin/sleep 1; done\n` : `exit ${options.exitCode}\n`),
+			`: > ${shellLiteral(argsFile)}\n` +
+			`for arg do printf '%s\\n' "$arg" >> ${shellLiteral(argsFile)}; done\n` +
+			`printf 'run\\n' >> ${shellLiteral(runsFile)}\n` +
+			`trap 'printf "SIGINT\\n" >> ${shellLiteral(signalsFile)}; exit 0' INT\n` +
+			`trap 'printf "SIGTERM\\n" >> ${shellLiteral(signalsFile)}; exit 0' TERM\n` +
+			`printf '%s\\n' ${shellLiteral(output)}\n` +
+			(restartMarker
+				? `if [ ! -e ${shellLiteral(restartMarker)} ]; then\n` +
+					`  printf 'first\\n' > ${shellLiteral(restartMarker)}\n` +
+					`  exit 23\n` +
+					`fi\n` +
+					`printf 'restarted\\n' >> ${shellLiteral(restartMarker)}\n`
+				: "") +
+			(options.exitCode === undefined ? `while :; do /bin/sleep 1; done\n` : `exit ${options.exitCode}\n`),
 	);
 	fs.chmodSync(target, 0o755);
 	for (const name of ["ssh", "devtunnel", "zrok", "bore", "cloudflared"]) {

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -147,6 +147,53 @@ describe("callSessionTool", () => {
 		expect(result).toBe("caller intent");
 	});
 
+	it("validates and preserves a schema-declared intent field", async () => {
+		const execute = async (_id: string, args: unknown) => ({
+			content: [
+				{
+					type: "text" as const,
+					text: `${typeof (args as Record<string, unknown>)[INTENT_FIELD]}:${String((args as Record<string, unknown>)[INTENT_FIELD])}`,
+				},
+			],
+		});
+		const tool: AgentTool = {
+			name: "required-intent",
+			label: "required intent",
+			description: "required intent tool",
+			parameters: type({ [INTENT_FIELD]: "number" }),
+			concurrency: "parallel",
+			execute,
+		} as unknown as AgentTool;
+
+		const result = await callSessionTool(
+			"required-intent",
+			{ [INTENT_FIELD]: "5" },
+			{ session: createSession([tool]) },
+		);
+
+		expect(result).toBe("number:5");
+	});
+
+	it("validates constrained tool-owned intent without supplying a missing optional value", async () => {
+		const execute = vi.fn(async (_id: string, args: unknown) => ({
+			content: [{ type: "text" as const, text: String((args as Record<string, unknown>)[INTENT_FIELD]) }],
+		}));
+		const tool: AgentTool = {
+			name: "constrained-intent",
+			label: "constrained intent",
+			description: "constrained intent tool",
+			parameters: type({ [`${INTENT_FIELD}?`]: "'allowed'" }),
+			concurrency: "parallel",
+			execute,
+		} as unknown as AgentTool;
+
+		await expect(
+			callSessionTool("constrained-intent", { [INTENT_FIELD]: "disallowed" }, { session: createSession([tool]) }),
+		).rejects.toThrow("Validation failed");
+		expect(execute).not.toHaveBeenCalled();
+		expect(await callSessionTool("constrained-intent", {}, { session: createSession([tool]) })).toBe("undefined");
+	});
+
 	it("recovers a missing todo operation from raw parse metadata", async () => {
 		let phases: TodoPhase[] = [];
 		const session: ToolSession = {

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -241,6 +241,22 @@ describe("callSessionTool", () => {
 		expect(execute).not.toHaveBeenCalled();
 	});
 
+	it("preserves harness intent when propertyNames does not open a closed schema", async () => {
+		const tool = createSchemaTool("closed-property-names", {
+			type: "object",
+			properties: { value: {} },
+			propertyNames: { type: "string" },
+			additionalProperties: false,
+		});
+		expect(
+			await callSessionTool(
+				"closed-property-names",
+				{ value: "x", i: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
 	it("preserves intent admitted by propertyNames", async () => {
 		const tool = createSchemaTool("property-name-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -207,6 +207,40 @@ describe("callSessionTool", () => {
 		).toBe("string:caller intent");
 	});
 
+	it("preserves intent required by a dependent property", async () => {
+		const tool = createSchemaTool("dependent-required-intent", {
+			type: "object",
+			properties: { mode: { type: "string" } },
+			dependentRequired: { mode: [INTENT_FIELD] },
+		});
+
+		expect(
+			await callSessionTool(
+				"dependent-required-intent",
+				{ mode: "active", [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
+	it("rejects a missing field required by supplied intent", async () => {
+		const tool = createSchemaTool("intent-dependent-trigger", {
+			type: "object",
+			dependentRequired: { [INTENT_FIELD]: ["value"] },
+		});
+		const execute = vi.fn(tool.execute);
+		tool.execute = execute;
+
+		await expect(
+			callSessionTool(
+				"intent-dependent-trigger",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).rejects.toThrow("Validation failed");
+		expect(execute).not.toHaveBeenCalled();
+	});
+
 	it("rejects invalid intent matched by patternProperties", async () => {
 		const tool = createSchemaTool("pattern-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -257,6 +257,16 @@ describe("callSessionTool", () => {
 		).toBe("string:caller intent");
 	});
 
+	it.each(["const", "enum"] as const)("preserves intent in object-valued %s", async keyword => {
+		const tool = createSchemaTool("object-constraint", {
+			type: "object",
+			[keyword]: keyword === "const" ? { i: "token" } : [{ i: "token" }],
+		});
+		expect(await callSessionTool("object-constraint", { i: "token" }, { session: createSession([tool]) })).toBe(
+			"string:token",
+		);
+	});
+
 	it("preserves intent admitted by propertyNames", async () => {
 		const tool = createSchemaTool("property-name-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -514,6 +514,27 @@ describe("callSessionTool", () => {
 		);
 	});
 
+	it("strips intent prohibited by a false pattern schema", async () => {
+		const tool = createSchemaTool("false-pattern-intent", {
+			type: "object",
+			patternProperties: { "^i$": false },
+		});
+		expect(
+			await callSessionTool("false-pattern-intent", { i: "caller intent" }, { session: createSession([tool]) }),
+		).toBe("string:caller intent");
+	});
+
+	it("preserves intent constrained by unevaluatedProperties", async () => {
+		const tool = createSchemaTool("unevaluated-intent", {
+			type: "object",
+			unevaluatedProperties: { type: "string" },
+			minProperties: 1,
+		});
+		expect(
+			await callSessionTool("unevaluated-intent", { i: "caller intent" }, { session: createSession([tool]) }),
+		).toBe("string:caller intent");
+	});
+
 	it("preserves data required by negating a false property schema", async () => {
 		const tool = createSchemaTool("not-false-intent", { type: "object", not: { properties: { i: false } } });
 		expect(await callSessionTool("not-false-intent", { i: "data" }, { session: createSession([tool]) })).toBe(

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -3,7 +3,7 @@ import { type } from "@oh-my-pi/omptype";
 import type { AgentTool, AgentToolContext, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { callSessionTool } from "@oh-my-pi/pi-coding-agent/eval/js/tool-bridge";
-import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { type TodoPhase, TodoTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 function createTool(name: string, execute: AgentTool["execute"]): AgentTool {
@@ -76,6 +76,103 @@ describe("callSessionTool", () => {
 			undefined,
 			context,
 		);
+	});
+
+	it("validates optional nulls before executing a real todo tool", async () => {
+		let phases: TodoPhase[] = [
+			{
+				name: "Regression",
+				tasks: [{ content: "Exercise bridge", status: "in_progress" }],
+			},
+		];
+		const session: ToolSession = {
+			...createSession([]),
+			getTodoPhases: () => phases,
+			setTodoPhases: next => {
+				phases = next;
+			},
+			getToolByName: name => (name === "todo" ? (todoTool as unknown as AgentTool) : undefined),
+		};
+		const todoTool = new TodoTool(session);
+
+		const result = await callSessionTool(
+			"todo",
+			{
+				op: "done",
+				phase: "Regression",
+				list: null,
+				task: null,
+				items: null,
+				reason: null,
+			},
+			{ session },
+		);
+
+		expect(result).not.toEqual(expect.objectContaining({ hasError: true }));
+		expect(phases[0]?.tasks.map(task => task.status)).toEqual(["completed"]);
+	});
+
+	it("rejects null for a required field before executing a strict tool", async () => {
+		const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "unexpected" }] });
+		const tool: AgentTool = {
+			name: "strict",
+			label: "strict",
+			description: "strict tool",
+			parameters: type({ value: "string" }),
+			concurrency: "parallel",
+			execute,
+		} as unknown as AgentTool;
+		await expect(callSessionTool("strict", { value: null }, { session: createSession([tool]) })).rejects.toThrow(
+			"Validation failed",
+		);
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("preserves caller intent through closed-schema validation", async () => {
+		const tool: AgentTool = {
+			name: "intent",
+			label: "intent",
+			description: "intent tool",
+			parameters: type({ "value?": "string" }).onUndeclaredKey("reject"),
+			concurrency: "shared",
+			execute: async (_id: string, args: unknown) => ({
+				content: [{ type: "text", text: String((args as Record<string, unknown>)[INTENT_FIELD]) }],
+			}),
+		} as unknown as AgentTool;
+		const result = await callSessionTool(
+			"intent",
+			{ value: "x", [INTENT_FIELD]: "caller intent" },
+			{ session: createSession([tool]) },
+		);
+		expect(result).toBe("caller intent");
+	});
+
+	it("recovers a missing todo operation from raw parse metadata", async () => {
+		let phases: TodoPhase[] = [];
+		const session: ToolSession = {
+			...createSession([]),
+			getTodoPhases: () => phases,
+			setTodoPhases: next => {
+				phases = next;
+			},
+			getToolByName: name => (name === "todo" ? (todoTool as unknown as AgentTool) : undefined),
+		};
+		const todoTool = new TodoTool(session);
+
+		const result = await callSessionTool(
+			"todo",
+			{
+				list: [{ phase: "Recovered", items: ["From malformed JSON"] }],
+				__parseError: "Unexpected token",
+				__rawJson: '{"list": [broken}',
+			},
+			{ session },
+		);
+
+		expect(result).not.toEqual(expect.objectContaining({ hasError: true }));
+		expect(phases).toEqual([
+			{ name: "Recovered", tasks: [{ content: "From malformed JSON", status: "in_progress" }] },
+		]);
 	});
 
 	it("returns structured tool results when details or images are present", async () => {

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -489,6 +489,24 @@ describe("callSessionTool", () => {
 		).rejects.toThrow("Validation failed");
 	});
 
+	it.each(["direct", "annotated", "reference"] as const)(
+		"keeps harness intent out of a presence prohibition (%s)",
+		async shape => {
+			const presence =
+				shape === "annotated"
+					? { type: "object", required: ["i"], description: "Reserved name" }
+					: { required: ["i"] };
+			const tool = createSchemaTool("forbidden-presence", {
+				type: "object",
+				not: shape === "reference" ? { $ref: "#/$defs/presence" } : presence,
+				$defs: { presence },
+			});
+			expect(
+				await callSessionTool("forbidden-presence", { i: "caller intent" }, { session: createSession([tool]) }),
+			).toBe("string:caller intent");
+		},
+	);
+
 	it("validates intent constraints inside a negated schema", async () => {
 		const tool = createSchemaTool("negated-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -17,6 +17,24 @@ function createTool(name: string, execute: AgentTool["execute"]): AgentTool {
 	} as unknown as AgentTool;
 }
 
+function createSchemaTool(name: string, parameters: Record<string, unknown>): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `${name} tool`,
+		parameters,
+		concurrency: "parallel",
+		execute: async (_id: string, args: unknown) => ({
+			content: [
+				{
+					type: "text" as const,
+					text: `${typeof (args as Record<string, unknown>)[INTENT_FIELD]}:${String((args as Record<string, unknown>)[INTENT_FIELD])}`,
+				},
+			],
+		}),
+	} as unknown as AgentTool;
+}
+
 function createSession(tools: AgentTool[]): ToolSession {
 	const registry = new Map(tools.map(tool => [tool.name, tool]));
 	return {
@@ -172,6 +190,122 @@ describe("callSessionTool", () => {
 		);
 
 		expect(result).toBe("number:5");
+	});
+
+	it("preserves and coerces a required intent field declared by an anyOf branch", async () => {
+		const tool = createSchemaTool("any-of-intent", {
+			anyOf: [
+				{
+					type: "object",
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: { value: { type: "string" } },
+					required: ["value"],
+					additionalProperties: false,
+				},
+			],
+		});
+
+		expect(await callSessionTool("any-of-intent", { [INTENT_FIELD]: "5" }, { session: createSession([tool]) })).toBe(
+			"number:5",
+		);
+	});
+
+	it("preserves and coerces an intent field declared by a oneOf branch", async () => {
+		const tool = createSchemaTool("one-of-intent", {
+			oneOf: [
+				{
+					type: "object",
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: { value: { type: "string" } },
+					required: ["value"],
+					additionalProperties: false,
+				},
+			],
+		});
+
+		expect(await callSessionTool("one-of-intent", { [INTENT_FIELD]: "5" }, { session: createSession([tool]) })).toBe(
+			"number:5",
+		);
+	});
+
+	it("preserves and coerces an intent field constrained by allOf", async () => {
+		const tool = createSchemaTool("all-of-intent", {
+			type: "object",
+			allOf: [
+				{
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+				},
+			],
+		});
+
+		expect(await callSessionTool("all-of-intent", { [INTENT_FIELD]: "5" }, { session: createSession([tool]) })).toBe(
+			"number:5",
+		);
+	});
+
+	it("preserves and coerces intent through an escaped local reference", async () => {
+		const tool = createSchemaTool("referenced-intent", {
+			$ref: "#/$defs/intent~1property~0schema",
+			$defs: {
+				"intent/property~schema": {
+					type: "object",
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+					additionalProperties: false,
+				},
+			},
+		});
+
+		expect(
+			await callSessionTool("referenced-intent", { [INTENT_FIELD]: "5" }, { session: createSession([tool]) }),
+		).toBe("number:5");
+	});
+
+	it("terminates cyclic local references without claiming intent ownership", async () => {
+		const tool = createSchemaTool("cyclic-schema", {
+			$ref: "#/$defs/cycle",
+			$defs: { cycle: { $ref: "#/$defs/cycle" } },
+		});
+
+		expect(
+			await callSessionTool(
+				"cyclic-schema",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
+	it("does not treat a nested intent property as a root tool parameter", async () => {
+		const tool = createSchemaTool("nested-intent", {
+			type: "object",
+			properties: {
+				wrapper: {
+					type: "object",
+					properties: { [INTENT_FIELD]: { type: "number" } },
+				},
+			},
+			additionalProperties: false,
+		});
+
+		expect(
+			await callSessionTool(
+				"nested-intent",
+				{ wrapper: {}, [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
 	});
 
 	it("validates constrained tool-owned intent without supplying a missing optional value", async () => {

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -507,6 +507,51 @@ describe("callSessionTool", () => {
 		},
 	);
 
+	it("keeps harness intent out of a false property schema", async () => {
+		const tool = createSchemaTool("false-intent", { type: "object", properties: { i: false } });
+		expect(await callSessionTool("false-intent", { i: "caller intent" }, { session: createSession([tool]) })).toBe(
+			"string:caller intent",
+		);
+	});
+
+	it("preserves data required by negating a false property schema", async () => {
+		const tool = createSchemaTool("not-false-intent", { type: "object", not: { properties: { i: false } } });
+		expect(await callSessionTool("not-false-intent", { i: "data" }, { session: createSession([tool]) })).toBe(
+			"string:data",
+		);
+	});
+
+	it("preserves false-property predicates as decision inputs", async () => {
+		const tool = createSchemaTool("false-intent-predicate", {
+			type: "object",
+			if: { properties: { i: false } },
+			// oxlint-disable-next-line unicorn/no-thenable -- JSON Schema if/then/else keyword
+			then: false,
+			else: true,
+		});
+		expect(await callSessionTool("false-intent-predicate", { i: "data" }, { session: createSession([tool]) })).toBe(
+			"string:data",
+		);
+	});
+
+	it("preserves intent required by double negation", async () => {
+		const tool = createSchemaTool("double-not-intent", { type: "object", not: { not: { required: ["i"] } } });
+		expect(await callSessionTool("double-not-intent", { i: "data" }, { session: createSession([tool]) })).toBe(
+			"string:data",
+		);
+	});
+
+	it("visits a shared reference under both negation polarities", async () => {
+		const tool = createSchemaTool("shared-polarity", {
+			type: "object",
+			anyOf: [{ $ref: "#/$defs/absent" }, { not: { $ref: "#/$defs/absent" } }],
+			$defs: { absent: { not: { required: ["i"] } } },
+		});
+		expect(await callSessionTool("shared-polarity", {}, { session: createSession([tool]) })).toBe(
+			"undefined:undefined",
+		);
+	});
+
 	it("validates intent constraints inside a negated schema", async () => {
 		const tool = createSchemaTool("negated-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -192,6 +192,74 @@ describe("callSessionTool", () => {
 		expect(result).toBe("number:5");
 	});
 
+	it("preserves a required-only intent field", async () => {
+		const tool = createSchemaTool("required-only-intent", {
+			type: "object",
+			required: [INTENT_FIELD],
+		});
+
+		expect(
+			await callSessionTool(
+				"required-only-intent",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
+	it("rejects invalid intent matched by patternProperties", async () => {
+		const tool = createSchemaTool("pattern-intent", {
+			type: "object",
+			patternProperties: { "^i$": { type: "number" } },
+		});
+		const execute = vi.fn(tool.execute);
+		tool.execute = execute;
+
+		await expect(
+			callSessionTool("pattern-intent", { [INTENT_FIELD]: "invalid" }, { session: createSession([tool]) }),
+		).rejects.toThrow("Validation failed");
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("preserves and coerces intent consumed by additionalProperties", async () => {
+		const tool = createSchemaTool("additional-intent", {
+			type: "object",
+			additionalProperties: { type: "number" },
+		});
+
+		expect(
+			await callSessionTool("additional-intent", { [INTENT_FIELD]: "5" }, { session: createSession([tool]) }),
+		).toBe("number:5");
+	});
+
+	it("treats intent ownership as schema-wide across anyOf branches", async () => {
+		const tool = createSchemaTool("schema-wide-intent", {
+			anyOf: [
+				{
+					type: "object",
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: { value: { type: "string" } },
+					required: ["value"],
+					additionalProperties: false,
+				},
+			],
+		});
+		const execute = vi.fn(tool.execute);
+		tool.execute = execute;
+		const session = createSession([tool]);
+
+		await expect(
+			callSessionTool("schema-wide-intent", { value: "x", [INTENT_FIELD]: "invalid" }, { session }),
+		).rejects.toThrow("Validation failed");
+		expect(execute).not.toHaveBeenCalled();
+		expect(await callSessionTool("schema-wide-intent", { value: "x" }, { session })).toBe("undefined:undefined");
+	});
+
 	it("preserves and coerces a required intent field declared by an anyOf branch", async () => {
 		const tool = createSchemaTool("any-of-intent", {
 			anyOf: [

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -254,6 +254,75 @@ describe("callSessionTool", () => {
 		);
 	});
 
+	it("preserves and coerces intent declared by a selected conditional branch", async () => {
+		const tool = createSchemaTool("conditional-intent", {
+			type: "object",
+			properties: { mode: { type: "string" } },
+			required: ["mode"],
+			if: {
+				properties: { mode: { const: "intent" } },
+				required: ["mode"],
+			},
+			// oxlint-disable-next-line unicorn/no-thenable -- JSON Schema if/then/else keyword
+			then: {
+				properties: { [INTENT_FIELD]: { type: "number" } },
+				required: [INTENT_FIELD],
+			},
+		});
+
+		expect(
+			await callSessionTool(
+				"conditional-intent",
+				{ mode: "intent", [INTENT_FIELD]: "5" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("number:5");
+	});
+
+	it("preserves and coerces intent declared by an activated dependent schema", async () => {
+		const tool = createSchemaTool("dependent-intent", {
+			type: "object",
+			properties: { enabled: { type: "boolean" } },
+			required: ["enabled"],
+			dependentSchemas: {
+				enabled: {
+					properties: { [INTENT_FIELD]: { type: "number" } },
+					required: [INTENT_FIELD],
+				},
+			},
+		});
+
+		expect(
+			await callSessionTool(
+				"dependent-intent",
+				{ enabled: true, [INTENT_FIELD]: "5" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("number:5");
+	});
+
+	it("keeps intent predicates from bypassing conditional validation", async () => {
+		const tool = createSchemaTool("intent-predicate", {
+			type: "object",
+			if: { properties: { i: { const: "strict" } }, required: ["i"] },
+			// oxlint-disable-next-line unicorn/no-thenable -- JSON Schema if/then/else keyword
+			then: { properties: { value: { type: "number" } }, required: ["value"] },
+		});
+		await expect(
+			callSessionTool("intent-predicate", { i: "strict", value: "invalid" }, { session: createSession([tool]) }),
+		).rejects.toThrow("Validation failed");
+	});
+
+	it("validates intent constraints inside a negated schema", async () => {
+		const tool = createSchemaTool("negated-intent", {
+			type: "object",
+			not: { properties: { i: { const: "forbidden" } }, required: ["i"] },
+		});
+		await expect(
+			callSessionTool("negated-intent", { i: "forbidden" }, { session: createSession([tool]) }),
+		).rejects.toThrow("Validation failed");
+	});
+
 	it("preserves and coerces intent through an escaped local reference", async () => {
 		const tool = createSchemaTool("referenced-intent", {
 			$ref: "#/$defs/intent~1property~0schema",

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -241,6 +241,54 @@ describe("callSessionTool", () => {
 		expect(execute).not.toHaveBeenCalled();
 	});
 
+	it("preserves intent admitted by propertyNames", async () => {
+		const tool = createSchemaTool("property-name-intent", {
+			type: "object",
+			propertyNames: { const: INTENT_FIELD },
+			minProperties: 1,
+		});
+
+		expect(
+			await callSessionTool(
+				"property-name-intent",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
+	it("preserves intent admitted by referenced propertyNames", async () => {
+		const tool = createSchemaTool("referenced-property-name-intent", {
+			type: "object",
+			propertyNames: { $ref: "#/$defs/intentName" },
+			minProperties: 1,
+			$defs: { intentName: { const: INTENT_FIELD } },
+		});
+
+		expect(
+			await callSessionTool(
+				"referenced-property-name-intent",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
+	it("does not claim intent excluded by propertyNames", async () => {
+		const tool = createSchemaTool("excluded-property-name-intent", {
+			type: "object",
+			propertyNames: { not: { const: INTENT_FIELD } },
+		});
+
+		expect(
+			await callSessionTool(
+				"excluded-property-name-intent",
+				{ [INTENT_FIELD]: "caller intent" },
+				{ session: createSession([tool]) },
+			),
+		).toBe("string:caller intent");
+	});
+
 	it("rejects invalid intent matched by patternProperties", async () => {
 		const tool = createSchemaTool("pattern-intent", {
 			type: "object",

--- a/packages/coding-agent/test/core/python-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/python-tool-bridge.test.ts
@@ -1,11 +1,13 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { PYTHON_PRELUDE } from "@oh-my-pi/pi-coding-agent/eval/py/prelude";
 import {
 	disposePyToolBridge,
 	ensurePyToolBridge,
 	registerPyToolBridge,
 } from "@oh-my-pi/pi-coding-agent/eval/py/tool-bridge";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { $which, isRecord } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 interface FakeCall {
@@ -65,18 +67,114 @@ describe("Python tool bridge HTTP server", () => {
 				session: "test-session-1",
 				run: "run-1",
 				name: "read",
-				args: { path: "foo.ts", [INTENT_FIELD]: "py prelude" },
+				args: { path: "foo.ts" },
 			});
 			const body = await res.json();
 			expect(res.status).toBe(200);
 			expect(body).toEqual({ ok: true, value: "file body" });
 			expect(calls).toHaveLength(1);
-			// `i` survives the bridge round trip so transcript renderers have a label.
-			expect((calls[0]!.args as Record<string, unknown>)[INTENT_FIELD]).toBe("py prelude");
+			expect(calls[0]!.args).toEqual({ path: "foo.ts", [INTENT_FIELD]: "py prelude" });
 		} finally {
 			unregister();
 		}
 	});
+
+	it("preserves explicit caller intent for tools whose schema does not declare it", async () => {
+		const calls: FakeCall[] = [];
+		const tool = makeFakeTool("inspect", calls, {
+			content: [{ type: "text", text: "done" }],
+		});
+		const session = makeSession(new Map([["inspect", tool]]));
+		const info = await ensurePyToolBridge();
+		const unregister = registerPyToolBridge("explicit-intent-session", "explicit-intent-run", {
+			toolSession: session,
+		});
+		try {
+			const res = await call(info, {
+				session: "explicit-intent-session",
+				run: "explicit-intent-run",
+				name: "inspect",
+				args: { target: "value", [INTENT_FIELD]: "caller supplied" },
+			});
+			expect(await res.json()).toEqual({ ok: true, value: "done" });
+			expect(calls[0]!.args).toEqual({ target: "value", [INTENT_FIELD]: "caller supplied" });
+		} finally {
+			unregister();
+		}
+	});
+	it("keeps Python defaults out of schema-owned intent parameters", async () => {
+		let executions = 0;
+		const constrained = {
+			name: "constrained",
+			label: "constrained",
+			description: "Reports the validated tool-owned parameter",
+			parameters: {
+				type: "object",
+				properties: { i: { type: "string", enum: ["allowed"] } },
+				additionalProperties: false,
+			},
+			async execute(_id: string, args: unknown): Promise<AgentToolResult> {
+				executions++;
+				if (!isRecord(args)) throw new Error("Expected object arguments");
+				return { content: [{ type: "text", text: String(args.i ?? "omitted") }] };
+			},
+		} as unknown as AgentTool;
+		const info = await ensurePyToolBridge();
+		const sessionId = `python-intent-${crypto.randomUUID()}`;
+		const unregister = registerPyToolBridge(sessionId, "run", {
+			toolSession: makeSession(new Map([["constrained", constrained]])),
+		});
+		try {
+			const prelude = PYTHON_PRELUDE.replace(
+				"from __future__ import annotations",
+				"from __future__ import annotations\n__omp_display = lambda *args, **kwargs: None",
+			);
+			const script = `${prelude}
+__omp_run_id__ = "run"
+async def check_intent():
+    print(await tool.constrained())
+    print(await tool.constrained(i=None))
+    print(await tool.constrained(i="allowed"))
+    try:
+        await tool.constrained(i="py prelude")
+    except RuntimeError:
+        print("invalid rejected")
+    else:
+        raise AssertionError("Invalid tool-owned intent reached execution")
+asyncio.run(check_intent())
+`;
+			const child = Bun.spawn([Bun.env.PYTHON ?? ($which("python3") ? "python3" : "python"), "-c", script], {
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+				signal: AbortSignal.timeout(10_000),
+				env: {
+					...process.env,
+					PI_TOOL_BRIDGE_URL: info.url,
+					PI_TOOL_BRIDGE_TOKEN: info.token,
+					PI_TOOL_BRIDGE_SESSION: sessionId,
+				},
+			});
+			try {
+				const [exitCode, stdout, stderr] = await Promise.all([
+					child.exited,
+					new Response(child.stdout).text(),
+					new Response(child.stderr).text(),
+				]);
+				expect({ exitCode, stdout: stdout.replaceAll("\r\n", "\n"), stderr }).toEqual({
+					exitCode: 0,
+					stdout: "omitted\nomitted\nallowed\ninvalid rejected\n",
+					stderr: "",
+				});
+				expect(executions).toBe(3);
+			} finally {
+				child.kill();
+				await child.exited;
+			}
+		} finally {
+			unregister();
+		}
+	}, 15_000);
 
 	it("returns ok=false when no session is registered for the given id", async () => {
 		const info = await ensurePyToolBridge();

--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -729,6 +729,7 @@ describe("agent() through eval runtimes", () => {
 		using tempDir = TempDir.createSync("@omp-eval-agent-progress-");
 		const { session, sessionFile } = makeEvalSession(tempDir, "js-agent-progress");
 		mockAgents();
+		const releaseCompletion = Promise.withResolvers<void>();
 
 		const makeProgress = (options: ExecutorOptions, overrides: Partial<AgentProgress>): AgentProgress => ({
 			index: options.index,
@@ -764,6 +765,7 @@ describe("agent() through eval runtimes", () => {
 					resolvedModel: "p/model",
 				}),
 			);
+			await releaseCompletion.promise;
 			options.onProgress?.(
 				makeProgress(options, {
 					status: "completed",
@@ -786,16 +788,28 @@ describe("agent() through eval runtimes", () => {
 				sessionId: sharedJsSessionId,
 				session,
 				sessionFile,
-				onStatus: event => events.push(event),
+				onStatus: event => {
+					events.push(event);
+					if (event.op === "agent" && event.status === "running") releaseCompletion.resolve();
+				},
 			},
 		);
 
 		expect(result.exitCode).toBe(0);
 
 		const agentEvents = events.filter(event => event.op === "agent");
-		expect(agentEvents).toHaveLength(1);
+		const completedIndex = agentEvents.findIndex(event => event.status === "completed");
+		expect(completedIndex).toBeGreaterThan(0);
+		expect(completedIndex).toBe(agentEvents.length - 1);
+		expect(agentEvents.slice(0, completedIndex).every(event => event.status === "running")).toBe(true);
 
-		const completed = agentEvents[0];
+		const running = agentEvents[completedIndex - 1];
+		const completed = agentEvents[completedIndex];
+		if (!running || !completed) throw new Error("agent progress was not streamed");
+		expect(running.currentTool).toBe("read");
+		expect(running.lastIntent).toBe("Reading config");
+		expect(running.toolCount).toBe(4);
+
 		expect(completed.status).toBe("completed");
 		expect(completed.toolCount).toBe(7);
 		expect(completed.cost).toBeCloseTo(0.06);
@@ -803,11 +817,12 @@ describe("agent() through eval runtimes", () => {
 		expect(completed.taskPreview).toBe("investigate");
 		expect(typeof completed.id).toBe("string");
 
-		// The same final snapshot is retained in the executor's display outputs.
+		// The latest retained agent snapshot matches the latest streamed one.
 		const displayAgentEvents = result.displayOutputs.filter(
-			(output): output is Extract<typeof output, { type: "status" }> => output.type === "status",
+			(output): output is Extract<typeof output, { type: "status" }> =>
+				output.type === "status" && output.event.op === "agent",
 		);
-		expect(displayAgentEvents).toHaveLength(1);
+		expect(displayAgentEvents.at(-1)?.event).toEqual(completed);
 	});
 
 	it("pauses the idle watchdog while a quiet agent() runs past the budget", async () => {

--- a/packages/coding-agent/test/eval/py/prelude.test.ts
+++ b/packages/coding-agent/test/eval/py/prelude.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { $which } from "@oh-my-pi/pi-utils";
 import { PYTHON_PRELUDE } from "../../../src/eval/py/prelude";
-
 const pythonPath = Bun.env.PYTHON ?? ($which("python3") ? "python3" : "python");
 
 async function runPrelude(
@@ -28,21 +27,6 @@ async function runPrelude(
 }
 
 describe("python prelude", () => {
-	it("exposes read(path, offset?, limit?) with positional optional args", () => {
-		// The eval docs advertise `read(path, offset?=1, limit?=None)`. A
-		// keyword-only signature (`def read(path, *, offset=1, limit=None)`)
-		// makes `read("file", 10)` raise `TypeError: read() takes 1 positional
-		// argument but 2 were given`, which agents in the wild repeatedly hit.
-		// Lock the contract so the helper accepts both positional and keyword
-		// forms.
-		const match = PYTHON_PRELUDE.match(/def\s+read\(([^)]+)\)/);
-		expect(match).not.toBeNull();
-		const signature = match?.[1] ?? "";
-		expect(signature).not.toContain("*,");
-		expect(signature).toContain("offset");
-		expect(signature).toContain("limit");
-	});
-
 	it("infers eval tool schemas and replaces definitions by name", async () => {
 		const result = await runPrelude(
 			[

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -19,12 +19,12 @@ afterEach(() => {
 	server = null;
 });
 
-async function connectedTransport(): Promise<HttpTransport> {
+async function connectedTransport(timeout = REQUEST_TIMEOUT_MS): Promise<HttpTransport> {
 	if (!server) throw new Error("Test server was not started");
 	const transport = new HttpTransport({
 		type: "http",
 		url: `http://127.0.0.1:${server.port}/mcp`,
-		timeout: REQUEST_TIMEOUT_MS,
+		timeout,
 	});
 	await transport.connect();
 	return transport;
@@ -657,7 +657,7 @@ describe("MCP Streamable HTTP GET listener resumption", () => {
 						{ headers: { "Content-Type": "text/event-stream" } },
 					);
 				}
-				return new Response(
+				const response = new Response(
 					new ReadableStream<Uint8Array>({
 						start(controller) {
 							controller.enqueue(
@@ -668,9 +668,13 @@ describe("MCP Streamable HTTP GET listener resumption", () => {
 					}),
 					{ headers: { "Content-Type": "text/event-stream" } },
 				);
+				return response;
 			},
 		});
-		const transport = await connectedTransport();
+		// This is a resumption test, not a deadline test. The 50ms request
+		// fixture above gives the optional GET only 12ms to connect, so a busy
+		// runner can abort it before any stream exists to resume.
+		const transport = await connectedTransport(0);
 		const notifications: string[] = [];
 		let closed = false;
 		const secondNotification = Promise.withResolvers<void>();
@@ -678,17 +682,22 @@ describe("MCP Streamable HTTP GET listener resumption", () => {
 			notifications.push(method);
 			if (notifications.length === 2) secondNotification.resolve();
 		};
+		transport.onError = error => secondNotification.reject(error);
 		transport.onClose = () => {
 			closed = true;
+			secondNotification.reject(new Error("Logical SSE listener closed before the resumed notification"));
 		};
 
-		await transport.startSSEListener();
-		await withPendingGuard(secondNotification.promise, "resumed notification");
+		try {
+			await transport.startSSEListener();
+			await secondNotification.promise;
 
-		expect(notifications).toEqual(["notifications/first", "notifications/second"]);
-		expect(observed.lastEventIds).toEqual([null, "poll-1"]);
-		// The resume replaced the manager-level reconnect: no close fired.
-		expect(closed).toBe(false);
-		await transport.close();
+			expect(notifications).toEqual(["notifications/first", "notifications/second"]);
+			expect(observed.lastEventIds).toEqual([null, "poll-1"]);
+			// The resume replaced the manager-level reconnect: no close fired.
+			expect(closed).toBe(false);
+		} finally {
+			await transport.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -222,6 +222,16 @@ describe("MCP tool arguments", () => {
 		]);
 	});
 
+	it("strips harness intent prohibited by a false property schema", async () => {
+		const calls: CapturedRequest[] = [];
+		const tool = new MCPTool(createCapturedConnection(calls), {
+			name: "false-intent",
+			inputSchema: { type: "object", properties: { i: false } },
+		});
+		await tool.execute("false", { i: "caller intent" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "false-intent", arguments: {} } }]);
+	});
+
 	it("strips harness intent explicitly prohibited by not-required", async () => {
 		const calls: CapturedRequest[] = [];
 		const tool = new MCPTool(createCapturedConnection(calls), {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -222,6 +222,16 @@ describe("MCP tool arguments", () => {
 		]);
 	});
 
+	it("strips harness intent explicitly prohibited by not-required", async () => {
+		const calls: CapturedRequest[] = [];
+		const tool = new MCPTool(createCapturedConnection(calls), {
+			name: "forbidden-presence",
+			inputSchema: { type: "object", not: { required: ["i"] } },
+		});
+		await tool.execute("not-required", { i: "caller intent" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "forbidden-presence", arguments: {} } }]);
+	});
+
 	it("forwards intent admitted by propertyNames", async () => {
 		const calls: CapturedRequest[] = [];
 		const definition: MCPToolDefinition = {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -232,6 +232,28 @@ describe("MCP tool arguments", () => {
 		expect(calls).toEqual([{ method: "tools/call", params: { name: "false-intent", arguments: {} } }]);
 	});
 
+	it("strips intent prohibited by a false pattern schema", async () => {
+		const calls: CapturedRequest[] = [];
+		const tool = new MCPTool(createCapturedConnection(calls), {
+			name: "false-pattern-intent",
+			inputSchema: { type: "object", patternProperties: { "^i$": false } },
+		});
+		await tool.execute("false-pattern", { i: "caller intent" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "false-pattern-intent", arguments: {} } }]);
+	});
+
+	it("forwards intent constrained by unevaluatedProperties", async () => {
+		const calls: CapturedRequest[] = [];
+		const tool = new MCPTool(createCapturedConnection(calls), {
+			name: "unevaluated-intent",
+			inputSchema: { type: "object", unevaluatedProperties: { type: "string" }, minProperties: 1 },
+		});
+		await tool.execute("unevaluated", { i: "caller intent" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([
+			{ method: "tools/call", params: { name: "unevaluated-intent", arguments: { i: "caller intent" } } },
+		]);
+	});
+
 	it("strips harness intent explicitly prohibited by not-required", async () => {
 		const calls: CapturedRequest[] = [];
 		const tool = new MCPTool(createCapturedConnection(calls), {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -170,7 +170,7 @@ describe("MCP tool arguments", () => {
 	it("preserves `i` when the server's own schema declares it", async () => {
 		// A server that legitimately exposes `i` as one of its parameters
 		// must receive the caller-supplied value untouched. The boundary
-		// guard checks the server's declared `properties` and steps aside.
+		// guard checks the server's schema and steps aside.
 		const calls: CapturedRequest[] = [];
 		const definition: MCPToolDefinition = {
 			name: "echo",
@@ -186,6 +186,42 @@ describe("MCP tool arguments", () => {
 		await tool.execute("call-1", { i: "hello" }, undefined, unusedContext, undefined);
 
 		expect(calls).toEqual([{ method: "tools/call", params: { name: "echo", arguments: { i: "hello" } } }]);
+	});
+
+	it("forwards schema-owned intent through a referenced MCP schema", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "referenced-input",
+			inputSchema: {
+				type: "object",
+				$ref: "#/$defs/input",
+				$defs: { input: { type: "object", properties: { i: { type: "string" } }, required: ["i"] } },
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+		await tool.execute("call-ref", { i: "server data" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([
+			{ method: "tools/call", params: { name: "referenced-input", arguments: { i: "server data" } } },
+		]);
+	});
+
+	it("does not claim intent from an unused MCP schema definition", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition = createSearchToolDefinition();
+		definition.inputSchema.$defs = {
+			unused: { type: "object", properties: { i: { type: "string" } }, required: ["i"] },
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+		await tool.execute(
+			"call-unused",
+			{ i: "harness intent", symbol: "Foo", language: "TypeScript" },
+			undefined,
+			unusedContext,
+			undefined,
+		);
+		expect(calls).toEqual([
+			{ method: "tools/call", params: { name: "search", arguments: { symbol: "Foo", language: "TypeScript" } } },
+		]);
 	});
 
 	it("resolves local image arguments before forwarding tools/call", async () => {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -206,6 +206,22 @@ describe("MCP tool arguments", () => {
 		]);
 	});
 
+	it.each(["const", "enum"] as const)("forwards intent owned by an object-valued %s", async keyword => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "object-constraint",
+			inputSchema: {
+				type: "object",
+				[keyword]: keyword === "const" ? { i: "token" } : [{ i: "token" }],
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+		await tool.execute("object", { i: "token" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([
+			{ method: "tools/call", params: { name: "object-constraint", arguments: { i: "token" } } },
+		]);
+	});
+
 	it("forwards intent admitted by propertyNames", async () => {
 		const calls: CapturedRequest[] = [];
 		const definition: MCPToolDefinition = {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -188,6 +188,58 @@ describe("MCP tool arguments", () => {
 		expect(calls).toEqual([{ method: "tools/call", params: { name: "echo", arguments: { i: "hello" } } }]);
 	});
 
+	it("forwards intent admitted by propertyNames", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "property-name-input",
+			description: "Echo property-name input",
+			inputSchema: {
+				type: "object",
+				propertyNames: { const: INTENT_FIELD },
+				minProperties: 1,
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+
+		await tool.execute("call-property-name", { [INTENT_FIELD]: "server data" }, undefined, unusedContext, undefined);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "property-name-input", arguments: { [INTENT_FIELD]: "server data" } },
+			},
+		]);
+	});
+
+	it("strips intent excluded by propertyNames", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "excluded-property-name-input",
+			description: "Echo ordinary input",
+			inputSchema: {
+				type: "object",
+				properties: { value: { type: "string" } },
+				propertyNames: { not: { const: INTENT_FIELD } },
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+
+		await tool.execute(
+			"call-excluded-property-name",
+			{ value: "ordinary", [INTENT_FIELD]: "harness intent" },
+			undefined,
+			unusedContext,
+			undefined,
+		);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "excluded-property-name-input", arguments: { value: "ordinary" } },
+			},
+		]);
+	});
+
 	it("forwards schema-owned intent through a referenced MCP schema", async () => {
 		const calls: CapturedRequest[] = [];
 		const definition: MCPToolDefinition = {

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -205,6 +205,35 @@ describe("MCP tool arguments", () => {
 		]);
 	});
 
+	it("preserves intent declared by legacy dependencies", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "legacy-dependent-input",
+			description: "Echo legacy dependent input",
+			inputSchema: {
+				type: "object",
+				properties: { mode: { type: "string" } },
+				dependencies: { mode: [INTENT_FIELD] },
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+
+		await tool.execute(
+			"call-legacy",
+			{ mode: "active", [INTENT_FIELD]: "server data" },
+			undefined,
+			unusedContext,
+			undefined,
+		);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "legacy-dependent-input", arguments: { mode: "active", [INTENT_FIELD]: "server data" } },
+			},
+		]);
+	});
+
 	it("does not claim intent from an unused MCP schema definition", async () => {
 		const calls: CapturedRequest[] = [];
 		const definition = createSearchToolDefinition();

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -188,6 +188,24 @@ describe("MCP tool arguments", () => {
 		expect(calls).toEqual([{ method: "tools/call", params: { name: "echo", arguments: { i: "hello" } } }]);
 	});
 
+	it("strips harness intent when propertyNames cannot admit an additional property", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "closed-property-names",
+			inputSchema: {
+				type: "object",
+				properties: { value: {} },
+				propertyNames: { type: "string" },
+				additionalProperties: false,
+			},
+		};
+		const tool = new MCPTool(createCapturedConnection(calls), definition);
+		await tool.execute("closed", { value: "x", i: "caller intent" }, undefined, unusedContext, undefined);
+		expect(calls).toEqual([
+			{ method: "tools/call", params: { name: "closed-property-names", arguments: { value: "x" } } },
+		]);
+	});
+
 	it("forwards intent admitted by propertyNames", async () => {
 		const calls: CapturedRequest[] = [];
 		const definition: MCPToolDefinition = {


### PR DESCRIPTION
## What

- Validate ordinary eval-bridged tool calls with the same `validateToolArguments` helper used by direct dispatch.
- Preserve harness intent outside validation, but validate `i` normally when the tool declares it, including composition branches and local references. Share this check with xdev and reuse the central schema reference resolver.
- Retain `lenientArgValidation` fallback and parse-metadata cleanup. Irreparable arguments for strict tools reject before execution; tool-returned errors still resolve with `hasError: true`.
- Inject Python's default intent at the host boundary rather than into caller arguments, so constrained tool-owned `i` parameters are not polluted by synthetic values.
- Add real TodoTool and schema-boundary regressions, plus a user-facing changelog entry.
- Stabilize the CI fixtures in separate commits: measure losing-timer cleanup by subprocess exit, isolate tunnel files across restarts, synchronize progress assertions on observed events, and separate positive MCP resumption coverage from the 12ms optional-listener deadline induced by timeout-test settings.

## Why

`await tool.todo(op="done", phase="Work", list=None, task=None, items=None, reason=None)` could return without raising while leaving the tasks incomplete. The bridge executed TodoTool directly, bypassing the central validator that removes optional null placeholders for direct calls. TodoTool returned an error value, so a following confirmation print still ran.

The fix is provider-independent and uses existing normalization rather than adding a todo-specific workaround. It deliberately shares argument validation with direct dispatch, not exception transport: strict bridge validation failures reject into eval/Python, while `isError` results returned by tools keep their existing error-as-value contract.

Related: #10648 began as the persistence/UI synchronization fix and has since added overlapping argument validation. This PR remains focused on validation, including host-owned Python defaults and actual local-reference traversal; it does not add todo persistence or change session events/UI rendering. The overlapping validation paths should be consolidated when landing the two changes, rather than retaining parallel implementations.

## Testing

Using CI-pinned Bun 1.4.0:

- `bun test packages/coding-agent/test/core/js-tool-bridge.test.ts packages/coding-agent/test/core/python-tool-bridge.test.ts packages/coding-agent/test/tools/todo.test.ts packages/coding-agent/test/eval/py/prelude.test.ts packages/coding-agent/test/write-xdev-dispatch.test.ts`: 133 passed, 0 failed.
- `bun run ci:test:coding-agent:singleton`: 865 passed, 2 skipped, 0 failed across 85 files.
- `bun run ci:test:ts:workspace`: all 8 groups passed.
- `bun run check:ts`: passed full-workspace lint, formatting, and type checks.
- `bun test packages/coding-agent/test/mcp-http-transport.test.ts`: 20 passed, 0 failed. The full native/tooling group passed 73 of 75 local groups; the other two reported a host zsh startup banner and unexpected locally discovered skills. No full local native-suite pass is claimed.
- Observed regressions fail before their fixes for optional-null TodoTool calls, closed-schema harness intent, required/constrained tool-owned `i`, composed/reference declarations, and real Python prelude calls that injected synthetic `i`. All pass afterward.
- Disposable Python HTTP-bridge + SessionManager probe on #10648's original `a71f90265fd3` head with this normalization change: completion survives flush/reopen; view and failed mutations add no snapshots. That original head failed the null case. This verifies compatibility with its separate persistence fix, not persistence added here.

The branch is based on upstream main. No daemon or other fork features are included. CI is being checked again after the review and test-stability commits.

---

- [x] Affected-package `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
