### PR TITLE
fix(ai): accept content:null on auth-gateway responses/chat routes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the auth-gateway rejecting `content: null` on `/v1/responses` and `/v1/chat/completions` message items with a 400; Codex and other OpenAI clients that emit null content on empty turns now work, matching OpenAI's tolerance ([#10956](https://github.com/can1357/oh-my-pi/issues/10956)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -30,6 +30,7 @@ import {
 	openaiChatRequestSchema,
 } from "./openai-chat-server-schema";
 import { decodeDataUri } from "./openai-data-uri";
+import { coerceNullMessageContentInPlace } from "./openai-shared";
 
 export type { ParsedRequest };
 
@@ -79,27 +80,6 @@ function rejectUnsupportedExplicitPromptCacheFields(body: unknown): void {
 	}
 }
 
-/**
- * Normalize `content: null` to `[]` in place for the roles whose content the
- * schema models as `string | array`.
- *
- * Codex (and other OpenAI clients) emit `content: null` on empty message turns.
- * OpenAI tolerates it; coercing to `[]` before validation lets the message take
- * the same path as an explicit empty content array instead of 400ing. The
- * legacy `function` role is excluded — its content is `string | null`, so `[]`
- * would be invalid there (and the walker already maps its null to ""). See #10956.
- */
-function coerceNullMessageContent(body: unknown): void {
-	if (typeof body !== "object" || body === null || Array.isArray(body)) return;
-	const request = body as Record<string, unknown>;
-	if (!Array.isArray(request.messages)) return;
-	for (const message of request.messages) {
-		if (typeof message !== "object" || message === null || Array.isArray(message)) continue;
-		const wireMessage = message as Record<string, unknown>;
-		if (wireMessage.content === null && wireMessage.role !== "function") wireMessage.content = [];
-	}
-}
-
 // ---------------------------------------------------------------------------
 // parseRequest
 // ---------------------------------------------------------------------------
@@ -111,7 +91,9 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// for `resolvePromptCacheKey` to pull a cache identity out of inbound
 	// vendor-neutral headers when the body doesn't carry one.
 	rejectUnsupportedExplicitPromptCacheFields(body);
-	coerceNullMessageContent(body);
+	const request =
+		typeof body === "object" && body !== null && !Array.isArray(body) ? (body as Record<string, unknown>) : undefined;
+	coerceNullMessageContentInPlace(request?.messages, message => message.role !== "function");
 	const parsed = openaiChatRequestSchema(body);
 	if (parsed instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-chat: ${parsed.summary}`);

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -79,6 +79,27 @@ function rejectUnsupportedExplicitPromptCacheFields(body: unknown): void {
 	}
 }
 
+/**
+ * Normalize `content: null` to `[]` in place for the roles whose content the
+ * schema models as `string | array`.
+ *
+ * Codex (and other OpenAI clients) emit `content: null` on empty message turns.
+ * OpenAI tolerates it; coercing to `[]` before validation lets the message take
+ * the same path as an explicit empty content array instead of 400ing. The
+ * legacy `function` role is excluded — its content is `string | null`, so `[]`
+ * would be invalid there (and the walker already maps its null to ""). See #10956.
+ */
+function coerceNullMessageContent(body: unknown): void {
+	if (typeof body !== "object" || body === null || Array.isArray(body)) return;
+	const request = body as Record<string, unknown>;
+	if (!Array.isArray(request.messages)) return;
+	for (const message of request.messages) {
+		if (typeof message !== "object" || message === null || Array.isArray(message)) continue;
+		const wireMessage = message as Record<string, unknown>;
+		if (wireMessage.content === null && wireMessage.role !== "function") wireMessage.content = [];
+	}
+}
+
 // ---------------------------------------------------------------------------
 // parseRequest
 // ---------------------------------------------------------------------------
@@ -90,6 +111,7 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// for `resolvePromptCacheKey` to pull a cache identity out of inbound
 	// vendor-neutral headers when the body doesn't carry one.
 	rejectUnsupportedExplicitPromptCacheFields(body);
+	coerceNullMessageContent(body);
 	const parsed = openaiChatRequestSchema(body);
 	if (parsed instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-chat: ${parsed.summary}`);

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -43,7 +43,7 @@ import {
 	type OpenAIResponsesTool,
 	openaiResponsesRequestSchema,
 } from "./openai-responses-server-schema";
-import { encodeTextSignatureV1, parseTextSignature } from "./openai-shared";
+import { coerceNullMessageContentInPlace, encodeTextSignatureV1, parseTextSignature } from "./openai-shared";
 
 export type { ParsedRequest };
 
@@ -355,23 +355,6 @@ function functionOutputContent(output: string | readonly unknown[] | undefined):
 	return content.length > 0 ? content : [{ type: "text", text: "" }];
 }
 
-/**
- * Normalize `content: null` on message input items to `[]` in place.
- *
- * Codex (and other OpenAI clients) emit `content: null` on empty message items
- * during multi-turn/tool turns. OpenAI tolerates it; coercing to `[]` before
- * validation lets the item take the same path as an explicit empty content
- * array — for both request validation and the native history replay clone —
- * instead of 400ing. Only message items carry `content`; other input items
- * (function_call_output, custom_tool_call_output) carry `output`. See #10956.
- */
-function coerceNullMessageContent(body: unknown): void {
-	if (!isObj(body) || !Array.isArray(body.input)) return;
-	for (const item of body.input) {
-		if (isObj(item) && item.content === null) item.content = [];
-	}
-}
-
 // ─── parseRequest ───────────────────────────────────────────────────────────
 
 export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
@@ -382,7 +365,7 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// `resolvePromptCacheKey` call further down.
 
 	rejectUnsupportedExplicitPromptCacheFields(body);
-	coerceNullMessageContent(body);
+	coerceNullMessageContentInPlace(isObj(body) ? body.input : undefined);
 	const data = openaiResponsesRequestSchema(body);
 	if (data instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-responses: ${data.summary}`);

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -355,6 +355,23 @@ function functionOutputContent(output: string | readonly unknown[] | undefined):
 	return content.length > 0 ? content : [{ type: "text", text: "" }];
 }
 
+/**
+ * Normalize `content: null` on message input items to `[]` in place.
+ *
+ * Codex (and other OpenAI clients) emit `content: null` on empty message items
+ * during multi-turn/tool turns. OpenAI tolerates it; coercing to `[]` before
+ * validation lets the item take the same path as an explicit empty content
+ * array — for both request validation and the native history replay clone —
+ * instead of 400ing. Only message items carry `content`; other input items
+ * (function_call_output, custom_tool_call_output) carry `output`. See #10956.
+ */
+function coerceNullMessageContent(body: unknown): void {
+	if (!isObj(body) || !Array.isArray(body.input)) return;
+	for (const item of body.input) {
+		if (isObj(item) && item.content === null) item.content = [];
+	}
+}
+
 // ─── parseRequest ───────────────────────────────────────────────────────────
 
 export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
@@ -365,6 +382,7 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// `resolvePromptCacheKey` call further down.
 
 	rejectUnsupportedExplicitPromptCacheFields(body);
+	coerceNullMessageContent(body);
 	const data = openaiResponsesRequestSchema(body);
 	if (data instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-responses: ${data.summary}`);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -749,6 +749,32 @@ export function applyOpenAIExtraBody<P extends object>(
 }
 
 /**
+ * Normalize `content: null` to `[]` in place across a list of inbound wire
+ * message items.
+ *
+ * Codex (and other OpenAI clients) emit `content: null` on empty message items
+ * during multi-turn/tool turns; OpenAI tolerates it. Normalizing before the
+ * auth-gateway's request schema validation lets the item take the same path as
+ * an explicit empty content array — for both validation and any native
+ * history-replay clone — instead of 400ing. Shared by the `/v1/responses`
+ * (`input[]`) and `/v1/chat/completions` (`messages[]`) routes.
+ *
+ * `isEligible` lets a route skip items whose content is not array-typed, e.g.
+ * the chat `function` role whose content is `string | null`. See issue #10956.
+ */
+export function coerceNullMessageContentInPlace(
+	items: unknown,
+	isEligible?: (item: Record<string, unknown>) => boolean,
+): void {
+	if (!Array.isArray(items)) return;
+	for (const item of items) {
+		if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+		const record = item as Record<string, unknown>;
+		if (record.content === null && (isEligible?.(record) ?? true)) record.content = [];
+	}
+}
+
+/**
  * Chat Completions streaming request body shaped by the OpenAI-family providers.
  * (binary `thinking`, Qwen `enable_thinking`/`chat_template_kwargs`, Venice
  * `venice_parameters`, nested `reasoning`, gateway `provider`/`providerOptions`,

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -147,6 +147,34 @@ describe("auth-gateway openai-chat: parseRequest", () => {
 		expect(parsed.options.extra).toEqual({ includeStreamingUsage: true });
 	});
 
+	it("coerces content:null to empty content for non-function roles (Codex #10956)", () => {
+		const parsed = parseRequest({
+			model: "gpt-5.2",
+			messages: [
+				{ role: "user", content: "hi" },
+				{ role: "user", content: null },
+			],
+		});
+		expect(parsed.context.messages).toHaveLength(2);
+		const empty = parsed.context.messages[1];
+		expect(empty.role).toBe("user");
+		if (empty.role !== "user") throw new Error("unreachable");
+		expect(empty.content).toEqual([]);
+	});
+
+	it("leaves legacy function-role content:null on the string path (Codex #10956)", () => {
+		const parsed = parseRequest({
+			model: "gpt-5.2",
+			messages: [{ role: "function", name: "lookup", content: null }],
+		});
+		expect(parsed.context.messages).toHaveLength(1);
+		const result = parsed.context.messages[0];
+		expect(result.role).toBe("toolResult");
+		if (result.role !== "toolResult") throw new Error("unreachable");
+		expect(result.toolName).toBe("lookup");
+		expect(result.content).toEqual([{ type: "text", text: "" }]);
+	});
+
 	it("rejects raw explicit prompt-cache controls instead of silently dropping them", () => {
 		expect(() =>
 			parseRequest({

--- a/packages/ai/test/auth-gateway-openai-responses.test.ts
+++ b/packages/ai/test/auth-gateway-openai-responses.test.ts
@@ -177,6 +177,27 @@ describe("openai-responses parseRequest", () => {
 		expect(parsed.options.extra).toBeUndefined();
 	});
 
+	it("coerces a message item with content:null to an empty content array (Codex #10956)", () => {
+		const parsed = parseRequest({
+			model: "gpt-5.3-codex-spark",
+			input: [
+				{ type: "message", role: "user", content: [{ type: "input_text", text: "again" }] },
+				{ type: "message", role: "user", content: null },
+			],
+			max_output_tokens: 16,
+		});
+
+		const msgs = parsed.context.messages;
+		expect(msgs).toHaveLength(2);
+		const empty = msgs[1]!;
+		if (empty.role !== "user") throw new Error("expected user");
+		expect(empty.content).toEqual([]);
+		// The null must not survive into the native history-replay clone — it
+		// carries `[]` so downstream providers see the same shape as content:[].
+		const replay = empty.providerPayload as { items: Array<{ content?: unknown }> };
+		expect(replay.items[0]!.content).toEqual([]);
+	});
+
 	it("preserves canonical multimodal order and nullable fallback sources", () => {
 		const imageData = Buffer.from("tool image").toString("base64");
 		const parsed = parseRequest({


### PR DESCRIPTION
## Repro
Codex CLI emits Responses `input[]` (and chat `messages[]`) message items with `content: null` on some multi-turn/tool turns. OpenAI's API accepts them, but `omp auth-gateway serve` rejected them with a 400 before forwarding. Reproduced by calling the gateway request parsers directly:

```
responses content:null -> openai-responses: input[3].content must be a string or an array (was null)
responses content:[]   -> OK
chat content:null      -> openai-chat: messages[1].content must be a string or an array (was null)
```

The `content:[]` control passes, isolating the `null` literal as the sole trigger.

## Cause
The request-validation schemas accept message `content` as `string | array` but not `null`:
- `openai-responses-server-schema.ts` — `userMessageItemSchema` / `systemMessageItemSchema` / `assistantMessageItemSchema` use `"content?": string | array`.
- `openai-chat-server-schema.ts` — `baseContent = string | array` (only the assistant role already tolerated null via `assistantContent = baseContent.or("null")`).

The gateway is marketed as a drop-in OpenAI-compatible proxy, so being stricter than OpenAI here breaks a real first-party client (Codex, an unmodifiable binary).

## Fix
- Add `coerceNullMessageContent(body)` to `openai-responses-server.ts` `parseRequest`, run before schema validation: replace `content: null` on message input items with `[]` in place. This also fixes the native history-replay clone (`structuredCloneJSON(item)`), which would otherwise carry `null` downstream.
- Add `coerceNullMessageContent(body)` to `openai-chat-server.ts` `parseRequest`, run before schema validation: replace `content: null` with `[]` for every role except the legacy `function` role (whose content is `string | null`, so `[]` would be invalid there and the walker already maps its null to `""`).
- Normalization (not a schema morph) was chosen because omptype rejects unions with overlapping morph inputs as indeterminate, and normalizing guarantees the exact `[]` path everywhere including native replay.
- Add regression tests in `auth-gateway-openai-responses.test.ts` and `auth-gateway-openai-chat.test.ts`.

## Verification
`bun test test/auth-gateway-openai-responses.test.ts test/auth-gateway-openai-chat.test.ts` -> 44 pass, 0 fail. Also confirmed `auth-gateway-openai-responses-caching` / `auth-gateway-openai-prompt-cache` still pass. The pre-publish `bun check` gate passed on push.

Fixes #10956