### PR TITLE
fix(tui): eliminate write preview highlighting stalls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -93,6 +93,9 @@
 - Fixed the fullscreen `/copy` and esc-esc rewind selectors repainting the whole frame for a wheel notch that cannot move the viewport; because both open scrolled to the newest turn, wheeling down there made the frame twitch.
 - The default `omp commit` agent now uses its displayed COMMIT model and honors `--model` instead of silently running on SMOL ([#10991](https://github.com/can1357/oh-my-pi/issues/10991)).
 - Fixed JavaScript `eval` `completion()`/`agent()` handles so the documented immediate-handle pattern works: `h.wait()`, `h.status()`, and the other handle methods now work on the un-awaited factory result ([#10986](https://github.com/can1357/oh-my-pi/issues/10986)).
+### Fixed
+
+- Fixed frame skips while streaming long markdown Write previews ([#10955](https://github.com/can1357/oh-my-pi/issues/10955)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -10,6 +10,7 @@ import type {
 	AgentToolUpdateCallback,
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
+import type { HighlightStream } from "@oh-my-pi/pi-natives";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
 import { isEnoent, isRecord, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import {
@@ -29,7 +30,7 @@ import { couldBecomeXdUrl, parseXdUrl } from "../internal-urls/xd-protocol";
 import { createLspWritethrough, type FileDiagnosticsResult, type WritethroughCallback, writethroughNoop } from "../lsp";
 import { DeferredDiagnostics } from "../lsp/deferred-diagnostics";
 import { getDiagnosticsLedger } from "../lsp/diagnostics-ledger";
-import { getLanguageFromPath, highlightCode, type Theme } from "../modes/theme/theme";
+import { createHighlightStream, getLanguageFromPath, highlightCode, type Theme } from "../modes/theme/theme";
 import writeDescription from "../prompts/tools/write.md" with { type: "text" };
 import writeDeviceOnlyDescription from "../prompts/tools/write-device-only.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
@@ -1427,80 +1428,93 @@ function normalizeDisplayText(text: unknown): string {
  */
 const WRITE_GUTTER_MIN_WIDTH = 3;
 
+const writeStreamingPreviewStateKey = Symbol("writeStreamingPreviewState");
+
 /**
- * Per-component streaming line index for {@link formatStreamingContent}.
- * Keyed on the ToolExecutionComponent's persistent render-state object (the
- * `options` argument renderers receive on every rebuild), so the entry lives
- * exactly as long as the component and never leaks across tool calls.
- *
- * Why: streamed write content is append-only, but the formatter used to
- * normalize + `split("\n")` the ENTIRE accumulated payload on every reveal
- * tick — O(n) per tick, O(n²) per stream, which was a measurable main-thread
- * stall on long writes (and multiplied across concurrent subagent writes).
- * Tracking the newline count incrementally and extracting only the tail
- * window makes each tick O(delta + preview lines).
+ * Per-component state for incrementally rendering a streamed write.
+ * The ToolExecutionComponent's persistent render options carry the state, so
+ * it lives exactly as long as the component and cannot leak across tool calls.
  */
-interface WriteStreamingLineIndex {
+interface WriteStreamingPreviewState {
 	/** Number of content code units scanned so far. */
 	length: number;
 	/** Bounded suffix used to detect a restarted/non-append stream. */
 	suffix: string;
 	/** `1 + count("\n")` over the scanned content. */
 	lineCount: number;
+	/** Raw offset immediately after the last newline consumed by `highlighter`. */
+	completeLength: number;
+	/** Highlighted, complete logical lines; the unfinished trailing line is rendered plain. */
+	highlightedLines: string[];
+	/** Stateful parser carrying syntax scopes across appended complete lines. */
+	highlighter: HighlightStream | null;
+	language: string | undefined;
+	uiTheme: Theme;
 }
 
-const writeStreamingLineIndex = new WeakMap<object, WriteStreamingLineIndex>();
+interface WriteStreamingPreviewStateCarrier {
+	[writeStreamingPreviewStateKey]?: WriteStreamingPreviewState;
+}
 
 /** Keep append validation constant-time instead of comparing the entire prior payload. */
 const WRITE_STREAMING_APPEND_GUARD_LENGTH = 64;
 
-/** Total logical line count of `content`, resuming from the cached prefix scan when append-only. */
-function streamingTotalLines(streamKey: object | undefined, content: string): number {
-	if (streamKey === undefined) {
-		let lines = 1;
-		for (let i = 0; i < content.length; i++) if (content.charCodeAt(i) === 10) lines++;
-		return lines;
-	}
-	let entry = writeStreamingLineIndex.get(streamKey);
-	const continuesPrevious =
-		entry !== undefined &&
-		content.length >= entry.length &&
-		content.startsWith(entry.suffix, entry.length - entry.suffix.length);
-	if (entry !== undefined && continuesPrevious) {
-		let lines = entry.lineCount;
-		for (let i = entry.length; i < content.length; i++) if (content.charCodeAt(i) === 10) lines++;
-		entry.length = content.length;
-		entry.suffix = content.slice(-WRITE_STREAMING_APPEND_GUARD_LENGTH);
-		entry.lineCount = lines;
-		return lines;
-	}
-	let lines = 1;
-	for (let i = 0; i < content.length; i++) if (content.charCodeAt(i) === 10) lines++;
-	entry = {
-		length: content.length,
-		suffix: content.slice(-WRITE_STREAMING_APPEND_GUARD_LENGTH),
-		lineCount: lines,
+function createWriteStreamingPreviewState(language: string | undefined, uiTheme: Theme): WriteStreamingPreviewState {
+	return {
+		length: 0,
+		suffix: "",
+		lineCount: 1,
+		completeLength: 0,
+		highlightedLines: [],
+		highlighter: createHighlightStream(language, uiTheme),
+		language,
+		uiTheme,
 	};
-	writeStreamingLineIndex.set(streamKey, entry);
-	return lines;
 }
 
 /**
- * Raw offset just after the (totalLines - previewLines)-th newline — i.e. the
- * start of the last `previewLines` logical lines — scanning back from the end.
- * Returns 0 when the whole content fits in the window. Equivalent to
- * `content.split("\n").slice(-previewLines).join("\n")` without materializing
- * the full line array.
+ * Advance line counting and syntax highlighting only across newly appended
+ * content. Complete lines are retained because Ctrl+O can expand the preview;
+ * the current partial line stays plain until its terminating newline arrives.
  */
-function tailWindowStart(content: string, previewLines: number): number {
-	let newlinesSeen = 0;
-	for (let i = content.length - 1; i >= 0; i--) {
+function updateStreamingPreview(
+	streamKey: WriteStreamingPreviewStateCarrier | undefined,
+	content: string,
+	language: string | undefined,
+	uiTheme: Theme,
+): WriteStreamingPreviewState | undefined {
+	if (streamKey === undefined) return undefined;
+
+	let state = streamKey[writeStreamingPreviewStateKey];
+	if (
+		state === undefined ||
+		state.language !== language ||
+		state.uiTheme !== uiTheme ||
+		content.length < state.length ||
+		!content.startsWith(state.suffix, state.length - state.suffix.length)
+	) {
+		state = createWriteStreamingPreviewState(language, uiTheme);
+		streamKey[writeStreamingPreviewStateKey] = state;
+	}
+
+	let completeLength = state.completeLength;
+	for (let i = state.length; i < content.length; i++) {
 		if (content.charCodeAt(i) === 10) {
-			newlinesSeen++;
-			if (newlinesSeen === previewLines) return i + 1;
+			state.lineCount++;
+			completeLength = i + 1;
 		}
 	}
-	return 0;
+	if (completeLength > state.completeLength) {
+		const chunk = content.slice(state.completeLength, completeLength).replace(/\r/g, "");
+		const highlighted = state.highlighter?.push(chunk) ?? chunk;
+		const lines = highlighted.split("\n");
+		lines.pop();
+		state.highlightedLines.push(...lines);
+		state.completeLength = completeLength;
+	}
+	state.length = content.length;
+	state.suffix = content.slice(-WRITE_STREAMING_APPEND_GUARD_LENGTH);
+	return state;
 }
 
 function formatStreamingContent(
@@ -1510,42 +1524,39 @@ function formatStreamingContent(
 	uiTheme: Theme,
 	spinnerFrame?: number,
 	cache?: RenderedStringCache,
-	streamKey?: object,
+	streamKey?: WriteStreamingPreviewStateCarrier,
 ): string {
 	if (!content) return "";
 	const bodyText = cachedRenderedString(cache, uiTheme, expanded, language ?? "", content, () => {
-		// Collapsed: follow the streaming edge with a bounded tail window so the box
-		// stays short enough not to strand its scrolled-off head above the viewport
-		// while the block is volatile. `Ctrl+O` (expanded) lifts the cap for a
-		// deliberate full view — matching the eval streaming preview.
+		const state = updateStreamingPreview(streamKey, content, language, uiTheme);
 		let totalLines: number;
 		let startIndex: number;
-		let visibleText: string;
-		if (expanded) {
-			visibleText = normalizeDisplayText(content);
-			totalLines = 1;
-			for (let i = 0; i < visibleText.length; i++) if (visibleText.charCodeAt(i) === 10) totalLines++;
-			startIndex = 0;
+		let visibleLines: string[];
+		if (state) {
+			totalLines = state.lineCount;
+			startIndex = expanded ? 0 : Math.max(0, totalLines - WRITE_STREAMING_PREVIEW_LINES);
+			const trailingLine = content.slice(state.completeLength).replace(/\r/g, "");
+			if (totalLines === 1 && trailingLine.length === 0) return "";
+			visibleLines = [...state.highlightedLines.slice(startIndex), trailingLine];
 		} else {
-			totalLines = streamingTotalLines(streamKey, content);
-			startIndex = Math.max(0, totalLines - WRITE_STREAMING_PREVIEW_LINES);
-			const tail =
-				startIndex === 0 ? content : content.slice(tailWindowStart(content, WRITE_STREAMING_PREVIEW_LINES));
-			visibleText = tail.replace(/\r/g, "");
+			const normalized = normalizeDisplayText(content);
+			if (normalized.length === 0) return "";
+			const lines = normalized.split("\n");
+			totalLines = lines.length;
+			startIndex = expanded ? 0 : Math.max(0, totalLines - WRITE_STREAMING_PREVIEW_LINES);
+			visibleLines = highlightCode(lines.slice(startIndex).join("\n"), language);
 		}
-		if (visibleText.length === 0) return "";
 		const hidden = startIndex;
-		const highlighted = highlightCode(visibleText, language);
 		const lineNumberWidth = Math.max(WRITE_GUTTER_MIN_WIDTH, String(totalLines).length);
 
 		let text = "\n\n";
 		if (hidden > 0) {
 			text += `${uiTheme.fg("dim", `… (${hidden} earlier line${hidden === 1 ? "" : "s"})`)}\n`;
 		}
-		for (let i = 0; i < highlighted.length; i++) {
+		for (let i = 0; i < visibleLines.length; i++) {
 			const lineNum = startIndex + i + 1;
 			const gutter = uiTheme.fg("dim", `${String(lineNum).padStart(lineNumberWidth, " ")} `);
-			const body = replaceTabs(highlighted[i] ?? "");
+			const body = replaceTabs(visibleLines[i] ?? "");
 			text += `${gutter}${body}\n`;
 		}
 		return text;
@@ -1618,7 +1629,7 @@ export const writeToolRenderer = {
 
 	renderCall(
 		args: WriteRenderArgs,
-		options: RenderResultOptions & { renderContext?: WriteRenderContext },
+		options: RenderResultOptions & WriteStreamingPreviewStateCarrier & { renderContext?: WriteRenderContext },
 		uiTheme: Theme,
 	): Component | undefined {
 		const rawPath =

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1436,10 +1436,8 @@ const writeStreamingPreviewStateKey = Symbol("writeStreamingPreviewState");
  * it lives exactly as long as the component and cannot leak across tool calls.
  */
 interface WriteStreamingPreviewState {
-	/** Number of content code units scanned so far. */
-	length: number;
-	/** Bounded suffix used to detect a restarted/non-append stream. */
-	suffix: string;
+	/** Prior full content; append-only growth is validated with an exact prefix check. */
+	previous: string;
 	/** `1 + count("\n")` over the scanned content. */
 	lineCount: number;
 	/** Raw offset immediately after the last newline consumed by `highlighter`. */
@@ -1450,25 +1448,27 @@ interface WriteStreamingPreviewState {
 	highlighter: HighlightStream | null;
 	language: string | undefined;
 	uiTheme: Theme;
+	/** Content length for which the trailing line was flushed as final (`argsComplete`); -1 when none. */
+	finalFlushedLength: number;
+	/** Highlighted trailing line from the final flush; rendered in place of the plain tail. */
+	finalTrailing: string;
 }
 
 interface WriteStreamingPreviewStateCarrier {
 	[writeStreamingPreviewStateKey]?: WriteStreamingPreviewState;
 }
 
-/** Keep append validation constant-time instead of comparing the entire prior payload. */
-const WRITE_STREAMING_APPEND_GUARD_LENGTH = 64;
-
 function createWriteStreamingPreviewState(language: string | undefined, uiTheme: Theme): WriteStreamingPreviewState {
 	return {
-		length: 0,
-		suffix: "",
+		previous: "",
 		lineCount: 1,
 		completeLength: 0,
 		highlightedLines: [],
 		highlighter: createHighlightStream(language, uiTheme),
 		language,
 		uiTheme,
+		finalFlushedLength: -1,
+		finalTrailing: "",
 	};
 }
 
@@ -1476,12 +1476,16 @@ function createWriteStreamingPreviewState(language: string | undefined, uiTheme:
  * Advance line counting and syntax highlighting only across newly appended
  * content. Complete lines are retained because Ctrl+O can expand the preview;
  * the current partial line stays plain until its terminating newline arrives.
+ * Once args are final, the trailing line is flushed through the highlighter
+ * (its only push without a trailing newline) so a settled-but-queued preview
+ * keeps syntax colors, including for one-line files.
  */
 function updateStreamingPreview(
 	streamKey: WriteStreamingPreviewStateCarrier | undefined,
 	content: string,
 	language: string | undefined,
 	uiTheme: Theme,
+	argsComplete = false,
 ): WriteStreamingPreviewState | undefined {
 	if (streamKey === undefined) return undefined;
 
@@ -1490,15 +1494,18 @@ function updateStreamingPreview(
 		state === undefined ||
 		state.language !== language ||
 		state.uiTheme !== uiTheme ||
-		content.length < state.length ||
-		!content.startsWith(state.suffix, state.length - state.suffix.length)
+		content.length < state.previous.length ||
+		!content.startsWith(state.previous) ||
+		// A final flush consumed the trailing partial line; later growth would
+		// re-feed it, so restart the parser instead of corrupting its state.
+		(state.finalFlushedLength !== -1 && content.length !== state.finalFlushedLength)
 	) {
 		state = createWriteStreamingPreviewState(language, uiTheme);
 		streamKey[writeStreamingPreviewStateKey] = state;
 	}
 
 	let completeLength = state.completeLength;
-	for (let i = state.length; i < content.length; i++) {
+	for (let i = state.previous.length; i < content.length; i++) {
 		if (content.charCodeAt(i) === 10) {
 			state.lineCount++;
 			completeLength = i + 1;
@@ -1506,14 +1513,35 @@ function updateStreamingPreview(
 	}
 	if (completeLength > state.completeLength) {
 		const chunk = content.slice(state.completeLength, completeLength).replace(/\r/g, "");
-		const highlighted = state.highlighter?.push(chunk) ?? chunk;
-		const lines = highlighted.split("\n");
+		let chunkHighlighted = chunk;
+		if (state.highlighter) {
+			try {
+				chunkHighlighted = state.highlighter.push(chunk);
+			} catch {
+				state.highlighter = null;
+			}
+		}
+		const lines = chunkHighlighted.split("\n");
 		lines.pop();
 		state.highlightedLines.push(...lines);
 		state.completeLength = completeLength;
 	}
-	state.length = content.length;
-	state.suffix = content.slice(-WRITE_STREAMING_APPEND_GUARD_LENGTH);
+	if (argsComplete && state.finalFlushedLength !== content.length && !content.endsWith("\n")) {
+		const trailing = content.slice(state.completeLength).replace(/\r/g, "");
+		if (trailing.length > 0) {
+			let trailingHighlighted = trailing;
+			if (state.highlighter) {
+				try {
+					trailingHighlighted = state.highlighter.push(trailing);
+				} catch {
+					state.highlighter = null;
+				}
+			}
+			state.finalTrailing = trailingHighlighted;
+			state.finalFlushedLength = content.length;
+		}
+	}
+	state.previous = content;
 	return state;
 }
 
@@ -1525,17 +1553,19 @@ function formatStreamingContent(
 	spinnerFrame?: number,
 	cache?: RenderedStringCache,
 	streamKey?: WriteStreamingPreviewStateCarrier,
+	argsComplete?: boolean,
 ): string {
 	if (!content) return "";
 	const bodyText = cachedRenderedString(cache, uiTheme, expanded, language ?? "", content, () => {
-		const state = updateStreamingPreview(streamKey, content, language, uiTheme);
+		const state = updateStreamingPreview(streamKey, content, language, uiTheme, argsComplete === true);
 		let totalLines: number;
 		let startIndex: number;
 		let visibleLines: string[];
 		if (state) {
 			totalLines = state.lineCount;
 			startIndex = expanded ? 0 : Math.max(0, totalLines - WRITE_STREAMING_PREVIEW_LINES);
-			const trailingLine = content.slice(state.completeLength).replace(/\r/g, "");
+			const flushed = argsComplete === true && state.finalFlushedLength === content.length;
+			const trailingLine = flushed ? state.finalTrailing : content.slice(state.completeLength).replace(/\r/g, "");
 			if (totalLines === 1 && trailingLine.length === 0) return "";
 			visibleLines = [...state.highlightedLines.slice(startIndex), trailingLine];
 		} else {
@@ -1682,8 +1712,10 @@ export const writeToolRenderer = {
 						streamingCache,
 						// `options` is the ToolExecutionComponent's persistent
 						// render-state object — a stable identity across reveal ticks
-						// that keys the incremental line index.
+						// that keys the incremental preview state. `argsComplete`
+						// flushes the trailing line through the highlighter once.
 						options,
+						options?.argsComplete,
 					)
 				: "";
 			const bodyLines = body ? body.split("\n") : [];

--- a/packages/coding-agent/test/write-streaming-incremental.test.ts
+++ b/packages/coding-agent/test/write-streaming-incremental.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
 
@@ -20,6 +20,10 @@ function referenceWindow(content: string): { total: number; start: number; visib
 
 describe("write streaming preview incremental line tracking", () => {
 	let initialized = false;
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
 
 	async function getUiTheme() {
 		if (!initialized) {
@@ -78,6 +82,30 @@ describe("write streaming preview incremental line tracking", () => {
 			}
 			if (start > 0) expect(rendered).toContain(`… (${start} earlier line${start === 1 ? "" : "s"})`);
 		}
+	});
+
+	it("does not re-tokenize the whole markdown window as streamed content grows", async () => {
+		const uiTheme = await getUiTheme();
+		const options = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		const highlightSpy = vi.spyOn(themeModule, "highlightCode");
+		const lines = Array.from(
+			{ length: 40 },
+			(_, index) => `- Step ${index + 1}: update \`src/example-${index + 1}.ts\` and verify the result`,
+		);
+
+		let rendered: readonly string[] = [];
+		for (let count = 1; count <= lines.length; count++) {
+			const component = writeToolRenderer.renderCall(
+				{ path: "/tmp/plan.md", content: lines.slice(0, count).join("\n") },
+				options,
+				uiTheme,
+			);
+			if (!component) throw new Error("expected a rendered component for a non-xdev write path");
+			rendered = component.render(120);
+		}
+
+		expect(stripAnsi(rendered.join("\n"))).toContain("Step 40");
+		expect(highlightSpy).not.toHaveBeenCalled();
 	});
 
 	it("does not compare the full accumulated payload when validating append-only growth", async () => {

--- a/packages/coding-agent/test/write-streaming-incremental.test.ts
+++ b/packages/coding-agent/test/write-streaming-incremental.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
+import type { HighlightStream } from "@oh-my-pi/pi-natives";
 
 const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, "");
 const hasLine = (lines: readonly string[], n: number): boolean =>
@@ -108,27 +109,80 @@ describe("write streaming preview incremental line tracking", () => {
 		expect(highlightSpy).not.toHaveBeenCalled();
 	});
 
-	it("does not compare the full accumulated payload when validating append-only growth", async () => {
+	it("resets on same-length prefix replacement above a preserved tail", async () => {
+		// A restarted stream can reuse the render state with a replacement that
+		// preserves more tail than any bounded suffix guard could validate, so
+		// only an exact append check may treat growth as incremental.
 		const uiTheme = await getUiTheme();
-		const options = { expanded: false, isPartial: true, spinnerFrame: 0 };
-		const first = Array.from({ length: 2_000 }, () => "x".repeat(64)).join("\n");
-		writeToolRenderer.renderCall({ path: "/tmp/inc.ts", content: first }, options, uiTheme)?.render(120);
-
-		const originalStartsWith = String.prototype.startsWith;
-		let wholePrefixComparisons = 0;
-		String.prototype.startsWith = function (this: string, searchString: string, position?: number): boolean {
-			if (searchString === first) wholePrefixComparisons++;
-			return originalStartsWith.call(this, searchString, position);
+		const options = { expanded: true, isPartial: true, spinnerFrame: 0 };
+		const render = (content: string) => {
+			const component = writeToolRenderer.renderCall({ path: "/tmp/restart.ts", content }, options, uiTheme);
+			if (!component) throw new Error("expected a rendered component for a non-xdev write path");
+			return component.render(120);
 		};
-		try {
-			writeToolRenderer
-				.renderCall({ path: "/tmp/inc.ts", content: `${first}\nlast` }, options, uiTheme)
-				?.render(120);
-		} finally {
-			String.prototype.startsWith = originalStartsWith;
-		}
+		const tail = `${"x".repeat(80)}\n`;
+		render(`const original = 1;\n${tail}`);
 
-		expect(wholePrefixComparisons).toBe(0);
+		const text = stripAnsi(render(`const replaced = 1;\n${tail}const extra = 3;\n`).join("\n"));
+		expect(text).toContain("replaced");
+		expect(text).not.toContain("original");
+		expect(text).toContain("extra");
+	});
+
+	it("feeds only newline-terminated chunks to the highlight stream", async () => {
+		const uiTheme = await getUiTheme();
+		const pushes: string[] = [];
+		vi.spyOn(themeModule, "createHighlightStream").mockImplementation(
+			() =>
+				({
+					push: (chunk: string) => {
+						pushes.push(chunk);
+						return chunk;
+					},
+				}) as unknown as HighlightStream,
+		);
+		const options = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		let acc = "";
+		for (const piece of ["const a = ", "1;\nconst b = ", "2;\nconst c = 3"]) {
+			acc += piece;
+			const component = writeToolRenderer.renderCall({ path: "/tmp/chunks.ts", content: acc }, options, uiTheme);
+			if (!component) throw new Error("expected a rendered component for a non-xdev write path");
+			component.render(120);
+		}
+		expect(pushes).toEqual(["const a = 1;\n", "const b = 2;\n"]);
+		const component = writeToolRenderer.renderCall({ path: "/tmp/chunks.ts", content: acc }, options, uiTheme);
+		if (!component) throw new Error("expected a rendered component for a non-xdev write path");
+		expect(stripAnsi(component.render(120).join("\n"))).toContain("const c = 3");
+	});
+
+	it("highlights the trailing line once args are complete", async () => {
+		const uiTheme = await getUiTheme();
+		const pushes: string[] = [];
+		vi.spyOn(themeModule, "createHighlightStream").mockImplementation(
+			() =>
+				({
+					push: (chunk: string) => {
+						pushes.push(chunk);
+						return `H(${chunk})`;
+					},
+				}) as unknown as HighlightStream,
+		);
+		const content = "const solo = 1;";
+		const streamingOptions = { expanded: true, isPartial: true, spinnerFrame: 0 };
+		const streaming = writeToolRenderer.renderCall({ path: "/tmp/solo.ts", content }, streamingOptions, uiTheme);
+		if (!streaming) throw new Error("expected a rendered component for a non-xdev write path");
+		const streamingText = stripAnsi(streaming.render(120).join("\n"));
+		expect(streamingText).toContain("const solo = 1;");
+		expect(streamingText).not.toContain("H(");
+		expect(pushes).toEqual([]);
+
+		const settledOptions = { expanded: true, isPartial: true, spinnerFrame: 0, argsComplete: true };
+		const settled = writeToolRenderer.renderCall({ path: "/tmp/solo.ts", content }, settledOptions, uiTheme);
+		if (!settled) throw new Error("expected a rendered component for a non-xdev write path");
+		expect(stripAnsi(settled.render(120).join("\n"))).toContain("H(const solo = 1;)");
+		expect(pushes).toEqual(["const solo = 1;"]);
+		settled.render(120);
+		expect(pushes).toEqual(["const solo = 1;"]);
 	});
 
 	it("normalizes CRLF only in the rendered tail, with correct line numbers", async () => {

--- a/packages/coding-agent/test/write-streaming-preview-expand.test.ts
+++ b/packages/coding-agent/test/write-streaming-preview-expand.test.ts
@@ -12,6 +12,9 @@ const stripAnsi = (s: string): string => s.replace(/\u001b\[[0-9;]*m/g, "");
 const hasLine = (lines: readonly string[], n: number): boolean =>
 	new RegExp(`\\bline ${n}\\b`).test(stripAnsi(lines.join("\n")));
 
+/** Rendered code rows between the framed block header and the status/footer rows. */
+const extractCodeRows = (lines: readonly string[]): string[] => lines.slice(1, -2);
+
 describe("write streaming preview honors Ctrl+O expansion", () => {
 	let initialized = false;
 
@@ -73,7 +76,7 @@ describe("write streaming preview honors Ctrl+O expansion", () => {
 		expect(hasLine(collapsed, 4)).toBe(true);
 		expect(stripAnsi(collapsed.join("\n"))).not.toContain("earlier line");
 	});
-	it("reuses the highlighted streaming body across frame renders", async () => {
+	it("keeps code rows unchanged when the spinner advances", async () => {
 		if (!initialized) {
 			await themeModule.initTheme();
 			initialized = true;
@@ -81,9 +84,6 @@ describe("write streaming preview honors Ctrl+O expansion", () => {
 		const uiTheme = (await themeModule.getThemeByName("dark")) ?? (await themeModule.getThemeByName("light"));
 		expect(uiTheme).toBeDefined();
 		const options = { expanded: false, isPartial: true, spinnerFrame: 0 };
-		const highlightSpy = vi
-			.spyOn(themeModule, "highlightCode")
-			.mockImplementation((code: string) => code.split("\n"));
 		const component = writeToolRenderer.renderCall(
 			{ path: "/tmp/cache.ts", content: "const a = 1;\nconst b = 2;" },
 			options,
@@ -91,13 +91,15 @@ describe("write streaming preview honors Ctrl+O expansion", () => {
 		);
 		if (!component) throw new Error("expected a rendered component for a non-xdev write path");
 
-		component.render(80);
-		component.render(120);
-		expect(highlightSpy).toHaveBeenCalledTimes(1);
+		const first = component.render(80);
+		const second = component.render(120);
 
 		options.spinnerFrame = 1;
-		component.render(120);
-		expect(highlightSpy).toHaveBeenCalledTimes(1);
+		const third = component.render(120);
+		expect(extractCodeRows(third)).toEqual(extractCodeRows(second));
+		expect(stripAnsi(first.join("\n"))).toContain("const a = 1;");
+		expect(stripAnsi(second.join("\n"))).toContain("const a = 1;");
+		expect(stripAnsi(third.join("\n"))).toContain("const a = 1;");
 	});
 
 	it("coerces truthy non-string content for pending write previews", async () => {


### PR DESCRIPTION
## Repro
Replaying the report’s 126-line markdown plan through the Write renderer at 128-code-unit streaming increments with `bun /tmp/issue10955-repro.ts` produced 289 renders in 14,962 ms; 152 exceeded the 33.3 ms frame budget, with p95 123.4 ms and max 207 ms.

## Cause
`formatStreamingContent` in `packages/coding-agent/src/tools/write.ts` called `highlightCode` on the changing visible markdown window for every reveal frame. Each content delta missed the whole-string highlight cache, so the native grammar repeatedly tokenized the same completed lines on the main thread.

## Fix
- Carry a stateful `HighlightStream` on the Write component’s render state and feed it only newly completed lines.
- Render the unfinished trailing line without advancing parser state, while preserving collapsed-tail, expansion, restart, and CRLF behavior.
- Add a regression test proving growing markdown streams do not invoke whole-window highlighting, plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/write-streaming-incremental.test.ts` passes: 9 tests, 185 expectations. `bun run check` passes in `packages/coding-agent`. The same 289-render harness now completes in 52.3 ms with p95 0.2 ms, max 4.7 ms, and zero frames over budget. Skipped the pre-publish gate because `bun run fix` fails identically on `origin/main`: this runner lacks `cmake`, which `audiopus_sys` requires to build bundled Opus; TypeScript formatting completed successfully.

Fixes #10955