### PR TITLE
fix(cli): initialize skills for standalone reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Standalone `omp read skill://…` commands now discover configured skills before resolving the URI ([#10961](https://github.com/can1357/oh-my-pi/issues/10961)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/cli/read-cli.ts
+++ b/packages/coding-agent/src/cli/read-cli.ts
@@ -8,6 +8,7 @@
 import { getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { Settings } from "../config/settings";
+import { loadSkills } from "../extensibility/skills";
 import { extractUriScheme } from "../internal-urls/parse";
 import { InternalUrlRouter } from "../internal-urls/router";
 import { closeDaemonClients } from "../launch/client";
@@ -57,6 +58,15 @@ export async function runReadCommand(cmd: ReadCommandArgs): Promise<void> {
 	let failed = false;
 
 	try {
+		if (extractUriScheme(cmd.path) === "skill") {
+			const discovered = await loadSkills({
+				...settings.getGroup("skills"),
+				cwd,
+				disabledExtensions: settings.get("disabledExtensions") ?? [],
+			});
+			session.skills = discovered.skills;
+		}
+
 		if (shouldDiscoverMcp(cmd.path)) {
 			authStorage = await discoverAuthStorage();
 			const result = await discoverAndLoadMCPTools(cwd, {

--- a/packages/coding-agent/test/read-cli-skill.test.ts
+++ b/packages/coding-agent/test/read-cli-skill.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const CLI_ENTRY = path.join(import.meta.dir, "..", "src", "cli.ts");
+
+describe("omp read skill resources", () => {
+	let root: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-read-skill-"));
+		projectDir = path.join(root, "project");
+		agentDir = path.join(root, "agent");
+		const skillDir = path.join(projectDir, ".omp", "skills", "standalone-skill");
+		await Promise.all([fs.mkdir(skillDir, { recursive: true }), fs.mkdir(agentDir)]);
+		await Bun.write(
+			path.join(skillDir, "SKILL.md"),
+			"---\nname: standalone-skill\ndescription: Readable from the standalone CLI.\n---\n\n# Standalone Skill\n",
+		);
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(root);
+	});
+
+	it("reads a discovered project skill through the standalone CLI", async () => {
+		const proc = Bun.spawn([process.execPath, CLI_ENTRY, "read", "skill://standalone-skill"], {
+			cwd: projectDir,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: root,
+				NO_COLOR: "1",
+				PI_CODING_AGENT_DIR: agentDir,
+			},
+		});
+		const stdout = new Response(proc.stdout).text();
+		const stderr = new Response(proc.stderr).text();
+		const [exitCode, output, error] = await Promise.all([proc.exited, stdout, stderr]);
+
+		expect(exitCode).toBe(0);
+		expect(output).toContain("# Standalone Skill");
+		expect(error).toBe("");
+	}, 30_000);
+});


### PR DESCRIPTION
## Repro
Running `bun packages/coding-agent/src/cli.ts read skill://semantic-compression` from a project containing `.omp/skills/semantic-compression/SKILL.md` exited 1 with `Unknown skill: semantic-compression` and `Available: none`.

## Cause
`runReadCommand` in `packages/coding-agent/src/cli/read-cli.ts` constructed a minimal `ToolSession` without discovering skills, so `ReadTool` passed no `ResolveContext.skills` to `SkillProtocolHandler` and the fresh process-global snapshot remained empty.

## Fix
- Discover configured skills when the standalone target uses the `skill` scheme and attach them to the read tool session.
- Add an end-to-end CLI regression covering a project-local skill.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test test/read-cli-skill.test.ts test/read-cli-mcp-resource.test.ts` passes (2 tests, 0 failures). `bun run check` passes in `packages/coding-agent`. A manual standalone read of `skill://semantic-compression` now prints its `SKILL.md`.

Fixes #10961