### PR TITLE
fix(cli): preserve Cursor sessions on signal exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Cursor sessions now preserve interrupted headless turns when SIGINT or SIGTERM stops print mode ([#10965](https://github.com/can1357/oh-my-pi/issues/10965)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -91,17 +91,26 @@ export function printableEvent(event: AgentSessionEvent): unknown {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
-	const cancelSignalTeardown = postmortem.register("print-mode-session", reason =>
-		session.dispose({ reason, mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS }),
-	);
+	// A signal (SIGINT/SIGTERM/SIGHUP) landing mid-turn drives the exit code
+	// through postmortem (130/143/129). Record the reason so the aborted-response
+	// branch below never races that with its own process.exit(1).
+	let signalReason: postmortem.Reason | undefined;
+	const cancelSignalTeardown = postmortem.register("print-mode-session", reason => {
+		signalReason = reason;
+		return session.dispose({ reason, mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+	});
 	try {
-		await runPrintModeCore(session, options);
+		await runPrintModeCore(session, options, () => signalReason !== undefined);
 	} finally {
 		cancelSignalTeardown();
 	}
 }
 
-async function runPrintModeCore(session: AgentSession, options: PrintModeOptions): Promise<void> {
+async function runPrintModeCore(
+	session: AgentSession,
+	options: PrintModeOptions,
+	signalTeardownActive: () => boolean,
+): Promise<void> {
 	const { mode, messages = [], initialMessage, initialImages, printThoughts, planYolo = false } = options;
 
 	// process.stdout.write is fire-and-forget: a large final record (e.g. a
@@ -204,10 +213,16 @@ async function runPrintModeCore(session: AgentSession, options: PrintModeOptions
 		const assistantMsg = session.getLastAssistantMessage();
 
 		if (assistantMsg) {
-			// Check for error/aborted — skip silent-abort (plan-mode compaction transition)
+			// Check for error/aborted — skip silent-abort (plan-mode compaction
+			// transition) and any abort a signal teardown produced: on SIGINT/
+			// SIGTERM/SIGHUP `dispose()` calls `agent.abort()`, which finalizes the
+			// turn as `stopReason:"aborted"`. Racing that with process.exit(1) here
+			// would clobber the postmortem-driven 130/143/129 with an ordinary
+			// failure code, so defer the exit to the signal handler.
 			if (
 				(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
-				!isSilentAbort(assistantMsg)
+				!isSilentAbort(assistantMsg) &&
+				!signalTeardownActive()
 			) {
 				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
 				// This branch hard-exits, bypassing the `await session.dispose()` at

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -7,7 +7,7 @@
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { logger, postmortem, sanitizeText } from "@oh-my-pi/pi-utils";
 import { type AgentSession, type AgentSessionEvent, SHUTDOWN_CONSOLIDATE_BUDGET_MS } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { flushTelemetryExport } from "../telemetry-export";
@@ -91,6 +91,17 @@ export function printableEvent(event: AgentSessionEvent): unknown {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
+	const cancelSignalTeardown = postmortem.register("print-mode-session", reason =>
+		session.dispose({ reason, mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS }),
+	);
+	try {
+		await runPrintModeCore(session, options);
+	} finally {
+		cancelSignalTeardown();
+	}
+}
+
+async function runPrintModeCore(session: AgentSession, options: PrintModeOptions): Promise<void> {
 	const { mode, messages = [], initialMessage, initialImages, printThoughts, planYolo = false } = options;
 
 	// process.stdout.write is fire-and-forget: a large final record (e.g. a

--- a/packages/coding-agent/test/fixtures/print-mode-signal.js
+++ b/packages/coding-agent/test/fixtures/print-mode-signal.js
@@ -1,0 +1,24 @@
+import { runPrintMode } from "../../src/modes/print-mode.ts";
+
+const marker = process.argv[2];
+if (!marker) throw new Error("Missing disposal marker path");
+
+const session = {
+	extensionRunner: undefined,
+	subscribe() {},
+	settings: { get: () => false },
+	sessionManager: {
+		buildSessionContext: () => ({ messages: [] }),
+		getEntries: () => [],
+	},
+	setTextOutputCommitted() {},
+	async prompt() {
+		process.kill(process.pid, "SIGTERM");
+		await Promise.withResolvers().promise;
+	},
+	async dispose(options = {}) {
+		await Bun.write(marker, options.reason ?? "dispose");
+	},
+};
+
+await runPrintMode(session, { mode: "text", initialMessage: "wait for signal" });

--- a/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
+++ b/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
@@ -6,7 +6,7 @@
 import * as path from "node:path";
 import { describe, expect, it, spyOn } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
 import { runPrintMode } from "../../src/modes/print-mode";
 import type { AgentSession } from "../../src/session/agent-session";
 import * as telemetryExport from "../../src/telemetry-export";
@@ -88,5 +88,63 @@ describe("print mode disposes the session before exit", () => {
 			throw new Error(`Print session was not disposed before signal exit ${exitCode}: ${stderr}`);
 		}
 		expect(await markerFile.text()).toBe("sigterm");
+	});
+
+	it("defers to the signal exit code instead of process.exit(1) when a signal aborts the turn", async () => {
+		const abortedMsg: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "cursor-agent",
+			provider: "cursor",
+			model: "cursor-grok-4.6",
+			usage: {} as AssistantMessage["usage"],
+			stopReason: "aborted",
+			errorMessage: "Request aborted",
+			timestamp: 1,
+		};
+
+		let signalCallback: ((reason: postmortem.Reason) => void | Promise<void>) | undefined;
+		let disposeReason: postmortem.Reason | "dispose" | undefined;
+		const session = {
+			extensionRunner: undefined,
+			subscribe: () => {},
+			settings: { get: () => false },
+			sessionManager: { buildSessionContext: () => ({ messages: [] }), getEntries: () => [] },
+			getLastAssistantMessage: () => abortedMsg,
+			prepareForHeadlessAdvisorDrain: () => {},
+			setTextOutputCommitted: () => {},
+			waitForAdvisorCatchup: async () => true,
+			// Mimic a real mid-turn signal: the postmortem teardown fires (which
+			// disposes and aborts the agent), and only then does the awaited turn
+			// settle with an aborted assistant message.
+			prompt: async () => {
+				await signalCallback?.(postmortem.Reason.SIGTERM);
+			},
+			dispose: async (options: { reason?: postmortem.Reason } = {}) => {
+				disposeReason ??= options.reason ?? "dispose";
+			},
+		} as unknown as AgentSession;
+
+		const registerSpy = spyOn(postmortem, "register").mockImplementation(
+			(_id: string, cb: (reason: postmortem.Reason) => void | Promise<void>) => {
+				signalCallback = cb;
+				return () => {};
+			},
+		);
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code: number) => {
+			throw new ProcessExit(code);
+		}) as never);
+		const stderrSpy = spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+
+		try {
+			await runPrintMode(session, { mode: "text", initialMessage: "go" });
+		} finally {
+			registerSpy.mockRestore();
+			exitSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+
+		expect(exitSpy).not.toHaveBeenCalled();
+		expect(disposeReason).toBe(postmortem.Reason.SIGTERM);
 	});
 });

--- a/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
+++ b/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
@@ -1,12 +1,12 @@
 /**
- * Contract: the print-mode assistant-error/aborted exit path MUST run the
- * awaited `session.dispose()` (which contains the bounded browser reaper
- * `releaseTabsForOwner`) before terminating the process. It previously called
- * `process.exit(1)` ahead of the `dispose()` at the end of `runPrintMode`, so
- * an OMP-owned Chromium survived the exit (issue #5643).
+ * Contract: non-interactive shutdown MUST await `session.dispose()` before the
+ * process exits. This releases owned resources and lets an interrupted agent
+ * finalize its partial assistant message into the session journal.
  */
+import * as path from "node:path";
 import { describe, expect, it, spyOn } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { runPrintMode } from "../../src/modes/print-mode";
 import type { AgentSession } from "../../src/session/agent-session";
 import * as telemetryExport from "../../src/telemetry-export";
@@ -18,7 +18,7 @@ class ProcessExit extends Error {
 	}
 }
 
-describe("print-mode error exit disposes the session before exit", () => {
+describe("print mode disposes the session before exit", () => {
 	it("disposes on the assistant-error path before process.exit(1)", async () => {
 		const order: string[] = [];
 		const errorMsg: AssistantMessage = {
@@ -70,5 +70,23 @@ describe("print-mode error exit disposes the session before exit", () => {
 		}
 
 		expect(order).toEqual(["catchup", "flush", "dispose", "exit"]);
+	});
+
+	it("disposes an active print session before SIGTERM exits", async () => {
+		using tempDir = TempDir.createSync("@omp-print-signal-");
+		const marker = tempDir.join("disposed");
+		const fixture = path.join(import.meta.dir, "..", "fixtures", "print-mode-signal.js");
+		const child = Bun.spawn([process.execPath, fixture, marker], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const exitCode = await child.exited;
+		const stderr = await new Response(child.stderr).text();
+		const markerFile = Bun.file(marker);
+
+		if (!(await markerFile.exists())) {
+			throw new Error(`Print session was not disposed before signal exit ${exitCode}: ${stderr}`);
+		}
+		expect(await markerFile.text()).toBe("sigterm");
 	});
 });


### PR DESCRIPTION
## Repro

A subprocess fixture starts print mode with a prompt that remains active, sends itself SIGTERM, and records whether session disposal runs. Before the fix, `cd packages/coding-agent && bun test test/modes/noninteractive-dispose.test.ts` exited the child with code 143 without creating the disposal marker, matching the missing Cursor session file.

## Cause

`runPrintMode` in `packages/coding-agent/src/modes/print-mode.ts` did not register signal-driven teardown with `postmortem`. On SIGINT or SIGTERM, only `AgentSession`'s exit diagnostic callback ran; the active provider stream was never cooperatively aborted and drained through `AgentSession.dispose()`, so Cursor's partial assistant message never reached `SessionManager`.

## Fix

- Register the active print-mode session for awaited postmortem disposal and cancel the registration after normal completion.
- Add a real SIGTERM subprocess regression proving disposal completes before exit.
- Document interrupted Cursor session preservation in the coding-agent changelog.

## Verification

`bun test test/modes/noninteractive-dispose.test.ts test/session-exit-diagnostics.test.ts` — 15 passed, 0 failed. `bun run check` in `packages/coding-agent` passed lint, formatting, and type checks.

Fixes #10965