### PR TITLE
fix(catalog): stop caching an empty catalog on LiteLLM discovery timeout

### DIFF
--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -336,8 +336,14 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				restorableHeaderFallback,
 			);
 		} else {
-			// Remote fetch failed — update cache with a non-authoritative snapshot so
-			// stale state remains visible while retry backoff still applies.
+			// Remote fetch failed. Re-persist any prior catalog as a
+			// non-authoritative snapshot so stale state stays visible while the
+			// retry backoff applies. When there is nothing to preserve (a
+			// discovery-only provider with no prior cache), leave the row absent
+			// rather than writing an empty snapshot: an empty non-authoritative row
+			// reads back as a fresh catalog and suppresses refetch for
+			// NON_AUTHORITATIVE_RETRY_MS, hiding every discovery-only model until it
+			// ages out. Writing nothing lets the next launch retry immediately (#10964).
 			const latestCache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
 			const latestRestoredCache = restoreCachedModelHeaders(
 				latestCache?.models ?? cache?.models ?? [],
@@ -362,16 +368,18 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			const fallbackSnapshotModels = collapseBuiltVariants(
 				mergeDynamicModels(mergeDynamicModels(staticModels, latestCacheModels), modelsDevModels),
 			);
-			writeModelCache(
-				cacheProviderId,
-				now(),
-				fallbackSnapshotModels,
-				false,
-				staticFingerprint,
-				dbPath,
-				staticModels,
-				restorableHeaderFallback,
-			);
+			if (fallbackSnapshotModels.length > 0) {
+				writeModelCache(
+					cacheProviderId,
+					now(),
+					fallbackSnapshotModels,
+					false,
+					staticFingerprint,
+					dbPath,
+					staticModels,
+					restorableHeaderFallback,
+				);
+			}
 		}
 	}
 	const cacheContributed = cacheModels.length > 0;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -338,12 +338,13 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		} else {
 			// Remote fetch failed. Re-persist any prior catalog as a
 			// non-authoritative snapshot so stale state stays visible while the
-			// retry backoff applies. When there is nothing to preserve (a
-			// discovery-only provider with no prior cache), leave the row absent
-			// rather than writing an empty snapshot: an empty non-authoritative row
-			// reads back as a fresh catalog and suppresses refetch for
-			// NON_AUTHORITATIVE_RETRY_MS, hiding every discovery-only model until it
-			// ages out. Writing nothing lets the next launch retry immediately (#10964).
+			// retry backoff applies. When there is no prior cache and nothing to
+			// preserve (a discovery-only provider on its first failed fetch), leave
+			// the row absent rather than writing an empty snapshot: an empty
+			// non-authoritative row reads back as a fresh catalog and suppresses
+			// refetch for NON_AUTHORITATIVE_RETRY_MS, hiding every discovery-only
+			// model until it ages out. Writing nothing lets the next launch retry
+			// immediately (#10964).
 			const latestCache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
 			const latestRestoredCache = restoreCachedModelHeaders(
 				latestCache?.models ?? cache?.models ?? [],
@@ -368,7 +369,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			const fallbackSnapshotModels = collapseBuiltVariants(
 				mergeDynamicModels(mergeDynamicModels(staticModels, latestCacheModels), modelsDevModels),
 			);
-			if (fallbackSnapshotModels.length > 0) {
+			if (fallbackSnapshotModels.length > 0 || latestCache !== null || cache !== null) {
 				writeModelCache(
 					cacheProviderId,
 					now(),

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -1203,6 +1203,51 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("refreshes an existing empty cache row when discovery fails to preserve retry backoff", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-empty-failure-backoff-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const recoveredModel = completionsSpec({ id: "recovered-model", provider: "empty-failure-backoff-test" });
+		let discoveredModels: readonly ModelSpec<"openai-completions">[] | null = [];
+		let fetches = 0;
+		let currentTime = 1_000_000;
+		const options = {
+			providerId: "empty-failure-backoff-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			now: () => currentTime,
+			fetchDynamicModels: async () => {
+				fetches++;
+				return discoveredModels;
+			},
+		};
+		try {
+			const empty = await resolveProviderModels(options, "online");
+			expect(empty.models).toEqual([]);
+			expect(fetches).toBe(1);
+
+			currentTime += 5 * 60 * 1_000;
+			discoveredModels = null;
+			const failedRefresh = await resolveProviderModels(options, "online-if-uncached");
+			expect(failedRefresh.models).toEqual([]);
+			expect(fetches).toBe(2);
+
+			// The failed refresh advances the existing empty row's timestamp, so
+			// another launch waits for the normal backoff instead of retrying now.
+			discoveredModels = [recoveredModel];
+			const backedOff = await resolveProviderModels(options, "online-if-uncached");
+			expect(backedOff.models).toEqual([]);
+			expect(fetches).toBe(2);
+
+			currentTime += 5 * 60 * 1_000;
+			const recovered = await resolveProviderModels(options, "online-if-uncached");
+			expect(recovered.models.map(model => model.id)).toEqual([recoveredModel.id]);
+			expect(fetches).toBe(3);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 	it("does not cache an empty row when discovery fails, so the next launch retries immediately (#10964)", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-failed-discovery-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -1203,6 +1203,45 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it("does not cache an empty row when discovery fails, so the next launch retries immediately (#10964)", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-failed-discovery-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const recoveredModel = completionsSpec({ id: "vendor-7/model-7", provider: "failed-discovery-test" });
+		let fetches = 0;
+		let fail = true;
+		const currentTime = 1_000_000;
+		const options = {
+			providerId: "failed-discovery-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			now: () => currentTime,
+			fetchDynamicModels: async () => {
+				fetches++;
+				// A timeout/network failure surfaces to the manager as null (distinct
+				// from a successful but empty [] catalog, which stays cached).
+				return fail ? null : [recoveredModel];
+			},
+		};
+		try {
+			const failed = await resolveProviderModels(options, "online");
+			expect(failed.models).toEqual([]);
+			expect(fetches).toBe(1);
+
+			// With no prior catalog and nothing static, the failure writes no cache
+			// row. Had it persisted an empty non-authoritative snapshot, the next
+			// launch inside the 5-min window would serve that empty catalog and skip
+			// discovery, hiding every discovery-only model. The clock does not advance,
+			// so a retry here proves the row is absent rather than aged out.
+			fail = false;
+			const recovered = await resolveProviderModels(options, "online-if-uncached");
+			expect(recovered.models.map(model => model.id)).toEqual([recoveredModel.id]);
+			expect(recovered.stale).toBe(false);
+			expect(fetches).toBe(2);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 	it("reports an authoritative catalog emptying as non-stale so removed models prune", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-empty-transition-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- LiteLLM discovery no longer caches an empty catalog after a timed-out run: a rich-metadata timeout now falls back to `/v1/models`, and a discovery failure with no prior catalog leaves the cache untouched so the next launch retries immediately instead of hiding discovery-only models ([#10964](https://github.com/can1357/oh-my-pi/issues/10964)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -971,11 +971,12 @@ export async function discoverLiteLLMModels(
 		richModels = apiKey
 			? await withAuth(apiKey, key => attempt({ ...baseHeaders, Authorization: `Bearer ${key}` }))
 			: await attempt(baseHeaders);
-	} catch (error) {
-		const status = typeof error === "object" && error !== null && "status" in error ? error.status : undefined;
-		if (status !== 401) {
-			throw error;
-		}
+	} catch {
+		// The rich-metadata probes failed (auth, timeout, or network). The cheap
+		// `/v1/models` fallback runs under its own independent budget and usually
+		// still resolves the catalog, so try it rather than aborting discovery and
+		// letting the caller cache an empty result (#10964). If the fallback also
+		// fails, its error propagates.
 		richModels = null;
 	}
 	if (!richModels || richModels.length === 0) {

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -2641,6 +2641,41 @@ providers:
 		expect(model?.api).toBe("openai-responses");
 	});
 
+	test("litellm discovery falls back to /v1/models when the rich phase times out (#10964)", async () => {
+		writeRawModelsJson({
+			"litellm-test": {
+				baseUrl: "http://127.0.0.1:4013/v1",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "litellm", timeoutMs: 50 },
+			},
+		});
+		const richHang = new Promise<Response>(() => {}); // never resolves
+		const richEndpoints = ["/model_group/info", "/v2/model/info", "/model/info", "/v1/model/info"];
+		let v1ModelsHits = 0;
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:4013/v1/models") {
+				v1ModelsHits++;
+				return Response.json({
+					object: "list",
+					data: [{ id: "vendor-7/model-7", object: "model", owned_by: "mockvendor" }],
+				});
+			}
+			// Rich metadata endpoints stall past the discovery budget; anything else
+			// (unrelated implicit probes) fails fast so it cannot hang the suite.
+			if (richEndpoints.some(endpoint => url === `http://127.0.0.1:4013${endpoint}`)) {
+				return richHang;
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+
+		expect(v1ModelsHits).toBeGreaterThan(0);
+		expect(registry.find("litellm-test", "vendor-7/model-7")?.baseUrl).toBe("http://127.0.0.1:4013/v1");
+	});
+
 	test("litellm discovery enriches configured proxy models with bundled references", async () => {
 		writeRawModelsJson({
 			"litellm-test": {

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -2650,7 +2650,7 @@ providers:
 				discovery: { type: "litellm", timeoutMs: 50 },
 			},
 		});
-		const richHang = new Promise<Response>(() => {}); // never resolves
+		const { promise: richHang } = Promise.withResolvers<Response>(); // never resolves
 		const richEndpoints = ["/model_group/info", "/v2/model/info", "/model/info", "/v1/model/info"];
 		let v1ModelsHits = 0;
 		const fetchMock: FetchImpl = async input => {


### PR DESCRIPTION
## Repro
For a `models.yml` provider with `discovery: { type: litellm }`, one timed-out discovery run leaves the provider empty and cached as empty; every discovery-only model then resolves to `Model "<provider>/<id>" not found` on later launches, silently, even after the endpoint recovers. Reproduced with a focused test that drives `discoverLiteLLMModels` against a fetch whose four rich-metadata endpoints hang and whose `/v1/models` answers instantly (`discovery.timeoutMs=50`): it threw `TimeoutError` instead of falling back. Run: `cd packages/coding-agent && bun test test/model-discovery.test.ts -t litellm` and `cd packages/catalog && bun test test/build.test.ts -t discovery`.

## Cause
`discoverLiteLLMModels` (`packages/coding-agent/src/config/model-discovery.ts`) wraps only the rich probe in `withTimeoutSignal`; on a rich-phase timeout the thrown `TimeoutError` (non-401) was rethrown, so the separate, cheap `/v1/models` fallback (`discoverOpenAIModelsList`, which has its own budget) never ran. Discovery then aborted, and `resolveProviderModels` (`packages/catalog/src/model-manager.ts`) took its failure branch: with no prior cache row and `staticModels: []`, it wrote an empty non-authoritative snapshot at `now()`. `readModelCache` (24h TTL) serves that as a fresh catalog and `shouldFetchRemoteSources` suppresses refetch until the row ages past `NON_AUTHORITATIVE_RETRY_MS` (5 min) — the silent "not found" window. The precedent for the intended contract is `resolveCodexDiscoveryAccounts` (`model-provider-discovery.ts:143-150`), which aborts rather than caching a partial catalog.

## Fix
- `discoverLiteLLMModels` now falls back to `/v1/models` on any rich-phase failure (auth, timeout, network) instead of rethrowing; if the fallback also fails, its error propagates.
- `resolveProviderModels` no longer writes a cache row when a failed fetch has nothing to preserve (a discovery-only provider with no prior cache): the row is left absent so the next launch retries discovery immediately. Prior non-empty catalogs are still re-persisted non-authoritative, and a successful-but-empty `[]` catalog still caches as before.
- Added regression tests for both the timeout-fallback path and the no-empty-poison-on-failure contract; added a coding-agent CHANGELOG entry.

## Verification
`cd packages/catalog && bun test test/build.test.ts` (54 pass) and `test/compat-collapse.test.ts test/codex-discovery.test.ts test/cursor-discovery.test.ts` (97 pass); `cd packages/coding-agent && bun test test/model-discovery.test.ts` (76 pass). `tsgo -p tsconfig.json --noEmit` clean for both `packages/catalog` and `packages/coding-agent`. `bun check`'s `check:rs` stage fails in this environment because `cmake` is not installed (unrelated to this TS-only change and identical on `main`); the TS type-checks were run directly and pass. Fixes #10964