### PR TITLE
fix(coding-agent): fall back to /v1/models when LiteLLM rich discovery fails, warn while backed off

### DIFF
--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -22,7 +22,7 @@ import {
 	resolveLiteLLMApi,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 import type { ModelSpec, OpenAICompat } from "@oh-my-pi/pi-catalog/types";
-import { isRecord } from "@oh-my-pi/pi-utils";
+import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import type { ProviderDiscovery } from "./models-config-schema";
 
 // Default cap on `max_tokens` for auto-discovered models that do not advertise
@@ -972,9 +972,25 @@ export async function discoverLiteLLMModels(
 			? await withAuth(apiKey, key => attempt({ ...baseHeaders, Authorization: `Bearer ${key}` }))
 			: await attempt(baseHeaders);
 	} catch (error) {
+		// The rich management endpoints (`/model_group/info`, `/v2/model/info`, …)
+		// only ENRICH the catalog; the runtime `/v1/models` list is what actually
+		// names the models. A proxy whose management endpoints are slow (the rich
+		// loop fetches them sequentially under one `timeoutMs` budget), return
+		// 5xx, or serve an unparseable body must therefore not take the whole
+		// provider offline — fall through to `/v1/models` exactly as an empty rich
+		// result does, and say so. Without this, one timed-out rich fetch left the
+		// provider with zero models and that empty result was cached for the
+		// non-authoritative retry window, so every discovery-only model resolved
+		// to "not found" on later launches while the proxy was perfectly healthy
+		// (issue #10964). A 401 is still the auth-retry path's business and stays
+		// silent here.
 		const status = typeof error === "object" && error !== null && "status" in error ? error.status : undefined;
 		if (status !== 401) {
-			throw error;
+			logger.warn("LiteLLM rich model discovery failed; falling back to /v1/models", {
+				provider: providerConfig.provider,
+				url: baseUrl,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 		richModels = null;
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1650,6 +1650,24 @@ export class ModelRegistry {
 		});
 		if (discoveryError) {
 			this.#warnProviderDiscoveryFailure(providerConfig, discoveryError);
+		} else if (
+			effectiveStrategy !== "offline" &&
+			result.source !== "provider" &&
+			result.models.length === 0 &&
+			cached !== null &&
+			!cached.authoritative
+		) {
+			// No successful fetch was applied this launch: the manager is inside the
+			// non-authoritative retry backoff after an earlier failed discovery, and
+			// that failure left no models behind. Every model of this provider now
+			// resolves to "not found", so without this line the only warning ever
+			// emitted was the one on the launch that failed — every later launch was
+			// silent (issue #10964). Routed through the same dedupe as a live failure
+			// so it prints once per process.
+			this.#warnProviderDiscoveryFailure(
+				providerConfig,
+				`no models cached: the last discovery attempt (${new Date(cached.updatedAt).toISOString()}) produced none and is backed off; retry happens automatically after the retry window`,
+			);
 		}
 		return this.#applyProviderModelOverrides(
 			providerId,

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -19,7 +19,7 @@ import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-r
 import { ProviderDiscoverySchema } from "@oh-my-pi/pi-coding-agent/config/models-config-schema";
 import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("ModelRegistry runtime discovery", () => {
 	let tempDir: string;
@@ -2697,6 +2697,151 @@ providers:
 
 		expect(registry.find("litellm-test", "default-litellm")?.baseUrl).toBe("http://localhost:4000/v1");
 		expect(registry.find("litellm-test", "openai/gpt-5")?.api).toBe("openai-responses");
+	});
+
+	test("litellm discovery falls back to /v1/models when the rich endpoints time out (#10964)", async () => {
+		writeRawModelsJson({
+			"litellm-test": {
+				baseUrl: "http://127.0.0.1:4000/v1",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "litellm", timeoutMs: 200 },
+			},
+		});
+		const richUrls = new Set([
+			"http://127.0.0.1:4000/model_group/info",
+			"http://127.0.0.1:4000/v2/model/info",
+			"http://127.0.0.1:4000/model/info",
+			"http://127.0.0.1:4000/v1/model/info",
+		]);
+		const seen: string[] = [];
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			seen.push(url);
+			if (richUrls.has(url)) {
+				// Slow management endpoint: only ever settles when the caller gives up.
+				const { promise, reject } = Promise.withResolvers<Response>();
+				init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+					once: true,
+				});
+				return promise;
+			}
+			if (url === "http://127.0.0.1:4000/v1/models") {
+				return Response.json({ data: [{ id: "vendor/slow-proxy-model" }] });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+			await registry.refresh();
+
+			expect(registry.find("litellm-test", "vendor/slow-proxy-model")?.baseUrl).toBe("http://127.0.0.1:4000/v1");
+			expect(seen).toContain("http://127.0.0.1:4000/v1/models");
+			expect(registry.getProviderDiscoveryState("litellm-test")?.status).toBe("ok");
+			expect(warn.mock.calls.some(([message]) => String(message).includes("falling back to /v1/models"))).toBe(true);
+			// Built-in providers (ollama, llama.cpp, …) may legitimately log their own
+			// probe failures here; only THIS provider must not be reported as failed.
+			const reportedFailures = warn.mock.calls
+				.filter(
+					([message, details]) =>
+						String(message) === "model discovery failed for provider" &&
+						(details as { provider?: string } | undefined)?.provider === "litellm-test",
+				)
+				.map(([, details]) => (details as { error?: string } | undefined)?.error);
+			expect(reportedFailures).toEqual([]);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	test("litellm discovery falls back to /v1/models when a rich endpoint returns 5xx (#10964)", async () => {
+		writeRawModelsJson({
+			"litellm-test": {
+				baseUrl: "http://127.0.0.1:4000/v1",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "litellm" },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:4000/model_group/info") {
+				return new Response("upstream exploded", { status: 502 });
+			}
+			if (
+				url === "http://127.0.0.1:4000/v2/model/info" ||
+				url === "http://127.0.0.1:4000/model/info" ||
+				url === "http://127.0.0.1:4000/v1/model/info"
+			) {
+				return new Response("not json at all", { status: 200 });
+			}
+			if (url === "http://127.0.0.1:4000/v1/models") {
+				return Response.json({ data: [{ id: "vendor/plain-model" }] });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+			await registry.refresh();
+
+			expect(registry.find("litellm-test", "vendor/plain-model")?.api).toBe("openai-completions");
+			expect(registry.getProviderDiscoveryState("litellm-test")?.status).toBe("ok");
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	test("provider served from an empty backed-off discovery snapshot warns on every launch (#10964)", async () => {
+		writeRawModelsJson({
+			"litellm-test": {
+				baseUrl: "http://127.0.0.1:4000/v1",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "litellm", timeoutMs: 200 },
+			},
+		});
+		// Launch 1: everything, including /v1/models, is unreachable → discovery
+		// fails and the manager writes an empty non-authoritative snapshot.
+		const deadFetch: FetchImpl = async () => {
+			throw new TypeError("Unable to connect");
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const first = new ModelRegistry(authStorage, modelsJsonPath, { fetch: deadFetch });
+			await first.refresh();
+			expect(first.getProviderDiscoveryState("litellm-test")?.status).toBe("unavailable");
+			expect(warn.mock.calls.some(([message]) => String(message) === "model discovery failed for provider")).toBe(
+				true,
+			);
+			warn.mockClear();
+
+			// Launch 2 (a new process, seconds later): the proxy is healthy again, but
+			// the manager is inside its retry backoff and serves the cached empty
+			// snapshot without fetching. The user must still be told why every model
+			// of this provider is missing.
+			const healthyFetch: FetchImpl = async input => {
+				const url = String(input);
+				if (url === "http://127.0.0.1:4000/model_group/info") {
+					return Response.json({ data: [{ model_group: "vendor/recovered-model" }] });
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			};
+			const second = new ModelRegistry(authStorage, modelsJsonPath, { fetch: healthyFetch });
+			await second.refresh();
+
+			expect(second.find("litellm-test", "vendor/recovered-model")).toBeUndefined();
+			expect(
+				warn.mock.calls.some(
+					([message, details]) =>
+						String(message) === "model discovery failed for provider" &&
+						String((details as { error?: string } | undefined)?.error).includes("backed off"),
+				),
+			).toBe(true);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	test("litellm discovery reuses configured bearer on rich and fallback requests", async () => {


### PR DESCRIPTION
Closes #10964.

I hit this on an internal LiteLLM proxy whose management endpoints take a few seconds each: one timed-out discovery left the provider with zero models, and every launch for the next several minutes reported `Model "…" not found` with no warning while the proxy's `/v1/models` was healthy. This PR makes the rich phase fall back to `/v1/models` on failure and makes the backed-off state visible; it deliberately does **not** change the non-authoritative retry backoff itself.

## What changed

**`packages/coding-agent/src/config/model-discovery.ts` — `discoverLiteLLMModels`**
A non-401 failure of the rich phase (timeout, 5xx, unparseable body) no longer propagates. It logs `LiteLLM rich model discovery failed; falling back to /v1/models` with the provider, URL and error, and falls through to `discoverOpenAIModelsList` — the same path an *empty* rich result already took. The rich endpoints only enrich the catalog; `/v1/models` is what names the models, so losing the enrichment should not lose the provider. 401 keeps its existing silent auth-retry handling.

**`packages/coding-agent/src/config/model-registry.ts` — `#discoverProviderModels`**
When a launch is served from an empty, non-authoritative snapshot inside the retry backoff (no live error this launch, `result.source !== "provider"`, zero models, cached row present and non-authoritative), emit the same `model discovery failed for provider` warning as a live failure, with an error text that names the last attempt time and says it is backed off. It goes through the existing per-process dedupe. Previously the only warning ever printed was on the launch that failed; every later launch inside the window was silent.

**Tests** (`packages/coding-agent/test/model-discovery.test.ts`, three new cases tagged `#10964`)
- rich endpoints hang past `discovery.timeoutMs` → provider resolves from `/v1/models`, state `ok`, fallback warning logged, no `model discovery failed for provider` for this provider;
- rich endpoint returns 502 and the others return non-JSON → same fallback;
- cold failed discovery, then a second registry with a healthy fetch inside the backoff → model still absent (unchanged behaviour) but the backed-off warning is emitted.

## Verification

Automated: `bun test test/model-discovery.test.ts` 78/78; the eight neighbouring `model-registry*` / discovery test files 135/135; `bun run check` in `packages/coding-agent` (oxlint, oxfmt, tsgo) clean.

Exercised end to end with the **patched source CLI** (`bun --cwd=packages/coding-agent src/cli.ts`) against the synthetic mock from #10964, isolated `--profile`, 40 synthetic model groups:

**Scenario A — every rich endpoint sleeps 4 s (`--delay 4`):**
```
$ omp -p --profile repro --model repro/vendor-7/model-7 --no-skills --tools read --thinking off "reply PONG only"
PONG                                   # 11 s wall clock
mock saw: GET /model_group/info, GET /v2/model/info, GET /v1/models, POST /v1/chat/completions
log:      warn  LiteLLM rich model discovery failed; falling back to /v1/models  error="The operation timed out."
cache:    repro:litellm-rich-v4  authoritative=1  models=40
```
On 18.1.11 unpatched the same scenario ends in `Model "repro/vendor-7/model-7" not found` with an `authoritative=0 models=0` row (see the issue).

**Scenario B — nothing listening on the port, then the mock comes up healthy:**
```
launch 1:  Model "repro/vendor-7/model-7" not found     cache: authoritative=0 models=0
           warn  model discovery failed for provider  error="Unable to connect…"
launch 2:  Model "repro/vendor-7/model-7" not found     (inside the retry backoff — unchanged)
           warn  model discovery failed for provider  error="no models cached: the last discovery attempt (…) produced none and is backed off; retry happens automatically after the retry window"
```
Launch 2 was silent before this change.

## Out of scope / question for maintainers

The issue also proposes not persisting an *empty* snapshot when a cold discovery fails, so the next launch retries immediately instead of waiting out the backoff. I left that alone because the backoff is a deliberate design (`NON_AUTHORITATIVE_RETRY_MS`, and the #6620 comment in `model-manager.ts`) and it lives in the catalog package. With the `/v1/models` fallback in place the cold-empty case only occurs when the proxy is fully unreachable, which the backoff is arguably right about. Happy to follow up separately if you'd rather change that too.
