### PR TITLE
fix(coding-agent): preserve cached models across extension reloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Extension provider reloads no longer remove cached models from unrelated credential-scoped providers ([#10973](https://github.com/can1357/oh-my-pi/issues/10973)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -698,6 +698,7 @@ export class ModelRegistry {
 					runtimeProviderIds: Set<string>;
 					configuredProviders: Map<string, DiscoveryProviderConfig>;
 					providerOverrides: Map<string, ProviderOverride>;
+					modelOverrides: Map<string, Map<string, ModelOverride>>;
 					keylessProviders: Set<string>;
 			  }
 			| undefined;
@@ -709,6 +710,7 @@ export class ModelRegistry {
 				runtimeProviderIds: new Set(this.#runtimeModelManagers.keys()),
 				configuredProviders: new Map(this.#discoverableProviders.map(config => [config.provider, config])),
 				providerOverrides: new Map(this.#providerOverrides),
+				modelOverrides: new Map(this.#modelOverrides),
 				keylessProviders: new Set(this.#keylessProviders),
 			};
 		}
@@ -748,7 +750,12 @@ export class ModelRegistry {
 					Bun.deepEquals(
 						preservedRuntimeState.providerOverrides.get(providerId),
 						this.#providerOverrides.get(providerId),
-					) && preservedRuntimeState.keylessProviders.has(providerId) === this.#keylessProviders.has(providerId);
+					) &&
+					Bun.deepEquals(
+						preservedRuntimeState.modelOverrides.get(providerId),
+						this.#modelOverrides.get(providerId),
+					) &&
+					preservedRuntimeState.keylessProviders.has(providerId) === this.#keylessProviders.has(providerId);
 				const discoveryIdentityUnchanged =
 					(previousConfig !== undefined &&
 						currentConfig !== undefined &&

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -683,9 +683,10 @@ export class ModelRegistry {
 		await this.#refreshRuntimeDiscoveries(strategy, new Set(this.#runtimeModelManagers.keys()));
 	}
 
-	#reloadStaticModels(options?: { preserveRuntimeDiscovery?: boolean }): void {
+	#reloadStaticModels(options?: { force?: boolean; preserveRuntimeDiscovery?: boolean }): void {
 		const currentMtime = this.#modelsConfigFile.getMtimeMs();
-		if (currentMtime !== null && currentMtime === this.#lastStaticLoadMtime) {
+		const staticConfigUnchanged = currentMtime === this.#lastStaticLoadMtime;
+		if (!options?.force && currentMtime !== null && staticConfigUnchanged) {
 			// Models config unchanged since last load; reloading would be redundant.
 			return;
 		}
@@ -694,18 +695,21 @@ export class ModelRegistry {
 					models: Model<Api>[];
 					authoritativeProviders: Set<string>;
 					discoveryStates: Map<string, ProviderDiscoveryState>;
+					runtimeProviderIds: Set<string>;
+					configuredProviders: Map<string, DiscoveryProviderConfig>;
+					providerOverrides: Map<string, ProviderOverride>;
+					keylessProviders: Set<string>;
 			  }
 			| undefined;
 		if (options?.preserveRuntimeDiscovery) {
-			const providerIds = new Set(this.#runtimeDiscoveredModels.map(model => model.provider));
-			for (const providerId of this.#runtimeAuthoritativeProviders) providerIds.add(providerId);
-			for (const providerId of this.#runtimeModelManagers.keys()) providerIds.add(providerId);
 			preservedRuntimeState = {
 				models: this.#runtimeDiscoveredModels,
 				authoritativeProviders: new Set(this.#runtimeAuthoritativeProviders),
-				discoveryStates: new Map(
-					[...this.#providerDiscoveryStates].filter(([providerId]) => providerIds.has(providerId)),
-				),
+				discoveryStates: new Map(this.#providerDiscoveryStates),
+				runtimeProviderIds: new Set(this.#runtimeModelManagers.keys()),
+				configuredProviders: new Map(this.#discoverableProviders.map(config => [config.provider, config])),
+				providerOverrides: new Map(this.#providerOverrides),
+				keylessProviders: new Set(this.#keylessProviders),
 			};
 		}
 		this.#modelsConfigFile.invalidate();
@@ -726,12 +730,43 @@ export class ModelRegistry {
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
 		this.#loadModels();
-		if (preservedRuntimeState) {
-			this.#runtimeDiscoveredModels = preservedRuntimeState.models;
-			this.#runtimeAuthoritativeProviders = preservedRuntimeState.authoritativeProviders;
-			for (const [providerId, state] of preservedRuntimeState.discoveryStates) {
-				this.#providerDiscoveryStates.set(providerId, state);
+		if (!preservedRuntimeState) return;
+
+		const preservedProviderIds = preservedRuntimeState.runtimeProviderIds;
+		const candidateProviderIds = new Set(preservedRuntimeState.models.map(model => model.provider));
+		for (const providerId of preservedRuntimeState.authoritativeProviders) candidateProviderIds.add(providerId);
+		for (const providerId of preservedRuntimeState.discoveryStates.keys()) candidateProviderIds.add(providerId);
+		if (staticConfigUnchanged) {
+			for (const providerId of candidateProviderIds) preservedProviderIds.add(providerId);
+		} else {
+			const configuredProviders = new Map(this.#discoverableProviders.map(config => [config.provider, config]));
+			const startupProviderIds = new Set(STARTUP_MODEL_CACHE_PROVIDER_IDS);
+			for (const providerId of candidateProviderIds) {
+				const previousConfig = preservedRuntimeState.configuredProviders.get(providerId);
+				const currentConfig = configuredProviders.get(providerId);
+				const providerSettingsUnchanged =
+					Bun.deepEquals(
+						preservedRuntimeState.providerOverrides.get(providerId),
+						this.#providerOverrides.get(providerId),
+					) && preservedRuntimeState.keylessProviders.has(providerId) === this.#keylessProviders.has(providerId);
+				const discoveryIdentityUnchanged =
+					(previousConfig !== undefined &&
+						currentConfig !== undefined &&
+						Bun.deepEquals(previousConfig, currentConfig)) ||
+					(previousConfig === undefined && currentConfig === undefined && startupProviderIds.has(providerId));
+				if (providerSettingsUnchanged && discoveryIdentityUnchanged) {
+					preservedProviderIds.add(providerId);
+				}
 			}
+		}
+		this.#runtimeDiscoveredModels = preservedRuntimeState.models.filter(model =>
+			preservedProviderIds.has(model.provider),
+		);
+		this.#runtimeAuthoritativeProviders = new Set(
+			[...preservedRuntimeState.authoritativeProviders].filter(providerId => preservedProviderIds.has(providerId)),
+		);
+		for (const [providerId, state] of preservedRuntimeState.discoveryStates) {
+			if (preservedProviderIds.has(providerId)) this.#providerDiscoveryStates.set(providerId, state);
 		}
 	}
 
@@ -2544,8 +2579,7 @@ export class ModelRegistry {
 			this.#runtimeProviderSourceByName.delete(providerName);
 			this.#clearRuntimeProviderState(providerName);
 		}
-		this.#lastStaticLoadMtime = null;
-		this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
+		this.#reloadStaticModels({ force: true, preserveRuntimeDiscovery: true });
 	}
 
 	/**
@@ -2564,8 +2598,7 @@ export class ModelRegistry {
 		unregisterOAuthProvider(providerName);
 		this.#ensureFullSnapshot();
 		this.#clearRuntimeProviderState(providerName);
-		this.#lastStaticLoadMtime = null;
-		this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
+		this.#reloadStaticModels({ force: true, preserveRuntimeDiscovery: true });
 	}
 
 	/**
@@ -2642,8 +2675,7 @@ export class ModelRegistry {
 			this.#runtimeProviderSourceByName.set(providerName, sourceId);
 		}
 		if (sourceHandoff) {
-			this.#lastStaticLoadMtime = null;
-			this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
+			this.#reloadStaticModels({ force: true, preserveRuntimeDiscovery: true });
 		}
 
 		// Extension usage providers override built-ins/configured resolvers for the

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -683,11 +683,30 @@ export class ModelRegistry {
 		await this.#refreshRuntimeDiscoveries(strategy, new Set(this.#runtimeModelManagers.keys()));
 	}
 
-	#reloadStaticModels(): void {
+	#reloadStaticModels(options?: { preserveRuntimeDiscovery?: boolean }): void {
 		const currentMtime = this.#modelsConfigFile.getMtimeMs();
 		if (currentMtime !== null && currentMtime === this.#lastStaticLoadMtime) {
 			// Models config unchanged since last load; reloading would be redundant.
 			return;
+		}
+		let preservedRuntimeState:
+			| {
+					models: Model<Api>[];
+					authoritativeProviders: Set<string>;
+					discoveryStates: Map<string, ProviderDiscoveryState>;
+			  }
+			| undefined;
+		if (options?.preserveRuntimeDiscovery) {
+			const providerIds = new Set(this.#runtimeDiscoveredModels.map(model => model.provider));
+			for (const providerId of this.#runtimeAuthoritativeProviders) providerIds.add(providerId);
+			for (const providerId of this.#runtimeModelManagers.keys()) providerIds.add(providerId);
+			preservedRuntimeState = {
+				models: this.#runtimeDiscoveredModels,
+				authoritativeProviders: new Set(this.#runtimeAuthoritativeProviders),
+				discoveryStates: new Map(
+					[...this.#providerDiscoveryStates].filter(([providerId]) => providerIds.has(providerId)),
+				),
+			};
 		}
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
@@ -707,6 +726,13 @@ export class ModelRegistry {
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
 		this.#loadModels();
+		if (preservedRuntimeState) {
+			this.#runtimeDiscoveredModels = preservedRuntimeState.models;
+			this.#runtimeAuthoritativeProviders = preservedRuntimeState.authoritativeProviders;
+			for (const [providerId, state] of preservedRuntimeState.discoveryStates) {
+				this.#providerDiscoveryStates.set(providerId, state);
+			}
+		}
 	}
 
 	/**
@@ -2491,6 +2517,10 @@ export class ModelRegistry {
 		this.#runtimeModelManagers.delete(providerName);
 		this.#runtimeModelModifiers.delete(providerName);
 		this.#lastModelModifierWarnings.delete(providerName);
+		this.#runtimeDiscoveredModels = this.#runtimeDiscoveredModels.filter(model => model.provider !== providerName);
+		this.#runtimeAuthoritativeProviders.delete(providerName);
+		this.#providerDiscoveryStates.delete(providerName);
+		this.#invalidateProviderModelCache(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
 		this.authStorage.removeRuntimeUsageProvider(providerName);
 	}
@@ -2515,7 +2545,7 @@ export class ModelRegistry {
 			this.#clearRuntimeProviderState(providerName);
 		}
 		this.#lastStaticLoadMtime = null;
-		this.#reloadStaticModels();
+		this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
 	}
 
 	/**
@@ -2535,7 +2565,7 @@ export class ModelRegistry {
 		this.#ensureFullSnapshot();
 		this.#clearRuntimeProviderState(providerName);
 		this.#lastStaticLoadMtime = null;
-		this.#reloadStaticModels();
+		this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
 	}
 
 	/**
@@ -2613,7 +2643,7 @@ export class ModelRegistry {
 		}
 		if (sourceHandoff) {
 			this.#lastStaticLoadMtime = null;
-			this.#reloadStaticModels();
+			this.#reloadStaticModels({ preserveRuntimeDiscovery: true });
 		}
 
 		// Extension usage providers override built-ins/configured resolvers for the

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2559,9 +2559,20 @@ export class ModelRegistry {
 		this.#runtimeModelManagers.delete(providerName);
 		this.#runtimeModelModifiers.delete(providerName);
 		this.#lastModelModifierWarnings.delete(providerName);
-		this.#runtimeDiscoveredModels = this.#runtimeDiscoveredModels.filter(model => model.provider !== providerName);
-		this.#runtimeAuthoritativeProviders.delete(providerName);
-		this.#providerDiscoveryStates.delete(providerName);
+		// A credential-scoped built-in provider (e.g. opencode-go) populates its
+		// slice of #runtimeDiscoveredModels from startup cache hydration, not from
+		// this extension. #reloadStaticModels excludes credential-scoped providers
+		// from synchronous cache loading and refreshRuntimeProviders only refetches
+		// registered managers, so neither restores that slice — discarding it here
+		// makes account-specific models vanish until a full refresh. Keep it for
+		// credential-scoped providers; discard for everyone else, where the slice is
+		// the extension's own discovery (or a non-credential-scoped built-in slice
+		// that baked this provider's now-removed override and must be recomposed).
+		if (!isCredentialScopedModelCacheProvider(providerName)) {
+			this.#runtimeDiscoveredModels = this.#runtimeDiscoveredModels.filter(model => model.provider !== providerName);
+			this.#runtimeAuthoritativeProviders.delete(providerName);
+			this.#providerDiscoveryStates.delete(providerName);
+		}
 		this.#invalidateProviderModelCache(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
 		this.authStorage.removeRuntimeUsageProvider(providerName);

--- a/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
@@ -108,6 +108,47 @@ describe("ModelRegistry runtime source cleanup", () => {
 		}
 	});
 
+	test("unloading an override-only extension keeps a built-in provider's hydrated discoveries", async () => {
+		using tempDir = TempDir.createSync("@omp-model-registry-override-only-");
+		const provider = "opencode-go";
+		const apiKey = "opencode-go-test-key";
+		const cachedModel = buildModel({
+			id: "cached-credential-model",
+			name: "Cached Credential Model",
+			api: "openai-responses",
+			provider,
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+		authStorage.setRuntimeApiKey(provider, apiKey);
+		writeModelCache(
+			resolveModelCacheProviderId(provider, { apiKey }),
+			Date.now(),
+			[cachedModel],
+			true,
+			"",
+			tempDir.join("models.db"),
+		);
+		const registry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		await registry.hydrateCredentialScopedModelCaches();
+		expect(registry.getAvailable().some(model => model.provider === provider && model.id === cachedModel.id)).toBe(
+			true,
+		);
+
+		// An extension registers only a transport override for the built-in
+		// provider — no models, no fetchDynamicModels manager.
+		registry.registerProvider(provider, { baseUrl: "https://gateway.example.com/v1" }, sourceId);
+		registry.clearSourceRegistrations(sourceId);
+
+		expect(registry.getAvailable().some(model => model.provider === provider && model.id === cachedModel.id)).toBe(
+			true,
+		);
+	});
+
 	test("extension rebinding discards discoveries removed from the model config", async () => {
 		using tempDir = TempDir.createSync("@omp-model-registry-config-rebind-");
 		const modelsPath = tempDir.join("models.json");

--- a/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { type AssistantMessageEventStream, clearCustomApis, getCustomApi } from "@oh-my-pi/pi-ai";
 import { getOAuthProvider } from "@oh-my-pi/pi-ai/oauth";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { resolveModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("ModelRegistry runtime source cleanup", () => {
 	let authStorage: AuthStorage;
@@ -51,6 +55,56 @@ describe("ModelRegistry runtime source cleanup", () => {
 		expect(registry.find("runtime-provider", "runtime-model")).toBeUndefined();
 		expect(registry.authStorage.hasAuth("runtime-provider")).toBe(false);
 		expect(getCustomApi("custom-runtime-cleanup-api")).toBeUndefined();
+	});
+
+	test("extension rebinding preserves unrelated credential-scoped cached models", async () => {
+		using tempDir = TempDir.createSync("@omp-model-registry-rebind-");
+		const provider = "opencode-go";
+		const apiKey = "opencode-go-test-key";
+		const cachedModel = buildModel({
+			id: "cached-credential-model",
+			name: "Cached Credential Model",
+			api: "openai-responses",
+			provider,
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+		authStorage.setRuntimeApiKey(provider, apiKey);
+		writeModelCache(
+			resolveModelCacheProviderId(provider, { apiKey }),
+			Date.now(),
+			[cachedModel],
+			true,
+			"",
+			tempDir.join("models.db"),
+		);
+		const registry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		await registry.hydrateCredentialScopedModelCaches();
+		expect(registry.getAvailable().some(model => model.provider === provider && model.id === cachedModel.id)).toBe(
+			true,
+		);
+
+		for (let cycle = 0; cycle < 2; cycle += 1) {
+			registry.registerProvider(
+				"runtime-provider",
+				{
+					baseUrl: "https://runtime.example.com/v1",
+					apiKey: "RUNTIME_KEY",
+					api: "openai-completions",
+					models: [baseModel],
+				},
+				sourceId,
+			);
+			registry.clearSourceRegistrations(sourceId);
+
+			expect(registry.getAvailable().some(model => model.provider === provider && model.id === cachedModel.id)).toBe(
+				true,
+			);
+		}
 	});
 
 	test("unregisterProvider removes only the named provider and its login entry", () => {

--- a/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
 import { type AssistantMessageEventStream, clearCustomApis, getCustomApi } from "@oh-my-pi/pi-ai";
 import { getOAuthProvider } from "@oh-my-pi/pi-ai/oauth";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
-import { resolveModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
+import { resolveModelCacheProviderId, resolveOllamaModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -105,6 +106,67 @@ describe("ModelRegistry runtime source cleanup", () => {
 				true,
 			);
 		}
+	});
+
+	test("extension rebinding discards discoveries removed from the model config", async () => {
+		using tempDir = TempDir.createSync("@omp-model-registry-config-rebind-");
+		const modelsPath = tempDir.join("models.json");
+		const cacheDbPath = tempDir.join("models.db");
+		const provider = "configured-ollama";
+		const baseUrl = "http://127.0.0.1:11435";
+		const discoveredModel = buildModel({
+			id: "removed-config-model",
+			name: "Removed Config Model",
+			api: "openai-completions",
+			provider,
+			baseUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					[provider]: {
+						baseUrl,
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "ollama" },
+					},
+				},
+			}),
+		);
+		const oldMtime = new Date("2020-01-01T00:00:00Z");
+		await fs.utimes(modelsPath, oldMtime, oldMtime);
+		writeModelCache(
+			resolveOllamaModelCacheProviderId(provider, baseUrl),
+			Date.now(),
+			[discoveredModel],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.refresh("offline");
+		expect(registry.find(provider, discoveredModel.id)).toBeDefined();
+		registry.registerProvider(
+			"runtime-provider",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				models: [baseModel],
+			},
+			sourceId,
+		);
+
+		await Bun.write(modelsPath, JSON.stringify({ providers: {} }));
+		registry.clearSourceRegistrations(sourceId);
+
+		expect(registry.find(provider, discoveredModel.id)).toBeUndefined();
 	});
 
 	test("unregisterProvider removes only the named provider and its login entry", () => {

--- a/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-cleanup.test.ts
@@ -169,6 +169,72 @@ describe("ModelRegistry runtime source cleanup", () => {
 		expect(registry.find(provider, discoveredModel.id)).toBeUndefined();
 	});
 
+	test("extension rebinding discards discoveries whose model overrides changed", async () => {
+		using tempDir = TempDir.createSync("@omp-model-registry-override-rebind-");
+		const modelsPath = tempDir.join("models.json");
+		const cacheDbPath = tempDir.join("models.db");
+		const provider = "configured-ollama";
+		const baseUrl = "http://127.0.0.1:11436";
+		const modelId = "override-config-model";
+		const discoveredModel = buildModel({
+			id: modelId,
+			name: "Override Config Model",
+			api: "openai-completions",
+			provider,
+			baseUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+		const writeConfig = (modelOverrides: Record<string, unknown> | undefined) =>
+			Bun.write(
+				modelsPath,
+				JSON.stringify({
+					providers: {
+						[provider]: {
+							baseUrl,
+							api: "openai-completions",
+							auth: "none",
+							discovery: { type: "ollama" },
+							...(modelOverrides ? { modelOverrides } : {}),
+						},
+					},
+				}),
+			);
+		await writeConfig({ [modelId]: { headers: { "X-Override": "stale" } } });
+		const oldMtime = new Date("2020-01-01T00:00:00Z");
+		await fs.utimes(modelsPath, oldMtime, oldMtime);
+		writeModelCache(
+			resolveOllamaModelCacheProviderId(provider, baseUrl),
+			Date.now(),
+			[discoveredModel],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.refresh("offline");
+		expect(registry.find(provider, modelId)?.headers?.["X-Override"]).toBe("stale");
+		registry.registerProvider(
+			"runtime-provider",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				models: [baseModel],
+			},
+			sourceId,
+		);
+
+		// Remove the per-model override, keeping the discovery config identical.
+		await writeConfig(undefined);
+		registry.clearSourceRegistrations(sourceId);
+
+		expect(registry.find(provider, modelId)?.headers?.["X-Override"]).toBeUndefined();
+	});
+
 	test("unregisterProvider removes only the named provider and its login entry", () => {
 		const registry = new ModelRegistry(authStorage, undefined, { ignoreLocalModelConfig: true });
 		registry.registerProvider(


### PR DESCRIPTION
## Repro
An isolated registry hydrates a credential-scoped `opencode-go` model cache, then registers and clears an unrelated extension provider twice. `bun test packages/coding-agent/test/model-registry-runtime-cleanup.test.ts` failed because `getAvailable()` no longer contained the cached model after the first `clearSourceRegistrations`.

## Cause
`ModelRegistry.clearSourceRegistrations` and `unregisterProvider` in `packages/coding-agent/src/config/model-registry.ts` forced `#reloadStaticModels`, whose `#resetStaticComposition` cleared every runtime-discovered model and authoritative-provider marker. The synchronous extension rebind had no subsequent credential-scoped cache hydration, so unrelated authenticated models remained absent from the shared registry.

## Fix
- Preserve unrelated runtime-discovered models, authoritative markers, and discovery states while extension cleanup rebuilds static configuration.
- Remove discovery state owned by the provider being unregistered so its dynamic models still disappear correctly.
- Add a repeated extension-rebind regression and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/model-registry-runtime-cleanup.test.ts packages/coding-agent/test/model-registry-runtime-provider.test.ts packages/coding-agent/test/model-discovery.test.ts` passes: 118 tests, 963 assertions. `bun test packages/coding-agent/test/sdk-restricted-extension-provider.test.ts packages/coding-agent/test/sdk-default-role-extension-provider.test.ts packages/coding-agent/test/sdk-model-selection.test.ts` passes: 39 tests, 126 assertions. `bun run check:ts` passes. Skipped the pre-publish gate because `bun run fix` fails identically on a clean `origin/main` export: `audiopus_sys` cannot execute missing CMake; TypeScript formatting completed successfully.

Fixes #10973