### PR TITLE
fix(ai): heal stale blocks during candidate selection for healable providers

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3574,6 +3574,9 @@ export class AuthStorage {
 		const cached = forceRefresh ? undefined : this.#usageCache.get<UsageReport | null>(cacheKey);
 		// Fresh cache hit: return whatever's there (success or null fallback).
 		if (cached && cached.expiresAt > now) {
+			if (cached.value !== null) {
+				this.#reconcileUsageBlock(request, cached.value);
+			}
 			return cached.value;
 		}
 
@@ -4202,7 +4205,7 @@ export class AuthStorage {
 				const credentialType = entry.credential.type;
 				const providerKey = this.#getProviderTypeKey(provider, credentialType);
 				let blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
-				if (blockedUntil !== undefined && provider !== "openai-codex") {
+				if (blockedUntil !== undefined && !this.#supportsUsageBlockHealing(provider)) {
 					return {
 						credentialId: entry.id,
 						credentialType,
@@ -4229,7 +4232,7 @@ export class AuthStorage {
 					planEligibilityByCredential.set(entry.id, getOpenAICodexPlanEligibility(report, planRequirement));
 				}
 
-				if (provider === "openai-codex") {
+				if (this.#supportsUsageBlockHealing(provider)) {
 					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				}
 				if (blockedUntil !== undefined) {
@@ -4431,6 +4434,7 @@ export class AuthStorage {
 					};
 				}),
 			});
+			this.#reconcileUsageBlocksFromReports(resolved);
 			this.#clearUsageForceRefresh(forcedRefresh);
 			return resolved;
 		})().finally(() => {
@@ -5009,7 +5013,7 @@ export class AuthStorage {
 				);
 				let usage: UsageReport | null = null;
 				let usageChecked = false;
-				if (blockedUntil !== undefined && args.provider === "openai-codex") {
+				if (blockedUntil !== undefined && this.#supportsUsageBlockHealing(args.provider)) {
 					usage = await this.#getUsageReport(args.provider, selection.credential, {
 						...args.options,
 						timeoutMs: this.#usageRequestTimeoutMs,
@@ -5151,7 +5155,14 @@ export class AuthStorage {
 		const blockScopes = credentialBlockScopesForRequest(provider, strategy, rankingContext, blockScope);
 		const planRequirement = resolveOpenAICodexPlanRequirement(provider, options?.modelId);
 		const hasPlanRequirement = planRequirement !== "none";
-		const checkUsage = strategy !== undefined && (credentials.length > 1 || hasPlanRequirement);
+		const hasBlockedCredential = credentials.some(entry =>
+			this.#isCredentialBlocked(provider, providerKey, entry.index, blockScopes),
+		);
+		const checkUsage =
+			strategy !== undefined &&
+			(credentials.length > 1 ||
+				hasPlanRequirement ||
+				(hasBlockedCredential && this.#supportsUsageBlockHealing(provider)));
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		const sessionPreferredIndex = sessionCredential?.type === "oauth" ? sessionCredential.index : undefined;
 		const sessionPreferredCredential =

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -348,4 +348,45 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		const loaded = counts.get("api-acct-loaded") ?? 0;
 		expect(fresh).toBeGreaterThan(loaded);
 	});
+
+	test("a healthy Gemini counter report heals a stale block during candidate selection without requiring fetchUsageReports", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+
+		await authStorage.set("google-antigravity", [
+			{
+				type: "oauth",
+				...createCredential("acct-direct-heal", "proj-direct-heal", "direct-heal@example.com"),
+			},
+		]);
+		const row = store.listAuthCredentials("google-antigravity")[0];
+		if (!row) throw new Error("expected credential row");
+
+		const weekAhead = Date.now() + 6 * 24 * HOUR_MS;
+		store.upsertCredentialBlock({
+			credentialId: row.id,
+			providerKey: "google-antigravity:oauth",
+			blockScope: "counter:google",
+			blockedUntilMs: weekAhead,
+		});
+		ageCredentialBlockRows(dbPath);
+		store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+
+		usageByAccount.set(
+			"acct-direct-heal",
+			createAntigravityReport({
+				accountId: "acct-direct-heal",
+				projectId: "proj-direct-heal",
+				windows: [{ counter: "google", usedFraction: 0, resetInMs: 5 * HOUR_MS }],
+			}),
+		);
+
+		// Must NOT call fetchUsageReports() here; getApiKey selection itself should probe usage and heal the block
+		const geminiKey = await authStorage.getApiKey("google-antigravity", "session-antigravity-direct-heal", {
+			modelId: "gemini-3-flash",
+		});
+		expect(geminiKey).toBe("api-acct-direct-heal");
+		expect(store.getCredentialBlock(row.id, "google-antigravity:oauth", "counter:google")).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What

- Use `this.#supportsUsageBlockHealing(provider)` instead of hardcoding `openai-codex` in candidate pre-fetching and blocked credential ranking logic in `AuthStorage`.
- Ensure usage is checked during candidate selection when accounts have active blocks on healable providers.
- Reconcile usage blocks on fresh cache hits and in the local `fetchUsageReports` path.
- Add unit test verifying that `google-antigravity` OAuth credentials automatically heal stale counter blocks during candidate selection.

## Why

Providers like `google-antigravity` implement `healableBlockScopes` (e.g. `counter:google`, `counter:claude`) and can reconcile quota blocks against live usage reports. However, candidate selection and usage probing previously hardcoded `provider === "openai-codex"`.

As a result:
1. When an account hit a rate limit (for example, a multi-day rate limit window on one model counter), a block was stored in `auth_credential_blocks`.
2. Even when another model had available quota (or when usage cleared), `#selectOptimalCandidate` treated the candidate as `depleted` and skipped querying live usage to heal the block.
3. This led to persistent `429` errors or suboptimal candidate fallback until manual database intervention or expiration of the longest block.

With this fix, any provider supporting block healing can probe live usage and clear stale blocks during candidate selection and report fetching.

## Testing

- Added unit test in `packages/ai/test/auth-storage-antigravity-selection.test.ts`:
  - `a healthy Gemini counter report heals a stale block during candidate selection without requiring fetchUsageReports`
- Ran full test suite for `packages/ai`: all 326 tests across 26 test files passed.
- Ran `bun check:ts` (`oxlint`, `oxfmt`, `tsgo` typecheck) across all monorepo workspaces: passed with 0 errors.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
