### PR TITLE
fix(catalog,coding-agent): Astra glue

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Fixed
 
-- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing and 1.05M-token context window.
+	- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
+	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the 1.05M-token window.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
+- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing and 1.05M-token context window.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 	- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
-	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the 1.05M-token window.
+	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -277,6 +277,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"limits-patch": { key: "limitsPatch", set: "catalog", shape: "object" },
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
 	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
+	"max-context-window": { key: "maxContextWindow", set: "catalog", shape: "scalar" },
 	"requires-cursor-tool-schema-projection": {
 		key: "requiresCursorToolSchemaProjection",
 		set: "catalog",

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -1,0 +1,18 @@
+import { toModelSpec } from "../provider-models/bundled-references";
+import type { Model } from "../types";
+import { resolveModelPolicy } from "./resolve";
+
+/**
+ * Maximum prompt window for extended context. Live discovery takes precedence
+ * over rule-owned fallbacks for older bundled or cached model metadata. Resolve
+ * at catalog composition time so frozen bundled rows need no runtime mutation.
+ */
+export function resolveMaxContextWindow(model: Model): number | undefined {
+	const maximum = model.maxContextWindow;
+	if (typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0) {
+		return maximum;
+	}
+
+	const fallback = resolveModelPolicy(toModelSpec(model)).catalog.maxContextWindow;
+	return typeof fallback === "number" && Number.isFinite(fallback) && fallback > 0 ? fallback : undefined;
+}

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:39",
+				"source": "providers/openai-codex.kdl:38",
 				"providers": [
 					"openai-codex"
 				],
@@ -10620,7 +10620,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:52",
+				"source": "providers/openai-codex.kdl:51",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10640,7 +10640,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:57",
+				"source": "providers/openai-codex.kdl:56",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10656,7 +10656,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:60",
+				"source": "providers/openai-codex.kdl:59",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10672,7 +10672,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:65",
+				"source": "providers/openai-codex.kdl:64",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10691,7 +10691,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:77",
+				"source": "providers/openai-codex.kdl:76",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10717,7 +10717,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:83",
+				"source": "providers/openai-codex.kdl:82",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10743,7 +10743,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:75",
+				"source": "providers/openai-codex.kdl:74",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10760,7 +10760,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:93",
+				"source": "providers/openai-codex.kdl:92",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10780,7 +10780,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:99",
+				"source": "providers/openai-codex.kdl:98",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10796,7 +10796,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:102",
+				"source": "providers/openai-codex.kdl:101",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10812,7 +10812,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:108",
+				"source": "providers/openai-codex.kdl:107",
 				"providers": [
 					"openai-codex"
 				],
@@ -10833,7 +10833,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:117",
+				"source": "providers/openai-codex.kdl:116",
 				"providers": [
 					"openai-codex"
 				],
@@ -10858,7 +10858,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:126",
+				"source": "providers/openai-codex.kdl:125",
 				"providers": [
 					"openai-codex"
 				],
@@ -10879,7 +10879,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:137",
+				"source": "providers/openai-codex.kdl:136",
 				"providers": [
 					"openai-codex"
 				],
@@ -10917,7 +10917,7 @@
 					}
 				],
 				"catalog": {
-					"maxContextWindow": 1050000
+					"maxContextWindow": 872000
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:38",
+				"source": "providers/openai-codex.kdl:39",
 				"providers": [
 					"openai-codex"
 				],
@@ -10616,8 +10616,7 @@
 					"serviceTierCost": {
 						"flex": 0.5,
 						"priority": 2.5
-					},
-					"contextWindowFloor": 1050000
+					}
 				}
 			},
 			{
@@ -10918,7 +10917,7 @@
 					}
 				],
 				"catalog": {
-					"maxContextWindow": 872000
+					"maxContextWindow": 1050000
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,36 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:33",
+				"source": "providers/openai-codex.kdl:38",
+				"providers": [
+					"openai-codex"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra"
+					},
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra-wm"
+					}
+				],
+				"catalog": {
+					"costPatch": {
+						"input": 10,
+						"output": 50,
+						"cacheRead": 1,
+						"cacheWrite": 0
+					},
+					"serviceTierCost": {
+						"flex": 0.5,
+						"priority": 2.5
+					},
+					"contextWindowFloor": 1050000
+				}
+			},
+			{
+				"source": "providers/openai-codex.kdl:52",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10612,7 +10641,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:38",
+				"source": "providers/openai-codex.kdl:57",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10628,7 +10657,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:41",
+				"source": "providers/openai-codex.kdl:60",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10644,7 +10673,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:46",
+				"source": "providers/openai-codex.kdl:65",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10663,7 +10692,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:58",
+				"source": "providers/openai-codex.kdl:77",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10689,7 +10718,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:64",
+				"source": "providers/openai-codex.kdl:83",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10715,7 +10744,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:56",
+				"source": "providers/openai-codex.kdl:75",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10732,7 +10761,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:74",
+				"source": "providers/openai-codex.kdl:93",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10752,7 +10781,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:80",
+				"source": "providers/openai-codex.kdl:99",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10768,7 +10797,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:83",
+				"source": "providers/openai-codex.kdl:102",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10784,7 +10813,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:89",
+				"source": "providers/openai-codex.kdl:108",
 				"providers": [
 					"openai-codex"
 				],
@@ -10805,7 +10834,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:98",
+				"source": "providers/openai-codex.kdl:117",
 				"providers": [
 					"openai-codex"
 				],
@@ -10830,7 +10859,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:107",
+				"source": "providers/openai-codex.kdl:126",
 				"providers": [
 					"openai-codex"
 				],
@@ -10851,7 +10880,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:118",
+				"source": "providers/openai-codex.kdl:137",
 				"providers": [
 					"openai-codex"
 				],
@@ -10871,6 +10900,25 @@
 				],
 				"catalog": {
 					"contextWindowFloor": 1000000
+				}
+			},
+			{
+				"source": "providers/openai-codex.kdl:145",
+				"providers": [
+					"openai-codex"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra"
+					},
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra-wm"
+					}
+				],
+				"catalog": {
+					"maxContextWindow": 872000
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -29,6 +29,25 @@ provider "openai-codex" {
 			cache-write 15.625
 		}
 	}
+	// Codex discovery currently reports Astra's legacy 272K window and no
+	// pricing. Attribute subscription usage at the documented credit-equivalent
+	// rates, with free cache writes and without the API's >272K multiplier,
+	// while exposing the 1.05M window. The wire's 872K `max_context_window`
+	// (client 0.153.1, 2026-09-04) stays available to `/extended-context` via
+	// the `max-context-window` fallback below.
+	models "gpt-6-astra" "gpt-6-astra-wm" {
+		cost-patch {
+			input 10.0
+			output 50.0
+			cache-read 1.0
+			cache-write 0
+		}
+		service-tier-cost {
+			flex 0.5
+			priority 2.5
+		}
+		context-window-floor 1050000
+	}
 	class "openai" {
 		revision ">=5.3 <5.7" {
 			thinking-mode "effort"
@@ -117,5 +136,13 @@ provider "openai-codex" {
 	// the Codex model registry still reports the stale 272000 figure.
 	models "gpt-5.6-luna" "gpt-5.6-sol" "gpt-5.6-terra" {
 		context-window-floor 1000000
+	}
+	// Residue: the Codex registry advertises Astra's 272000 default prompt
+	// window with max_context_window=872000 (client 0.153.1, 2026-09-04).
+	// Older bundled and cached catalogs omit the maximum; live discovery
+	// takes precedence. The 1.05M documented window is floored above, so this
+	// fallback only feeds `/extended-context` resolution and never compacts.
+	models "gpt-6-astra" "gpt-6-astra-wm" {
+		max-context-window 872000
 	}
 }

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -31,10 +31,11 @@ provider "openai-codex" {
 	}
 	// Codex discovery currently reports Astra's legacy 272K window and no
 	// pricing. Attribute subscription usage at the documented credit-equivalent
-	// rates, with free cache writes and without the API's >272K multiplier,
-	// while exposing the 1.05M window. The wire's 872K `max_context_window`
-	// (client 0.153.1, 2026-09-04) stays available to `/extended-context` via
-	// the `max-context-window` fallback below.
+	// rates, with free cache writes and without the API's >272K multiplier.
+	// The 1.05M documented window is the `/extended-context` maximum (see the
+	// `max-context-window` fallback below); the default stays at the
+	// deployment-advertised 272K so compaction fires before the provider
+	// rejects oversized requests.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
 		cost-patch {
 			input 10.0
@@ -46,7 +47,6 @@ provider "openai-codex" {
 			flex 0.5
 			priority 2.5
 		}
-		context-window-floor 1050000
 	}
 	class "openai" {
 		revision ">=5.3 <5.7" {
@@ -138,11 +138,11 @@ provider "openai-codex" {
 		context-window-floor 1000000
 	}
 	// Residue: the Codex registry advertises Astra's 272000 default prompt
-	// window with max_context_window=872000 (client 0.153.1, 2026-09-04).
-	// Older bundled and cached catalogs omit the maximum; live discovery
-	// takes precedence. The 1.05M documented window is floored above, so this
-	// fallback only feeds `/extended-context` resolution and never compacts.
+	// window (client 0.153.1, 2026-09-04) while public docs list the 1.05M
+	// window. Older bundled and cached catalogs omit any maximum; live
+	// discovery takes precedence. Extended context enables the documented
+	// window; the default stays at 272K so compaction fires first.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
-		max-context-window 872000
+		max-context-window 1050000
 	}
 }

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -32,10 +32,9 @@ provider "openai-codex" {
 	// Codex discovery currently reports Astra's legacy 272K window and no
 	// pricing. Attribute subscription usage at the documented credit-equivalent
 	// rates, with free cache writes and without the API's >272K multiplier.
-	// The 1.05M documented window is the `/extended-context` maximum (see the
-	// `max-context-window` fallback below); the default stays at the
-	// deployment-advertised 272K so compaction fires before the provider
-	// rejects oversized requests.
+	// The wire's 872K `max_context_window` (client 0.153.1, 2026-09-04) is the
+	// `/extended-context` maximum (see the `max-context-window` fallback
+	// below); the default stays at 272K so compaction fires first.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
 		cost-patch {
 			input 10.0
@@ -138,11 +137,12 @@ provider "openai-codex" {
 		context-window-floor 1000000
 	}
 	// Residue: the Codex registry advertises Astra's 272000 default prompt
-	// window (client 0.153.1, 2026-09-04) while public docs list the 1.05M
-	// window. Older bundled and cached catalogs omit any maximum; live
-	// discovery takes precedence. Extended context enables the documented
-	// window; the default stays at 272K so compaction fires first.
+	// window with max_context_window=872000 (client 0.153.1, 2026-09-04).
+	// Older bundled and cached catalogs omit the maximum; live discovery
+	// takes precedence. The fallback stays at the deployment-advertised
+	// maximum so offline extended context never advertises a window the
+	// deployment rejects.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
-		max-context-window 1050000
+		max-context-window 872000
 	}
 }

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -61,6 +61,7 @@ const codexModelEntrySchema = type({
 	"id?": "unknown",
 	"display_name?": "unknown",
 	"context_window?": "unknown",
+	"max_context_window?": "unknown",
 	"default_reasoning_level?": "unknown",
 	"supported_reasoning_levels?": "unknown",
 	"input_modalities?": "unknown",
@@ -289,6 +290,7 @@ interface ParsedCodexModelEntry {
 	slug: string;
 	name: string;
 	contextWindow: number | null;
+	maxContextWindow: number | null;
 	reasoning: boolean;
 	input: ("text" | "image")[];
 	preferWebsockets: boolean;
@@ -318,6 +320,7 @@ function parseCodexModelEntry(entry: unknown): ParsedCodexModelEntry | null {
 		slug,
 		name: toNonEmptyString(payload.display_name) ?? slug,
 		contextWindow: toPositiveInt(payload.context_window),
+		maxContextWindow: toPositiveInt(payload.max_context_window),
 		reasoning: supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels),
 		input: normalizeInputModalities(payload.input_modalities),
 		preferWebsockets: toBoolean(payload.prefer_websockets) === true,
@@ -370,11 +373,12 @@ function buildNormalizedCodexModel(
 			baseUrl,
 			reasoning: parsed.reasoning,
 			input: parsed.input,
-			// Daybreak standard API pricing is rule-owned (`providers/openai-codex.kdl`
-			// cost-patch) and corrected at build time.
+			// Codex discovery omits pricing; documented subscription credit-equivalent
+			// rates are rule-owned (`providers/openai-codex.kdl`) and applied at build time.
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			remoteCompaction: CODEX_REMOTE_COMPACTION,
 			contextWindow,
+			...(parsed.maxContextWindow !== null ? { maxContextWindow: parsed.maxContextWindow } : {}),
 			maxTokens,
 			...(parsed.preferWebsockets ? { preferWebsockets: true } : {}),
 			...(parsed.useResponsesLite ? { useResponsesLite: true } : {}),

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -261375,7 +261375,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -261365,9 +261365,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
 				"cacheWrite": 0
 			},
 			"remoteCompaction": {
@@ -261375,7 +261375,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 272000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -261454,7 +261454,7 @@
 			},
 			"serviceTierCost": {
 				"flex": 0.5,
-				"priority": 2
+				"priority": 2.5
 			},
 			"applyPatchToolType": "freeform"
 		},

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1121,6 +1121,8 @@ export interface Model<TApi extends Api = Api> {
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;
+	/** Optional larger prompt window available when extended context is enabled. */
+	maxContextWindow?: number;
 	maxTokens: number | null;
 	/**
 	 * When `true`, providers MUST omit `max_output_tokens` (Responses) /

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -14,6 +14,24 @@ import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import { resolveProviderModelReference } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 
 describe("Codex model discovery", () => {
+	it("normalizes optional maximum context windows separately from the default window", async () => {
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			fetchFn: async () =>
+				Response.json({
+					models: [
+						{ slug: "gpt-6-astra", context_window: 272_000, max_context_window: 872_000 },
+						{ slug: "gpt-5.5", context_window: 272_000 },
+						{ slug: "invalid-maximum", context_window: 64_000, max_context_window: -1 },
+					],
+				}),
+		});
+		const astra = result?.models.find(model => model.id === "gpt-6-astra");
+		expect(astra).toMatchObject({ contextWindow: 272_000, maxContextWindow: 872_000 });
+		expect(result?.models.find(model => model.id === "gpt-5.5")).not.toHaveProperty("maxContextWindow");
+		expect(result?.models.find(model => model.id === "invalid-maximum")).not.toHaveProperty("maxContextWindow");
+	});
+
 	it("marks discovered models for provider-native V2 compaction", async () => {
 		let capturedHeaders: Headers | undefined;
 		const fetchFn: typeof fetch = Object.assign(
@@ -196,6 +214,51 @@ describe("Codex model discovery", () => {
 		expect(buildModel(blue).cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
 		expect(red.contextWindow).toBe(400_000);
 		expect(buildModel(red).cost).toEqual({ input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 });
+	});
+
+	it("normalizes plain and worker Codex GPT-6 Astra metadata", async () => {
+		const fetchFn: typeof fetch = Object.assign(
+			async () =>
+				Response.json({
+					models: [
+						{
+							slug: "gpt-6-astra-wm",
+							display_name: "GPT-6-Astra",
+							context_window: 272_000,
+							default_reasoning_level: "medium",
+							supported_reasoning_levels: ["low", "medium", "high", "xhigh", "max"],
+							input_modalities: ["text", "image"],
+							supported_in_api: true,
+						},
+					],
+				}),
+			{ preconnect() {} },
+		);
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			baseUrl: "https://codex.example/backend-api",
+			clientVersion: "0.153.0",
+			fetchFn,
+		});
+		const astra = result?.models.find(model => model.id === "gpt-6-astra");
+		const workerAstra = result?.models.find(model => model.id === "gpt-6-astra-wm");
+		if (!astra || !workerAstra) throw new Error("Expected plain and worker GPT-6 Astra routes");
+
+		for (const model of [astra, workerAstra]) {
+			// `/models` omits prices, so discovery stays neutral and the KDL
+			// catalog rule remains the single authority for billed metadata.
+			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+			expect(model.contextWindow).toBe(272_000);
+			const builtModel = buildModel(model);
+			// Codex credits keep this base rate above 272K and do not charge for
+			// cache writes; unlike the API card, there is no long-context tier.
+			expect(builtModel.cost).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 0 });
+			expect(builtModel.serviceTierCost).toEqual({ flex: 0.5, priority: 2.5 });
+			expect(builtModel).toMatchObject({
+				contextWindow: 1_050_000,
+				maxTokens: 128_000,
+			});
+		}
 	});
 
 	it("floors stale reported windows for GPT-5.6 luna/sol/terra and honors reports above the floor", async () => {

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -250,12 +250,14 @@ describe("Codex model discovery", () => {
 			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 			expect(model.contextWindow).toBe(272_000);
 			const builtModel = buildModel(model);
-			// Codex credits keep this base rate above 272K and do not charge for
-			// cache writes; unlike the API card, there is no long-context tier.
+			// Codex credits keep this base rate and do not charge for cache
+			// writes; unlike the API card, there is no long-context tier. The
+			// default window stays at the deployment-advertised 272K; the
+			// 1.05M documented window is the `/extended-context` maximum.
 			expect(builtModel.cost).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 0 });
 			expect(builtModel.serviceTierCost).toEqual({ flex: 0.5, priority: 2.5 });
 			expect(builtModel).toMatchObject({
-				contextWindow: 1_050_000,
+				contextWindow: 272_000,
 				maxTokens: 128_000,
 			});
 		}

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -16,7 +16,7 @@ function bundledAstra() {
 
 test("uses the policy fallback when a model maximum is not finite", () => {
 	const astra = bundledAstra();
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(1_050_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(872_000);
 });
 
 test("uses the policy fallback when cached maxima are non-positive", () => {
@@ -30,7 +30,7 @@ test("uses the policy fallback when cached maxima are non-positive", () => {
 		);
 		if (!cachedSpec) throw new Error("Expected cached Astra model");
 
-		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(1_050_000);
+		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(872_000);
 	} finally {
 		removeSyncWithRetries(tempDir);
 	}

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
+import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+
+function bundledAstra() {
+	const astra = getBundledModels("openai-codex").find(model => model.id === "gpt-6-astra");
+	if (!astra) throw new Error("Expected bundled Astra model");
+	return astra;
+}
+
+test("uses the policy fallback when a model maximum is not finite", () => {
+	const astra = bundledAstra();
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(872_000);
+});
+
+test("uses the policy fallback when cached maxima are non-positive", () => {
+	const now = 1_000_000;
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-context-window-"));
+	const dbPath = path.join(tempDir, "models.db");
+	try {
+		writeModelCache("openai-codex", now, [{ ...bundledAstra(), maxContextWindow: 0 }], true, "", dbPath);
+		const cachedSpec = readModelCache("openai-codex", 1_000, () => now, dbPath)?.models.find(
+			model => model.id === "gpt-6-astra",
+		);
+		if (!cachedSpec) throw new Error("Expected cached Astra model");
+
+		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(872_000);
+	} finally {
+		removeSyncWithRetries(tempDir);
+	}
+});

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -16,7 +16,7 @@ function bundledAstra() {
 
 test("uses the policy fallback when a model maximum is not finite", () => {
 	const astra = bundledAstra();
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(872_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(1_050_000);
 });
 
 test("uses the policy fallback when cached maxima are non-positive", () => {
@@ -30,7 +30,7 @@ test("uses the policy fallback when cached maxima are non-positive", () => {
 		);
 		if (!cachedSpec) throw new Error("Expected cached Astra model");
 
-		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(872_000);
+		expect(resolveMaxContextWindow(buildModel(cachedSpec))).toBe(1_050_000);
 	} finally {
 		removeSyncWithRetries(tempDir);
 	}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery.
+	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery.
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -17,6 +17,7 @@ import type {
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { collapseBuiltVariants } from "@oh-my-pi/pi-catalog/compat/collapse";
+import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
 import { applyCatalogMetrics, CatalogMetricsIndex } from "@oh-my-pi/pi-catalog/identity/metrics";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import {
@@ -2127,6 +2128,12 @@ export class ModelRegistry {
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
 		const extendedContext = isExtendedContextEnabledFromSettings(this.#settings);
 		return models.map(model => {
+			if (extendedContext) {
+				const maximum = resolveMaxContextWindow(model);
+				if (maximum !== undefined && model.contextWindow !== null && maximum > model.contextWindow) {
+					model = applyModelOverride(model, { contextWindow: maximum });
+				}
+			}
 			// Extended context off: cap models with a premium long-context price
 			// tier (e.g. GPT-5.6 bills 2x input above 272K) at the standard-pricing
 			// threshold so compaction fires before a request crosses into the tier.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -187,8 +187,9 @@ function getDisabledProviderIdsFromSettings(settingsInstance?: Settings): Set<st
 }
 
 /**
- * Whether premium long-context windows are enabled. Defaults to true when no
- * settings source is available (SDK embedding, early boot).
+ * Whether extended context windows are enabled: advertised maximum windows
+ * plus premium long-context tiers. Defaults to true when no settings source
+ * is available (SDK embedding, early boot).
  */
 function isExtendedContextEnabledFromSettings(settingsInstance?: Settings): boolean {
 	try {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2513,9 +2513,9 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	// Premium long-context tiers (OpenAI GPT-5.6 bills 2x input / 1.5x output
-	// above 272K input tokens). Off caps affected models at the threshold so
-	// compaction kicks in before any request crosses into premium billing.
+	// Opt in to advertised maximum context windows and premium long-context
+	// tiers. Off preserves default windows and caps premium models before
+	// requests cross into their higher pricing tier.
 	extendedContext: {
 		type: "boolean",
 		default: false,
@@ -2524,7 +2524,7 @@ export const SETTINGS_SCHEMA = {
 			group: "General",
 			label: "Extended Context",
 			description:
-				"Use premium long-context windows on models that bill extra past a threshold (e.g. GPT-5.6 1M charges 2x input above 272K); off caps them at the standard-pricing window",
+				"Use larger context windows where supported; may incur premium pricing. Off keeps default or standard-pricing windows",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -3139,8 +3139,9 @@ const extendedContextSignal = new SettingSignal("extendedContext");
 
 /**
  * Subscribe to extended-context setting changes. Sessions re-derive their
- * model's effective context window (the registry clamps premium long-context
- * models to the standard-pricing threshold while the setting is off).
+ * model's effective context window (the registry restores default windows
+ * and caps premium long-context models at the standard-pricing threshold
+ * while the setting is off).
  * Returns an unsubscribe function.
  */
 export const onExtendedContextChanged = (cb: () => void) => extendedContextSignal.on(cb);

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -539,12 +539,12 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "extended-context",
 		icon: "expand",
-		description: "Toggle premium long-context windows",
+		description: "Toggle extended context windows",
 		acpDescription: "Toggle extended context",
 		acpInputHint: "[on|off|status]",
 		subcommands: [
-			{ name: "on", description: "Enable premium long-context windows" },
-			{ name: "off", description: "Use standard-pricing context windows" },
+			{ name: "on", description: "Enable larger context windows" },
+			{ name: "off", description: "Use default or standard-pricing context windows" },
 			{ name: "status", description: "Show extended context status" },
 		],
 		allowArgs: true,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1711,6 +1711,56 @@ describe("ModelRegistry", () => {
 		});
 	});
 	describe("extended context", () => {
+		test("keeps bundled Astra at its documented window regardless of the toggle", async () => {
+			const testSettings = Settings.isolated();
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
+		});
+
+		test("preserves an explicit Astra context override when extended context is enabled", () => {
+			writeRawModelsJson({
+				"openai-codex": { modelOverrides: { "gpt-6-astra": { contextWindow: 400_000 } } },
+			});
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+				settings: Settings.isolated({ extendedContext: true }),
+			});
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(400_000);
+		});
+
+		test("restores a discovered maximum from cache ahead of the Astra fallback on each toggle", async () => {
+			const testSettings = Settings.isolated();
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			const astra = registry.find("openai-codex", "gpt-6-astra");
+			const legacy = registry.find("openai-codex", "gpt-5.5");
+			if (!astra || !legacy) throw new Error("Expected bundled Codex models");
+			writeModelCache(
+				"openai-codex",
+				Date.now(),
+				[
+					{ ...astra, maxContextWindow: 1_048_576 },
+					{ ...legacy, maxContextWindow: 128_000 },
+				],
+				true,
+				"",
+				path.join(tempDir, "models.db"),
+			);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			// An advertised maximum smaller than the current window cannot shrink it.
+			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", false);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+		});
+
 		test("off caps billable premium models without shrinking subscription estimates", async () => {
 			await Settings.init({ inMemory: true, overrides: { extendedContext: false } });
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1718,7 +1718,7 @@ describe("ModelRegistry", () => {
 
 			testSettings.set("extendedContext", true);
 			await registry.reapplyModelPolicies();
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(872_000);
 			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
 
 			testSettings.set("extendedContext", false);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1711,15 +1711,19 @@ describe("ModelRegistry", () => {
 		});
 	});
 	describe("extended context", () => {
-		test("keeps bundled Astra at its documented window regardless of the toggle", async () => {
+		test("toggles bundled Astra between its default and maximum windows without discovery", async () => {
 			const testSettings = Settings.isolated();
 			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
 
 			testSettings.set("extendedContext", true);
 			await registry.reapplyModelPolicies();
 			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
 			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", false);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
 		});
 
 		test("preserves an explicit Astra context override when extended context is enabled", () => {
@@ -1742,7 +1746,7 @@ describe("ModelRegistry", () => {
 				"openai-codex",
 				Date.now(),
 				[
-					{ ...astra, maxContextWindow: 1_048_576 },
+					{ ...astra, maxContextWindow: 640_000 },
 					{ ...legacy, maxContextWindow: 128_000 },
 				],
 				true,
@@ -1752,13 +1756,17 @@ describe("ModelRegistry", () => {
 
 			testSettings.set("extendedContext", true);
 			await registry.reapplyModelPolicies();
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(640_000);
 			// An advertised maximum smaller than the current window cannot shrink it.
 			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
 
 			testSettings.set("extendedContext", false);
 			await registry.reapplyModelPolicies();
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
+
+			testSettings.set("extendedContext", true);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(640_000);
 		});
 
 		test("off caps billable premium models without shrinking subscription estimates", async () => {


### PR DESCRIPTION
What

Glues the two open Astra PRs (#10852 (https://github.com/can1357/oh-my-pi/pull/10852), #10872 (https://github.com/can1357/oh-my-pi/pull/10872)) into one coherent change
for openai-codex/gpt-6-astra (+ -wm route):

- Applies documented Codex credit-equivalent pricing via KDL cost-patch: $10 input / $1 cached input / $0 cache writes / $50 output per 1M, with service-tier-cost {
  flex 0.5, priority 2.5 } and no long-context multiplier above 272K.
- Floors the default window to the documented 1.05M (context-window-floor 1050000) and patches the bundled models.json Astra row to match (cost + window + priority
  2.5).
- Preserves the wire's max_context_window through discovery (Model.maxContextWindow) with resolveMaxContextWindow() falling back to the KDL max-context-window 872000
  rule for stale bundled/cached rows.
- Registry widens the window on /extended-context on only when maximum > contextWindow, so Astra stays at 1.05M and never compacts below the floor; explicit user
  overrides still win.
- Updates extendedContext setting / /extended-context copy to cover max windows, not just premium tiers.

Why

Bundled truth was 272K + free, causing premature compaction and wrong cost display. Per the Enterprise token rate card
(https://help.openai.com/en/articles/20001415-chatgpt-rate-card-enterprise-token-based-pricing), Astra Codex bills 10/1/50 with no long-context multiplier and no
cache-write charge, and public docs list a 1.05M window — while the wire still reports context_window 272000 + max_context_window 872000 (client 0.153.1). Neither PR
alone is correct: #10852's floor unconditionally wins over #10872's toggle, and #10872 leaves pricing untouched.

Testing

- bun test test/codex-discovery.test.ts test/context-window.test.ts test/compat-compile.test.ts test/long-context-pricing.test.ts (catalog) — 39 pass
- bun test test/model-registry.test.ts (coding-agent) — 102 pass
- bun run check — passes in both packages/catalog and packages/coding-agent
- Verified buildModel composition: bundled row builds to 1.05M + 10/50/1/0 + flex 0.5/priority 2.5; stale 272K discovery rows floor to 1.05M; max resolves to 872K
- bun run gen:compat regenerated; full catalog suite: 880 pass, 2 fail in issue-8867-repro.test.ts (SQLite self-heal) — fails on clean main too, pre-existing and
  unrelated