### PR TITLE
fix(ai): heal anthropic tier blocks on recovered usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added Muse Code subscription sign-in, credential refresh, inference, and quota reporting in `/usage`, with durable rate-limit backoff so quota refresh recovers instead of repeatedly retrying.
 
+### Fixed
+
+- Anthropic Fable/Mythos tier credential blocks now clear when a later live usage report shows the tier back under its cap, instead of forcing a model fallback until the advertised weekly reset ([#10978](https://github.com/can1357/oh-my-pi/issues/10978)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -748,11 +748,7 @@ function isConfirmedExhaustedTierRow(limit: UsageLimit, nowMs: number): boolean 
  * while unconfirmed rows remain ranking pressure and opt-in reserve health via
  * scopeClaudeLimitsForModel.
  */
-function scopeClaudeLimitsForModelHardBlock(
-	report: UsageReport,
-	context: CredentialRankingContext | undefined,
-): UsageLimit[] {
-	const kind = getClaudeModelKind(context);
+function scopeClaudeLimitsForKindHardBlock(report: UsageReport, kind: ClaudeModelKind | undefined): UsageLimit[] {
 	const requireConfirmedTierRow = kind === "fable" || kind === "mythos";
 	const nowMs = Date.now();
 	return report.limits.filter(limit => {
@@ -760,6 +756,13 @@ function scopeClaudeLimitsForModelHardBlock(
 		if (kind === undefined || limit.scope.tier !== kind) return false;
 		return !requireConfirmedTierRow || isConfirmedExhaustedTierRow(limit, nowMs);
 	});
+}
+
+function scopeClaudeLimitsForModelHardBlock(
+	report: UsageReport,
+	context: CredentialRankingContext | undefined,
+): UsageLimit[] {
+	return scopeClaudeLimitsForKindHardBlock(report, getClaudeModelKind(context));
 }
 
 function rankingUsedFraction(limit: UsageLimit): number {
@@ -809,20 +812,22 @@ function findClaudeSecondaryLimit(
 /**
  * Backoff scopes a fresh usage report can vouch for. A Fable/Mythos usage-limit
  * error writes a reactive `tier:` block whose deadline follows the 429
- * retry-after (the advertised weekly reset); when a later live counter for that
- * tier is below the cap, the block is stale and must clear instead of idling the
- * account until the clock runs out. Each tier is judged only by its own weekly
- * row so an exhausted Fable cap never keeps a recovered Mythos block alive, and
- * vice versa. Only Fable/Mythos are returned because {@link blockScope} scopes
- * backoff for exactly those tiers; every other Anthropic exhaustion blocks the
- * whole credential and expires by clock. Mirrors the per-counter healing in
- * packages/ai/src/usage/google-antigravity.ts.
+ * retry-after (the advertised weekly reset); when a later report no longer
+ * confirms that tier's exhaustion, the block is stale and must clear instead
+ * of idling the account until the clock runs out. Each tier is judged with the
+ * same hard-block predicate as selection, including shared limits, so a missing
+ * or elapsed tier reset authorizes a probe while an account-wide exhaustion
+ * still preserves the block. Only Fable/Mythos are returned because
+ * {@link blockScope} scopes backoff for exactly those tiers.
  */
 function healableClaudeTierBlockScopes(report: UsageReport): { blockScope: string; limits: UsageLimit[] }[] {
 	const scopes: { blockScope: string; limits: UsageLimit[] }[] = [];
 	for (const tier of ["fable", "mythos"] as const) {
-		const limits = report.limits.filter(limit => limit.scope.tier === tier);
-		if (limits.length > 0) scopes.push({ blockScope: `tier:${tier}`, limits });
+		if (!report.limits.some(limit => limit.scope.tier === tier)) continue;
+		scopes.push({
+			blockScope: `tier:${tier}`,
+			limits: scopeClaudeLimitsForKindHardBlock(report, tier),
+		});
 	}
 	return scopes;
 }

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -806,6 +806,27 @@ function findClaudeSecondaryLimit(
 		.reduce<UsageLimit | undefined>((selected, limit) => morePressuredLimit(selected, limit, nowMs), undefined);
 }
 
+/**
+ * Backoff scopes a fresh usage report can vouch for. A Fable/Mythos usage-limit
+ * error writes a reactive `tier:` block whose deadline follows the 429
+ * retry-after (the advertised weekly reset); when a later live counter for that
+ * tier is below the cap, the block is stale and must clear instead of idling the
+ * account until the clock runs out. Each tier is judged only by its own weekly
+ * row so an exhausted Fable cap never keeps a recovered Mythos block alive, and
+ * vice versa. Only Fable/Mythos are returned because {@link blockScope} scopes
+ * backoff for exactly those tiers; every other Anthropic exhaustion blocks the
+ * whole credential and expires by clock. Mirrors the per-counter healing in
+ * packages/ai/src/usage/google-antigravity.ts.
+ */
+function healableClaudeTierBlockScopes(report: UsageReport): { blockScope: string; limits: UsageLimit[] }[] {
+	const scopes: { blockScope: string; limits: UsageLimit[] }[] = [];
+	for (const tier of ["fable", "mythos"] as const) {
+		const limits = report.limits.filter(limit => limit.scope.tier === tier);
+		if (limits.length > 0) scopes.push({ blockScope: `tier:${tier}`, limits });
+	}
+	return scopes;
+}
+
 export const claudeRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report, context) {
 		const primary = report.limits.find(limit => limit.id === "anthropic:5h");
@@ -827,5 +848,10 @@ export const claudeRankingStrategy: CredentialRankingStrategy = {
 		const kind = getClaudeModelKind(context);
 		return kind === "fable" || kind === "mythos" ? `tier:${kind}` : undefined;
 	},
+	// A Fable/Mythos 429 backoff follows the advertised weekly reset, which can
+	// sit days past the tier's real recovery. Let a fresh healthy usage report
+	// clear the stale scoped block instead of pinning the account to a fallback
+	// model until the clock runs out (issue #10978).
+	healableBlockScopes: healableClaudeTierBlockScopes,
 	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 7 * 24 * 60 * 60 * 1000 },
 };

--- a/packages/ai/test/auth-storage-claude-tier-heal.test.ts
+++ b/packages/ai/test/auth-storage-claude-tier-heal.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Anthropic tier self-heal regression (issue #10978). A Fable/Mythos 429 writes
+ * a scoped `tier:` credential block whose deadline follows the advertised weekly
+ * reset. When a later live usage report shows the tier back at `status: ok`, the
+ * stale block must clear via {@link claudeRankingStrategy.healableBlockScopes}
+ * instead of pinning the account to a fallback model until the clock runs out.
+ *
+ * Each tier is judged on its own weekly row: a recovered Fable block clears
+ * while a still-exhausted Mythos block on the same credential survives.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { claudeRankingStrategy } from "@oh-my-pi/pi-ai/usage/claude";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const HOUR_MS = 60 * 60 * 1000;
+const WEEK_MS = 7 * 24 * HOUR_MS;
+const STALE_BLOCK_GUARD_MS = 5 * 60_000 + 1;
+
+/** Age persisted block rows past the post-429 probe guard so healing may run. */
+function ageCredentialBlockRows(dbPath: string): void {
+	const db = new Database(dbPath);
+	try {
+		db.prepare("UPDATE auth_credential_blocks SET updated_at = ?").run(
+			Math.floor((Date.now() - STALE_BLOCK_GUARD_MS) / 1000),
+		);
+	} finally {
+		db.close();
+	}
+}
+
+function tierLimit(tier: "fable" | "mythos", usedFraction: number, resetInMs: number): UsageLimit {
+	const used = Math.min(Math.max(usedFraction, 0), 1);
+	return {
+		id: `anthropic:7d:${tier}`,
+		label: `Claude 7 Day (${tier})`,
+		scope: { provider: "anthropic", windowId: "7d", tier },
+		window: { id: "7d", label: "7 Day", resetsAt: Date.now() + resetInMs },
+		amount: { unit: "percent", used: used * 100, limit: 100, usedFraction: used },
+		status: used >= 1 ? "exhausted" : "ok",
+	};
+}
+
+function sharedLimit(windowId: "5h" | "7d", usedFraction: number): UsageLimit {
+	return {
+		id: `anthropic:${windowId}`,
+		label: windowId === "5h" ? "Claude 5 Hour" : "Claude 7 Day",
+		scope: { provider: "anthropic", windowId, shared: true },
+		window: { id: windowId, label: windowId === "5h" ? "5 Hour" : "7 Day" },
+		amount: { unit: "percent", used: usedFraction * 100, limit: 100, usedFraction },
+		status: usedFraction >= 1 ? "exhausted" : "ok",
+	};
+}
+
+function claudeReport(accountId: string, email: string, tiers: UsageLimit[]): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt: Date.now(),
+		limits: [sharedLimit("5h", 0.18), sharedLimit("7d", 0.12), ...tiers],
+		metadata: { accountId, email },
+	};
+}
+
+function createCredential(accountId: string, email: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+		email,
+	};
+}
+
+let tempDir = "";
+let dbPath = "";
+let store: AuthCredentialStore | null = null;
+let authStorage: AuthStorage | null = null;
+const usageByAccount = new Map<string, UsageReport>();
+
+const usageProvider: UsageProvider = {
+	id: "anthropic",
+	async fetchUsage(params) {
+		const accountId = params.credential.accountId;
+		if (!accountId) return null;
+		return usageByAccount.get(accountId) ?? null;
+	},
+};
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-claude-heal-"));
+	dbPath = path.join(tempDir, "agent.db");
+	store = await SqliteAuthCredentialStore.open(dbPath);
+	authStorage = new AuthStorage(store, {
+		usageProviderResolver: provider => (provider === "anthropic" ? usageProvider : undefined),
+		rankingStrategyResolver: provider => (provider === "anthropic" ? claudeRankingStrategy : undefined),
+	});
+	usageByAccount.clear();
+	vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+		const credential = credentials.anthropic as OAuthCredentials | undefined;
+		if (!credential?.accountId) return null;
+		return { apiKey: `api-${credential.accountId}`, newCredentials: credential };
+	});
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	store?.close();
+	store = null;
+	authStorage = null;
+	if (tempDir) {
+		await removeWithRetries(tempDir);
+		tempDir = "";
+	}
+});
+
+test("a recovered Fable usage report clears its stale tier block without touching a still-exhausted Mythos block", async () => {
+	if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+		throw new Error("test setup failed");
+	}
+
+	await authStorage.set("anthropic", [{ type: "oauth", ...createCredential("acct-1", "user@example.com") }]);
+	const row = store.listAuthCredentials("anthropic")[0];
+	if (!row) throw new Error("expected credential row");
+
+	// Both scopes were blocked by a 429 whose retry-after pointed at the
+	// advertised weekly reset, days ahead of the real recovery.
+	const weekAhead = Date.now() + WEEK_MS;
+	store.upsertCredentialBlock({
+		credentialId: row.id,
+		providerKey: "anthropic:oauth",
+		blockScope: "tier:fable",
+		blockedUntilMs: weekAhead,
+	});
+	store.upsertCredentialBlock({
+		credentialId: row.id,
+		providerKey: "anthropic:oauth",
+		blockScope: "tier:mythos",
+		blockedUntilMs: weekAhead,
+	});
+	ageCredentialBlockRows(dbPath);
+	store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+
+	// Fable is back to ok; Mythos is still pinned at the cap.
+	usageByAccount.set(
+		"acct-1",
+		claudeReport("acct-1", "user@example.com", [tierLimit("fable", 0.04, WEEK_MS), tierLimit("mythos", 1, WEEK_MS)]),
+	);
+
+	await authStorage.fetchUsageReports();
+
+	expect(store.getCredentialBlock(row.id, "anthropic:oauth", "tier:fable")).toBeUndefined();
+	expect(store.getCredentialBlock(row.id, "anthropic:oauth", "tier:mythos")).toBe(weekAhead);
+
+	// The recovered Fable scope is selectable again instead of falling back to
+	// another model; the per-scope store assertions above prove the still-exhausted
+	// Mythos block was left intact.
+	expect(await authStorage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" })).toBe("api-acct-1");
+});

--- a/packages/ai/test/auth-storage-claude-tier-heal.test.ts
+++ b/packages/ai/test/auth-storage-claude-tier-heal.test.ts
@@ -36,13 +36,19 @@ function ageCredentialBlockRows(dbPath: string): void {
 	}
 }
 
-function tierLimit(tier: "fable" | "mythos", usedFraction: number, resetInMs: number): UsageLimit {
+type ClaudeTier = "fable" | "mythos";
+
+function tierLimit(tier: ClaudeTier, usedFraction: number, resetInMs?: number): UsageLimit {
 	const used = Math.min(Math.max(usedFraction, 0), 1);
 	return {
 		id: `anthropic:7d:${tier}`,
 		label: `Claude 7 Day (${tier})`,
 		scope: { provider: "anthropic", windowId: "7d", tier },
-		window: { id: "7d", label: "7 Day", resetsAt: Date.now() + resetInMs },
+		window: {
+			id: "7d",
+			label: "7 Day",
+			...(resetInMs === undefined ? {} : { resetsAt: Date.now() + resetInMs }),
+		},
 		amount: { unit: "percent", used: used * 100, limit: 100, usedFraction: used },
 		status: used >= 1 ? "exhausted" : "ok",
 	};
@@ -93,6 +99,29 @@ const usageProvider: UsageProvider = {
 	},
 };
 
+async function seedStaleTierBlocks(tiers: readonly ClaudeTier[]): Promise<{
+	credentialId: number;
+	blockedUntilMs: number;
+}> {
+	if (!authStorage || !store?.upsertCredentialBlock) throw new Error("test setup failed");
+	await authStorage.set("anthropic", [{ type: "oauth", ...createCredential("acct-1", "user@example.com") }]);
+	const row = store.listAuthCredentials("anthropic")[0];
+	if (!row) throw new Error("expected credential row");
+
+	const blockedUntilMs = Date.now() + WEEK_MS;
+	for (const tier of tiers) {
+		store.upsertCredentialBlock({
+			credentialId: row.id,
+			providerKey: "anthropic:oauth",
+			blockScope: `tier:${tier}`,
+			blockedUntilMs,
+		});
+	}
+	ageCredentialBlockRows(dbPath);
+	store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+	return { credentialId: row.id, blockedUntilMs };
+}
+
 beforeEach(async () => {
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-claude-heal-"));
 	dbPath = path.join(tempDir, "agent.db");
@@ -121,33 +150,10 @@ afterEach(async () => {
 });
 
 test("a recovered Fable usage report clears its stale tier block without touching a still-exhausted Mythos block", async () => {
-	if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
-		throw new Error("test setup failed");
-	}
+	if (!authStorage || !store?.getCredentialBlock) throw new Error("test setup failed");
+	const { credentialId, blockedUntilMs } = await seedStaleTierBlocks(["fable", "mythos"]);
 
-	await authStorage.set("anthropic", [{ type: "oauth", ...createCredential("acct-1", "user@example.com") }]);
-	const row = store.listAuthCredentials("anthropic")[0];
-	if (!row) throw new Error("expected credential row");
-
-	// Both scopes were blocked by a 429 whose retry-after pointed at the
-	// advertised weekly reset, days ahead of the real recovery.
-	const weekAhead = Date.now() + WEEK_MS;
-	store.upsertCredentialBlock({
-		credentialId: row.id,
-		providerKey: "anthropic:oauth",
-		blockScope: "tier:fable",
-		blockedUntilMs: weekAhead,
-	});
-	store.upsertCredentialBlock({
-		credentialId: row.id,
-		providerKey: "anthropic:oauth",
-		blockScope: "tier:mythos",
-		blockedUntilMs: weekAhead,
-	});
-	ageCredentialBlockRows(dbPath);
-	store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
-
-	// Fable is back to ok; Mythos is still pinned at the cap.
+	// Fable is back to ok; Mythos is still pinned at the cap with a live reset.
 	usageByAccount.set(
 		"acct-1",
 		claudeReport("acct-1", "user@example.com", [tierLimit("fable", 0.04, WEEK_MS), tierLimit("mythos", 1, WEEK_MS)]),
@@ -155,11 +161,45 @@ test("a recovered Fable usage report clears its stale tier block without touchin
 
 	await authStorage.fetchUsageReports();
 
-	expect(store.getCredentialBlock(row.id, "anthropic:oauth", "tier:fable")).toBeUndefined();
-	expect(store.getCredentialBlock(row.id, "anthropic:oauth", "tier:mythos")).toBe(weekAhead);
+	expect(store.getCredentialBlock(credentialId, "anthropic:oauth", "tier:fable")).toBeUndefined();
+	expect(store.getCredentialBlock(credentialId, "anthropic:oauth", "tier:mythos")).toBe(blockedUntilMs);
 
 	// The recovered Fable scope is selectable again instead of falling back to
 	// another model; the per-scope store assertions above prove the still-exhausted
 	// Mythos block was left intact.
 	expect(await authStorage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" })).toBe("api-acct-1");
+});
+
+test("clears a stale Fable block when the exhausted tier row has no reset timestamp", async () => {
+	if (!authStorage || !store?.getCredentialBlock) throw new Error("test setup failed");
+	const { credentialId } = await seedStaleTierBlocks(["fable"]);
+	usageByAccount.set("acct-1", claudeReport("acct-1", "user@example.com", [tierLimit("fable", 1)]));
+
+	await authStorage.fetchUsageReports();
+
+	expect(store.getCredentialBlock(credentialId, "anthropic:oauth", "tier:fable")).toBeUndefined();
+});
+
+test("clears a stale Fable block when the exhausted tier row reset has elapsed", async () => {
+	if (!authStorage || !store?.getCredentialBlock) throw new Error("test setup failed");
+	const { credentialId } = await seedStaleTierBlocks(["fable"]);
+	usageByAccount.set("acct-1", claudeReport("acct-1", "user@example.com", [tierLimit("fable", 1, -HOUR_MS)]));
+
+	await authStorage.fetchUsageReports();
+
+	expect(store.getCredentialBlock(credentialId, "anthropic:oauth", "tier:fable")).toBeUndefined();
+});
+
+test("keeps a stale Fable block while an applicable shared window remains exhausted", async () => {
+	if (!authStorage || !store?.getCredentialBlock) throw new Error("test setup failed");
+	const { credentialId, blockedUntilMs } = await seedStaleTierBlocks(["fable"]);
+	const report = claudeReport("acct-1", "user@example.com", [tierLimit("fable", 0.04, WEEK_MS)]);
+	usageByAccount.set("acct-1", {
+		...report,
+		limits: [sharedLimit("5h", 1), ...report.limits.filter(limit => limit.id !== "anthropic:5h")],
+	});
+
+	await authStorage.fetchUsageReports();
+
+	expect(store.getCredentialBlock(credentialId, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
 });


### PR DESCRIPTION
## Repro
An Anthropic Fable/Mythos 429 (extra-usage exhaustion) writes a scoped `auth_credential_blocks` row (`block_scope = "tier:fable"`) whose `blocked_until_ms` follows the advertised weekly reset. After the meter recovers (later `usage_history` snapshots for `Claude 7 Day (Fable)` are `status = "ok"`), the block is never reconciled: selecting `anthropic/claude-fable-5-1` immediately applies `retry.modelFallback` and the Fable request is never sent, for days, until the wall-clock deadline (or a manual DB delete). Reproduced by `packages/ai/test/auth-storage-claude-tier-heal.test.ts`: with `healableBlockScopes` disabled, `fetchUsageReports()` leaves the stale `tier:fable` block in place (`getCredentialBlock(...) === 1789243261187` instead of `undefined`).

## Cause
The self-heal path added for #4980 (`AuthStorage.#reconcileUsageBlock` → `#reconcileUsageBlockForCredential`) is gated on `#supportsUsageBlockHealing(provider)`, which is `provider === "openai-codex" || strategy.healableBlockScopes !== undefined` (`packages/ai/src/auth-storage.ts`). `claudeRankingStrategy` (`packages/ai/src/usage/claude.ts`) defined `blockScope` (`tier:fable`/`tier:mythos`) but never implemented `healableBlockScopes`, so healing was a no-op for the entire Anthropic provider — scoped tier blocks only lifted by clock expiry. `google-antigravity` opted in via `healableBlockScopes`; Anthropic simply was never wired in.

## Fix
- Add `healableClaudeTierBlockScopes(report)` to `packages/ai/src/usage/claude.ts`: returns one healable scope per Fable/Mythos weekly counter present in the report, each carrying only its own tier row, mirroring `blockScope` and the per-counter healing in `google-antigravity`.
- Register it as `claudeRankingStrategy.healableBlockScopes`, flipping `#supportsUsageBlockHealing("anthropic")` to true so a fresh healthy usage report clears the stale `tier:` block (subject to the existing post-429 reconcile-after probe guard) while a still-exhausted sibling tier stays blocked.
- Add `packages/ai/test/auth-storage-claude-tier-heal.test.ts` covering the recovered-Fable-clears / exhausted-Mythos-persists contract via `fetchUsageReports()`.
- Changelog entry under `packages/ai/CHANGELOG.md` `[Unreleased]`.

## Verification
`cd packages/ai && bun test test/auth-storage-claude-tier-heal.test.ts test/auth-storage-claude-fable-fallback.test.ts test/claude-usage-headers.test.ts test/auth-storage-model-usage-health.test.ts test/auth-storage-antigravity-selection.test.ts` → 101 pass / 0 fail. Confirmed the new test fails without the fix (stale `tier:fable` block survives) and passes with it. Pre-publish gate (`bun run fix` + `bun check`) ran clean on push.

Fixes #10978