### PR TITLE
fix(edit): preserve formatted writethrough content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -647,8 +647,8 @@ export class EditTool implements AgentTool<TInput> {
 		invalidateFsScanAfterWrite(request.path);
 		this.session.bumpFileMutationVersion?.(request.path);
 		return {
-			written: request.content,
-			diagnosticsJson: diagnostics ? JSON.stringify(diagnostics) : undefined,
+			written: diagnostics.finalContent,
+			diagnosticsJson: diagnostics.diagnostics ? JSON.stringify(diagnostics.diagnostics) : undefined,
 		};
 	}
 }

--- a/packages/coding-agent/src/lsp/writethrough.ts
+++ b/packages/coding-agent/src/lsp/writethrough.ts
@@ -48,8 +48,7 @@ export type WritethroughDeferredHandle = {
 	finalize: (diagnostics: FileDiagnosticsResult | undefined) => void;
 };
 
-export interface WritethroughResult extends Partial<FileDiagnosticsResult> {
-	/** Structured diagnostics remain nested for tool details. */
+export interface WritethroughResult {
 	diagnostics?: FileDiagnosticsResult;
 	finalContent: string;
 }
@@ -476,7 +475,7 @@ async function runLspWritethrough(
 		diagnostics.formatter = formatter;
 	}
 
-	return diagnostics ? { ...diagnostics, finalContent, diagnostics } : { finalContent };
+	return { finalContent, diagnostics };
 }
 
 async function flushWritethroughBatch(

--- a/packages/coding-agent/src/lsp/writethrough.ts
+++ b/packages/coding-agent/src/lsp/writethrough.ts
@@ -48,6 +48,12 @@ export type WritethroughDeferredHandle = {
 	finalize: (diagnostics: FileDiagnosticsResult | undefined) => void;
 };
 
+export interface WritethroughResult extends Partial<FileDiagnosticsResult> {
+	/** Structured diagnostics remain nested for tool details. */
+	diagnostics?: FileDiagnosticsResult;
+	finalContent: string;
+}
+
 /** Callback type for the LSP writethrough */
 export type WritethroughCallback = (
 	dst: string,
@@ -56,7 +62,7 @@ export type WritethroughCallback = (
 	file?: BunFile,
 	batch?: LspWritethroughBatchRequest,
 	getDeferred?: (dst: string) => WritethroughDeferredHandle | undefined,
-) => Promise<FileDiagnosticsResult | undefined>;
+) => Promise<WritethroughResult>;
 
 /** No-op writethrough callback */
 export async function writethroughNoop(
@@ -66,9 +72,9 @@ export async function writethroughNoop(
 	file?: BunFile,
 	_batch?: LspWritethroughBatchRequest,
 	_getDeferred?: (dst: string) => WritethroughDeferredHandle | undefined,
-): Promise<FileDiagnosticsResult | undefined> {
+): Promise<WritethroughResult> {
 	await writeFileWithFallback(dst, content, file);
-	return undefined;
+	return { finalContent: content };
 }
 
 interface PendingWritethrough {
@@ -125,7 +131,8 @@ export async function flushLspWritethroughBatch(
 		return undefined;
 	}
 	writethroughBatches.delete(id);
-	return flushWritethroughBatch(Array.from(state.entries.values()), cwd, state.options, signal);
+	return (await flushWritethroughBatch(Array.from(state.entries.values()), "", cwd, state.options, signal))
+		.diagnostics;
 }
 
 function mergeDiagnostics(
@@ -301,7 +308,7 @@ async function runLspWritethrough(
 		signal: AbortSignal;
 	},
 	runOptions?: RunLspWritethroughOptions,
-): Promise<FileDiagnosticsResult | undefined> {
+): Promise<WritethroughResult> {
 	const { enableFormat, enableDiagnostics } = options;
 	const contentAlreadyWritten = runOptions?.contentAlreadyWritten ?? false;
 
@@ -330,7 +337,7 @@ async function runLspWritethrough(
 	if (!enableFormat && !enableDiagnostics) {
 		await getWritePromise();
 		await notifyWriteCommitted();
-		return undefined;
+		return { finalContent, diagnostics: undefined };
 	}
 
 	const config = getConfig(cwd);
@@ -339,7 +346,7 @@ async function runLspWritethrough(
 	if (servers.length === 0) {
 		await getWritePromise();
 		await notifyWriteCommitted();
-		return undefined;
+		return { finalContent, diagnostics: undefined };
 	}
 	const { lspServers, customLinterServers } = splitServers(servers);
 	const useCustomFormatter = enableFormat && customLinterServers.length > 0;
@@ -469,20 +476,22 @@ async function runLspWritethrough(
 		diagnostics.formatter = formatter;
 	}
 
-	return diagnostics;
+	return diagnostics ? { ...diagnostics, finalContent, diagnostics } : { finalContent };
 }
 
 async function flushWritethroughBatch(
 	batch: PendingWritethrough[],
+	requestedDst: string | undefined,
 	cwd: string,
 	options: ResolvedWritethroughOptions,
 	signal?: AbortSignal,
 	getDeferred?: (dst: string) => WritethroughDeferredHandle | undefined,
-): Promise<FileDiagnosticsResult | undefined> {
+): Promise<WritethroughResult> {
 	if (batch.length === 0) {
-		return undefined;
+		return { finalContent: "" };
 	}
 	const results: Array<FileDiagnosticsResult | undefined> = [];
+	const finalContents = new Map<string, string>();
 	for (const entry of batch) {
 		const bundle = getDeferred?.(entry.dst);
 		let content: string;
@@ -493,10 +502,8 @@ async function flushWritethroughBatch(
 				bundle?.finalize(undefined);
 				continue;
 			}
-			// A brokered write lands bytes this process may not be able to read
-			// back: a sandbox that denies the write commonly denies the read too.
-			// Failing here would fail a flush whose every write succeeded, so the
-			// content this entry committed stands in for the unreadable file.
+			// A brokered write may deny read-back even after the write succeeds.
+			// Keep the committed request content as the source for diagnostics.
 			if (!isPermissionDeniedError(error)) throw error;
 			content = entry.content;
 		}
@@ -517,10 +524,17 @@ async function flushWritethroughBatch(
 			deferredInner,
 			{ contentAlreadyWritten: true },
 		);
-		bundle?.finalize(diag);
-		results.push(diag);
+		finalContents.set(entry.dst, diag.finalContent);
+		bundle?.finalize(diag.diagnostics);
+		results.push(diag.diagnostics);
 	}
-	return mergeDiagnostics(results, options);
+	const finalContent = requestedDst
+		? (finalContents.get(requestedDst) ?? batch.find(entry => entry.dst === requestedDst)?.content ?? "")
+		: "";
+	return {
+		finalContent,
+		diagnostics: mergeDiagnostics(results, options),
+	};
 }
 
 /** Create a writethrough callback for LSP aware write operations */
@@ -557,7 +571,7 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 				file,
 				deferredInner,
 			);
-			bundle?.finalize(diagnostics);
+			bundle?.finalize(diagnostics.diagnostics);
 			return diagnostics;
 		}
 
@@ -573,6 +587,7 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 					try {
 						await flushWritethroughBatch(
 							Array.from(pending.entries.values()),
+							"",
 							cwd,
 							pending.options,
 							signal,
@@ -591,9 +606,16 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 
 		const state = getOrCreateWritethroughBatch(batch.id, resolvedOptions);
 		state.entries.set(dst, { dst, file, changeType, content });
-		if (!batch.flush) return undefined;
-
+		if (!batch.flush) return { finalContent: content };
 		writethroughBatches.delete(batch.id);
-		return flushWritethroughBatch(Array.from(state.entries.values()), cwd, state.options, signal, getDeferred);
+		const result = await flushWritethroughBatch(
+			Array.from(state.entries.values()),
+			dst,
+			cwd,
+			state.options,
+			signal,
+			getDeferred,
+		);
+		return result;
 	};
 }

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1332,10 +1332,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			if (!this.#deferredDiagnostics || batchRequest?.flush === false) {
 				this.session.bumpFileMutationVersion?.(absolutePath);
 			}
-			const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, cleanContent);
+			const finalContent = diagnostics.finalContent;
+			const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, finalContent);
 
-			const header = maybeWriteSnapshotHeader(this.session, absolutePath, cleanContent);
-			const writeLine = `Successfully wrote ${cleanContent.length} bytes to ${displayPath}`;
+			const header = maybeWriteSnapshotHeader(this.session, absolutePath, finalContent);
+			const writeLine = `Successfully wrote ${finalContent.length} bytes to ${displayPath}`;
 			let resultText = header ? `${header}\n${writeLine}` : writeLine;
 			if (stripped) {
 				resultText += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
@@ -1343,7 +1344,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			if (madeExecutable) {
 				resultText += `\n${EXECUTABLE_NOTICE}`;
 			}
-			if (!diagnostics) {
+			if (!diagnostics.diagnostics) {
 				return {
 					content: [{ type: "text", text: resultText }],
 					details: { resolvedPath: absolutePath, madeExecutable: madeExecutable || undefined },
@@ -1354,10 +1355,10 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				content: [{ type: "text", text: resultText }],
 				details: {
 					resolvedPath: absolutePath,
-					diagnostics,
+					diagnostics: diagnostics.diagnostics,
 					madeExecutable: madeExecutable || undefined,
 					meta: outputMeta()
-						.diagnostics(diagnostics.summary, diagnostics.messages ?? [])
+						.diagnostics(diagnostics.diagnostics.summary, diagnostics.diagnostics.messages ?? [])
 						.get(),
 				},
 			};

--- a/packages/coding-agent/test/edit-patch-unchanged-error.test.ts
+++ b/packages/coding-agent/test/edit-patch-unchanged-error.test.ts
@@ -42,7 +42,7 @@ describe("EditTool patch post-write verification", () => {
 		await fs.mkdir(path.join(tempDir, "deep", "nested"), { recursive: true });
 		await fs.writeFile(path.join(tempDir, relPath), "a\n");
 
-		spyOn(lsp, "writethroughNoop").mockImplementation(async () => undefined);
+		spyOn(lsp, "writethroughNoop").mockImplementation(async () => ({ finalContent: "" }));
 		const result = await new EditTool(makeSession(tempDir), "patch").execute("unchanged", {
 			path: relPath,
 			edits: [{ op: "update", diff: "@@\n-a\n+b" }],

--- a/packages/coding-agent/test/tools/lsp-batching.test.ts
+++ b/packages/coding-agent/test/tools/lsp-batching.test.ts
@@ -48,7 +48,7 @@ describe("createLspWritethrough batching", () => {
 			flush: false,
 		});
 
-		expect(firstResult).toBeUndefined();
+		expect(firstResult.finalContent).toBe("const a = 1;\n");
 		expect(getServersSpy).toHaveBeenCalledTimes(0);
 		expect(loadConfigSpy).toHaveBeenCalledTimes(0);
 		expect(await Bun.file(fileA).text()).toBe("const a = 1;\n");
@@ -58,7 +58,7 @@ describe("createLspWritethrough batching", () => {
 			flush: true,
 		});
 
-		expect(secondResult).toBeUndefined();
+		expect(secondResult.finalContent).toBe("const b = 2;\n");
 		expect(getServersSpy).toHaveBeenCalledTimes(2);
 		expect(loadConfigSpy).toHaveBeenCalledTimes(1);
 		expect(await Bun.file(fileA).text()).toBe("const a = 1;\n");
@@ -127,10 +127,11 @@ describe("createLspWritethrough batching", () => {
 			id: batchId,
 			flush: false,
 		});
-		await writethrough(fileB, "const other=1\n", undefined, undefined, {
+		const result = await writethrough(fileB, "const other=1\n", undefined, undefined, {
 			id: batchId,
 			flush: true,
 		});
+		expect(result.finalContent).toBe("const other = 1;\n");
 
 		const bytes = new Uint8Array(await Bun.file(fileA).arrayBuffer());
 		expect([...bytes.subarray(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
@@ -157,7 +158,7 @@ describe("createLspWritethrough batching", () => {
 			flush: true,
 		});
 
-		expect(result?.formatter).toBe(FileFormatResult.FAILED);
+		expect(result.diagnostics?.formatter).toBe(FileFormatResult.FAILED);
 	});
 
 	it("flushes earlier entries when the final batch write fails", async () => {
@@ -199,7 +200,7 @@ describe("createLspWritethrough batching", () => {
 		const filePath = path.join(tempDir.path(), "single.ts");
 		const result = await writethrough(filePath, "const single = true;\n");
 
-		expect(result).toBeUndefined();
+		expect(result.finalContent).toBe("const single = true;\n");
 		expect(getServersSpy).toHaveBeenCalledTimes(1);
 		expect(loadConfigSpy).toHaveBeenCalledTimes(1);
 		expect(await Bun.file(filePath).text()).toBe("const single = true;\n");

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -199,7 +199,7 @@ describe("LSP diagnostics freshness", () => {
 		});
 		const result = await writethrough(filePath, "export const value=1\n");
 
-		expect(result?.formatter).toBe(FileFormatResult.FORMATTED);
+		expect(result?.diagnostics?.formatter).toBe(FileFormatResult.FORMATTED);
 		expect(await Bun.file(filePath).text()).toBe("export const value = 1;\n");
 		expect(getOrCreate).not.toHaveBeenCalled();
 		expect(sync).not.toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe("LSP diagnostics freshness", () => {
 		const content = "export const value=1\n";
 		const result = await writethrough(filePath, content);
 
-		expect(result?.formatter).toBe(FileFormatResult.FAILED);
+		expect(result?.diagnostics?.formatter).toBe(FileFormatResult.FAILED);
 		expect(await Bun.file(filePath).text()).toBe(content);
 	});
 
@@ -345,8 +345,8 @@ describe("LSP diagnostics freshness", () => {
 		});
 		const result = await writethrough(filePath, "export const value=1\n");
 
-		expect(result?.formatter).toBe(FileFormatResult.FORMATTED);
-		expect(result?.messages).toEqual([]);
+		expect(result?.diagnostics?.formatter).toBe(FileFormatResult.FORMATTED);
+		expect(result?.diagnostics?.messages).toEqual([]);
 		expect(await Bun.file(filePath).text()).toBe("export const value = 1;\n");
 	});
 
@@ -432,9 +432,9 @@ describe("LSP diagnostics freshness", () => {
 		const result = await writethrough(filePath, "export const value = 2;\n");
 
 		expect(result).toBeDefined();
-		expect(result?.messages).toEqual([]);
-		expect(result?.summary).toBe("OK");
-		expect(result?.errored).toBe(false);
+		expect(result?.diagnostics?.messages).toEqual([]);
+		expect(result?.diagnostics?.summary).toBe("OK");
+		expect(result?.diagnostics?.errored).toBe(false);
 		expect(await Bun.file(filePath).text()).toBe("export const value = 2;\n");
 	});
 
@@ -476,9 +476,9 @@ describe("LSP diagnostics freshness", () => {
 		const result = await writethrough(filePath, "export const value: number = 'x';\n");
 
 		expect(result).toBeDefined();
-		expect(result?.errored).toBe(true);
-		expect(result?.messages?.some(m => m.includes("real error"))).toBe(true);
-		expect(result?.messages?.some(m => m.includes("stale error"))).toBe(false);
+		expect(result?.diagnostics?.errored).toBe(true);
+		expect(result?.diagnostics?.messages?.some(m => m.includes("real error"))).toBe(true);
+		expect(result?.diagnostics?.messages?.some(m => m.includes("stale error"))).toBe(false);
 	});
 
 	it("matches published diagnostics when the server renormalizes the document URI", async () => {
@@ -508,8 +508,8 @@ describe("LSP diagnostics freshness", () => {
 		});
 		const result = await writethrough(filePath, "export const value = missing;\n");
 
-		expect(result?.errored).toBe(true);
-		expect(result?.messages?.some(message => message.includes("renormalized URI error"))).toBe(true);
+		expect(result?.diagnostics?.errored).toBe(true);
+		expect(result?.diagnostics?.messages?.some(message => message.includes("renormalized URI error"))).toBe(true);
 	});
 
 	it("matches Windows drive-letter case and percent-encoding differences", () => {
@@ -570,8 +570,8 @@ describe("LSP diagnostics freshness", () => {
 		);
 		deferredController.abort();
 
-		expect(inline?.errored).toBe(true);
-		expect(inline?.messages?.some(message => message.includes("pull error"))).toBe(true);
+		expect(inline?.diagnostics?.errored).toBe(true);
+		expect(inline?.diagnostics?.messages?.some(message => message.includes("pull error"))).toBe(true);
 		expect(onDeferredDiagnostics).not.toHaveBeenCalled();
 	});
 
@@ -733,10 +733,10 @@ describe("LSP diagnostics freshness", () => {
 			const result = await writethrough(filePath, 'import { Database } from "bun:sqlite";\nawait Bun.sleep(1)\n');
 
 			expect(result).toBeDefined();
-			expect(result?.errored).toBe(true);
-			expect(result?.messages?.some(message => message.includes("bun:sqlite"))).toBe(false);
-			expect(result?.messages?.some(message => message.includes("Cannot find name 'Bun'"))).toBe(false);
-			expect(result?.messages?.some(message => message.includes("';' expected."))).toBe(true);
+			expect(result?.diagnostics?.errored).toBe(true);
+			expect(result?.diagnostics?.messages?.some(message => message.includes("bun:sqlite"))).toBe(false);
+			expect(result?.diagnostics?.messages?.some(message => message.includes("Cannot find name 'Bun'"))).toBe(false);
+			expect(result?.diagnostics?.messages?.some(message => message.includes("';' expected."))).toBe(true);
 			expect(await Bun.file(filePath).text()).toBe('import { Database } from "bun:sqlite";\nawait Bun.sleep(1)\n');
 		} finally {
 			orphanDir.removeSync();

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -141,7 +141,7 @@ describe("LSP diagnostics freshness", () => {
 		});
 		const result = await writethrough(filePath, ".section {}\n");
 
-		expect(result).toBeUndefined();
+		expect(result.finalContent).toBe(".section {}\n");
 		expect(await Bun.file(filePath).text()).toBe(".section {}\n");
 		expect(notify).toHaveBeenCalledWith(
 			tempDir.path(),
@@ -165,7 +165,7 @@ describe("LSP diagnostics freshness", () => {
 		});
 		const result = await writethrough(filePath, "export const value = 1;\n");
 
-		expect(result).toBeUndefined();
+		expect(result.finalContent).toBe("export const value = 1;\n");
 		expect(await Bun.file(filePath).text()).toBe("export const value = 1;\n");
 		expect(notify).toHaveBeenCalledWith(
 			tempDir.path(),
@@ -388,7 +388,7 @@ describe("LSP diagnostics freshness", () => {
 			flush: true,
 		});
 
-		expect(result?.summary).toBe("no issues");
+		expect(result.diagnostics?.summary).toBe("no issues");
 		expect(events[0]).toBe(`watched:probe.module.scss:${lspClient.FileChangeType.Created}`);
 		expect(notifySignals.some(signal => signal instanceof AbortSignal)).toBe(true);
 		expect(events).toContain("sync:probe.tsx");
@@ -477,8 +477,8 @@ describe("LSP diagnostics freshness", () => {
 
 		expect(result).toBeDefined();
 		expect(result?.errored).toBe(true);
-		expect(result?.messages.some(m => m.includes("real error"))).toBe(true);
-		expect(result?.messages.some(m => m.includes("stale error"))).toBe(false);
+		expect(result?.messages?.some(m => m.includes("real error"))).toBe(true);
+		expect(result?.messages?.some(m => m.includes("stale error"))).toBe(false);
 	});
 
 	it("matches published diagnostics when the server renormalizes the document URI", async () => {
@@ -509,7 +509,7 @@ describe("LSP diagnostics freshness", () => {
 		const result = await writethrough(filePath, "export const value = missing;\n");
 
 		expect(result?.errored).toBe(true);
-		expect(result?.messages.some(message => message.includes("renormalized URI error"))).toBe(true);
+		expect(result?.messages?.some(message => message.includes("renormalized URI error"))).toBe(true);
 	});
 
 	it("matches Windows drive-letter case and percent-encoding differences", () => {
@@ -571,7 +571,7 @@ describe("LSP diagnostics freshness", () => {
 		deferredController.abort();
 
 		expect(inline?.errored).toBe(true);
-		expect(inline?.messages.some(message => message.includes("pull error"))).toBe(true);
+		expect(inline?.messages?.some(message => message.includes("pull error"))).toBe(true);
 		expect(onDeferredDiagnostics).not.toHaveBeenCalled();
 	});
 
@@ -622,10 +622,8 @@ describe("LSP diagnostics freshness", () => {
 			() => handle,
 		);
 
-		// Inline returns undefined: the writethrough deferred rather than blocking on
-		// the slow publish. A result fresh within the inline budget would be returned
-		// inline, so `undefined` is proof it returned promptly via the deferred path.
-		expect(inline).toBeUndefined();
+		// The result carries the committed bytes while diagnostics may arrive later.
+		expect(inline.finalContent).toBe("export const value: number = 'x';\n");
 
 		// ...and the diagnostics arrive afterwards via the deferred channel.
 		const lateResult = await late.promise;
@@ -736,9 +734,9 @@ describe("LSP diagnostics freshness", () => {
 
 			expect(result).toBeDefined();
 			expect(result?.errored).toBe(true);
-			expect(result?.messages.some(message => message.includes("bun:sqlite"))).toBe(false);
-			expect(result?.messages.some(message => message.includes("Cannot find name 'Bun'"))).toBe(false);
-			expect(result?.messages.some(message => message.includes("';' expected."))).toBe(true);
+			expect(result?.messages?.some(message => message.includes("bun:sqlite"))).toBe(false);
+			expect(result?.messages?.some(message => message.includes("Cannot find name 'Bun'"))).toBe(false);
+			expect(result?.messages?.some(message => message.includes("';' expected."))).toBe(true);
 			expect(await Bun.file(filePath).text()).toBe('import { Database } from "bun:sqlite";\nawait Bun.sleep(1)\n');
 		} finally {
 			orphanDir.removeSync();


### PR DESCRIPTION
## What

- Return the content actually committed by LSP writethrough, separately from diagnostics.
- Use per-destination final content when flushing a batch instead of the last queued entry or a second read-back.
- Keep edit details, write snapshots, executable checks, byte counts, and hashline output aligned with the committed bytes.
- Keep diagnostics structured without embedding file contents.

## Why

With format-on-write enabled, the request content could differ from the bytes persisted by the formatter. Edit details and write snapshots then reported stale content, and a batched flush could return another file's pre-format content.

## Testing

- `bun run --cwd packages/coding-agent check:types`
- `bun test packages/coding-agent/test/tools/lsp-batching.test.ts packages/coding-agent/test/edit-tool-details.test.ts packages/coding-agent/test/write-hashline-header.test.ts packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts packages/coding-agent/test/edit-patch-unchanged-error.test.ts`
- Result: 38 tests passed, 0 failed.

The changes are limited to the writethrough/edit/write contract and its regression coverage.