### PR TITLE
fix(eval): persist reserved global reassignment across cells

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Reassigning a reserved JS Eval global (e.g. `var fs = await import("node:fs/promises")`) now persists across cells instead of silently reverting to the injected value on the next cell ([#10988](https://github.com/can1357/oh-my-pi/issues/10988)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -195,6 +195,18 @@ export class JsRuntime {
 		activateGlobalOwner(this.#globalOwner, this.#ownedGlobalKeys, action);
 	}
 
+	/**
+	 * Capture the current values of every owned global back into this owner's
+	 * global stack. A cell may rebind a reserved injected global (e.g.
+	 * `var fs = await import("node:fs/promises")`); without this, the next
+	 * `activateGlobalOwner` would restore the install-time value and silently
+	 * clobber the reassignment. Called after each run so bindings persist across
+	 * cells like the eval persistence contract promises.
+	 */
+	#recordGlobals(): void {
+		for (const key of this.#ownedGlobalKeys) recordGlobalValue(key, this.#globalOwner);
+	}
+
 	readonly helpers: HelperBundle;
 	#cwd: string;
 	#session: { cwd: string; sessionId: string };
@@ -329,6 +341,7 @@ export class JsRuntime {
 		try {
 			return await this.#als.run(context, callback);
 		} finally {
+			this.#recordGlobals();
 			leaveRun();
 		}
 	}
@@ -365,6 +378,7 @@ export class JsRuntime {
 				return await awaitMaybePromise(value);
 			});
 		} finally {
+			this.#recordGlobals();
 			leaveRun();
 		}
 	}

--- a/packages/coding-agent/test/eval/reserved-global-reassignment.test.ts
+++ b/packages/coding-agent/test/eval/reserved-global-reassignment.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { JsRuntime, type RuntimeHooks } from "@oh-my-pi/pi-coding-agent/eval/js/shared/runtime";
+import type { JsDisplayOutput } from "@oh-my-pi/pi-coding-agent/eval/js/shared/types";
+
+let runtime: JsRuntime;
+
+function makeHooks(): { hooks: RuntimeHooks; texts: string[] } {
+	const texts: string[] = [];
+	const displays: JsDisplayOutput[] = [];
+	const hooks: RuntimeHooks = {
+		onText: (chunk: string) => {
+			texts.push(chunk);
+		},
+		onDisplay: (output: JsDisplayOutput) => {
+			displays.push(output);
+		},
+		callTool: async () => undefined,
+	};
+	return { hooks, texts };
+}
+
+describe("JsRuntime reserved global reassignment", () => {
+	beforeAll(() => {
+		runtime = new JsRuntime({ initialCwd: process.cwd(), sessionId: "reserved-global-reassignment" });
+	});
+
+	afterAll(() => {
+		runtime.dispose();
+	});
+
+	it("retains a user reassignment of a reserved global across cells", async () => {
+		const cell1 = makeHooks();
+		await runtime.run('var fs = await import("node:fs/promises");', undefined, cell1.hooks);
+
+		const cell2 = makeHooks();
+		const value = await runtime.run("typeof fs.readFileSync;", undefined, cell2.hooks);
+		expect(value).toBe("undefined");
+	});
+});


### PR DESCRIPTION
## Repro
Running two JS Eval cells on one persistent runtime, cell 1 rebinds a reserved injected global and cell 2 reads it back:

- Cell 1: `var fs = await import("node:fs/promises");`
- Cell 2: `typeof fs.readFileSync;` → `"function"` (the callback-based `node:fs`), expected `"undefined"`.

The reassignment is silently reverted, so promise-style fs calls in later cells fail with callback-argument errors. Reproduced with `bun test test/eval/reserved-global-reassignment.test.ts`.

## Cause
`packages/coding-agent/src/eval/js/shared/runtime.ts` tracks reserved injected globals (`fs`, `read`, `require`, …) in a per-owner global stack so multiple same-realm runtimes (cmux tabs, inline fallback) can coexist. `activateGlobalOwner` restores each owned key's recorded value at the start of every `run()`. That value is recorded once, at install time (`recordGlobalValue`, `#install`), and never again — so `run()`/`runCallback()` leave the user's reassignment on `globalThis` but the stack entry still holds the install-time `node:fs`. The next cell's `activateGlobalOwner` overwrites `globalThis.fs` with that stale value. Non-reserved names (e.g. `fsp`) are untracked and persist, matching the reporter's control probe.

## Fix
- Add `JsRuntime.#recordGlobals()` which re-records every owned global's current value into this owner's stack.
- Call it in the `finally` of `run()` and `runCallback()` so a cell's reassignment of a reserved global is captured before the next `activateGlobalOwner` runs.
- Add regression test `test/eval/reserved-global-reassignment.test.ts`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/eval/reserved-global-reassignment.test.ts test/eval/runtime-global-dispose.test.ts test/eval/console-table.test.ts test/eval/process-stdio-capture.test.ts` → 10 pass, 0 fail. Pre-existing failures elsewhere in `test/eval/` are unrelated import errors for the ungenerated `src/export/html/tool-views.generated.js` (a `prepack` artifact), not caused by this change. Fixes #10988