### PR TITLE
fix(eval): return immediate thenable handles from JS completion/agent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Fixed JavaScript `eval` `completion()`/`agent()` handles so the documented immediate-handle pattern works: `h.wait()`, `h.status()`, and the other handle methods now work on the un-awaited factory result ([#10986](https://github.com/can1357/oh-my-pi/issues/10986)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/eval/js/shared/prelude.txt
+++ b/packages/coding-agent/src/eval/js/shared/prelude.txt
@@ -185,6 +185,55 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 		}
 	}
 
+	// Immediate-return wrapper for the async `completion()`/`agent()` factories.
+	// JS cannot hand back a handle synchronously — the bridge allocates the id
+	// over an async round-trip — so the factory returns this thenable instead:
+	// `await` it to get the resolved handle (for dag wiring via `.id`/`.handle`),
+	// or call the handle methods directly (`h.wait()`, `h.status()`, …) and they
+	// await resolution internally. This matches the documented immediate-handle
+	// contract that Python satisfies natively via its synchronous bridge.
+	class PendingHandle {
+		constructor(promise) {
+			this._promise = promise;
+		}
+
+		then(onFulfilled, onRejected) {
+			return this._promise.then(onFulfilled, onRejected);
+		}
+
+		catch(onRejected) {
+			return this._promise.catch(onRejected);
+		}
+
+		finally(onFinally) {
+			return this._promise.finally(onFinally);
+		}
+
+		async status() {
+			return (await this._promise).status();
+		}
+
+		async done() {
+			return (await this._promise).done();
+		}
+
+		async wait(options) {
+			return (await this._promise).wait(options);
+		}
+
+		async cancel() {
+			return (await this._promise).cancel();
+		}
+
+		async send(message) {
+			return (await this._promise).send(message);
+		}
+
+		async output(options) {
+			return (await this._promise).output(options);
+		}
+	}
+
 	const resolveHandleSnapshot = (handle, snapshot) => {
 		const status = snapshot?.status ?? "failed";
 		if (status === "running") throw timeoutError(`${handle.kind} handle ${handle.id} is still running`);
@@ -201,7 +250,8 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 	};
 
 	const wait = async (handles, { timeout, raiseErrors = true } = {}) => {
-		const raw = handles instanceof EvalHandle ? [handles] : Array.from(handles ?? []);
+		const isHandleLike = value => value instanceof EvalHandle || value instanceof PendingHandle;
+		const raw = isHandleLike(handles) ? [handles] : Array.from(handles ?? []);
 		const items = await Promise.all(raw);
 		for (const handle of items) {
 			if (!(handle instanceof EvalHandle)) throw new TypeError("wait() expects agent or completion handles");
@@ -241,24 +291,30 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 		return results;
 	};
 
-	const completion = async (prompt, opts, ...rest) => {
-		const options = optionsArg("completion", opts, rest, ["model", "system", "schema"], "{ model, system, schema }");
-		const result = await globalThis.__omp_call_tool__("__completion__", { prompt, ...options });
-		if (!result || typeof result.id !== "string") throw new Error("completion() did not return a handle");
-		return new CompletionHandle(result.id, options.schema);
+	const completion = (prompt, opts, ...rest) => {
+		const promise = (async () => {
+			const options = optionsArg("completion", opts, rest, ["model", "system", "schema"], "{ model, system, schema }");
+			const result = await globalThis.__omp_call_tool__("__completion__", { prompt, ...options });
+			if (!result || typeof result.id !== "string") throw new Error("completion() did not return a handle");
+			return new CompletionHandle(result.id, options.schema);
+		})();
+		return new PendingHandle(promise);
 	};
 
-	const agent = async (prompt, opts, ...rest) => {
-		const options = optionsArg(
-			"agent",
-			opts,
-			rest,
-			["agent", "label", "schema", "isolated", "apply", "merge", "schemaMode", "tools"],
-			"{ agent, label, schema, schemaMode, isolated, apply, merge, tools }",
-		);
-		const result = await globalThis.__omp_call_tool__("__agent__", { prompt, ...options });
-		if (!result || typeof result.id !== "string") throw new Error("agent() did not return a handle");
-		return new AgentHandle(result.id, result.agent, options.schema);
+	const agent = (prompt, opts, ...rest) => {
+		const promise = (async () => {
+			const options = optionsArg(
+				"agent",
+				opts,
+				rest,
+				["agent", "label", "schema", "isolated", "apply", "merge", "schemaMode", "tools"],
+				"{ agent, label, schema, schemaMode, isolated, apply, merge, tools }",
+			);
+			const result = await globalThis.__omp_call_tool__("__agent__", { prompt, ...options });
+			if (!result || typeof result.id !== "string") throw new Error("agent() did not return a handle");
+			return new AgentHandle(result.id, result.agent, options.schema);
+		})();
+		return new PendingHandle(promise);
 	};
 
 	class WorkPool {

--- a/packages/coding-agent/test/eval/prelude-agent.test.ts
+++ b/packages/coding-agent/test/eval/prelude-agent.test.ts
@@ -72,7 +72,11 @@ describe("eval js agent() handle", () => {
 
 	it("throws when the bridge omits the handle id", async () => {
 		const sandbox = loadPrelude(async () => ({ text: "lonely" }));
-		await expect((sandbox.agent as AgentHelper)("x")).rejects.toThrow("agent() did not return a handle");
+		// The factory returns a thenable handle wrapper, so normalize to a Promise
+		// before asserting rejection (Bun's `.rejects` requires a real Promise).
+		await expect(Promise.resolve((sandbox.agent as AgentHelper)("x"))).rejects.toThrow(
+			"agent() did not return a handle",
+		);
 	});
 
 	it("parses wait() text as JSON only when a schema was given", async () => {
@@ -90,6 +94,35 @@ describe("eval js agent() handle", () => {
 			wait(): Promise<unknown>;
 		};
 		expect(await plain.wait()).toBe('{"k":1}');
+	});
+});
+
+describe("eval js immediate-handle contract", () => {
+	// Regression for #10986: the JS factories return immediately, so the
+	// documented pattern `const h = completion(...); await h.wait()` must work
+	// without first `await`-ing the factory itself.
+	it("exposes handle methods on the un-awaited factory result", async () => {
+		const sandbox = loadPrelude(async name => {
+			if (name === "__completion__") return { id: "c-1" };
+			if (name === "__wait__") return { items: [{ status: "completed", text: "OK" }] };
+			throw new Error(`unexpected bridge call ${name}`);
+		});
+		const completion = sandbox.completion as (prompt: string, opts?: unknown) => { wait(): Promise<unknown> };
+
+		const handle = completion("Return OK", { model: "smol" });
+		expect(typeof handle.wait).toBe("function");
+		expect(await handle.wait()).toBe("OK");
+	});
+
+	it("treats an un-awaited factory result as a single handle in wait()", async () => {
+		const sandbox = loadPrelude(async name => {
+			if (name === "__agent__") return { id: "a-2", agent: "task" };
+			if (name === "__wait__") return { items: [{ status: "completed", text: "done" }] };
+			throw new Error(`unexpected bridge call ${name}`);
+		});
+		const waitAll = sandbox.wait as (handles: unknown) => Promise<unknown[]>;
+
+		expect(await waitAll((sandbox.agent as AgentHelper)("go"))).toEqual(["done"]);
 	});
 });
 


### PR DESCRIPTION
## Repro
In JavaScript Eval the tool prompt documents `completion()`/`agent()` as returning immediate handles, but the prelude factories were `async`, so they returned `Promise<Handle>`. Following the documented pattern threw `TypeError: h.wait is not a function`:

```js
const handle = completion("Return OK", { model: "smol" });
await handle.wait(); // handle is a Promise, .wait is undefined
```

Reproduced by executing the shipped prelude verbatim in a `node:vm` with a stubbed `__omp_call_tool__`, running the pattern above:

```text
HEAD (pre-fix):      TypeError: handle.wait is not a function
worktree (fixed):    OK -> "OK"
```

## Cause
`completion` and `agent` in `packages/coding-agent/src/eval/js/shared/prelude.txt` were `async` arrow functions that `await`ed `__omp_call_tool__` for the bridge-allocated id before constructing the handle, so the call site received a `Promise<CompletionHandle>`/`Promise<AgentHandle>` — not a handle. Python's factories (`prelude.py`) are synchronous (blocking `_bridge_call`) and already returned a handle in one call, which is why "returns immediately" reads correctly for Python but broke in JS.

## Fix
- Add a `PendingHandle` thenable wrapper in `prelude.txt`. It holds the `Promise<Handle>`, is `await`-able (delegates `then`/`catch`/`finally` to resolve the real handle for `.id`/`.handle` dag wiring), and exposes `status()`/`done()`/`wait()`/`cancel()`/`send()`/`output()` that await id resolution internally.
- `completion()` and `agent()` now return this wrapper synchronously; the bridge round-trip and existing error contracts run inside the wrapped promise, so awaiting the factory or a handle method surfaces the same errors as before.
- Teach the global `wait()` single-handle detection to accept a `PendingHandle` (previously only `EvalHandle`), so `wait(completion(...))` works without a prior `await`.
- Provider completions remain asynchronous; only the factory return shape changed.

## Verification
`bun test test/eval test/tools/eval-agent-progress.test.ts test/tools/eval-auto-background.test.ts test/core/eval-workflow-helpers.integration.test.ts` → 210 pass, 0 fail (5 skip). Added regression tests in `test/eval/prelude-agent.test.ts` proving `completion(...).wait()` works on the un-awaited factory result and that `wait()` accepts an un-awaited factory result; the existing missing-id test was updated to normalize the thenable before `expect().rejects` (Bun's matcher requires a real Promise). The before/after `node:vm` repro above confirms the reporter's `TypeError` is gone. Fixes #10986