### PR TITLE
fix(commit): route agentic pipeline through commit model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- The default `omp commit` agent now uses its displayed COMMIT model and honors `--model` instead of silently running on SMOL ([#10991](https://github.com/can1357/oh-my-pi/issues/10991)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -6,7 +6,7 @@ import { applyChangelogProposals } from "../../commit/changelog";
 import { detectChangelogBoundaries } from "../../commit/changelog/detect";
 import { parseUnreleasedSection } from "../../commit/changelog/parse";
 import { formatCommitMessage } from "../../commit/message";
-import { resolvePrimaryModel, resolveSmolModel } from "../../commit/model-selection";
+import { resolvePrimaryModel } from "../../commit/model-selection";
 import type { CommitCommandArgs, ConventionalAnalysis, NumstatEntry } from "../../commit/types";
 import { ModelRegistry } from "../../config/model-registry";
 import { Settings } from "../../config/settings";
@@ -47,15 +47,8 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<{ usedF
 
 	const primaryModelPromise = resolvePrimaryModel(args.model, settings, modelRegistry);
 	const [primaryModelResult, stagedFiles] = await Promise.all([primaryModelPromise, stagedFilesPromise]);
-	const { model: primaryModel, apiKey: primaryApiKey } = primaryModelResult;
+	const { model: primaryModel, thinkingLevel: primaryThinkingLevel } = primaryModelResult;
 	process.stdout.write(`  └─ ${primaryModel.name}\n`);
-
-	const { model: agentModel, thinkingLevel: agentThinkingLevel } = await resolveSmolModel(
-		settings,
-		modelRegistry,
-		primaryModel,
-		primaryApiKey,
-	);
 
 	if (stagedFiles.length === 0) {
 		if (args.push) {
@@ -143,8 +136,8 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<{ usedF
 	try {
 		await runCommitAgentSession({
 			cwd,
-			model: agentModel,
-			thinkingLevel: agentThinkingLevel,
+			model: primaryModel,
+			thinkingLevel: primaryThinkingLevel,
 			settings,
 			modelRegistry,
 			authStorage,

--- a/packages/coding-agent/test/commit-agent-model-routing.test.ts
+++ b/packages/coding-agent/test/commit-agent-model-routing.test.ts
@@ -1,0 +1,78 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AuthStorage, Effort, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { runAgenticCommit } from "@oh-my-pi/pi-coding-agent/commit/agentic";
+import * as agentModule from "@oh-my-pi/pi-coding-agent/commit/agentic/agent";
+import type { CommitAgentInput } from "@oh-my-pi/pi-coding-agent/commit/agentic/agent";
+import type { CommitAgentState } from "@oh-my-pi/pi-coding-agent/commit/agentic/state";
+import * as modelSelection from "@oh-my-pi/pi-coding-agent/commit/model-selection";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { VcsGitRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+let authStorage: AuthStorage | undefined;
+
+afterEach(() => {
+	authStorage?.close();
+	authStorage = undefined;
+	vi.restoreAllMocks();
+});
+
+describe("agentic commit model routing", () => {
+	it("runs the parent commit agent on the selected commit model", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-opus-4-5");
+		const smolModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primaryModel || !smolModel) throw new Error("Expected bundled commit test models");
+
+		authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:")));
+		await authStorage.reload();
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated());
+		vi.spyOn(ModelRegistry.prototype, "refresh").mockResolvedValue(undefined);
+		vi.spyOn(sdkModule, "discoverAuthStorage").mockResolvedValue(authStorage);
+		vi.spyOn(sdkModule, "discoverContextFiles").mockResolvedValue([]);
+		vi.spyOn(sdkModule, "loadCliExtensionProviders").mockResolvedValue(undefined);
+		vi.spyOn(modelSelection, "resolvePrimaryModel").mockResolvedValue({
+			model: primaryModel,
+			apiKey: "primary-key",
+			thinkingLevel: Effort.High,
+		});
+		vi.spyOn(modelSelection, "resolveSmolModel").mockResolvedValue({
+			model: smolModel,
+			apiKey: "smol-key",
+			thinkingLevel: Effort.Minimal,
+		});
+		vi.spyOn(vcs, "requireGit").mockReturnValue({
+			changedFiles: async () => ["src/a.ts"],
+			commitCreate: async () => "0123456789abcdef0123456789abcdef01234567",
+			diffText: async () => "diff --git a/src/a.ts b/src/a.ts\n+export const value = 1;\n",
+			numstat: async () => [{ path: "src/a.ts", added: 1, removed: 0 }],
+		} as unknown as VcsGitRepo);
+		const runSession = vi
+			.spyOn(agentModule, "runCommitAgentSession")
+			.mockImplementation(async (input: CommitAgentInput) => {
+				const state: CommitAgentState = {
+					proposal: {
+						analysis: { type: "fix", scope: "test", details: [], issueRefs: [] },
+						summary: "fixed model routing",
+						warnings: [],
+					},
+				};
+				await input.onComplete?.(state);
+				return state;
+			});
+
+		await runAgenticCommit({
+			noChangelog: true,
+			push: false,
+			dryRun: true,
+			model: `${primaryModel.provider}/${primaryModel.id}`,
+		});
+
+		expect(runSession).toHaveBeenCalledWith(
+			expect.objectContaining({ model: primaryModel, thinkingLevel: Effort.High }),
+		);
+	});
+});


### PR DESCRIPTION
## Repro

With distinct primary and SMOL model results, run `bun test packages/coding-agent/test/commit-agent-model-routing.test.ts`. Before the fix, `omp commit` displayed Claude Opus 4.5 while `runCommitAgentSession()` received Claude Sonnet 4.5 at `minimal` thinking, and the regression failed.

## Cause

`runAgenticCommit()` in `packages/coding-agent/src/commit/agentic/index.ts` resolved the primary COMMIT/`--model` selection for display, then called `resolveSmolModel()` and passed that second result to the parent `runCommitAgentSession()`.

## Fix

- Pass the resolved primary model and thinking level directly to the parent commit-agent session.
- Keep SMOL resolution available to the deterministic pipeline and independent Sonic workers.
- Add regression coverage with distinct primary and SMOL selections.
- Document the corrected user-visible routing in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/commit-agent-model-routing.test.ts packages/coding-agent/test/commit-model-selection-role-thinking.test.ts packages/coding-agent/test/commit-fallback-exit.test.ts` — 6 passed, 0 failed.

`bun --cwd=packages/coding-agent run check:types` — passed.

Fixes #10991