### PR TITLE
fix(catalog): clamp anthropic adaptive minimal effort to low

### DIFF
--- a/packages/ai/test/issue-10994-repro.test.ts
+++ b/packages/ai/test/issue-10994-repro.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Context, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-thinking";
+
+/**
+ * Custom `anthropic-messages` provider (issue #10994): unlike the built-in
+ * Claude ladders, its adaptive effort ladder exposes `minimal`, which the
+ * Anthropic Messages wire rejects as an `output_config.effort` value.
+ */
+function customAdaptiveModel(): Model<"anthropic-messages"> {
+	const base = buildModel({
+		id: "claude-opus-5",
+		name: "claude-opus-5",
+		api: "anthropic-messages",
+		provider: "ccs",
+		baseUrl: "https://ccs.example/anthropic",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	});
+	return buildModel({
+		...base,
+		thinking: {
+			mode: "anthropic-adaptive",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+		},
+		compat: base.compatConfig,
+	} as ModelSpec<"anthropic-messages">);
+}
+
+const CONTEXT: Context = {
+	systemPrompt: ["Stay concise."],
+	messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+};
+
+function abortedSignal(): AbortSignal {
+	const c = new AbortController();
+	c.abort();
+	return c.signal;
+}
+
+describe("issue #10994 — anthropic adaptive minimal effort clamp", () => {
+	it("clamps minimal to low in the adaptive effort mapper", () => {
+		const model = customAdaptiveModel();
+		expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Minimal)).toBe("low");
+		// Higher tiers pass through unchanged.
+		expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Medium)).toBe("medium");
+	});
+
+	it("never serializes output_config.effort=minimal", async () => {
+		const model = customAdaptiveModel();
+		const { promise, resolve } = Promise.withResolvers<{ output_config?: { effort?: string } }>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: "sk-ant-oat-test",
+			isOAuth: true,
+			signal: abortedSignal(),
+			thinkingEnabled: true,
+			reasoning: Effort.Minimal,
+			onPayload: p => resolve(p as { output_config?: { effort?: string } }),
+		});
+		const payload = await promise;
+		expect(payload.output_config?.effort).toBe("low");
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed custom `anthropic-messages` providers whose adaptive effort ladder exposes `minimal` sending `output_config.effort: "minimal"`, which the Anthropic Messages API rejects with `400 level "minimal" not supported`; the adaptive effort mapper now clamps `minimal` to `low` ([#10994](https://github.com/can1357/oh-my-pi/issues/10994)).
 - Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
 
 ## [18.1.9] - 2026-09-04

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -108,19 +108,22 @@ export function mapEffortToGoogleThinkingLevel<TApi extends Api>(
 /**
  * Maps a normalized thinking effort to Anthropic adaptive effort values via
  * the model's baked `thinking.effortMap` (identity for unmapped efforts).
+ *
+ * The Anthropic adaptive wire vocabulary has no `minimal` tier (valid values:
+ * `low`, `medium`, `high`, `xhigh`, `max`); a model ladder that exposes
+ * `minimal` — custom `anthropic-messages` providers do, unlike the built-in
+ * Claude ladders — would otherwise serialize `output_config.effort: "minimal"`
+ * and 400 (`level "minimal" not supported`). Clamp it to the lowest real tier,
+ * mirroring {@link mapEffortToGoogleThinkingLevel}'s `minimal` handling.
  */
 export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 	model: ApiModel<TApi>,
 	effort: Effort,
 ): "low" | "medium" | "high" | "xhigh" | "max" | "adaptive" {
 	const supported = requireSupportedEffort(model, effort);
-	return (model.thinking?.effortMap?.[supported] ?? supported) as
-		| "low"
-		| "medium"
-		| "high"
-		| "xhigh"
-		| "max"
-		| "adaptive";
+	const mapped = model.thinking?.effortMap?.[supported] ?? supported;
+	if (mapped === Effort.Minimal) return "low";
+	return mapped as "low" | "medium" | "high" | "xhigh" | "max" | "adaptive";
 }
 
 /**

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -720,6 +720,25 @@ describe("model thinking derivation", () => {
 		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.Max)).toThrow(/not supported/);
 	});
 
+	it("clamps a custom adaptive ladder's minimal tier to low (issue #10994)", () => {
+		// Built-in Claude ladders exclude minimal, but a custom anthropic-messages
+		// provider can declare it. The Anthropic adaptive wire has no minimal tier,
+		// so the mapper must clamp rather than forward it verbatim (400).
+		const custom = createModel({
+			id: "claude-opus-5",
+			api: "anthropic-messages",
+			provider: "ccs",
+			baseUrl: "https://ccs.example/anthropic",
+			thinking: {
+				mode: "anthropic-adaptive",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+		expect(getSupportedEfforts(custom)).toContain(Effort.Minimal);
+		expect(mapEffortToAnthropicAdaptiveEffort(custom, Effort.Minimal)).toBe("low");
+		expect(mapEffortToAnthropicAdaptiveEffort(custom, Effort.High)).toBe("high");
+	});
+
 	it("bakes adaptive display support for Opus 4.7+, Sonnet 5+, and Fable/Mythos 5", () => {
 		const opus46 = createModel({ id: "claude-opus-4.6", api: "anthropic-messages", provider: "anthropic" });
 		const opus47 = createModel({ id: "claude-opus-4-7", api: "anthropic-messages", provider: "anthropic" });


### PR DESCRIPTION
## Repro
With a custom `anthropic-messages` provider (`ccs`/`claude-opus-5`) whose adaptive effort ladder exposes `minimal` and thinking on `auto`/`minimal`, omp serializes `output_config.effort: "minimal"`. The Anthropic Messages wire has no `minimal` tier, so every request 400s: `level "minimal" not supported, valid levels: low, medium, high, xhigh, max`. Reproduced in-repo with `bun test packages/ai/test/issue-10994-repro.test.ts` — before the fix, `mapEffortToAnthropicAdaptiveEffort(model, minimal)` returned `"minimal"` and `streamAnthropic` emitted `output_config.effort="minimal"`.

## Cause
`mapEffortToAnthropicAdaptiveEffort` (`packages/catalog/src/model-thinking.ts`) returns `model.thinking?.effortMap?.[supported] ?? supported` and casts to the adaptive wire union `low|medium|high|xhigh|max|adaptive`. Its return type already excludes `minimal`, but the cast let a ladder that includes `minimal` (custom anthropic-messages providers — built-in Claude ladders deliberately exclude it) forward the tier verbatim into `output_config.effort`, which the wire rejects. The Anthropic adaptive path applies no effort remap, so nothing downstream corrected it.

## Fix
- `packages/catalog/src/model-thinking.ts`: clamp `minimal` to `low` in `mapEffortToAnthropicAdaptiveEffort` (after any `effortMap` remap), mirroring `mapEffortToGoogleThinkingLevel`'s existing `minimal` handling in the same file. Single point — both the top-level and per-message effort serialization route through this mapper.
- `packages/catalog/test/model-thinking.test.ts`: unit assertion that a custom adaptive ladder containing `minimal` maps `minimal→low` while higher tiers pass through.
- `packages/ai/test/issue-10994-repro.test.ts`: end-to-end assertion that `streamAnthropic` never serializes `output_config.effort=minimal` for such a model.
- `packages/catalog/CHANGELOG.md`: Fixed entry.

## Verification
`bun test packages/catalog/test/model-thinking.test.ts packages/ai/test/issue-10994-repro.test.ts packages/ai/test/anthropic-fable-request-shaping.test.ts packages/ai/test/anthropic-alignment.test.ts` → 164 pass / 0 fail. Fixes #10994