### PR TITLE
fix(coding-agent): accept empty-string yield error beside data

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Subagent `yield` no longer rejects a valid `data` payload because a non-strict OpenAI-compatible backend filled the optional `error` field with `""`; previously the worker retried the identical call until the invalid-yield cap and the parent received nothing.
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -121,10 +121,12 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 
 /**
  * Read the optional `error` argument. Strict-mode providers (OpenAI/Codex) send
- * omitted optionals as `null`, so null and undefined both mean "no error".
+ * omitted optionals as `null`; non-strict OpenAI-compatible backends routinely
+ * fill the optional string with `""` next to a valid `data` payload. Both mean
+ * "no error" — an empty string is never a usable failure reason.
  */
 function parseYieldError(value: unknown): string | undefined {
-	if (value === undefined || value === null) return undefined;
+	if (value === undefined || value === null || value === "") return undefined;
 	if (typeof value === "string") return value;
 	throw new Error("error must be a string");
 }

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -725,6 +725,18 @@ describe("YieldTool", () => {
 		);
 	});
 
+	it("accepts data alongside an empty-string error (non-strict OpenAI-compatible backends)", async () => {
+		const tool = new YieldTool(createSession());
+		const result = await tool.execute("call-empty-error", { type: "result", data: { ok: true }, error: "" } as never);
+		expect(result.details?.status).toBe("success");
+		expect(result.details?.data).toEqual({ ok: true });
+		expect(result.details?.error).toBeUndefined();
+
+		const failure = await tool.execute("call-only-empty-error", { error: "" } as never).catch(err => err);
+		expect(failure).toBeInstanceOf(Error);
+		expect(String(failure.message)).toContain("yield must contain either `data` or `error`");
+	});
+
 	it("aborts instead of throwing forever after repeated untyped empty results", async () => {
 		const tool = new YieldTool(createSession());
 		const expectedGuidance =


### PR DESCRIPTION
## What

`parseYieldError` in `packages/coding-agent/src/tools/yield.ts` now treats `error: ""` like `null`/`undefined` (absent). One-line change plus a regression test and changelog entry.

## Why

Non-strict OpenAI-compatible backends fill the optional `error` string with `""` next to a valid `data` payload. Observed with `gpt-5.6`/`gpt-6` family models behind a local proxy at `127.0.0.1`, where `supportsStrictMode` auto-detects `false` so tools are sent without `strict: true`. In 12/12 direct probes of the `yield` schema in non-strict form the model returned `{"type":"result","data":{…},"error":""}`; with a strict+nullable schema the same models return `error: null` (6/6), which already passes.

With `""` treated as a real error, the terminal yield fails with `yield cannot contain both data and error`. The worker then retries the identical call until `MAX_YIELD_TOOL_ERRORS` (6) and the task fails — the complete payload was present on attempt 1 and is only recoverable by parsing the child JSONL. Across 3 baseline runs of a scout task each worker burned 13–15 turns and ~4 minutes before failing; with the fix the same task yields on the first call in 5–9 turns / ~1.5 minutes (3/3 runs), parent receives the result normally.

An empty string is never a usable failure reason, so `{ error: "" }` alone still lands on the existing empty-result retry path rather than being reported as an aborted task.

## Testing

- `bun test test/tools/yield.test.ts` — 49 pass. New test `accepts data alongside an empty-string error` fails on `v18.1.11` (`yield cannot contain both data and error`) and passes with the change.
- Built the binary from this branch and ran a real `scout` delegation 3× plus once through the production launcher: 0 yield errors, results delivered.
- `oxfmt --check` / `oxlint` clean on the touched files.

---

- [ ] `bun check` passes (ran the yield test file, formatter and linter on the touched files; full `bun check` not run locally)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
