### PR TITLE
fix(tui): chain directory at-completions on Enter acceptance

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Avoid inserting a trailing space when auto-completing directory paths with `@`.
+- Avoid inserting a trailing space when auto-completing directory paths with `@`, and keep autocomplete open when accepting a directory with Tab or Enter.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -111,6 +111,16 @@ function parsePathPrefix(prefix: string): { rawPrefix: string; isAtPrefix: boole
 	return { rawPrefix: prefix, isAtPrefix: false, isQuotedPrefix: false };
 }
 
+/**
+ * Whether an autocomplete value represents a directory: trailing slash or
+ * backslash, optionally followed by a closing quote for quoted paths.
+ * Shared by the provider suffix logic and the editor chain-on-accept
+ * behavior so Tab and Enter acceptance stay in sync.
+ */
+export function isDirectoryCompletionValue(value: string): boolean {
+	return /[\\/]["']?$/.test(value);
+}
+
 function buildCompletionValue(
 	path: string,
 	options: { isDirectory: boolean; isAtPrefix: boolean; isQuotedPrefix: boolean },
@@ -738,7 +748,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				beforePrefix = currentLine.slice(0, cursorCol - liveAtPrefix.length);
 			}
 			// This is a file attachment completion
-			const isDirectory = /[\\/]["']?$/.test(item.value);
+			const isDirectory = isDirectoryCompletionValue(item.value);
 			const suffix = isDirectory ? "" : " ";
 			const newLine = `${beforePrefix + item.value}${suffix}${afterCursor}`;
 			const newLines = [...lines];

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -4,6 +4,7 @@ import {
 	type AutocompleteProvider,
 	findLeadingSlashCommandStart,
 	findTrailingSlashCommandStart,
+	isDirectoryCompletionValue,
 	midPromptSkillTokenMatches,
 	SKILL_NAMESPACE,
 } from "../autocomplete";
@@ -1468,7 +1469,7 @@ export class Editor implements Component, Focusable {
 					}
 					if (selected && this.#autocompleteProvider) {
 						const shouldChainAutocomplete =
-							this.#isSlashCommandNameAutocompleteSelection() || /[\\/]["']?$/.test(selected.value);
+							this.#isSlashCommandNameAutocompleteSelection() || isDirectoryCompletionValue(selected.value);
 						const result = this.#autocompleteProvider.applyCompletion(
 							this.#state.lines,
 							this.#state.cursorLine,
@@ -1544,6 +1545,7 @@ export class Editor implements Component, Focusable {
 					} else {
 						if (selected && this.#autocompleteProvider) {
 							const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
+							const shouldChainDirectoryCompletion = isDirectoryCompletionValue(selected.value);
 							const result = this.#autocompleteProvider.applyCompletion(
 								this.#state.lines,
 								this.#state.cursorLine,
@@ -1564,7 +1566,9 @@ export class Editor implements Component, Focusable {
 							}
 
 							result.onApplied?.();
-							if (shouldChainSlashCommandAutocomplete && this.#isCompletedSlashCommandAtCursor()) {
+							if (shouldChainDirectoryCompletion) {
+								queueMicrotask(() => void this.#tryTriggerAutocomplete());
+							} else if (shouldChainSlashCommandAutocomplete && this.#isCompletedSlashCommandAtCursor()) {
 								void this.#tryTriggerAutocomplete();
 							}
 						}

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -223,6 +223,35 @@ describe("Editor slash autocomplete acceptance", () => {
 			fs.rmSync(baseDir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps autocomplete open after accepting an @ directory with Enter", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-at-directory-enter-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "packages", "tui"), { recursive: true });
+			fs.mkdirSync(path.join(baseDir, "packages", "utils"), { recursive: true });
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+			let submitted = "";
+			editor.onSubmit = text => {
+				submitted = text;
+			};
+			editor.setText("@pack");
+
+			const autocompleteOpened = untilAutocompleteShown(editor);
+			editor.handleInput("\t");
+			await autocompleteOpened;
+
+			editor.handleInput("\r");
+			await untilAutocompleteShown(editor);
+
+			expect(editor.getText()).toBe("@packages/");
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			expect(submitted).toBe("");
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
 	it("shows a sole forced file suggestion before applying it", async () => {
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-single-file-tab-"));
 		try {


### PR DESCRIPTION
Follow-up to #10613 addressing the post-merge Codex nit.

## Problem

The directory chaining added in #10613 only ran in the Tab/right-arrow acceptance branch. Accepting an `@` directory with Enter hit the generic Enter branch, which only chained slash commands — the popup closed instead of drilling into the directory.

## Solution

- Extract the shared `isDirectoryCompletionValue` check into `packages/tui/src/autocomplete.ts` (used by the provider suffix logic and both editor accept branches, so they stay in sync).
- Enter branch now re-triggers autocomplete via `queueMicrotask` when the accepted value is a directory, mirroring the Tab path; slash-command chaining behavior unchanged.
- Added `keeps autocomplete open after accepting an @ directory with Enter` regression test (verified it fails without the fix).

## Verification

- `bun test packages/tui/test/editor-autocomplete-actions.test.ts packages/tui/test/autocomplete.test.ts`: 114 pass, 1 skip.
- `bun check` in `packages/tui`: clean.