### PR TITLE
perf(tui): open /copy on the recent tail and cache selector rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed fullscreen `/copy` outlining only a lazily created grouped Read card, so Enter copies the assistant yield instead of tool output.
 - `memory://` now resolves against the session that issued it: a caller's own memory backend answers `memory://<id>`, so co-located sessions no longer read each other's memory rows, and a caller whose session is no longer live fails closed instead of being answered by a peer. Prompt completion binds to the same caller, so `memory://<memory-id>` stays on offer while a subagent shares the working directory. Advisors retain their owning session's memory access even without a session file.
 - Fullscreen `/copy` now opens on the recent tail of the branch instead of replaying the whole session, so it appears immediately and steps without lag on long sessions (`a` loads the earlier turns). Both it and the esc-esc rewind selector also cache each transcript row set instead of re-stripping it every frame.
+- Fixed the fullscreen `/copy` and esc-esc rewind selectors repainting the whole frame for a wheel notch that cannot move the viewport; because both open scrolled to the newest turn, wheeling down there made the frame twitch.
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Fixed fullscreen `/copy` outlining only a lazily created grouped Read card, so Enter copies the assistant yield instead of tool output.
 - `memory://` now resolves against the session that issued it: a caller's own memory backend answers `memory://<id>`, so co-located sessions no longer read each other's memory rows, and a caller whose session is no longer live fails closed instead of being answered by a peer. Prompt completion binds to the same caller, so `memory://<memory-id>` stays on offer while a subagent shares the working directory. Advisors retain their owning session's memory access even without a session file.
+- Fullscreen `/copy` now opens on the recent tail of the branch instead of replaying the whole session, so it appears immediately and steps without lag on long sessions (`a` loads the earlier turns). Both it and the esc-esc rewind selector also cache each transcript row set instead of re-stripping it every frame.
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -26,6 +26,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import type { SessionMessageEntry } from "../../session/session-entries";
+import { isUserTurnInitiator } from "../../session/messages";
 import { replaceTabs } from "../../tools/render-utils";
 import { highlightCode, type ThemeColor, theme } from "../theme/theme";
 import { commandFromToolCall, extractBlocks, extractLinks } from "../utils/copy-targets";
@@ -475,22 +476,29 @@ export class CopySelectorComponent implements Component {
 }
 
 /**
- * The trailing slice starting at the last user message at or before
- * `entries.length - limit`.
+ * The trailing slice starting at the last turn initiator at or before
+ * `entries.length - limit`: a user message, or a custom message that starts
+ * a user-attributed turn (a directly invoked `/skill:` prompt, a collab peer's
+ * prompt), the same boundary `ChatTranscriptBuilder` uses.
  *
- * The cut has to land on a turn boundary: `ChatTranscriptBuilder` drops a tool
- * result whose initiating call was sliced away, so a tail beginning mid-turn
- * renders without its command — and a tail of nothing but orphaned results
- * would leave the picker with no target at all. Scanning backwards keeps the
- * whole final turn instead, and a branch whose last turn is itself longer than
+ * The cut has to land on a turn boundary: the builder drops a tool result
+ * whose initiating call was sliced away, so a tail beginning mid-turn renders
+ * without its command — and a tail of nothing but orphaned results would
+ * leave the picker with no target at all. Scanning backwards keeps the whole
+ * final turn instead, and a branch whose last turn is itself longer than
  * `limit` replays in full.
  */
 function recentEntries(entries: SessionMessageEntry[], limit: number): SessionMessageEntry[] {
 	if (entries.length <= limit) return entries;
 	for (let index = entries.length - limit; index > 0; index--) {
-		if (entries[index]!.message.role === "user") return entries.slice(index);
+		if (startsTurn(entries[index]!)) return entries.slice(index);
 	}
 	return entries;
+}
+
+function startsTurn(entry: SessionMessageEntry): boolean {
+	const message = entry.message;
+	return message.role === "user" || (message.role === "custom" && isUserTurnInitiator(message));
 }
 
 /** Raw multi-line text of a user message (string or text blocks). */

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -206,8 +206,11 @@ export class CopySelectorComponent implements Component {
 		if (data.startsWith("\x1b[<")) {
 			routeSgrMouseInput(data, event => {
 				if (event.wheel !== null) {
+					// A wheel notch at either end moves nothing: repainting it
+					// anyway makes the frame twitch under a fast wheel.
+					const before = this.#scrollView.getScrollOffset();
 					this.#scrollView.scroll(event.wheel * 3);
-					this.deps.requestRender();
+					if (this.#scrollView.getScrollOffset() !== before) this.deps.requestRender();
 					return true;
 				}
 				if (event.leftClick) this.#click(event.row, event.col);

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -41,10 +41,10 @@ import {
 	appendOutlineEntries,
 	type ComposedColumn,
 	composeOutlineColumn,
+	OutlineRowCache,
 	type OutlineTarget,
 	outlineRows,
 	outlineVisibility,
-	stripPromptZones,
 } from "./transcript-outline";
 
 export interface CopySelectorDeps {
@@ -85,6 +85,13 @@ const BLOCK_PREVIEW_LINES = 12;
 const OUTLINE_COLOR: ThemeColor = "success";
 /** Rows above the scroll view: top rule, header, rule. Mouse rows map through this offset. */
 const CONTENT_TOP = 3;
+/**
+ * Entries replayed when the picker opens. Replaying a long session's whole
+ * branch costs seconds before the first frame (one component built and
+ * rendered per entry), and the clipboard target is almost always recent, so
+ * the picker starts at this tail and loads the rest on demand (`a`).
+ */
+const INITIAL_ENTRIES = 600;
 
 /** A clickable control on a block caption, in composed-column columns. */
 interface ControlRegion {
@@ -109,29 +116,65 @@ export class CopySelectorComponent implements Component {
 	#blockCache = new Map<string, CopyBlock[]>();
 	/** Click targets of the last render, keyed by composed-column line index. */
 	#controls = new Map<number, ControlRegion[]>();
+	#rowCache = new OutlineRowCache();
+
+	/** Whole branch; the picker may currently replay only its tail. */
+	#entries: SessionMessageEntry[];
+	/** True while older history is still unreplayed. */
+	#truncated = false;
 
 	constructor(
 		entries: SessionMessageEntry[],
 		private readonly deps: CopySelectorDeps,
 	) {
-		this.#builder = new ChatTranscriptBuilder({
-			ui: deps.ui,
-			getTool: deps.getTool,
-			isBuiltInTool: deps.isBuiltInTool,
-			getMessageRenderer: deps.getMessageRenderer,
-			cwd: deps.cwd,
-			hideThinkingBlock: deps.hideThinkingBlock,
-			proseOnlyThinking: deps.proseOnlyThinking,
-			linkTargets: deps.linkTargets,
-			requestRender: deps.requestRender,
-		});
-		this.#targets = appendOutlineEntries(this.#builder, entries);
+		this.#entries = entries;
+		const tail = recentEntries(entries, INITIAL_ENTRIES);
+		this.#truncated = tail.length < entries.length;
+		this.#builder = this.#replay(tail);
 		this.#selected = Math.max(0, this.#targets.length - 1);
 		this.#scrollView = new ScrollView([], {
 			height: 10,
 			scrollbar: "auto",
 			theme: { track: t => theme.fg("dim", t), thumb: t => theme.fg("accent", t) },
 		});
+	}
+
+	/** Build a transcript for `entries` and adopt its targets. */
+	#replay(entries: SessionMessageEntry[]): ChatTranscriptBuilder {
+		const builder = new ChatTranscriptBuilder({
+			ui: this.deps.ui,
+			getTool: this.deps.getTool,
+			isBuiltInTool: this.deps.isBuiltInTool,
+			getMessageRenderer: this.deps.getMessageRenderer,
+			cwd: this.deps.cwd,
+			hideThinkingBlock: this.deps.hideThinkingBlock,
+			proseOnlyThinking: this.deps.proseOnlyThinking,
+			linkTargets: this.deps.linkTargets,
+			requestRender: this.deps.requestRender,
+		});
+		builder.setExpanded(this.#expanded);
+		this.#targets = appendOutlineEntries(builder, entries);
+		return builder;
+	}
+
+	/**
+	 * Replay the whole branch, keeping the outline on the same turn. Pays the
+	 * full replay cost once, only when the user asks for older history.
+	 */
+	#loadFullHistory(): void {
+		if (!this.#truncated) return;
+		const selectedId = this.#targets[this.#selected]?.turnId;
+		const previous = this.#builder;
+		this.#builder = this.#replay(this.#entries);
+		previous.dispose();
+		this.#truncated = false;
+		this.#visible = undefined;
+		const restored = selectedId ? this.#targets.findIndex(target => target.turnId === selectedId) : -1;
+		this.#selected = restored >= 0 ? restored : Math.max(0, this.#targets.length - 1);
+		this.#blocks = undefined;
+		this.#blockSelected = 0;
+		this.#scrollToSelection = true;
+		this.deps.requestRender();
 	}
 
 	/** Number of copyable transcript items; hosts skip mounting when zero. */
@@ -205,6 +248,10 @@ export class CopySelectorComponent implements Component {
 		}
 		if (matchesKey(data, "left")) {
 			if (this.#blocks) this.#ascend();
+			return;
+		}
+		if ((data === "a" || data === "A") && !this.#blocks) {
+			this.#loadFullHistory();
 			return;
 		}
 		if (data === "o" || data === "O") {
@@ -286,7 +333,7 @@ export class CopySelectorComponent implements Component {
 		const contentWidth = Math.max(1, width - 1);
 		const children = this.#builder.container.children;
 		const inner = Math.max(10, contentWidth - 4);
-		const childRows = children.map(child => stripPromptZones(child.render(inner)));
+		const childRows = this.#rowCache.rows(children, inner);
 
 		this.#visible = outlineVisibility(childRows, this.#targets);
 		if (this.#visible[this.#selected] === false) {
@@ -353,8 +400,10 @@ export class CopySelectorComponent implements Component {
 		const openHint = selectedBlock?.href && this.deps.onOpen ? "  o open" : "";
 		const hint = this.#blocks
 			? `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  ←/esc back  enter copy${openHint}  click ${theme.cmd.copy}/${theme.cmd.share}`
-			: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  ctrl+o expand  esc close`;
-		output.push(` ${theme.fg("dim", hint)}`);
+			: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  ${this.#truncated ? "a earlier turns  " : ""}ctrl+o expand  esc close`;
+		// The hint grows with the load-all affordance; an over-width row would
+		// wrap and shift the mouse rows CONTENT_TOP/CHROME_ROWS assume.
+		output.push(` ${theme.fg("dim", truncateToWidth(hint, Math.max(0, width - 1)))}`);
 		output.push(...this.#border.render(width));
 		return output;
 	}
@@ -420,6 +469,25 @@ export class CopySelectorComponent implements Component {
 		lines.push("");
 		return { lines, selStart, selEnd };
 	}
+}
+
+/**
+ * The trailing slice starting at the last user message at or before
+ * `entries.length - limit`.
+ *
+ * The cut has to land on a turn boundary: `ChatTranscriptBuilder` drops a tool
+ * result whose initiating call was sliced away, so a tail beginning mid-turn
+ * renders without its command — and a tail of nothing but orphaned results
+ * would leave the picker with no target at all. Scanning backwards keeps the
+ * whole final turn instead, and a branch whose last turn is itself longer than
+ * `limit` replays in full.
+ */
+function recentEntries(entries: SessionMessageEntry[], limit: number): SessionMessageEntry[] {
+	if (entries.length <= limit) return entries;
+	for (let index = entries.length - limit; index > 0; index--) {
+		if (entries[index]!.message.role === "user") return entries.slice(index);
+	}
+	return entries;
 }
 
 /** Raw multi-line text of a user message (string or text blocks). */

--- a/packages/coding-agent/src/modes/components/rewind-selector.ts
+++ b/packages/coding-agent/src/modes/components/rewind-selector.ts
@@ -49,10 +49,10 @@ import {
 	appendOutlineEntries,
 	type ComposedColumn,
 	composeOutlineColumn,
+	OutlineRowCache,
 	type OutlineTarget,
 	outlineVisibility,
 	positionRail,
-	stripPromptZones,
 	userMessageHasText,
 	userMessageText,
 } from "./transcript-outline";
@@ -109,6 +109,7 @@ export class RewindSelectorComponent implements Component {
 	#siblingVisible: boolean[] | undefined;
 	#scrollToSelection = true;
 	#expanded = false;
+	#rowCache = new OutlineRowCache();
 
 	// Branch strip: present when the selected turn has sibling branches.
 	// Column 0 is the current path; siblings follow in tree order.
@@ -351,7 +352,7 @@ export class RewindSelectorComponent implements Component {
 		const contentWidth = Math.max(1, width - 1);
 		const children = this.#builder.container.children;
 		const mainInner = Math.max(10, contentWidth - 4);
-		const childRows = children.map(child => stripPromptZones(child.render(mainInner)));
+		const childRows = this.#rowCache.rows(children, mainInner);
 
 		this.#mainVisible = outlineVisibility(childRows, this.#targets);
 		if (!this.#isMainSelectable(this.#selected)) {
@@ -422,10 +423,7 @@ export class RewindSelectorComponent implements Component {
 		const prefix = composeOutlineColumn(mainRows, 0, anchor.start, [], -1, contentWidth, undefined);
 
 		// Column 0: the current path from the fork down, re-rendered at column width.
-		const suffixRows: (readonly string[])[] = [];
-		for (let index = anchor.start; index < this.#builder.container.children.length; index++) {
-			suffixRows.push(stripPromptZones(this.#builder.container.children[index]!.render(colInner)));
-		}
+		const suffixRows = this.#rowCache.rows(this.#builder.container.children.slice(anchor.start), colInner);
 		const suffixTargets = this.#targets.slice(this.#selected).map(target => ({
 			...target,
 			start: target.start - anchor.start,
@@ -444,7 +442,7 @@ export class RewindSelectorComponent implements Component {
 		];
 		for (let index = 0; index < columns.length; index++) {
 			const column = columns[index]!;
-			const rows = column.builder.container.children.map(child => stripPromptZones(child.render(colInner)));
+			const rows = this.#rowCache.rows(column.builder.container.children, colInner);
 			if (this.#activeVariant === index + 1) {
 				this.#siblingVisible = outlineVisibility(rows, column.targets);
 			}

--- a/packages/coding-agent/src/modes/components/rewind-selector.ts
+++ b/packages/coding-agent/src/modes/components/rewind-selector.ts
@@ -243,8 +243,11 @@ export class RewindSelectorComponent implements Component {
 		if (data.startsWith("\x1b[<")) {
 			routeSgrMouseInput(data, event => {
 				if (event.wheel !== null) {
+					// A wheel notch at either end moves nothing: repainting it
+					// anyway makes the frame twitch under a fast wheel.
+					const before = this.#scrollView.getScrollOffset();
 					this.#scrollView.scroll(event.wheel * 3);
-					this.deps.requestRender();
+					if (this.#scrollView.getScrollOffset() !== before) this.deps.requestRender();
 				}
 				return true;
 			});

--- a/packages/coding-agent/src/modes/components/transcript-outline.ts
+++ b/packages/coding-agent/src/modes/components/transcript-outline.ts
@@ -4,6 +4,7 @@
  * map each rendered turn to a selectable target, and compose gutter-prefixed
  * columns with a dotted outline around the selected target.
  */
+import type { Component } from "@oh-my-pi/pi-tui";
 import { visibleWidth } from "@oh-my-pi/pi-tui";
 import type { SessionMessageEntry } from "../../session/session-entries";
 import { type ThemeColor, theme } from "../theme/theme";
@@ -55,6 +56,36 @@ export function stripPromptZones(rows: readonly string[]): readonly string[] {
 		sanitized[index] = rows[index]!.replace(OSC133_SPAN_REGEX, "");
 	}
 	return sanitized ?? rows;
+}
+
+/**
+ * Prompt-zone-stripped rows for one selector column.
+ *
+ * The selectors recompose their whole column on every keystroke, and stripping
+ * every child's rows again per frame is pure waste on a long session. Per the
+ * {@link Component} render contract a child returns the same array while its
+ * rows are unchanged, so the stripped copy is keyed on that array: a child that
+ * repaints itself asynchronously (Kitty image conversion, todo strike frames)
+ * hands back a new array and is stripped again.
+ */
+export class OutlineRowCache {
+	#stripped = new WeakMap<Component, { rows: readonly string[]; stripped: readonly string[] }>();
+
+	rows(children: readonly Component[], width: number): Array<readonly string[]> {
+		const columns: Array<readonly string[]> = [];
+		for (const child of children) {
+			const rows = child.render(width);
+			const cached = this.#stripped.get(child);
+			if (cached && cached.rows === rows) {
+				columns.push(cached.stripped);
+				continue;
+			}
+			const stripped = stripPromptZones(rows);
+			this.#stripped.set(child, { rows, stripped });
+			columns.push(stripped);
+		}
+		return columns;
+	}
 }
 
 /**

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -389,21 +389,21 @@ describe("CopySelectorComponent", () => {
 	function pickerOver(
 		entries: SessionMessageEntry[],
 		picks: Array<{ content: string; label: string }>,
+		onRender: () => void = () => {},
 	): CopySelectorComponent {
 		return new CopySelectorComponent(entries, {
 			ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
 			cwd: "/tmp",
-			requestRender: () => {},
+			requestRender: onRender,
 			onPick: (content, label) => picks.push({ content, label }),
 			onCancel: () => {},
 		});
 	}
 
-	it("replays only the recent tail of a long branch until `a` loads the earlier turns", () => {
-		// One component is built and rendered per entry, so a long session cost
-		// seconds before its first frame; the picker starts at the tail instead.
+	/** `count` user turns, oldest first, chained by parent id. */
+	function promptChain(count: number): SessionMessageEntry[] {
 		const entries: SessionMessageEntry[] = [];
-		for (let index = 0; index < 900; index++) {
+		for (let index = 0; index < count; index++) {
 			entries.push(
 				entry(`u${index}`, index === 0 ? null : `u${index - 1}`, {
 					role: "user",
@@ -412,6 +412,40 @@ describe("CopySelectorComponent", () => {
 				} as AgentMessage),
 			);
 		}
+		return entries;
+	}
+
+	it("does not repaint for a wheel notch that cannot move the viewport", () => {
+		// The picker opens scrolled to the newest turn, so every wheel-down
+		// notch there used to repaint the whole frame and make it twitch.
+		let renders = 0;
+		const selector = pickerOver(promptChain(120), [], () => renders++);
+		const wheelDown = "\x1b[<65;1;10M";
+		const wheelUp = "\x1b[<64;1;10M";
+		try {
+			selector.render(100);
+
+			selector.handleInput(wheelDown);
+			selector.handleInput(wheelDown);
+			expect(renders).toBe(0);
+
+			// A notch that moves the viewport still repaints, in both directions.
+			selector.handleInput(wheelUp);
+			expect(renders).toBe(1);
+			selector.handleInput(wheelDown);
+			expect(renders).toBe(2);
+
+			selector.handleInput(wheelDown);
+			expect(renders).toBe(2);
+		} finally {
+			selector.dispose();
+		}
+	});
+
+	it("replays only the recent tail of a long branch until `a` loads the earlier turns", () => {
+		// One component is built and rendered per entry, so a long session cost
+		// seconds before its first frame; the picker starts at the tail instead.
+		const entries = promptChain(900);
 		const picks: Array<{ content: string; label: string }> = [];
 		const selector = pickerOver(entries, picks);
 		try {

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -384,4 +384,108 @@ describe("CopySelectorComponent", () => {
 		expect(boxed).toContain("const answer = 42;");
 		expect(boxed).not.toContain("bun test");
 	});
+
+	/** A picker over `entries` with the harness deps, recording picks. */
+	function pickerOver(
+		entries: SessionMessageEntry[],
+		picks: Array<{ content: string; label: string }>,
+	): CopySelectorComponent {
+		return new CopySelectorComponent(entries, {
+			ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
+			cwd: "/tmp",
+			requestRender: () => {},
+			onPick: (content, label) => picks.push({ content, label }),
+			onCancel: () => {},
+		});
+	}
+
+	it("replays only the recent tail of a long branch until `a` loads the earlier turns", () => {
+		// One component is built and rendered per entry, so a long session cost
+		// seconds before its first frame; the picker starts at the tail instead.
+		const entries: SessionMessageEntry[] = [];
+		for (let index = 0; index < 900; index++) {
+			entries.push(
+				entry(`u${index}`, index === 0 ? null : `u${index - 1}`, {
+					role: "user",
+					content: `prompt ${index}`,
+					timestamp: index,
+				} as AgentMessage),
+			);
+		}
+		const picks: Array<{ content: string; label: string }> = [];
+		const selector = pickerOver(entries, picks);
+		try {
+			expect(selector.targetCount).toBeLessThan(entries.length);
+			expect(Bun.stripANSI(selector.render(100).join("\n"))).toContain("a earlier turns");
+
+			// Step off the newest turn: the reload must restore this turn, not
+			// fall back to the last target of the fuller transcript.
+			selector.handleInput(UP);
+			selector.handleInput(UP);
+			selector.handleInput("a");
+			expect(selector.targetCount).toBe(entries.length);
+			const loaded = Bun.stripANSI(selector.render(100).join("\n"));
+			expect(loaded).not.toContain("a earlier turns");
+			expect(loaded).toContain(`${entries.length - 2}/${entries.length}`);
+
+			selector.handleInput(ENTER);
+			expect(picks).toEqual([{ content: "prompt 897", label: "user message" }]);
+		} finally {
+			selector.dispose();
+		}
+	});
+
+	it("keeps a copyable target when the final turn is longer than the replay cap", () => {
+		// Cutting blindly at `length - limit` would start the tail inside the
+		// tool results, whose calls are gone: the builder drops them and the
+		// picker mounts with nothing to copy.
+		const entries: SessionMessageEntry[] = [
+			entry("u1", null, { role: "user", content: "run the sweep", timestamp: 1 } as AgentMessage),
+		];
+		for (let index = 0; index < 700; index++) {
+			const call = `call-${index}`;
+			entries.push(
+				entry(`a${index}`, entries.at(-1)!.id, {
+					role: "assistant",
+					content: [{ type: "toolCall", id: call, name: "bash", arguments: { command: `step ${index}` } }],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					stopReason: "toolUse",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: 2 + index * 2,
+				} as unknown as AgentMessage),
+			);
+			entries.push(
+				entry(`t${index}`, entries.at(-1)!.id, {
+					role: "toolResult",
+					toolCallId: call,
+					toolName: "bash",
+					content: [{ type: "text", text: `output ${index}` }],
+					isError: false,
+					timestamp: 3 + index * 2,
+				} as unknown as AgentMessage),
+			);
+		}
+		const picks: Array<{ content: string; label: string }> = [];
+		const selector = pickerOver(entries, picks);
+		try {
+			// The single user turn is the only boundary, so the whole branch replays.
+			expect(selector.targetCount).toBeGreaterThan(0);
+			expect(Bun.stripANSI(selector.render(100).join("\n"))).not.toContain("a earlier turns");
+
+			selector.handleInput(ENTER);
+			expect(picks).toHaveLength(1);
+			expect(picks[0]!.content).toContain("output 699");
+		} finally {
+			selector.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -522,4 +522,30 @@ describe("CopySelectorComponent", () => {
 			selector.dispose();
 		}
 	});
+
+	it("cuts the tail at a directly invoked skill prompt, not only at a user message", () => {
+		// A `/skill:` prompt the user invoked starts a turn of its own, so a
+		// branch whose recent history is skill turns must not walk back to a
+		// far older user message and replay thousands of entries.
+		const entries = promptChain(50);
+		for (let index = 0; index < 900; index++) {
+			entries.push(
+				entry(`s${index}`, entries.at(-1)!.id, {
+					role: "custom",
+					customType: "skill-prompt",
+					attribution: "user",
+					content: `skill step ${index}`,
+					display: true,
+					timestamp: 1000 + index,
+				} as unknown as AgentMessage),
+			);
+		}
+		const selector = pickerOver(entries, []);
+		try {
+			expect(selector.targetCount).toBeLessThan(700);
+			expect(Bun.stripANSI(selector.render(100).join("\n"))).toContain("a earlier turns");
+		} finally {
+			selector.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/transcript-outline-row-cache.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-outline-row-cache.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The fullscreen transcript selectors recompose their whole column on every
+ * keystroke, so the prompt-zone strip is cached per child. The cache keys on
+ * the array a child returns, which is the {@link Component} render contract's
+ * "nothing changed" signal — a child that repaints itself asynchronously
+ * (Kitty image conversion, todo strike frames) must not keep serving the rows
+ * it had before.
+ */
+import { describe, expect, it } from "bun:test";
+import { OutlineRowCache } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-outline";
+import type { Component } from "@oh-my-pi/pi-tui";
+
+/** A child that honors the render contract: same array until its rows change. */
+function child(initial: string): Component & { update(text: string): void; strips: number } {
+	let rows = [initial];
+	return {
+		strips: 0,
+		update(text: string) {
+			rows = [text];
+		},
+		render(): readonly string[] {
+			return rows;
+		},
+	} as unknown as Component & { update(text: string): void; strips: number };
+}
+
+describe("OutlineRowCache", () => {
+	it("reuses the stripped rows while a child returns the same array", () => {
+		const cache = new OutlineRowCache();
+		const children = [child("a"), child("b")];
+
+		const first = cache.rows(children, 40);
+		const second = cache.rows(children, 40);
+
+		expect(first).toEqual([["a"], ["b"]]);
+		expect(second[0]).toBe(first[0]);
+		expect(second[1]).toBe(first[1]);
+	});
+
+	it("serves the new rows after a child repaints itself", () => {
+		const cache = new OutlineRowCache();
+		const target = child("converting image…");
+		cache.rows([target], 40);
+
+		(target as unknown as { update(text: string): void }).update("<image>");
+
+		expect(cache.rows([target], 40)).toEqual([["<image>"]]);
+	});
+
+	it("strips OSC 133 prompt zones, which would garble the overlay frame", () => {
+		const cache = new OutlineRowCache();
+		const bubble = {
+			render: () => ["\x1b]133;A\x07 prompt \x1b]133;B\x07"],
+		} as unknown as Component;
+
+		expect(cache.rows([bubble], 40)).toEqual([[" prompt "]]);
+	});
+});


### PR DESCRIPTION
I checked this on my own sessions: it no longer lags. I reviewed the diff.

## What

- `/copy` replays the recent tail of the branch (600 entries, cut back to the last user message so the tail never starts inside a turn) instead of the whole session; `a` loads the earlier turns and keeps the outline on the same turn.
- `OutlineRowCache` in the shared outline engine keeps the prompt-zone-stripped rows per child, keyed on the array the child returns, so a child that repaints itself is stripped again. The esc-esc rewind selector uses it too.

## Why

`CopySelectorComponent` built and rendered a component per entry on open, so cost scaled with session length. Measured at width 120 on two real sessions, same base commit:

| branch | open before | open after | keystroke before | keystroke after |
| --- | --- | --- | --- | --- |
| 30,462 entries | 11.9 s | 1.05 s | 153–183 ms | 3.3–5.3 ms |
| 11,394 entries | 4.9 s | 1.33 s | 44–49 ms | 3.1–5.8 ms |

Opening again in the same process (the live-session case, modules and highlighters already warm) costs 33–50 ms of replay plus ~200 ms for the first frame. After an explicit `a` the frame is O(branch) again by design (121–142 ms per keystroke on the 30k branch); the tail is what the picker opens on. #4238 fixed the same class of per-keystroke work for the preview highlight; this is the transcript column above it.

## Testing

- Live TUI, dev build of this branch, resumed 17.5k-line session at width 120: `/copy` opened immediately at `391/391` with `a earlier turns` in the footer; two `↑` moved to `389/391` and stepping was instant; `a` expanded to `5777/5779`, i.e. the outline stayed on the same turn instead of resetting to the newest one, and the hint disappeared; `esc` closed the picker.
- Before the change the same picker on the same session needed seconds to appear and 44–49 ms per arrow key.
- `bun test packages/coding-agent/test/modes/components packages/coding-agent/test/rewind-selector.test.ts packages/coding-agent/test/slash-commands/copy.test.ts` — 550 passed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

