### PR TITLE
feat(contrib): add portable omp-sync snapshot/rollback wrapper

### DIFF
--- a/contrib/omp-sync/README.md
+++ b/contrib/omp-sync/README.md
@@ -1,0 +1,145 @@
+# omp-sync
+
+Optional, portable snapshot/rollback wrapper around official
+[`omp update`](https://github.com/can1357/oh-my-pi) / `omp update --check`.
+
+Core `omp update` already installs updates. This contrib only adds fail-soft
+behavior around that command: keep a copy of the previous launcher, restore it
+if the update or an optional smoke check fails, and leave user config alone.
+
+It is not part of the omp CLI. Nothing in `packages/coding-agent` calls it.
+
+## Why
+
+`omp update` talks to npm/GitHub and then replaces the active launcher. A
+timeout, a truncated download, or a binary that no longer starts can leave you
+without a working `omp`. This script:
+
+1. Checks for an update first (`omp update --check`).
+2. Copies the current launcher into a snapshot directory.
+3. Runs `omp update`.
+4. Restores the snapshot if the updater exits non-zero, the new binary cannot
+   run `--version`, or `OMP_SYNC_SMOKE_CMD` fails.
+
+Network failures during the check never replace the binary.
+
+## Install
+
+The script is POSIX `sh` (Linux and macOS). Copy or symlink it somewhere on
+`PATH`:
+
+```sh
+install -m 0755 contrib/omp-sync/omp-sync.sh ~/.local/bin/omp-sync
+```
+
+Or run it from a clone:
+
+```sh
+./contrib/omp-sync/omp-sync.sh --check
+```
+
+## Usage
+
+```sh
+omp-sync.sh --check                 # omp update --check only
+omp-sync.sh --apply                 # snapshot, then omp update
+omp-sync.sh --apply -- --canary     # extra args forwarded to omp update
+omp-sync.sh --list                  # snapshots (newest last)
+omp-sync.sh --rollback              # restore the latest snapshot
+omp-sync.sh --rollback <id>         # restore a specific snapshot
+```
+
+`--check` is the safe default for cron: it never writes snapshots or replaces
+the binary. `--apply` is the mutating path.
+
+## Snapshot location
+
+Snapshots live **only** under the sync root:
+
+| Precedence | Path |
+| --- | --- |
+| 1 | `$OMP_SYNC_DIR` if set |
+| 2 | `$OMP_HOME/sync` if `OMP_HOME` is set |
+| 3 | `$HOME/$PI_CONFIG_DIR/sync` (default `~/.omp/sync`) |
+
+Each snapshot is `$sync_root/snapshots/<utc>-<version>-<pid>/` with:
+
+- `omp` — copy of the resolved launcher
+- `meta` — version, source path, UTC timestamp, sha256
+
+After a **successful** apply, older snapshots are pruned so at most
+`OMP_SYNC_KEEP` remain (default 5, minimum 1). Failed applies do not prune.
+
+## Safety guarantees
+
+- **Never deletes user config.** The script does not remove or rewrite
+  `config.yml`, `settings.json`, `agent/`, sessions, auth, or plugin state.
+  The only paths it creates or deletes are under the sync root (`snapshots/`,
+  the lock file, and `last-run.log`).
+- **No machine-specific paths.** Home is `$HOME`. There are no hard-coded
+  user home directories.
+- **Locking.** Concurrent runs are rejected (`flock` when available, otherwise
+  a directory lock). Exit code 5.
+- **Fail-soft network.** Registry/DNS/TLS/timeouts during `--check` or apply
+  exit 2 and leave the existing launcher in place (apply restores the snapshot
+  if the updater had already started).
+- **Restore on apply failure.** Non-zero `omp update`, a launcher that cannot
+  run `--version`, or a failed smoke command restores the snapshot taken for
+  that apply before exiting 3.
+- **Best-effort rollback target.** The snapshot is the resolved file behind
+  `omp` on `PATH` (symlink targets are followed). Homebrew/Nix/mise installs
+  that `omp update` itself refuses to replace are unchanged; this wrapper does
+  not fight those managers.
+
+## Optional environment
+
+| Variable | Purpose |
+| --- | --- |
+| `OMP_SYNC_BIN` | Launcher to wrap (default: `omp` on `PATH`) |
+| `OMP_SYNC_KEEP` | Snapshots to keep after a successful apply (default 5) |
+| `OMP_SYNC_RELINK_EXT` | Colon-separated local plugin directories passed to `omp plugin link` after a successful apply. Missing paths are skipped; link failures are warnings and do **not** roll back. |
+| `OMP_SYNC_SMOKE_CMD` | Shell command run after a successful `omp update`. Non-zero exit restores the previous binary. Keep this generic (for example `omp --version` or your own health check). |
+
+`OMP_SYNC_RELINK_EXT` is for **your** local plugins. It is not a place to
+hard-wire project-specific overlays.
+
+Example:
+
+```sh
+export OMP_SYNC_SMOKE_CMD='omp --version'
+export OMP_SYNC_RELINK_EXT="$HOME/src/my-omp-plugin"
+./contrib/omp-sync/omp-sync.sh --apply
+```
+
+## Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| 0 | Success, or already up to date |
+| 1 | Usage error |
+| 2 | Network / registry failure; binary unchanged |
+| 3 | Apply failed; previous binary restored when a snapshot existed |
+| 4 | Rollback failed |
+| 5 | Another omp-sync holds the lock |
+| 6 | `omp` executable not found |
+| 7 | Snapshot I/O error |
+
+## What this is not
+
+- Not a replacement for `omp update`.
+- Not an auto-updater service or launchd plist.
+- Not a plugin or skill pack.
+- Not Windows-oriented (`flock` / POSIX `sh` / Unix launchers).
+
+Official update behavior, channels, and install methods remain documented on
+`omp update --help` and in [Safe binary update](../../docs/safe-binary-update.md).
+
+## Tests
+
+The wrapper is covered by a fake-`omp` contract script (no network, no real
+install). It checks snapshot/rollback, network fail-soft, smoke-command
+restore, snapshot prune, and that user config is never deleted:
+
+```sh
+sh contrib/omp-sync/omp-sync.test.sh
+```

--- a/contrib/omp-sync/README.md
+++ b/contrib/omp-sync/README.md
@@ -15,13 +15,16 @@ It is not part of the omp CLI. Nothing in `packages/coding-agent` calls it.
 timeout, a truncated download, or a binary that no longer starts can leave you
 without a working `omp`. This script:
 
-1. Checks for an update first (`omp update --check`).
+1. Checks for an update first (`omp update --check`, including any `--`
+   flags such as `--canary` / `--stable` / `--force`).
 2. Copies the current launcher into a snapshot directory.
-3. Runs `omp update`.
+3. Runs `omp update` with those same flags.
 4. Restores the snapshot if the updater exits non-zero, the new binary cannot
    run `--version`, or `OMP_SYNC_SMOKE_CMD` fails.
 
-Network failures during the check never replace the binary.
+Network failures during the check never replace the binary. Network failures
+after the updater has started restore the snapshot (when one exists) and still
+exit 2.
 
 ## Install
 
@@ -43,7 +46,7 @@ Or run it from a clone:
 ```sh
 omp-sync.sh --check                 # omp update --check only
 omp-sync.sh --apply                 # snapshot, then omp update
-omp-sync.sh --apply -- --canary     # extra args forwarded to omp update
+omp-sync.sh --apply -- --canary     # extra args forwarded to check and update
 omp-sync.sh --list                  # snapshots (newest last)
 omp-sync.sh --rollback              # restore the latest snapshot
 omp-sync.sh --rollback <id>         # restore a specific snapshot
@@ -62,10 +65,18 @@ Snapshots live **only** under the sync root:
 | 2 | `$OMP_HOME/sync` if `OMP_HOME` is set |
 | 3 | `$HOME/$PI_CONFIG_DIR/sync` (default `~/.omp/sync`) |
 
+`HOME` is required only for row 3 when `PI_CONFIG_DIR` is relative. An
+absolute `$OMP_SYNC_DIR`, `$OMP_HOME`, or `$PI_CONFIG_DIR` is enough in
+minimal environments that omit `HOME`.
+
 Each snapshot is `$sync_root/snapshots/<utc>-<version>-<pid>/` with:
 
 - `omp` — copy of the resolved launcher
-- `meta` — version, source path, UTC timestamp, sha256
+- `meta` — version, source path, launcher path, UTC timestamp, sha256
+
+A snapshot directory is published only after `omp` and `meta` are both
+written (staging directory, then rename). Incomplete dirs without `meta` are
+not restorable and are ignored (and removed on prune).
 
 After a **successful** apply, older snapshots are pruned so at most
 `OMP_SYNC_KEEP` remain (default 5, minimum 1). Failed applies do not prune.
@@ -83,13 +94,30 @@ After a **successful** apply, older snapshots are pruned so at most
 - **Fail-soft network.** Registry/DNS/TLS/timeouts during `--check` or apply
   exit 2 and leave the existing launcher in place (apply restores the snapshot
   if the updater had already started).
-- **Restore on apply failure.** Non-zero `omp update`, a launcher that cannot
-  run `--version`, or a failed smoke command restores the snapshot taken for
-  that apply before exiting 3.
-- **Best-effort rollback target.** The snapshot is the resolved file behind
-  `omp` on `PATH` (symlink targets are followed). Homebrew/Nix/mise installs
-  that `omp update` itself refuses to replace are unchanged; this wrapper does
-  not fight those managers.
+- **Restore on apply failure (binary/shim).** Non-zero `omp update`, a
+  launcher that cannot run `--version`, or a failed smoke command restores the
+  snapshot taken for that apply before exiting 3 — **when the install is a
+  standalone binary or a shim-takeover launcher that `omp update` replaces in
+  place.** bun/npm *managed* updates reinstall the package under
+  `node_modules`; this wrapper only copies the resolved launcher file, so
+  restore is partial there (the entry may revert while the rest of the tree
+  stays new) even though the script still reports a successful restore.
+- **Best-effort rollback target.** Restore overwrites the file `omp` on
+  `PATH` currently resolves to (symlink targets are followed at restore time,
+  so a retargeted launcher is not left pointing at the new binary).
+  Homebrew/mise installs that `omp update` itself drives are unchanged; this
+  wrapper does not fight those managers. Nix-managed installs are
+  detection-only (`omp update` refuses to replace them).
+
+### Rollback coverage
+
+| Install method | What restore does |
+| --- | --- |
+| Standalone binary | Full — the resolved file is replaced in place |
+| Shim takeover | Full — the PATH launcher file is replaced in place |
+| bun / npm managed (`updateViaManager`) | Partial — only the resolved launcher file is snapshotted; the rest of `node_modules` is not reverted |
+| Homebrew / mise | Unchanged — `omp update` uses the manager |
+| Nix | Detection-only — `omp update` does not install; update the flake input or profile and rebuild |
 
 ## Optional environment
 
@@ -97,7 +125,7 @@ After a **successful** apply, older snapshots are pruned so at most
 | --- | --- |
 | `OMP_SYNC_BIN` | Launcher to wrap (default: `omp` on `PATH`) |
 | `OMP_SYNC_KEEP` | Snapshots to keep after a successful apply (default 5) |
-| `OMP_SYNC_RELINK_EXT` | Colon-separated local plugin directories passed to `omp plugin link` after a successful apply. Missing paths are skipped; link failures are warnings and do **not** roll back. |
+| `OMP_SYNC_RELINK_EXT` | Colon-separated local plugin directories passed to `omp plugin link` after a successful apply. Missing paths are skipped; link failures are warnings and do **not** roll back. A `~/` prefix is treated as a literal tilde (not expanded by the matcher) and then replaced with `$HOME`. |
 | `OMP_SYNC_SMOKE_CMD` | Shell command run after a successful `omp update`. Non-zero exit restores the previous binary. Keep this generic (for example `omp --version` or your own health check). |
 
 `OMP_SYNC_RELINK_EXT` is for **your** local plugins. It is not a place to
@@ -117,7 +145,7 @@ export OMP_SYNC_RELINK_EXT="$HOME/src/my-omp-plugin"
 | ---: | --- |
 | 0 | Success, or already up to date |
 | 1 | Usage error |
-| 2 | Network / registry failure; binary unchanged |
+| 2 | Network / registry failure; binary unchanged (apply restores the snapshot if the updater had started) |
 | 3 | Apply failed; previous binary restored when a snapshot existed |
 | 4 | Rollback failed |
 | 5 | Another omp-sync holds the lock |
@@ -137,8 +165,9 @@ Official update behavior, channels, and install methods remain documented on
 ## Tests
 
 The wrapper is covered by a fake-`omp` contract script (no network, no real
-install). It checks snapshot/rollback, network fail-soft, smoke-command
-restore, snapshot prune, and that user config is never deleted:
+install). It checks snapshot/rollback, network fail-soft (including apply),
+smoke-command restore, snapshot prune, incomplete-snapshot rejection, and that
+user config is never deleted:
 
 ```sh
 sh contrib/omp-sync/omp-sync.test.sh

--- a/contrib/omp-sync/omp-sync.sh
+++ b/contrib/omp-sync/omp-sync.sh
@@ -1,0 +1,609 @@
+#!/bin/sh
+# Portable fail-soft wrapper around official `omp update` / `omp update --check`.
+#
+# Snapshots the current omp launcher before applying an update, keeps the last N
+# snapshots, and restores that launcher if the update or an optional smoke
+# command fails. User config (settings, sessions, auth, plugins) is never
+# deleted or rewritten by this script.
+#
+# This is an optional contrib. It does not change core `omp update` behavior.
+set -eu
+
+EX_OK=0
+EX_USAGE=1
+EX_NETWORK=2
+EX_APPLY=3
+EX_ROLLBACK=4
+EX_LOCK=5
+EX_MISSING=6
+EX_IO=7
+
+KEEP_DEFAULT=5
+LOCK_FD=9
+ACTION=""
+ROLLBACK_ID=""
+PASS_THROUGH=""
+LOCK_KIND=""
+LOCK_DIR=""
+LOCK_FILE=""
+
+usage() {
+	cat <<'EOF'
+Usage: omp-sync.sh --check | --apply | --rollback [id] | --list | --help
+
+Fail-soft snapshot/rollback wrapper around official `omp update`.
+
+Actions:
+  --check              Run `omp update --check` (no install, no snapshot)
+  --apply              Snapshot the current omp binary, then `omp update`
+  --rollback [id]      Restore the latest snapshot, or the named snapshot id
+  --list               List snapshots (newest last)
+  --help               Show this help
+
+Extra arguments after `--` are forwarded to `omp update` on --apply:
+  omp-sync.sh --apply -- --canary
+
+Environment:
+  HOME                 Used to resolve ~/.omp (never hard-coded user paths)
+  OMP_HOME             If set, snapshots live under $OMP_HOME/sync
+  PI_CONFIG_DIR        Official config-dir name or absolute path (default .omp)
+  OMP_SYNC_DIR         Snapshot root override (takes precedence)
+  OMP_SYNC_BIN         omp executable to wrap (default: omp on PATH)
+  OMP_SYNC_KEEP        Snapshots to retain after a successful apply (default 5)
+  OMP_SYNC_RELINK_EXT  Optional colon-separated local plugin paths to
+                       `omp plugin link` after a successful apply
+  OMP_SYNC_SMOKE_CMD   Optional shell command run after apply; failure rolls back
+
+Exit codes:
+  0  success / already up to date
+  1  usage error
+  2  network / registry failure (no binary change)
+  3  apply failed; previous binary restored when a snapshot existed
+  4  rollback failed
+  5  another omp-sync holds the lock
+  6  omp executable not found
+  7  snapshot I/O error
+EOF
+}
+
+log() {
+	printf '%s\n' "$*" >&2
+}
+
+die() {
+	_rc=$1
+	shift
+	log "omp-sync: $*"
+	exit "$_rc"
+}
+
+is_abs() {
+	case "$1" in
+		/*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+config_root() {
+	if [ -n "${OMP_HOME:-}" ]; then
+		printf '%s\n' "$OMP_HOME"
+		return 0
+	fi
+	_cfg=${PI_CONFIG_DIR:-.omp}
+	if is_abs "$_cfg"; then
+		printf '%s\n' "$_cfg"
+	else
+		printf '%s\n' "${HOME:?HOME is not set}/$_cfg"
+	fi
+}
+
+sync_root() {
+	if [ -n "${OMP_SYNC_DIR:-}" ]; then
+		printf '%s\n' "$OMP_SYNC_DIR"
+		return 0
+	fi
+	printf '%s/sync\n' "$(config_root)"
+}
+
+snapshots_dir() {
+	printf '%s/snapshots\n' "$(sync_root)"
+}
+
+ensure_sync_dirs() {
+	_root=$(sync_root)
+	_snaps=$(snapshots_dir)
+	mkdir -p "$_snaps" || die "$EX_IO" "could not create snapshot directory $_snaps"
+	# Refuse to operate if sync root is not a directory we own as a folder.
+	if [ ! -d "$_root" ]; then
+		die "$EX_IO" "sync root is not a directory: $_root"
+	fi
+}
+
+release_lock() {
+	case "$LOCK_KIND" in
+		mkdir)
+			if [ -n "$LOCK_DIR" ] && [ -d "$LOCK_DIR" ]; then
+				rm -f "$LOCK_DIR/pid" 2>/dev/null || true
+				rmdir "$LOCK_DIR" 2>/dev/null || true
+			fi
+			;;
+		flock)
+			# Unlocked when this process exits (lock fd closed).
+			;;
+	esac
+	LOCK_KIND=""
+}
+
+acquire_lock() {
+	_root=$(sync_root)
+	mkdir -p "$_root" || die "$EX_IO" "could not create sync root $_root"
+	LOCK_FILE=$_root/omp-sync.lock
+	LOCK_DIR=$_root/omp-sync.lock.d
+
+	if command -v flock >/dev/null 2>&1; then
+		# shellcheck disable=SC2094
+		eval "exec ${LOCK_FD}>\"$LOCK_FILE\""
+		if flock -n "$LOCK_FD"; then
+			LOCK_KIND=flock
+			return 0
+		fi
+		die "$EX_LOCK" "another omp-sync process holds $LOCK_FILE"
+	fi
+
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" >"$LOCK_DIR/pid"
+		LOCK_KIND=mkdir
+		return 0
+	fi
+
+	if [ -f "$LOCK_DIR/pid" ]; then
+		_old=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+		if [ -n "$_old" ] && kill -0 "$_old" 2>/dev/null; then
+			die "$EX_LOCK" "another omp-sync process (pid $_old) holds $LOCK_DIR"
+		fi
+	fi
+	# Stale lock: take it over.
+	rm -rf "$LOCK_DIR" 2>/dev/null || true
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" >"$LOCK_DIR/pid"
+		LOCK_KIND=mkdir
+		return 0
+	fi
+	die "$EX_LOCK" "another omp-sync process holds $LOCK_DIR"
+}
+
+resolve_omp() {
+	if [ -n "${OMP_SYNC_BIN:-}" ]; then
+		_omp=$OMP_SYNC_BIN
+	else
+		_omp=$(command -v omp 2>/dev/null || true)
+	fi
+	if [ -z "$_omp" ]; then
+		die "$EX_MISSING" "omp not found on PATH (set OMP_SYNC_BIN to override)"
+	fi
+	if [ ! -e "$_omp" ]; then
+		die "$EX_MISSING" "omp path does not exist: $_omp"
+	fi
+	_base=$(basename "$_omp")
+	if [ "$_base" = "omp-sync.sh" ]; then
+		die "$EX_MISSING" "refusing to treat omp-sync.sh as the omp binary"
+	fi
+	printf '%s\n' "$_omp"
+}
+
+resolve_file() {
+	_path=$1
+	_i=0
+	while [ -L "$_path" ] && [ "$_i" -lt 40 ]; do
+		_target=$(readlink "$_path")
+		case "$_target" in
+			/*) _path=$_target ;;
+			*) _path=$(dirname "$_path")/$_target ;;
+		esac
+		_i=$((_i + 1))
+	done
+	if [ ! -e "$_path" ]; then
+		die "$EX_MISSING" "could not resolve omp file: $1"
+	fi
+	_dir=$(CDPATH='' cd -- "$(dirname "$_path")" && pwd -P)
+	printf '%s/%s\n' "$_dir" "$(basename "$_path")"
+}
+
+file_sha256() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | awk '{print $1}'
+	elif command -v openssl >/dev/null 2>&1; then
+		openssl dgst -sha256 "$1" | awk '{print $NF}'
+	else
+		printf '\n'
+	fi
+}
+
+omp_version() {
+	_bin=$1
+	_out=$("$_bin" --version 2>/dev/null || true)
+	_ver=$(printf '%s\n' "$_out" | sed -n 's/.*\/\([0-9][0-9A-Za-z._-]*\).*/\1/p' | head -n 1)
+	if [ -z "$_ver" ]; then
+		printf 'unknown\n'
+	else
+		printf '%s\n' "$_ver"
+	fi
+}
+
+sanitize_id_part() {
+	printf '%s\n' "$1" | tr '/ ' '--' | tr -cd 'A-Za-z0-9._-'
+}
+
+is_snapshot_id() {
+	printf '%s\n' "$1" | grep -Eq '^[0-9]{8}T[0-9]{6}Z-[A-Za-z0-9._-]+$'
+}
+
+write_meta() {
+	_meta=$1
+	_version=$2
+	_source=$3
+	_sha=$4
+	{
+		printf 'version=%s\n' "$_version"
+		printf 'source=%s\n' "$_source"
+		printf 'created=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+		printf 'sha256=%s\n' "$_sha"
+	} >"$_meta"
+}
+
+read_meta_field() {
+	_file=$1
+	_key=$2
+	sed -n "s/^${_key}=//p" "$_file" | head -n 1
+}
+
+snapshot_current() {
+	_omp_cmd=$(resolve_omp)
+	_source=$(resolve_file "$_omp_cmd")
+	_version=$(omp_version "$_omp_cmd")
+	_stamp=$(date -u +%Y%m%dT%H%M%SZ)
+	_id=${_stamp}-$(sanitize_id_part "$_version")-$$
+	_dir=$(snapshots_dir)/$_id
+	mkdir -p "$_dir" || die "$EX_IO" "could not create snapshot $_dir"
+	if ! cp -p "$_source" "$_dir/omp"; then
+		rm -rf "$_dir"
+		die "$EX_IO" "could not copy $_source into snapshot"
+	fi
+	_sha=$(file_sha256 "$_dir/omp")
+	write_meta "$_dir/meta" "$_version" "$_source" "$_sha"
+	printf '%s\n' "$_id"
+}
+
+restore_snapshot() {
+	_id=$1
+	_dir=$(snapshots_dir)/$_id
+	if [ ! -d "$_dir" ] || [ ! -f "$_dir/omp" ]; then
+		die "$EX_ROLLBACK" "snapshot not found: $_id"
+	fi
+	_source=$(read_meta_field "$_dir/meta" source)
+	if [ -z "$_source" ]; then
+		_omp_cmd=$(resolve_omp)
+		_source=$(resolve_file "$_omp_cmd")
+	fi
+	_parent=$(dirname "$_source")
+	if [ ! -d "$_parent" ]; then
+		die "$EX_ROLLBACK" "restore target directory missing: $_parent"
+	fi
+	_tmp=$_source.omp-sync-restore.$$
+	if ! cp -p "$_dir/omp" "$_tmp"; then
+		rm -f "$_tmp"
+		die "$EX_ROLLBACK" "could not stage restored binary at $_tmp"
+	fi
+	chmod +x "$_tmp" 2>/dev/null || true
+	if ! mv -f "$_tmp" "$_source"; then
+		rm -f "$_tmp"
+		die "$EX_ROLLBACK" "could not replace $_source with snapshot $_id"
+	fi
+	log "omp-sync: restored $_source from snapshot $_id"
+}
+
+latest_snapshot_id() {
+	_snaps=$(snapshots_dir)
+	if [ ! -d "$_snaps" ]; then
+		return 1
+	fi
+	_last=""
+	for _name in "$_snaps"/*; do
+		[ -d "$_name" ] || continue
+		_id=$(basename "$_name")
+		is_snapshot_id "$_id" || continue
+		_last=$_id
+	done
+	if [ -z "$_last" ]; then
+		return 1
+	fi
+	printf '%s\n' "$_last"
+}
+
+prune_snapshots() {
+	_keep=${OMP_SYNC_KEEP:-$KEEP_DEFAULT}
+	case "$_keep" in
+		'' | *[!0-9]*) _keep=$KEEP_DEFAULT ;;
+	esac
+	if [ "$_keep" -lt 1 ]; then
+		_keep=1
+	fi
+	_snaps=$(snapshots_dir)
+	_list=""
+	_n=0
+	for _name in "$_snaps"/*; do
+		[ -d "$_name" ] || continue
+		_id=$(basename "$_name")
+		is_snapshot_id "$_id" || continue
+		_list="$_list $_id"
+		_n=$((_n + 1))
+	done
+	# Word-split is safe: snapshot ids never contain whitespace.
+	# shellcheck disable=SC2086
+	set -- $_list
+	while [ "$#" -gt "$_keep" ]; do
+		_old=$1
+		shift
+		# Only delete a recognized snapshot directory under the snapshots root.
+		if is_snapshot_id "$_old" && [ -d "$_snaps/$_old" ]; then
+			rm -rf "$_snaps/$_old"
+			log "omp-sync: pruned snapshot $_old"
+		fi
+	done
+}
+
+looks_like_network_error() {
+	_text=$1
+	printf '%s\n' "$_text" | grep -Ei \
+		'failed to check for updates|unable to connect|enotfound|econnreset|etimedout|networkerror|getaddrinfo|could not resolve host|operation timed out|certificate|tls|socket hang up|network is unreachable|temporary failure in name resolution|429|rate.?limit|fetch failed' \
+		>/dev/null 2>&1
+}
+
+LAST_UPDATE_RC=0
+
+run_omp_update() {
+	_omp=$1
+	shift
+	_log=$(sync_root)/last-run.log
+	set +e
+	"$_omp" update "$@" >"$_log" 2>&1
+	LAST_UPDATE_RC=$?
+	set -e
+	cat "$_log" || true
+}
+
+cmd_check() {
+	_omp=$(resolve_omp)
+	run_omp_update "$_omp" --check
+	_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
+	if [ "$LAST_UPDATE_RC" -eq 0 ]; then
+		exit "$EX_OK"
+	fi
+	if looks_like_network_error "$_log"; then
+		log "omp-sync: update check failed due to network; existing install left unchanged"
+		exit "$EX_NETWORK"
+	fi
+	die "$EX_APPLY" "omp update --check failed (exit $LAST_UPDATE_RC)"
+}
+
+relink_extensions() {
+	_omp=$1
+	_spec=${OMP_SYNC_RELINK_EXT:-}
+	if [ -z "$_spec" ]; then
+		return 0
+	fi
+	_oldifs=$IFS
+	IFS=:
+	# shellcheck disable=SC2086
+	set -- $_spec
+	IFS=$_oldifs
+	for _path in "$@"; do
+		[ -n "$_path" ] || continue
+		case "$_path" in
+			~/*) _path=$HOME/${_path#~/} ;;
+		esac
+		if [ ! -e "$_path" ]; then
+			log "omp-sync: skip relink, path does not exist: $_path"
+			continue
+		fi
+		log "omp-sync: relinking local plugin $_path"
+		if ! "$_omp" plugin link "$_path"; then
+			log "omp-sync: warning: plugin link failed for $_path"
+		fi
+	done
+}
+
+run_smoke() {
+	if [ -z "${OMP_SYNC_SMOKE_CMD:-}" ]; then
+		return 0
+	fi
+	log "omp-sync: running smoke command"
+	# Intentionally a shell command so callers can compose checks.
+	# shellcheck disable=SC2086
+	sh -c "$OMP_SYNC_SMOKE_CMD"
+}
+
+restore_and_fail() {
+	_id=$1
+	_msg=$2
+	if [ -n "$_id" ]; then
+		restore_snapshot "$_id" || die "$EX_APPLY" "update failed and restore of $_id also failed: $_msg"
+		log "omp-sync: $_msg; previous binary restored"
+	else
+		log "omp-sync: $_msg; no snapshot to restore"
+	fi
+	exit "$EX_APPLY"
+}
+
+cmd_apply() {
+	_omp=$(resolve_omp)
+	_source=$(resolve_file "$_omp")
+	_before=$(omp_version "$_omp")
+
+	# Probe first so a registry outage never replaces the binary.
+	run_omp_update "$_omp" --check
+	_check_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
+	if [ "$LAST_UPDATE_RC" -ne 0 ]; then
+		if looks_like_network_error "$_check_log"; then
+			log "omp-sync: network failure during check; not applying"
+			exit "$EX_NETWORK"
+		fi
+		die "$EX_APPLY" "omp update --check failed (exit $LAST_UPDATE_RC); not applying"
+	fi
+	if printf '%s\n' "$_check_log" | grep -q 'Already up to date'; then
+		log "omp-sync: already up to date ($_before); no snapshot taken"
+		exit "$EX_OK"
+	fi
+
+	_id=$(snapshot_current)
+	log "omp-sync: snapshot $_id of $_source ($_before)"
+
+	# Re-resolve in case PATH/env changed; still the official updater.
+	set +e
+	# shellcheck disable=SC2086
+	"$_omp" update $PASS_THROUGH >"$(sync_root)/last-run.log" 2>&1
+	_upd_rc=$?
+	set -e
+	cat "$(sync_root)/last-run.log" >&2 || true
+	_upd_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
+
+	if [ "$_upd_rc" -ne 0 ]; then
+		if looks_like_network_error "$_upd_log"; then
+			restore_and_fail "$_id" "network failure during apply"
+		fi
+		restore_and_fail "$_id" "omp update failed (exit $_upd_rc)"
+	fi
+
+	_after_bin=$(resolve_omp)
+	if ! "$_after_bin" --version >/dev/null 2>&1; then
+		restore_and_fail "$_id" "updated binary does not run --version"
+	fi
+
+	if ! run_smoke; then
+		restore_and_fail "$_id" "smoke command failed"
+	fi
+
+	relink_extensions "$_after_bin"
+	prune_snapshots
+	_after=$(omp_version "$_after_bin")
+	log "omp-sync: apply complete ($_before -> $_after); snapshot $_id retained"
+	exit "$EX_OK"
+}
+
+cmd_rollback() {
+	_id=${ROLLBACK_ID:-}
+	if [ -z "$_id" ]; then
+		_id=$(latest_snapshot_id) || die "$EX_ROLLBACK" "no snapshots under $(snapshots_dir)"
+	fi
+	if ! is_snapshot_id "$_id"; then
+		die "$EX_USAGE" "invalid snapshot id: $_id"
+	fi
+	restore_snapshot "$_id"
+	_omp=$(resolve_omp)
+	if ! "$_omp" --version >/dev/null 2>&1; then
+		die "$EX_ROLLBACK" "restored binary does not run --version"
+	fi
+	log "omp-sync: rollback complete to $_id ($(omp_version "$_omp"))"
+	exit "$EX_OK"
+}
+
+cmd_list() {
+	_snaps=$(snapshots_dir)
+	if [ ! -d "$_snaps" ]; then
+		log "omp-sync: no snapshot directory"
+		exit "$EX_OK"
+	fi
+	_any=0
+	for _dir in "$_snaps"/*; do
+		[ -d "$_dir" ] || continue
+		_id=$(basename "$_dir")
+		is_snapshot_id "$_id" || continue
+		_any=1
+		_ver=$(read_meta_field "$_dir/meta" version)
+		_src=$(read_meta_field "$_dir/meta" source)
+		_created=$(read_meta_field "$_dir/meta" created)
+		_size=$(wc -c <"$_dir/omp" 2>/dev/null | tr -d ' ')
+		printf '%s\t%s\t%s\t%s\t%s bytes\n' "$_id" "${_ver:-?}" "${_created:-?}" "${_src:-?}" "${_size:-?}"
+	done
+	if [ "$_any" -eq 0 ]; then
+		log "omp-sync: no snapshots"
+	fi
+	exit "$EX_OK"
+}
+
+parse_args() {
+	if [ "$#" -eq 0 ]; then
+		usage
+		exit "$EX_USAGE"
+	fi
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--check)
+				[ -z "$ACTION" ] || die "$EX_USAGE" "conflicting actions"
+				ACTION=check
+				shift
+				;;
+			--apply)
+				[ -z "$ACTION" ] || die "$EX_USAGE" "conflicting actions"
+				ACTION=apply
+				shift
+				;;
+			--rollback)
+				[ -z "$ACTION" ] || die "$EX_USAGE" "conflicting actions"
+				ACTION=rollback
+				shift
+				if [ "$#" -gt 0 ]; then
+					case "$1" in
+						--*) ;;
+						*)
+							ROLLBACK_ID=$1
+							shift
+							;;
+					esac
+				fi
+				;;
+			--list)
+				[ -z "$ACTION" ] || die "$EX_USAGE" "conflicting actions"
+				ACTION=list
+				shift
+				;;
+			--help | -h)
+				usage
+				exit "$EX_OK"
+				;;
+			--)
+				shift
+				PASS_THROUGH=$*
+				break
+				;;
+			*)
+				die "$EX_USAGE" "unknown option: $1"
+				;;
+		esac
+	done
+	if [ -z "$ACTION" ]; then
+		usage
+		exit "$EX_USAGE"
+	fi
+}
+
+main() {
+	parse_args "$@"
+	if [ -z "${HOME:-}" ]; then
+		die "$EX_USAGE" "HOME is not set"
+	fi
+	ensure_sync_dirs
+	trap release_lock EXIT INT TERM HUP
+	acquire_lock
+	case "$ACTION" in
+		check) cmd_check ;;
+		apply) cmd_apply ;;
+		rollback) cmd_rollback ;;
+		list) cmd_list ;;
+		*) die "$EX_USAGE" "unknown action: $ACTION" ;;
+	esac
+}
+
+main "$@"

--- a/contrib/omp-sync/omp-sync.sh
+++ b/contrib/omp-sync/omp-sync.sh
@@ -6,6 +6,11 @@
 # command fails. User config (settings, sessions, auth, plugins) is never
 # deleted or rewritten by this script.
 #
+# Restore is the resolved file currently selected by PATH (symlink targets are
+# followed at restore time). That fully reverts standalone-binary and
+# shim-takeover installs. bun/npm managed updates rewrite node_modules, so
+# restoring the launcher entry there is partial — see contrib/omp-sync/README.md.
+#
 # This is an optional contrib. It does not change core `omp update` behavior.
 set -eu
 
@@ -40,11 +45,12 @@ Actions:
   --list               List snapshots (newest last)
   --help               Show this help
 
-Extra arguments after `--` are forwarded to `omp update` on --apply:
+Extra arguments after `--` are forwarded to `omp update` and to the apply
+preflight (`omp update --check`), preserving argument boundaries:
   omp-sync.sh --apply -- --canary
 
 Environment:
-  HOME                 Used to resolve ~/.omp (never hard-coded user paths)
+  HOME                 Used to resolve ~/.omp when the sync root is relative
   OMP_HOME             If set, snapshots live under $OMP_HOME/sync
   PI_CONFIG_DIR        Official config-dir name or absolute path (default .omp)
   OMP_SYNC_DIR         Snapshot root override (takes precedence)
@@ -54,10 +60,15 @@ Environment:
                        `omp plugin link` after a successful apply
   OMP_SYNC_SMOKE_CMD   Optional shell command run after apply; failure rolls back
 
+HOME is required only when the sync root is derived from a relative
+PI_CONFIG_DIR (default ~/.omp/sync). Absolute OMP_SYNC_DIR, OMP_HOME, or
+PI_CONFIG_DIR is enough without HOME.
+
 Exit codes:
   0  success / already up to date
   1  usage error
-  2  network / registry failure (no binary change)
+  2  network / registry failure (existing binary left in place; apply
+     restores the snapshot if the updater had already started)
   3  apply failed; previous binary restored when a snapshot existed
   4  rollback failed
   5  another omp-sync holds the lock
@@ -77,11 +88,31 @@ die() {
 	exit "$_rc"
 }
 
+# Single-quote a string so eval keeps the original argument boundaries.
+quote_shell() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
 is_abs() {
 	case "$1" in
 		/*) return 0 ;;
 		*) return 1 ;;
 	esac
+}
+
+# True when config_root/sync_root would expand $HOME.
+sync_root_needs_home() {
+	if [ -n "${OMP_SYNC_DIR:-}" ]; then
+		return 1
+	fi
+	if [ -n "${OMP_HOME:-}" ]; then
+		return 1
+	fi
+	_cfg=${PI_CONFIG_DIR:-.omp}
+	if is_abs "$_cfg"; then
+		return 1
+	fi
+	return 0
 }
 
 config_root() {
@@ -134,6 +165,13 @@ release_lock() {
 	LOCK_KIND=""
 }
 
+exit_on_signal() {
+	_num=$1
+	release_lock
+	trap - EXIT INT TERM HUP
+	exit $((128 + _num))
+}
+
 acquire_lock() {
 	_root=$(sync_root)
 	mkdir -p "$_root" || die "$EX_IO" "could not create sync root $_root"
@@ -141,8 +179,10 @@ acquire_lock() {
 	LOCK_DIR=$_root/omp-sync.lock.d
 
 	if command -v flock >/dev/null 2>&1; then
+		# Expand $LOCK_FILE at eval time so a quote/backtick in the path
+		# cannot break the redirect or run as shell source.
 		# shellcheck disable=SC2094
-		eval "exec ${LOCK_FD}>\"$LOCK_FILE\""
+		eval "exec ${LOCK_FD}>\"\$LOCK_FILE\""
 		if flock -n "$LOCK_FD"; then
 			LOCK_KIND=flock
 			return 0
@@ -240,14 +280,21 @@ is_snapshot_id() {
 	printf '%s\n' "$1" | grep -Eq '^[0-9]{8}T[0-9]{6}Z-[A-Za-z0-9._-]+$'
 }
 
+snapshot_is_complete() {
+	_sdir=$1
+	[ -d "$_sdir" ] && [ -f "$_sdir/omp" ] && [ -f "$_sdir/meta" ]
+}
+
 write_meta() {
 	_meta=$1
 	_version=$2
 	_source=$3
 	_sha=$4
+	_launcher=${5:-}
 	{
 		printf 'version=%s\n' "$_version"
 		printf 'source=%s\n' "$_source"
+		printf 'launcher=%s\n' "$_launcher"
 		printf 'created=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 		printf 'sha256=%s\n' "$_sha"
 	} >"$_meta"
@@ -261,32 +308,46 @@ read_meta_field() {
 
 snapshot_current() {
 	_omp_cmd=$(resolve_omp)
+	_launcher=$_omp_cmd
 	_source=$(resolve_file "$_omp_cmd")
 	_version=$(omp_version "$_omp_cmd")
 	_stamp=$(date -u +%Y%m%dT%H%M%SZ)
 	_id=${_stamp}-$(sanitize_id_part "$_version")-$$
-	_dir=$(snapshots_dir)/$_id
-	mkdir -p "$_dir" || die "$EX_IO" "could not create snapshot $_dir"
-	if ! cp -p "$_source" "$_dir/omp"; then
-		rm -rf "$_dir"
+	_snaps=$(snapshots_dir)
+	_staging=$_snaps/.tmp-$_id
+	_dir=$_snaps/$_id
+	rm -rf "$_staging"
+	mkdir -p "$_staging" || die "$EX_IO" "could not create snapshot $_staging"
+	if ! cp -p "$_source" "$_staging/omp"; then
+		rm -rf "$_staging"
 		die "$EX_IO" "could not copy $_source into snapshot"
 	fi
-	_sha=$(file_sha256 "$_dir/omp")
-	write_meta "$_dir/meta" "$_version" "$_source" "$_sha"
+	_sha=$(file_sha256 "$_staging/omp")
+	write_meta "$_staging/meta" "$_version" "$_source" "$_sha" "$_launcher"
+	if ! mv "$_staging" "$_dir"; then
+		rm -rf "$_staging"
+		die "$EX_IO" "could not finalize snapshot $_dir"
+	fi
 	printf '%s\n' "$_id"
 }
 
 restore_snapshot() {
 	_id=$1
 	_dir=$(snapshots_dir)/$_id
-	if [ ! -d "$_dir" ] || [ ! -f "$_dir/omp" ]; then
-		die "$EX_ROLLBACK" "snapshot not found: $_id"
+	if ! snapshot_is_complete "$_dir"; then
+		die "$EX_ROLLBACK" "snapshot not found or incomplete: $_id"
 	fi
-	_source=$(read_meta_field "$_dir/meta" source)
-	if [ -z "$_source" ]; then
-		_omp_cmd=$(resolve_omp)
-		_source=$(resolve_file "$_omp_cmd")
+	_want=$(read_meta_field "$_dir/meta" sha256)
+	if [ -n "$_want" ]; then
+		_got=$(file_sha256 "$_dir/omp")
+		if [ -n "$_got" ] && [ "$_got" != "$_want" ]; then
+			die "$EX_ROLLBACK" "snapshot $_id checksum mismatch"
+		fi
 	fi
+	# Overwrite the file PATH currently resolves to, not the possibly stale
+	# source recorded at snapshot time (an update may have retargeted a symlink).
+	_omp_cmd=$(resolve_omp)
+	_source=$(resolve_file "$_omp_cmd")
 	_parent=$(dirname "$_source")
 	if [ ! -d "$_parent" ]; then
 		die "$EX_ROLLBACK" "restore target directory missing: $_parent"
@@ -314,6 +375,7 @@ latest_snapshot_id() {
 		[ -d "$_name" ] || continue
 		_id=$(basename "$_name")
 		is_snapshot_id "$_id" || continue
+		snapshot_is_complete "$_name" || continue
 		_last=$_id
 	done
 	if [ -z "$_last" ]; then
@@ -337,6 +399,11 @@ prune_snapshots() {
 		[ -d "$_name" ] || continue
 		_id=$(basename "$_name")
 		is_snapshot_id "$_id" || continue
+		if ! snapshot_is_complete "$_name"; then
+			rm -rf "$_name"
+			log "omp-sync: removed incomplete snapshot $_id"
+			continue
+		fi
 		_list="$_list $_id"
 		_n=$((_n + 1))
 	done
@@ -374,9 +441,21 @@ run_omp_update() {
 	cat "$_log" || true
 }
 
+# Invoke run_omp_update with eval-quoted extra args from PASS_THROUGH.
+omp_update_with_pass_through() {
+	_bin=$(quote_shell "$1")
+	shift
+	_pre=""
+	while [ "$#" -gt 0 ]; do
+		_pre="$_pre $(quote_shell "$1")"
+		shift
+	done
+	eval "run_omp_update ${_bin}${_pre}${PASS_THROUGH}"
+}
+
 cmd_check() {
 	_omp=$(resolve_omp)
-	run_omp_update "$_omp" --check
+	omp_update_with_pass_through "$_omp" --check
 	_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
 	if [ "$LAST_UPDATE_RC" -eq 0 ]; then
 		exit "$EX_OK"
@@ -401,8 +480,16 @@ relink_extensions() {
 	IFS=$_oldifs
 	for _path in "$@"; do
 		[ -n "$_path" ] || continue
+		# Quoted/escaped tilde so a literal ~/ prefix is not expanded to $HOME
+		# by the case pattern (which would skip values such as ~/src/plugin).
 		case "$_path" in
-			~/*) _path=$HOME/${_path#~/} ;;
+			'~/'* | \~/*)
+				if [ -z "${HOME:-}" ]; then
+					log "omp-sync: skip relink, cannot expand ~ without HOME: $_path"
+					continue
+				fi
+				_path="${HOME}/${_path#~/}"
+				;;
 		esac
 		if [ ! -e "$_path" ]; then
 			log "omp-sync: skip relink, path does not exist: $_path"
@@ -428,13 +515,14 @@ run_smoke() {
 restore_and_fail() {
 	_id=$1
 	_msg=$2
+	_rc=${3:-$EX_APPLY}
 	if [ -n "$_id" ]; then
 		restore_snapshot "$_id" || die "$EX_APPLY" "update failed and restore of $_id also failed: $_msg"
 		log "omp-sync: $_msg; previous binary restored"
 	else
 		log "omp-sync: $_msg; no snapshot to restore"
 	fi
-	exit "$EX_APPLY"
+	exit "$_rc"
 }
 
 cmd_apply() {
@@ -442,8 +530,9 @@ cmd_apply() {
 	_source=$(resolve_file "$_omp")
 	_before=$(omp_version "$_omp")
 
-	# Probe first so a registry outage never replaces the binary.
-	run_omp_update "$_omp" --check
+	# Probe first so a registry outage never replaces the binary. Forward
+	# --canary/--stable/--force so a channel switch is not skipped as current.
+	omp_update_with_pass_through "$_omp" --check
 	_check_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
 	if [ "$LAST_UPDATE_RC" -ne 0 ]; then
 		if looks_like_network_error "$_check_log"; then
@@ -460,18 +549,13 @@ cmd_apply() {
 	_id=$(snapshot_current)
 	log "omp-sync: snapshot $_id of $_source ($_before)"
 
-	# Re-resolve in case PATH/env changed; still the official updater.
-	set +e
-	# shellcheck disable=SC2086
-	"$_omp" update $PASS_THROUGH >"$(sync_root)/last-run.log" 2>&1
-	_upd_rc=$?
-	set -e
-	cat "$(sync_root)/last-run.log" >&2 || true
+	omp_update_with_pass_through "$_omp"
+	_upd_rc=$LAST_UPDATE_RC
 	_upd_log=$(cat "$(sync_root)/last-run.log" 2>/dev/null || true)
 
 	if [ "$_upd_rc" -ne 0 ]; then
 		if looks_like_network_error "$_upd_log"; then
-			restore_and_fail "$_id" "network failure during apply"
+			restore_and_fail "$_id" "network failure during apply" "$EX_NETWORK"
 		fi
 		restore_and_fail "$_id" "omp update failed (exit $_upd_rc)"
 	fi
@@ -520,6 +604,7 @@ cmd_list() {
 		[ -d "$_dir" ] || continue
 		_id=$(basename "$_dir")
 		is_snapshot_id "$_id" || continue
+		snapshot_is_complete "$_dir" || continue
 		_any=1
 		_ver=$(read_meta_field "$_dir/meta" version)
 		_src=$(read_meta_field "$_dir/meta" source)
@@ -575,7 +660,11 @@ parse_args() {
 				;;
 			--)
 				shift
-				PASS_THROUGH=$*
+				PASS_THROUGH=""
+				while [ "$#" -gt 0 ]; do
+					PASS_THROUGH="$PASS_THROUGH $(quote_shell "$1")"
+					shift
+				done
 				break
 				;;
 			*)
@@ -591,11 +680,14 @@ parse_args() {
 
 main() {
 	parse_args "$@"
-	if [ -z "${HOME:-}" ]; then
+	if sync_root_needs_home && [ -z "${HOME:-}" ]; then
 		die "$EX_USAGE" "HOME is not set"
 	fi
 	ensure_sync_dirs
-	trap release_lock EXIT INT TERM HUP
+	trap release_lock EXIT
+	trap 'exit_on_signal 2' INT
+	trap 'exit_on_signal 15' TERM
+	trap 'exit_on_signal 1' HUP
 	acquire_lock
 	case "$ACTION" in
 		check) cmd_check ;;

--- a/contrib/omp-sync/omp-sync.sh
+++ b/contrib/omp-sync/omp-sync.sh
@@ -31,6 +31,7 @@ PASS_THROUGH=""
 LOCK_KIND=""
 LOCK_DIR=""
 LOCK_FILE=""
+CHILD_PID=""
 
 usage() {
 	cat <<'EOF'
@@ -167,6 +168,17 @@ release_lock() {
 
 exit_on_signal() {
 	_num=$1
+	# Kill the in-flight updater/smoke child so `exit` is not deferred until
+	# that foreground-equivalent wait finishes, and so the lock is not
+	# released while `omp update` is still running.
+	if [ -n "${CHILD_PID:-}" ]; then
+		kill -TERM "$CHILD_PID" 2>/dev/null || true
+		kill -KILL "$CHILD_PID" 2>/dev/null || true
+		set +e
+		wait "$CHILD_PID" 2>/dev/null
+		set -e
+		CHILD_PID=""
+	fi
 	release_lock
 	trap - EXIT INT TERM HUP
 	exit $((128 + _num))
@@ -435,8 +447,11 @@ run_omp_update() {
 	shift
 	_log=$(sync_root)/last-run.log
 	set +e
-	"$_omp" update "$@" >"$_log" 2>&1
+	"$_omp" update "$@" >"$_log" 2>&1 &
+	CHILD_PID=$!
+	wait "$CHILD_PID"
 	LAST_UPDATE_RC=$?
+	CHILD_PID=""
 	set -e
 	cat "$_log" || true
 }
@@ -488,7 +503,7 @@ relink_extensions() {
 					log "omp-sync: skip relink, cannot expand ~ without HOME: $_path"
 					continue
 				fi
-				_path="${HOME}/${_path#~/}"
+				_path="${HOME}/${_path#"~/"}"
 				;;
 		esac
 		if [ ! -e "$_path" ]; then
@@ -508,8 +523,15 @@ run_smoke() {
 	fi
 	log "omp-sync: running smoke command"
 	# Intentionally a shell command so callers can compose checks.
+	set +e
 	# shellcheck disable=SC2086
-	sh -c "$OMP_SYNC_SMOKE_CMD"
+	sh -c "$OMP_SYNC_SMOKE_CMD" &
+	CHILD_PID=$!
+	wait "$CHILD_PID"
+	_smoke_rc=$?
+	CHILD_PID=""
+	set -e
+	return "$_smoke_rc"
 }
 
 restore_and_fail() {

--- a/contrib/omp-sync/omp-sync.test.sh
+++ b/contrib/omp-sync/omp-sync.test.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+# Contract tests for omp-sync.sh. Run from this directory or via:
+#   sh contrib/omp-sync/omp-sync.test.sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT=$ROOT/omp-sync.sh
+FAILED=0
+
+assert_eq() {
+	_name=$1
+	_got=$2
+	_want=$3
+	if [ "$_got" = "$_want" ]; then
+		printf 'ok  %s\n' "$_name"
+	else
+		printf 'not ok  %s: got %s want %s\n' "$_name" "$_got" "$_want"
+		FAILED=$((FAILED + 1))
+	fi
+}
+
+assert_file() {
+	_name=$1
+	_path=$2
+	if [ -f "$_path" ]; then
+		printf 'ok  %s\n' "$_name"
+	else
+		printf 'not ok  %s: missing %s\n' "$_name" "$_path"
+		FAILED=$((FAILED + 1))
+	fi
+}
+
+assert_not_file_changed() {
+	_name=$1
+	_path=$2
+	_want=$3
+	_got=$(cat "$_path")
+	assert_eq "$_name" "$_got" "$_want"
+}
+
+write_fake_omp() {
+	_dest=$1
+	_version=$2
+	_mode=${3:-ok}
+	cat >"$_dest" <<EOF
+#!/bin/sh
+VERSION=$_version
+MODE=$_mode
+STATE=\$(dirname "\$0")/state
+cmd=\${1:-}
+if [ "\$cmd" = "--version" ]; then
+	printf 'omp/%s\n' "\$VERSION"
+	exit 0
+fi
+if [ "\$cmd" = "plugin" ] && [ "\${2:-}" = "link" ]; then
+	printf '%s\n' "\$3" >>"\$STATE/relinked"
+	exit 0
+fi
+if [ "\$cmd" != "update" ]; then
+	printf 'unexpected: %s\n' "\$*" >&2
+	exit 99
+fi
+if [ "\${2:-}" = "--check" ]; then
+	if [ "\$MODE" = "net" ]; then
+		printf 'Failed to check for updates: Unable to connect. getaddrinfo ENOTFOUND\n' >&2
+		exit 1
+	fi
+	if [ "\$MODE" = "current" ]; then
+		printf 'Already up to date\n'
+		exit 0
+	fi
+	printf 'New version available: 2.0.0\n'
+	exit 0
+fi
+if [ "\$MODE" = "fail" ]; then
+	printf '#!/bin/sh\necho broken\nexit 1\n' >"\$0"
+	chmod +x "\$0"
+	printf 'Update failed: boom\n' >&2
+	exit 1
+fi
+if [ "\$MODE" = "net-apply" ]; then
+	printf 'Failed to check for updates: fetch failed\n' >&2
+	exit 1
+fi
+# Successful self-replace: rewrite VERSION in this file.
+tmp=\$0.tmp.\$\$
+sed "s/^VERSION=.*/VERSION=2.0.0/" "\$0" >"\$tmp"
+chmod +x "\$tmp"
+mv -f "\$tmp" "\$0"
+printf 'Updated to 2.0.0\n'
+exit 0
+EOF
+	chmod +x "$_dest"
+}
+
+run_sync() {
+	set +e
+	HOME=$TEST_HOME \
+		OMP_HOME=$TEST_HOME/.omp \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		PATH="$(dirname "$FAKE_OMP"):$PATH" \
+		"$SCRIPT" "$@" >"$TEST_ROOT/last-stdout" 2>"$TEST_ROOT/last-stderr"
+	_rc=$?
+	set -e
+	printf '%s\n' "$_rc"
+}
+
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/omp-sync-test.XXXXXX")
+TEST_HOME=$TEST_ROOT/home
+mkdir -p "$TEST_HOME/.omp/agent" "$TEST_HOME/bin" "$TEST_HOME/plugin"
+printf 'keep-me: true\n' >"$TEST_HOME/.omp/config.yml"
+printf 'sessions-ok\n' >"$TEST_HOME/.omp/agent/session-marker"
+FAKE_OMP=$TEST_HOME/bin/omp
+CONFIG_COPY='keep-me: true'
+
+# --help
+rc=$(
+	set +e
+	"$SCRIPT" --help >/dev/null
+	printf '%s\n' $?
+)
+assert_eq "help exits 0" "$rc" "0"
+
+# missing binary
+rc=$(
+	set +e
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$TEST_HOME/bin/missing \
+		"$SCRIPT" --check >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "missing omp exits 6" "$rc" "6"
+assert_not_file_changed "config intact after missing omp" "$TEST_HOME/.omp/config.yml" "$CONFIG_COPY"
+
+# --check already up to date
+write_fake_omp "$FAKE_OMP" "1.0.0" current
+rc=$(run_sync --check)
+assert_eq "check up to date exits 0" "$rc" "0"
+
+# --check network
+write_fake_omp "$FAKE_OMP" "1.0.0" net
+rc=$(run_sync --check)
+assert_eq "check network exits 2" "$rc" "2"
+assert_not_file_changed "config intact after network check" "$TEST_HOME/.omp/config.yml" "$CONFIG_COPY"
+assert_file "session marker intact after network check" "$TEST_HOME/.omp/agent/session-marker"
+
+# --apply already up to date: no snapshot
+write_fake_omp "$FAKE_OMP" "1.0.0" current
+rc=$(run_sync --apply)
+assert_eq "apply up to date exits 0" "$rc" "0"
+snap_count=$(find "$TEST_HOME/.omp/sync/snapshots" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "apply up to date takes no snapshot" "$snap_count" "0"
+
+# --apply success
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+rc=$(run_sync --apply)
+assert_eq "apply success exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "apply success updates version" "$got" "omp/2.0.0"
+snap_count=$(find "$TEST_HOME/.omp/sync/snapshots" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+assert_eq "apply success keeps one snapshot" "$snap_count" "1"
+
+# --list is non-empty
+list_out=$(
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$FAKE_OMP "$SCRIPT" --list 2>/dev/null
+)
+case "$list_out" in
+	*1.0.0*) printf 'ok  list shows snapshot version\n' ;;
+	*)
+		printf 'not ok  list shows snapshot version: %s\n' "$list_out"
+		FAILED=$((FAILED + 1))
+		;;
+esac
+
+# --rollback restores 1.0.0
+rc=$(run_sync --rollback)
+assert_eq "rollback exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "rollback restores previous version" "$got" "omp/1.0.0"
+
+# --apply failure restores previous binary
+write_fake_omp "$FAKE_OMP" "1.0.0" fail
+rc=$(run_sync --apply)
+assert_eq "apply failure exits 3" "$rc" "3"
+got=$("$FAKE_OMP" --version)
+assert_eq "apply failure restores binary" "$got" "omp/1.0.0"
+assert_not_file_changed "config intact after failed apply" "$TEST_HOME/.omp/config.yml" "$CONFIG_COPY"
+
+# smoke failure restores
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+rc=$(
+	set +e
+	HOME=$TEST_HOME \
+		OMP_HOME=$TEST_HOME/.omp \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		OMP_SYNC_SMOKE_CMD='exit 42' \
+		"$SCRIPT" --apply >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "smoke failure exits 3" "$rc" "3"
+got=$("$FAKE_OMP" --version)
+assert_eq "smoke failure restores binary" "$got" "omp/1.0.0"
+
+# relink after success
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+mkdir -p "$TEST_HOME/plugin"
+printf 'plugin\n' >"$TEST_HOME/plugin/package.json"
+mkdir -p "$(dirname "$FAKE_OMP")/state"
+rc=$(
+	set +e
+	HOME=$TEST_HOME \
+		OMP_HOME=$TEST_HOME/.omp \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		OMP_SYNC_RELINK_EXT="$TEST_HOME/plugin" \
+		"$SCRIPT" --apply >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "apply with relink exits 0" "$rc" "0"
+relinked=$(cat "$(dirname "$FAKE_OMP")/state/relinked")
+assert_eq "relink called plugin path" "$relinked" "$TEST_HOME/plugin"
+
+# prune keeps last N
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+i=0
+while [ "$i" -lt 4 ]; do
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$FAKE_OMP \
+		OMP_SYNC_KEEP=2 "$SCRIPT" --apply >/dev/null 2>&1 || true
+	write_fake_omp "$FAKE_OMP" "1.0.0" ok
+	i=$((i + 1))
+done
+snap_count=$(find "$TEST_HOME/.omp/sync/snapshots" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+assert_eq "prune keeps 2 snapshots" "$snap_count" "2"
+assert_file "config still present after prune" "$TEST_HOME/.omp/config.yml"
+assert_file "agent marker still present after prune" "$TEST_HOME/.omp/agent/session-marker"
+
+# network during apply check does not snapshot-replace
+write_fake_omp "$FAKE_OMP" "1.0.0" net
+before=$("$FAKE_OMP" --version)
+rc=$(run_sync --apply)
+assert_eq "apply network check exits 2" "$rc" "2"
+got=$("$FAKE_OMP" --version)
+assert_eq "apply network leaves binary" "$got" "$before"
+
+rm -rf "$TEST_ROOT"
+
+if [ "$FAILED" -ne 0 ]; then
+	printf '\n%d test(s) failed\n' "$FAILED"
+	exit 1
+fi
+printf '\nall tests passed\n'
+exit 0

--- a/contrib/omp-sync/omp-sync.test.sh
+++ b/contrib/omp-sync/omp-sync.test.sh
@@ -275,7 +275,7 @@ rc=$(
 	printf '%s\n' $?
 )
 assert_eq "apply with ~/ relink exits 0" "$rc" "0"
-relinked=$(cat "$(dirname "$FAKE_OMP")/state/relinked")
+relinked=$(cat "$(dirname "$FAKE_OMP")/state/relinked" 2>/dev/null || true)
 assert_eq "relink expands literal tilde prefix" "$relinked" "$TEST_HOME/plugin"
 
 # prune keeps last N
@@ -453,6 +453,14 @@ if [ ! -f "$(dirname "$FAKE_OMP")/state/hanging" ]; then
 	kill -KILL "$hang_pid" 2>/dev/null || true
 else
 	kill -TERM "$hang_pid" 2>/dev/null || true
+	j=0
+	while [ "$j" -lt 50 ]; do
+		if ! kill -0 "$hang_pid" 2>/dev/null; then
+			break
+		fi
+		sleep 0.1
+		j=$((j + 1))
+	done
 	set +e
 	wait "$hang_pid"
 	hang_rc=$?
@@ -467,6 +475,12 @@ else
 		kill -KILL "$hang_pid" 2>/dev/null || true
 	fi
 	assert_eq "SIGTERM apply does not stay running" "$still" "0"
+	if [ "$j" -ge 50 ]; then
+		printf 'not ok  SIGTERM apply returns promptly: still waited 5s\n'
+		FAILED=$((FAILED + 1))
+	else
+		printf 'ok  SIGTERM apply returns promptly\n'
+	fi
 	if [ "$hang_rc" -eq 0 ]; then
 		printf 'not ok  SIGTERM apply exits non-zero: got 0\n'
 		FAILED=$((FAILED + 1))

--- a/contrib/omp-sync/omp-sync.test.sh
+++ b/contrib/omp-sync/omp-sync.test.sh
@@ -42,17 +42,28 @@ write_fake_omp() {
 	_dest=$1
 	_version=$2
 	_mode=${3:-ok}
+	_launcher=${4:-}
 	cat >"$_dest" <<EOF
 #!/bin/sh
 VERSION=$_version
 MODE=$_mode
+LAUNCHER=$_launcher
 STATE=\$(dirname "\$0")/state
 cmd=\${1:-}
+is_check=0
+has_channel_or_force=0
+for _a in "\$@"; do
+	case "\$_a" in
+		--check | -c) is_check=1 ;;
+		--canary | --stable | --force | -f) has_channel_or_force=1 ;;
+	esac
+done
 if [ "\$cmd" = "--version" ]; then
 	printf 'omp/%s\n' "\$VERSION"
 	exit 0
 fi
 if [ "\$cmd" = "plugin" ] && [ "\${2:-}" = "link" ]; then
+	mkdir -p "\$STATE"
 	printf '%s\n' "\$3" >>"\$STATE/relinked"
 	exit 0
 fi
@@ -60,12 +71,17 @@ if [ "\$cmd" != "update" ]; then
 	printf 'unexpected: %s\n' "\$*" >&2
 	exit 99
 fi
-if [ "\${2:-}" = "--check" ]; then
+if [ "\$is_check" -eq 1 ]; then
+	mkdir -p "\$STATE"
+	: >"\$STATE/check-args"
+	for _a in "\$@"; do
+		printf '%s\n' "\$_a" >>"\$STATE/check-args"
+	done
 	if [ "\$MODE" = "net" ]; then
 		printf 'Failed to check for updates: Unable to connect. getaddrinfo ENOTFOUND\n' >&2
 		exit 1
 	fi
-	if [ "\$MODE" = "current" ]; then
+	if [ "\$MODE" = "current" ] && [ "\$has_channel_or_force" -eq 0 ]; then
 		printf 'Already up to date\n'
 		exit 0
 	fi
@@ -81,6 +97,25 @@ fi
 if [ "\$MODE" = "net-apply" ]; then
 	printf 'Failed to check for updates: fetch failed\n' >&2
 	exit 1
+fi
+if [ "\$MODE" = "hang" ]; then
+	mkdir -p "\$STATE"
+	printf '%s\n' "\$\$" >"\$STATE/hang-pid"
+	printf 'hanging\n' >"\$STATE/hanging"
+	sleep 60
+	exit 0
+fi
+if [ "\$MODE" = "retarget" ]; then
+	_target=\$LAUNCHER
+	if [ -z "\$_target" ]; then
+		_target=\$0
+	fi
+	_new=\$(dirname "\$_target")/omp-new
+	printf '#!/bin/sh\nprintf "omp/2.0.0\\n"\n' >"\$_new"
+	chmod +x "\$_new"
+	ln -sfn "\$_new" "\$_target"
+	printf 'Updated to 2.0.0\n'
+	exit 0
 fi
 # Successful self-replace: rewrite VERSION in this file.
 tmp=\$0.tmp.\$\$
@@ -185,6 +220,14 @@ got=$("$FAKE_OMP" --version)
 assert_eq "apply failure restores binary" "$got" "omp/1.0.0"
 assert_not_file_changed "config intact after failed apply" "$TEST_HOME/.omp/config.yml" "$CONFIG_COPY"
 
+# network during apply (after a successful check) restores and exits 2
+write_fake_omp "$FAKE_OMP" "1.0.0" net-apply
+before=$("$FAKE_OMP" --version)
+rc=$(run_sync --apply)
+assert_eq "apply network after check exits 2" "$rc" "2"
+got=$("$FAKE_OMP" --version)
+assert_eq "apply network after check restores binary" "$got" "$before"
+
 # smoke failure restores
 write_fake_omp "$FAKE_OMP" "1.0.0" ok
 rc=$(
@@ -205,6 +248,7 @@ write_fake_omp "$FAKE_OMP" "1.0.0" ok
 mkdir -p "$TEST_HOME/plugin"
 printf 'plugin\n' >"$TEST_HOME/plugin/package.json"
 mkdir -p "$(dirname "$FAKE_OMP")/state"
+rm -f "$(dirname "$FAKE_OMP")/state/relinked"
 rc=$(
 	set +e
 	HOME=$TEST_HOME \
@@ -217,6 +261,22 @@ rc=$(
 assert_eq "apply with relink exits 0" "$rc" "0"
 relinked=$(cat "$(dirname "$FAKE_OMP")/state/relinked")
 assert_eq "relink called plugin path" "$relinked" "$TEST_HOME/plugin"
+
+# literal ~/ prefix in OMP_SYNC_RELINK_EXT expands via $HOME, not case-tilde
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+rm -f "$(dirname "$FAKE_OMP")/state/relinked"
+rc=$(
+	set +e
+	HOME=$TEST_HOME \
+		OMP_HOME=$TEST_HOME/.omp \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		OMP_SYNC_RELINK_EXT='~/plugin' \
+		"$SCRIPT" --apply >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "apply with ~/ relink exits 0" "$rc" "0"
+relinked=$(cat "$(dirname "$FAKE_OMP")/state/relinked")
+assert_eq "relink expands literal tilde prefix" "$relinked" "$TEST_HOME/plugin"
 
 # prune keeps last N
 write_fake_omp "$FAKE_OMP" "1.0.0" ok
@@ -239,6 +299,183 @@ rc=$(run_sync --apply)
 assert_eq "apply network check exits 2" "$rc" "2"
 got=$("$FAKE_OMP" --version)
 assert_eq "apply network leaves binary" "$got" "$before"
+
+# --apply -- --canary on a current install must still apply (preflight gets --canary)
+write_fake_omp "$FAKE_OMP" "1.0.0" current
+mkdir -p "$(dirname "$FAKE_OMP")/state"
+rm -f "$(dirname "$FAKE_OMP")/state/check-args"
+rc=$(run_sync --apply -- --canary)
+assert_eq "apply --canary on current exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "apply --canary on current updates version" "$got" "omp/2.0.0"
+if grep -qx -- --canary "$(dirname "$FAKE_OMP")/state/check-args" &&
+	grep -qx -- --check "$(dirname "$FAKE_OMP")/state/check-args"; then
+	printf 'ok  preflight check received --canary\n'
+else
+	printf 'not ok  preflight check received --canary: %s\n' "$(cat "$(dirname "$FAKE_OMP")/state/check-args")"
+	FAILED=$((FAILED + 1))
+fi
+
+# --apply -- --force with a spaced extra arg keeps argument boundaries
+write_fake_omp "$FAKE_OMP" "1.0.0" current
+rm -f "$(dirname "$FAKE_OMP")/state/check-args"
+rc=$(run_sync --apply -- --force --note "hello world")
+assert_eq "apply --force with spaced arg exits 0" "$rc" "0"
+if grep -qx -- --force "$(dirname "$FAKE_OMP")/state/check-args" &&
+	grep -qx -- "hello world" "$(dirname "$FAKE_OMP")/state/check-args"; then
+	printf 'ok  preflight preserves spaced argument\n'
+else
+	printf 'not ok  preflight preserves spaced argument: %s\n' "$(cat "$(dirname "$FAKE_OMP")/state/check-args")"
+	FAILED=$((FAILED + 1))
+fi
+
+# incomplete snapshot without meta is skipped; rollback uses a complete one
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+rc=$(run_sync --apply)
+assert_eq "apply before incomplete-snapshot test exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "version is 2.0.0 before incomplete rollback" "$got" "omp/2.0.0"
+incomplete_id='20990101T000000Z-incomplete-1'
+incomplete_dir=$TEST_HOME/.omp/sync/snapshots/$incomplete_id
+mkdir -p "$incomplete_dir"
+printf 'partial-not-a-binary\n' >"$incomplete_dir/omp"
+rc=$(run_sync --rollback)
+assert_eq "rollback skips incomplete snapshot without meta" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "rollback from complete snapshot restores 1.0.0" "$got" "omp/1.0.0"
+rc=$(
+	set +e
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --rollback "$incomplete_id" >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "explicit incomplete snapshot exits 4" "$rc" "4"
+
+# checksum mismatch is rejected before replacing the live binary
+write_fake_omp "$FAKE_OMP" "1.0.0" ok
+rc=$(run_sync --apply)
+assert_eq "apply before checksum test exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "checksum test starts at 2.0.0" "$got" "omp/2.0.0"
+good_id=$(
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --list 2>/dev/null | awk 'NF{id=$1} END{print id}'
+)
+printf 'tampered\n' >"$TEST_HOME/.omp/sync/snapshots/$good_id/omp"
+rc=$(
+	set +e
+	HOME=$TEST_HOME OMP_HOME=$TEST_HOME/.omp OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --rollback "$good_id" >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "checksum mismatch exits 4" "$rc" "4"
+got=$("$FAKE_OMP" --version)
+assert_eq "checksum mismatch leaves live binary" "$got" "omp/2.0.0"
+
+# retargeted PATH symlink is restored at the live target, not the stale source
+RETARGET_ROOT=$TEST_HOME/retarget
+mkdir -p "$RETARGET_ROOT/v1" "$TEST_HOME/bin"
+write_fake_omp "$RETARGET_ROOT/v1/omp" "1.0.0" retarget "$TEST_HOME/bin/omp"
+ln -sfn "$RETARGET_ROOT/v1/omp" "$TEST_HOME/bin/omp"
+FAKE_OMP=$TEST_HOME/bin/omp
+rc=$(run_sync --apply)
+assert_eq "retarget apply exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "retarget apply updates via new symlink target" "$got" "omp/2.0.0"
+rc=$(run_sync --rollback)
+assert_eq "retarget rollback exits 0" "$rc" "0"
+got=$("$FAKE_OMP" --version)
+assert_eq "retarget rollback restores PATH-resolved binary" "$got" "omp/1.0.0"
+FAKE_OMP=$TEST_HOME/bin/omp
+
+# lock path with a quote in OMP_SYNC_DIR does not break eval
+QUOTE_SYNC=$TEST_ROOT/dir-with-\'-quote
+mkdir -p "$QUOTE_SYNC"
+write_fake_omp "$FAKE_OMP" "1.0.0" current
+rc=$(
+	set +e
+	HOME=$TEST_HOME \
+		OMP_SYNC_DIR="$QUOTE_SYNC" \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --list >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "list with quote in sync dir exits 0" "$rc" "0"
+
+# HOME unset is allowed when an absolute sync root is provided
+rc=$(
+	set +e
+	env -u HOME \
+		OMP_SYNC_DIR="$TEST_HOME/.omp/sync" \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --list >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "list without HOME with abs OMP_SYNC_DIR exits 0" "$rc" "0"
+
+rc=$(
+	set +e
+	env -u HOME \
+		OMP_HOME="$TEST_HOME/.omp" \
+		OMP_SYNC_BIN=$FAKE_OMP \
+		"$SCRIPT" --list >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "list without HOME with OMP_HOME exits 0" "$rc" "0"
+
+rc=$(
+	set +e
+	env -u HOME \
+		"$SCRIPT" --list >/dev/null 2>&1
+	printf '%s\n' $?
+)
+assert_eq "list without HOME or abs root exits 1" "$rc" "1"
+
+# SIGTERM during apply must exit instead of finishing the update
+write_fake_omp "$FAKE_OMP" "1.0.0" hang
+rm -f "$(dirname "$FAKE_OMP")/state/hanging" "$(dirname "$FAKE_OMP")/state/hang-pid"
+HOME=$TEST_HOME \
+	OMP_HOME=$TEST_HOME/.omp \
+	OMP_SYNC_BIN=$FAKE_OMP \
+	"$SCRIPT" --apply >/dev/null 2>&1 &
+hang_pid=$!
+i=0
+while [ "$i" -lt 50 ]; do
+	if [ -f "$(dirname "$FAKE_OMP")/state/hanging" ]; then
+		break
+	fi
+	sleep 0.1
+	i=$((i + 1))
+done
+if [ ! -f "$(dirname "$FAKE_OMP")/state/hanging" ]; then
+	printf 'not ok  hang apply started: marker missing\n'
+	FAILED=$((FAILED + 1))
+	kill -KILL "$hang_pid" 2>/dev/null || true
+else
+	kill -TERM "$hang_pid" 2>/dev/null || true
+	set +e
+	wait "$hang_pid"
+	hang_rc=$?
+	set -e
+	child=$(cat "$(dirname "$FAKE_OMP")/state/hang-pid" 2>/dev/null || true)
+	if [ -n "$child" ]; then
+		kill -KILL "$child" 2>/dev/null || true
+	fi
+	still=0
+	if kill -0 "$hang_pid" 2>/dev/null; then
+		still=1
+		kill -KILL "$hang_pid" 2>/dev/null || true
+	fi
+	assert_eq "SIGTERM apply does not stay running" "$still" "0"
+	if [ "$hang_rc" -eq 0 ]; then
+		printf 'not ok  SIGTERM apply exits non-zero: got 0\n'
+		FAILED=$((FAILED + 1))
+	else
+		printf 'ok  SIGTERM apply exits non-zero\n'
+	fi
+	got=$("$FAKE_OMP" --version)
+	assert_eq "SIGTERM apply does not finish update" "$got" "omp/1.0.0"
+fi
 
 rm -rf "$TEST_ROOT"
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -239,7 +239,7 @@ Run `omp <command> --help` for each command's own flags and examples.
 | `render` | Draw a session's entire thread through the production transcript pipeline (with repaint timing). | |
 | `ssh` | Manage SSH host configurations. | |
 | `stats` | View usage statistics. | |
-| `update` | Check for and install updates; `--canary`/`--stable` switch release channels. | |
+| `update` | Check for and install updates; `--canary`/`--stable` switch release channels. | [Safe binary update](./safe-binary-update.md) |
 | `usage` | Show provider usage limits for every authenticated account; `usage clients` breaks token burn down per client (with `--days`), `usage invalidate` drops cached reports. | |
 | `tiny-models` | Download tiny local models (session titles + memory). | [local models](./local-models.md) |
 | `token` | Get the API key or OAuth token for a provider. | [secrets](./secrets.md) |

--- a/docs/safe-binary-update.md
+++ b/docs/safe-binary-update.md
@@ -1,0 +1,19 @@
+# Safe binary update
+
+Official updates are `omp update` and `omp update --check`. Those commands
+detect the active install (standalone binary, bun, npm, Homebrew, mise, Nix)
+and install the selected channel. See `omp update --help` and the `update`
+row in the [CLI reference](./cli-reference.md).
+
+This repository also ships an **optional** contrib wrapper that adds
+snapshot/rollback around that same CLI. It does not change core update
+behavior:
+
+- [`contrib/omp-sync/omp-sync.sh`](../contrib/omp-sync/omp-sync.sh) — portable
+  fail-soft wrapper (`--check`, `--apply`, `--rollback`, `--list`)
+- [`contrib/omp-sync/README.md`](../contrib/omp-sync/README.md) — usage, exit
+  codes, snapshot location, and safety guarantees
+
+Use the wrapper when you want a copy of the previous launcher kept under
+`~/.omp/sync/` (or `$OMP_HOME/sync`) and restored if `omp update` or an
+optional smoke command fails. User config is never deleted by the wrapper.

--- a/docs/safe-binary-update.md
+++ b/docs/safe-binary-update.md
@@ -1,9 +1,13 @@
 # Safe binary update
 
 Official updates are `omp update` and `omp update --check`. Those commands
-detect the active install (standalone binary, bun, npm, Homebrew, mise, Nix)
-and install the selected channel. See `omp update --help` and the `update`
-row in the [CLI reference](./cli-reference.md).
+detect the active install (standalone binary, bun, npm, Homebrew, mise, Nix).
+Standalone binary, bun, npm, Homebrew, and mise installs can install the
+selected channel. Nix-managed installs are detection-only: `omp update`
+reports that the installation cannot update itself and returns without
+installing anything — update the flake input or profile that provides omp,
+then rebuild. See `omp update --help` and the `update` row in the
+[CLI reference](./cli-reference.md).
 
 This repository also ships an **optional** contrib wrapper that adds
 snapshot/rollback around that same CLI. It does not change core update
@@ -12,8 +16,10 @@ behavior:
 - [`contrib/omp-sync/omp-sync.sh`](../contrib/omp-sync/omp-sync.sh) — portable
   fail-soft wrapper (`--check`, `--apply`, `--rollback`, `--list`)
 - [`contrib/omp-sync/README.md`](../contrib/omp-sync/README.md) — usage, exit
-  codes, snapshot location, and safety guarantees
+  codes, snapshot location, rollback coverage, and safety guarantees
 
 Use the wrapper when you want a copy of the previous launcher kept under
 `~/.omp/sync/` (or `$OMP_HOME/sync`) and restored if `omp update` or an
-optional smoke command fails. User config is never deleted by the wrapper.
+optional smoke command fails. Restore fully covers standalone-binary and
+shim-takeover installs; bun/npm managed updates that rewrite `node_modules`
+are only partially reverted. User config is never deleted by the wrapper.


### PR DESCRIPTION
## Summary
Adds a portable omp-sync snapshot/rollback wrapper for local Oh My Pi installs (check, snapshot, apply, verify, fail-soft rollback).

General-purpose only — no private FlexAIDDS/Shannon overlay.

## Test plan
- [ ] omp-sync.sh --check reports current vs latest
- [ ] --apply snapshots then updates
- [ ] --rollback restores prior binary