### PR TITLE
fix(tui): keep editor pinned to bottom after inline content shrinks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
+- Fixed the composer stranding blank rows below the input after a confirmation dialog or tall multi-line editor collapses; the editor now stays pinned to the bottom instead of drifting up until a resize ([#11007](https://github.com/can1357/oh-my-pi/issues/11007)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -195,10 +195,13 @@ export class Composer implements TerminalFrameProvider {
 	#resizeRetiredHeaderStart: number | undefined;
 	#lastNormalRows = 0;
 	// Smallest below-transcript chrome height (editor + status + any transient
-	// inline dialog) seen at the current terminal height. Retirement is billed
-	// against this persistent baseline, never the transient peak, so a dialog or
-	// tall editor that later shrinks never leaves committed transcript rows the
-	// live viewport cannot reclaim (#11007). Reset when the height changes.
+	// inline dialog) seen since mount. Retirement is billed against this
+	// persistent baseline, never the transient peak, so a dialog or tall editor
+	// that later shrinks never leaves committed transcript rows the live viewport
+	// cannot reclaim (#11007). The baseline is terminal-height independent — the
+	// editor and status floors do not scale with rows — so it is retained across
+	// resizes rather than rediscovered from whatever chrome is expanded at the
+	// moment the height changes.
 	#retirementBelowFloor: number | undefined;
 	#lastInterruptAt = 0;
 	#started = false;
@@ -262,7 +265,6 @@ export class Composer implements TerminalFrameProvider {
 			this.#retiredHeaderStart = this.#resizeRetiredHeaderStart;
 			this.#resizeRetiredHeaderStart = undefined;
 		}
-		if (rows !== this.#lastNormalRows) this.#retirementBelowFloor = undefined;
 		this.#lastNormalRows = rows;
 		const roots = this.#runtimeMounted
 			? [...this.#runtimeChildren, this.#statusHost]

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -194,6 +194,12 @@ export class Composer implements TerminalFrameProvider {
 	#retiredHeaderStart = 0;
 	#resizeRetiredHeaderStart: number | undefined;
 	#lastNormalRows = 0;
+	// Smallest below-transcript chrome height (editor + status + any transient
+	// inline dialog) seen at the current terminal height. Retirement is billed
+	// against this persistent baseline, never the transient peak, so a dialog or
+	// tall editor that later shrinks never leaves committed transcript rows the
+	// live viewport cannot reclaim (#11007). Reset when the height changes.
+	#retirementBelowFloor: number | undefined;
 	#lastInterruptAt = 0;
 	#started = false;
 	#stopped = false;
@@ -256,6 +262,7 @@ export class Composer implements TerminalFrameProvider {
 			this.#retiredHeaderStart = this.#resizeRetiredHeaderStart;
 			this.#resizeRetiredHeaderStart = undefined;
 		}
+		if (rows !== this.#lastNormalRows) this.#retirementBelowFloor = undefined;
 		this.#lastNormalRows = rows;
 		const roots = this.#runtimeMounted
 			? [...this.#runtimeChildren, this.#statusHost]
@@ -271,7 +278,16 @@ export class Composer implements TerminalFrameProvider {
 		// reflowing to the current width) while the screen has room. A batch
 		// leaves the mutable viewport in the same frame it is appended, so its
 		// rows are never painted twice.
-		const history = this.#offerHistory(transcript, width, rows, preRoots.length + after.length);
+		//
+		// Retirement is billed against the persistent below-transcript chrome
+		// baseline, not the transient peak: a confirmation dialog or a tall
+		// multi-line editor swapped in below the transcript clips the live tail
+		// for its lifetime, but must not permanently commit transcript rows to
+		// native history — otherwise a later shrink cannot refill the freed rows
+		// and the editor drifts up above a band of blank rows (#11007).
+		this.#retirementBelowFloor =
+			this.#retirementBelowFloor === undefined ? after.length : Math.min(this.#retirementBelowFloor, after.length);
+		const history = this.#offerHistory(transcript, width, rows, preRoots.length + this.#retirementBelowFloor);
 		const headerVisible = !this.#headerRetired && this.#offeredHistory?.source !== "header";
 		const headerRows = headerVisible ? this.#header.render(width) : [];
 		const before = [...headerRows, ...preRoots];

--- a/packages/coding-agent/test/composer-inline-shrink.test.ts
+++ b/packages/coding-agent/test/composer-inline-shrink.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { COMPOSER_DEFAULTS, Composer } from "@oh-my-pi/pi-coding-agent/modes/composer";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { type Component, Container, Text } from "@oh-my-pi/pi-tui";
+import { VirtualRenderScheduler } from "../../tui/test/virtual-render-scheduler";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
+
+withoutTerminalMultiplexer();
+
+const ROWS = 40;
+const COLUMNS = 100;
+const TRANSCRIPT_ROWS = 60;
+const TRANSCRIPT_PREFIX = "Settled transcript row ";
+
+/** Below-transcript chrome that inflates on demand, mimicking a confirmation dialog or a tall multi-line editor swapped in above the input. */
+class InlineWidget implements Component {
+	expanded = false;
+
+	render(): readonly string[] {
+		return this.expanded ? Array.from({ length: 24 }, (_, i) => `Live widget row ${i}`) : [];
+	}
+}
+
+interface Harness {
+	terminal: VirtualTerminal;
+	scheduler: VirtualRenderScheduler;
+	composer: Composer;
+	widget: InlineWidget;
+}
+
+function makeHarness(): Harness {
+	const terminal = new VirtualTerminal(COLUMNS, ROWS);
+	const scheduler = new VirtualRenderScheduler();
+	const composer = new Composer({
+		terminal,
+		tuiOptions: { renderScheduler: scheduler },
+		preferences: { ...COMPOSER_DEFAULTS, quiet: true },
+	});
+	const transcript = new TranscriptContainer();
+	for (let i = 0; i < TRANSCRIPT_ROWS; i++) {
+		const row = i;
+		transcript.addChild({ render: () => [`${TRANSCRIPT_PREFIX}${row}`] });
+	}
+	const editor = new Container();
+	const widget = new InlineWidget();
+	editor.addChild(widget);
+	editor.addChild(new Text("EDITOR", 0, 0));
+	composer.setRuntimeChildren([transcript, editor]);
+	composer.start({ playWelcomeIntro: false });
+	return { terminal, scheduler, composer, widget };
+}
+
+/** Settle, grow the inline chrome, settle, shrink it back, settle. */
+async function cycleWidget(h: Harness): Promise<void> {
+	await h.scheduler.settle(h.terminal);
+	h.widget.expanded = true;
+	h.composer.ui.requestRender();
+	await h.scheduler.settle(h.terminal);
+	h.widget.expanded = false;
+	h.composer.ui.requestRender();
+	await h.scheduler.settle(h.terminal);
+}
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("composer inline shrink (#11007)", () => {
+	it("keeps the editor pinned to the bottom after transient below-transcript chrome shrinks", async () => {
+		const h = makeHarness();
+		await h.scheduler.settle(h.terminal);
+		const before = h.terminal.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+		expect(before.findIndex(row => row.includes("EDITOR"))).toBe(ROWS - 1);
+
+		await cycleWidget(h);
+
+		const after = h.terminal.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+		// Regression: the editor used to strand ~24 blank rows below it after the
+		// shrink because retired transcript rows never returned to the live tail.
+		expect(after.findIndex(row => row.includes("EDITOR"))).toBe(ROWS - 1);
+		const lastContent = after.reduce((last, row, i) => (row.length > 0 ? i : last), -1);
+		expect(lastContent).toBe(ROWS - 1);
+
+		h.composer.stop();
+	});
+
+	it("retires transcript rows contiguously with no duplication or gaps across the grow/shrink cycle", async () => {
+		const h = makeHarness();
+		await cycleWidget(h);
+
+		// Every transcript row appears exactly once (native scrollback + live grid),
+		// in order — the shrink must not drop rows into a gap or duplicate them.
+		const indices = h.terminal
+			.getScrollBuffer()
+			.map(row => Bun.stripANSI(row).trimEnd())
+			.filter(row => row.startsWith(TRANSCRIPT_PREFIX))
+			.map(row => Number(row.slice(TRANSCRIPT_PREFIX.length)));
+		expect(indices).toEqual(Array.from({ length: TRANSCRIPT_ROWS }, (_, i) => i));
+
+		h.composer.stop();
+	});
+});

--- a/packages/coding-agent/test/composer-inline-shrink.test.ts
+++ b/packages/coding-agent/test/composer-inline-shrink.test.ts
@@ -101,4 +101,34 @@ describe("composer inline shrink (#11007)", () => {
 
 		h.composer.stop();
 	});
+
+	it("keeps the below-chrome baseline across a height resize while inline chrome is expanded", async () => {
+		const shorter = ROWS - 10;
+		const h = makeHarness();
+		await h.scheduler.settle(h.terminal);
+
+		// Expand, resize the terminal height *while still expanded*, then keep
+		// rendering before shrinking. The retirement baseline must not adopt the
+		// expanded peak at the resize, or the frames before the shrink retire
+		// rows the shrink cannot reclaim and the editor is stranded again.
+		h.widget.expanded = true;
+		h.composer.ui.requestRender();
+		await h.scheduler.settle(h.terminal);
+		h.terminal.resize(COLUMNS, shorter);
+		await h.scheduler.advance(h.terminal, 300);
+		for (let frame = 0; frame < 5; frame++) {
+			h.composer.ui.requestRender();
+			await h.scheduler.settle(h.terminal);
+		}
+		h.widget.expanded = false;
+		h.composer.ui.requestRender();
+		await h.scheduler.settle(h.terminal);
+
+		const after = h.terminal.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+		expect(after.findIndex(row => row.includes("EDITOR"))).toBe(shorter - 1);
+		const lastContent = after.reduce((last, row, i) => (row.length > 0 ? i : last), -1);
+		expect(lastContent).toBe(shorter - 1);
+
+		h.composer.stop();
+	});
 });


### PR DESCRIPTION
## Repro
With a full transcript and 40-row terminal, opening a hook confirmation dialog (or a tall multi-line editor) below the transcript and then dismissing it leaves the editor stranded mid-screen above a band of blank rows; a resize restores it. Reproduced with the reporter's script (`bun tmp/confirm-drift.ts` and `bun tmp/confirm-drift.ts --widget`): editor row goes 40 -> 16 (24 blank rows below) -> 40 only after a resize. The `--widget` variant confirms it is general — any component that grows below the transcript and shrinks triggers it, not just the confirmation.

## Cause
`Composer.renderFrame` (`packages/coding-agent/src/modes/composer.ts`) bills transcript retirement against `preRoots.length + after.length`, where `after` is the below-transcript chrome (editor + status + whatever is swapped into the editor container). When that chrome transiently inflates, `TranscriptContainer.peekFinalizedBatch(rows - chromeRows)` permanently commits older settled rows to native history. There is no un-retire path, so once the chrome shrinks the live viewport returns short, `TUI` anchors the shortened viewport high (`newTop = min(startTop + history, height - rows)`) and clears the trailing rows, leaving the blank band until a resize rebuild replays the ledger.

## Fix
- `composer.ts`: track `#retirementBelowFloor`, the smallest below-transcript chrome height seen at the current terminal height (reset on height change), and bill retirement against `preRoots.length + #retirementBelowFloor` instead of the transient `after.length`. Display still uses the real `after`, so a dialog / tall editor clips the live tail for its lifetime and the rows reflow back when it shrinks; genuine transcript growth still retires normally. When below-chrome is stable the floor equals `after`, so steady-state retirement is byte-identical and native scrollback stays contiguous.
- `composer-inline-shrink.test.ts`: new regression test driving the grow/shrink cycle through the real `Composer` + kitty-WASM `VirtualTerminal`, asserting the editor stays on the bottom row and every transcript row appears exactly once (no duplication or gaps) across native scrollback + the live grid.
- CHANGELOG entry.

## Verification
`bun test packages/coding-agent/test/composer-inline-shrink.test.ts` — 2 pass (and fails as expected on the pre-fix composer: editor lands on row 15 instead of 39). Regression suites `bun test packages/tui/test/history-frame-plan.test.ts packages/tui/test/resize-anchor-recovery.test.ts packages/tui/test/resize-preserved-clear.test.ts packages/tui/test/resize-multiplexer-anchor.test.ts packages/coding-agent/test/modes/components/transcript-container.test.ts` — all green. Full scroll-buffer inspection in both dialog and widget modes confirms all 60 transcript rows remain contiguous with no duplication or gaps.

Fixes #11007