### PR TITLE
fix(utils): interpret Zhipu reset times as UTC+8

### DIFF
--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -1756,6 +1756,7 @@ export async function instrumentedCompleteSimple<TApi extends Api>(
 			const message = span.retry
 				? await retryTransientCompletion(runOnce, {
 						...span.retry,
+						provider: model.provider,
 						// Framework-owned: the caller must not be able to detach the
 						// abort signal or the header source by passing them itself.
 						signal: options.signal,

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added Muse Code subscription sign-in, credential refresh, inference, and quota reporting in `/usage`, with durable rate-limit backoff so quota refresh recovers instead of repeatedly retrying.
 
+### Fixed
+
+- Fixed Z.AI and Zhipu usage-limit credential blocks expiring eight hours late when provider responses omit the reset timestamp timezone ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Z.AI and Zhipu usage-limit credential blocks expiring eight hours late when provider responses omit the reset timestamp timezone ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+- Fixed Z.AI and Zhipu usage-limit credential blocks and oneshot completion retries (titles, summaries, classifiers) resolving eight hours late when provider responses omit the reset timestamp timezone ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -19,7 +19,7 @@
  */
 
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { extractHttpStatusFromError, extractRetryHint, logger } from "@oh-my-pi/pi-utils";
+import { extractHttpStatusFromError, logger } from "@oh-my-pi/pi-utils";
 import type { ApiKeyResolver } from "../auth-retry";
 import type { AuthStorage } from "../auth-storage";
 import * as AIError from "../error";
@@ -34,6 +34,7 @@ import type { Api, AssistantMessage, AssistantMessageEventStream, Context, Model
 import type { ClientUsageIdentity } from "../usage";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { parseBind } from "../utils/parse-bind";
+import { extractProviderRetryHint } from "../utils/retry-after";
 import {
 	captureRequestHeaders,
 	corsHeaders,
@@ -248,7 +249,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 	const message = error instanceof Error ? error.message : String(error);
 	const status = extractHttpStatusFromError(error);
 	if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
-		const retryAfterMs = extractRetryHint(undefined, message);
+		const retryAfterMs = extractProviderRetryHint(provider, message);
 		const { switched, retryAtMs } = await storage.markUsageLimitReached(provider, sessionId, {
 			retryAfterMs,
 			providerTimed: retryAfterMs !== undefined,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -9,7 +9,7 @@
  */
 import { createHash } from "node:crypto";
 import { planRequirementFor } from "@oh-my-pi/pi-catalog/compat/behavior";
-import { $env, $envExact, extractRetryHint, getAgentDbPath, logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { $env, $envExact, getAgentDbPath, logger, untilAborted } from "@oh-my-pi/pi-utils";
 import {
 	isSqliteCorruptionError,
 	resolveCredentialIdentityKey,
@@ -31,6 +31,7 @@ import type {
 } from "./registry/oauth/types";
 import { AUTHENTICATED_SENTINEL } from "./registry/types";
 import { getEnvApiKey, getEnvApiKeyName } from "./stream";
+import { extractProviderRetryHint } from "./utils/retry-after";
 import type { Provider } from "./types";
 import type {
 	ClientUsageIdentity,
@@ -6868,7 +6869,7 @@ export class AuthStorage {
 			// Thread the provider-specified reset window (e.g. Devin "Your limit
 			// will reset in 13 minutes") into the block duration so the credential
 			// is not reselected and hammered while the cap remains active.
-			const retryAfterMs = extractRetryHint(undefined, message);
+			const retryAfterMs = extractProviderRetryHint(provider, message);
 			return (
 				await this.markUsageLimitReached(provider, sessionId, {
 					retryAfterMs,

--- a/packages/ai/src/oneshot-retry.ts
+++ b/packages/ai/src/oneshot-retry.ts
@@ -1,7 +1,11 @@
-import { extractRetryHint } from "@oh-my-pi/pi-utils";
 import * as AIError from "./error";
 import type { AssistantMessage } from "./types";
-import { getHeadersFromError, getRetryAfterMsFromHeaders, type HeadersLike } from "./utils/retry-after";
+import {
+	extractProviderRetryHint,
+	getHeadersFromError,
+	getRetryAfterMsFromHeaders,
+	type HeadersLike,
+} from "./utils/retry-after";
 
 /**
  * Transient-failure retry for **oneshot** (non-agent-loop) completions.
@@ -66,6 +70,12 @@ export interface OneshotRetryOptions {
 	 * Thrown errors need no wiring — headers are recovered from the error itself.
 	 */
 	getResponseHeaders?: () => HeadersLike;
+	/**
+	 * Provider id of the model being retried. Selects the catalog-declared
+	 * timezone for a timezone-naive absolute reset stamp (Z.AI/Zhipu report
+	 * Beijing time), so an over-cap wait is not misread as UTC and discarded.
+	 */
+	provider?: string;
 	/** Observability hook. Fires immediately before sleeping. */
 	onRetry?: (info: OneshotRetryInfo) => void;
 }
@@ -195,7 +205,7 @@ export async function retryTransientCompletion(
 		// errors (e.g. AnthropicApiError) carry their own headers.
 		const headers: HeadersLike = thrown !== undefined ? getHeadersFromError(thrown) : options?.getResponseHeaders?.();
 		const headerHintMs = getRetryAfterMsFromHeaders(headers);
-		const extractedTextHintMs = extractRetryHint(undefined, errorMessage);
+		const extractedTextHintMs = extractProviderRetryHint(options?.provider, errorMessage);
 		const suffixValue = RETRY_AFTER_MS_SUFFIX.exec(errorMessage)?.[1];
 		const parsedSuffixMs = suffixValue === undefined ? undefined : Number(suffixValue);
 		const suffixHintMs =

--- a/packages/ai/src/utils/retry-after.ts
+++ b/packages/ai/src/utils/retry-after.ts
@@ -1,4 +1,16 @@
+import { retryResetTimezoneOffsetFor } from "@oh-my-pi/pi-catalog/compat/behavior";
+import { extractRetryHint } from "@oh-my-pi/pi-utils";
+
 export type HeadersLike = Headers | Record<string, string | undefined> | undefined | null;
+
+/** Extracts retry timing using the provider's catalog-declared timestamp timezone. */
+export function extractProviderRetryHint(
+	provider: string | undefined,
+	message: string | undefined,
+): number | undefined {
+	const naiveResetTimezoneOffset = provider === undefined ? undefined : retryResetTimezoneOffsetFor(provider);
+	return extractRetryHint(undefined, message, { naiveResetTimezoneOffset });
+}
 
 const RETRY_AFTER_HINT = "retry-after-ms=";
 

--- a/packages/ai/test/oneshot-retry.test.ts
+++ b/packages/ai/test/oneshot-retry.test.ts
@@ -419,4 +419,41 @@ describe("retryTransientCompletion", () => {
 		expect(calls).toBe(2);
 		expect(observedDelay).toBe(90);
 	});
+
+	it("applies the provider reset-timezone policy to a naive absolute reset", async () => {
+		// "2099-09-01 06:00:00" with no offset: Z.AI reads it as Beijing time
+		// (2099-08-31T22:00Z, already elapsed → discarded → normal backoff retry),
+		// while a provider with no declared offset reads it as UTC (now+6h, over
+		// the 3h cap → fail fast). Same body; provider policy flips the flow.
+		const fixedNow = Date.parse("2099-09-01T00:00:00Z");
+		const realNow = Date.now;
+		Date.now = () => fixedNow;
+		try {
+			const errorMessage = "rate_limit_error: too many requests. Your limit will reset at 2099-09-01 06:00:00";
+			const opts = { baseDelayMs: 1, maxAttempts: 2, maxDelayMs: 3 * 60 * 60_000 } as const;
+
+			let genericCalls = 0;
+			const generic = await retryTransientCompletion(() => {
+				genericCalls += 1;
+				return Promise.resolve(message({ stopReason: "error", errorStatus: 429, errorMessage }));
+			}, opts);
+			expect(genericCalls).toBe(1);
+			expect(generic.stopReason).toBe("error");
+
+			let zaiCalls = 0;
+			const zai = await retryTransientCompletion(
+				() => {
+					zaiCalls += 1;
+					return Promise.resolve(
+						zaiCalls === 1 ? message({ stopReason: "error", errorStatus: 429, errorMessage }) : message(),
+					);
+				},
+				{ ...opts, provider: "zai" },
+			);
+			expect(zaiCalls).toBe(2);
+			expect(zai.stopReason).toBe("stop");
+		} finally {
+			Date.now = realNow;
+		}
+	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed Z.AI and Zhipu timezone-naive quota reset timestamps resolving eight hours late by declaring their UTC+8 reset timezone ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+
 	- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
 	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 

--- a/packages/catalog/scripts/compat-compiler/compile-behavior.ts
+++ b/packages/catalog/scripts/compat-compiler/compile-behavior.ts
@@ -4,8 +4,8 @@
  * Ports the o2 runtime-behavior grammar (openai-responses-heuristic,
  * model-operations, cursor-effort, cursor-model-parameter, quota-tiers,
  * hosted-default) and adds the pi-only nodes: api-routes, model-limits,
- * exclude-models, plan-requirement, pricing-peer. Every node kind is
- * optional; per-node shapes are strict.
+ * exclude-models, plan-requirement, pricing-peer, and retry-reset-timezone.
+ * Every node kind is optional; per-node shapes are strict.
  */
 import type {
 	CompiledApiRoutes,
@@ -16,6 +16,7 @@ import type {
 	CompiledModelOperations,
 	CompiledPlanRequirement,
 	CompiledPricingPeer,
+	CompiledRetryResetTimezone,
 	CompiledQuotaRule,
 	CompiledResponsesHeuristic,
 } from "../../src/compat/types";
@@ -79,6 +80,16 @@ function matchListFromProps(node: KdlNodeView, skip: readonly string[]): Compile
 		}
 	}
 	return match;
+}
+
+const UTC_OFFSET_PATTERN = /^(?:Z|[+-](?:(?:0\d|1[0-3]):[0-5]\d|14:00))$/;
+
+function parseRetryResetTimezone(node: KdlNodeView): CompiledRetryResetTimezone {
+	ensureLeaf(node, ["provider", "offset"]);
+	const provider = requiredProp(node, "provider");
+	const offset = requiredProp(node, "offset");
+	if (!provider || !UTC_OFFSET_PATTERN.test(offset) || node.args.length > 0) malformed(node);
+	return { provider, offset };
 }
 
 function hasMatchers(match: CompiledMatchList): boolean {
@@ -278,6 +289,7 @@ export function compileBehavior(source: { file: string; text: string } | undefin
 		excludeModels: [],
 		retiredProviders: [],
 		planRequirements: [],
+		retryResetTimezones: [],
 		pricingPeers: [],
 	};
 	if (!source) return behavior;
@@ -340,6 +352,9 @@ export function compileBehavior(source: { file: string; text: string } | undefin
 				break;
 			case "plan-requirement":
 				behavior.planRequirements.push(parsePlanRequirement(node));
+				break;
+			case "retry-reset-timezone":
+				behavior.retryResetTimezones.push(parseRetryResetTimezone(node));
 				break;
 			case "pricing-peer":
 				behavior.pricingPeers.push(parsePricingPeer(node));

--- a/packages/catalog/src/compat/behavior.ts
+++ b/packages/catalog/src/compat/behavior.ts
@@ -103,6 +103,11 @@ export function quotaTierFor(provider: string, model: string): string | undefine
 	return undefined;
 }
 
+/** UTC offset for a provider's timezone-naive absolute retry-reset timestamps. */
+export function retryResetTimezoneOffsetFor(provider: string): string | undefined {
+	return behavior.retryResetTimezones.find(rule => rule.provider === provider)?.offset;
+}
+
 /** Whether a provider has catalog-authored model quota scopes. */
 export function hasQuotaTierPolicy(provider: string): boolean {
 	return behavior.quotaTiers.some(rule => rule.provider === provider);

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -14961,6 +14961,16 @@
 				]
 			}
 		],
+		"retryResetTimezones": [
+			{
+				"provider": "zai",
+				"offset": "+08:00"
+			},
+			{
+				"provider": "zhipu-coding-plan",
+				"offset": "+08:00"
+			}
+		],
 		"pricingPeers": [
 			{
 				"provider": "google-antigravity",

--- a/packages/catalog/src/compat/rules/README.md
+++ b/packages/catalog/src/compat/rules/README.md
@@ -247,6 +247,7 @@ behavior {
     model-limits provider="github-copilot" { limits "gpt-5.6" context=272000 max-tokens=128000 }
     exclude-models provider="nanogpt" substring="embed" substring="tts"
     plan-requirement provider="openai-codex" { tier "pro" substring="-spark" }
+    retry-reset-timezone provider="zai" offset="+08:00"
     pricing-peer provider="google-antigravity" peers="google" "google-vertex" {
         alias "gemini-3-pro" peer-id="gemini-3-pro-preview"
     }

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -83,6 +83,11 @@ behavior {
 			glob="*/gpt-5.6-sol-pro" glob="*/gpt-5.6-luna" glob="*/gpt-5.6-luna-pro"
 	}
 
+	// Z.AI and Zhipu emit timezone-naive account-reset wall clocks in Beijing
+	// time. Provider-aware retry paths append this offset before parsing.
+	retry-reset-timezone provider="zai" offset="+08:00"
+	retry-reset-timezone provider="zhipu-coding-plan" offset="+08:00"
+
 	// Cloudflare AI Gateway namespace routing. The Workers AI prefix remains
 	// on the request id; the upstream namespaces are stripped.
 	api-routes provider="cloudflare-ai-gateway" {

--- a/packages/catalog/src/compat/types.ts
+++ b/packages/catalog/src/compat/types.ts
@@ -304,6 +304,12 @@ export interface CompiledPricingPeer {
 	aliases: { model: string; peerId: string }[];
 }
 
+/** Provider timezone assumption for offset-less absolute retry-reset timestamps. */
+export interface CompiledRetryResetTimezone {
+	provider: string;
+	offset: string;
+}
+
 /** Compiled runtime behavior vocabulary (`runtime/behavior.kdl`). */
 export interface CompiledBehavior {
 	openaiResponsesHeuristic?: CompiledResponsesHeuristic;
@@ -317,6 +323,7 @@ export interface CompiledBehavior {
 	excludeModels: CompiledExcludeModels[];
 	planRequirements: CompiledPlanRequirement[];
 	pricingPeers: CompiledPricingPeer[];
+	retryResetTimezones: CompiledRetryResetTimezone[];
 	retiredProviders: string[];
 }
 

--- a/packages/catalog/test/compat-conformance.test.ts
+++ b/packages/catalog/test/compat-conformance.test.ts
@@ -54,6 +54,7 @@ function collectReferencedProviders(): Map<string, string> {
 		behavior.modelLimits,
 		behavior.excludeModels,
 		behavior.planRequirements,
+		behavior.retryResetTimezones,
 		behavior.pricingPeers,
 	];
 	for (const list of lists) {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Fixed `retry.waitForUsageReset` scheduling Z.AI and Zhipu resets eight hours late when provider responses omit the reset timestamp timezone ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+
 	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -170,7 +170,7 @@ async function classifyOnline(input: string, deps: ClassifyDifficultyDeps, ceili
 						}),
 				},
 			),
-		{ signal: deps.signal },
+		{ signal: deps.signal, provider: model.provider },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/cli/git-tui/ai-stage.ts
+++ b/packages/coding-agent/src/cli/git-tui/ai-stage.ts
@@ -232,7 +232,7 @@ function createCompleter(
 					{ messages: [{ role: "user", content: userPrompt, timestamp: Date.now() }] },
 					{ apiKey, sessionId, maxTokens: SAFE_MAX_TOKENS, temperature: 0, disableReasoning: true, signal },
 				),
-			{ signal },
+			{ signal, provider: model.provider },
 		);
 		if (response.stopReason === "error") {
 			throw new Error(`AI staging request failed: ${response.errorMessage ?? "unknown error"}`);

--- a/packages/coding-agent/src/commit/changelog/generate.ts
+++ b/packages/coding-agent/src/commit/changelog/generate.ts
@@ -57,16 +57,18 @@ export async function generateChangelogEntries({
 		stat,
 		diff,
 	});
-	const response = await retryTransientCompletion(() =>
-		completeSimple(
-			model,
-			{
-				systemPrompt: [prompt.render(changelogSystemPrompt)],
-				messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
-				tools: [changelogTool],
-			},
-			{ apiKey, sessionId, maxTokens: 1200, reasoning: toReasoningEffort(thinkingLevel) },
-		),
+	const response = await retryTransientCompletion(
+		() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [prompt.render(changelogSystemPrompt)],
+					messages: [{ role: "user", content: userContent, timestamp: Date.now() }],
+					tools: [changelogTool],
+				},
+				{ apiKey, sessionId, maxTokens: 1200, reasoning: toReasoningEffort(thinkingLevel) },
+			),
+		{ provider: model.provider },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/edit/auto-repair.ts
+++ b/packages/coding-agent/src/edit/auto-repair.ts
@@ -326,7 +326,7 @@ export async function attemptEditAutoRepair(options: {
 						signal,
 					},
 				),
-			{ signal },
+			{ signal, provider: model.provider },
 		);
 		if (response.stopReason === "error") {
 			throw new Error(response.errorMessage ?? "auto-repair completion failed");

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -753,21 +753,23 @@ async function runStage1Job(options: {
 			response_items_json: truncatedItems,
 		});
 
-		const response = await retryTransientCompletion(() =>
-			completeSimple(
-				model,
-				{
-					systemPrompt: [stageOneSystemTemplate],
-					messages: [{ role: "user", content: [{ type: "text", text: inputPrompt }], timestamp: Date.now() }],
-				},
-				{
-					apiKey,
-					sessionId: options.sessionId,
-					metadata: options.metadata,
-					maxTokens: Math.max(1024, Math.min(4096, Math.floor(modelMaxTokens * 0.2))),
-					reasoning: clampThinkingLevelForModel(model, Effort.Low),
-				},
-			),
+		const response = await retryTransientCompletion(
+			() =>
+				completeSimple(
+					model,
+					{
+						systemPrompt: [stageOneSystemTemplate],
+						messages: [{ role: "user", content: [{ type: "text", text: inputPrompt }], timestamp: Date.now() }],
+					},
+					{
+						apiKey,
+						sessionId: options.sessionId,
+						metadata: options.metadata,
+						maxTokens: Math.max(1024, Math.min(4096, Math.floor(modelMaxTokens * 0.2))),
+						reasoning: clampThinkingLevelForModel(model, Effort.Low),
+					},
+				),
+			{ provider: model.provider },
 		);
 
 		if (response.stopReason === "error") {
@@ -894,21 +896,23 @@ async function runConsolidationModel(options: {
 		rollout_summaries: truncateByApproxTokens(rolloutSummaries, 12_000),
 	});
 
-	const response = await retryTransientCompletion(() =>
-		completeSimple(
-			model,
-			{
-				systemPrompt: [consolidationSystemTemplate],
-				messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
-			},
-			{
-				apiKey,
-				sessionId: options.sessionId,
-				metadata: options.metadata,
-				maxTokens: 8192,
-				reasoning: clampThinkingLevelForModel(model, Effort.Medium),
-			},
-		),
+	const response = await retryTransientCompletion(
+		() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [consolidationSystemTemplate],
+					messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
+				},
+				{
+					apiKey,
+					sessionId: options.sessionId,
+					metadata: options.metadata,
+					maxTokens: 8192,
+					reasoning: clampThinkingLevelForModel(model, Effort.Medium),
+				},
+			),
+		{ provider: model.provider },
 	);
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "phase2 model error");

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -579,20 +579,22 @@ async function resolveMnemopiProviderOptions(
 					});
 					return null;
 				}
-				const message = await retryTransientCompletion(() =>
-					completeSimple(
-						model,
-						{
-							...(request.systemPrompt ? { systemPrompt: [request.systemPrompt] } : {}),
-							messages: [{ role: "user", content: request.prompt, timestamp: Date.now() }],
-						},
-						{
-							apiKey: modelRegistry.resolver(model, sessionId),
-							sessionId,
-							maxTokens: opts?.maxTokens,
-							temperature: opts?.temperature,
-						},
-					),
+				const message = await retryTransientCompletion(
+					() =>
+						completeSimple(
+							model,
+							{
+								...(request.systemPrompt ? { systemPrompt: [request.systemPrompt] } : {}),
+								messages: [{ role: "user", content: request.prompt, timestamp: Date.now() }],
+							},
+							{
+								apiKey: modelRegistry.resolver(model, sessionId),
+								sessionId,
+								maxTokens: opts?.maxTokens,
+								temperature: opts?.temperature,
+							},
+						),
+					{ provider: model.provider },
 				);
 				return message.content
 					.filter(

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -34,8 +34,9 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import { isUsageLimitOutcome, resolveModelServiceTier, streamSimple } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { extractProviderRetryHint } from "@oh-my-pi/pi-ai/utils/retry-after";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { extractHttpStatusFromError, extractRetryHint, logger } from "@oh-my-pi/pi-utils";
+import { extractHttpStatusFromError, logger } from "@oh-my-pi/pi-utils";
 import {
 	ADVISOR_DEFAULT_TOOL_NAMES,
 	AdviseTool,
@@ -1441,7 +1442,7 @@ export class SessionAdvisors {
 			if (switched) return true;
 		}
 
-		const retryAfterMs = extractRetryHint(undefined, message);
+		const retryAfterMs = extractProviderRetryHint(currentModel.provider, message);
 		const usageLimit =
 			AIError.is(errorId, AIError.Flag.UsageLimit) ||
 			isUsageLimitOutcome(extractHttpStatusFromError(error), message);

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -20,10 +20,11 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { extractProviderRetryHint } from "@oh-my-pi/pi-ai/utils/retry-after";
 import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
+import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelStringWithRouting, resolveModelOverride } from "../config/model-resolver";
 
@@ -2076,11 +2077,11 @@ export class TurnRecovery {
 	}
 
 	#parseRetryAfterMsFromError(errorMessage: string): number | undefined {
-		// Single call into the centralized parser: it merges every supported
+		// Single call into the provider-aware parser: it merges every supported
 		// form (account resets, retry-after-ms, legacy retry-after /
 		// x-ratelimit-reset text) by longest-wins, so a shorter reset phrase
 		// can never shadow a longer retry signal carried in the same message.
-		return extractRetryHint(undefined, errorMessage);
+		return extractProviderRetryHint(this.#host.model()?.provider, errorMessage);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -114,7 +114,7 @@ async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): P
 					signal: deps.signal,
 				},
 			),
-		{ signal: deps.signal },
+		{ signal: deps.signal, provider: model.provider },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/sharpshooter/consolidate.ts
+++ b/packages/coding-agent/src/sharpshooter/consolidate.ts
@@ -153,22 +153,24 @@ async function consolidateLocked(
 			maxFileLines: SHARPSHOOTER_MAX_FILE_LINES,
 		});
 
-		const response = await retryTransientCompletion(() =>
-			completeSimple(
-				model,
-				{
-					systemPrompt: [system],
-					messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
-					tools: [replaceMemoryFilesTool],
-				},
-				{
-					apiKey: options.modelRegistry.resolver(model, options.sessionId),
-					sessionId: options.sessionId,
-					maxTokens: 8192,
-					reasoning: clampThinkingLevelForModel(model, Effort.Medium),
-					toolChoice: "required",
-				},
-			),
+		const response = await retryTransientCompletion(
+			() =>
+				completeSimple(
+					model,
+					{
+						systemPrompt: [system],
+						messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
+						tools: [replaceMemoryFilesTool],
+					},
+					{
+						apiKey: options.modelRegistry.resolver(model, options.sessionId),
+						sessionId: options.sessionId,
+						maxTokens: 8192,
+						reasoning: clampThinkingLevelForModel(model, Effort.Medium),
+						toolChoice: "required",
+					},
+				),
+			{ provider: model.provider },
 		);
 		if (response.stopReason === "error") {
 			throw new Error(response.errorMessage || "sharpshooter consolidation model error");

--- a/packages/coding-agent/src/sharpshooter/extract.ts
+++ b/packages/coding-agent/src/sharpshooter/extract.ts
@@ -212,22 +212,24 @@ async function runSharpshooterExtraction(
 	if (!model || session.isDisposed) return;
 
 	const input = prompt.render(extractInputTemplate, { ...envelope });
-	const response = await retryTransientCompletion(() =>
-		completeSimple(
-			model,
-			{
-				systemPrompt: [prompt.render(extractSystemTemplate)],
-				messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
-				tools: [recordDeltasTool],
-			},
-			{
-				apiKey: modelRegistry.resolver(model, session.sessionId),
-				sessionId: session.sessionId,
-				maxTokens: 2048,
-				reasoning: clampThinkingLevelForModel(model, Effort.Low),
-				toolChoice: "required",
-			},
-		),
+	const response = await retryTransientCompletion(
+		() =>
+			completeSimple(
+				model,
+				{
+					systemPrompt: [prompt.render(extractSystemTemplate)],
+					messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
+					tools: [recordDeltasTool],
+				},
+				{
+					apiKey: modelRegistry.resolver(model, session.sessionId),
+					sessionId: session.sessionId,
+					maxTokens: 2048,
+					reasoning: clampThinkingLevelForModel(model, Effort.Low),
+					toolChoice: "required",
+				},
+			),
+		{ provider: model.provider },
 	);
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "Sharpshooter extraction model error");

--- a/packages/coding-agent/src/tts/speech-enhancer.ts
+++ b/packages/coding-agent/src/tts/speech-enhancer.ts
@@ -101,7 +101,7 @@ export class SpeechEnhancer {
 						},
 					);
 				},
-				{ signal },
+				{ signal, provider: model.provider },
 			);
 			if (response.stopReason === "error") {
 				logger.debug("speech-enhancer: rewrite errored", { error: response.errorMessage });

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -106,20 +106,22 @@ export async function generateCommitMessage(
 
 		try {
 			const maxTokens = COMMIT_MAX_TOKENS;
-			const response = await retryTransientCompletion(() =>
-				completeSimple(
-					candidate.model,
-					{
-						systemPrompt: [COMMIT_SYSTEM_PROMPT],
-						messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
-					},
-					{
-						apiKey: registry.resolver(candidate.model, sessionId),
-						sessionId,
-						maxTokens,
-						reasoning: toReasoningEffort(candidate.thinkingLevel),
-					},
-				),
+			const response = await retryTransientCompletion(
+				() =>
+					completeSimple(
+						candidate.model,
+						{
+							systemPrompt: [COMMIT_SYSTEM_PROMPT],
+							messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+						},
+						{
+							apiKey: registry.resolver(candidate.model, sessionId),
+							sessionId,
+							maxTokens,
+							reasoning: toReasoningEffort(candidate.thinkingLevel),
+						},
+					),
+				{ provider: candidate.model.provider },
 			);
 
 			if (response.stopReason === "error") {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -301,7 +301,7 @@ export async function generateTitleOnline(
 						signal,
 					},
 				),
-			{ signal },
+			{ signal, provider: model.provider },
 		);
 
 		if (response.stopReason === "error") {

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -203,9 +203,9 @@ describe("AgentSession retry delay cap", () => {
 			throw new Error("Expected bundled Anthropic test model to exist");
 		}
 
-		// Reset two hours out, formatted like the provider timestamp (parsed
-		// as UTC, so toISOString stays exact); bounds below absorb test time.
-		const resetStamp = new Date(Date.now() + 7_200_000).toISOString().slice(0, 19).replace("T", " ");
+		// Reset two hours out, formatted as the Beijing wall clock the Zhipu
+		// timestamp reports (parsed as UTC+8); bounds below absorb test time.
+		const resetStamp = new Date(Date.now() + 7_200_000 + 8 * 3_600_000).toISOString().slice(0, 19).replace("T", " ");
 		const usageLimitError = `429 已达到 5 小时的使用上限。您的限额将在 ${resetStamp} 重置。`;
 
 		const mock = createMockModel({

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -96,6 +96,7 @@ describe("AgentSession retry delay cap", () => {
 			"opencode-go",
 			"openrouter",
 			"github-copilot",
+			"zai",
 			"cursor",
 		]) {
 			authStorage.removeRuntimeApiKey(provider);
@@ -193,20 +194,19 @@ describe("AgentSession retry delay cap", () => {
 
 	it("waits past retry.maxDelayMs for a usage-limit reset when retry.waitForUsageReset is set", async () => {
 		// Contract: with the opt-in set, a provider-stated usage-limit reset
-		// sleeps until the reset instead of failing fast. Uses the reported
-		// ZAI shape (Zhipu 5h 使用上限 with an absolute reset timestamp,
-		// single credential so no rotation can save it); the bypass keys off
-		// Flag.UsageLimit, so every provider whose exhaustion classifies as
-		// a usage limit is covered.
-		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		// sleeps until the reset instead of failing fast. Uses Z.AI's English
+		// code-1308 shape: a timezone-naive Beijing reset timestamp plus a
+		// shorter retry-after-ms, with one credential so rotation cannot save it.
+		const model = getBundledModel("zai", "glm-5.3");
 		if (!model) {
-			throw new Error("Expected bundled Anthropic test model to exist");
+			throw new Error("Expected bundled Z.AI test model to exist");
 		}
+		authStorage.setRuntimeApiKey("zai", "zai-test-key");
 
-		// Reset two hours out, formatted as the Beijing wall clock the Zhipu
-		// timestamp reports (parsed as UTC+8); bounds below absorb test time.
+		// Reset two hours out, formatted as the Beijing wall clock Z.AI reports;
+		// the provider policy applies UTC+8 before longest-window selection.
 		const resetStamp = new Date(Date.now() + 7_200_000 + 8 * 3_600_000).toISOString().slice(0, 19).replace("T", " ");
-		const usageLimitError = `429 已达到 5 小时的使用上限。您的限额将在 ${resetStamp} 重置。`;
+		const usageLimitError = `429 code 1308, Usage limit reached for 5 hour. Your limit will reset at ${resetStamp} retry-after-ms=5000`;
 
 		const mock = createMockModel({
 			responses: [{ throw: usageLimitError }, { content: ["recovered after usage reset"], stopReason: "stop" }],

--- a/packages/mnemopi/src/core/local-llm.ts
+++ b/packages/mnemopi/src/core/local-llm.ts
@@ -189,18 +189,20 @@ export async function callConfiguredCompletion(
 		return null;
 	}
 	try {
-		const message = await retryTransientCompletion(() =>
-			completeSimple(
-				model,
-				{
-					messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
-				},
-				{
-					apiKey: llmApiKey() || undefined,
-					maxTokens: opts.maxTokens ?? llmMaxTokens(),
-					temperature,
-				},
-			),
+		const message = await retryTransientCompletion(
+			() =>
+				completeSimple(
+					model,
+					{
+						messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
+					},
+					{
+						apiKey: llmApiKey() || undefined,
+						maxTokens: opts.maxTokens ?? llmMaxTokens(),
+						temperature,
+					},
+				),
+			{ provider: model.provider },
 		);
 		return assistantText(message).trim() || null;
 	} catch {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Zhipu usage-limit reset timestamps being treated as UTC instead of UTC+8, preventing `waitForUsageReset` sessions from resuming eight hours late ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Zhipu usage-limit reset timestamps being treated as UTC instead of UTC+8, preventing `waitForUsageReset` sessions from resuming eight hours late ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+- Fixed Zhipu/Z.AI usage-limit reset timestamps making `waitForUsageReset` sessions resume up to eight hours late: naive Chinese stamps are read as UTC+8, and a naive absolute reset stamp no longer outranks an explicit `retry-after-ms` hint ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Zhipu/Z.AI usage-limit reset timestamps making `waitForUsageReset` sessions resume up to eight hours late: naive Chinese stamps are read as UTC+8, and a naive absolute reset stamp no longer outranks an explicit `retry-after-ms` hint ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
+- Fixed provider-local usage-limit reset timestamps making `waitForUsageReset` sessions resume up to eight hours late while preserving longest-window semantics for naive UTC timestamps ([#11014](https://github.com/can1357/oh-my-pi/issues/11014)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -16,6 +16,10 @@ const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s
 const WILL_RESET_AT_PATTERN =
 	/(?:will\s+)?reset at\s+([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:?[0-9]{2})?)/i;
 const CN_RESET_AT_PATTERN = /将在\s*([0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s*重置/;
+const RESET_AT_PATTERNS: readonly { pattern: RegExp; assumedOffset: string }[] = [
+	{ pattern: WILL_RESET_AT_PATTERN, assumedOffset: "Z" },
+	{ pattern: CN_RESET_AT_PATTERN, assumedOffset: "+08:00" },
+];
 // "retry-after-ms=98497000" / "retry-after-ms: 7200000" / "retry-after-ms = 7200000"
 const RETRY_AFTER_MS_BODY_PATTERN = /\bretry-after-ms\s*[:=]\s*([0-9]+)\b/i;
 
@@ -117,13 +121,14 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 			consider(totalMs > 0 ? totalMs : undefined);
 		}
 	}
-	for (const pattern of [WILL_RESET_AT_PATTERN, CN_RESET_AT_PATTERN]) {
+	for (const { pattern, assumedOffset } of RESET_AT_PATTERNS) {
 		const match = pattern.exec(body);
 		if (match?.[1]) {
-			// Provider timestamps without an explicit offset are interpreted as UTC.
+			// English providers historically report naive UTC stamps; Zhipu's
+			// Chinese response reports its naive stamp in Beijing time.
 			const normalized = match[1].replace(" ", "T");
 			const hasOffset = /(?:Z|[+-][0-9]{2}:?[0-9]{2})$/i.test(normalized);
-			const parsed = Date.parse(hasOffset ? normalized : `${normalized}Z`);
+			const parsed = Date.parse(hasOffset ? normalized : `${normalized}${assumedOffset}`);
 			if (!Number.isNaN(parsed) && parsed > Date.now()) {
 				consider(parsed - Date.now());
 			}

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -102,6 +102,14 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 	// when the parse returns undefined, which would sleep a session the
 	// provider told to retry immediately.
 	let retryNow = false;
+	// A naive absolute reset stamp (no explicit offset) is timezone-ambiguous:
+	// English providers historically report UTC, but Z.AI/Zhipu report Beijing
+	// time in both their Chinese ("将在 … 重置") and English ("reset at …")
+	// bodies. Held back as a fallback so it never outranks an unambiguous
+	// signal (an explicit `retry-after-ms`, or an offset-qualified stamp);
+	// Z.AI's 1308 body carries such a relative hint, so the wrong UTC reading
+	// can no longer win the longest-wins merge and sleep ~8h too long.
+	let naiveResetMs: number | undefined;
 	const consider = (ms: number | undefined): void => {
 		if (ms !== undefined && ms > 0 && (longestMs === undefined || ms > longestMs)) longestMs = ms;
 	};
@@ -123,15 +131,20 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 	}
 	for (const { pattern, assumedOffset } of RESET_AT_PATTERNS) {
 		const match = pattern.exec(body);
-		if (match?.[1]) {
-			// English providers historically report naive UTC stamps; Zhipu's
-			// Chinese response reports its naive stamp in Beijing time.
-			const normalized = match[1].replace(" ", "T");
-			const hasOffset = /(?:Z|[+-][0-9]{2}:?[0-9]{2})$/i.test(normalized);
-			const parsed = Date.parse(hasOffset ? normalized : `${normalized}${assumedOffset}`);
-			if (!Number.isNaN(parsed) && parsed > Date.now()) {
-				consider(parsed - Date.now());
-			}
+		if (!match?.[1]) continue;
+		const normalized = match[1].replace(" ", "T");
+		const hasOffset = /(?:Z|[+-][0-9]{2}:?[0-9]{2})$/i.test(normalized);
+		if (hasOffset) {
+			// An explicit offset is authoritative; compete in longest-wins.
+			const parsed = Date.parse(normalized);
+			if (!Number.isNaN(parsed) && parsed > Date.now()) consider(parsed - Date.now());
+			continue;
+		}
+		// Defer the assumed-offset reading of a naive stamp to the fallback.
+		const parsed = Date.parse(`${normalized}${assumedOffset}`);
+		if (!Number.isNaN(parsed) && parsed > Date.now()) {
+			const delta = parsed - Date.now();
+			if (naiveResetMs === undefined || delta > naiveResetMs) naiveResetMs = delta;
 		}
 	}
 	const accountResetMatch = WILL_RESET_IN_PATTERN.exec(body);
@@ -193,6 +206,9 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 			considerClamped(resetSeconds > 1_000_000_000 ? resetSeconds * 1000 - Date.now() : resetSeconds * 1000);
 		}
 	}
+	// Only trust a naive absolute reset when nothing unambiguous was found and
+	// the provider did not ask to retry now.
+	if (longestMs === undefined && !retryNow) longestMs = naiveResetMs;
 	return longestMs ?? (retryNow ? 0 : undefined);
 }
 

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -15,11 +15,11 @@ const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s
 // "Your limit will reset at 2026-09-01 09:44:51" / "reset at 2026-09-01T09:44:51Z"
 const WILL_RESET_AT_PATTERN =
 	/(?:will\s+)?reset at\s+([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:?[0-9]{2})?)/i;
+// Both grammars carry a timezone-naive wall clock. The default reading is UTC;
+// a provider-specific offset (Z.AI/Zhipu Beijing time) is applied only through
+// `RetryHintOptions.naiveResetTimezoneOffset`, never inferred from the language.
 const CN_RESET_AT_PATTERN = /将在\s*([0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s*重置/;
-const RESET_AT_PATTERNS: readonly { pattern: RegExp; assumedOffset: string }[] = [
-	{ pattern: WILL_RESET_AT_PATTERN, assumedOffset: "Z" },
-	{ pattern: CN_RESET_AT_PATTERN, assumedOffset: "+08:00" },
-];
+const RESET_AT_PATTERNS: readonly RegExp[] = [WILL_RESET_AT_PATTERN, CN_RESET_AT_PATTERN];
 // "retry-after-ms=98497000" / "retry-after-ms: 7200000" / "retry-after-ms = 7200000"
 const RETRY_AFTER_MS_BODY_PATTERN = /\bretry-after-ms\s*[:=]\s*([0-9]+)\b/i;
 
@@ -131,12 +131,12 @@ export function extractRetryHint(
 			consider(totalMs > 0 ? totalMs : undefined);
 		}
 	}
-	for (const { pattern, assumedOffset } of RESET_AT_PATTERNS) {
+	for (const pattern of RESET_AT_PATTERNS) {
 		const match = pattern.exec(body);
 		if (!match?.[1]) continue;
 		const normalized = match[1].replace(" ", "T");
 		const hasOffset = /(?:Z|[+-][0-9]{2}:?[0-9]{2})$/i.test(normalized);
-		const offset = options?.naiveResetTimezoneOffset ?? assumedOffset;
+		const offset = options?.naiveResetTimezoneOffset ?? "Z";
 		const parsed = Date.parse(hasOffset ? normalized : `${normalized}${offset}`);
 		if (!Number.isNaN(parsed) && parsed > Date.now()) consider(parsed - Date.now());
 	}

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -23,6 +23,12 @@ const RESET_AT_PATTERNS: readonly { pattern: RegExp; assumedOffset: string }[] =
 // "retry-after-ms=98497000" / "retry-after-ms: 7200000" / "retry-after-ms = 7200000"
 const RETRY_AFTER_MS_BODY_PATTERN = /\bretry-after-ms\s*[:=]\s*([0-9]+)\b/i;
 
+/** Provider-specific interpretation for timezone-naive retry timestamps. */
+export interface RetryHintOptions {
+	/** UTC offset appended to an absolute reset stamp that omits its timezone. */
+	naiveResetTimezoneOffset?: string;
+}
+
 /**
  * Server-suggested retry delay extraction. Merges the patterns historically used
  * by the OpenAI Codex and Google Gemini retry helpers.
@@ -46,7 +52,11 @@ const RETRY_AFTER_MS_BODY_PATTERN = /\bretry-after-ms\s*[:=]\s*([0-9]+)\b/i;
  * explicitly asks for an immediate retry (`retry-after…=0`, or an absolute
  * reset timestamp that has already elapsed).
  */
-export function extractRetryHint(source: Response | Headers | null | undefined, body?: string): number | undefined {
+export function extractRetryHint(
+	source: Response | Headers | null | undefined,
+	body?: string,
+	options?: RetryHintOptions,
+): number | undefined {
 	const headers = source instanceof Headers ? source : (source?.headers ?? undefined);
 	if (headers) {
 		const retryAfterMs = headers.get("retry-after-ms");
@@ -102,14 +112,6 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 	// when the parse returns undefined, which would sleep a session the
 	// provider told to retry immediately.
 	let retryNow = false;
-	// A naive absolute reset stamp (no explicit offset) is timezone-ambiguous:
-	// English providers historically report UTC, but Z.AI/Zhipu report Beijing
-	// time in both their Chinese ("将在 … 重置") and English ("reset at …")
-	// bodies. Held back as a fallback so it never outranks an unambiguous
-	// signal (an explicit `retry-after-ms`, or an offset-qualified stamp);
-	// Z.AI's 1308 body carries such a relative hint, so the wrong UTC reading
-	// can no longer win the longest-wins merge and sleep ~8h too long.
-	let naiveResetMs: number | undefined;
 	const consider = (ms: number | undefined): void => {
 		if (ms !== undefined && ms > 0 && (longestMs === undefined || ms > longestMs)) longestMs = ms;
 	};
@@ -134,18 +136,9 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 		if (!match?.[1]) continue;
 		const normalized = match[1].replace(" ", "T");
 		const hasOffset = /(?:Z|[+-][0-9]{2}:?[0-9]{2})$/i.test(normalized);
-		if (hasOffset) {
-			// An explicit offset is authoritative; compete in longest-wins.
-			const parsed = Date.parse(normalized);
-			if (!Number.isNaN(parsed) && parsed > Date.now()) consider(parsed - Date.now());
-			continue;
-		}
-		// Defer the assumed-offset reading of a naive stamp to the fallback.
-		const parsed = Date.parse(`${normalized}${assumedOffset}`);
-		if (!Number.isNaN(parsed) && parsed > Date.now()) {
-			const delta = parsed - Date.now();
-			if (naiveResetMs === undefined || delta > naiveResetMs) naiveResetMs = delta;
-		}
+		const offset = options?.naiveResetTimezoneOffset ?? assumedOffset;
+		const parsed = Date.parse(hasOffset ? normalized : `${normalized}${offset}`);
+		if (!Number.isNaN(parsed) && parsed > Date.now()) consider(parsed - Date.now());
 	}
 	const accountResetMatch = WILL_RESET_IN_PATTERN.exec(body);
 	if (accountResetMatch?.[1]) {
@@ -206,9 +199,6 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 			considerClamped(resetSeconds > 1_000_000_000 ? resetSeconds * 1000 - Date.now() : resetSeconds * 1000);
 		}
 	}
-	// Only trust a naive absolute reset when nothing unambiguous was found and
-	// the provider did not ask to retry now.
-	if (longestMs === undefined && !retryNow) longestMs = naiveResetMs;
 	return longestMs ?? (retryNow ? 0 : undefined);
 }
 

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -205,11 +205,12 @@ describe("extractRetryHint", () => {
 		expect(hint).toBeLessThanOrEqual(3_600_000);
 	});
 
-	it("parses Chinese '将在 YYYY-MM-DD HH:MM:SS 重置' reset timestamp in error body", () => {
-		const future = new Date(Date.now() + 3_600_000).toISOString().replace("T", " ").slice(0, 19);
-		const hint = extractRetryHint(undefined, `已达到使用上限。您的限额将在 ${future} 重置。`);
-		expect(hint).toBeGreaterThan(3_500_000);
-		expect(hint).toBeLessThanOrEqual(3_600_000);
+	it("interprets Chinese reset timestamps as Beijing time", () => {
+		const targetMs = Date.parse("2099-09-01T09:44:51+08:00");
+		const expected = targetMs - Date.now();
+		const hint = extractRetryHint(undefined, "已达到使用上限。您的限额将在 2099-09-01 09:44:51 重置。");
+		expect(hint).toBeDefined();
+		expect(Math.abs(hint! - expected)).toBeLessThan(100);
 	});
 
 	// Zero-valued and elapsed signals are authoritative "retry now" replies:

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -213,6 +213,16 @@ describe("extractRetryHint", () => {
 		expect(Math.abs(hint! - expected)).toBeLessThan(100);
 	});
 
+	// Z.AI's English code-1308 body reports its Beijing-time reset stamp
+	// without an offset alongside an unambiguous retry-after-ms. Reading the
+	// naive stamp as UTC would win longest-wins and sleep ~8h too long, so the
+	// explicit relative hint must take precedence.
+	it("prefers an explicit retry-after-ms over a naive absolute reset stamp", () => {
+		const body =
+			"429 Usage limit reached for 5 hour. Your limit will reset at 2099-09-01 03:40:47 retry-after-ms=2325000";
+		expect(extractRetryHint(undefined, body)).toBe(2_325_000);
+	});
+
 	// Zero-valued and elapsed signals are authoritative "retry now" replies:
 	// collapsing them into `undefined` lets callers substitute a heuristic
 	// wait (30-minute quota guess) for a provider that said retry immediately.

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -213,14 +213,11 @@ describe("extractRetryHint", () => {
 		expect(Math.abs(hint! - expected)).toBeLessThan(100);
 	});
 
-	// Z.AI's English code-1308 body reports its Beijing-time reset stamp
-	// without an offset alongside an unambiguous retry-after-ms. Reading the
-	// naive stamp as UTC would win longest-wins and sleep ~8h too long, so the
-	// explicit relative hint must take precedence.
-	it("prefers an explicit retry-after-ms over a naive absolute reset stamp", () => {
-		const body =
-			"429 Usage limit reached for 5 hour. Your limit will reset at 2099-09-01 03:40:47 retry-after-ms=2325000";
-		expect(extractRetryHint(undefined, body)).toBe(2_325_000);
+	it("keeps a longer naive UTC reset over a shorter retry-after-ms", () => {
+		const future = new Date(Date.now() + 3_600_000).toISOString().slice(0, 19).replace("T", " ");
+		const hint = extractRetryHint(undefined, `Your limit will reset at ${future} retry-after-ms=5000`);
+		expect(hint).toBeGreaterThan(3_500_000);
+		expect(hint).toBeLessThanOrEqual(3_600_000);
 	});
 
 	// Zero-valued and elapsed signals are authoritative "retry now" replies:

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -205,10 +205,20 @@ describe("extractRetryHint", () => {
 		expect(hint).toBeLessThanOrEqual(3_600_000);
 	});
 
-	it("interprets Chinese reset timestamps as Beijing time", () => {
-		const targetMs = Date.parse("2099-09-01T09:44:51+08:00");
+	it("reads a naive Chinese reset stamp as UTC without a provider offset", () => {
+		const targetMs = Date.parse("2099-09-01T09:44:51Z");
 		const expected = targetMs - Date.now();
 		const hint = extractRetryHint(undefined, "已达到使用上限。您的限额将在 2099-09-01 09:44:51 重置。");
+		expect(hint).toBeDefined();
+		expect(Math.abs(hint! - expected)).toBeLessThan(100);
+	});
+
+	it("applies naiveResetTimezoneOffset to a naive Chinese reset stamp", () => {
+		const targetMs = Date.parse("2099-09-01T09:44:51+08:00");
+		const expected = targetMs - Date.now();
+		const hint = extractRetryHint(undefined, "已达到使用上限。您的限额将在 2099-09-01 09:44:51 重置。", {
+			naiveResetTimezoneOffset: "+08:00",
+		});
 		expect(hint).toBeDefined();
 		expect(Math.abs(hint! - expected)).toBeLessThan(100);
 	});


### PR DESCRIPTION
## Repro

On current `main`, pass Zhipu's timezone-naive Chinese reset body to `extractRetryHint` with `bun -e 'import { extractRetryHint } from "./packages/utils/src/fetch-retry.ts"; const now = Date.now(); const hint = extractRetryHint(undefined, "429 已达到使用上限。您的限额将在 2026-09-07 09:04:58 重置。"); console.log(new Date(now + hint).toISOString())'`; it schedules `2026-09-07T09:04:58Z` instead of the provider's UTC+8 instant, `2026-09-07T01:04:58Z`.

## Cause

`extractRetryHint` in `packages/utils/src/fetch-retry.ts` routed `WILL_RESET_AT_PATTERN` and `CN_RESET_AT_PATTERN` through one UTC fallback, appending `Z` whenever the matched timestamp lacked an explicit offset. Zhipu's Chinese response reports a Beijing-time wall clock without an offset, so that fallback shifted the deadline by eight hours.

## Fix

- Associate each absolute-reset grammar with its assumed offset: UTC for the existing English grammar and UTC+8 for Zhipu's Chinese grammar.
- Replace the Chinese reset regression test with a fixed Beijing timestamp that fails by exactly eight hours under the old parser.
- Document the corrected wait behavior in the utils changelog.

## Verification

`bun test packages/utils/test/fetch-retry.test.ts` passes: 30 tests, 0 failures. Re-running the reproduction schedules exactly `2026-09-07T01:04:58.000Z` with `errorMs: 0`. The publish gate also ran `bun run fix` and `bun check` successfully.

Fixes #11014