### PR TITLE
fix(task): pin isolated subagent cwd to its worktree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Isolated subagents now keep the worktree created for them even when a stale transcript already occupies the child session path; previously the recorded parent-checkout cwd was adopted and bash ran in the parent session directory.
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.
 
 ### Changed

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1407,7 +1407,8 @@ export class SessionManager {
 		await this.#setSessionFile(sessionFile);
 	}
 
-	async #setSessionFile(sessionFile: string, loadedSession?: SessionLoadResult): Promise<void> {
+	/** @param pinnedCwd Caller-authoritative cwd; when set, the header cwd is never adopted. */
+	async #setSessionFile(sessionFile: string, loadedSession?: SessionLoadResult, pinnedCwd?: string): Promise<void> {
 		await this.#drainAndCloseWriter();
 		this.#clearDiskError();
 		this.#draftOnlySessionCleanupArmed = false;
@@ -1447,8 +1448,17 @@ export class SessionManager {
 		// (extension UI, RPC) would otherwise track a directory the process
 		// cannot enter. Keep the current cwd so the session stays where the
 		// user already is.
+		//
+		// A pinned cwd skips adoption entirely: the caller's directory is
+		// authoritative, not a default. An isolated subagent run pins the
+		// worktree created for it, so a cwd recorded by whatever transcript
+		// already occupies this path can never relocate the run back into the
+		// parent checkout (#10914). Nothing is pending relocation, so workspace
+		// edits stay persistable.
 		const headerCwd = header.cwd ? path.resolve(header.cwd) : undefined;
-		if (headerCwd && headerCwd !== path.resolve(this.#cwd) && (await directoryIsEnterable(headerCwd))) {
+		if (pinnedCwd !== undefined) {
+			this.#fallbackRuntimeOnly = false;
+		} else if (headerCwd && headerCwd !== path.resolve(this.#cwd) && (await directoryIsEnterable(headerCwd))) {
 			this.#cwd = headerCwd;
 			this.#sessionDir = path.dirname(resolvedSessionFile);
 			this.#fallbackRuntimeOnly = false;
@@ -2914,7 +2924,7 @@ export class SessionManager {
 		filePath: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { initialCwd?: string; suppressBreadcrumb?: boolean },
+		options?: { initialCwd?: string; suppressBreadcrumb?: boolean; pinnedCwd?: string },
 	): Promise<SessionManager> {
 		const loaded = await loadSessionFile(filePath, storage);
 		const header = loaded.entries.find(entry => entry.type === "session") as SessionHeader | undefined;
@@ -2924,9 +2934,13 @@ export class SessionManager {
 		// interactive mode runs next — fail, so fall back to the launch cwd and
 		// anchor /new and /branch there too, keeping the resumed session where
 		// the user already is.
+		// A pinned cwd wins over the recorded one: an isolated subagent run
+		// pins the worktree created for it, so a cwd recorded by whatever
+		// transcript already occupies this path can never relocate the run
+		// back into the parent checkout (#10914).
 		const recordedCwd = header?.cwd;
 		const recordedCwdUsable = !!recordedCwd && (await directoryIsEnterable(recordedCwd));
-		const cwd = recordedCwdUsable ? recordedCwd : (options?.initialCwd ?? getProjectDir());
+		const cwd = options?.pinnedCwd ?? (recordedCwdUsable ? recordedCwd : (options?.initialCwd ?? getProjectDir()));
 		const dir =
 			sessionDir ??
 			(recordedCwd && !recordedCwdUsable
@@ -2934,7 +2948,7 @@ export class SessionManager {
 				: path.dirname(path.resolve(filePath)));
 		const manager = new SessionManager(cwd, dir, true, storage);
 		manager.#suppressBreadcrumb = options?.suppressBreadcrumb === true;
-		await manager.#setSessionFile(filePath, loaded);
+		await manager.#setSessionFile(filePath, loaded, options?.pinnedCwd);
 		return manager;
 	}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1473,7 +1473,11 @@ export class SessionManager {
 		}
 
 		this.#applyEntries(header, fileEntries.slice(1) as SessionEntry[]);
-		this.#additionalDirectories = header.additionalDirectories ?? [];
+		// A pinned cwd also drops recorded workspace roots: the executor clears
+		// `workspace.additionalDirectories` for isolated runs, but createAgentSession
+		// only calls setAdditionalDirectories when the configured list is nonempty,
+		// so restored stale roots would otherwise stay exposed (#10914).
+		this.#additionalDirectories = pinnedCwd !== undefined ? [] : (header.additionalDirectories ?? []);
 		this.#titleUpdatedAt = titleSlot?.updatedAt ?? header.timestamp;
 		this.#hasTitleSlot = titleSlot !== undefined;
 		this.#fileIsCurrent = true;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3235,6 +3235,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const sessionManagerPromise = sessionFile
 				? SessionManager.open(sessionFile, undefined, undefined, {
 						initialCwd: effectiveCwd,
+						// Isolated runs execute in the worktree; a stale transcript at
+						// the child session path must not relocate them (#10914).
+						...(worktree !== undefined ? { pinnedCwd: worktree } : {}),
 						suppressBreadcrumb: true,
 					})
 				: Promise.resolve(SessionManager.inMemory(effectiveCwd));

--- a/packages/coding-agent/test/task/subagent-lsp.test.ts
+++ b/packages/coding-agent/test/task/subagent-lsp.test.ts
@@ -20,7 +20,8 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/tools/yield";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
-const TEST_TASK: TaskParams = { agent: "task", name: "CheckLsp", task: "Inspect LSP tools." };
+const TEST_TASK_NAME = "CheckLsp";
+const TEST_TASK: TaskParams = { agent: "task", name: TEST_TASK_NAME, task: "Inspect LSP tools." };
 
 function createAssistantStopMessage(text: string): AssistantMessage {
 	return {
@@ -254,6 +255,44 @@ describe("subagent LSP availability", () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolated-session-cwd-"));
 		try {
 			const parentSessionFile = path.join(tempDir, "parent.jsonl");
+			const tool = await TaskTool.create(createSession({ isolationEnabled: true, sessionFile: parentSessionFile }));
+			await tool.execute("tool-call", { ...TEST_TASK, isolated: true });
+
+			const sessionManager = getOptions()?.sessionManager as { getCwd?: () => string } | undefined;
+			expect(getOptions()?.cwd).toBe("/tmp/isolated-subagent");
+			expect(sessionManager?.getCwd?.()).toBe("/tmp/isolated-subagent");
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+
+	it("keeps the isolated worktree cwd when a transcript already occupies the child session path", async () => {
+		mockAgents({
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Use normal tools.",
+			source: "bundled",
+			tools: ["write"],
+		});
+		mockIsolation();
+		const { getOptions } = mockCreateAgentSession();
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolated-session-cwd-"));
+		try {
+			const parentSessionFile = path.join(tempDir, "parent.jsonl");
+			// A transcript from an earlier run already sits at the child's session
+			// path and records the parent checkout as its cwd. Adopting a recorded
+			// cwd is right for a resume, but an isolated run's cwd is the worktree
+			// that was just created for it (#10914).
+			await Bun.write(
+				path.join(tempDir, "parent", `${TEST_TASK_NAME}.jsonl`),
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "stale-transcript",
+					timestamp: new Date().toISOString(),
+					cwd: tempDir,
+				})}\n`,
+			);
 			const tool = await TaskTool.create(createSession({ isolationEnabled: true, sessionFile: parentSessionFile }));
 			await tool.execute("tool-call", { ...TEST_TASK, isolated: true });
 

--- a/packages/coding-agent/test/task/subagent-lsp.test.ts
+++ b/packages/coding-agent/test/task/subagent-lsp.test.ts
@@ -291,14 +291,18 @@ describe("subagent LSP availability", () => {
 					id: "stale-transcript",
 					timestamp: new Date().toISOString(),
 					cwd: tempDir,
+					additionalDirectories: [tempDir],
 				})}\n`,
 			);
 			const tool = await TaskTool.create(createSession({ isolationEnabled: true, sessionFile: parentSessionFile }));
 			await tool.execute("tool-call", { ...TEST_TASK, isolated: true });
 
-			const sessionManager = getOptions()?.sessionManager as { getCwd?: () => string } | undefined;
+			const sessionManager = getOptions()?.sessionManager as
+				| { getCwd?: () => string; getAdditionalDirectories?: () => string[] }
+				| undefined;
 			expect(getOptions()?.cwd).toBe("/tmp/isolated-subagent");
 			expect(sessionManager?.getCwd?.()).toBe("/tmp/isolated-subagent");
+			expect(sessionManager?.getAdditionalDirectories?.()).toEqual([]);
 		} finally {
 			await removeWithRetries(tempDir);
 		}


### PR DESCRIPTION
## Why

A subagent spawned with `isolated:true` runs its bash tool calls in the parent session directory instead of its assigned worktree when a stale transcript already occupies the child session path. The transcript header records the parent checkout cwd, and `SessionManager.open` prefers any usable recorded cwd over the `initialCwd` the executor passes (the freshly created worktree). Observed on omp 18.1.10 as coordinator-checkout pollution, a moved untracked file, and a detached HEAD. Fixes #10914.

## Scope

- `packages/coding-agent/src/session/session-manager.ts`: `SessionManager.open` accepts `pinnedCwd`, which wins over the recorded cwd and is threaded into `#setSessionFile` so the header cwd is never adopted for that open. `#setSessionFile` (prior half of this change) already skips adoption when pinned.
- `packages/coding-agent/src/task/executor.ts`: isolated spawns pass `pinnedCwd: worktree`. Non-isolated resumes are untouched.
- `packages/coding-agent/test/task/subagent-lsp.test.ts`: regression test placing a stale parent-cwd transcript at the child session path, asserting both the session options cwd and the opened manager cwd stay in the worktree.
- `packages/coding-agent/CHANGELOG.md`: entry under [Unreleased].

A resume of a normal session still adopts its recorded cwd. The pin applies only when the caller supplies it, and only the isolated spawn path does.

## Blast Radius

Only `SessionManager.open` calls that pass `pinnedCwd` change behavior, which is exactly one: the isolated subagent spawn. All other callers (main, share, render-cli, persisted-revive, transcript-recorder) omit it and keep recorded-cwd-first resume. The added field is optional, so no caller signature breaks.

## Verification

New test fails before the fix (`Received: /tmp/omp-isolated-session-cwd-*` for the manager cwd) and passes after. Full file suite: 7 pass, 0 fail. Neighbors `sdk-session-isolation.test.ts` plus `agent-session-handoff.test.ts`: 39 pass, 0 fail. Package `bun run check` (oxlint, oxfmt, tsgo --noEmit) clean.