### PR TITLE
fix(prewalk): hand off after eval-wrapped edit/write under Code Mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed fullscreen `/copy` outlining only a lazily created grouped Read card, so Enter copies the assistant yield instead of tool output.
+- Fixed prewalk not handing off after an `edit`/`write` dispatched through Eval under Codex Code Mode; the eval bridge now flags nested workspace-mutating actions so the switch fires while read-only cells and read-tier `xd://` device ops still don't ([#11018](https://github.com/can1357/oh-my-pi/issues/11018)).
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/src/eval/js/shared/helpers.ts
+++ b/packages/coding-agent/src/eval/js/shared/helpers.ts
@@ -64,7 +64,9 @@ export function createHelpers(ctx: HelperContext): HelperBundle {
 			} else {
 				await Bun.write(filePath, new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
 			}
-			ctx.emitStatus({ op: "write", path: filePath, bytes: getDataSize(data) });
+			// A `write()` prelude call mutates the workspace like `tool.write`, so
+			// flag it as a prewalk implementation action (issue #11018).
+			ctx.emitStatus({ op: "write", path: filePath, bytes: getDataSize(data), implementationAction: true });
 			return filePath;
 		},
 		env: (key, value) => {

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -2,6 +2,7 @@ import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
 import { isRecord } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import { isImplementationActionResult } from "../../session/implementation-action";
 import type { ToolSession } from "../../tools";
 import { ToolError } from "../../tools/tool-errors";
 import { schemaDeclaresIntentField } from "../../utils/tool-schema";
@@ -139,7 +140,14 @@ function normalizeAgentToolResult(
 	);
 	const text = textBlocks.map(block => block.text).join("");
 	const hasError = toolResultHasError(result);
-	options.emitStatus?.(summarizeToolResult(name, args, result, text, hasError));
+	const statusEvent = summarizeToolResult(name, args, result, text, hasError);
+	// Code Mode routes edit/write through this bridge, so the turn-level result
+	// is `eval`. Flag a nested workspace-mutating action here so the prewalk
+	// coordinator can recognize it from the eval result (issue #11018).
+	if (!hasError && isImplementationActionResult({ toolName: name, details: result.details })) {
+		statusEvent.implementationAction = true;
+	}
+	options.emitStatus?.(statusEvent);
 	if (result.details === undefined && imageBlocks.length === 0 && !hasError) {
 		return text;
 	}

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -139,7 +139,10 @@ if "__omp_prelude_loaded__" not in globals():
         p = _resolve_omp_path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
-        _emit_status("write", path=str(p), chars=len(content))
+        # A write() prelude call mutates the workspace like tool.write, so flag
+        # it as a prewalk implementation action (issue #11018). The camelCase key
+        # matches the marker prewalk reads on the JS side.
+        _emit_status("write", path=str(p), chars=len(content), implementationAction=True)
         return p
 
     def output(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2167,6 +2167,7 @@ export class AgentSession {
 	async #deliverAsyncJobResult(manager: AsyncJobManager, jobId: string, text: string, job?: AsyncJob): Promise<void> {
 		if (this.#isDisposed) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
+		await this.#prewalk.advanceAtAsyncJobEnd(job);
 		// Snapshot the generation before the async format step: a `/new` during it
 		// bumps the epoch, so this delivery belongs to the replaced session and
 		// must not enqueue — the suppression marker alone is unreliable because

--- a/packages/coding-agent/src/session/implementation-action.ts
+++ b/packages/coding-agent/src/session/implementation-action.ts
@@ -1,0 +1,37 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+
+/**
+ * Minimal completed-tool-result shape needed to classify a workspace-mutating
+ * implementation action. Both a turn-level `ToolResultMessage` and a nested
+ * eval-bridge tool result satisfy it.
+ */
+export interface ImplementationActionResult {
+	toolName: string;
+	details: unknown;
+}
+
+/** Tool names whose successful completion mutates the workspace. */
+const IMPLEMENTATION_ACTION_TOOLS: Record<string, true> = {
+	edit: true,
+	write: true,
+};
+
+/**
+ * Whether a completed tool result is a workspace-mutating implementation action.
+ * A direct `edit`/`write` call always counts; a `write` that dispatched an
+ * `xd://` device (e.g. `lsp`, `ast_edit`, `debug`) counts only when the wrapped
+ * tool resolved to a `write`/`exec` approval tier. Read-only device calls — LSP
+ * navigation, `debug` inspection, `ast_edit` on internal URLs, help lookups —
+ * leave the tier `read` (or absent) and are not implementation actions (issue #7312).
+ */
+export function isImplementationActionResult(result: ImplementationActionResult): boolean {
+	if (!IMPLEMENTATION_ACTION_TOOLS[result.toolName]) return false;
+	const details = result.details;
+	// A direct filesystem edit/write carries no `xd://` dispatch metadata.
+	if (!isRecord(details) || !("xdev" in details) || !details.xdev) return true;
+	const xdev = details.xdev;
+	// Device dispatch: switch only on a genuine mutation tier. An absent tier
+	// (help lookup, unresolved approval) declines the switch.
+	if (!isRecord(xdev) || !("tier" in xdev)) return false;
+	return xdev.tier === "write" || xdev.tier === "exec";
+}

--- a/packages/coding-agent/src/session/implementation-action.ts
+++ b/packages/coding-agent/src/session/implementation-action.ts
@@ -7,7 +7,7 @@ import { isRecord } from "@oh-my-pi/pi-utils";
  */
 export interface ImplementationActionResult {
 	toolName: string;
-	details: unknown;
+	details?: unknown;
 }
 
 /** Tool names whose successful completion mutates the workspace. */

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -41,7 +41,7 @@ const PLAN_YOLO_HANDOFF_MESSAGE_TYPE = "plan-yolo-handoff";
  */
 function isPrewalkImplementationAction(result: ToolResultMessage): boolean {
 	if (isImplementationActionResult(result)) return true;
-	if (result.toolName !== "eval" || result.isError === true) return false;
+	if (result.toolName !== "eval") return false;
 	const details = result.details;
 	if (!isRecord(details) || !Array.isArray(details.statusEvents)) return false;
 	return details.statusEvents.some(event => isRecord(event) && event[EVAL_IMPLEMENTATION_ACTION_MARKER] === true);

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -1,7 +1,7 @@
 import type { Agent, AgentMessage, AgentToolResult, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
 import { invalidateMessageCache } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { isRecord, prompt } from "@oh-my-pi/pi-utils";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { resolveApprovedPlan } from "../plan-mode/approved-plan";
 import { listPlanFiles, readPlanFile } from "../plan-mode/plan-files";
@@ -15,6 +15,7 @@ import { isMCPToolName } from "../tools/builtin-names";
 import type { PlanProposalHandler } from "../tools/resolve";
 import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
+import { isImplementationActionResult } from "./implementation-action";
 import { PREWALK_PLAN_MESSAGE_TYPE } from "./messages";
 import type { SessionManager } from "./session-manager";
 
@@ -25,32 +26,25 @@ const PREWALK_CHECKLIST_MESSAGE_TYPE = "prewalk-checklist";
 export function isPrewalkPlanNudge(message: AgentMessage): boolean {
 	return message.role === "custom" && message.customType === PREWALK_PLAN_MESSAGE_TYPE;
 }
-const PREWALK_ACTION_TOOLS: Record<string, true> = {
-	edit: true,
-	write: true,
-};
+/** Marker set on an eval status event whose nested tool call was a workspace-mutating implementation action. */
+const EVAL_IMPLEMENTATION_ACTION_MARKER = "implementationAction";
 const PLAN_YOLO_HANDOFF_MESSAGE_TYPE = "plan-yolo-handoff";
 
 /**
  * Whether a completed tool result is the first workspace-mutating action that
- * arms the prewalk hand-off. A direct `edit`/`write` call always counts; a
- * `write` that dispatched an `xd://` device (e.g. `lsp`, `ast_edit`, `debug`)
- * counts only when the wrapped tool resolved to a `write`/`exec` approval tier.
- * Read-only device calls — LSP navigation, `debug` inspection, `ast_edit` on
- * internal URLs, help lookups — leave the tier `read` (or absent) and must not
- * switch the model mid-investigation (issue #7312).
+ * arms the prewalk hand-off. A direct `edit`/`write` counts via
+ * {@link isImplementationActionResult}; under Code Mode those tools leave the
+ * direct surface and run through the eval bridge, so the turn-level result is
+ * named `eval` and the nested action is recognized from the bridge's marker
+ * (issue #11018). Read-only eval cells and read-tier `xd://` device ops carry
+ * no marker, preserving the mid-investigation exclusion (issue #7312).
  */
 function isPrewalkImplementationAction(result: ToolResultMessage): boolean {
-	if (!PREWALK_ACTION_TOOLS[result.toolName]) return false;
+	if (isImplementationActionResult(result)) return true;
+	if (result.toolName !== "eval" || result.isError === true) return false;
 	const details = result.details;
-	// A direct filesystem edit/write carries no `xd://` dispatch metadata.
-	if (!details || typeof details !== "object" || !("xdev" in details) || !details.xdev) return true;
-	const xdev = details.xdev;
-	// Device dispatch: switch only on a genuine mutation tier. An absent tier
-	// (help lookup, unresolved approval) declines the switch, matching the
-	// reporter's "stay on the large model a couple turns longer" preference.
-	if (typeof xdev !== "object" || !("tier" in xdev)) return false;
-	return xdev.tier === "write" || xdev.tier === "exec";
+	if (!isRecord(details) || !Array.isArray(details.statusEvents)) return false;
+	return details.statusEvents.some(event => isRecord(event) && event[EVAL_IMPLEMENTATION_ACTION_MARKER] === true);
 }
 
 /** Capabilities the prewalk coordinator borrows from its owning session. */

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -2,6 +2,7 @@ import type { Agent, AgentMessage, AgentToolResult, AgentTurnEndContext } from "
 import { invalidateMessageCache } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { isRecord, prompt } from "@oh-my-pi/pi-utils";
+import type { AsyncJob } from "../async";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { resolveApprovedPlan } from "../plan-mode/approved-plan";
 import { listPlanFiles, readPlanFile } from "../plan-mode/plan-files";
@@ -42,11 +43,17 @@ const PLAN_YOLO_HANDOFF_MESSAGE_TYPE = "plan-yolo-handoff";
 function isPrewalkImplementationAction(result: ToolResultMessage): boolean {
 	if (isImplementationActionResult(result)) return true;
 	if (result.toolName !== "eval") return false;
-	const details = result.details;
-	if (!isRecord(details) || !Array.isArray(details.statusEvents)) return false;
-	return details.statusEvents.some(event => isRecord(event) && event[EVAL_IMPLEMENTATION_ACTION_MARKER] === true);
+	return evalImplementationActionName(result.details) !== undefined;
 }
 
+function evalImplementationActionName(details: unknown): string | undefined {
+	if (!isRecord(details) || !Array.isArray(details.statusEvents)) return undefined;
+	const event = details.statusEvents.find(
+		candidate => isRecord(candidate) && candidate[EVAL_IMPLEMENTATION_ACTION_MARKER] === true,
+	);
+	if (!isRecord(event)) return undefined;
+	return typeof event.op === "string" ? event.op : "eval implementation";
+}
 /** Capabilities the prewalk coordinator borrows from its owning session. */
 export interface PrewalkCoordinatorHost {
 	agent: Agent;
@@ -86,6 +93,8 @@ export class PrewalkCoordinator {
 	#planInjected = false;
 	#continuePending = false;
 	#todoSeen = false;
+	#asyncImplementationName: string | undefined;
+	#handoffPromise: Promise<void> | undefined;
 	#planYolo: PlanYolo | undefined;
 	#planYoloPreviousNonMCPPresentation: { enabled: string[]; mounted: string[] } | undefined;
 	#planYoloArmed = false;
@@ -116,11 +125,16 @@ export class PrewalkCoordinator {
 		);
 	}
 
+	#todoGateOpen(): boolean {
+		return this.#todoSeen || !this.#host.getActiveToolNames().includes("todo");
+	}
+
 	#clearPrewalkState(): void {
 		this.#prewalk = undefined;
 		this.#planInjected = false;
 		this.#continuePending = false;
 		this.#todoSeen = false;
+		this.#asyncImplementationName = undefined;
 	}
 
 	#disarmNoop(prewalk: Prewalk): void {
@@ -136,6 +150,10 @@ export class PrewalkCoordinator {
 	async advanceAtTurnEnd(liveMessages: AgentMessage[], context: AgentTurnEndContext | undefined): Promise<void> {
 		const prewalk = this.#prewalk;
 		if (!prewalk || context?.message.role !== "assistant") return;
+		if (this.#handoffPromise) {
+			await this.#handoffPromise;
+			return;
+		}
 		if (this.#isNoop(prewalk)) {
 			this.#scrubPlanNudge(liveMessages);
 			this.#disarmNoop(prewalk);
@@ -158,11 +176,12 @@ export class PrewalkCoordinator {
 			});
 		}
 
-		const todoGateOpen = this.#todoSeen || !this.#host.getActiveToolNames().includes("todo");
+		const todoGateOpen = this.#todoGateOpen();
 		const action = todoGateOpen
 			? context.toolResults.find(result => isPrewalkImplementationAction(result))
 			: undefined;
-		if (!action) {
+		const actionName = action?.toolName ?? (todoGateOpen ? this.#asyncImplementationName : undefined);
+		if (!actionName) {
 			if (!this.#planInjected) {
 				this.#planInjected = true;
 				this.#continuePending = true;
@@ -179,10 +198,59 @@ export class PrewalkCoordinator {
 			return;
 		}
 
-		await this.#host.waitForSessionMessagePersistence(context.message);
-		for (const toolResult of context.toolResults) {
-			await this.#host.waitForSessionMessagePersistence(toolResult);
+		await this.#handoff(prewalk, liveMessages, actionName, async () => {
+			await this.#host.waitForSessionMessagePersistence(context.message);
+			for (const toolResult of context.toolResults) {
+				await this.#host.waitForSessionMessagePersistence(toolResult);
+			}
+		});
+	}
+
+	/**
+	 * Records an implementation action completed by a background Eval job and,
+	 * once the todo gate is open, switches before its `async-result` follow-up.
+	 */
+	async advanceAtAsyncJobEnd(job: AsyncJob | undefined): Promise<void> {
+		const prewalk = this.#prewalk;
+		if (!prewalk || job?.type !== "eval") return;
+		const actionName = evalImplementationActionName(job.latestDetails);
+		if (!actionName) return;
+		this.#asyncImplementationName = actionName;
+		if (!this.#todoGateOpen()) return;
+		if (this.#isNoop(prewalk)) {
+			this.#scrubPlanNudge(this.#host.agent.state.messages);
+			this.#disarmNoop(prewalk);
+			return;
 		}
+		await this.#handoff(prewalk, this.#host.agent.state.messages, actionName);
+	}
+
+	async #handoff(
+		prewalk: Prewalk,
+		liveMessages: AgentMessage[],
+		actionName: string,
+		waitForPersistence?: () => Promise<void>,
+	): Promise<void> {
+		if (this.#handoffPromise) {
+			await this.#handoffPromise;
+			return;
+		}
+		const handoff = this.#completeHandoff(prewalk, liveMessages, actionName, waitForPersistence);
+		this.#handoffPromise = handoff;
+		try {
+			await handoff;
+		} finally {
+			if (this.#handoffPromise === handoff) this.#handoffPromise = undefined;
+		}
+	}
+
+	async #completeHandoff(
+		prewalk: Prewalk,
+		liveMessages: AgentMessage[],
+		actionName: string,
+		waitForPersistence?: () => Promise<void>,
+	): Promise<void> {
+		await waitForPersistence?.();
 		this.#scrubPlanNudge(liveMessages);
 		const target = prewalk.target;
 		if (this.#isNoop(prewalk)) {
@@ -193,7 +261,7 @@ export class PrewalkCoordinator {
 		this.#clearPrewalkState();
 		this.#host.emitNotice(
 			"info",
-			`Prewalk: switched to ${target.provider}/${target.id} after first ${action.toolName} call.`,
+			`Prewalk: switched to ${target.provider}/${target.id} after first ${actionName} call.`,
 			"prewalk",
 		);
 		this.#host.agent.steer({

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -107,6 +107,21 @@ describe("AgentSession prewalk", () => {
 		return { content: [{ type: "toolCall", id, name, arguments: {} }], stopReason: "toolUse" };
 	}
 
+	const evalToolSchema = type({});
+	function makeEvalTool(
+		statusEvents: Array<Record<string, unknown>>,
+	): AgentTool<typeof evalToolSchema, { statusEvents: Array<Record<string, unknown>> }> {
+		return {
+			name: "eval",
+			label: "Eval",
+			description: "Run an eval cell",
+			parameters: evalToolSchema,
+			async execute() {
+				return { content: [{ type: "text", text: "ran cell" }], details: { statusEvents } };
+			},
+		};
+	}
+
 	it("prewalks at the first edit/write after the todo gate opens; bash and todo don't trigger", async () => {
 		const primary = modelOrThrow("claude-sonnet-4-5");
 		const target = modelOrThrow("claude-sonnet-4-6");
@@ -499,6 +514,108 @@ describe("AgentSession prewalk", () => {
 			`${target.provider}/${target.id}`,
 		]);
 		expect(session.model?.id).toBe(target.id);
+	});
+
+	it("prewalks on an edit/write dispatched through an eval cell under Code Mode (issue #11018)", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+
+		// Code Mode removes edit/write from the direct surface and runs them
+		// through the eval bridge, so the turn-level result is named `eval`. The
+		// bridge flags the nested write; prewalk must hand off exactly as it would
+		// for a direct write. Turn 1 (todo) opens the gate; turn 2 (eval write)
+		// switches, so turn 3 runs on the target.
+		const evalWrite = makeEvalTool([{ op: "write", path: "example.txt", chars: 7, implementationAction: true }]);
+		const mock = createMockModel({
+			responses: [toolCall("t1", "todo"), toolCall("t2", "eval"), { content: ["done"] }],
+		});
+		const requested: string[] = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [todoTool as AgentTool, evalWrite as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (model, context, options) => {
+				requested.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry: new Map([
+				[todoTool.name, todoTool as AgentTool],
+				[evalWrite.name, evalWrite as AgentTool],
+			]),
+			prewalk: { target },
+		});
+
+		await session.prompt("implement via eval");
+
+		expect(requested).toEqual([
+			`${primary.provider}/${primary.id}`,
+			`${primary.provider}/${primary.id}`,
+			`${target.provider}/${target.id}`,
+		]);
+		expect(session.model?.id).toBe(target.id);
+	});
+
+	it("does not switch on a read-only eval cell (issue #11018 keeps the #7312 exclusion)", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+
+		// A read-only eval cell (or a read-tier `xd://` device op) carries no
+		// implementation-action marker, so the model keeps reasoning on the strong
+		// model. Mirrors the #7312 read-only device flow: one continuation, four
+		// turns, all primary, then a clean stop.
+		const evalRead = makeEvalTool([{ op: "read", path: "example.txt", chars: 10 }]);
+		const mock = createMockModel({
+			responses: [
+				toolCall("t1", "record"),
+				toolCall("t2", "eval"),
+				{ content: [{ type: "text", text: "Still planning." }], stopReason: "stop" },
+				{ content: [{ type: "text", text: "Done planning." }], stopReason: "stop" },
+			],
+		});
+		const requested: string[] = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [recordTool as AgentTool, evalRead as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (model, context, options) => {
+				requested.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry: new Map([
+				[recordTool.name, recordTool as AgentTool],
+				[evalRead.name, evalRead as AgentTool],
+			]),
+			prewalk: { target },
+		});
+
+		await session.prompt("investigate via eval");
+
+		expect(requested).toEqual(Array(4).fill(`${primary.provider}/${primary.id}`));
+		expect(session.model?.id).toBe(primary.id);
 	});
 
 	it("re-arms continuation after tool progress between prose turns", async () => {

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -5,6 +5,7 @@ import { Agent, type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -125,6 +126,22 @@ describe("AgentSession prewalk", () => {
 				};
 			},
 		};
+	}
+
+	function registerBackgroundEvalStatus(
+		manager: AsyncJobManager,
+		ownerId: string,
+		statusEvent: Record<string, unknown>,
+	): string {
+		return manager.register(
+			"eval",
+			"background eval",
+			async ({ reportProgress }) => {
+				await reportProgress("eval completed", { statusEvents: [statusEvent] });
+				return "done";
+			},
+			{ ownerId },
+		);
 	}
 
 	it("prewalks at the first edit/write after the todo gate opens; bash and todo don't trigger", async () => {
@@ -628,6 +645,79 @@ describe("AgentSession prewalk", () => {
 		expect(requested).toEqual(Array(4).fill(`${primary.provider}/${primary.id}`));
 		expect(session.model?.id).toBe(primary.id);
 	});
+
+	const backgroundEvalCases: Array<{
+		title: string;
+		todoGate: boolean;
+		statusEvent: Record<string, unknown>;
+		switches: boolean;
+	}> = [
+		{
+			title: "prewalks on a write completed after Eval backgrounds before the async-result follow-up",
+			todoGate: false,
+			statusEvent: { op: "write", path: "example.txt", implementationAction: true },
+			switches: true,
+		},
+		{
+			title: "prewalks on a write completed after Eval backgrounds after the todo gate opens",
+			todoGate: true,
+			statusEvent: { op: "write", path: "example.txt", implementationAction: true },
+			switches: true,
+		},
+		{
+			title: "does not prewalk on a read-only background Eval job",
+			todoGate: false,
+			statusEvent: { op: "read", path: "example.txt" },
+			switches: false,
+		},
+	];
+	for (const { title, todoGate, statusEvent, switches } of backgroundEvalCases) {
+		it(`${title} (issue #11018)`, async () => {
+			const primary = modelOrThrow("claude-sonnet-4-5");
+			const target = modelOrThrow("claude-sonnet-4-6");
+			const responses: MockResponse[] = todoGate
+				? [toolCall("t1", "todo"), { content: ["done"] }]
+				: [{ content: ["done"] }];
+			const mock = createMockModel({ responses });
+			const requested: string[] = [];
+			const agent = new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model: primary,
+					systemPrompt: ["Test"],
+					tools: todoGate ? [todoTool as AgentTool] : [],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+				convertToLlm,
+				streamFn: (model, context, options) => {
+					requested.push(`${model.provider}/${model.id}`);
+					return mock.stream(model, context, options);
+				},
+			});
+			const manager = new AsyncJobManager({});
+			const ownerId = "PrewalkBackgroundEval";
+			session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "compaction.enabled": false }),
+				modelRegistry,
+				toolRegistry: new Map(todoGate ? [[todoTool.name, todoTool as AgentTool]] : []),
+				prewalk: { target },
+				agentId: ownerId,
+				ownedAsyncJobManager: manager,
+			});
+
+			registerBackgroundEvalStatus(manager, ownerId, statusEvent);
+			await session.settleAsyncWork();
+
+			const primaryId = `${primary.provider}/${primary.id}`;
+			const targetId = `${target.provider}/${target.id}`;
+			const expected = todoGate ? [primaryId, targetId] : switches ? [targetId] : [primaryId, primaryId];
+			expect(requested).toEqual(expected);
+			expect(session.model?.id).toBe(switches ? target.id : primary.id);
+		});
+	}
 
 	it("re-arms continuation after tool progress between prose turns", async () => {
 		// Regression: a normal prewalk can split planning across several turns:

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -110,6 +110,7 @@ describe("AgentSession prewalk", () => {
 	const evalToolSchema = type({});
 	function makeEvalTool(
 		statusEvents: Array<Record<string, unknown>>,
+		options?: { isError?: boolean },
 	): AgentTool<typeof evalToolSchema, { statusEvents: Array<Record<string, unknown>> }> {
 		return {
 			name: "eval",
@@ -117,7 +118,11 @@ describe("AgentSession prewalk", () => {
 			description: "Run an eval cell",
 			parameters: evalToolSchema,
 			async execute() {
-				return { content: [{ type: "text", text: "ran cell" }], details: { statusEvents } };
+				return {
+					content: [{ type: "text", text: "ran cell" }],
+					details: { statusEvents },
+					isError: options?.isError,
+				};
 			},
 		};
 	}
@@ -516,56 +521,62 @@ describe("AgentSession prewalk", () => {
 		expect(session.model?.id).toBe(target.id);
 	});
 
-	it("prewalks on an edit/write dispatched through an eval cell under Code Mode (issue #11018)", async () => {
-		const primary = modelOrThrow("claude-sonnet-4-5");
-		const target = modelOrThrow("claude-sonnet-4-6");
+	for (const evalIsError of [false, true]) {
+		const outcome = evalIsError ? "later fails" : "completes";
+		it(`prewalks when an eval cell writes and then ${outcome} (issue #11018)`, async () => {
+			const primary = modelOrThrow("claude-sonnet-4-5");
+			const target = modelOrThrow("claude-sonnet-4-6");
 
-		// Code Mode removes edit/write from the direct surface and runs them
-		// through the eval bridge, so the turn-level result is named `eval`. The
-		// bridge flags the nested write; prewalk must hand off exactly as it would
-		// for a direct write. Turn 1 (todo) opens the gate; turn 2 (eval write)
-		// switches, so turn 3 runs on the target.
-		const evalWrite = makeEvalTool([{ op: "write", path: "example.txt", chars: 7, implementationAction: true }]);
-		const mock = createMockModel({
-			responses: [toolCall("t1", "todo"), toolCall("t2", "eval"), { content: ["done"] }],
-		});
-		const requested: string[] = [];
-		const agent = new Agent({
-			getApiKey: () => "test-key",
-			initialState: {
-				model: primary,
-				systemPrompt: ["Test"],
-				tools: [todoTool as AgentTool, evalWrite as AgentTool],
-				messages: [],
-				thinkingLevel: Effort.Medium,
-			},
-			convertToLlm,
-			streamFn: (model, context, options) => {
-				requested.push(`${model.provider}/${model.id}`);
-				return mock.stream(model, context, options);
-			},
-		});
-		session = new AgentSession({
-			agent,
-			sessionManager: SessionManager.inMemory(),
-			settings: Settings.isolated({ "compaction.enabled": false }),
-			modelRegistry,
-			toolRegistry: new Map([
-				[todoTool.name, todoTool as AgentTool],
-				[evalWrite.name, evalWrite as AgentTool],
-			]),
-			prewalk: { target },
-		});
+			// Code Mode removes edit/write from the direct surface and runs them
+			// through the eval bridge, so the turn-level result is named `eval`.
+			// The successful nested write must hand off even if a later statement
+			// makes the enclosing cell fail; failed nested calls never receive the
+			// implementation-action marker. Turn 1 (todo) opens the gate, turn 2
+			// mutates through eval, and turn 3 runs on the target.
+			const evalWrite = makeEvalTool([{ op: "write", path: "example.txt", chars: 7, implementationAction: true }], {
+				isError: evalIsError,
+			});
+			const mock = createMockModel({
+				responses: [toolCall("t1", "todo"), toolCall("t2", "eval"), { content: ["done"] }],
+			});
+			const requested: string[] = [];
+			const agent = new Agent({
+				getApiKey: () => "test-key",
+				initialState: {
+					model: primary,
+					systemPrompt: ["Test"],
+					tools: [todoTool as AgentTool, evalWrite as AgentTool],
+					messages: [],
+					thinkingLevel: Effort.Medium,
+				},
+				convertToLlm,
+				streamFn: (model, context, options) => {
+					requested.push(`${model.provider}/${model.id}`);
+					return mock.stream(model, context, options);
+				},
+			});
+			session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "compaction.enabled": false }),
+				modelRegistry,
+				toolRegistry: new Map([
+					[todoTool.name, todoTool as AgentTool],
+					[evalWrite.name, evalWrite as AgentTool],
+				]),
+				prewalk: { target },
+			});
 
-		await session.prompt("implement via eval");
+			await session.prompt("implement via eval");
 
-		expect(requested).toEqual([
-			`${primary.provider}/${primary.id}`,
-			`${primary.provider}/${primary.id}`,
-			`${target.provider}/${target.id}`,
-		]);
-		expect(session.model?.id).toBe(target.id);
-	});
+			expect(requested).toEqual([
+				`${primary.provider}/${primary.id}`,
+				`${primary.provider}/${primary.id}`,
+				`${target.provider}/${target.id}`,
+			]);
+			expect(session.model?.id).toBe(target.id);
+		});
+	}
 
 	it("does not switch on a read-only eval cell (issue #11018 keeps the #7312 exclusion)", async () => {
 		const primary = modelOrThrow("claude-sonnet-4-5");

--- a/packages/coding-agent/test/eval/helpers-local-roots.test.ts
+++ b/packages/coding-agent/test/eval/helpers-local-roots.test.ts
@@ -53,3 +53,30 @@ describe("eval js helpers internal-url resolution", () => {
 		expect(await helpers.read("foo/bar.txt")).toBe("bar");
 	});
 });
+
+/**
+ * Under Code Mode a model may mutate the workspace through the documented
+ * `write(path, content)` prelude instead of `tool.write`. That write must carry
+ * the prewalk implementation-action marker so the armed hand-off still fires
+ * (issue #11018); `read` stays unmarked so read-only cells never switch.
+ */
+describe("eval js helpers prewalk implementation marker", () => {
+	it("flags write() but not read() as an implementation action", async () => {
+		using tmp = TempDir.createSync("@eval-helpers-impl-");
+		const events: Array<Record<string, unknown>> = [];
+		const helpers = createHelpers({
+			cwd: () => tmp.path(),
+			env: new Map(),
+			localRoots: () => ({}),
+			emitStatus: event => events.push(event),
+		});
+
+		await helpers.writeFile("out.txt", "content");
+		await helpers.read("out.txt");
+
+		const write = events.find(event => event.op === "write");
+		const read = events.find(event => event.op === "read");
+		expect(write?.implementationAction).toBe(true);
+		expect(read?.implementationAction).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/eval/tool-bridge-implementation-action.test.ts
+++ b/packages/coding-agent/test/eval/tool-bridge-implementation-action.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { callSessionTool, type JsStatusEvent } from "@oh-my-pi/pi-coding-agent/eval/js/tool-bridge";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+
+/**
+ * Under Code Mode edit/write leave the direct tool surface and run through the
+ * eval bridge, so the turn-level result is `eval`. The bridge flags a nested
+ * workspace-mutating call on the emitted status event so the prewalk coordinator
+ * can recognize it (issue #11018). Read-only calls and read-tier `xd://` device
+ * dispatches carry no flag, preserving the mid-investigation exclusion (#7312).
+ */
+const emptySchema = type({});
+
+function stubTool(name: string, details: unknown): AgentTool {
+	const tool: AgentTool<typeof emptySchema, unknown> = {
+		name,
+		label: name,
+		description: `stub ${name}`,
+		parameters: emptySchema,
+		async execute(): Promise<AgentToolResult<unknown>> {
+			return { content: [{ type: "text", text: "ok" }], details };
+		},
+	};
+	return tool as AgentTool;
+}
+
+async function bridgeStatus(tool: AgentTool): Promise<JsStatusEvent> {
+	const events: JsStatusEvent[] = [];
+	const session = {
+		getToolByName: (name: string) => (name === tool.name ? tool : undefined),
+	} as unknown as ToolSession;
+	await callSessionTool(tool.name, {}, { session, emitStatus: event => events.push(event) });
+	const settled = events.filter(event => event.error === undefined);
+	expect(settled).toHaveLength(1);
+	return settled[0];
+}
+
+describe("eval bridge implementation-action flag", () => {
+	it("flags a direct write", async () => {
+		const event = await bridgeStatus(stubTool("write", undefined));
+		expect(event.op).toBe("write");
+		expect(event.implementationAction).toBe(true);
+	});
+
+	it("flags a direct edit", async () => {
+		const event = await bridgeStatus(stubTool("edit", { edited: true }));
+		expect(event.implementationAction).toBe(true);
+	});
+
+	it("flags a write-tier xd:// device dispatched through write", async () => {
+		const event = await bridgeStatus(stubTool("write", { xdev: { tool: "lsp", mode: "execute", tier: "write" } }));
+		expect(event.implementationAction).toBe(true);
+	});
+
+	it("does not flag a read", async () => {
+		const event = await bridgeStatus(stubTool("read", { lines: 3 }));
+		expect(event.op).toBe("read");
+		expect(event.implementationAction).toBeUndefined();
+	});
+
+	it("does not flag a read-tier xd:// device dispatched through write", async () => {
+		const event = await bridgeStatus(stubTool("write", { xdev: { tool: "lsp", mode: "execute", tier: "read" } }));
+		expect(event.implementationAction).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
With prewalk armed and Codex Code Mode active, an implementation action executed through Eval (`await tool.write(...)` / `await tool.edit(...)`) does not trigger the prewalk handoff: the nested tool runs but the session stays on the starting model/effort. Code Mode removes `edit`/`write` from the direct tool surface, so with both features on this is the normal execution path. Reproduced against the real `Agent` turn loop + `AgentSession` + prewalk coordinator: with prewalk's eval-detection branch removed (pre-fix behavior), `bun test test/agent-session-prewalk.test.ts` fails — the eval-wrapped write stays on the primary model (`anthropic/claude-sonnet-4-5`) instead of handing off to the target (`anthropic/claude-sonnet-4-6`), while the direct-write control switches.

## Cause
`PrewalkCoordinator.advanceAtTurnEnd` (`src/session/prewalk.ts`) recognized an implementation action only from a turn-level `ToolResultMessage` whose `toolName` is `edit`/`write`. Under Code Mode those tools leave the direct surface and run through the eval bridge (`src/eval/js/tool-bridge.ts` `callSessionTool`), so the turn-level result is named `eval` and the nested write is invisible to the detector. This mirrors the existing `checkpoint`/`rewind` keep-set note in `src/session/code-mode.ts`: an eval-wrapped result loses its `toolName` identity — edit/write detection was the case left unhandled.

## Fix
- Extract the tier-aware predicate into `src/session/implementation-action.ts` (`isImplementationActionResult`), preserving the direct-write and `xd://` device-tier (`write`/`exec` only) semantics from #7312.
- In the eval bridge (`normalizeAgentToolResult`), flag a nested workspace-mutating call by setting `implementationAction: true` on the emitted status event, using that same predicate. Read-only calls and read-tier `xd://` device dispatches carry no flag.
- In prewalk, recognize an `eval` turn result carrying that marker in `details.statusEvents` as an implementation action. The todo gate and read-only exclusions are unchanged.

## Verification
`bun test test/agent-session-prewalk.test.ts test/eval/tool-bridge-implementation-action.test.ts` → 24 pass. New tests cover: eval-wrapped write hands off after the todo gate; a read-only eval cell does not (keeps the #7312 exclusion); and the bridge flags direct `write`/`edit` and write-tier device dispatch but not `read` or read-tier device dispatch. Confirmed the prewalk test fails without the fix (stays on primary). The changed code is TypeScript-only in `packages/coding-agent`; my touched files independently pass `oxlint` and `oxfmt --check`. Skipped the pre-publish `bun check` gate: this worktree carries ~150 pre-existing untracked WIP files unrelated to this change (e.g. `src/advisor/__tests__/advisor.test.ts`, which `oxlint .` flags for `prefer-const`), which are not part of this diff and not on `main`. Fixes #11018