### PR TITLE
feat(cli): add session browsing commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.
 
+### Added
+
+- Added `omp sessions list` for listing saved sessions in the current project or all projects.
+
 ### Changed
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Added
 
-- Added `omp sessions list` for listing saved sessions in the current project or all projects.
-- Added `omp sessions roots` and `omp sessions list --cwd <path>` for browsing session work directories.
+- Added `omp sessions list` for listing saved sessions in the current project or all projects ([#11025](https://github.com/can1357/oh-my-pi/pull/11025) by [@kearril](https://github.com/kearril)).
+- Added `omp sessions roots` and `omp sessions list --cwd <path>` for browsing session work directories ([#11025](https://github.com/can1357/oh-my-pi/pull/11025) by [@kearril](https://github.com/kearril)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Added `omp sessions list` for listing saved sessions in the current project or all projects.
+- Added `omp sessions roots` and `omp sessions list --cwd <path>` for browsing session work directories.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -158,6 +158,11 @@ export const commands: CommandEntry[] = [
 		help: commandHelp.shareHelp,
 	},
 	{
+		name: "sessions",
+		load: () => import("./commands/sessions").then(m => m.default),
+		help: commandHelp.sessionsHelp,
+	},
+	{
 		name: "setup",
 		load: () => import("./commands/setup").then(m => m.default),
 		help: commandHelp.setupHelp,

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -469,12 +469,16 @@ export async function runCli(argv: string[]): Promise<void> {
 
 // Floating call instead of top-level await: TLA forces `--bytecode` (CJS
 // lowering) builds to fail, and the entrypoint needs nothing after this.
+// A referenced timer keeps Bun alive while a command awaits filesystem-only
+// work; those operations alone do not hold the event loop open on all platforms.
 // The catch mirrors what an unhandled TLA rejection produced: error dump to
-// stderr, exit code 1. Success paths resolve without touching the exit code.
-// Guarded so importing `runCli` (profile CLI tests, SDK embedding) does not
-// launch the agent as a side effect. Worker threads re-enter this module as
-// their entry with `import.meta.main === false`, so the worker-host dispatch
-// is admitted via `!Bun.isMainThread`.
+// stderr, exit code 1. Guarded so importing `runCli` (profile CLI tests, SDK
+// embedding) does not launch the agent as a side effect. Worker threads re-enter
+// this module as their entry with `import.meta.main === false`, so the
+// worker-host dispatch is admitted via `!Bun.isMainThread`.
 if (isProcessEntry || !Bun.isMainThread) {
-	runCli(process.argv.slice(2)).catch(fatal);
+	const keepalive = setInterval(() => {}, 2 ** 30);
+	runCli(process.argv.slice(2))
+		.catch(fatal)
+		.finally(() => clearInterval(keepalive));
 }

--- a/packages/coding-agent/src/cli/command-help.ts
+++ b/packages/coding-agent/src/cli/command-help.ts
@@ -82,6 +82,10 @@ export const psHelp = {
 	description: "List and control daemon-supervised background processes (logs, stop, kill, restart)",
 } satisfies CommandMetadata;
 
+export const sessionsHelp = {
+	description: "List saved sessions in the current project or every project",
+} satisfies CommandMetadata;
+
 export const readHelp = {
 	description: "Show what the read tool will return for a path, URL, or internal URI",
 } satisfies CommandMetadata;

--- a/packages/coding-agent/src/cli/sessions-cli.ts
+++ b/packages/coding-agent/src/cli/sessions-cli.ts
@@ -1,5 +1,5 @@
 import { truncateToWidth } from "@oh-my-pi/pi-tui";
-import { sanitizeText } from "@oh-my-pi/pi-utils";
+import { normalizePathForComparison, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import type { SessionInfo, SessionStatus } from "../session/session-listing";
 import { SessionManager } from "../session/session-manager";
@@ -9,6 +9,7 @@ import { shortenPath, TRUNCATE_LENGTHS } from "../tools/render-utils";
 export interface SessionsCommandArgs {
 	flags: {
 		all: boolean;
+		cwd?: string;
 		json: boolean;
 	};
 }
@@ -25,6 +26,13 @@ export interface SessionListEntry {
 	status: SessionStatus;
 	messageCount: number;
 	sizeBytes: number;
+}
+
+export interface SessionRootEntry {
+	cwd: string;
+	sessionCount: number;
+	pinnedCount: number;
+	latestModifiedAt: string;
 }
 
 function toSessionListEntry(session: SessionInfo, pinnedIds: ReadonlySet<string>): SessionListEntry {
@@ -48,7 +56,42 @@ function toSessionListEntry(session: SessionInfo, pinnedIds: ReadonlySet<string>
 	};
 }
 
-function tableCells(entry: SessionListEntry, includeCwd: boolean): string[] {
+async function readSessionEntries(options: { all: boolean; cwd?: string }): Promise<SessionListEntry[]> {
+	const sessions = options.all
+		? await SessionManager.listAll()
+		: await SessionManager.list(options.cwd ?? process.cwd());
+	const pinnedIds = await loadPinnedSessionIds();
+	return sessions.map(session => toSessionListEntry(session, pinnedIds));
+}
+
+function toSessionRootEntries(entries: SessionListEntry[]): SessionRootEntry[] {
+	const roots = new Map<string, SessionRootEntry>();
+	for (const entry of entries) {
+		const cwd = entry.cwd.trim() || "(unknown cwd)";
+		const key = entry.cwd.trim() ? normalizePathForComparison(entry.cwd) : "\0unknown-cwd";
+		const root = roots.get(key);
+		if (!root) {
+			roots.set(key, {
+				cwd,
+				sessionCount: 1,
+				pinnedCount: entry.pinned ? 1 : 0,
+				latestModifiedAt: entry.modifiedAt,
+			});
+			continue;
+		}
+		root.sessionCount++;
+		if (entry.pinned) root.pinnedCount++;
+		if (entry.modifiedAt > root.latestModifiedAt) {
+			root.cwd = cwd;
+			root.latestModifiedAt = entry.modifiedAt;
+		}
+	}
+	return [...roots.values()].sort(
+		(left, right) => right.latestModifiedAt.localeCompare(left.latestModifiedAt) || left.cwd.localeCompare(right.cwd),
+	);
+}
+
+function sessionTableCells(entry: SessionListEntry, includeCwd: boolean): string[] {
 	const label =
 		sanitizeText(entry.title ?? entry.preview)
 			.replace(/\s+/g, " ")
@@ -64,9 +107,7 @@ function tableCells(entry: SessionListEntry, includeCwd: boolean): string[] {
 	];
 }
 
-function printTable(entries: SessionListEntry[], includeCwd: boolean): void {
-	const header = ["ID", "PIN", "STATUS", "MODIFIED", "MSGS", ...(includeCwd ? ["CWD"] : []), "TITLE / PREVIEW"];
-	const rows = entries.map(entry => tableCells(entry, includeCwd));
+function printTable(header: string[], rows: string[][]): void {
 	const widths = header.map((title, column) =>
 		Math.max(title.length, ...rows.map(row => Bun.stringWidth(row[column]))),
 	);
@@ -83,9 +124,7 @@ function printTable(entries: SessionListEntry[], includeCwd: boolean): void {
 }
 
 export async function runSessionsCommand(cmd: SessionsCommandArgs): Promise<void> {
-	const sessions = cmd.flags.all ? await SessionManager.listAll() : await SessionManager.list(process.cwd());
-	const pinnedIds = await loadPinnedSessionIds();
-	const entries = sessions.map(session => toSessionListEntry(session, pinnedIds));
+	const entries = await readSessionEntries(cmd.flags);
 
 	if (cmd.flags.json) {
 		process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
@@ -93,11 +132,37 @@ export async function runSessionsCommand(cmd: SessionsCommandArgs): Promise<void
 	}
 	if (entries.length === 0) {
 		if (cmd.flags.all) process.stdout.write(`${chalk.dim("No saved sessions found.")}\n`);
+		else if (cmd.flags.cwd) process.stdout.write(`${chalk.dim(`No saved sessions in ${cmd.flags.cwd}.`)}\n`);
 		else
 			process.stdout.write(
 				`${chalk.dim("No saved sessions in the current directory.\nUse --all to list sessions from every project.")}\n`,
 			);
 		return;
 	}
-	printTable(entries, cmd.flags.all);
+	printTable(
+		["ID", "PIN", "STATUS", "MODIFIED", "MSGS", ...(cmd.flags.all ? ["CWD"] : []), "TITLE / PREVIEW"],
+		entries.map(entry => sessionTableCells(entry, cmd.flags.all)),
+	);
+}
+
+export async function runSessionRootsCommand(json: boolean): Promise<void> {
+	const roots = toSessionRootEntries(await readSessionEntries({ all: true }));
+
+	if (json) {
+		process.stdout.write(`${JSON.stringify(roots, null, 2)}\n`);
+		return;
+	}
+	if (roots.length === 0) {
+		process.stdout.write(`${chalk.dim("No saved session roots found.")}\n`);
+		return;
+	}
+	printTable(
+		["CWD", "SESSIONS", "PINNED", "LAST MODIFIED"],
+		roots.map(root => [
+			truncateToWidth(shortenPath(root.cwd) || root.cwd, TRUNCATE_LENGTHS.CONTENT),
+			String(root.sessionCount),
+			String(root.pinnedCount),
+			`${root.latestModifiedAt.slice(0, 10)} ${root.latestModifiedAt.slice(11, 16)}Z`,
+		]),
+	);
 }

--- a/packages/coding-agent/src/cli/sessions-cli.ts
+++ b/packages/coding-agent/src/cli/sessions-cli.ts
@@ -59,7 +59,7 @@ function toSessionListEntry(session: SessionInfo, pinnedIds: ReadonlySet<string>
 async function readSessionEntries(options: { all: boolean; cwd?: string }): Promise<SessionListEntry[]> {
 	const sessions = options.all
 		? await SessionManager.listAll()
-		: await SessionManager.list(options.cwd ?? process.cwd());
+		: await SessionManager.listReadOnly(options.cwd ?? process.cwd());
 	const pinnedIds = await loadPinnedSessionIds();
 	return sessions.map(session => toSessionListEntry(session, pinnedIds));
 }
@@ -102,7 +102,14 @@ function sessionTableCells(entry: SessionListEntry, includeCwd: boolean): string
 		entry.status,
 		`${entry.modifiedAt.slice(0, 10)} ${entry.modifiedAt.slice(11, 16)}Z`,
 		String(entry.messageCount),
-		...(includeCwd ? [truncateToWidth(shortenPath(entry.cwd) || "-", TRUNCATE_LENGTHS.CONTENT)] : []),
+		...(includeCwd
+			? [
+					truncateToWidth(
+						shortenPath(sanitizeText(entry.cwd).replace(/\s+/g, " ").trim()) || "-",
+						TRUNCATE_LENGTHS.CONTENT,
+					),
+				]
+			: []),
 		truncateToWidth(label, TRUNCATE_LENGTHS.CONTENT),
 	];
 }
@@ -132,7 +139,10 @@ export async function runSessionsCommand(cmd: SessionsCommandArgs): Promise<void
 	}
 	if (entries.length === 0) {
 		if (cmd.flags.all) process.stdout.write(`${chalk.dim("No saved sessions found.")}\n`);
-		else if (cmd.flags.cwd) process.stdout.write(`${chalk.dim(`No saved sessions in ${cmd.flags.cwd}.`)}\n`);
+		else if (cmd.flags.cwd)
+			process.stdout.write(
+				`${chalk.dim(`No saved sessions in ${sanitizeText(cmd.flags.cwd).replace(/\s+/g, " ").trim()}.`)}\n`,
+			);
 		else
 			process.stdout.write(
 				`${chalk.dim("No saved sessions in the current directory.\nUse --all to list sessions from every project.")}\n`,
@@ -158,11 +168,14 @@ export async function runSessionRootsCommand(json: boolean): Promise<void> {
 	}
 	printTable(
 		["CWD", "SESSIONS", "PINNED", "LAST MODIFIED"],
-		roots.map(root => [
-			truncateToWidth(shortenPath(root.cwd) || root.cwd, TRUNCATE_LENGTHS.CONTENT),
-			String(root.sessionCount),
-			String(root.pinnedCount),
-			`${root.latestModifiedAt.slice(0, 10)} ${root.latestModifiedAt.slice(11, 16)}Z`,
-		]),
+		roots.map(root => {
+			const cwd = sanitizeText(root.cwd).replace(/\s+/g, " ").trim() || "(unknown cwd)";
+			return [
+				truncateToWidth(shortenPath(cwd) || cwd, TRUNCATE_LENGTHS.CONTENT),
+				String(root.sessionCount),
+				String(root.pinnedCount),
+				`${root.latestModifiedAt.slice(0, 10)} ${root.latestModifiedAt.slice(11, 16)}Z`,
+			];
+		}),
 	);
 }

--- a/packages/coding-agent/src/cli/sessions-cli.ts
+++ b/packages/coding-agent/src/cli/sessions-cli.ts
@@ -1,0 +1,103 @@
+import { truncateToWidth } from "@oh-my-pi/pi-tui";
+import { sanitizeText } from "@oh-my-pi/pi-utils";
+import chalk from "@oh-my-pi/pi-utils/chalk";
+import type { SessionInfo, SessionStatus } from "../session/session-listing";
+import { SessionManager } from "../session/session-manager";
+import { loadPinnedSessionIds } from "../session/session-pins";
+import { shortenPath, TRUNCATE_LENGTHS } from "../tools/render-utils";
+
+export interface SessionsCommandArgs {
+	flags: {
+		all: boolean;
+		json: boolean;
+	};
+}
+
+export interface SessionListEntry {
+	id: string;
+	pinned: boolean;
+	title: string | null;
+	preview: string;
+	cwd: string;
+	path: string;
+	createdAt: string | null;
+	modifiedAt: string;
+	status: SessionStatus;
+	messageCount: number;
+	sizeBytes: number;
+}
+
+function toSessionListEntry(session: SessionInfo, pinnedIds: ReadonlySet<string>): SessionListEntry {
+	const createdAt = Number.isNaN(session.created.getTime()) ? null : session.created.toISOString();
+	const modifiedAt = session.modified.toISOString();
+	return {
+		id: session.id,
+		pinned: pinnedIds.has(session.id),
+		title: session.title ?? null,
+		preview: truncateToWidth(
+			sanitizeText(session.firstMessage).replace(/\s+/g, " ").trim() || "(no messages)",
+			TRUNCATE_LENGTHS.CONTENT,
+		),
+		cwd: session.cwd,
+		path: session.path,
+		createdAt,
+		modifiedAt,
+		status: session.status ?? "unknown",
+		messageCount: session.messageCount,
+		sizeBytes: session.size,
+	};
+}
+
+function tableCells(entry: SessionListEntry, includeCwd: boolean): string[] {
+	const label =
+		sanitizeText(entry.title ?? entry.preview)
+			.replace(/\s+/g, " ")
+			.trim() || "(no messages)";
+	return [
+		entry.id.slice(0, 12),
+		entry.pinned ? "*" : "",
+		entry.status,
+		`${entry.modifiedAt.slice(0, 10)} ${entry.modifiedAt.slice(11, 16)}Z`,
+		String(entry.messageCount),
+		...(includeCwd ? [truncateToWidth(shortenPath(entry.cwd) || "-", TRUNCATE_LENGTHS.CONTENT)] : []),
+		truncateToWidth(label, TRUNCATE_LENGTHS.CONTENT),
+	];
+}
+
+function printTable(entries: SessionListEntry[], includeCwd: boolean): void {
+	const header = ["ID", "PIN", "STATUS", "MODIFIED", "MSGS", ...(includeCwd ? ["CWD"] : []), "TITLE / PREVIEW"];
+	const rows = entries.map(entry => tableCells(entry, includeCwd));
+	const widths = header.map((title, column) =>
+		Math.max(title.length, ...rows.map(row => Bun.stringWidth(row[column]))),
+	);
+	const maxWidth = process.stdout.isTTY ? (process.stdout.columns ?? 120) : Number.POSITIVE_INFINITY;
+	const render = (row: string[]): string => {
+		const line = `  ${row
+			.map((cell, column) => cell + " ".repeat(Math.max(0, widths[column] - Bun.stringWidth(cell))))
+			.join("  ")}`.trimEnd();
+		return Number.isFinite(maxWidth) ? truncateToWidth(line, maxWidth) : line;
+	};
+
+	process.stdout.write(`${chalk.dim(render(header))}\n`);
+	for (const row of rows) process.stdout.write(`${render(row)}\n`);
+}
+
+export async function runSessionsCommand(cmd: SessionsCommandArgs): Promise<void> {
+	const sessions = cmd.flags.all ? await SessionManager.listAll() : await SessionManager.list(process.cwd());
+	const pinnedIds = await loadPinnedSessionIds();
+	const entries = sessions.map(session => toSessionListEntry(session, pinnedIds));
+
+	if (cmd.flags.json) {
+		process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
+		return;
+	}
+	if (entries.length === 0) {
+		if (cmd.flags.all) process.stdout.write(`${chalk.dim("No saved sessions found.")}\n`);
+		else
+			process.stdout.write(
+				`${chalk.dim("No saved sessions in the current directory.\nUse --all to list sessions from every project.")}\n`,
+			);
+		return;
+	}
+	printTable(entries, cmd.flags.all);
+}

--- a/packages/coding-agent/src/commands/sessions.ts
+++ b/packages/coding-agent/src/commands/sessions.ts
@@ -1,0 +1,32 @@
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { sessionsHelp as commandHelp } from "../cli/command-help";
+import { runSessionsCommand } from "../cli/sessions-cli";
+
+export default class Sessions extends Command {
+	static description = commandHelp.description;
+
+	static args = {
+		action: Args.string({
+			description: "List saved sessions",
+			required: true,
+			options: ["list"],
+		}),
+	};
+
+	static flags = {
+		all: Flags.boolean({ char: "a", description: "List sessions from every project" }),
+		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON" }),
+	};
+
+	static examples = [
+		"omp sessions list",
+		"omp sessions list --all",
+		"omp sessions list --json",
+		"omp sessions list --all --json",
+	];
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(Sessions);
+		await runSessionsCommand({ flags: { all: flags.all ?? false, json: flags.json ?? false } });
+	}
+}

--- a/packages/coding-agent/src/commands/sessions.ts
+++ b/packages/coding-agent/src/commands/sessions.ts
@@ -2,6 +2,7 @@ import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { sessionsHelp as commandHelp } from "../cli/command-help";
 import { runSessionRootsCommand, runSessionsCommand } from "../cli/sessions-cli";
 import { CliUsageError } from "../cli/usage-error";
+import { expandPath } from "../tools/path-utils";
 
 export default class Sessions extends Command {
 	static description = commandHelp.description;
@@ -30,15 +31,18 @@ export default class Sessions extends Command {
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Sessions);
+		const hasCwd = flags.cwd !== undefined;
+		const cwd = flags.cwd?.trim();
+		if (hasCwd && !cwd) throw new CliUsageError("--cwd must not be empty");
 		if (args.action === "roots") {
 			if (flags.all) throw new CliUsageError("--all only applies to sessions list");
-			if (flags.cwd) throw new CliUsageError("--cwd only applies to sessions list");
+			if (hasCwd) throw new CliUsageError("--cwd only applies to sessions list");
 			await runSessionRootsCommand(flags.json ?? false);
 			return;
 		}
-		if (flags.all && flags.cwd) throw new CliUsageError("--all and --cwd are mutually exclusive");
+		if (flags.all && hasCwd) throw new CliUsageError("--all and --cwd are mutually exclusive");
 		await runSessionsCommand({
-			flags: { all: flags.all ?? false, cwd: flags.cwd, json: flags.json ?? false },
+			flags: { all: flags.all ?? false, cwd: cwd ? expandPath(cwd) : undefined, json: flags.json ?? false },
 		});
 	}
 }

--- a/packages/coding-agent/src/commands/sessions.ts
+++ b/packages/coding-agent/src/commands/sessions.ts
@@ -1,32 +1,44 @@
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { sessionsHelp as commandHelp } from "../cli/command-help";
-import { runSessionsCommand } from "../cli/sessions-cli";
+import { runSessionRootsCommand, runSessionsCommand } from "../cli/sessions-cli";
+import { CliUsageError } from "../cli/usage-error";
 
 export default class Sessions extends Command {
 	static description = commandHelp.description;
 
 	static args = {
 		action: Args.string({
-			description: "List saved sessions",
+			description: "List sessions or working directories",
 			required: true,
-			options: ["list"],
+			options: ["list", "roots"],
 		}),
 	};
 
 	static flags = {
-		all: Flags.boolean({ char: "a", description: "List sessions from every project" }),
+		all: Flags.boolean({ char: "a", description: "List sessions from every project (list)" }),
+		cwd: Flags.string({ description: "List sessions from this working directory (list)" }),
 		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON" }),
 	};
 
 	static examples = [
 		"omp sessions list",
-		"omp sessions list --all",
-		"omp sessions list --json",
+		"omp sessions list --cwd ~/projects/app",
 		"omp sessions list --all --json",
+		"omp sessions roots",
+		"omp sessions roots --json",
 	];
 
 	async run(): Promise<void> {
-		const { flags } = await this.parse(Sessions);
-		await runSessionsCommand({ flags: { all: flags.all ?? false, json: flags.json ?? false } });
+		const { args, flags } = await this.parse(Sessions);
+		if (args.action === "roots") {
+			if (flags.all) throw new CliUsageError("--all only applies to sessions list");
+			if (flags.cwd) throw new CliUsageError("--cwd only applies to sessions list");
+			await runSessionRootsCommand(flags.json ?? false);
+			return;
+		}
+		if (flags.all && flags.cwd) throw new CliUsageError("--all and --cwd are mutually exclusive");
+		await runSessionsCommand({
+			flags: { all: flags.all ?? false, cwd: flags.cwd, json: flags.json ?? false },
+		});
 	}
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -60,7 +60,13 @@ import {
 	type TtsrInjectionEntry,
 	type UsageStatistics,
 } from "./session-entries";
-import { findMostRecentSession, listAllSessions, listSessions, type SessionInfo } from "./session-listing";
+import {
+	findMostRecentSession,
+	listAllSessions,
+	listSessions,
+	listSessionsReadOnly,
+	type SessionInfo,
+} from "./session-listing";
 import {
 	loadEntriesFromFile,
 	loadSessionFile,
@@ -73,6 +79,7 @@ import {
 	computeDefaultSessionDir,
 	readTerminalBreadcrumbEntry,
 	resolveManagedSessionRoot,
+	resolveReadOnlySessionDirCandidates,
 	writeTerminalBreadcrumb,
 } from "./session-paths";
 import { prepareEntryForPersistence } from "./session-persistence";
@@ -3120,6 +3127,28 @@ export class SessionManager {
 	): Promise<SessionInfo[]> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
 		const sessions = await listSessions(dir, storage);
+		return sortPinnedFirst(sessions, await loadPinnedSessionIds());
+	}
+
+	/**
+	 * List sessions for a project directory without creating, migrating, or
+	 * recovering any session directory.
+	 */
+	static async listReadOnly(
+		cwd: string,
+		options: { sessionsRoot?: string; storage?: SessionStorage } = {},
+	): Promise<SessionInfo[]> {
+		const storage = options.storage ?? new FileSessionStorage();
+		const sessionDirs = resolveReadOnlySessionDirCandidates(cwd, options.sessionsRoot);
+		const sessions = (
+			await Promise.all(sessionDirs.map(sessionDir => listSessionsReadOnly(sessionDir, storage)))
+		).flat();
+		sessions.sort(
+			(a, b) =>
+				b.modified.getTime() - a.modified.getTime() ||
+				b.created.getTime() - a.created.getTime() ||
+				b.path.localeCompare(a.path),
+		);
 		return sortPinnedFirst(sessions, await loadPinnedSessionIds());
 	}
 

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -62,6 +62,7 @@ function encodeHashedSessionDirName(canonicalCwd: string, scope: "home" | "tmp" 
 function getDefaultSessionDirName(cwd: string): {
 	encodedDirName: string;
 	hashedDirName: string;
+	legacyHomeDirName?: string;
 	resolvedCwd: string;
 } {
 	const resolvedCwd = path.resolve(cwd);
@@ -84,7 +85,33 @@ function getDefaultSessionDirName(cwd: string): {
 		encodedDirName = encodeLegacyAbsoluteSessionDirName(canonicalCwd);
 		scope = "abs";
 	}
-	return { encodedDirName, hashedDirName: encodeHashedSessionDirName(canonicalCwd, scope), resolvedCwd };
+	const legacyHomeDirName =
+		scope === "home"
+			? homeRelative
+				? `--${home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}-${homeRelative.replace(/[/\\:]/g, "-")}--`
+				: `--${home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`
+			: undefined;
+	return {
+		encodedDirName,
+		hashedDirName: encodeHashedSessionDirName(canonicalCwd, scope),
+		legacyHomeDirName,
+		resolvedCwd,
+	};
+}
+
+/**
+ * Resolve every known session directory for a cwd without creating, migrating,
+ * or otherwise modifying any path.
+ */
+export function resolveReadOnlySessionDirCandidates(cwd: string, sessionsRoot: string = getSessionsDir()): string[] {
+	const { encodedDirName, hashedDirName, legacyHomeDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
+	const dirNames = new Set([
+		encodedDirName,
+		encodeLegacyAbsoluteSessionDirName(resolvedCwd),
+		hashedDirName,
+		legacyHomeDirName,
+	]);
+	return [...dirNames].filter((name): name is string => name !== undefined).map(name => path.join(sessionsRoot, name));
 }
 
 /**

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import {
+	computeDefaultSessionDir,
+	resolveReadOnlySessionDirCandidates,
+} from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 
 const cleanup: string[] = [];
@@ -63,5 +67,69 @@ describe("legacy session directory migration", () => {
 
 		expect(fs.readFileSync(recreated, "utf8")).toBe("older-process-write\n");
 		expect(fs.readFileSync(destination, "utf8")).toBe("canonical\n");
+	});
+});
+
+describe("read-only session discovery", () => {
+	test("resolves canonical and legacy candidates without materializing the sessions root", () => {
+		const parent = makeTempDir("omp-session-parent-");
+		const sessionsRoot = path.join(parent, "sessions");
+		const cwd = makeTempDir("omp-session-cwd-");
+
+		const candidates = resolveReadOnlySessionDirCandidates(cwd, sessionsRoot);
+
+		expect(fs.existsSync(sessionsRoot)).toBe(false);
+		expect(candidates).toContain(legacySessionDir(sessionsRoot, cwd));
+		expect(candidates[0]).toBe(
+			path.join(
+				sessionsRoot,
+				path.basename(computeDefaultSessionDir(cwd, new FileSessionStorage(), makeTempDir("omp-session-root-"))),
+			),
+		);
+	});
+
+	test("includes the legacy home candidate without scanning or migrating it", () => {
+		const sessionsRoot = path.join(makeTempDir("omp-session-parent-"), "sessions");
+		const home = os.homedir();
+		const legacyHomeName = `--${home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+
+		const candidates = resolveReadOnlySessionDirCandidates(home, sessionsRoot);
+
+		expect(candidates).toContain(path.join(sessionsRoot, legacyHomeName));
+		expect(fs.existsSync(sessionsRoot)).toBe(false);
+	});
+
+	test("lists canonical and legacy sessions without recovering orphaned backups", async () => {
+		const sessionsRoot = makeTempDir("omp-session-root-");
+		const cwd = makeTempDir("omp-session-cwd-");
+		const storage = new FileSessionStorage();
+		const [canonicalDir, legacyDir, hashedDir] = resolveReadOnlySessionDirCandidates(cwd, sessionsRoot);
+		expect(legacyDir).toBe(legacySessionDir(sessionsRoot, cwd));
+		const backupPath = path.join(canonicalDir, "orphan.jsonl.1.bak");
+		fs.mkdirSync(canonicalDir, { recursive: true });
+		fs.mkdirSync(legacyDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(canonicalDir, "canonical.jsonl"),
+			`${JSON.stringify({ type: "session", version: 3, id: "canonical", cwd, timestamp: "2026-09-06T10:00:00.000Z" })}\n`,
+		);
+		fs.writeFileSync(
+			path.join(legacyDir, "legacy.jsonl"),
+			`${JSON.stringify({ type: "session", version: 3, id: "legacy", cwd, timestamp: "2026-09-06T11:00:00.000Z" })}\n`,
+		);
+		fs.mkdirSync(hashedDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(hashedDir, "hashed.jsonl"),
+			`${JSON.stringify({ type: "session", version: 3, id: "hashed", cwd, timestamp: "2026-09-06T10:30:00.000Z" })}\n`,
+		);
+		fs.writeFileSync(
+			backupPath,
+			`${JSON.stringify({ type: "session", version: 3, id: "orphan", cwd, timestamp: "2026-09-06T12:00:00.000Z" })}\n`,
+		);
+
+		const sessions = await SessionManager.listReadOnly(cwd, { sessionsRoot, storage });
+
+		expect(new Set(sessions.map(session => session.id))).toEqual(new Set(["legacy", "hashed", "canonical"]));
+		expect(fs.existsSync(backupPath)).toBe(true);
+		expect(fs.existsSync(path.join(canonicalDir, "orphan.jsonl"))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/sessions-cli.test.ts
+++ b/packages/coding-agent/test/sessions-cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
-import { runSessionsCommand } from "@oh-my-pi/pi-coding-agent/cli/sessions-cli";
+import { runSessionRootsCommand, runSessionsCommand } from "@oh-my-pi/pi-coding-agent/cli/sessions-cli";
 import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as sessionPins from "@oh-my-pi/pi-coding-agent/session/session-pins";
@@ -61,6 +61,17 @@ describe("sessions list CLI", () => {
 		]);
 	});
 
+	it("lists sessions from the requested working directory", async () => {
+		const output = captureOutput();
+		const list = spyOn(SessionManager, "list").mockResolvedValue([session({ cwd: "/other-project" })]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionsCommand({ flags: { all: false, cwd: "/other-project", json: true } });
+
+		expect(list).toHaveBeenCalledWith("/other-project");
+		expect(JSON.parse(output.join("\n"))[0].cwd).toBe("/other-project");
+	});
+
 	it("includes sessions from every project only when --all is selected", async () => {
 		const output = captureOutput();
 		const local = spyOn(SessionManager, "list").mockResolvedValue([]);
@@ -105,6 +116,64 @@ describe("sessions list CLI", () => {
 		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
 
 		await runSessionsCommand({ flags: { all: false, json: true } });
+
+		expect(output).toEqual(["[]\n"]);
+	});
+});
+
+describe("session roots CLI", () => {
+	it("aggregates session roots with pinned counts and recency ordering", async () => {
+		const output = captureOutput();
+		spyOn(SessionManager, "listAll").mockResolvedValue([
+			session(),
+			session({
+				id: "newer",
+				cwd: "/project",
+				modified: new Date("2026-09-06T12:00:00.000Z"),
+			}),
+			session({
+				id: "other",
+				cwd: "/other-project",
+				modified: new Date("2026-09-06T09:00:00.000Z"),
+			}),
+			session({
+				id: "unknown",
+				cwd: "",
+				modified: new Date("2026-09-06T08:00:00.000Z"),
+			}),
+		]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set(["local", "newer"]));
+
+		await runSessionRootsCommand(true);
+
+		expect(JSON.parse(output.join("\n"))).toEqual([
+			{
+				cwd: "/project",
+				sessionCount: 2,
+				pinnedCount: 2,
+				latestModifiedAt: "2026-09-06T12:00:00.000Z",
+			},
+			{
+				cwd: "/other-project",
+				sessionCount: 1,
+				pinnedCount: 0,
+				latestModifiedAt: "2026-09-06T09:00:00.000Z",
+			},
+			{
+				cwd: "(unknown cwd)",
+				sessionCount: 1,
+				pinnedCount: 0,
+				latestModifiedAt: "2026-09-06T08:00:00.000Z",
+			},
+		]);
+	});
+
+	it("renders an empty JSON array when no session roots exist", async () => {
+		const output = captureOutput();
+		spyOn(SessionManager, "listAll").mockResolvedValue([]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionRootsCommand(true);
 
 		expect(output).toEqual(["[]\n"]);
 	});

--- a/packages/coding-agent/test/sessions-cli.test.ts
+++ b/packages/coding-agent/test/sessions-cli.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 describe("sessions list CLI", () => {
 	it("lists only the current working directory's saved sessions as JSON", async () => {
 		const output = captureOutput();
-		const list = spyOn(SessionManager, "list").mockResolvedValue([session()]);
+		const list = spyOn(SessionManager, "listReadOnly").mockResolvedValue([session()]);
 		spyOn(SessionManager, "listAll").mockResolvedValue([]);
 		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set(["local"]));
 
@@ -63,7 +63,7 @@ describe("sessions list CLI", () => {
 
 	it("lists sessions from the requested working directory", async () => {
 		const output = captureOutput();
-		const list = spyOn(SessionManager, "list").mockResolvedValue([session({ cwd: "/other-project" })]);
+		const list = spyOn(SessionManager, "listReadOnly").mockResolvedValue([session({ cwd: "/other-project" })]);
 		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
 
 		await runSessionsCommand({ flags: { all: false, cwd: "/other-project", json: true } });
@@ -74,7 +74,7 @@ describe("sessions list CLI", () => {
 
 	it("includes sessions from every project only when --all is selected", async () => {
 		const output = captureOutput();
-		const local = spyOn(SessionManager, "list").mockResolvedValue([]);
+		const local = spyOn(SessionManager, "listReadOnly").mockResolvedValue([]);
 		const all = spyOn(SessionManager, "listAll").mockResolvedValue([
 			session(),
 			session({
@@ -96,10 +96,20 @@ describe("sessions list CLI", () => {
 		]);
 	});
 
+	it("sanitizes cwd control characters in the global session table", async () => {
+		const output = captureOutput();
+		spyOn(SessionManager, "listAll").mockResolvedValue([session({ cwd: "/project\u001b[2J" })]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionsCommand({ flags: { all: true, json: false } });
+
+		expect(output.join("\n")).not.toContain("\u001b");
+	});
+
 	it("keeps JSON output to public, bounded session metadata", async () => {
 		const output = captureOutput();
 		const preview = "long preview ".repeat(20);
-		spyOn(SessionManager, "list").mockResolvedValue([session({ firstMessage: preview })]);
+		spyOn(SessionManager, "listReadOnly").mockResolvedValue([session({ firstMessage: preview })]);
 		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
 
 		await runSessionsCommand({ flags: { all: false, json: true } });
@@ -112,7 +122,7 @@ describe("sessions list CLI", () => {
 
 	it("renders an empty JSON array when the selected scope has no sessions", async () => {
 		const output = captureOutput();
-		spyOn(SessionManager, "list").mockResolvedValue([]);
+		spyOn(SessionManager, "listReadOnly").mockResolvedValue([]);
 		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
 
 		await runSessionsCommand({ flags: { all: false, json: true } });
@@ -166,6 +176,16 @@ describe("session roots CLI", () => {
 				latestModifiedAt: "2026-09-06T08:00:00.000Z",
 			},
 		]);
+	});
+
+	it("sanitizes cwd control characters in the roots table", async () => {
+		const output = captureOutput();
+		spyOn(SessionManager, "listAll").mockResolvedValue([session({ cwd: "/project\u001b[2J" })]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionRootsCommand(false);
+
+		expect(output.join("\n")).not.toContain("\u001b");
 	});
 
 	it("renders an empty JSON array when no session roots exist", async () => {

--- a/packages/coding-agent/test/sessions-cli.test.ts
+++ b/packages/coding-agent/test/sessions-cli.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { runSessionsCommand } from "@oh-my-pi/pi-coding-agent/cli/sessions-cli";
+import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as sessionPins from "@oh-my-pi/pi-coding-agent/session/session-pins";
+
+function session(overrides: Partial<SessionInfo> = {}): SessionInfo {
+	return {
+		path: "/sessions/project/2026-09-06_local.jsonl",
+		id: "local",
+		cwd: "/project",
+		title: "Local session",
+		created: new Date("2026-09-06T10:00:00.000Z"),
+		modified: new Date("2026-09-06T11:00:00.000Z"),
+		messageCount: 4,
+		size: 1_024,
+		firstMessage: "Build a session list command",
+		allMessagesText: "private searchable transcript text",
+		status: "complete",
+		...overrides,
+	};
+}
+
+function captureOutput(): string[] {
+	const output: string[] = [];
+	spyOn(process.stdout, "write").mockImplementation(chunk => {
+		output.push(String(chunk));
+		return true;
+	});
+	return output;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("sessions list CLI", () => {
+	it("lists only the current working directory's saved sessions as JSON", async () => {
+		const output = captureOutput();
+		const list = spyOn(SessionManager, "list").mockResolvedValue([session()]);
+		spyOn(SessionManager, "listAll").mockResolvedValue([]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set(["local"]));
+
+		await runSessionsCommand({ flags: { all: false, json: true } });
+
+		expect(list).toHaveBeenCalledWith(process.cwd());
+		expect(JSON.parse(output.join("\n"))).toEqual([
+			{
+				id: "local",
+				pinned: true,
+				title: "Local session",
+				preview: "Build a session list command",
+				cwd: "/project",
+				path: "/sessions/project/2026-09-06_local.jsonl",
+				createdAt: "2026-09-06T10:00:00.000Z",
+				modifiedAt: "2026-09-06T11:00:00.000Z",
+				status: "complete",
+				messageCount: 4,
+				sizeBytes: 1_024,
+			},
+		]);
+	});
+
+	it("includes sessions from every project only when --all is selected", async () => {
+		const output = captureOutput();
+		const local = spyOn(SessionManager, "list").mockResolvedValue([]);
+		const all = spyOn(SessionManager, "listAll").mockResolvedValue([
+			session(),
+			session({
+				id: "other",
+				cwd: "/other-project",
+				path: "/sessions/other/2026-09-06_other.jsonl",
+				title: "Other project session",
+			}),
+		]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionsCommand({ flags: { all: true, json: true } });
+
+		expect(local).not.toHaveBeenCalled();
+		expect(all).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(output.join("\n")).map((entry: { cwd: string }) => entry.cwd)).toEqual([
+			"/project",
+			"/other-project",
+		]);
+	});
+
+	it("keeps JSON output to public, bounded session metadata", async () => {
+		const output = captureOutput();
+		const preview = "long preview ".repeat(20);
+		spyOn(SessionManager, "list").mockResolvedValue([session({ firstMessage: preview })]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionsCommand({ flags: { all: false, json: true } });
+
+		const [entry] = JSON.parse(output.join("\n")) as [{ preview: string }];
+		expect(output.join("\n")).not.toContain("private searchable transcript text");
+		expect(entry.preview).not.toBe(preview);
+		expect(Bun.stringWidth(entry.preview)).toBeLessThanOrEqual(80);
+	});
+
+	it("renders an empty JSON array when the selected scope has no sessions", async () => {
+		const output = captureOutput();
+		spyOn(SessionManager, "list").mockResolvedValue([]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+
+		await runSessionsCommand({ flags: { all: false, json: true } });
+
+		expect(output).toEqual(["[]\n"]);
+	});
+});

--- a/packages/coding-agent/test/sessions-command.test.ts
+++ b/packages/coding-agent/test/sessions-command.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import * as os from "node:os";
+import Sessions from "@oh-my-pi/pi-coding-agent/commands/sessions";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as sessionPins from "@oh-my-pi/pi-coding-agent/session/session-pins";
+
+const config = { bin: "omp", version: "0.0.0-test", commands: new Map() };
+
+function command(argv: string[]): Sessions {
+	return new Sessions(argv, config);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("sessions command flags", () => {
+	it("rejects an empty cwd before selecting an action", async () => {
+		await expect(command(["roots", "--cwd", ""]).run()).rejects.toThrow("--cwd must not be empty");
+	});
+
+	it("rejects --all combined with an explicitly provided cwd", async () => {
+		await expect(command(["list", "--all", "--cwd", "/project"]).run()).rejects.toThrow(
+			"--all and --cwd are mutually exclusive",
+		);
+	});
+
+	it("expands a tilde cwd before listing sessions", async () => {
+		const output: string[] = [];
+		const list = spyOn(SessionManager, "listReadOnly").mockResolvedValue([]);
+		spyOn(sessionPins, "loadPinnedSessionIds").mockResolvedValue(new Set());
+		spyOn(process.stdout, "write").mockImplementation(chunk => {
+			output.push(String(chunk));
+			return true;
+		});
+
+		await command(["list", "--cwd", "~/projects/app", "--json"]).run();
+
+		expect(list).toHaveBeenCalledWith(`${os.homedir()}/projects/app`);
+		expect(output).toEqual(["[]\n"]);
+	});
+});


### PR DESCRIPTION
## What

Adds read-only session browsing commands:

```text
omp sessions list
omp sessions list --all
omp sessions list --cwd <path>
omp sessions list --json
omp sessions list --all --json
omp sessions roots
omp sessions roots --json
```

`omp sessions list` provides text and JSON session metadata. `omp sessions roots` aggregates managed sessions by working directory, and `--cwd <path>` browses sessions for a specified working directory.

All session browsing commands are read-only: they do not create session buckets, migrate legacy session directories, recover or rename backups, or modify session JSONL files, pins, artifacts, or transcripts.

Text output sanitizes control characters and truncates previews. JSON output contains only necessary metadata; it excludes full transcripts, tool payloads, artifact contents, and credential data.

This PR implements only read-only `sessions` list and roots commands. Whether additional `sessions` commands such as `show`, `pin` / `unpin`, or `delete` are needed remains an upstream maintainer decision.

## Why

The design provides safe, composable, automation-friendly saved-session discovery:

```text
sessions roots          discover working directories
sessions list           browse sessions in the current, specified, or global scope
sessions list --json    consume metadata from scripts and external tools
```

The priorities are read-only inspection, complementary root discovery and cwd browsing, a stable metadata boundary, and explicit mutually exclusive session scopes.

Typical usage:

```text
omp sessions roots
omp sessions list --cwd <path>
omp sessions list --all --json
```

## Testing

- `bun test test/session-paths.test.ts test/sessions-cli.test.ts test/sessions-command.test.ts`
  - 17 passed
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- Verified the built Windows executable against real local session history:
  - list, all, JSON, and all + JSON;
  - roots and roots + JSON;
  - text and JSON output for a specified cwd;
  - a missing cwd returns `[]` without creating a managed session bucket;
  - combining `--all` and `--cwd` reports a usage error.

I manually verified the commands implemented by this PR using the built Windows executable and real local session history.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)