### PR TITLE
perf(read): skip lexical context scans for bracket-free text

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Changed
 
+- Ranged reads of text without bracket characters skip unnecessary lexical context scanning.
+
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
 ### Fixed

--- a/packages/coding-agent/src/utils/block-context.ts
+++ b/packages/coding-agent/src/utils/block-context.ts
@@ -13,6 +13,13 @@ const CLOSE_TO_OPEN: Record<string, string> = {
 	"}": "{",
 };
 
+/**
+ * Lines containing any of these characters need char-by-char scanning when
+ * the scanner is in code mode: brackets, string quotes, or comment markers.
+ * Anything else can neither add boundaries nor change scanner state.
+ */
+const LINE_SCAN_PATTERN = /[()[\]{}'"`/#]/;
+
 export interface LineSpan {
 	startLine: number;
 	endLine: number;
@@ -161,15 +168,21 @@ function isHashCommentStart(line: string, index: number): boolean {
  */
 function lexicalBracketContext(fullLines: readonly string[], visible: ReadonlySet<number>): Map<number, string> {
 	const context = new Map<number, string>();
-	// Without bracket characters, the lexical fallback cannot add boundary lines.
-	if (!fullLines.some(line => /[()[\]{}]/.test(line))) return context;
 	const stack: StackEntry[] = [];
 	let mode: ScannerMode = "code";
 	let escaped = false;
-
+	// Set when the single pass below sees a bracket opener outside strings
+	// and comments. Without one, no boundary lines can exist and the trailing
+	// visible-line sweep is skipped.
+	let sawBracket = false;
 	for (let lineIndex = 0; lineIndex < fullLines.length; lineIndex++) {
-		const lineNumber = lineIndex + 1;
 		const line = fullLines[lineIndex] ?? "";
+		// In code mode a line without brackets, quotes, or comment markers can
+		// neither add boundaries nor change scanner state: skip it char-by-char
+		// cost without a separate pre-scan pass. Other modes still scan every
+		// line so multi-line strings and block comments track their end.
+		if (mode === "code" && !LINE_SCAN_PATTERN.test(line)) continue;
+		const lineNumber = lineIndex + 1;
 		const lineVisible = visible.has(lineNumber);
 		let index = 0;
 		while (index < line.length) {
@@ -235,6 +248,7 @@ function lexicalBracketContext(fullLines: readonly string[], visible: ReadonlySe
 			}
 
 			if (OPEN_TO_CLOSE[ch]) {
+				sawBracket = true;
 				stack.push({ opener: ch, lineNumber, text: line, visible: lineVisible });
 				index++;
 				continue;
@@ -260,8 +274,9 @@ function lexicalBracketContext(fullLines: readonly string[], visible: ReadonlySe
 			escaped = false;
 		}
 	}
-
-	for (const lineNumber of visible) context.delete(lineNumber);
+	// No openers outside strings/comments means no boundary lines exist;
+	// skip the visible-line sweep entirely.
+	if (sawBracket) for (const lineNumber of visible) context.delete(lineNumber);
 	return context;
 }
 

--- a/packages/coding-agent/src/utils/block-context.ts
+++ b/packages/coding-agent/src/utils/block-context.ts
@@ -161,6 +161,8 @@ function isHashCommentStart(line: string, index: number): boolean {
  */
 function lexicalBracketContext(fullLines: readonly string[], visible: ReadonlySet<number>): Map<number, string> {
 	const context = new Map<number, string>();
+	// Without bracket characters, the lexical fallback cannot add boundary lines.
+	if (!fullLines.some(line => /[()[\]{}]/.test(line))) return context;
 	const stack: StackEntry[] = [];
 	let mode: ScannerMode = "code";
 	let escaped = false;

--- a/packages/coding-agent/test/block-context.test.ts
+++ b/packages/coding-agent/test/block-context.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { buildLineEntriesWithBlockContext, findBlockContextLines } from "../src/utils/block-context";
+
+describe("block context for partial reads", () => {
+	it("keeps disjoint selections in order when text has no bracket boundaries", () => {
+		const lines = ["first", "second", "third", "fourth", "fifth"];
+		expect(
+			buildLineEntriesWithBlockContext(lines, [
+				{ startLine: 2, endLine: 2 },
+				{ startLine: 4, endLine: 4 },
+			]),
+		).toEqual([
+			{ kind: "line", lineNumber: 2, text: "second", context: false },
+			{ kind: "ellipsis" },
+			{ kind: "line", lineNumber: 4, text: "fourth", context: false },
+		]);
+	});
+
+	it("finds all lexical bracket pairs while ignoring comments and quoted brackets", () => {
+		const lines = ["/* { */", "'['", '"("', "(", "plain", ")", "[", "plain", "]", "{", "plain", "}"];
+		expect([...findBlockContextLines(lines, [4, 7, 10])]).toEqual([
+			[6, ")"],
+			[9, "]"],
+			[12, "}"],
+		]);
+		expect([...findBlockContextLines(lines, [6, 9, 12])]).toEqual([
+			[4, "("],
+			[7, "["],
+			[10, "{"],
+		]);
+	});
+
+	it("retains native indentation boundaries for Python without brackets", () => {
+		const lines = ["if True:", "    value = 1", "    result = value", "outside = 2"];
+		const context = findBlockContextLines(lines, [1], { path: "fixture.py" });
+		expect(context.get(3)).toBe("    result = value");
+		expect(context.has(4)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

Reduce character-by-character work in the lexical block-context fallback. While the scanner is in code mode, skip lines without brackets, quotes or comment markers. Lines inside multiline strings or block comments still run through the scanner. The same pass tracks bracket openers and skips the final visible-line cleanup when none occurred.

Tree-sitter still runs first, preserving indentation-based context. Tests cover disjoint selections, all three bracket pairs, quoted/commented brackets and bracket-free Python blocks.

## Why

A short selection from a large plain-text file spent most of its time walking characters that could not affect block context. The line-level check avoids that work without adding a separate whole-file prescan. It also benefits sparse-bracket files where most lines have no scanner markers.

## Measurements and findings

Measured revision `80c0e8ceba`, compared with upstream `b2f25dbfe1` and a negative control restoring the upstream helper. A 30-line middle selection from a 40,000-line, 1,028,901-byte bracket-free text fixture; each route had one first call, five warmups and 30 measured calls. Values are **median / p95 milliseconds** (the harness uses the upper middle observation for the 30-sample median):

| Route | Upstream | Single-pass change | Reverted source |
| --- | ---: | ---: | ---: |
| Direct ReadTool | 38.55 / 42.52 | 5.27 / 6.95 | 36.93 / 41.80 |
| Host bridge | 39.44 / 43.21 | 4.98 / 7.06 | 35.02 / 37.92 |
| JS eval | 39.63 / 42.82 | 6.11 / 7.89 | 36.62 / 42.37 |
| Python eval | 37.60 / 38.90 | 7.33 / 10.24 | 38.43 / 42.02 |

The direct ReadTool saved about 33 ms on this fixture. Separate 40,000-line helper probes also improved when their only bracket pair was on the final line (29.64 → 1.11 ms median) or first line (29.60 → 1.06 ms). These sparse fixtures do not establish a gain for dense source code or text dominated by strings/comments.

Apple M5 Pro / macOS arm64, Bun 1.4.0, Python 3.9.6 and native addon 18.1.11. Baseline/candidate/revert runs changed only the block-context helper. No model, outer agent loop, hooks, approvals or UI time is included. Timings are local observations and vary with host load.

## Testing

- At `80c0e8ceba`, all 33 focused tests passed (124 assertions) across block context, single-pass reads, multi-range reads, raw ranges and column-truncation snapshots.
- Exploratory baseline/candidate differential run: 3,612 identical context results and 17 identical complete ReadTool results, including anchors and metadata.
- Actual ReadTool and JS/Python executor benchmark: zero errors in baseline, candidate and reverted-source runs.
- Full GitHub CI and Nix checks passed at `80c0e8ceba`, including lint, formatting, type checking and workspace tests.

---

- [x] Package-local checks pass
- [x] Tested locally as described above
- [x] CHANGELOG updated
