### PR TITLE
test(coding-agent): benchmark local tools, cold kernels and direnv

### DIFF
--- a/packages/coding-agent/scripts/bench-tool-latency.ts
+++ b/packages/coding-agent/scripts/bench-tool-latency.ts
@@ -8,16 +8,31 @@ import { parseOptions } from "./tool-latency/sampling";
 const args = process.argv.slice(2);
 if (args.length === 1 && args[0] === "--help") {
 	console.log(
-		"Usage: bun scripts/bench-tool-latency.ts [--runs 30] [--warmups 5] [--python /path/to/python3]\nWrites JSON to stdout. Uses temporary read/search fixtures and JS eval; Python is opt-in.",
+		"Usage: bun scripts/bench-tool-latency.ts [--runs 30] [--warmups 5] [--python /path/to/python3] [--cold-runs 5] [--direnv /path/to/direnv]\nWrites JSON to stdout. Uses temporary read/search fixtures and JS eval; Python, cold-process sampling and isolated direnv fixtures are opt-in.",
 	);
 } else {
-	parseOptions(args);
+	const options = parseOptions(args);
+	if (options.python && !path.isAbsolute(options.python)) throw new Error("--python requires an absolute path");
+	if (options.direnv && (!path.isAbsolute(options.direnv) || process.platform === "win32"))
+		throw new Error("--direnv requires an absolute path on a POSIX host");
 	const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "omp-tool-latency-"));
 	try {
+		let searchPath = process.env.PATH ?? "";
+		if (options.direnv) {
+			await fs.access(options.direnv, fs.constants.X_OK);
+			const bin = path.join(scratch, "bin");
+			await fs.mkdir(bin);
+			await fs.symlink(options.direnv, path.join(bin, "direnv"));
+			searchPath = `${bin}${path.delimiter}${searchPath}`;
+		}
 		const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "tool-latency/runner.ts"), ...args], {
 			cwd: scratch,
 			env: {
-				PATH: process.env.PATH ?? "",
+				PATH: searchPath,
+				HOME: scratch,
+				XDG_CONFIG_HOME: path.join(scratch, "config"),
+				XDG_DATA_HOME: path.join(scratch, "data"),
+				XDG_CACHE_HOME: path.join(scratch, "cache"),
 				SystemRoot: process.env.SystemRoot,
 				WINDIR: process.env.WINDIR,
 				TMPDIR: scratch,

--- a/packages/coding-agent/scripts/bench-tool-latency.ts
+++ b/packages/coding-agent/scripts/bench-tool-latency.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+/** Launch the measurement process with isolated OMP state before module initialization. */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseOptions } from "./tool-latency/sampling";
+
+const args = process.argv.slice(2);
+if (args.length === 1 && args[0] === "--help") {
+	console.log(
+		"Usage: bun scripts/bench-tool-latency.ts [--runs 30] [--warmups 5] [--python /path/to/python3]\nWrites JSON to stdout. Uses temporary read/search fixtures and JS eval; Python is opt-in.",
+	);
+} else {
+	parseOptions(args);
+	const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "omp-tool-latency-"));
+	try {
+		const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "tool-latency/runner.ts"), ...args], {
+			cwd: scratch,
+			env: {
+				PATH: process.env.PATH ?? "",
+				SystemRoot: process.env.SystemRoot,
+				WINDIR: process.env.WINDIR,
+				TMPDIR: scratch,
+				TMP: scratch,
+				TEMP: scratch,
+				PI_CODING_AGENT_DIR: path.join(scratch, "agent"),
+			},
+			stdin: "ignore",
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+		const stop = () => child.kill("SIGTERM");
+		process.on("SIGINT", stop);
+		process.on("SIGTERM", stop);
+		try {
+			process.exitCode = await child.exited;
+		} finally {
+			process.off("SIGINT", stop);
+			process.off("SIGTERM", stop);
+		}
+	} finally {
+		await fs.rm(scratch, { recursive: true, force: true });
+	}
+}

--- a/packages/coding-agent/scripts/tool-latency/README.md
+++ b/packages/coding-agent/scripts/tool-latency/README.md
@@ -13,7 +13,7 @@ calling a model. It launches a measurement process with a temporary agent
 directory, minimal environment, in-memory settings and a tool registry limited
 to read, grep and a fixed 50 ms delay probe. The parent removes temporary state
 after the measurement process exits. Python is opt-in; supply a working Python
-interpreter. No user hooks, provider credentials, `.envrc`, shell profiles or
+interpreter by absolute path. No user hooks, provider credentials, `.envrc`, shell profiles or
 workspace scripts are executed. It does not introduce a doctor command or a CI
 performance threshold. `--help` and invalid arguments do not start workloads.
 
@@ -35,7 +35,7 @@ imports and canonical fixture validation happen before measurement. Only the fir
 cell in each language includes its kernel initialization; later workload first
 calls reuse the kernel. JS/Python measurements include JSON serialization and
 kernel output. The output column cap is disabled for lossless JSON transport. No internal phase durations are inferred. The outer agent loop,
-model, approvals, hooks, UI rendering, shell and direnv are outside this benchmark.
+model, approvals, hooks, UI rendering and general shell execution are outside this benchmark. Direnv is measured only when explicitly selected below.
 
 Compare reports on the same machine and runtime, using baseline, candidate and
 reverted code. Dirty state includes untracked files, so writing reports inside
@@ -43,3 +43,35 @@ the checkout can set it. Keep output elsewhere for a clean revision comparison.
 Use multiple runs for small differences; JIT and system load can affect them.
 Do not describe these measurements as whole-agent speedups. The delay probe
 demonstrates transport overlap, not a speedup for real reads.
+
+
+## Optional cold kernels and direnv
+
+```sh
+bun packages/coding-agent/scripts/bench-tool-latency.ts --runs 10 --warmups 3 --python /path/to/python3 --cold-runs 10 --direnv /path/to/direnv > tool-startup.json
+```
+
+`--cold-runs N` (1–30) adds paired empty-cell measurements in N fresh Bun
+processes per language. `coldKernels[].raw` reports `firstCellMs`, `secondCellMs`
+and `processMs` for each pair. The first cell includes kernel startup and
+interpreter discovery but excludes host module imports and fixture setup; the
+second cell reuses that kernel. `processMs` includes host imports, both cells,
+output collection and teardown. This is a benchmark harness process, not CLI
+startup or time to first model token. OS filesystem caches remain warm between
+processes. Failures are retained and excluded from the corresponding summaries.
+
+`--direnv /absolute/path/to/direnv` is POSIX-only and adds no-envrc, blocked,
+allowed-simple and allowed-watched-file rows using the real `loadDirenvEnv`.
+The launcher gives the child a temporary HOME and XDG config/data/cache roots,
+and puts a link to the selected binary first on PATH. It allows only generated
+`.envrc` fixtures in this temporary state. It never approves or sources the
+caller's workspace `.envrc`. No Nix/devenv environment is built.
+
+Direnv timing windows include ancestor lookup, process execution, parsing and
+result validation. Approval and fixture creation happen before measurement.
+Outside the timing windows, the suite verifies that a watched-file change is
+reflected, revoked approval is respected, editing an approved `.envrc` requires renewed approval, and a blocked
+fixture never executes. `unchangedEvaluations` counts how often the watched
+fixture was evaluated across its first call, warmups and measured calls. These
+checks guard against interpreting a stale environment cache as a performance
+improvement. Both optional sections are separate from the original `rows`.

--- a/packages/coding-agent/scripts/tool-latency/README.md
+++ b/packages/coding-agent/scripts/tool-latency/README.md
@@ -1,0 +1,45 @@
+# Local tool latency benchmark
+
+From the repository root, after installing dependencies and the matching native
+addon and running `bun run gen:tool-views`:
+
+```sh
+bun packages/coding-agent/scripts/bench-tool-latency.ts > tool-latency.json
+bun packages/coding-agent/scripts/bench-tool-latency.ts --runs 10 --warmups 3 --python /path/to/python3 > tool-latency-python.json
+```
+
+This developer command runs deterministic local read/search fixtures without
+calling a model. It launches a measurement process with a temporary agent
+directory, minimal environment, in-memory settings and a tool registry limited
+to read, grep and a fixed 50 ms delay probe. The parent removes temporary state
+after the measurement process exits. Python is opt-in; supply a working Python
+interpreter. No user hooks, provider credentials, `.envrc`, shell profiles or
+workspace scripts are executed. It does not introduce a doctor command or a CI
+performance threshold. `--help` and invalid arguments do not start workloads.
+
+The JSON report contains the checkout revision/dirty state, OS/runtime, fixture
+sizes, first-call latency, raw warm samples, median, nearest-rank p95, errors and
+observed concurrency. Failed observations are excluded from percentiles, remain
+visible in the report and cause a nonzero exit. Startup/setup failures are fatal
+and go to stderr. Progress goes to stderr, so stdout stays machine-readable.
+
+Routes use the real tool implementations: direct execution, host bridge, JS eval
+and optional Python eval. Every result's formatted text must match the canonical
+tool result after removing the variable repeat-read notice; the fixture check also requires the expected content. Workloads
+include a small file, a middle range in a 1 MB text file and native grep. Four
+reads and four controlled delays run both sequentially and concurrently inside
+each route. Batch timing is elapsed time, never the sum of concurrent durations.
+
+First-call timings are single observations, not cold-start distributions. Module
+imports and canonical fixture validation happen before measurement. Only the first
+cell in each language includes its kernel initialization; later workload first
+calls reuse the kernel. JS/Python measurements include JSON serialization and
+kernel output. The output column cap is disabled for lossless JSON transport. No internal phase durations are inferred. The outer agent loop,
+model, approvals, hooks, UI rendering, shell and direnv are outside this benchmark.
+
+Compare reports on the same machine and runtime, using baseline, candidate and
+reverted code. Dirty state includes untracked files, so writing reports inside
+the checkout can set it. Keep output elsewhere for a clean revision comparison.
+Use multiple runs for small differences; JIT and system load can affect them.
+Do not describe these measurements as whole-agent speedups. The delay probe
+demonstrates transport overlap, not a speedup for real reads.

--- a/packages/coding-agent/scripts/tool-latency/cold-kernel-probe.ts
+++ b/packages/coding-agent/scripts/tool-latency/cold-kernel-probe.ts
@@ -1,0 +1,43 @@
+/** One fresh host process: report a cold cell and a second cell in the same kernel. */
+import { Settings } from "../../src/config/settings";
+import { disposeAllVmContexts } from "../../src/eval/js/context-manager";
+import { executeJs } from "../../src/eval/js/executor";
+import { disposeAllKernelSessions, executePython } from "../../src/eval/py/executor";
+import { disposePyToolBridge } from "../../src/eval/py/tool-bridge";
+import type { ToolSession } from "../../src/tools";
+
+const [route, interpreter] = process.argv.slice(2);
+if (route !== "js" && route !== "python") throw new Error("Expected js or python route");
+const settings = await Settings.init({ inMemory: true, cwd: process.cwd() });
+const session: ToolSession = {
+	cwd: process.cwd(),
+	hasUI: false,
+	settings,
+	getSessionFile: () => null,
+	getSessionSpawns: () => null,
+};
+async function cell(): Promise<number> {
+	const started = performance.now();
+	const result =
+		route === "js"
+			? await executeJs('console.log("kernel-ready")', { sessionId: "cold-benchmark", session, timeoutMs: 30_000 })
+			: await executePython('print("kernel-ready")', {
+					sessionId: "cold-benchmark",
+					toolSession: session,
+					interpreter,
+					timeoutMs: 30_000,
+				});
+	if (result.exitCode !== 0 || result.cancelled || result.truncated || result.output.trim() !== "kernel-ready") {
+		throw new Error(`${route} cell failed: ${result.output}`);
+	}
+	return performance.now() - started;
+}
+try {
+	const firstCellMs = await cell();
+	const secondCellMs = await cell();
+	console.log(JSON.stringify({ firstCellMs, secondCellMs }));
+} finally {
+	await disposeAllVmContexts();
+	await disposeAllKernelSessions();
+	await disposePyToolBridge();
+}

--- a/packages/coding-agent/scripts/tool-latency/cold-kernels.ts
+++ b/packages/coding-agent/scripts/tool-latency/cold-kernels.ts
@@ -1,0 +1,65 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { summarize } from "./sampling";
+
+export async function measureColdKernels(runs: number, fixture: string, python?: string) {
+	const rows = [];
+	for (const route of python ? ["js", "python"] : ["js"]) {
+		const raw: Array<{ firstCellMs: number; secondCellMs: number; processMs: number }> = [];
+		const errors: string[] = [];
+		for (let i = 0; i < runs; i++) {
+			const scratch = await fs.mkdtemp(path.join(fixture, "cold-"));
+			try {
+				const started = performance.now();
+				const child = Bun.spawn(
+					[
+						process.execPath,
+						path.join(import.meta.dir, "cold-kernel-probe.ts"),
+						route,
+						...(route === "python" ? [python!] : []),
+					],
+					{
+						cwd: scratch,
+						env: { ...process.env, PI_CODING_AGENT_DIR: path.join(scratch, "agent") },
+						stdin: "ignore",
+						stdout: "pipe",
+						stderr: "pipe",
+						timeout: 60_000,
+					},
+				);
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(child.stdout).text(),
+					new Response(child.stderr).text(),
+					child.exited,
+				]);
+				const processMs = performance.now() - started;
+				if (exitCode !== 0) throw new Error(`child exit ${exitCode}: ${stderr.trim()}`);
+				const value = JSON.parse(stdout) as { firstCellMs?: unknown; secondCellMs?: unknown };
+				if (
+					typeof value.firstCellMs !== "number" ||
+					!Number.isFinite(value.firstCellMs) ||
+					value.firstCellMs < 0 ||
+					typeof value.secondCellMs !== "number" ||
+					!Number.isFinite(value.secondCellMs) ||
+					value.secondCellMs < 0
+				)
+					throw new Error("Invalid cold-kernel timing report");
+				raw.push({ firstCellMs: value.firstCellMs, secondCellMs: value.secondCellMs, processMs });
+			} catch (error) {
+				errors.push(`sample ${i + 1}: ${error instanceof Error ? error.message : String(error)}`);
+			} finally {
+				await fs.rm(scratch, { recursive: true, force: true });
+			}
+		}
+		rows.push({
+			route,
+			runs,
+			raw,
+			firstCell: summarize(raw.map(row => row.firstCellMs)),
+			secondCell: summarize(raw.map(row => row.secondCellMs)),
+			process: summarize(raw.map(row => row.processMs)),
+			errors,
+		});
+	}
+	return rows;
+}

--- a/packages/coding-agent/scripts/tool-latency/direnv.ts
+++ b/packages/coding-agent/scripts/tool-latency/direnv.ts
@@ -1,0 +1,83 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { findEnvrc, loadDirenvEnv } from "../../src/exec/direnv";
+import { measure, type Samples } from "./sampling";
+
+/** Only the generated fixtures are allowed, under the launcher's isolated XDG directories. */
+export async function measureDirenv(fixture: string, runs: number, warmups: number) {
+	const bin = Bun.which("direnv");
+	if (!bin) throw new Error("The selected direnv binary is not available");
+	async function command(args: string[], cwd: string): Promise<string> {
+		const child = Bun.spawn([bin!, ...args], {
+			cwd,
+			env: process.env,
+			stdout: "pipe",
+			stderr: "pipe",
+			timeout: 10_000,
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		if (exitCode !== 0) throw new Error(`direnv ${args[0]} failed: ${stderr.trim()}`);
+		return stdout.trim();
+	}
+	const version = await command(["version"], fixture);
+	const rows: Array<Samples & { name: string }> = [];
+	async function scenario(name: string, source?: string, allow = false) {
+		const cwd = path.join(fixture, name);
+		await fs.mkdir(cwd);
+		if (source !== undefined) await Bun.write(path.join(cwd, ".envrc"), source);
+		if (allow) await command(["allow", "."], cwd);
+		return cwd;
+	}
+	const empty = await scenario("no-envrc");
+	if ((await findEnvrc(empty)) !== null) throw new Error("Unexpected ancestor .envrc outside the benchmark fixture");
+	const blocked = await scenario("blocked", "echo unsafe > ran\nexport OMP_LATENCY_VALUE=blocked\n");
+	const simple = await scenario("allowed-simple", "export OMP_LATENCY_VALUE=ready\n", true);
+	const watched = await scenario(
+		"allowed-watched",
+		'watch_file value.txt\nexport OMP_LATENCY_VALUE="$(cat value.txt)"\necho evaluated >> evaluations\n',
+		true,
+	);
+	await Bun.write(path.join(watched, "value.txt"), "initial");
+	for (const [name, cwd, expected] of [
+		["no-envrc", empty, null],
+		["blocked", blocked, null],
+		["allowed-simple", simple, "ready"],
+		["allowed-watched", watched, "initial"],
+	] as const) {
+		const samples = await measure(
+			async () => {
+				const result = await loadDirenvEnv(cwd);
+				if (expected === null ? result !== null : result?.set.OMP_LATENCY_VALUE !== expected)
+					throw new Error(`Unexpected export for ${name}`);
+			},
+			runs,
+			warmups,
+		);
+		rows.push({ name, ...samples });
+	}
+	const unchangedEvaluations = (await Bun.file(path.join(watched, "evaluations")).text()).trim().split("\n").length;
+	// Semantic checks are outside the timing windows: a stale cache would fail these.
+	await Bun.write(path.join(watched, "value.txt"), "changed");
+	const refreshed = await loadDirenvEnv(watched);
+	if (refreshed?.set.OMP_LATENCY_VALUE !== "changed")
+		throw new Error("Watched-file change was not reflected in the export");
+	await command(["deny", "."], watched);
+	const revoked = await loadDirenvEnv(watched);
+	if (revoked?.set.OMP_LATENCY_VALUE !== undefined) throw new Error("Revoked .envrc approval was not respected");
+	await Bun.write(path.join(simple, ".envrc"), "export OMP_LATENCY_VALUE=unapproved-change\n");
+	if ((await loadDirenvEnv(simple)) !== null) throw new Error("Changed .envrc executed without renewed approval");
+	if (await Bun.file(path.join(blocked, "ran")).exists()) throw new Error("Blocked fixture was executed");
+	return {
+		version,
+		rows,
+		unchangedEvaluations,
+		watchedFileRefreshVerified: true,
+		revokedApprovalBlockedVerified: true,
+		changedEnvrcBlockedVerified: true,
+		blockedFixtureNotExecuted: true,
+	};
+}

--- a/packages/coding-agent/scripts/tool-latency/runner.ts
+++ b/packages/coding-agent/scripts/tool-latency/runner.ts
@@ -13,6 +13,8 @@ import { disposePyToolBridge } from "../../src/eval/py/tool-bridge";
 import type { ToolSession } from "../../src/tools";
 import { GrepTool } from "../../src/tools/grep";
 import { ReadTool } from "../../src/tools/read";
+import { measureColdKernels } from "./cold-kernels";
+import { measureDirenv } from "./direnv";
 import { measure, parseOptions, type Samples } from "./sampling";
 import nativePackage from "../../../natives/package.json" with { type: "json" };
 
@@ -189,6 +191,9 @@ try {
 		await record(route, { name: "four-delays-parallel", tool: "latency_probe", args: {} }, "probe-complete", 4, true);
 	}
 	const repo = vcs.git(path.resolve(import.meta.dir, "../../../.."));
+	const coldKernels = options.coldRuns ? await measureColdKernels(options.coldRuns, fixture, options.python) : [];
+	const direnv = options.direnv ? await measureDirenv(fixture, options.runs, options.warmups) : null;
+
 	const pythonInfo = options.python
 		? await executePython("import sys; print(sys.version)", {
 				cwd: fixture,
@@ -216,14 +221,16 @@ try {
 				},
 				options,
 				fixtures: { smallBytes: Buffer.byteLength(small), largeBytes: Buffer.byteLength(large), largeLines: 40000 },
-				scope: "Real read/grep tools and eval kernels with an isolated ToolSession. Excludes model, outer agent loop, approvals, hooks, shell, direnv and UI rendering. JS/Python include JSON serialization and kernel output. First-call samples exclude module startup and canonical fixture validation; only the first cell per language includes kernel startup.",
+				scope: "Real read/grep tools and eval kernels with an isolated ToolSession. Excludes model, outer agent loop, user approvals/hooks, shell and UI rendering. Optional direnv rows use only generated fixtures. JS/Python include JSON serialization and kernel output. Main-row first-call samples exclude module startup and canonical fixture validation; only the first cell per language includes kernel startup. Optional coldKernels rows use fresh host processes: firstCell excludes host imports, secondCell reuses the kernel, process includes host startup, both cells and teardown.",
 				rows,
+				coldKernels,
+				direnv,
 			},
 			null,
 			2,
 		),
 	);
-	if (rows.some(row => row.errors.length > 0)) process.exitCode = 1;
+	if ([...rows, ...coldKernels, ...(direnv?.rows ?? [])].some(row => row.errors.length > 0)) process.exitCode = 1;
 } finally {
 	try {
 		await disposeAllVmContexts();

--- a/packages/coding-agent/scripts/tool-latency/runner.ts
+++ b/packages/coding-agent/scripts/tool-latency/runner.ts
@@ -1,0 +1,241 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { Settings } from "../../src/config/settings";
+import { disposeAllVmContexts } from "../../src/eval/js/context-manager";
+import { executeJs } from "../../src/eval/js/executor";
+import { callSessionTool } from "../../src/eval/js/tool-bridge";
+import { disposeAllKernelSessions, executePython } from "../../src/eval/py/executor";
+import { disposePyToolBridge } from "../../src/eval/py/tool-bridge";
+import type { ToolSession } from "../../src/tools";
+import { GrepTool } from "../../src/tools/grep";
+import { ReadTool } from "../../src/tools/read";
+import { measure, parseOptions, type Samples } from "./sampling";
+import nativePackage from "../../../natives/package.json" with { type: "json" };
+
+type Route = "direct" | "host-bridge" | "js" | "python";
+interface Workload {
+	name: string;
+	tool: string;
+	args: Record<string, unknown>;
+}
+interface Row extends Samples {
+	name: string;
+	route: Route;
+	batchSize: number;
+	peakConcurrency: number;
+}
+
+const options = parseOptions(process.argv.slice(2));
+const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "fixtures-"));
+const settings = await Settings.init({
+	inMemory: true,
+	cwd: fixture,
+	overrides: { "read.summarize.enabled": false, "tools.outputMaxColumns": 0 },
+});
+const registry = new Map<string, AgentTool>();
+const session: ToolSession = {
+	cwd: fixture,
+	hasUI: false,
+	settings,
+	getSessionFile: () => null,
+	getSessionSpawns: () => "*",
+	getToolForEvalBridge: name => registry.get(name),
+};
+registry.set("read", new ReadTool(session) as unknown as AgentTool);
+registry.set("grep", new GrepTool(session) as unknown as AgentTool);
+let active = 0;
+let peak = 0;
+registry.set("latency_probe", {
+	name: "latency_probe",
+	label: "latency_probe",
+	description: "Controlled local overlap probe",
+	parameters: type({}),
+	async execute() {
+		active++;
+		peak = Math.max(peak, active);
+		try {
+			await Bun.sleep(50);
+			return { content: [{ type: "text", text: "probe-complete" }] };
+		} finally {
+			active--;
+		}
+	},
+});
+
+// Only the documented repeat-read notice varies across identical fixture calls.
+function comparableText(text: string): string {
+	return text.replace(
+		/\n\n\[You have received this identical output \d+ times\. Re-reading '[^\n]*' will not change it — use a narrower selector \(path:A-B\), or proceed with the edit\.\]$/,
+		"",
+	);
+}
+
+function resultText(result: AgentToolResult): string {
+	return result.content
+		.filter(c => c.type === "text")
+		.map(c => c.text)
+		.join("");
+}
+function bridgeText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (
+		value &&
+		typeof value === "object" &&
+		"text" in value &&
+		typeof value.text === "string" &&
+		!("hasError" in value && value.hasError)
+	)
+		return value.text;
+	throw new Error("Tool returned an invalid or failed result");
+}
+async function invoke(route: Route, w: Workload, count = 1, parallel = false): Promise<string[]> {
+	const args = JSON.stringify(w.args);
+	if (route === "direct" || route === "host-bridge") {
+		const call = async () =>
+			route === "direct"
+				? resultText(await registry.get(w.tool)!.execute("benchmark", w.args))
+				: bridgeText(await callSessionTool(w.tool, w.args, { session }));
+		if (parallel) return Promise.all(Array.from({ length: count }, call));
+		const results: string[] = [];
+		for (let i = 0; i < count; i++) results.push(await call());
+		return results;
+	}
+	let output: string;
+	if (route === "js") {
+		const call = `tool.${w.tool}(${args})`;
+		const expression = parallel
+			? `await Promise.all(Array.from({length:${count}},()=>${call}))`
+			: `await (async()=>{const values=[];for(let i=0;i<${count};i++)values.push(await ${call});return values;})()`;
+		const result = await executeJs(`console.log(JSON.stringify(${expression}));`, {
+			cwd: fixture,
+			sessionId: "tool-latency-js",
+			session,
+			timeoutMs: 10000,
+		});
+		if (result.exitCode !== 0 || result.cancelled || result.truncated)
+			throw new Error(`JS execution failed: ${result.output}`);
+		output = result.output;
+	} else {
+		// JSON inside a Python string literal avoids Python/JSON boolean and null differences.
+		const call = `tool.${w.tool}(**json.loads(${JSON.stringify(args)}))`;
+		const expression = parallel
+			? `await asyncio.gather(*[${call} for _ in range(${count})])`
+			: `[await ${call} for _ in range(${count})]`;
+		const result = await executePython(`print(json.dumps(${expression}))`, {
+			cwd: fixture,
+			sessionId: "tool-latency-python",
+			toolSession: session,
+			interpreter: options.python,
+			timeoutMs: 10000,
+		});
+		if (result.exitCode !== 0 || result.cancelled || result.truncated)
+			throw new Error(`Python execution failed: ${result.output}`);
+		output = result.output;
+	}
+	const values: unknown = JSON.parse(output.trim());
+	if (!Array.isArray(values) || values.length !== count) throw new Error(`Expected ${count} results`);
+	return values.map(bridgeText);
+}
+
+const rows: Row[] = [];
+const small = Array.from({ length: 80 }, (_, i) => `line ${i + 1}: fixture alpha\n`).join("");
+const large = Array.from(
+	{ length: 40000 },
+	(_, i) => `line ${i + 1}: fixture ${i === 20000 ? "LATENCY_NEEDLE" : "alpha"}\n`,
+).join("");
+const routes: Route[] = ["direct", "host-bridge", "js", ...(options.python ? ["python" as const] : [])];
+
+try {
+	await Bun.write(path.join(fixture, "small.txt"), small);
+	await Bun.write(path.join(fixture, "large.txt"), large);
+	const workloads: Workload[] = [
+		{ name: "small-read", tool: "read", args: { path: "small.txt" } },
+		{ name: "large-range", tool: "read", args: { path: "large.txt:19990-20019" } },
+		{ name: "grep", tool: "grep", args: { path: "large.txt", pattern: "LATENCY_NEEDLE" } },
+	];
+	async function record(route: Route, w: Workload, expected: string, count = 1, parallel = false) {
+		peak = 0;
+		const samples = await measure(
+			async () => {
+				const values = await invoke(route, w, count, parallel);
+				if (values.length !== count || values.some(value => comparableText(value) !== comparableText(expected)))
+					throw new Error(`Output mismatch: ${w.name}`);
+			},
+			options.runs,
+			options.warmups,
+		);
+		rows.push({ name: w.name, route, batchSize: count, peakConcurrency: peak, ...samples });
+		console.error(
+			`${route}/${w.name}: median=${samples.medianMs?.toFixed(2) ?? "n/a"} ms, errors=${samples.errors.length}`,
+		);
+	}
+	for (const w of workloads) {
+		// One canonical untimed tool call supplies the exact formatted text contract for every route.
+		const [expected] = await invoke("direct", w);
+		if (!expected.includes(w.name === "small-read" ? "80: fixture alpha" : "LATENCY_NEEDLE"))
+			throw new Error(`Fixture validation failed: ${w.name}`);
+		for (const route of routes) await record(route, w, expected);
+	}
+	const read = workloads[0];
+	const [expected] = await invoke("direct", read);
+	for (const route of routes) {
+		await record(route, { ...read, name: "four-reads-sequential" }, expected, 4);
+		await record(route, { ...read, name: "four-reads-parallel" }, expected, 4, true);
+		await record(route, { name: "four-delays-sequential", tool: "latency_probe", args: {} }, "probe-complete", 4);
+		await record(route, { name: "four-delays-parallel", tool: "latency_probe", args: {} }, "probe-complete", 4, true);
+	}
+	const repo = vcs.git(path.resolve(import.meta.dir, "../../../.."));
+	const pythonInfo = options.python
+		? await executePython("import sys; print(sys.version)", {
+				cwd: fixture,
+				sessionId: "tool-latency-python",
+				toolSession: session,
+				interpreter: options.python,
+				timeoutMs: 10000,
+			})
+		: null;
+	console.log(
+		JSON.stringify(
+			{
+				schemaVersion: 1,
+				revision: (await repo?.headSha()) ?? null,
+				dirty: repo ? await repo.isDirty() : null,
+				environment: {
+					platform: process.platform,
+					arch: process.arch,
+					release: os.release(),
+					cpu: os.cpus()[0]?.model,
+					bun: Bun.version,
+					python: options.python ?? null,
+					nativeVersion: nativePackage.version,
+					pythonVersion: pythonInfo?.exitCode === 0 ? pythonInfo.output.trim() : null,
+				},
+				options,
+				fixtures: { smallBytes: Buffer.byteLength(small), largeBytes: Buffer.byteLength(large), largeLines: 40000 },
+				scope: "Real read/grep tools and eval kernels with an isolated ToolSession. Excludes model, outer agent loop, approvals, hooks, shell, direnv and UI rendering. JS/Python include JSON serialization and kernel output. First-call samples exclude module startup and canonical fixture validation; only the first cell per language includes kernel startup.",
+				rows,
+			},
+			null,
+			2,
+		),
+	);
+	if (rows.some(row => row.errors.length > 0)) process.exitCode = 1;
+} finally {
+	try {
+		await disposeAllVmContexts();
+	} finally {
+		try {
+			await disposeAllKernelSessions();
+		} finally {
+			try {
+				await disposePyToolBridge();
+			} finally {
+				await fs.rm(fixture, { recursive: true, force: true });
+			}
+		}
+	}
+}

--- a/packages/coding-agent/scripts/tool-latency/sampling.ts
+++ b/packages/coding-agent/scripts/tool-latency/sampling.ts
@@ -1,0 +1,65 @@
+export interface Samples {
+	firstCallMs: number | null;
+	warmups: number;
+	rawMs: number[];
+	medianMs: number | null;
+	p95Ms: number | null;
+	errors: string[];
+}
+
+export function summarize(samples: number[]): { medianMs: number | null; p95Ms: number | null } {
+	if (samples.length === 0) return { medianMs: null, p95Ms: null };
+	const sorted = samples.toSorted((a, b) => a - b);
+	const middle = Math.floor(sorted.length / 2);
+	return {
+		medianMs: sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2,
+		p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
+	};
+}
+
+/** Failed observations remain errors, never successful latency samples. */
+export async function measure(run: () => Promise<void>, runs: number, warmups: number): Promise<Samples> {
+	const rawMs: number[] = [];
+	const errors: string[] = [];
+	const observe = async (phase: string): Promise<number | null> => {
+		const start = performance.now();
+		try {
+			await run();
+			return performance.now() - start;
+		} catch (error) {
+			errors.push(`${phase}: ${error instanceof Error ? error.message : String(error)}`);
+			return null;
+		}
+	};
+	const first = await observe("first call");
+	for (let i = 0; i < warmups; i++) await observe(`warmup ${i + 1}`);
+	for (let i = 0; i < runs; i++) {
+		const sample = await observe(`sample ${i + 1}`);
+		if (sample !== null) rawMs.push(sample);
+	}
+	return { firstCallMs: first, warmups, rawMs, ...summarize(rawMs), errors };
+}
+
+export interface Options {
+	runs: number;
+	warmups: number;
+	python?: string;
+}
+
+export function parseOptions(args: string[]): Options {
+	const options: Options = { runs: 30, warmups: 5 };
+	for (let i = 0; i < args.length; i += 2) {
+		const flag = args[i];
+		const value = args[i + 1];
+		if (!value || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
+		if (flag === "--python") options.python = value;
+		else if (flag === "--runs" || flag === "--warmups") {
+			const number = Number(value);
+			if (!Number.isInteger(number) || number < (flag === "--runs" ? 1 : 0) || number > 1000) {
+				throw new Error(`${flag} must be an integer from ${flag === "--runs" ? 1 : 0} to 1000`);
+			}
+			options[flag === "--runs" ? "runs" : "warmups"] = number;
+		} else throw new Error(`Unknown option: ${flag}`);
+	}
+	return options;
+}

--- a/packages/coding-agent/scripts/tool-latency/sampling.ts
+++ b/packages/coding-agent/scripts/tool-latency/sampling.ts
@@ -44,6 +44,8 @@ export interface Options {
 	runs: number;
 	warmups: number;
 	python?: string;
+	coldRuns?: number;
+	direnv?: string;
 }
 
 export function parseOptions(args: string[]): Options {
@@ -53,7 +55,13 @@ export function parseOptions(args: string[]): Options {
 		const value = args[i + 1];
 		if (!value || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
 		if (flag === "--python") options.python = value;
-		else if (flag === "--runs" || flag === "--warmups") {
+		else if (flag === "--direnv") options.direnv = value;
+		else if (flag === "--cold-runs") {
+			const number = Number(value);
+			if (!Number.isInteger(number) || number < 1 || number > 30)
+				throw new Error("--cold-runs must be an integer from 1 to 30");
+			options.coldRuns = number;
+		} else if (flag === "--runs" || flag === "--warmups") {
 			const number = Number(value);
 			if (!Number.isInteger(number) || number < (flag === "--runs" ? 1 : 0) || number > 1000) {
 				throw new Error(`${flag} must be an integer from ${flag === "--runs" ? 1 : 0} to 1000`);

--- a/packages/coding-agent/test/tool-latency-sampling.test.ts
+++ b/packages/coding-agent/test/tool-latency-sampling.test.ts
@@ -27,5 +27,8 @@ it("rejects invalid sample budgets and unknown options before starting workloads
 	expect(() => parseOptions(["--runs", "0"])).toThrow("--runs must be an integer");
 	expect(() => parseOptions(["--warmups", "1001"])).toThrow("--warmups must be an integer");
 	expect(() => parseOptions(["--python"])).toThrow("Missing value");
+	expect(() => parseOptions(["--cold-runs", "0"])).toThrow("--cold-runs must be an integer");
+	expect(() => parseOptions(["--cold-runs", "31"])).toThrow("--cold-runs must be an integer");
+	expect(() => parseOptions(["--direnv"])).toThrow("Missing value");
 	expect(() => parseOptions(["--command", "echo"])).toThrow("Unknown option");
 });

--- a/packages/coding-agent/test/tool-latency-sampling.test.ts
+++ b/packages/coding-agent/test/tool-latency-sampling.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test";
+import { measure, parseOptions, summarize } from "../scripts/tool-latency/sampling";
+
+it("reports the even-sample median and nearest-rank p95 without reordering raw samples", () => {
+	const raw = Array.from({ length: 20 }, (_, i) => 20 - i);
+	expect(summarize(raw)).toEqual({ medianMs: 10.5, p95Ms: 19 });
+	expect(raw[0]).toBe(20);
+	expect(summarize([])).toEqual({ medianMs: null, p95Ms: null });
+});
+
+it("excludes failed observations from warm latency samples and labels their phase", async () => {
+	let calls = 0;
+	const report = await measure(
+		async () => {
+			calls++;
+			if (calls === 1 || calls === 4) throw new Error("fixture mismatch");
+		},
+		3,
+		1,
+	);
+	expect(report.firstCallMs).toBeNull();
+	expect(report.rawMs).toHaveLength(2);
+	expect(report.errors).toEqual(["first call: fixture mismatch", "sample 2: fixture mismatch"]);
+});
+
+it("rejects invalid sample budgets and unknown options before starting workloads", () => {
+	expect(() => parseOptions(["--runs", "0"])).toThrow("--runs must be an integer");
+	expect(() => parseOptions(["--warmups", "1001"])).toThrow("--warmups must be an integer");
+	expect(() => parseOptions(["--python"])).toThrow("Missing value");
+	expect(() => parseOptions(["--command", "echo"])).toThrow("Unknown option");
+});


### PR DESCRIPTION
## What

Add an isolated developer benchmark for local tool latency, with optional cold-kernel and direnv measurements. The command writes JSON with revision/dirty state, runtime versions, fixture sizes, raw samples, median/p95, errors and observed concurrency.

- Real read/grep calls through direct execution, the host bridge, JS eval and opt-in Python eval; sequential/parallel four-call controls compare real reads and fixed delays.
- `--cold-runs N`: paired first/second cells in fresh host processes, reported separately from total harness process time.
- `--direnv /absolute/path`: generated no-envrc, blocked, allowed and watched-file fixtures using the real export helper. Semantic checks cover watched-file refresh, approval revocation, changed-rc approval and non-execution of blocked fixtures.

The launcher isolates OMP state, HOME and XDG directories, and approves only its own generated direnv fixtures. No model calls, user hooks, user shell profiles, workspace `.envrc`, new dependencies, doctor command or CI performance thresholds are introduced. Failures stay visible and cause a nonzero exit; failed observations are excluded from percentiles.

## Why

Native operation timings miss formatting, eval dispatch and environment setup. This benchmark exposed the lexical scanning cost addressed separately in #11030 and measures that change independently from main.

All routes validate formatted tool output against a canonical result, excluding the changing repeat-read notice. Kernel measurements distinguish cold initialization from a second cell in the same process. Direnv checks prevent a stale or unauthorized environment from appearing to be a successful performance improvement. Batch timing is elapsed time, not a sum of overlapping calls.

## Measurements and findings

Ten fresh host processes per language, with one first cell and one second cell per process. Values are **median / p95 milliseconds**:

| Kernel | First cell | Second cell |
| --- | ---: | ---: |
| js | 62.04 / 67.77 | 0.74 / 1.84 |
| python | 151.67 / 186.32 | 0.70 / 1.15 |

The first cell includes kernel initialization and interpreter discovery but excludes host imports and fixture setup. The second cell uses the same kernel. These are harness measurements, not CLI startup or time to first model token; OS caches remain warm between processes. They support measuring cold starts separately, but do not establish that automatic prewarming is worthwhile.

Direnv 2.37.1, with one first call, three warmups and ten measured exports:

| Generated fixture | Median ms | p95 ms |
| --- | ---: | ---: |
| no-envrc | 0.31 | 0.38 |
| blocked | 10.17 | 10.63 |
| allowed-simple | 74.69 | 76.45 |
| allowed-watched | 91.94 | 95.88 |

The watched fixture evaluated 14 times, once for every export. A separate state-reuse experiment reduced unchanged exports to a 7.66 ms median and evaluated the fixture once. However, a changed file read by `.envrc` without `watch_file` stayed stale under state reuse while OMP's fresh-export path saw the new value. No runtime environment cache is included: it would need an explicit freshness contract. This benchmark tests watched-file changes, approval revocation and changed-rc approval independently of latency.

These results use Apple M5 Pro / macOS arm64, Bun 1.4.0, Python 3.9.6 and native addon 18.1.11. Shorter runs varied with host load; these synthetic fixtures do not measure Nix/devenv startup. To reproduce on this host:

```sh
bun packages/coding-agent/scripts/bench-tool-latency.ts --runs 10 --warmups 3 --python /usr/bin/python3 --cold-runs 10 --direnv /opt/homebrew/bin/direnv > /tmp/tool-startup.json
```

## Testing

- Coding-agent lint, formatting and type checks passed; three sampling/argument tests passed with 13 assertions.
- 28 tool-route rows with Python, 10 measured samples and 3 warmups per row: zero errors. The original default-only run covered 21 rows without Python.
- Final smoke run exercised all optional sections, including approval revocation, from the committed head.
- An isolated-direnv run ignored deliberately invalid caller OMP config and caller direnv config, and left caller HOME/XDG/agent directories unchanged.
- Help and invalid arguments exit before workloads start.

Tested on macOS arm64 with Bun 1.4.0, Python 3.9.6 and native addon 18.1.11. OS caches remain warm between fresh processes. Main-row first calls remain single observations; only their first cell per language includes kernel startup. No whole-agent speedup is claimed, and other platforms were not exercised locally.

---

- [x] Package-local `bun check` passes
- [x] Tested locally as described above
- [x] CHANGELOG not applicable: developer-only command
