### PR TITLE
perf(shell): coalesce concurrent snapshot initialization

### DIFF
--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -476,25 +476,18 @@ describe("OpenAI-family first-event timeouts", () => {
 	});
 
 	it("forwards streamSimple per-call timeout options to OpenAI-family providers", async () => {
-		const fetchMock = createHangingFetch();
-		const controller = new AbortController();
-		const abortTimer = setTimeout(() => controller.abort(new Error("fallback abort")), 200);
-		abortTimer.unref();
-
-		try {
-			const result = await streamSimple(openAIResponsesModel, baseContext(), {
-				apiKey: "test-key",
-				signal: controller.signal,
-				streamFirstEventTimeoutMs: 20,
-				streamIdleTimeoutMs: 20,
-				fetch: fetchMock,
-			}).result();
-
-			expect(result.stopReason).toBe("error");
-			expect(result.errorMessage).toBe("OpenAI responses stream timed out while waiting for the first event");
-		} finally {
-			clearTimeout(abortTimer);
-		}
+		// A competing caller-abort timer can fire during streamSimple startup on
+		// a busy worker and mask the provider timeout this test is checking.
+		await expectFirstEventTimeout(
+			(streamFirstEventTimeoutMs, fetchMock) =>
+				streamSimple(openAIResponsesModel, baseContext(), {
+					apiKey: "test-key",
+					streamFirstEventTimeoutMs,
+					streamIdleTimeoutMs: 20,
+					fetch: fetchMock,
+				}).result(),
+			"OpenAI responses stream timed out while waiting for the first event",
+		);
 	});
 
 	it("surfaces the OpenAI completions first-event timeout message", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Concurrent first bash commands now share shell snapshot initialization when their environment and startup timeout match.
+
 	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed

--- a/packages/coding-agent/src/utils/shell-snapshot.ts
+++ b/packages/coding-agent/src/utils/shell-snapshot.ts
@@ -12,6 +12,7 @@ import { getSafeProjectCwd, logger, postmortem } from "@oh-my-pi/pi-utils";
 import fnEnvHelper from "./shell-snapshot-fn-env.sh" with { type: "text" };
 
 const cachedSnapshotPaths = new Map<string, string>();
+const pendingSnapshots = new Map<string, Promise<string | null>>();
 const SNAPSHOT_TIMEOUT_MS = 2_000;
 
 /**
@@ -232,6 +233,36 @@ export async function getOrCreateSnapshot(
 		return null;
 	}
 
+	// Only share work with callers using the same environment and startup budget.
+	// Keep the completed shell cache above unchanged, and discard this key on
+	// settlement so a failed or timed-out creation can be retried.
+	const snapshotEnv = sanitizeSnapshotEnv(env);
+	const pendingKey = JSON.stringify([
+		shell,
+		timeoutMs,
+		Object.entries(snapshotEnv)
+			.filter(([, value]) => value !== undefined)
+			.sort(([a], [b]) => a.localeCompare(b)),
+	]);
+	const pending = pendingSnapshots.get(pendingKey);
+	if (pending) return pending;
+
+	const creation = createSnapshot(shell, snapshotEnv, timeoutMs);
+	pendingSnapshots.set(pendingKey, creation);
+	try {
+		const snapshotPath = await creation;
+		if (snapshotPath) cachedSnapshotPaths.set(cacheKey, snapshotPath);
+		return snapshotPath;
+	} finally {
+		pendingSnapshots.delete(pendingKey);
+	}
+}
+
+async function createSnapshot(
+	shell: string,
+	env: Record<string, string | undefined>,
+	timeoutMs: number,
+): Promise<string | null> {
 	const rcFile = getShellConfigFile(shell, env);
 
 	// Snapshot dir is per-uid. `os.tmpdir()` is shared between accounts on Linux and
@@ -276,9 +307,8 @@ export async function getOrCreateSnapshot(
 
 	let succeeded = false;
 	try {
-		const snapshotEnv = sanitizeSnapshotEnv(env);
 		const spawnEnv: Record<string, string> = {};
-		for (const [key, value] of Object.entries(snapshotEnv)) {
+		for (const [key, value] of Object.entries(env)) {
 			if (value !== undefined) {
 				spawnEnv[key] = value;
 			}
@@ -304,7 +334,6 @@ export async function getOrCreateSnapshot(
 				// best-effort
 			}
 			scrubSnapshotInPlace(snapshotPath);
-			cachedSnapshotPaths.set(cacheKey, snapshotPath);
 			succeeded = true;
 			return snapshotPath;
 		}

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -101,6 +101,34 @@ describe("executeBash", () => {
 		}
 	});
 
+	it.skipIf(process.platform === "win32" || !fs.existsSync("/bin/bash"))(
+		"initializes the user shell once for concurrent first commands",
+		async () => {
+			const shell = path.join(tempDir, "fixture-bash");
+			fs.symlinkSync("/bin/bash", shell);
+			await Bun.write(
+				path.join(tempDir, ".bashrc"),
+				'echo invoked >> "$HOME/rc-count"\nprobe_ready () { echo ready; }\n',
+			);
+			vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+				shell,
+				args: ["-c"],
+				env: { HOME: tempDir, PATH: Bun.env.PATH ?? "/usr/bin:/bin" },
+				prefix: undefined,
+			});
+			Settings.instance.set("bash.direnv", "off");
+			Settings.instance.set("shellMinimizer.enabled", false);
+			const run = () => executeBash("probe_ready", { cwd: tempDir, timeout: 5_000 });
+			const results = await Promise.all(Array.from({ length: 4 }, run));
+			results.push(await run());
+			for (const result of results) {
+				expect(result.exitCode).toBe(0);
+				expect(result.output.trim()).toBe("ready");
+			}
+			expect(await Bun.file(path.join(tempDir, "rc-count")).text()).toBe("invoked\n");
+		},
+	);
+
 	it("omits minimizer options when the feature is disabled", () => {
 		const group: ShellMinimizerSettings = {
 			enabled: false,

--- a/packages/coding-agent/test/shell-snapshot.test.ts
+++ b/packages/coding-agent/test/shell-snapshot.test.ts
@@ -451,3 +451,76 @@ describe("getOrCreateSnapshot", () => {
 		}
 	});
 });
+
+describe.skipIf(process.platform === "win32" || !existsSync(REAL_BASH))("concurrent shell snapshots", () => {
+	async function withFixture(run: (shell: string, env: Record<string, string>, rc: string) => Promise<void>) {
+		const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-snap-concurrent-"));
+		const shell = path.join(fixtureDir, "fixture-bash");
+		await fs.symlink(REAL_BASH, shell);
+		try {
+			await run(
+				shell,
+				{ HOME: fixtureDir, PATH: process.env.PATH ?? "/usr/bin:/bin" },
+				path.join(fixtureDir, ".bashrc"),
+			);
+		} finally {
+			await fs.rm(fixtureDir, { recursive: true, force: true });
+		}
+	}
+
+	it("sources an equivalent environment once and recreates a deleted snapshot", async () => {
+		await withFixture(async (shell, env, rc) => {
+			await Bun.write(rc, 'echo invoked >> "$HOME/count"\n');
+			const results = await Promise.all([
+				getOrCreateSnapshot(shell, env),
+				getOrCreateSnapshot(shell, { PATH: env.PATH, HOME: env.HOME, OMITTED: undefined }),
+			]);
+			expect(results[0]).not.toBeNull();
+			expect(await Bun.file(path.join(env.HOME, "count")).text()).toBe("invoked\n");
+			await fs.rm(results[0]!);
+			const recreated = await getOrCreateSnapshot(shell, env);
+			expect(recreated).not.toBeNull();
+			expect(await Bun.file(path.join(env.HOME, "count")).text()).toBe("invoked\ninvoked\n");
+		});
+	});
+
+	it("does not share in-flight snapshots with different environments", async () => {
+		await withFixture(async (shell, env, rc) => {
+			await Bun.write(rc, 'show_probe () { echo "$PROBE_VALUE"; }\n');
+			const results = await Promise.all([
+				getOrCreateSnapshot(shell, { ...env, PROBE_VALUE: "first" }),
+				getOrCreateSnapshot(shell, { ...env, PROBE_VALUE: "second" }),
+			]);
+			for (const [index, value] of ["first", "second"].entries()) {
+				expect(results[index]).not.toBeNull();
+				expect(await Bun.file(results[index]!).text()).toContain(`export PROBE_VALUE='${value}'`);
+			}
+		});
+	});
+
+	it("keeps a short startup timeout from cancelling a longer request", async () => {
+		await withFixture(async (shell, env, rc) => {
+			await Bun.write(rc, "sleep 0.2\n");
+			const results = await Promise.all([
+				getOrCreateSnapshot(shell, env, 25),
+				getOrCreateSnapshot(shell, env, 2_000),
+			]);
+			expect(results[0]).toBeNull();
+			expect(results[1]).not.toBeNull();
+		});
+	});
+
+	it("retries after concurrent callers observe a failed creation", async () => {
+		await withFixture(async (shell, env, rc) => {
+			await Bun.write(rc, "exit 7\n");
+			expect(await Promise.all([getOrCreateSnapshot(shell, env), getOrCreateSnapshot(shell, env)])).toEqual([
+				null,
+				null,
+			]);
+			await Bun.write(rc, "recovered () { echo ready; }\n");
+			const snapshot = await getOrCreateSnapshot(shell, env);
+			expect(snapshot).not.toBeNull();
+			expect(await Bun.file(snapshot!).text()).toContain("recovered ()");
+		});
+	});
+});


### PR DESCRIPTION
## What

Concurrent first bash tool calls can all miss the completed snapshot cache and each source the user's rc file. This change shares pending snapshot creation for equivalent sanitized environments and startup timeouts, then retains the existing completed-shell cache. Failed creations release the pending entry so later calls can retry.

## Why

The end-to-end regression invokes four concurrent `executeBash` commands and then one warm command using an isolated fixture shell. All five return the snapshotted function's expected output. Upstream sources the fixture four times; this change sources it once. This proves redundant initialization is removed, not a fourfold latency improvement.

## Measurements and findings

Thirty fresh snapshot entries per condition. Each sample uses a unique `/bin/bash` symlink, four concurrent `getOrCreateSnapshot` calls, then one warm lookup. The isolated rc file appends a counter and defines a function; no artificial sleep is added. Every resulting snapshot retained the fixture function.

| Condition | First four-call batch: median / p95 ms | Warm lookup median ms | Rc invocations per batch |
| --- | ---: | ---: | ---: |
| Upstream | 44.93 / 58.46 | 0.011 | 4 |
| Deduplicated | 34.23 / 39.54 | 0.010 | 1 |
| Reverted source | 42.74 / 46.19 | 0.012 | 4 |

Baseline was upstream `b2f25dbfe1`; candidate used the snapshot change in `cc128d4304`; the negative control restored the upstream helper. Apple M5 Pro / macOS arm64, Bun 1.4.0, native addon 18.1.11. Module imports occur before timing. This measures snapshot initialization, not entire bash calls or model latency. The observed gain is about 11 ms for this minimal first batch, with four rc evaluations reduced to one; expensive real rc files and other platforms were not measured.

## Testing

- Reproduced the integration test failure against unchanged upstream, then confirmed it passes with the fix.
- 101 shell snapshot and bash executor tests passed, including different environments, separate timeout budgets, failure/retry, deleted snapshot recreation, permissions, and cancellation coverage.
- Coding-agent lint, formatting, and type checks passed.
- CI repair: the separate AI timeout-forwarding test raced its 20 ms provider deadline against a 200 ms caller-abort fallback. A simulated 300 ms scheduler stall reproduced the exact `error` versus `aborted` failure. The follow-up test-only commit uses the existing timeout helper, retaining the exact error assertion without the competing abort. Five stalled runs, all 26 tests in that file (67 assertions), and AI package lint/format/type checks passed. Provider runtime behavior is unchanged.

- Full GitHub CI and Nix checks passed at `897727836d`, including all applicable workspace test jobs.

Contributor review and a contributor-written rationale are still pending before it is ready for review.

---

- [x] Package `bun check` passes
- [x] Tested locally with the isolated bash fixture
- [x] CHANGELOG updated
