### PR TITLE
feat(eval): trace nested session tool execution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.
 
+### Added
+
+- Tools invoked from JS and Python eval now appear as child spans in configured OpenTelemetry traces.
+
 ### Changed
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -1,3 +1,4 @@
+import { type Context, context } from "@opentelemetry/api";
 import { logger, postmortem, Snowflake, workerHostEntry } from "@oh-my-pi/pi-utils";
 import {
 	createWorkerHandle,
@@ -55,6 +56,7 @@ interface PendingRun {
 	runId: string;
 	runState: VmRunState;
 	toolSession: ToolSession;
+	telemetryContext: Context;
 	resolve(value: { value: unknown }): void;
 	reject(error: Error): void;
 	toolCalls: Map<string, AbortController>;
@@ -223,6 +225,7 @@ export async function invokeJsTool(
 			},
 		},
 		toolSession: options.session,
+		telemetryContext: context.active(),
 		resolve,
 		reject,
 		toolCalls: new Map(),
@@ -391,6 +394,7 @@ async function runOnce(
 		runId,
 		runState: options.runState,
 		toolSession: options.session,
+		telemetryContext: context.active(),
 		resolve,
 		reject,
 		toolCalls: new Map(),
@@ -645,14 +649,16 @@ async function handleToolCall(session: JsSession, msg: Extract<WorkerOutbound, {
 	const ctrl = new AbortController();
 	pending.toolCalls.set(msg.id, ctrl);
 	try {
-		const value = await callSessionTool(msg.name, msg.args, {
-			session: pending.toolSession,
-			signal: ctrl.signal,
-			emitStatus: (event: JsStatusEvent) => {
-				trackDeferPhase(pending, event);
-				pending.runState.onDisplay?.({ type: "status", event });
-			},
-		});
+		const value = await context.with(pending.telemetryContext, () =>
+			callSessionTool(msg.name, msg.args, {
+				session: pending.toolSession,
+				signal: ctrl.signal,
+				emitStatus: (event: JsStatusEvent) => {
+					trackDeferPhase(pending, event);
+					pending.runState.onDisplay?.({ type: "status", event });
+				},
+			}),
+		);
 		safeSend(session, { type: "tool-reply", id: msg.id, reply: { ok: true, value } });
 	} catch (error) {
 		safeSend(session, { type: "tool-reply", id: msg.id, reply: { ok: false, error: toErrorPayload(error) } });

--- a/packages/coding-agent/src/eval/js/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/js/tool-bridge.ts
@@ -1,4 +1,11 @@
-import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import {
+	type AgentTool,
+	type AgentToolResult,
+	finishExecuteToolSpan,
+	resolveTelemetry,
+	runInActiveSpan,
+	startExecuteToolSpan,
+} from "@oh-my-pi/pi-agent-core";
 import { toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
 import { isRecord } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -205,6 +212,46 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 	}
 	const tool = getTool(options.session, name);
 	const toolCallId = `js-${name}-${crypto.randomUUID()}`;
+	// Use an independent collector: these child spans describe work already
+	// included in the outer eval tool's duration and must not inflate run totals.
+	const telemetry = resolveTelemetry(options.session.getTelemetry?.(), options.session.getSessionId?.() ?? undefined);
+	const span = startExecuteToolSpan(telemetry, { tool, toolName: name, toolCallId, args });
+	let result: AgentToolResult | undefined;
+	let caughtError: unknown;
+	let failed = false;
+	try {
+		const execution = await runInActiveSpan(span, () => executeSessionTool(name, tool, toolCallId, args, options));
+		result = execution.result;
+		return normalizeAgentToolResult(name, execution.args, result, options);
+	} catch (error) {
+		failed = true;
+		caughtError = error;
+		throw error;
+	} finally {
+		const isError = failed || (result !== undefined && toolResultHasError(result));
+		const reason = options.signal?.reason;
+		finishExecuteToolSpan(telemetry, span, {
+			toolName: name,
+			toolCallId,
+			result,
+			isError,
+			status: options.signal?.aborted
+				? reason instanceof Error && reason.name === "TimeoutError"
+					? "timeout"
+					: "aborted"
+				: undefined,
+			errorObject: caughtError,
+		});
+	}
+}
+
+async function executeSessionTool(
+	name: string,
+	tool: AgentTool,
+	toolCallId: string,
+	args: unknown,
+	options: ToolBridgeOptions,
+): Promise<{ result: AgentToolResult; args: unknown }> {
 	// A schema-owned name stays tool data across alternatives. Deleting an
 	// invalid value to make another branch match could select a different operation.
 	const intentIsDeclared = schemaDeclaresIntentField(toolWireSchema(tool));
@@ -251,7 +298,7 @@ export async function callSessionTool(name: string, args: unknown, options: Tool
 			undefined,
 			options.session.getToolContext?.(),
 		);
-		return normalizeAgentToolResult(name, normalizedArgs, result, options);
+		return { result, args: normalizedArgs };
 	} catch (error) {
 		options.emitStatus?.({
 			op: name,

--- a/packages/coding-agent/src/eval/py/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/py/tool-bridge.ts
@@ -7,6 +7,7 @@
  * current execution and forwards to the same `callSessionTool` implementation
  * the JavaScript bridge uses.
  */
+import { type Context, context } from "@opentelemetry/api";
 import { logger, postmortem } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "../../tools";
 import { callSessionTool, type JsStatusEvent } from "../js/tool-bridge";
@@ -40,7 +41,11 @@ interface BridgeServer {
 	stop: () => Promise<void>;
 }
 
-const registrations = new Map<string, PyToolBridgeEntry>();
+interface RegisteredPyToolBridgeEntry extends PyToolBridgeEntry {
+	telemetryContext: Context;
+}
+
+const registrations = new Map<string, RegisteredPyToolBridgeEntry>();
 let serverPromise: Promise<BridgeServer> | null = null;
 
 function markExpectedBridgeShutdownError(error: unknown): error is Error {
@@ -73,16 +78,22 @@ function markExpectedBridgeShutdownError(error: unknown): error is Error {
  * matters for tools that ignore the signal, keeping the kernel unwinding
  * promptly instead of being hard-killed.
  */
-async function callSessionToolPromptOnAbort(name: string, args: unknown, entry: PyToolBridgeEntry): Promise<unknown> {
+async function callSessionToolPromptOnAbort(
+	name: string,
+	args: unknown,
+	entry: RegisteredPyToolBridgeEntry,
+): Promise<unknown> {
 	if (entry.abortRequested?.()) {
 		throw new Error(`bridge call ${JSON.stringify(name)} aborted: eval cell was interrupted`);
 	}
-	const call = callSessionTool(name, args, {
-		session: entry.toolSession,
-		signal: entry.signal,
-		emitStatus: entry.emitStatus,
-		defaultIntent: "py prelude",
-	});
+	const call = context.with(entry.telemetryContext, () =>
+		callSessionTool(name, args, {
+			session: entry.toolSession,
+			signal: entry.signal,
+			emitStatus: entry.emitStatus,
+			defaultIntent: "py prelude",
+		}),
+	);
 	const signal = entry.shieldedSignal ?? entry.signal;
 	if (!signal) return await call;
 	if (signal.aborted) {
@@ -204,9 +215,10 @@ function bridgeRegistrationKey(sessionId: string, runId: string): string {
 
 export function registerPyToolBridge(sessionId: string, runId: string, entry: PyToolBridgeEntry): () => void {
 	const key = bridgeRegistrationKey(sessionId, runId);
-	registrations.set(key, entry);
+	const registration = { ...entry, telemetryContext: context.active() };
+	registrations.set(key, registration);
 	return () => {
-		if (registrations.get(key) === entry) {
+		if (registrations.get(key) === registration) {
 			registrations.delete(key);
 		}
 	};

--- a/packages/coding-agent/test/eval-tool-telemetry-probe.ts
+++ b/packages/coding-agent/test/eval-tool-telemetry-probe.ts
@@ -1,0 +1,176 @@
+// Subprocess-only: registering an OTEL context manager must not affect sibling tests.
+import assert from "node:assert/strict";
+import { type } from "@oh-my-pi/omptype";
+import {
+	type AgentTool,
+	finishExecuteToolSpan,
+	GenAIAttr,
+	PiGenAIAttr,
+	resolveTelemetry,
+	runInActiveSpan,
+	startExecuteToolSpan,
+} from "@oh-my-pi/pi-agent-core";
+import { context, SpanStatusCode } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { Settings } from "../src/config/settings";
+import { disposeAllVmContexts } from "../src/eval/js/context-manager";
+import { executeJs } from "../src/eval/js/executor";
+import { callSessionTool } from "../src/eval/js/tool-bridge";
+import { disposeAllKernelSessions, executePython } from "../src/eval/py/executor";
+import { disposePyToolBridge } from "../src/eval/py/tool-bridge";
+import type { ToolSession } from "../src/tools";
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+const tracer = provider.getTracer("eval-telemetry-test");
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+const settings = await Settings.init({ inMemory: true, cwd: process.cwd() });
+settings.set("tools.outputMaxColumns", 0);
+let active = 0;
+let peak = 0;
+const probe: AgentTool = {
+	name: "probe",
+	label: "probe",
+	description: "Exercise real bridge execution",
+	parameters: type({ "mode?": "'throw' | 'returned-error' | 'abort'" }),
+	execute: async (_id, args, signal) => {
+		const { mode } = args as { mode?: string };
+		if (mode === "throw") throw new Error("fixture failure");
+		if (mode === "returned-error") return { content: [{ type: "text", text: "failed" }], details: { isError: true } };
+		if (mode === "abort") signal?.throwIfAborted();
+		const body = tracer.startSpan("probe body");
+		active++;
+		peak = Math.max(peak, active);
+		try {
+			await Bun.sleep(20);
+			return { content: [{ type: "text", text: "ready" }] };
+		} finally {
+			active--;
+			body.end();
+		}
+	},
+};
+const config = { tracer, captureMessageContent: "none" as const };
+const session: ToolSession = {
+	cwd: process.cwd(),
+	hasUI: false,
+	settings,
+	getSessionFile: () => null,
+	getSessionSpawns: () => null,
+	getSessionId: () => "eval-telemetry",
+	getTelemetry: () => config,
+	getToolByName: name => (name === probe.name ? probe : undefined),
+};
+
+try {
+	if (process.argv[2] === "direct") {
+		await callSessionTool("probe", {}, { session });
+		await callSessionTool("probe", { mode: "returned-error" }, { session });
+		await assert.rejects(callSessionTool("probe", { mode: "throw" }, { session }), /fixture failure/);
+		await assert.rejects(
+			callSessionTool("probe", { mode: { invalid: true } }, { session }),
+			"validation must reject",
+		);
+		for (const reason of [
+			new DOMException("cancelled", "AbortError"),
+			new DOMException("deadline", "TimeoutError"),
+		]) {
+			await assert.rejects(
+				callSessionTool("probe", { mode: "abort" }, { session, signal: AbortSignal.abort(reason) }),
+				"abort must reject",
+			);
+		}
+		const spans = exporter.getFinishedSpans().filter(span => span.name === "execute_tool probe");
+		assert.deepEqual(
+			spans.map(span => span.attributes[PiGenAIAttr.ToolStatus]),
+			["ok", "error", "error", "error", "aborted", "timeout"],
+		);
+		for (const span of spans) {
+			assert.equal(span.attributes[GenAIAttr.ToolCallArguments], undefined);
+			assert.equal(span.attributes[GenAIAttr.ToolCallResult], undefined);
+			if (span.attributes[PiGenAIAttr.ToolStatus] !== "ok") assert.equal(span.status.code, SpanStatusCode.ERROR);
+		}
+		const before = spans.length;
+		await callSessionTool("probe", {}, { session: { ...session, getTelemetry: () => undefined } });
+		assert.equal(exporter.getFinishedSpans().filter(span => span.name === "execute_tool probe").length, before);
+		await callSessionTool(
+			"probe",
+			{},
+			{ session: { ...session, getTelemetry: () => ({ tracer, captureMessageContent: "full" }) } },
+		);
+		const captured = exporter
+			.getFinishedSpans()
+			.filter(span => span.name === "execute_tool probe")
+			.at(-1)!;
+		assert.equal(typeof captured.attributes[GenAIAttr.ToolCallArguments], "string");
+		assert.equal(typeof captured.attributes[GenAIAttr.ToolCallResult], "string");
+		console.log(
+			"direct: success, returned/thrown/validation errors, abort, timeout, disabled telemetry and capture policy verified",
+		);
+	} else {
+		const python = Bun.which("python3");
+		const routes = python ? ["js", "python"] : ["js"];
+		for (const route of routes) {
+			// The second invocation reuses the worker/server created under a different parent.
+			for (let run = 0; run < 2; run++) {
+				const telemetry = resolveTelemetry(config, "eval-telemetry")!;
+				const parent = startExecuteToolSpan(telemetry, {
+					tool: undefined,
+					toolName: route,
+					toolCallId: `${route}-${run}`,
+					args: {},
+				})!;
+				await runInActiveSpan(parent, async () => {
+					const result =
+						route === "js"
+							? await executeJs(
+									"console.log(JSON.stringify(await Promise.all(Array.from({length:4},()=>tool.probe({})))));",
+									{ sessionId: "traced-js", cwd: process.cwd(), session, timeoutMs: 10_000 },
+								)
+							: await executePython(
+									"print(json.dumps(await asyncio.gather(*[tool.probe() for _ in range(4)])))",
+									{
+										sessionId: "traced-python",
+										cwd: process.cwd(),
+										toolSession: session,
+										interpreter: python!,
+										timeoutMs: 10_000,
+									},
+								);
+					assert.equal(result.exitCode, 0, result.output);
+					assert.deepEqual(JSON.parse(result.output.trim()), ["ready", "ready", "ready", "ready"]);
+				});
+				finishExecuteToolSpan(telemetry, parent, {
+					toolName: route,
+					toolCallId: `${route}-${run}`,
+					isError: false,
+				});
+				const children = exporter
+					.getFinishedSpans()
+					.filter(span => span.parentSpanContext?.spanId === parent.spanContext().spanId);
+				assert.equal(children.length, 4);
+				for (const child of children) {
+					assert.equal(child.name, "execute_tool probe");
+					assert.equal(child.spanContext().traceId, parent.spanContext().traceId);
+					const bodies = exporter
+						.getFinishedSpans()
+						.filter(span => span.parentSpanContext?.spanId === child.spanContext().spanId);
+					assert.equal(bodies.length, 1);
+					assert.equal(bodies[0].name, "probe body");
+				}
+				assert.equal(telemetry.collector.snapshot({ stepCount: 1 }).summary.tools.total, 1);
+			}
+		}
+		assert.ok(peak > 1, "tracing must preserve parallel execution");
+		console.log(
+			`kernels: ${routes.join(", ")} parent linkage, downstream context, warm reuse and non-duplicated run totals verified; peak=${peak}`,
+		);
+	}
+} finally {
+	await disposeAllVmContexts();
+	await disposeAllKernelSessions();
+	await disposePyToolBridge();
+	await provider.shutdown();
+	context.disable();
+}

--- a/packages/coding-agent/test/eval-tool-telemetry.test.ts
+++ b/packages/coding-agent/test/eval-tool-telemetry.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+it.each(["direct", "kernels"])(
+	"records eval tool telemetry through %s execution",
+	async mode => {
+		const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "omp-eval-spans-"));
+		try {
+			const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "eval-tool-telemetry-probe.ts"), mode], {
+				cwd: fixture,
+				env: {
+					PATH: process.env.PATH ?? "",
+					SystemRoot: process.env.SystemRoot,
+					PI_CODING_AGENT_DIR: path.join(fixture, "agent"),
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+				timeout: 30_000,
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+			expect({ exitCode, stderr, stdout }).toEqual({
+				exitCode: 0,
+				stderr: "",
+				stdout: expect.stringContaining(`${mode}:`),
+			});
+		} finally {
+			await fs.rm(fixture, { recursive: true, force: true });
+		}
+	},
+	35_000,
+);


### PR DESCRIPTION
## What

Record configured OpenTelemetry `execute_tool` child spans for session tools invoked through JS and Python eval. Capture the host context per execution so a reused JS worker or shared Python HTTP server attaches calls to the current eval span. Downstream instrumentation runs inside each child span.

The shared bridge uses the existing span helpers and content-capture policy. It records success, returned errors, thrown/validation failures, cancellation and timeout. Nested spans use a separate collector so their durations and counts are not added again to the outer agent run's tool totals.

## Why

A parallel eval cell currently exposes its outer tool span without timings for the concrete tools it invokes. Creating child spans without preserving execution context would also attach calls from reused transports to the wrong parent. The new hierarchy makes nested work inspectable without treating the sum of overlapping calls as elapsed time.

This covers resolved session tools, not special eval control or prelude operations. Existing tracing configuration enables it; no new setting, exporter, dependency, dashboard or agent-run summary schema is introduced. It is an observability improvement, not an execution-speed claim.

## Measurements and findings

The integration probe runs four concurrent fixture tools in a real JS cell and a real Python cell, then repeats each using the same kernel under a different parent. Each fixture tool waits 20 ms to make overlap observable; this is a tracing/concurrency check, not a representative workload benchmark.

| Observation | Result |
| --- | --- |
| Nested `execute_tool probe` spans before this change | 0 |
| Nested tool spans after this change | 4 per cell, 16 across the four cells |
| Parent relationship | Every tool span belongs to its current cell, including warm kernel/server reuse |
| Downstream instrumentation | One correctly parented `probe body` span beneath each tool span |
| Peak simultaneous fixture calls | 4 |
| Outer run collector | 1 eval tool per cell; nested work is not added again |
| Terminal outcomes checked | success, returned error, thrown error, validation failure, abort, timeout |
| Capture policy | Arguments/results absent with `none`, present with `full`; disabled telemetry emits no tool spans |

Tested on macOS arm64, Bun 1.4.0, Python 3.9.6 and native addon 18.1.11. The baseline probe fails because these nested tool spans are missing. The change provides evidence for future performance work; no execution-speed improvement or measured instrumentation-overhead claim is made.

## Testing

- 89 tests passed across the shared bridge, Python HTTP bridge, JS/Python executors and the new telemetry probes.
- Real JS and Python kernels each execute four concurrent fixture tools, then repeat using the same kernel under a different parent span. Verified four correctly parented tool spans per cell, downstream child linkage, expected tool output, retained concurrency and one outer tool in the run collector.
- Separate probe verifies terminal statuses, disabled telemetry and content-capture policy. OTEL globals are confined to subprocesses.
- The new probes fail against unchanged upstream and pass with this change.
- Coding-agent lint, formatting and type checks passed. Tested on macOS arm64 with Bun 1.4.0, Python 3.9.6 and native addon 18.1.11. No model calls were made.

Contributor review and a contributor-written rationale remain pending before this draft is ready for review.

---

- [x] Package-local `bun check` passes
- [x] Tested locally as described above
- [x] CHANGELOG updated
