### PR TITLE
docs: explain and fix model-side edit-tool avoidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Get a clear verdict on whether the change ships, with every issue ranked P0 thro
 
 Perfect edits, fewer tokens. The model points at anchors instead of retyping the lines it wants to change, so whitespace battles and string-not-found loops just stop happening. Edit a stale file and the anchors diverge — we reject the patch before it corrupts anything. Grok 4 Fast spends 61% fewer output tokens on the same work.
 
+Some models still rewrite files from a code cell instead of calling `edit`. That is a model prior, not a harness fault — [measure it and switch it off](docs/edit-tool-adherence.md).
+
 ### 12 · GitHub is just another filesystem
 
 Other harnesses bolt on gh_issue_view, gh_pr_view, gh_search — each with its own parameters the agent has to learn and you have to debug. We skipped that. read already handles paths; PRs are paths. One interface to teach the model, one surface to keep correct.

--- a/docs/edit-tool-adherence.md
+++ b/docs/edit-tool-adherence.md
@@ -1,0 +1,193 @@
+# Edit-tool adherence by model
+
+Some models do not use `edit`. They read a source file inside an `eval` cell, run
+`.replace(old, new)` in Python or JavaScript, and write the whole file back. The
+change lands, so nothing looks broken — but you lose the hashline snapshot check,
+the edit preview card, and the token savings, and the model spends part of every
+turn debugging its own escaping.
+
+This page shows how to measure the behaviour in your own sessions, why it is a
+model habit rather than a harness fault, and the three ways to stop it.
+
+## The shape of the problem
+
+A model that avoids `edit` produces cells like this:
+
+```python
+p = Path("orders.go")
+s = p.read_text(encoding="utf-8")
+old = '''func (a *application) ordersPage(w http.ResponseWriter, r *http.Request) {
+	data := a.basePage(r, "orders", "Orders")
+	...'''            # 40 lines of exactly-quoted old source
+assert s.count(old) == 1
+p.write_text(s.replace(old, new), encoding="utf-8")
+```
+
+The equivalent `edit` call names the line range and supplies only the new body.
+The JavaScript form is the same move with `Bun.file` / `replaceAll` / `Bun.write`,
+and the shell form is `sed -i`.
+
+## Measure it
+
+`scripts/session-stats/edit_adherence.py` walks your session logs and counts, per
+model, the edit-tool calls against the read-replace-write cells. It reads the
+JSONL directly, so it needs no `stats:sync` and no tiktoken:
+
+```
+$ bun run stats:adherence
+201 session files under ~/.omp/agent/sessions
+
+model                           edit  surgery  fail%  bypass%
+gpt-5.6-sol                     6122       87   2.7%       1%
+claude-opus-5                   1896      458   3.9%      19%
+claude-fable-5                  2031      126   4.0%       6%
+claude-fable-5-1                 269       76   1.1%      22%
+z-ai/glm-5.3-flash               195       27  14.4%      12%
+gpt-5.6-luna                      68       27   5.9%      28%
+```
+
+`bypass%` is the share of source changes that skipped the edit tool. `fail%` is
+the share of that model's `edit` calls that returned an error. Numbers above are
+one user's 201 sessions on omp 18.x; run it on yours before drawing conclusions.
+
+Narrow the same scan to a single project and the split gets sharper. In one
+25k-record session, `gpt-5.6-sol` made 372 Go edits through `edit` and 2 through
+Python; `claude-opus-5` made 162 through `edit` and 173 through Python.
+
+## It is not the edit tool failing
+
+Three checks, all against the same logs:
+
+1. **Failure rates do not track avoidance.** In the table above the model with
+   the highest bypass share does not have the highest `edit` failure rate. In the
+   session measured most closely, `claude-opus-5` failed 5 of 219 `edit` calls
+   (2.3%) while routing 39% of its edits through Python; `gpt-5.6-sol` failed 14
+   of 564 (2.5%) and routed 3%.
+2. **Avoidance does not follow a failure.** Only 16 of 202 surgery cells in that
+   session occurred within 60 records after a failed `edit`. The rest started
+   cold: the model never tried `edit` for that change.
+3. **The causation runs the other way.** 13 of 27 `edit` failures in that session
+   were snapshot rejections — `hash #XXXX is not from this session` or `file
+   changed between read and edit`. An external write is exactly what produces
+   them: the cell rewrites the file, the hashline anchor the model still holds
+   goes stale, and the next `edit` is refused. Surgery manufactures the failures
+   that appear to justify surgery.
+
+A model that writes source from `eval` on its first attempt is expressing a
+prior, not reacting to your setup.
+
+## What it costs
+
+- No snapshot check. `edit` rejects a patch when the file moved under the model;
+  `write_text` overwrites whatever is there now.
+- No preview card and no diff in the TUI. The change is invisible until you read
+  the file or the commit.
+- The old block must be re-quoted verbatim, so a multi-line change pays for the
+  old text and the new text, and one wrong space turns into a failed assertion or
+  a wrong replacement.
+- The payload is a string inside another language. Every `\n`, quote, and
+  backslash in the target file becomes an escaping problem in the cell.
+- Whole-file rewrite touches encoding and line endings on files the change never
+  intended to reach.
+
+## Three fixes, cheapest first
+
+### 1. A rule that fires only when it happens
+
+Rules cost nothing until the pattern appears in the stream. Put this in
+`~/.omp/agent/rules/edit-tool-only.md` (user-wide) or `.omp/rules/edit-tool-only.md`
+(one project):
+
+```markdown
+---
+description: Source edits go through edit/ast_edit/lsp, never through a rewritten file
+condition:
+  - "write_text\\s*\\(|open\\s*\\([^)]*['\\\"][wa]"
+  - "Bun\\.write\\s*\\(|writeFileSync\\s*\\("
+  - "\\bsed\\b\\s+-[a-z]*i|\\bperl\\b\\s+-[a-z]*i"
+---
+
+Do not rewrite a source file from a code cell or the shell.
+
+- one hunk -> `edit`
+- a pattern across files -> `ast_edit`
+- a symbol -> `lsp` rename
+- a brand new or fully replaced file -> `write`
+
+`assert count == 1` does not make string surgery safe: it bypasses the hashline
+snapshot, hides the diff from the user, and invalidates the anchors the next
+`edit` needs.
+```
+
+`condition` entries are regexes matched against the streamed turn; the default
+scope covers text and tool-call arguments, so the surgery cell matches while the
+model is still writing it. Under the default interrupt mode the stream aborts and
+the turn retries with the rule attached; with `interruptMode: never` the rule is
+folded into that tool call's result as a `<system-reminder>` instead. See
+[rulebook-matching-pipeline.md](rulebook-matching-pipeline.md) for the matching
+pipeline and [ttsr-injection-lifecycle.md](ttsr-injection-lifecycle.md) for the
+interrupt-and-retry lifecycle.
+
+### 2. Pin the tool set for edit-heavy work
+
+If a run is meant to change code and not to compute anything, do not offer the
+kernel at all:
+
+```bash
+omp --tools read,grep,glob,edit,ast_edit,lsp,write,bash
+```
+
+The model cannot reach for `eval` if `eval` is not in the session.
+
+### 3. Block it outright with a pre-tool hook
+
+A rule persuades; a hook enforces. `.omp/hooks/pre/eval.ts` (project) or
+`~/.omp/agent/hooks/pre/eval.ts` (user-wide) runs before every `eval` call and can
+refuse it:
+
+```ts
+import type { HookAPI } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
+
+const SURGERY = [
+	/\bwrite_text\s*\(/, // python: Path(...).write_text(...)
+	/\bopen\s*\([^)]*['"][wa]/, // python: open(path, "w")
+	/\bBun\.write\s*\(/, // bun
+	/\bwriteFileSync\s*\(/, // node
+	/\bfs\.promises\.writeFile\s*\(/,
+];
+
+export default function (api: HookAPI) {
+	api.on("tool_call", async (event) => {
+		if (event.toolName !== "eval") return;
+		const input = event.input;
+		const raw = input && typeof input === "object" && "code" in input ? input.code : undefined;
+		const code = typeof raw === "string" ? raw : "";
+		if (!SURGERY.some((re) => re.test(code))) return;
+		return {
+			block: true,
+			reason:
+				"eval must not write source files. Use edit for a hunk, ast_edit for a codemod, " +
+				"lsp rename for a symbol, or write for a whole new file.",
+		};
+	});
+}
+```
+
+The returned `reason` becomes the tool error the model reads, so it retries with
+`edit` instead of guessing why the cell failed. Add a sibling
+`.omp/hooks/pre/bash.ts` with the `sed -i` pattern if your models reach for the
+shell. Hook discovery, event names, and blocking semantics are in
+[hooks.md](hooks.md).
+
+## Which fix to use
+
+| Situation | Fix |
+| --- | --- |
+| Model mostly behaves, occasional relapse | rule (1) |
+| Long unattended run, edits only | pinned tool set (2) |
+| Model with a high bypass share, or a repo where a bad rewrite is expensive | hook (3) |
+| Choosing a model for an edit-heavy job | measure first, then pick a low-bypass one |
+
+Generated files and a genuine bulk mechanical pass are the honest exceptions.
+Keep those in a committed script and run the project formatter afterwards, rather
+than as an ad-hoc cell in the middle of a turn.

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
 		"stats:tools": "python3 scripts/session-stats/analyze.py tools",
 		"stats:edits": "python3 scripts/session-stats/analyze.py edits",
 		"stats:followups": "python3 scripts/session-stats/analyze.py followups",
+		"stats:adherence": "python3 scripts/session-stats/edit_adherence.py",
 		"stats:audit": "bun scripts/session-stats/audit.ts",
 		"test:py": "python3 -m pytest -x python/omp-rpc/tests && python3 -m pytest -x python/robomp/tests",
 		"robomp:install": "pip install -e 'python/robomp[dev]'",

--- a/scripts/session-stats/README.md
+++ b/scripts/session-stats/README.md
@@ -12,6 +12,7 @@ scripts/session-stats/
   sync.py          # walks ~/.omp/agent/sessions/ and populates ss_* tables
   analyze.py       # tools | edits | followups subcommands over the synced db
   audit.ts         # LLM-assisted token-usage audit (no sync needed)
+  edit_adherence.py # per-model edit-tool use vs read-replace-write cells (no sync needed)
   audit-prompt.md  # system prompt for the audit classifier
 ```
 
@@ -63,9 +64,11 @@ bun run stats:edits                        # edit-tool reliability audit
 bun run stats:edits -- --since w           # edit sub-types over the last week
 bun run stats:followups                    # five hashline-edit detectors
 bun run stats:followups -- --max-fix 2 --min-dup 8 --show 20
+bun run stats:adherence                    # per-model edit tool vs file-surgery cells
+bun run stats:adherence -- <sessions_dir>  # scan another corpus
 ```
 
-All three accept `-n N` / `--folder SUBSTR` to scope the query, plus
+`tools`, `edits`, and `followups` accept `-n N` / `--folder SUBSTR` to scope the query, plus
 `--since <h|d|w|m|Nh|Nd|Nw>` to keep only calls newer than a time window
 (per-call `timestamp`, so it slices long sessions precisely). The `edits`
 audit reads each call's `is_error` flag as the authoritative success/failure

--- a/scripts/session-stats/edit_adherence.py
+++ b/scripts/session-stats/edit_adherence.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Report how often each model edited files with the edit tool versus rewriting
+them from an eval cell (read-replace-write surgery).
+
+Usage:
+    python scripts/edit-adherence.py [sessions_dir]
+
+Default sessions_dir is ~/.omp/agent/sessions. Output is one row per model:
+edit calls, surgery calls, edit failures, and the share of source changes that
+bypassed the edit tool.
+"""
+
+import collections
+import glob
+import json
+import os
+import re
+import sys
+
+SRC = re.compile(r"\.(go|ts|tsx|js|jsx|py|rs|css|html|svelte|vue|md|json|ya?ml)\b")
+PY_SURGERY = re.compile(r"\bwrite_text\s*\(|\bopen\s*\([^)]*['\"][wa]")
+JS_SURGERY = re.compile(r"\bBun\.write\s*\(|\bwriteFileSync\s*\(|\bfs\.promises\.writeFile\s*\(")
+SED_SURGERY = re.compile(r"\bsed\b\s+-[a-z]*i|\bperl\b\s+-[a-z]*i|\bpython\b\s+-c|\bnode\b\s+-e")
+
+
+def rows(path):
+    with open(path, encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            try:
+                yield json.loads(line)
+            except ValueError:
+                yield None
+
+
+def scan(path, stats):
+    records = list(rows(path))
+    model = None
+    for record in records:
+        if not record or record.get("type") != "message":
+            continue
+        message = record["message"]
+        role = message.get("role")
+        if role == "assistant":
+            model = message.get("model") or model
+            continue
+        if role != "toolResult":
+            continue
+        tool = message.get("toolName")
+        payload = json.dumps(message.get("details") or "")
+        entry = stats[model]
+        if tool == "edit":
+            entry["edit"] += 1
+            if message.get("isError"):
+                entry["edit_failed"] += 1
+        elif tool == "eval" and SRC.search(payload):
+            if PY_SURGERY.search(payload) or JS_SURGERY.search(payload):
+                entry["surgery"] += 1
+        elif tool == "bash" and SRC.search(payload) and SED_SURGERY.search(payload):
+            entry["surgery"] += 1
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else os.path.expanduser("~/.omp/agent/sessions")
+    stats = collections.defaultdict(lambda: {"edit": 0, "surgery": 0, "edit_failed": 0})
+    files = glob.glob(os.path.join(base, "*", "*.jsonl"))
+    for path in files:
+        scan(path, stats)
+    print(f"{len(files)} session files under {base}\n")
+    print(f"{'model':28}{'edit':>8}{'surgery':>9}{'fail%':>7}{'bypass%':>9}")
+    for model, entry in sorted(stats.items(), key=lambda kv: -(kv[1]["edit"] + kv[1]["surgery"])):
+        total = entry["edit"] + entry["surgery"]
+        if not model or total < 20:
+            continue
+        fail = 100 * entry["edit_failed"] / entry["edit"] if entry["edit"] else 0
+        print(f"{model:28}{entry['edit']:8}{entry['surgery']:9}{fail:6.1f}%{100 * entry['surgery'] / total:8.0f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Some models never reach for `edit`. They read a source file inside an `eval` cell, `.replace(old, new)` it in Python or JavaScript, and write the whole file back. The change lands, so nothing looks broken — until the next `edit` is rejected with `hash #XXXX is not from this session`, and the user concludes the harness is at fault. It isn't: the cell wrote the file outside the harness and invalidated the anchor.

I hit this on my own setup and measured it instead of guessing.

## Evidence

201 local session files, omp 18.x, one user's corpus. `bypass%` is the share of source changes that skipped the edit tool; `fail%` is that model's `edit` error rate:

| model | edit | surgery | fail% | bypass% |
| --- | --- | --- | --- | --- |
| gpt-5.6-sol | 6122 | 87 | 2.7% | 1% |
| claude-opus-5 | 1896 | 458 | 3.9% | 19% |
| claude-fable-5 | 2031 | 126 | 4.0% | 6% |
| claude-fable-5-1 | 269 | 76 | 1.1% | 22% |
| gpt-5.6-luna | 68 | 27 | 5.9% | 28% |

Three checks say it is a model prior, not a harness fault:

1. Failure rates do not track avoidance — in the single session I measured most closely, `claude-opus-5` failed 5 of 219 `edit` calls (2.3%) while routing 39% of edits through Python; `gpt-5.6-sol` failed 14 of 564 (2.5%) and routed 3%.
2. Only 16 of 202 surgery cells occurred within 60 records after a failed `edit` — the rest started cold.
3. 13 of 27 `edit` failures in that session were snapshot rejections, which an external write is exactly what produces. Surgery manufactures the failures that appear to justify surgery.

## What this PR adds

- `docs/edit-tool-adherence.md` — the measurement, the disproof, the cost, and three fixes ordered by cost: a TTSR rule (`condition:` regexes, free until the pattern appears), a pinned `--tools` set, and a `.omp/hooks/pre/eval.ts` `tool_call` hook that blocks the cell with a `reason` the model can act on.
- `scripts/session-stats/edit_adherence.py` + `stats:adherence` — reads session JSONL directly (no `stats:sync`, no tiktoken), so any user can run the same measurement on their own corpus before believing my table.
- One pointer line under README §11 (Hashline), since that is where a reader forms the expectation that every model edits by anchor.

## Verification

- `python scripts/session-stats/edit_adherence.py` — ran over 201 sessions, output is the table above.
- `ruff check scripts/session-stats/edit_adherence.py` — clean (line-length 120, matching `python/robomp` config).
- The doc's rule block was parsed with the repo's own `parseFrontmatter` + `parseRuleConditionAndScope` + `compileRuleCondition`, then matched against 7 sample cells: all 5 surgery forms hit, both benign cells (`open("nums.txt")` read, `gofmt -w`) do not.
- The hook example was executed against a stubbed `HookAPI` with the same 7 cases: blocks the 4 write forms, passes the read-only cells, ignores non-`eval` tools.
- `python -c "json.load(open('package.json'))"` — valid after the script entry.

No runtime code changes; docs plus one standalone analysis script.

## Open question for maintainers

If you would rather ship the guard as a first-class opt-in than as a doc snippet, the natural shape is an `edit.forbidSurgeryInEval` setting (or a builtin rule under `builtin-defaults`) wrapping the same `tool_call` block. Happy to follow up with that if you want it in the box rather than in the docs.