### PR TITLE
fix(tui): do not decode horizontal wheel reports as a vertical direction

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Avoid inserting a trailing space when auto-completing directory paths with `@`, and keep autocomplete open when accepting a directory with Tab or Enter.
+- Horizontal wheel reports (the sideways drift of a two-finger trackpad scroll) no longer decode as a vertical wheel direction, so fullscreen selectors such as `/copy` and the rewind picker stop jumping up and back down at the end of a scroll gesture.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/tui/src/mouse.ts
+++ b/packages/tui/src/mouse.ts
@@ -18,7 +18,12 @@ export interface SgrMouseEvent {
 	row: number;
 	/** True for a release report (`m` suffix). */
 	release: boolean;
-	/** Wheel direction: -1 up, 1 down, null when not a wheel event. */
+	/**
+	 * Vertical wheel direction: -1 up, 1 down, null when not a vertical wheel
+	 * event. Horizontal wheel reports (buttons 66/67, the sideways drift of a
+	 * two-finger trackpad scroll) are not a direction: treating them as one
+	 * scrolled the selectors up and back down at the end of a gesture.
+	 */
 	wheel: -1 | 1 | null;
 	/** True when the pointer moved (hover or drag) rather than clicked. */
 	motion: boolean;
@@ -38,7 +43,7 @@ export function parseSgrMouse(data: string): SgrMouseEvent | null {
 	const col = Number(match[2]) - 1;
 	const row = Number(match[3]) - 1;
 	const release = match[4] === "m";
-	const wheel = button & 64 ? ((button & 1 ? 1 : -1) as 1 | -1) : null;
+	const wheel = button & 64 && !(button & 2) ? ((button & 1 ? 1 : -1) as 1 | -1) : null;
 	const motion = (button & 32) !== 0 && wheel === null;
 	const leftClick = !release && wheel === null && !motion && (button & 3) === 0;
 	return { button, col, row, release, wheel, motion, leftClick };

--- a/packages/tui/test/mouse.test.ts
+++ b/packages/tui/test/mouse.test.ts
@@ -39,6 +39,19 @@ describe("parseSgrMouse", () => {
 		expect(parseSgrMouse("\x1b[<65;1;1M")?.leftClick).toBe(false);
 	});
 
+	it("does not read a horizontal wheel report as a vertical direction", () => {
+		// A two-finger trackpad scroll drifts sideways; buttons 66/67 must not
+		// move a list up and back down.
+		for (const report of ["\x1b[<66;1;1M", "\x1b[<67;1;1M", "\x1b[<70;1;1M"]) {
+			const event = parseSgrMouse(report);
+			expect(event?.wheel).toBeNull();
+			expect(event?.leftClick).toBe(false);
+			expect(event?.motion).toBe(false);
+		}
+		// Modifier bits on a vertical wheel still decode as a direction.
+		expect(parseSgrMouse("\x1b[<69;1;1M")?.wheel).toBe(1);
+	});
+
 	it("decodes motion reports without treating them as clicks", () => {
 		const event = parseSgrMouse("\x1b[<35;10;3M");
 		expect(event?.motion).toBe(true);


### PR DESCRIPTION
Scrolling `/copy` with a trackpad made the list twitch at the end of every gesture; I recorded it, traced it to the sideways wheel reports, and checked the fix on my own sessions.

## What

`parseSgrMouse` reports `wheel: null` for horizontal wheel buttons (66/67 and their modifier variants) instead of decoding them as up/down. Vertical wheel reports with modifier bits (e.g. 69 = shift+down) still decode as before.

## Why

Xterm encodes the wheel in button bit 64 and the direction in bit 1, but bit 2 selects the horizontal axis: 64 up, 65 down, 66 left, 67 right. The parser only tested bit 64 and bit 1, so `left` read as **up** and `right` as **down**. A two-finger trackpad scroll almost always carries a little sideways drift, so at the end of a scroll-down gesture the selectors received `left` -> up 3 rows, then the next real notch -> back down: a visible jump up and back on every gesture, in both directions, never with the arrow keys.

Reproduced on a real `/copy` session by sending `\x1b[<66;60;20M` at the bottom: the picker scrolled up exactly 3 rows; `\x1b[<67;60;20M` scrolled it back. After the fix the same reports emit 0 bytes and the frame is unchanged.

## Testing

- `bun test packages/tui/test/mouse.test.ts` — 13 pass; the new case fails on the previous parser (66/67 decoded as a direction).
- Live TUI: `/copy` on a resumed session, four alternating horizontal reports at the bottom -> no output, frame identical, `337/337` unchanged; vertical reports still scroll 3 rows per notch.
- Installed the patched build and scrolled `/copy` and the rewind picker with the trackpad in my own sessions: the jump at the end of a gesture is gone in both directions.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

