### PR TITLE
fix(coding-agent): preserve session settings in npm extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions.
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/scripts/bundle-dist.ts
+++ b/packages/coding-agent/scripts/bundle-dist.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { buildDocsIndexPayload } from "./generate-docs-index";
+import { createLegacyPiVirtualModulePlugin } from "./legacy-pi-virtual-module";
 
 const packageDir = path.join(import.meta.dir, "..");
 const outDir = path.join(packageDir, "dist");
@@ -12,15 +13,7 @@ const shebang = "#!/usr/bin/env bun\n";
 const legacyHtmlExportAssetPattern = /^(?:template-[^.]+\.(?:css|html|js)|tool-views\.generated-[^.]+\.js)$/;
 
 // Native / optional / platform-specific deps are loaded from installed files.
-// `omp-legacy-pi-modules` exists only in compiled binaries via the build plugin;
-// the npm bundle never executes that `isCompiledBinary()` branch.
-const ALWAYS_EXTERNAL = [
-	"@oh-my-pi/pi-natives",
-	"@huggingface/transformers",
-	"fastembed",
-	"onnxruntime-node",
-	"omp-legacy-pi-modules",
-];
+const ALWAYS_EXTERNAL = ["@oh-my-pi/pi-natives", "@huggingface/transformers", "fastembed", "onnxruntime-node"];
 
 // Heavy, lazily-used third-party leaf deps. Each is a declared `dependency`, so the
 // published package resolves it from node_modules at runtime; bundling only embeds a
@@ -98,6 +91,7 @@ async function main(): Promise<void> {
 			entrypoints: [path.join(packageDir, "src/cli.ts")],
 			outdir: outDir,
 			target: "bun",
+			plugins: [await createLegacyPiVirtualModulePlugin()],
 			external: [...ALWAYS_EXTERNAL, ...RUNTIME_EXTERNAL],
 			define: {
 				"process.env.PI_BUNDLED": JSON.stringify("true"),

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -17,7 +17,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { registerPluginCacheInvalidator } from "../../discovery/helpers";
 
-const IS_COMPILED_BINARY = isCompiledBinary();
+const USE_BUNDLED_PI_MODULES = isCompiledBinary() || Boolean(process.env.PI_BUNDLED);
 
 // === Bundled host modules (issue #3423) ===
 //
@@ -27,7 +27,7 @@ const IS_COMPILED_BINARY = isCompiledBinary();
 // embedded entries. Bun.plugin `onResolve` also no longer fires for transitive
 // imports inside runtime-loaded extensions.
 //
-// Compiled builds retain lazy loaders for host packages and serve requested
+// Compiled binaries and npm bundles retain lazy host-package loaders and serve requested
 // surfaces through `omp-legacy-pi-bundled:<key>` synthetic modules.
 // `scripts/legacy-pi-virtual-module.ts` derives literal dynamic-import edges
 // from current package exports inside a Bun build plugin: no generated source
@@ -742,11 +742,11 @@ let bundledModuleLoadersPromise: Promise<BundledModuleLoaders> | null = null;
  *
  * `globalThis` bridges the synthetic ES modules, which cannot close over this
  * file's lexical scope. Dev/test runs never execute the conditional import;
- * binary builds resolve it through the in-memory build plugin.
+ * binary and npm builds resolve it through the in-memory build plugin.
  */
 function ensureBundledModuleLoadersLoaded(): Promise<BundledModuleLoaders> {
-	if (!IS_COMPILED_BINARY) {
-		return Promise.reject(new Error("omp:legacy-pi-shim: bundled modules are only available in compiled mode"));
+	if (!USE_BUNDLED_PI_MODULES) {
+		return Promise.reject(new Error("omp:legacy-pi-shim: bundled modules are only available in bundled mode"));
 	}
 	if (!bundledModuleLoadersPromise) {
 		bundledModuleLoadersPromise = import("omp-legacy-pi-modules").then(module => {
@@ -977,9 +977,9 @@ function sourceShimPath(file: string): string {
  * TypeBox facade with legacy `Type.Unsafe`, then drop the remap when that
  * entrypoint is missing.
  *
- * In compiled-binary mode the surface is served through the
+ * In compiled binaries and npm bundles the surface is served through the
  * `omp-legacy-pi-bundled:` virtual namespace (issue #3423). Dev, source-link,
- * and installed-package modes use the shipped source module.
+ * and source SDK imports use the shipped source module.
  *
  * Exported for tests; production callers use `TYPEBOX_SHIM_PATH`.
  */
@@ -994,7 +994,7 @@ export function __resolveTypeBoxShimPath(
 	return pathExistsSync(sourcePath) ? sourcePath : null;
 }
 
-const TYPEBOX_SHIM_PATH = __resolveTypeBoxShimPath(IS_COMPILED_BINARY, sourceShimPath("legacy-typebox.ts"));
+const TYPEBOX_SHIM_PATH = __resolveTypeBoxShimPath(USE_BUNDLED_PI_MODULES, sourceShimPath("legacy-typebox.ts"));
 
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
 // the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
@@ -1004,33 +1004,33 @@ const TYPEBOX_SHIM_PATH = __resolveTypeBoxShimPath(IS_COMPILED_BINARY, sourceShi
 // plus the borrowed `Type` runtime from the omptype TypeBox facade. Subpath
 // imports such as `@oh-my-pi/pi-ai/oauth` continue to resolve directly
 // against the bundled pi-ai package.
-const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
+const LEGACY_PI_AI_SHIM_PATH = USE_BUNDLED_PI_MODULES
 	? bundledModuleVirtualSpecifier(`${CANONICAL_PI_SCOPE}/pi-ai`)
 	: sourceShimPath("legacy-pi-ai-shim.ts");
 
 // The coding-agent's own `./src/index.ts` cannot be listed as an extra
 // `bun --compile` entrypoint alongside the CLI entry without breaking binary
-// startup (issue #1474 follow-up). In compiled-binary mode the legacy
+// startup (issue #1474 follow-up). In compiled binaries and npm bundles the legacy
 // `@(scope)/pi-coding-agent` root therefore resolves through the bundled
-// module shim; in dev / source-link / installed-package mode it points at the
+// module shim; in dev / source-link / source SDK mode it points at the
 // sibling source shim whose distinct file path avoids the #1474 collision
 // while still re-exporting the canonical package surface.
-const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
+const LEGACY_PI_CODING_AGENT_SHIM_PATH = USE_BUNDLED_PI_MODULES
 	? bundledModuleVirtualSpecifier(`${CANONICAL_PI_SCOPE}/pi-coding-agent`)
 	: sourceShimPath("legacy-pi-coding-agent-shim.ts");
 
 // Legacy pi-tui exported `decodeKittyPrintable` from its package root. The
 // canonical TUI replaced it with the broader `decodePrintableKey`; route only
 // legacy root imports through a sibling shim that preserves the old name.
-const LEGACY_PI_TUI_SHIM_PATH = IS_COMPILED_BINARY
+const LEGACY_PI_TUI_SHIM_PATH = USE_BUNDLED_PI_MODULES
 	? bundledModuleVirtualSpecifier(`${CANONICAL_PI_SCOPE}/pi-tui`)
 	: sourceShimPath("legacy-pi-tui-shim.ts");
 
 // Package-root overrides. Shim entries (`pi-ai`, `pi-coding-agent`, `pi-tui`)
 // always replace the canonical surface so legacy helpers stay reachable. The
 // other bundled host packages (`pi-agent-core`, `pi-natives`, `pi-utils`) are
-// added only in compiled-binary mode to route extensions onto the in-process
-// module instance — in dev / source-link / installed-package mode the canonical
+// added in compiled binaries and npm bundles to route extensions onto the in-process
+// module instance — in dev / source-link / source SDK mode the canonical
 // specifier resolves cleanly through `Bun.resolveSync` and hardcoding a
 // source-tree path would miss installs where bundled packages live at
 // `node_modules/@oh-my-pi/pi-*`.
@@ -1091,14 +1091,14 @@ export function __buildLegacyPiPackageRootOverrides(
 	return __validateLegacyPiPackageRootOverrides(candidates);
 }
 
-// Seeded with compat roots at module init; first compiled extension load adds
+// Seeded with compat roots at module init; first bundled extension load adds
 // every key supplied by the in-memory build module.
-let legacyPiPackageRootOverrides = __buildLegacyPiPackageRootOverrides(IS_COMPILED_BINARY);
+let legacyPiPackageRootOverrides = __buildLegacyPiPackageRootOverrides(USE_BUNDLED_PI_MODULES);
 let legacyPiOverridesReadyPromise: Promise<void> | null = null;
 
-/** Complete compiled-mode overrides from the lazy host-module registry. */
+/** Complete bundled-mode overrides from the lazy host-module registry. */
 function ensureLegacyPiOverridesReady(): Promise<void> {
-	if (!IS_COMPILED_BINARY) {
+	if (!USE_BUNDLED_PI_MODULES) {
 		return Promise.resolve();
 	}
 	if (!legacyPiOverridesReadyPromise) {

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -33,6 +33,7 @@ smoke_cli() {
    # probe for #1011/#1027 worker loading and for npm/compiled distributions
    # missing the dashboard assets that `stats --summary` never touches.
    XDG_DATA_HOME="$runtime_dir/xdg" HOME="$runtime_dir/home" "$omp_bin" --smoke-test
+   bun "$ROOT_DIR/scripts/install-tests/settings-session.ts" "$omp_bin"
 }
 
 find_tarball() {

--- a/scripts/install-tests/settings-session.ts
+++ b/scripts/install-tests/settings-session.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Run the supplied CLI, never import the SDK into this driver. Extensions must
+// cross the same package boundary as an installed user's extension.
+const cli = process.argv.slice(2).map(arg => (arg.includes("/") ? path.resolve(arg) : arg));
+assert(cli.length > 0, "Usage: bun scripts/install-tests/settings-session.ts <cli> [cli entrypoint]");
+const work = await fs.mkdtemp(path.join(os.tmpdir(), "omp-settings-session-"));
+const cwd = path.join(work, "project");
+const agentDir = path.join(work, "agent");
+const extensionPath = path.join(work, "probe.mjs");
+const resultPath = path.join(work, "result.json");
+
+// A local OpenAI-compatible fixture exercises the native task's resolved model
+// without credentials or network services. Yield completes the real child turn.
+const requestedModels: string[] = [];
+const server = Bun.serve({
+	hostname: "127.0.0.1",
+	port: 0,
+	async fetch(request) {
+		const body = (await request.json()) as { model: string; tools?: { function: { name: string } }[] };
+		const canYield = body.tools?.some(tool => tool.function.name === "yield");
+		if (canYield) requestedModels.push(body.model);
+		const delta = canYield
+			? {
+					role: "assistant",
+					tool_calls: [
+						{
+							index: 0,
+							id: `yield-${requestedModels.length}`,
+							type: "function",
+							function: { name: "yield", arguments: JSON.stringify({ data: { model: body.model } }) },
+						},
+					],
+				}
+			: { role: "assistant", content: "Fixture task" };
+		const chunk = { id: "fixture", object: "chat.completion.chunk", model: body.model, created: 1 };
+		return new Response(
+			`data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta, finish_reason: null }] })}\n\n` +
+				`data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: {}, finish_reason: canYield ? "tool_calls" : "stop" }] })}\n\n` +
+				"data: [DONE]\n\n",
+			{ headers: { "content-type": "text/event-stream" } },
+		);
+	},
+});
+
+try {
+	await Promise.all([cwd, agentDir, path.join(work, "home")].map(dir => fs.mkdir(dir, { recursive: true })));
+	for (const name of ["a", "b"]) {
+		const agents = path.join(work, `extension-${name}`, "agents");
+		await Bun.write(
+			path.join(agents, `only-${name}.md`),
+			`---\nname: only-${name}\ndescription: Installed session fixture ${name}.\nmodel: fixture/fallback\nblocking: true\ntools: []\n---\nReturn the fixture result.\n`,
+		);
+	}
+	await Bun.write(
+		extensionPath,
+		`const fixture = ${JSON.stringify({ work, cwd, agentDir, resultPath, baseUrl: server.url.href })};\n` +
+			String.raw`
+import assert from "node:assert/strict";
+import { SettingsManager } from "@mariozechner/pi-coding-agent";
+import { hasMatch } from "@oh-my-pi/pi-natives";
+import { git } from "@oh-my-pi/pi-natives/vcs";
+
+function registerFixtureProvider(api) {
+	// Same registration shape as sdk-default-role-extension-provider.test.ts.
+	api.registerProvider("fixture", {
+		baseUrl: fixture.baseUrl,
+		apiKey: "offline-fixture-key",
+		api: "openai-completions",
+		models: ["fallback", "model-a", "model-b"].map(id => ({
+			id, name: id, reasoning: false, input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000, maxTokens: 1024,
+		})),
+	});
+}
+
+export default function (api) {
+	registerFixtureProvider(api);
+	api.registerCommand("settings-session-smoke", {
+		handler: async (_args, ctx) => {
+			const { createAgentSession, Settings, AgentRegistry, SessionManager, ModelRegistry } = api.pi;
+			const sessions = [];
+			const entered = [Promise.withResolvers(), Promise.withResolvers()];
+			const disposedA = Promise.withResolvers();
+			const failures = [];
+			const checked = [];
+			try {
+				assert.equal(hasMatch("installed native fixture", "native"), true);
+				assert.equal(hasMatch("installed native fixture", "absent"), false);
+				assert.equal(git(fixture.cwd), null);
+				for (const [index, name] of ["a", "b"].entries()) {
+					const settings = await Settings.loadIsolated({
+						cwd: fixture.cwd, agentDir: fixture.agentDir,
+						overrides: {
+							"async.enabled": false, "task.batch": false,
+							"task.isolation.enabled": false, "task.enableLsp": false,
+							"modelRoles": { default: "fixture/fallback", tiny: "fixture/fallback" },
+						},
+					});
+					const { session } = await createAgentSession({
+						cwd: fixture.cwd, agentDir: fixture.agentDir, settings,
+						agentRegistry: new AgentRegistry(),
+						modelRegistry: new ModelRegistry(ctx.modelRegistry.authStorage, fixture.agentDir + "/models.yml"),
+						sessionManager: SessionManager.inMemory(fixture.cwd),
+						// Merge mode lets runtime settings supply roots. Empty preloaded
+						// paths prevent this driver extension from loading recursively.
+						preloadedExtensionPaths: [], preloadedCustomToolPaths: [],
+						skills: [], rules: [], contextFiles: [], promptTemplates: [], slashCommands: [],
+						enableMCP: false, enableLsp: false, enableIrc: false,
+						skipPythonPreflight: true, toolNames: ["task"], autoApprove: true,
+						extensions: [registerFixtureProvider, childApi => childApi.registerCommand("probe", {
+							handler: async (_args, childCtx) => {
+								try {
+									SettingsManager.create(childCtx.cwd).override("extensions", [fixture.work + "/extension-" + name]);
+									entered[index].resolve();
+									await entered[1 - index].promise;
+									if (name === "b") await disposedA.promise;
+									// Re-enter after an overlapping callback (and, for B,
+									// after A's disposal) before mutating a second setting.
+									SettingsManager.create(childCtx.cwd).override("task.agentModelOverrides", {
+										["only-" + name]: "fixture/model-" + name,
+									});
+									const task = session.getToolByName("task");
+									assert(task, "Native task tool is unavailable");
+									const sibling = name === "a" ? "only-b" : "only-a";
+									const rejected = await task.execute("reject-" + name, { agent: sibling, task: "Fixture check" });
+									const errorText = rejected.content.filter(part => part.type === "text").map(part => part.text).join("\n");
+									assert(errorText.includes('Unknown agent "' + sibling + '"'), errorText);
+									const available = errorText.split("Available: ")[1]?.split(", ") ?? [];
+									assert(available.includes("only-" + name), errorText);
+									assert(!available.includes(sibling), errorText);
+									const result = await task.execute("own-" + name, { agent: "only-" + name, task: "Fixture check" });
+									const child = result.details?.results?.[0];
+									assert.equal(child?.exitCode, 0, JSON.stringify(result));
+									assert.equal(child.resolvedModel, "fixture/model-" + name);
+									assert(child.output.includes("model-" + name), child.output);
+									checked.push(name);
+								} catch (error) {
+									failures.push(String(error.stack ?? error));
+								} finally {
+									entered[index].resolve();
+								}
+							},
+						})],
+					});
+					sessions.push(session);
+				}
+				const a = sessions[0].prompt("/probe");
+				const b = sessions[1].prompt("/probe");
+				await a;
+				await sessions[0].dispose();
+				disposedA.resolve();
+				await b;
+				assert.deepEqual(failures, []);
+				assert.deepEqual(checked, ["a", "b"]);
+				await Bun.write(fixture.resultPath, JSON.stringify(checked));
+			} finally {
+				disposedA.resolve();
+				for (const session of sessions) await session.dispose();
+				ctx.shutdown();
+			}
+		},
+	});
+}
+`,
+	);
+	const child = Bun.spawn(
+		[
+			...cli,
+			"--no-extensions",
+			"--extension",
+			extensionPath,
+			"--no-session",
+			"--no-tools",
+			"--no-lsp",
+			"--no-skills",
+			"--no-rules",
+			"--no-title",
+			"--model",
+			"fixture/fallback",
+			"--print",
+			"/settings-session-smoke",
+		],
+		{
+			cwd,
+			// Whitelist the runtime environment: no ambient credentials, settings,
+			// plugins or user configuration can make a broken fixture succeed.
+			env: {
+				PATH: process.env.PATH,
+				HOME: path.join(work, "home"),
+				XDG_DATA_HOME: path.join(work, "xdg"),
+				PI_CODING_AGENT_DIR: agentDir,
+				TMPDIR: work,
+			},
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+			timeout: 120_000,
+		},
+	);
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	assert.equal(exitCode, 0, `Settings session CLI failed (${exitCode})\n${stdout}\n${stderr}`);
+	const result = await Bun.file(resultPath)
+		.json()
+		.catch(error => {
+			throw new Error(`Settings session probe did not complete\n${stdout}\n${stderr}`, { cause: error });
+		});
+	assert.deepEqual(result, ["a", "b"]);
+	assert.deepEqual(requestedModels, ["model-a", "model-b"]);
+	console.log("Installed CLI settings/session isolation smoke passed");
+} finally {
+	server.stop(true);
+	await fs.rm(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

Use the existing lazy bundled-module registry for npm CLI extension imports, as compiled executables already do. Keep source-mode imports, native externals, and public APIs unchanged.

Add an installation regression for scoped settings, generated-agent discovery, independent model selection, sibling-agent rejection, and session disposal. The probe covers source, compiled, and installed npm entries through the existing installation checks.

## Why

Fixes #11048.

The npm CLI bundles its Settings module, but extension imports previously loaded a separate source shim. Its scoped settings lookup returned isolated defaults. Native task discovery could not see generated agent roots, and other session overrides were ineffective.

Reported in https://github.com/mgpai22/supership/issues/10. The standalone executable did not reproduce the npm module-identity failure.

## Testing

- Built and installed local npm tarballs through the real published bin mapping to dist/cli.js.
- Passed the new behavioral probe against source, compiled, and installed npm entries, including concurrent sessions with identical cwd and agentDir.
- Passed native root/subpath checks and both packaged executable smoke tests.
- Passed the complete affected loader, SDK isolation, discovery, and worker test files.
- Passed coding-agent typecheck, scoped lint/format, and shell syntax checks.
- Passed the unchanged downstream test/control-delivery.test.ts through the repaired npm executable, including persisted and ephemeral sessions and cancellation.

The final artifacts use verified released 18.1.11 native addons. Native source is unchanged. The full monorepo bun check was not run. Optional onnxruntime-node/protobufjs postinstall scripts remained untrusted, and their optional features were not exercised.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
