### PR TITLE
fix(tui): deliver notifications inside Herdr panes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed notifications never arriving in a Herdr pane. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and has no passthrough envelope, so a backgrounded pane got no signal at all; delivery now goes through `herdr notification show`, and the in-band write stays as the fallback when the pane id or the `herdr` binary is missing.
 - Avoid inserting a trailing space when auto-completing directory paths with `@`, and keep autocomplete open when accepting a directory with Tab or Enter.
 
 ## [18.1.9] - 2026-09-04

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed notifications never arriving in a Herdr pane. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and has no passthrough envelope, so a backgrounded pane got no signal at all; delivery now goes through `herdr notification show`, and the in-band write stays as the fallback when the pane id or the `herdr` binary is missing.
+- Fixed notifications never arriving in a Herdr pane. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and has no passthrough envelope, so a backgrounded pane got no signal at all; delivery now goes through `herdr notification show` (a waiting question or an error rings `request`, a settled turn rings `done`), and the in-band write stays as the fallback when the pane id or the `herdr` binary is missing.
 - Avoid inserting a trailing space when auto-completing directory paths with `@`, and keep autocomplete open when accepting a directory with Tab or Enter.
 
 ## [18.1.9] - 2026-09-04

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -43,6 +43,12 @@ export type TerminalId =
 const CMUX_NOTIFICATION_TITLE = "Oh My Pi";
 const CMUX_SURFACE_ID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/iu;
 
+/** Title and body for an out-of-band multiplexer notification (cmux, Herdr). */
+function notificationTitleAndBody(message: string | TerminalNotification): { title: string; body: string } {
+	if (typeof message === "string") return { title: CMUX_NOTIFICATION_TITLE, body: message };
+	return { title: message.title?.trim() || CMUX_NOTIFICATION_TITLE, body: message.body ?? "" };
+}
+
 /**
  * Route a notification through cmux when the process belongs to a concrete
  * surface. Workspace/socket state alone is not enough: only the injected
@@ -54,9 +60,7 @@ function sendCmuxNotification(message: string | TerminalNotification, env: NodeJ
 	const surfaceId = env.CMUX_SURFACE_ID?.trim();
 	if (!surfaceId || !CMUX_SURFACE_ID_PATTERN.test(surfaceId)) return false;
 
-	const title =
-		typeof message === "string" ? CMUX_NOTIFICATION_TITLE : message.title?.trim() || CMUX_NOTIFICATION_TITLE;
-	const body = typeof message === "string" ? message : (message.body ?? "");
+	const { title, body } = notificationTitleAndBody(message);
 	try {
 		const child = Bun.spawn({
 			cmd: ["cmux", "notify", "--surface", surfaceId, "--title", title, "--body", body],
@@ -82,7 +86,8 @@ const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
  * at all that the agent finished or is waiting for input.
  *
  * `sound` maps the notification kind onto what Herdr offers: a question waiting
- * on the user rings `request`, a settled turn rings `done`, anything else stays
+ * on the user and a turn that stopped with an error both need the human and
+ * ring `request`, a settled turn rings `done`, anything else stays
  * silent. Returns whether Herdr owns delivery, so every existing terminal
  * fallback is preserved when the pane id is absent or the binary is missing.
  */
@@ -94,11 +99,10 @@ function sendHerdrNotification(message: string | TerminalNotification, env: Node
 	const paneId = env.HERDR_PANE_ID?.trim();
 	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
 
-	const title =
-		typeof message === "string" ? CMUX_NOTIFICATION_TITLE : message.title?.trim() || CMUX_NOTIFICATION_TITLE;
-	const body = typeof message === "string" ? message : (message.body ?? "");
+	const { title, body } = notificationTitleAndBody(message);
 	const kinds = typeof message === "string" ? [] : [message.type ?? []].flat();
-	const sound = kinds.includes("ask") ? "request" : kinds.includes("completion") ? "done" : "none";
+	const sound =
+		kinds.includes("ask") || kinds.includes("error") ? "request" : kinds.includes("completion") ? "done" : "none";
 	try {
 		const child = Bun.spawn({
 			cmd: ["herdr", "notification", "show", title, "--body", body, "--sound", sound],

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -77,6 +77,12 @@ function sendCmuxNotification(message: string | TerminalNotification, env: NodeJ
 }
 
 const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
+/**
+ * `herdr notification show` takes the title as its first positional and reads
+ * exactly these three values there as a help request; it has no `--`
+ * terminator. Any other text, including one starting with `-`, is a title.
+ */
+const HERDR_USAGE_TOKENS = new Set(["help", "--help", "-h"]);
 
 /**
  * Route a notification through Herdr when the process runs inside one of its
@@ -99,7 +105,9 @@ function sendHerdrNotification(message: string | TerminalNotification, env: Node
 	const paneId = env.HERDR_PANE_ID?.trim();
 	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
 
-	const { title, body } = notificationTitleAndBody(message);
+	const parsed = notificationTitleAndBody(message);
+	const title = HERDR_USAGE_TOKENS.has(parsed.title) ? CMUX_NOTIFICATION_TITLE : parsed.title;
+	const body = parsed.body;
 	const kinds = typeof message === "string" ? [] : [message.type ?? []].flat();
 	const sound =
 		kinds.includes("ask") || kinds.includes("error") ? "request" : kinds.includes("completion") ? "done" : "none";

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -72,6 +72,48 @@ function sendCmuxNotification(message: string | TerminalNotification, env: NodeJ
 	return true;
 }
 
+const HERDR_PANE_ID_PATTERN = /^[0-9A-Za-z:_-]{1,64}$/u;
+
+/**
+ * Route a notification through Herdr when the process runs inside one of its
+ * panes. Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99 and
+ * has no DCS passthrough envelope, and its bell relay does not flag a
+ * backgrounded tab — so without this branch a backgrounded pane gets no signal
+ * at all that the agent finished or is waiting for input.
+ *
+ * `sound` maps the notification kind onto what Herdr offers: a question waiting
+ * on the user rings `request`, a settled turn rings `done`, anything else stays
+ * silent. Returns whether Herdr owns delivery, so every existing terminal
+ * fallback is preserved when the pane id is absent or the binary is missing.
+ */
+function sendHerdrNotification(message: string | TerminalNotification, env: NodeJS.ProcessEnv = Bun.env): boolean {
+	// Pane-only detection, like `isInsideHerdr`: an env-sanitizing launcher can
+	// drop HERDR_ENV and keep the pane identity, and that pane can still be
+	// backgrounded. The pane id itself is what the CLI needs, so it stays required.
+	if (!isInsideHerdr(env)) return false;
+	const paneId = env.HERDR_PANE_ID?.trim();
+	if (!paneId || !HERDR_PANE_ID_PATTERN.test(paneId)) return false;
+
+	const title =
+		typeof message === "string" ? CMUX_NOTIFICATION_TITLE : message.title?.trim() || CMUX_NOTIFICATION_TITLE;
+	const body = typeof message === "string" ? message : (message.body ?? "");
+	const kinds = typeof message === "string" ? [] : [message.type ?? []].flat();
+	const sound = kinds.includes("ask") ? "request" : kinds.includes("completion") ? "done" : "none";
+	try {
+		const child = Bun.spawn({
+			cmd: ["herdr", "notification", "show", title, "--body", body, "--sound", sound],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		child.unref();
+	} catch {
+		// A missing herdr binary leaves delivery to the existing terminal fallback.
+		return false;
+	}
+	return true;
+}
+
 function hasNeedleBefore(line: string, needle: string, limit: number): boolean {
 	const index = line.indexOf(needle);
 	return index !== -1 && index + needle.length <= limit;
@@ -159,6 +201,11 @@ export class TerminalInfo {
 
 	sendNotification(message: string | TerminalNotification): void {
 		if (isNotificationSuppressed() || isTerminalHeadless()) return;
+		// Innermost surface first. A Herdr pane launched inside a cmux surface
+		// inherits both `HERDR_PANE_ID` and the outer `CMUX_SURFACE_ID`; routing to
+		// cmux there would flag the containing surface and leave the backgrounded
+		// Herdr pane — the one actually waiting — without a sound or a marker.
+		if (sendHerdrNotification(message)) return;
 		if (sendCmuxNotification(message)) return;
 		const formatted = this.formatNotification(message);
 		// Under tmux, terminals whose notify protocol is OSC 9 / OSC 99 would

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -232,6 +232,114 @@ describe("terminal notifications", () => {
 		expect(stdout).not.toHaveBeenCalled();
 	});
 
+	it("routes a Herdr pane notification through the CLI instead of a swallowed OSC", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const unref = vi.fn();
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(spawn).toHaveBeenCalledWith({
+			cmd: ["herdr", "notification", "show", "session", "--body", "Waiting for input", "--sound", "request"],
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		expect(unref).toHaveBeenCalledTimes(1);
+		// Herdr swallows bare OSC 9/99 and its bell relay never flags the tab, so
+		// the in-band write must not be the only signal.
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("routes through the CLI when a launcher dropped HERDR_ENV but kept the pane id", () => {
+		delete Bun.env.HERDR_ENV;
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("rings Herdr's completion sound for a settled turn and stays silent otherwise", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Complete", type: "completion" });
+		TERMINAL.sendNotification({ title: "session", body: "Stopped with error", type: "error" });
+
+		const sounds = spawn.mock.calls.map(call => {
+			const { cmd } = call[0] as unknown as { cmd: string[] };
+			return cmd[cmd.indexOf("--sound") + 1];
+		});
+		expect(sounds).toEqual(["done", "none"]);
+	});
+
+	it("keeps the OSC fallback when the Herdr pane id is absent", () => {
+		Bun.env.HERDR_ENV = "1";
+		delete Bun.env.HERDR_PANE_ID;
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification("no pane");
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(writes).toEqual(["\x1b]99;;no pane\x1b\\"]);
+	});
+
+	it("routes to the Herdr pane, not the cmux surface it was launched inside", () => {
+		// A Herdr pane started inside a cmux surface inherits both sets of vars.
+		// The pane is the innermost surface and the one that can be backgrounded,
+		// so it must win over the container.
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		Bun.env.CMUX_SURFACE_ID = "123e4567-e89b-12d3-a456-426614174000";
+		Bun.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "session", body: "Waiting for input", type: "ask" });
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		const argv = (spawn.mock.calls[0]?.[0] as unknown as { cmd?: string[] } | undefined)?.cmd;
+		expect(argv?.[0]).toBe("herdr");
+		expect(stdout).not.toHaveBeenCalled();
+	});
+
+	it("keeps the OSC fallback when the herdr binary is missing", () => {
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+		// A pane id says "inside Herdr", but the CLI itself may not be on PATH —
+		// a stripped container, or a pane inherited into a different environment.
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => {
+			throw new Error("spawn herdr ENOENT");
+		});
+
+		TERMINAL.sendNotification("no binary");
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(writes).toEqual(["\x1b]99;;no binary\x1b\\"]);
+	});
+
 	it("keeps the existing OSC fallback for cmux workspace or socket state without a surface", () => {
 		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
 		const writes: string[] = [];

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -285,6 +285,22 @@ describe("terminal notifications", () => {
 		expect(sounds).toEqual(["done", "request", "none"]);
 	});
 
+	it("never hands Herdr a title it would read as a help request", () => {
+		// The title is the CLI's first positional; `help`, `--help` and `-h` there
+		// print usage instead of showing anything, while the spawn still succeeds
+		// and would suppress the OSC fallback. Other hyphen titles are fine.
+		Bun.env.HERDR_ENV = "1";
+		Bun.env.HERDR_PANE_ID = "w6:p1";
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
+
+		TERMINAL.sendNotification({ title: "--help", body: "Complete", type: "completion" });
+		TERMINAL.sendNotification({ title: "-x session", body: "Complete", type: "completion" });
+
+		const titles = spawn.mock.calls.map(call => (call[0] as unknown as { cmd: string[] }).cmd[3]);
+		expect(titles).toEqual(["Oh My Pi", "-x session"]);
+	});
+
 	it("keeps the OSC fallback when the Herdr pane id is absent", () => {
 		Bun.env.HERDR_ENV = "1";
 		delete Bun.env.HERDR_PANE_ID;

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -267,20 +267,22 @@ describe("terminal notifications", () => {
 		expect(stdout).not.toHaveBeenCalled();
 	});
 
-	it("rings Herdr's completion sound for a settled turn and stays silent otherwise", () => {
+	it("rings done for a settled turn, request for an error, and stays silent otherwise", () => {
 		Bun.env.HERDR_ENV = "1";
 		Bun.env.HERDR_PANE_ID = "w6:p1";
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
 
 		TERMINAL.sendNotification({ title: "session", body: "Complete", type: "completion" });
+		// A turn that stopped on an error needs the human as much as a question does.
 		TERMINAL.sendNotification({ title: "session", body: "Stopped with error", type: "error" });
+		TERMINAL.sendNotification({ title: "session", body: "Reminder", type: "info" });
 
 		const sounds = spawn.mock.calls.map(call => {
 			const { cmd } = call[0] as unknown as { cmd: string[] };
 			return cmd[cmd.indexOf("--sound") + 1];
 		});
-		expect(sounds).toEqual(["done", "none"]);
+		expect(sounds).toEqual(["done", "request", "none"]);
 	});
 
 	it("keeps the OSC fallback when the Herdr pane id is absent", () => {


### PR DESCRIPTION
I run OMP inside Herdr all day and a background pane never told me the agent had finished or was waiting. I reviewed the diff and have used this build daily since August. Split out of #8927 so the two halves can be reviewed on their own; the review history is there.

## What

`TerminalInfo.sendNotification` gains a Herdr branch, next to the existing cmux one: inside a Herdr pane the notification runs through `herdr notification show <title> --body <body> --sound <request|done|none>`, with `ask` -> `request` and `completion` -> `done`. Detection uses the shared `isInsideHerdr()`, so a launcher that strips `HERDR_ENV` but keeps the pane id still routes; a missing pane id or `herdr` binary keeps the existing OSC/BEL fallback byte-for-byte, and a Herdr pane launched inside a cmux surface routes to the innermost (Herdr) surface.

## Why

Herdr multiplexes panes like tmux but swallows bare OSC 9 / OSC 99, has no DCS passthrough envelope, and its bell relay never flags a backgrounded tab — so every completion, error and prompt notification went nowhere.

## Testing

- `bun test packages/tui/test/notifications.test.ts` — 28 pass: a Herdr pane routes through the CLI exactly once with explicit argv and no stdout write; sounds map `ask -> request`, `completion -> done`, else `none`; pane-only detection without `HERDR_ENV` still routes; a missing pane id or binary keeps the OSC fallback; Herdr wins over an enclosing cmux surface.
- Daily use in my own Herdr panes: a finished turn in a background tab now rings `done` and flags the tab; an `ask` rings `request`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
