### PR TITLE
fix(azure): disable astra reasoning with function tools

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added Muse Code subscription sign-in, credential refresh, inference, and quota reporting in `/usage`, with durable rate-limit backoff so quota refresh recovers instead of repeatedly retrying.
 
+### Fixed
+
+- Fixed Azure GPT-6 Astra Chat Completions requests with function tools sending a non-`none` reasoning effort, which Azure rejects with HTTP 400 ([#11052](https://github.com/can1357/oh-my-pi/issues/11052)).
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -675,7 +675,7 @@ const streamOpenAICompletionsOnce = (
 	(async () => {
 		const startTime = performance.now();
 		let firstTokenTime: number | undefined;
-		const policy = resolveOpenAICompatForRequest(model, options);
+		const policy = resolveOpenAICompatForRequest(model, options, Boolean(context.tools?.length));
 
 		const output: AssistantMessage = createInitialResponsesAssistantMessage(model.api, model.provider, model.id);
 		let rawRequestDump: RawHttpRequestDump | undefined;
@@ -1540,12 +1540,14 @@ function createRequestSetup(
 function resolveOpenAICompatForRequest(
 	model: Model<"openai-completions">,
 	options: OpenAICompletionsOptions | undefined,
+	hasTools: boolean,
 ): OpenAICompatPolicy {
 	return resolveOpenAICompatPolicy(model, {
 		endpoint: "chat-completions",
 		reasoning: options?.reasoning,
 		disableReasoning: options?.disableReasoning,
 		toolChoice: mapToOpenAICompletionsToolChoice(options?.toolChoice),
+		hasTools,
 	});
 }
 
@@ -1649,7 +1651,7 @@ function buildParams(
 	toolStrictMode: AppliedToolStrictMode;
 	strictToolsApplied: boolean;
 } {
-	const initialPolicy = resolveOpenAICompatForRequest(model, options);
+	const initialPolicy = resolveOpenAICompatForRequest(model, options, Boolean(context.tools?.length));
 	const initialCompat = initialPolicy.compat as ResolvedOpenAICompat;
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 
@@ -1803,6 +1805,7 @@ function buildParams(
 		reasoning: options?.reasoning,
 		disableReasoning: options?.disableReasoning,
 		toolChoice: params.tool_choice,
+		hasTools: Array.isArray(params.tools) && params.tools.length > 0,
 	});
 	const compat = finalPolicy.compat as ResolvedOpenAICompat;
 	const messages = convertMessages(model, context, compat);
@@ -1827,7 +1830,11 @@ function buildParams(
 	}
 	applyChatCompletionsToolStream(params, model, compat);
 
-	applyChatCompletionsReasoningParams(params, model, compat, { ...options, toolChoice: params.tool_choice });
+	applyChatCompletionsReasoningParams(params, model, compat, {
+		...options,
+		toolChoice: params.tool_choice,
+		hasTools: Array.isArray(params.tools) && params.tools.length > 0,
+	});
 	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
 	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none");

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -755,14 +755,17 @@ const streamOpenAICompletionsOnce = (
 				const builtParams = buildParams(model, context, options, effectiveToolStrictModeOverride);
 				appliedStrictTools = builtParams.strictToolsApplied;
 				let params = builtParams.params;
-				const reasoningEffortFallbackKey = createOpenAIReasoningEffortFallbackKey(
-					"chat-completions",
-					trimmedBaseUrl,
-					params.model,
-				);
-				const requestReasoningEffortFallback = requestReasoningEffortFallbacks.has(reasoningEffortFallbackKey)
-					? requestReasoningEffortFallbacks.get(reasoningEffortFallbackKey)
-					: getOpenAIReasoningEffortFallback(providerSessionState, reasoningEffortFallbackKey);
+				// Tool-triggered suppression is a hard wire constraint; cached
+				// enabled-effort negotiation must not overwrite its `none`.
+				const reasoningEffortFallbackKey = builtParams.reasoningEffortFallbackAllowed
+					? createOpenAIReasoningEffortFallbackKey("chat-completions", trimmedBaseUrl, params.model)
+					: undefined;
+				const requestReasoningEffortFallback =
+					reasoningEffortFallbackKey === undefined
+						? undefined
+						: requestReasoningEffortFallbacks.has(reasoningEffortFallbackKey)
+							? requestReasoningEffortFallbacks.get(reasoningEffortFallbackKey)
+							: getOpenAIReasoningEffortFallback(providerSessionState, reasoningEffortFallbackKey);
 				if (requestReasoningEffortFallback !== undefined) {
 					applyOpenAIReasoningEffortFallback(params, requestReasoningEffortFallback);
 				}
@@ -1650,6 +1653,7 @@ function buildParams(
 	params: OpenAICompletionsParams;
 	toolStrictMode: AppliedToolStrictMode;
 	strictToolsApplied: boolean;
+	reasoningEffortFallbackAllowed: boolean;
 } {
 	const initialPolicy = resolveOpenAICompatForRequest(model, options, Boolean(context.tools?.length));
 	const initialCompat = initialPolicy.compat as ResolvedOpenAICompat;
@@ -1844,7 +1848,12 @@ function buildParams(
 	});
 	applyOpenAIChatCompletionsPromptCachePolicy(params, model, options);
 
-	return { params, toolStrictMode, strictToolsApplied };
+	return {
+		params,
+		toolStrictMode,
+		strictToolsApplied,
+		reasoningEffortFallbackAllowed: finalPolicy.reasoning.disableReason !== "tools",
+	};
 }
 
 export function parseChunkUsage(

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -786,7 +786,7 @@ export interface ChatCompletionsReasoningOptions {
 
 export type OpenAICompatEndpoint = "chat-completions" | "responses";
 
-export type OpenAIReasoningDisableReason = "caller" | "forced-tool-choice" | "tool-choice" | "not-requested";
+export type OpenAIReasoningDisableReason = "caller" | "forced-tool-choice" | "tool-choice" | "tools" | "not-requested";
 
 export type OpenAICompatPolicyCompat = ResolvedOpenAISharedCompat &
 	Partial<ResolvedOpenAICompat> &
@@ -798,6 +798,7 @@ export interface ResolveOpenAICompatPolicyOptions {
 	reasoning?: string;
 	disableReasoning?: boolean;
 	toolChoice?: unknown;
+	hasTools?: boolean;
 	strictResponsesPairing?: boolean;
 	includeEncryptedReasoning?: boolean;
 	filterReasoningHistory?: boolean;
@@ -905,12 +906,19 @@ export function resolveOpenAICompatPolicy<TApi extends Api>(
 		!forcedToolChoiceSuppressesReasoning &&
 		baseCompat.disableReasoningOnToolChoice &&
 		options.toolChoice !== undefined;
+	const toolsSuppressReasoning =
+		!forcedToolChoiceSuppressesReasoning &&
+		!anyToolChoiceSuppressesReasoning &&
+		baseCompat.disableReasoningWithTools &&
+		options.hasTools === true;
 	const requestedAndAllowed = requestedEffort !== undefined && !options.disableReasoning && modelSupported;
 	const conflictDisableReason: OpenAIReasoningDisableReason | undefined = forcedToolChoiceSuppressesReasoning
 		? "forced-tool-choice"
 		: anyToolChoiceSuppressesReasoning
 			? "tool-choice"
-			: undefined;
+			: toolsSuppressReasoning
+				? "tools"
+				: undefined;
 	const disableReason: OpenAIReasoningDisableReason | undefined = options.disableReasoning
 		? "caller"
 		: conflictDisableReason;
@@ -1168,7 +1176,7 @@ export function applyChatCompletionsReasoningParams(
 	params: OpenAICompletionsParams,
 	model: Model<"openai-completions">,
 	compat: ResolvedOpenAICompat,
-	options: (ChatCompletionsReasoningOptions & { toolChoice?: unknown }) | undefined,
+	options: (ChatCompletionsReasoningOptions & { toolChoice?: unknown; hasTools?: boolean }) | undefined,
 ): void {
 	const policy = resolveOpenAICompatPolicy(model, {
 		endpoint: "chat-completions",
@@ -1176,6 +1184,7 @@ export function applyChatCompletionsReasoningParams(
 		reasoning: options?.reasoning,
 		disableReasoning: options?.disableReasoning,
 		toolChoice: options?.toolChoice,
+		hasTools: options?.hasTools,
 	});
 	applyChatCompletionsCompatPolicy(params, policy);
 	if (

--- a/packages/ai/test/openai-completions-disable-reasoning.test.ts
+++ b/packages/ai/test/openai-completions-disable-reasoning.test.ts
@@ -100,6 +100,58 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 		expect(payload.reasoning).toBeUndefined();
 	});
 
+	it("sends reasoning_effort none for Azure Astra only when function tools are present", async () => {
+		const model = buildModel({
+			id: "gpt-6-astra",
+			name: "GPT-6 Astra",
+			api: "openai-completions",
+			provider: "azure",
+			baseUrl: "https://resource.openai.azure.com/openai/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 262_144,
+			maxTokens: 128_000,
+		});
+		const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+		streamOpenAICompletions(
+			model,
+			{
+				messages: testContext.messages,
+				tools: [
+					{
+						name: "read",
+						description: "Read a file",
+						parameters: { type: "object", properties: {} },
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				fetch: createMockFetchForQwen(resolve),
+				reasoning: "high",
+			},
+		);
+
+		const payload = await promise;
+		expect(payload.tools).toHaveLength(1);
+		expect(payload.reasoning_effort).toBe("none");
+
+		const { promise: noToolsPromise, resolve: resolveNoTools } = Promise.withResolvers<Record<string, unknown>>();
+		streamOpenAICompletions(model, testContext, {
+			apiKey: "test-key",
+			fetch: createMockFetchForQwen(resolveNoTools),
+			reasoning: "high",
+		});
+
+		const noToolsPayload = await noToolsPromise;
+		expect(noToolsPayload.tools).toBeUndefined();
+		expect(noToolsPayload.reasoning_effort).toBe("high");
+
+		const disabledPayload = await captureDisableReasoningPayload(model);
+		expect(disabledPayload.reasoning_effort).toBe("none");
+	});
+
 	// Additional requested tests for applyChatCompletionsReasoningParams dialect / behavior verification
 	it("sets OpenRouter thinking disabled when disableReasoning: true", async () => {
 		const model = buildModel({
@@ -280,7 +332,7 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 	});
 });
 
-function createMockFetchForQwen(resolve: (value: unknown) => void): FetchImpl {
+function createMockFetchForQwen(resolve: (value: Record<string, unknown>) => void): FetchImpl {
 	const fetchMock: FetchImpl = Object.assign(
 		async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
 			const payload = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<string, unknown>;

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -208,6 +208,21 @@ function createCompletionsModel(): Model<"openai-completions"> {
 	});
 }
 
+function createAzureAstraCompletionsModel(): Model<"openai-completions"> {
+	return buildModel({
+		id: "gpt-6-astra",
+		name: "GPT-6 Astra",
+		api: "openai-completions",
+		provider: "azure",
+		baseUrl: "https://resource.openai.azure.com/openai/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262_144,
+		maxTokens: 128_000,
+	});
+}
+
 function createResponsesModel(): Model<"openai-responses"> {
 	return buildModel({
 		id: "fallback-responses-reasoner",
@@ -298,6 +313,52 @@ describe("OpenAI reasoning effort fallback retry", () => {
 
 		expect(result.stopReason).toBe("stop");
 		expect(bodies.map(body => body.reasoning_effort)).toEqual(["xhigh", "max"]);
+	});
+
+	it("does not apply a cached enabled-effort fallback to tool-suppressed Azure Astra requests", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(init);
+				bodies.push(body);
+				return bodies.length === 1 ? invalidReasoningResponse("reasoning_effort", "max") : createChatSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const model = createAzureAstraCompletionsModel();
+
+		const first = await streamOpenAICompletions(model, testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "max",
+			providerSessionState,
+		}).result();
+		expect(first.stopReason).toBe("stop");
+
+		const second = await streamOpenAICompletions(
+			model,
+			{
+				messages: testContext.messages,
+				tools: [
+					{
+						name: "read",
+						description: "Read a file",
+						parameters: { type: "object", properties: {} },
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				reasoning: "max",
+				providerSessionState,
+			},
+		).result();
+
+		expect(second.stopReason).toBe("stop");
+		expect(bodies.map(body => body.reasoning_effort)).toEqual(["max", "high", "none"]);
+		expect(bodies[2]!.tools).toHaveLength(1);
 	});
 
 	it("retries Responses xhigh as provider max and stores the successful fallback params", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 
 - Fixed OpenCode Go/Zen live model discovery (`GET /v1/models`) missing `x-opencode-session` and omp's `User-Agent`: discovery requests now attribute with the stable install id so the requests OpenCode flags as `Bun fetch` carry the required session header.
+
+- Fixed Azure GPT-6 Astra Chat Completions policy to disable reasoning with function tools and encode thinking-off as `reasoning_effort: "none"` ([#11052](https://github.com/can1357/oh-my-pi/issues/11052)).
+
 ### Added
 
 - Added Muse Code as a provider with Muse Spark models and live account-scoped discovery.

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -93,6 +93,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"clamp-output-to-model-max": wire("clampOutputToModelMax", OAI),
 	"disable-reasoning-on-forced-tool-choice": wire("disableReasoningOnForcedToolChoice", OAI),
 	"disable-reasoning-on-tool-choice": wire("disableReasoningOnToolChoice", OAI),
+	"disable-reasoning-with-tools": wire("disableReasoningWithTools", ["openai"]),
 	"drop-thinking-when-reasoning-effort": wire("dropThinkingWhenReasoningEffort", ["openai"]),
 	"empty-length-finish-is-context-error": wire("emptyLengthFinishIsContextError", OAI),
 	"extra-body": { ...wire("extraBody", ["openai"], "object"), verbatimKeys: true },

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -483,6 +483,7 @@ function detectOpenAICompat(
 		disableReasoningOnForcedToolChoice:
 			!d.isClinePass && ((facts.is("kimi") && !isMoonshotKimiK3) || isAnthropicModel),
 		disableReasoningOnToolChoice: !d.isClinePass && isDeepseekFamily && Boolean(spec.reasoning) && !d.isOpenRouter,
+		disableReasoningWithTools: false,
 		supportsToolChoice: d.isClinePass || !d.isDirectDeepseekReasoning,
 		supportsForcedToolChoice:
 			!d.requiresEnabledThinking && !(d.isOpenCodeHost && d.isDeepseekReasoning) && !(d.isClinePass && isQwen),
@@ -729,6 +730,7 @@ function resolveOpenAIResponsesPolicy(
 		filterReasoningHistory: isOpenRouter && isAnthropicModel,
 		disableReasoningOnForcedToolChoice: facts.is("kimi"),
 		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
+		disableReasoningWithTools: false,
 		supportsToolChoice: true,
 		supportsForcedToolChoice: provider !== "opencode-go" && provider !== "opencode-zen",
 		supportsNamedToolChoice: true,

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7335,6 +7335,22 @@
 				}
 			},
 			{
+				"source": "providers/azure.kdl:21",
+				"providers": [
+					"azure"
+				],
+				"models": [
+					{
+						"kind": "glob",
+						"value": "gpt-6-astra*"
+					}
+				],
+				"wire": {
+					"disableReasoningWithTools": true,
+					"reasoningDisableMode": "none-effort"
+				}
+			},
+			{
 				"source": "providers/baseten.kdl:7",
 				"providers": [
 					"baseten"

--- a/packages/catalog/src/compat/rules/providers/azure.kdl
+++ b/packages/catalog/src/compat/rules/providers/azure.kdl
@@ -16,4 +16,10 @@ provider "azure" {
 	models "gpt-5.1-codex-mini" {
 		thinking-efforts "medium" "high"
 	}
+	// Azure Chat Completions rejects Astra reasoning whenever function tools are
+	// present; the documented escape hatch is an explicit `none` effort.
+	models "gpt-6-astra*" {
+		disable-reasoning-with-tools #true
+		reasoning-disable-mode "none-effort"
+	}
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -327,6 +327,12 @@ export interface OpenAICompat {
 	 * Default: auto-detected (DeepSeek reasoning models).
 	 */
 	disableReasoningOnToolChoice?: boolean;
+	/**
+	 * Disable reasoning whenever the request advertises function tools.
+	 * Use for model surfaces that reject every tools-plus-reasoning combination.
+	 * Default: false.
+	 */
+	disableReasoningWithTools?: boolean;
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
@@ -674,6 +680,7 @@ export interface ResolvedOpenAISharedCompat {
 	filterReasoningHistory: boolean;
 	disableReasoningOnForcedToolChoice: boolean;
 	disableReasoningOnToolChoice: boolean;
+	disableReasoningWithTools?: boolean;
 	supportsToolChoice: boolean;
 	supportsForcedToolChoice: boolean;
 	supportsNamedToolChoice: boolean;
@@ -751,6 +758,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "filterReasoningHistory"
 			| "disableReasoningOnForcedToolChoice"
 			| "disableReasoningOnToolChoice"
+			| "disableReasoningWithTools"
 			| "supportsToolChoice"
 			| "supportsForcedToolChoice"
 			| "supportsNamedToolChoice"

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -41,6 +41,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"supportsForcedToolChoice?": "boolean",
 		"disableReasoningOnForcedToolChoice?": "boolean",
 		"disableReasoningOnToolChoice?": "boolean",
+		"disableReasoningWithTools?": "boolean",
 		"thinkingFormat?": '"openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template"',
 		"qwenTemplateReasoningEffort?": "boolean",
 		"openRouterRouting?": OpenRouterRoutingSchema,


### PR DESCRIPTION
## Repro
An Azure `gpt-6-astra` model using `openai-completions` serializes `reasoning_effort: "high"` alongside function tools, reproducing Azure's HTTP 400. The regression command is `bun test packages/ai/test/openai-completions-disable-reasoning.test.ts`; before the fix its Azure case received `"high"` instead of the required `"none"`.

## Cause
`resolveOpenAICompatPolicy` in `packages/ai/src/providers/openai-shared.ts` could suppress reasoning for forced or explicit `tool_choice`, but had no policy input for advertised function tools. `packages/catalog/src/compat/rules/providers/azure.kdl` therefore could not express Astra's Chat Completions constraint that any tools-plus-reasoning request is invalid.

## Fix
- Add the `disable-reasoning-with-tools` catalog axis and apply it to Azure `gpt-6-astra*` with the `none-effort` disable mode.
- Thread function-tool presence through Chat Completions policy resolution so Astra requests serialize `reasoning_effort: "none"` while tool-free requests preserve the selected effort.
- Cover tools, tool-free reasoning, and explicit thinking-off payloads with a regression test; expose the compat field through `models.yml`.

## Verification
`bun test packages/ai/test/openai-completions-disable-reasoning.test.ts packages/catalog/test/compat-compile.test.ts packages/catalog/test/compat-conformance.test.ts packages/catalog/test/azure-provider.test.ts` passes: 32 tests, 65 assertions. `bun run check:ts` passes. `bun check` fails on `main` for an unrelated environment dependency: `audiopus_sys` cannot execute missing `cmake`; skipped the pre-publish gate.

Fixes #11052