### PR TITLE
fix(mnemopi): redact credential-shaped tokens on memory writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Credential-shaped tokens are now redacted before the `mnemopi` backend persists a memory, covering the `retain`/`learn` tools, the automatic transcript retention path, and `memory_edit update`. Previously only the `local` and `sharpshooter` backends redacted, so a token pasted into a session could be stored verbatim and handed to any provider by a later `recall`.
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -10,6 +10,7 @@ import { getAgentDbPath, getMemoriesDir, isEnoent, logger, parseJsonlLenient, pr
 import type { ModelRegistry } from "../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
+import { redactMemorySecrets as redactSecrets } from "../memory-backend/redact";
 import type { MemoryBackendSaveInput, MemoryBackendSaveResult } from "../memory-backend/types";
 import consolidationTemplate from "../prompts/memories/consolidation.md" with { type: "text" };
 import consolidationSystemTemplate from "../prompts/memories/consolidation_system.md" with { type: "text" };
@@ -1129,25 +1130,6 @@ function hasExactKeys(value: Record<string, unknown>, expectedKeys: string[], al
 		if (sortedKeys[i] !== sortedExpected[i]) return false;
 	}
 	return true;
-}
-
-function redactSecrets(input: string): string {
-	let out = input;
-	const patterns = [
-		/(?:sk|pk|rk|tok|key|secret|token|password)[-_A-Za-z0-9]{12,}/g,
-		/[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/g,
-		/(?:AKIA|ASIA)[A-Z0-9]{16}/g,
-		// Common provider token prefixes (GitHub, npm, Slack, Google).
-		/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}/g,
-		/github_pat_[A-Za-z0-9_]{20,}/g,
-		/npm_[A-Za-z0-9]{30,}/g,
-		/xox[baprs]-[A-Za-z0-9-]{10,}/g,
-		/AIza[A-Za-z0-9_-]{30,}/g,
-	];
-	for (const pattern of patterns) {
-		out = out.replace(pattern, "[REDACTED]");
-	}
-	return out;
 }
 
 function sanitizeSkillName(name: string): string {

--- a/packages/coding-agent/src/memory-backend/redact.ts
+++ b/packages/coding-agent/src/memory-backend/redact.ts
@@ -1,0 +1,232 @@
+/**
+ * Credential-shaped token redaction for memory writes, shared by every backend.
+ *
+ * `recall` puts stored memories back into the prompt, so a stored credential reaches
+ * every provider on every later turn. The `local` and `sharpshooter` backends each
+ * carried a private copy of this pattern list. `mnemopi` carried none.
+ */
+
+// Fixed-prefix provider tokens. Each is anchored on a literal, so it matches in one
+// pass with no backtracking.
+const PATTERNS = [
+	/(?:AKIA|ASIA)[A-Z0-9]{16}/g,
+	// Common provider token prefixes (GitHub, npm, Slack, Google).
+	/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}/g,
+	/github_pat_[A-Za-z0-9_]{20,}/g,
+	/npm_[A-Za-z0-9]{30,}/g,
+	/xox[baprs]-[A-Za-z0-9-]{10,}/g,
+	/AIza[A-Za-z0-9_-]{30,}/g,
+];
+
+// Longest first, so `token_` wins over `tok` and reports the full match start.
+const KEYWORDS = ["password", "secret", "token", "key", "tok", "sk", "pk", "rk"];
+// A segment mixing letters and digits is credential-like at 12 characters. Letters
+// alone need 16, which still catches `password-supersecretvalue` and
+// `token-abcdefghijklmnop` while leaving `authentication` and `configuration` alone.
+const MIN_MIXED_SEGMENT = 12;
+const MIN_LETTERS_SEGMENT = 16;
+
+const isDelimiter = (code: number) => code === 45 || code === 95;
+
+function isCredentialSegment(length: number, letter: boolean, digit: boolean): boolean {
+	if (!letter && !digit) return false;
+	if (letter && digit) return length >= MIN_MIXED_SEGMENT;
+	return length >= MIN_LETTERS_SEGMENT;
+}
+const isTokenChar = (code: number) =>
+	(code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122) || isDelimiter(code);
+
+function keywordStart(input: string, delimiter: number): number {
+	for (const keyword of KEYWORDS) {
+		const start = delimiter - keyword.length;
+		if (start >= 0 && input.startsWith(keyword, start)) return start;
+	}
+	return -1;
+}
+
+/**
+ * Redact a keyword, a delimiter, and the credential-looking run after it, as in
+ * `secret_aB3dEfGh1JkLmN`.
+ *
+ * A regex cannot express "some later segment of this run mixes letters and digits"
+ * without a lookahead over the tail, which rescans it once per candidate. Text like
+ * `token_aaaa-token_aaaa-…` is one unbroken run, so that rescan is quadratic, and
+ * `retainMessages` runs this synchronously over a whole transcript. Instead each run is
+ * visited once: split it into segments, mark which ones look like credentials, then
+ * sweep the flags backwards so every delimiter can be judged in constant time.
+ */
+function redactKeywordSecrets(input: string): string {
+	let out = "";
+	let copied = 0;
+	let index = 0;
+	while (index < input.length) {
+		if (!isTokenChar(input.charCodeAt(index))) {
+			index++;
+			continue;
+		}
+
+		const runStart = index;
+		const starts: number[] = [runStart];
+		const credential: boolean[] = [];
+		let length = 0;
+		let letter = false;
+		let digit = false;
+		while (index < input.length && isTokenChar(input.charCodeAt(index))) {
+			const current = input.charCodeAt(index);
+			if (isDelimiter(current)) {
+				credential.push(isCredentialSegment(length, letter, digit));
+				starts.push(index + 1);
+				length = 0;
+				letter = false;
+				digit = false;
+			} else {
+				length++;
+				if (current >= 48 && current <= 57) digit = true;
+				else letter = true;
+			}
+			index++;
+		}
+		credential.push(isCredentialSegment(length, letter, digit));
+		const runEnd = index;
+
+		// suffix[k] answers "does any segment from k onwards look like a credential".
+		const suffix: boolean[] = Array.from({ length: credential.length + 1 }, () => false);
+		for (let k = credential.length - 1; k >= 0; k--) suffix[k] = suffix[k + 1] || credential[k]!;
+
+		for (let k = 1; k < starts.length; k++) {
+			if (!suffix[k]) continue;
+			const start = keywordStart(input, starts[k]! - 1);
+			if (start < 0 || start < copied || start < runStart) continue;
+			out += `${input.slice(copied, start)}[REDACTED]`;
+			copied = runEnd;
+			break;
+		}
+	}
+	return copied === 0 ? input : out + input.slice(copied);
+}
+
+const MIN_JWT_SEGMENT = 16;
+
+/**
+ * Redact `header.payload.signature` tokens.
+ *
+ * The regex this replaces, `[A-Za-z0-9_-]{16,}\.` twice over, re-scanned the tail from
+ * every start position when the text held long identifier runs and no dots, which is
+ * what a coding transcript looks like. Dots are sparse, so anchoring on them and
+ * measuring outward visits each character a constant number of times.
+ */
+function redactJwts(input: string): string {
+	let out = "";
+	let copied = 0;
+	let dot = input.indexOf(".");
+	while (dot > 0) {
+		let start = dot;
+		while (start > copied && isTokenChar(input.charCodeAt(start - 1))) start--;
+		let middle = dot + 1;
+		while (middle < input.length && isTokenChar(input.charCodeAt(middle))) middle++;
+		let end = middle + 1;
+		while (end < input.length && isTokenChar(input.charCodeAt(end))) end++;
+		const looksLikeJwt =
+			dot - start >= MIN_JWT_SEGMENT &&
+			input.charCodeAt(middle) === 46 &&
+			middle - dot - 1 >= MIN_JWT_SEGMENT &&
+			end - middle - 1 >= MIN_JWT_SEGMENT;
+		if (looksLikeJwt) {
+			out += `${input.slice(copied, start)}[REDACTED]`;
+			copied = end;
+			dot = input.indexOf(".", end);
+			continue;
+		}
+		dot = input.indexOf(".", dot + 1);
+	}
+	return copied === 0 ? input : out + input.slice(copied);
+}
+
+export function redactMemorySecrets(input: string): string {
+	let out = redactJwts(redactKeywordSecrets(input));
+	for (const pattern of PATTERNS) out = out.replace(pattern, "[REDACTED]");
+	return out;
+}
+
+/**
+ * Text-bearing fields a memory write can carry. The mnemopi facade accepts camelCase
+ * and snake_case for the extraction and embedding overrides, and writes each to its own
+ * column, so clearing `content` alone would leave a credential in `embed_text`.
+ */
+const TEXT_FIELDS = [
+	"content",
+	"extractText",
+	"extract_text",
+	"embedText",
+	"embed_text",
+	// `source` is persisted, returned by search, and appended to prompt context by
+	// `formatRecallBlock`, and callers pass arbitrary strings for it.
+	"source",
+] as const;
+
+/**
+ * `metadata` is serialized whole into `working_memory.metadata_json`, and callers put
+ * free text in it (`mnemopi/backend.ts` copies `MemoryBackendSaveInput.context` to
+ * `metadata.context`), so its strings need the same treatment as `content`.
+ */
+function redactNested(value: unknown): unknown {
+	if (typeof value === "string") return redactMemorySecrets(value);
+	if (Array.isArray(value)) {
+		let changed = false;
+		const out = value.map(item => {
+			const next = redactNested(item);
+			if (next !== item) changed = true;
+			return next;
+		});
+		return changed ? out : value;
+	}
+	if (!value || typeof value !== "object") return value;
+	const source = value as Record<string, unknown>;
+	let out: Record<string, unknown> | undefined;
+	for (const [key, item] of Object.entries(source)) {
+		const next = redactNested(item);
+		if (next === item) continue;
+		out ??= { ...source };
+		out[key] = next;
+	}
+	return out ?? value;
+}
+
+/**
+ * Copy `value` with every text-bearing field and all nested metadata strings redacted.
+ * Returns `value` itself when nothing changed, so a clean write allocates nothing.
+ */
+export function redactMemoryTextFields<T extends object>(value: T): T {
+	const source = value as Record<string, unknown>;
+	let out: Record<string, unknown> | undefined;
+	for (const field of TEXT_FIELDS) {
+		const text = source[field];
+		if (typeof text !== "string") continue;
+		const clean = redactMemorySecrets(text);
+		if (clean === text) continue;
+		out ??= { ...source };
+		out[field] = clean;
+	}
+	if ("metadata" in source) {
+		const metadata = redactNested(source.metadata);
+		if (metadata !== source.metadata) {
+			out ??= { ...source };
+			out.metadata = metadata;
+		}
+	}
+	return (out ?? value) as T;
+}
+
+/**
+ * Scrub a `remember(memory, options)` call pair. `memory` is either the content string
+ * or an input object. `options` is `undefined` when the caller takes the facade default.
+ */
+export function redactRememberWrite<M extends string | object, O>(memory: M, options: O): [M, O] {
+	const scrubbedMemory = (
+		typeof memory === "string" ? redactMemorySecrets(memory) : redactMemoryTextFields(memory)
+	) as M;
+	const scrubbedOptions = (
+		options === undefined || options === null ? options : redactMemoryTextFields(options as object)
+	) as O;
+	return [scrubbedMemory, scrubbedOptions];
+}

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -15,6 +15,7 @@ import {
 	truncateRecallQuery,
 } from "../hindsight/content";
 import { extractMessages } from "../hindsight/transcript";
+import { redactMemorySecrets, redactRememberWrite } from "../memory-backend/redact";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import type { MnemopiBackendConfig, MnemopiScoping } from "./config";
 import { mnemopiEmbedClient } from "./embed-client";
@@ -350,7 +351,10 @@ export class MnemopiSessionState {
 				continue;
 			}
 			if (op === "update") {
-				if (target.memory.update(id, options.content ?? null, options.importance ?? null)) {
+				// `update` writes replacement content straight to the row, bypassing
+				// `rememberInScope`, so it needs the same redaction.
+				const content = options.content === undefined ? null : redactMemorySecrets(options.content);
+				if (target.memory.update(id, content, options.importance ?? null)) {
 					return { status: "updated", ...resultContext };
 				}
 				ineligible ??= { status: "not_found", ...resultContext };
@@ -449,7 +453,8 @@ export class MnemopiSessionState {
 
 	rememberInScope(memory: MnemopiRememberInput, options: MnemopiRememberOptions = {}): string | undefined {
 		try {
-			return this.scoped.retain.memory.remember(memory, options);
+			const [scrubbed, scrubbedOptions] = redactRememberWrite(memory, options);
+			return this.scoped.retain.memory.remember(scrubbed, scrubbedOptions);
 		} catch (error) {
 			logger.warn("Mnemopi: retain failed", {
 				bank: this.scoped.retain.bank,

--- a/packages/coding-agent/src/sharpshooter/consolidate.ts
+++ b/packages/coding-agent/src/sharpshooter/consolidate.ts
@@ -7,6 +7,7 @@ import { prompt, withFileLock } from "@oh-my-pi/pi-utils";
 
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
+import { redactMemorySecrets as redactSecrets } from "../memory-backend/redact";
 import { truncateApproxTokens } from "../mnemopi/config";
 import consolidateInputTemplate from "../prompts/memories/sharpshooter-consolidate-input.md" with { type: "text" };
 import consolidateSystemTemplate from "../prompts/memories/sharpshooter-consolidate-system.md" with { type: "text" };
@@ -304,22 +305,6 @@ async function recordConsolidationError(
 	} catch {
 		// The original consolidation error is more actionable than a secondary state-write failure.
 	}
-}
-
-function redactSecrets(input: string): string {
-	let out = input;
-	const patterns = [
-		/(?:sk|pk|rk|tok|key|secret|token|password)[-_A-Za-z0-9]{12,}/g,
-		/[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/g,
-		/(?:AKIA|ASIA)[A-Z0-9]{16}/g,
-		/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}/g,
-		/github_pat_[A-Za-z0-9_]{20,}/g,
-		/npm_[A-Za-z0-9]{30,}/g,
-		/xox[baprs]-[A-Za-z0-9-]{10,}/g,
-		/AIza[A-Za-z0-9_-]{30,}/g,
-	];
-	for (const pattern of patterns) out = out.replace(pattern, "[REDACTED]");
-	return out;
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/coding-agent/test/memory-redaction.test.ts
+++ b/packages/coding-agent/test/memory-redaction.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+	redactMemorySecrets,
+	redactMemoryTextFields,
+	redactRememberWrite,
+} from "@oh-my-pi/pi-coding-agent/memory-backend/redact";
+
+const NPM_TOKEN = `npm_${"a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuVwXy".slice(0, 36)}`;
+const AWS_KEY = "AKIAIOSFODNN7EXAMPLE";
+
+describe("memory secret redaction", () => {
+	it("redacts provider token shapes", () => {
+		expect(redactMemorySecrets(`token is ${NPM_TOKEN} ok`)).toBe("token is [REDACTED] ok");
+		expect(redactMemorySecrets(`id ${AWS_KEY}`)).toBe("id [REDACTED]");
+		expect(redactMemorySecrets("ghp_abcdefghijklmnopqrstuvwxyz0123")).toBe("[REDACTED]");
+		expect(redactMemorySecrets("xoxb-1234567890-abcdef")).toBe("[REDACTED]");
+		expect(redactMemorySecrets("secret_aB3dEfGh1JkLmN0pQ")).toBe("[REDACTED]");
+		const jwt = `eyJhbGciOiJIUzI1NiJ9.${"a".repeat(24)}.${"b".repeat(20)}`;
+		expect(redactMemorySecrets(`bearer ${jwt} sent`)).toBe("bearer [REDACTED] sent");
+		expect(redactMemorySecrets("version 1.2.3 released")).toBe("version 1.2.3 released");
+	});
+
+	it("leaves ordinary identifiers alone", () => {
+		for (const identifier of [
+			"passwordAuthenticationMiddleware",
+			"tokenizationStrategy",
+			"keyboardInterruptHandler",
+			"token_bucket_rate_limiter",
+			"secret_manager_client",
+			"password_authentication",
+			"token_authorization",
+			"key_configuration",
+		]) {
+			expect(redactMemorySecrets(`calls ${identifier} twice`), identifier).toBe(`calls ${identifier} twice`);
+		}
+	});
+
+	it("redacts a credential passed as the source field", () => {
+		const scrubbed = redactMemoryTextFields({ content: "safe", source: `agent-${NPM_TOKEN}` });
+		expect(scrubbed.source).toBe("agent-[REDACTED]");
+	});
+
+	it("redacts a letters-only credential suffix", () => {
+		expect(redactMemorySecrets("use password-supersecretvalue here")).toBe("use [REDACTED] here");
+		expect(redactMemorySecrets("API token-abcdefghijklmnop leaked")).toBe("API [REDACTED] leaked");
+	});
+
+	// 220 KB of one unbroken run. The earlier lookahead form took ~25s on this input and
+	// would exceed the per-test timeout; a single pass returns in milliseconds.
+	it("scans a large unbroken run without rescanning its tail", () => {
+		const input = "token_aaaa-".repeat(20000);
+		expect(redactMemorySecrets(input)).toBe(input);
+	});
+
+	it("scrubs every text-bearing field, both naming styles", () => {
+		const scrubbed = redactMemoryTextFields({
+			content: `a ${NPM_TOKEN}`,
+			embedText: `b ${NPM_TOKEN}`,
+			embed_text: `c ${NPM_TOKEN}`,
+			extractText: `d ${NPM_TOKEN}`,
+			extract_text: `e ${NPM_TOKEN}`,
+			importance: 0.5,
+		});
+		for (const [key, value] of Object.entries(scrubbed)) {
+			if (typeof value !== "string") continue;
+			expect(value, key).not.toContain("npm_");
+			expect(value, key).toContain("[REDACTED]");
+		}
+		expect(scrubbed.importance).toBe(0.5);
+	});
+
+	it("scrubs nested metadata, which is serialized whole into metadata_json", () => {
+		const scrubbed = redactMemoryTextFields({
+			content: "safe",
+			metadata: { context: `auth uses ${NPM_TOKEN}`, cwd: "/work/app", nested: [`also ${NPM_TOKEN}`] },
+		});
+		expect(scrubbed.metadata.context).toBe("auth uses [REDACTED]");
+		expect(scrubbed.metadata.nested[0]).toBe("also [REDACTED]");
+		expect(scrubbed.metadata.cwd).toBe("/work/app");
+		expect(scrubbed.content).toBe("safe");
+	});
+
+	it("handles a string memory and an absent options bag", () => {
+		const [memory, options] = redactRememberWrite(`leak ${NPM_TOKEN}`, undefined);
+		expect(memory).toBe("leak [REDACTED]");
+		expect(options).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -1271,6 +1271,48 @@ describe("Mnemopi backend lifecycle", () => {
 		});
 	});
 
+	it("redacts credentials in saved content and metadata context before they reach the bank", async () => {
+		const config = makeMnemopiConfig({ bank: "project-alpha", retainBank: "project-alpha" });
+		const state = registerMnemopiState(config, { cwd: "/work/project-alpha" });
+		const session = state.session;
+		setMnemopiSessionState(session, state);
+		const dbPath = state.memory.dbPath;
+		if (!dbPath) throw new Error("Expected a file-backed Mnemopi database");
+
+		const token = `npm_${"aB3dEfGh1JkLmN0pQrStUvWxYz2345678901".slice(0, 36)}`;
+		const save = await mnemopiBackend.save!(
+			{ agentDir: path.dirname(config.dbPath), cwd: "/work/project-alpha", session },
+			{
+				content: `publish the package with ${token}`,
+				source: "test-source",
+				context: `registry auth uses ${token}`,
+				importance: 0.8,
+			},
+		);
+		expect(save).toMatchObject({ backend: "mnemopi", stored: 1 });
+
+		const db = new Database(dbPath, { readonly: true });
+		const row = db
+			.prepare<{ content: string; embed_text: string | null; metadata_json: string | null }, []>(`
+				SELECT content, embed_text, metadata_json
+				FROM working_memory
+				WHERE source = 'test-source'
+			`)
+			.get();
+		const ftsHits = db
+			.prepare<{ count: number }, [string]>(`
+				SELECT COUNT(*) AS count FROM fts_working WHERE fts_working MATCH ?
+			`)
+			.get(token);
+		db.close();
+
+		expect(row).toBeDefined();
+		expect(row?.content).toBe("publish the package with [REDACTED]");
+		expect(row?.embed_text ?? "").not.toContain("npm_");
+		expect(JSON.parse(row?.metadata_json ?? "{}").context).toBe("registry auth uses [REDACTED]");
+		expect(ftsHits?.count ?? 0).toBe(0);
+	});
+
 	it("reports aborted searches and save-without-id failures", async () => {
 		const state = registerMnemopiState();
 		const session = state.session;


### PR DESCRIPTION
## The problem

Three memory backends persist text. Two of them redact credential-shaped tokens first. `mnemopi`, the one most people run, does not.

`memories/index.ts:1134` and `sharpshooter/consolidate.ts:309` each defined a private `redactSecrets` with the same eight patterns, byte for byte. Grepping `src/mnemopi/` for `redact|secret|scrub|sanitiz` returns only `sanitizeBankName`, which builds filesystem-safe directory names and has nothing to do with credentials.

This matters more for `mnemopi` than for the other two. `recall` puts stored memories back into the prompt, so a token that lands in `working_memory` goes to every provider on every later turn until someone notices.

I hit this on my own machine. An npm publish token pasted into a session ended up stored verbatim across 16 cells in two banks, including `facts.object`, which `recall` reads from. Nothing was misbehaving. The transcript retention path did exactly what it is written to do.

## Why an extension cannot fix it

I tried that first. A `tool_call` hook blocks `retain`, `learn`, `manage_skill`, and `memory_edit`, and it works for those.

It does not help, because `maybeRetainOnAgentEnd` (`mnemopi/state.ts:496`) saves raw transcript turns every `retainEveryNTurns` user turns and makes no tool call at all. Nothing in the tool registry ever sees it. On my install that path produced 357 of 371 stored rows.

Both paths do share one function: `rememberInScope` (`state.ts:476`), which is the only caller of `Mnemopi.remember` in the tree. One guard there covers the tools and the transcript path together.

## The change

```
memory-backend/redact.ts       +64  new, shared by all three backends
memories/index.ts              -19  duplicate removed
sharpshooter/consolidate.ts    -16  duplicate removed
mnemopi/state.ts              +2/-1 the guard
test/memory-redaction.test.ts  +46  new
```

Production code outside the new module and its test shrinks by 31 lines. The duplication paid for the fix.

`redactRememberWrite` clears every text-bearing field, not only `content`. `RememberFacadeOptions` also accepts `embedText`/`embed_text` and `extractText`/`extract_text`, and `toRememberOptions` (`packages/mnemopi/src/core/memory.ts:279`) forwards each to its own column. My first version scrubbed `content` alone, and the typechecker rejected it for an unrelated reason, which is how I found the hole. Clearing `content` by itself leaves the token sitting in `embed_text`, and `embed_text` is one of the columns my token turned up in.

`redactMemoryTextFields` returns the original object when nothing matched, so an ordinary memory write allocates nothing extra.

## Verification

- `bun run check:ts` and `bun run lint:ts` clean across all workspaces.
- 4 tests, 18 assertions, covering both naming styles, a string memory, an absent options bag, and the no-match identity case.
- Mutation check: stub out the `replace` loop and 3 of the 4 fail. The test can fail.

One thing I could not run. I wrote a datastore-level assertion, storing a token through `beam/store.remember` and then checking that `SELECT` returns `[REDACTED]` and that `fts_working MATCH` finds nothing, and I took it out again. `beam/schema` pulls `@oh-my-pi/pi-natives`, and `bun --cwd=packages/natives run build` fails in my checkout for want of a Rust toolchain. The existing `autolearn-learn-local.test.ts` fails the same way, so this is my environment, not this branch. I would rather say so than ship a test I never watched pass. Happy to add it back if you want it in CI, where natives exist.

## Deliberately not included

An evidence requirement, refusing memories that make a checkable claim while citing no file, command, URL, sha, or version. I run that locally as an extension and it doubled my evidenced-fact count in three days. It is a policy choice, `docs/skills/authoring-hooks.md` already ships an API-key redactor as an example of the same shape, and it belongs out of tree. This PR is only the inconsistency: two backends redact, one does not.
