### PR TITLE
fix(stt): implement CUDA GPU lease for concurrent local whisper workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ packages/coding-agent/bench/boot-baseline.json
 /.bazelrc.user
 
 .parity/
+scripts/reapply-stt-fix.sh

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -63,6 +63,9 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
+### Added
+
+- Added opt-in `stt.cudaLease` coordination so Linux OMP sessions and named profiles can safely transfer CUDA STT ownership without interrupting active transcription ([#11059](https://github.com/can1357/oh-my-pi/pull/11059) by [@Roden69](https://github.com/Roden69)).
 
 ## [18.1.12] - 2026-09-06
 
@@ -71,6 +74,7 @@
 ### Changed
 
 - Ranged reads of text without bracket characters skip unnecessary lexical context scanning.
+
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 - Transcript usage row now shows the prompt-to-yield time as a bare delta, keeping the clock icon for time to first token only.
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -34,6 +34,7 @@ import { extractProfileFlags } from "./cli/profile-bootstrap";
 import { startJsEvalProcess } from "./eval/js/process-entry";
 import type { WorkerInbound as JsWorkerInbound, WorkerOutbound as JsWorkerOutbound } from "./eval/js/worker-protocol";
 import { DAEMON_BROKER_WORKER_ARG } from "./launch/protocol";
+import { STT_WORKER_ARG } from "./stt/worker-config";
 import { TERMINAL_OUTPUT_WORKER_ARG } from "./launch/terminal-output-worker-protocol";
 import { LSP_MUX_WORKER_ARG } from "./lsp/mux/protocol";
 import { STATS_ACTIVITY_WORKER_ARG } from "./stats/activity-protocol";
@@ -139,7 +140,6 @@ const STATS_SYNC_WORKER_ARG = "__omp_worker_stats_sync";
 const TAB_WORKER_ARG = "__omp_worker_tab";
 const JS_EVAL_WORKER_ARG = "__omp_worker_js_eval";
 const JS_EVAL_PROCESS_ARG = "__omp_worker_js_eval_process";
-const STT_WORKER_ARG = "__omp_worker_stt";
 const TTS_WORKER_ARG = "__omp_worker_tts";
 const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2503,6 +2503,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"stt.cudaLease": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Speech",
+			label: "Share STT CUDA Device",
+			description:
+				"Let the active Linux OMP session evict an idle STT worker from CUDA; waits up to 15 seconds for active transcription before falling back to CPU",
+		},
+	},
+
 	"stt.language": {
 		type: "string",
 		default: "en",
@@ -6379,6 +6391,7 @@ export interface ThinkingBudgetsSettings {
 
 export interface SttSettings {
 	enabled: boolean;
+	cudaLease: boolean;
 	language: string | undefined;
 	modelName: string;
 	streaming: boolean;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -3088,6 +3088,9 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	"hindsight.bankIdPrefix": () => hindsightScopeSignal.fire(),
 	"hindsight.scoping": () => hindsightScopeSignal.fire(),
 	extendedContext: () => extendedContextSignal.fire(),
+	"stt.cudaLease": value => {
+		if (typeof value === "boolean") sttCudaLeaseSignal.fire(value);
+	},
 	"worktree.base": value => {
 		const dir = typeof value === "string" && value.trim() ? value : undefined;
 		// Always call so an unset/empty value clears a previously-applied override.
@@ -3109,6 +3112,17 @@ const appendOnlyModeSignal = new SettingSignal<[value: string]>("provider.append
  * can register independently without overwriting each other.
  */
 export const onAppendOnlyModeChanged = (cb: (value: string) => void) => appendOnlyModeSignal.on(cb);
+
+/** Fires when `stt.cudaLease` changes at runtime. */
+const sttCudaLeaseSignal = new SettingSignal<[value: boolean]>("stt.cudaLease");
+
+/**
+ * Subscribe to `stt.cudaLease` changes so the STT worker subprocess (which
+ * only samples the setting at spawn time via an env var) can be recreated
+ * with the new value. Returns an unsubscribe function.
+ */
+export const onSttCudaLeaseChanged: (cb: (value: boolean) => void) => () => void =
+	sttCudaLeaseSignal.on.bind(sttCudaLeaseSignal);
 
 /** Fires when any model role changes at runtime. */
 const modelRolesSignal = new SettingSignal("modelRoles");

--- a/packages/coding-agent/src/stt/asr-client.ts
+++ b/packages/coding-agent/src/stt/asr-client.ts
@@ -1,4 +1,5 @@
 import { logger } from "@oh-my-pi/pi-utils";
+import { onSttCudaLeaseChanged, settings } from "../config/settings";
 import {
 	createUnavailableWorker,
 	createWorkerHandle,
@@ -15,6 +16,8 @@ import { tinyWorkerEnv } from "../tiny/title-client";
 import { safeSend } from "../utils/ipc";
 import type { SttProgressEvent, SttWorkerInbound, SttWorkerOutbound } from "./asr-protocol";
 import type { SttModelKey } from "./models";
+import { STT_CUDA_LEASE_ENV, STT_WORKER_ARG } from "./worker-config";
+export * from "./worker-config";
 
 type PendingRequest =
 	| { kind: "transcribe"; modelKey: SttModelKey; resolve: (text: string) => void; reject: (error: Error) => void }
@@ -65,19 +68,21 @@ interface StreamState {
 }
 
 /**
- * Hidden subcommand on the main CLI that boots the speech-recognition worker in
- * the spawned subprocess. Kept in sync with the dispatch in `cli.ts`.
- */
-export const STT_WORKER_ARG = "__omp_worker_stt";
-
-/**
  * Spawn the speech worker as a subprocess. Exported for tests and the smoke
  * probe; production callers go through {@link spawnSttWorker}.
  */
 export function createSttSubprocess(): SpawnedSubprocess<SttWorkerOutbound> {
+	const env = tinyWorkerEnv();
+	if (env[STT_CUDA_LEASE_ENV] === undefined) {
+		try {
+			if (settings.get("stt.cudaLease")) env[STT_CUDA_LEASE_ENV] = "1";
+		} catch {
+			// Settings may be uninitialized during the compiled smoke test.
+		}
+	}
 	return createWorkerSubprocess<SttWorkerOutbound>({
 		spawnCommand: resolveWorkerSpawnCmd(STT_WORKER_ARG),
-		env: tinyWorkerEnv(),
+		env,
 		exitLabel: "stt subprocess",
 	});
 }
@@ -131,9 +136,27 @@ export class SttClient {
 	#nextRequestId = 0;
 	#refed = false;
 	#spawnWorker: () => RefCountedWorkerHandle<SttWorkerInbound, SttWorkerOutbound>;
+	#cudaLeaseSettingDirty = false;
 
 	constructor(spawnWorker: () => RefCountedWorkerHandle<SttWorkerInbound, SttWorkerOutbound> = spawnSttWorker) {
 		this.#spawnWorker = spawnWorker;
+		onSttCudaLeaseChanged(() => this.#handleCudaLeaseSettingChanged());
+	}
+
+	/**
+	 * `stt.cudaLease` is only sampled when the worker subprocess spawns (via
+	 * env var, since the worker has no direct settings access). Recreate an
+	 * idle worker immediately so the new value takes effect; a worker with
+	 * in-flight work is left alone until it goes idle to avoid interrupting
+	 * active transcription.
+	 */
+	#handleCudaLeaseSettingChanged(): void {
+		if (!this.#worker) return;
+		if (this.#pending.size > 0 || this.#streams.size > 0) {
+			this.#cudaLeaseSettingDirty = true;
+			return;
+		}
+		void this.terminate();
 	}
 
 	onProgress(listener: (event: SttProgressEvent) => void): () => void {
@@ -313,7 +336,10 @@ export class SttClient {
 		if (shouldRef === this.#refed) return;
 		this.#refed = shouldRef;
 		if (shouldRef) worker.ref();
-		else worker.unref();
+		else if (this.#cudaLeaseSettingDirty) {
+			this.#cudaLeaseSettingDirty = false;
+			void this.terminate();
+		} else worker.unref();
 	}
 
 	#handleMessage(message: SttWorkerOutbound): void {

--- a/packages/coding-agent/src/stt/asr-protocol.ts
+++ b/packages/coding-agent/src/stt/asr-protocol.ts
@@ -61,5 +61,7 @@ export type SttWorkerOutbound =
  */
 export interface SttTransport {
 	send(message: SttWorkerOutbound): void;
+	/** Awaits the underlying IPC write; use before releasing CUDA lease busy state. */
+	sendAndFlush(message: SttWorkerOutbound): Promise<void>;
 	onMessage(handler: (message: SttWorkerInbound) => void): () => void;
 }

--- a/packages/coding-agent/src/stt/asr-worker.ts
+++ b/packages/coding-agent/src/stt/asr-worker.ts
@@ -1,14 +1,15 @@
 import * as fs from "node:fs/promises";
-import { createRequire } from "node:module";
-import * as os from "node:os";
-import * as path from "node:path";
 import type {
 	AutomaticSpeechRecognitionOutput,
 	AutomaticSpeechRecognitionPipeline,
 	ProgressInfo,
 } from "@huggingface/transformers";
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
 	ensureRuntimeInstalled,
+	getGlobalDaemonRuntimeDir,
 	getTinyModelsCacheDir,
 	isCompiledBinary,
 	resolveRuntimeModule,
@@ -27,6 +28,8 @@ import {
 import { resolveTinyModelDevicePreference, type TinyModelDevice, tinyModelDeviceLoadOrder } from "../tiny/device";
 import { resolveTinyModelDtypeOverride, type TinyModelDtype } from "../tiny/dtype";
 import type { SttTransport, SttWorkerInbound } from "./asr-protocol";
+import { STT_CUDA_LEASE_ENV } from "./worker-config";
+import { CudaSttLease } from "./cuda-lease";
 import { type EndpointerEvent, StreamEndpointer } from "./endpointer";
 import {
 	getSttModelSpec,
@@ -54,6 +57,7 @@ const PROGRESS_EMIT_BYTES = 4_000_000;
 
 const sttModelDevicePreference = resolveTinyModelDevicePreference();
 const sttModelDtypeOverride = resolveTinyModelDtypeOverride();
+const sttCudaLeaseEnabled = process.env[STT_CUDA_LEASE_ENV] === "1";
 
 /**
  * Subset of the transformers.js ASR call options we set. The index signature
@@ -96,12 +100,40 @@ type LoadedModel =
 	| { engine: "sherpa"; recognizer: SherpaOfflineRecognizer };
 
 const models = new Map<SttModelKey, Promise<LoadedModel>>();
+
+/** Active CUDA lease for this worker, set as soon as ownership is claimed. */
+let activeCudaLease: CudaSttLease | undefined;
+let cudaLeaseActivityCount = 0;
+
+async function beginCudaLeaseActivity(): Promise<void> {
+	cudaLeaseActivityCount += 1;
+	if (cudaLeaseActivityCount === 1) await activeCudaLease?.markBusy();
+}
+
+async function endCudaLeaseActivity(): Promise<void> {
+	cudaLeaseActivityCount -= 1;
+	if (cudaLeaseActivityCount === 0) await activeCudaLease?.markIdle();
+}
+
+async function runWithCudaLeaseActivity<T>(work: () => Promise<T>): Promise<T> {
+	await beginCudaLeaseActivity();
+	try {
+		return await work();
+	} finally {
+		await endCudaLeaseActivity();
+	}
+}
+
 // Serialize all model inference on a single chain: the recognizers are not
 // guaranteed reentrant and there is one CPU-bound model per tier. Batch
 // transcribes and live-stream segment/partial decodes share this lock.
 let modelLock = Promise.resolve();
+// Different model keys may begin loading concurrently; serialize their pipeline
+// creation so they share one worker-level CUDA lease.
+let modelLoadLock = Promise.resolve();
 function runOnModel<T>(work: () => Promise<T>): Promise<T> {
-	const run = modelLock.then(work, work);
+	const wrappedWork = () => runWithCudaLeaseActivity(work);
+	const run = modelLock.then(wrappedWork, wrappedWork);
 	modelLock = run.then(
 		() => undefined,
 		() => undefined,
@@ -199,14 +231,39 @@ async function loadPipelineWithDeviceFallback(
 	}
 	for (let i = 0; i < devices.length; i += 1) {
 		const device = devices[i]!;
+		const fallbackDevice = devices[i + 1];
+		const usesCudaLease =
+			sttCudaLeaseEnabled &&
+			process.platform === "linux" &&
+			process.arch === "x64" &&
+			(device === "cuda" || device === "gpu" || device === "auto");
+		const existingCudaLease = activeCudaLease;
+		const cudaLease = usesCudaLease
+			? (existingCudaLease ?? new CudaSttLease(getGlobalDaemonRuntimeDir("stt-cuda")))
+			: undefined;
+		const acquiredCudaLease = cudaLease !== undefined && existingCudaLease === undefined;
 		try {
-			return {
-				pipeline: await loadPipelineOnDevice(transformers, spec, modelKey, transport, requestId, device),
-				device,
-			};
+			if (acquiredCudaLease) {
+				if (!(await cudaLease.claim(cudaLeaseActivityCount > 0))) {
+					if (!fallbackDevice) throw new Error("Unable to evict the current CUDA STT worker");
+					sendLog(transport, "warn", "stt: CUDA model is still owned by another instance; falling back", {
+						modelKey,
+						repo: spec.repo,
+						device,
+						fallbackDevice,
+					});
+					continue;
+				}
+				activeCudaLease = cudaLease;
+			}
+			const pipeline = await loadPipelineOnDevice(transformers, spec, modelKey, transport, requestId, device);
+			return { pipeline, device };
 		} catch (error) {
-			if (i === devices.length - 1) throw error;
-			const fallbackDevice = devices[i + 1]!;
+			if (acquiredCudaLease) {
+				if (activeCudaLease === cudaLease) activeCudaLease = undefined;
+				await cudaLease.release().catch(() => {});
+			}
+			if (!fallbackDevice) throw error;
 			sendLog(transport, "warn", "stt: accelerated device failed; falling back", {
 				modelKey,
 				repo: spec.repo,
@@ -225,31 +282,40 @@ async function loadTransformersModel(
 	transport: SttTransport,
 	requestId: string,
 ): Promise<LoadedModel> {
-	const transformers = await loadTransformersRuntime(
-		transformersRuntime,
-		transport,
-		requestId,
-		modelKey,
-		getSttRuntimeDir,
+	const loading = modelLoadLock.then(() =>
+		runWithCudaLeaseActivity(async (): Promise<LoadedModel> => {
+			const transformers = await loadTransformersRuntime(
+				transformersRuntime,
+				transport,
+				requestId,
+				modelKey,
+				getSttRuntimeDir,
+			);
+			const startedAt = performance.now();
+			const { pipeline, device } = await loadPipelineWithDeviceFallback(
+				transformers,
+				spec,
+				modelKey,
+				transport,
+				requestId,
+			);
+			sendLog(transport, "debug", "stt: local model loaded", {
+				modelKey,
+				repo: spec.repo,
+				engine: "transformers",
+				device,
+				requestedDevice: sttModelDevicePreference.device,
+				dtype: sttModelDtypeOverride ?? spec.dtype,
+				elapsedMs: Math.round(performance.now() - startedAt),
+			});
+			return { engine: "transformers", pipeline };
+		}),
 	);
-	const startedAt = performance.now();
-	const { pipeline, device } = await loadPipelineWithDeviceFallback(
-		transformers,
-		spec,
-		modelKey,
-		transport,
-		requestId,
+	modelLoadLock = loading.then(
+		() => undefined,
+		() => undefined,
 	);
-	sendLog(transport, "debug", "stt: local model loaded", {
-		modelKey,
-		repo: spec.repo,
-		engine: "transformers",
-		device,
-		requestedDevice: sttModelDevicePreference.device,
-		dtype: sttModelDtypeOverride ?? spec.dtype,
-		elapsedMs: Math.round(performance.now() - startedAt),
-	});
-	return { engine: "transformers", pipeline };
+	return loading;
 }
 
 /**
@@ -430,28 +496,32 @@ async function transcribeAudio(
 	modelKey: SttModelKey,
 	audio: Float32Array,
 	language: string | undefined,
-): Promise<string> {
+): Promise<void> {
 	const spec = getSttModelSpec(modelKey);
 	if (!spec) throw new Error(`Unknown stt model: ${modelKey}`);
 	const model = await loadModel(modelKey, transport, requestId);
-	return runOnModel(() => decodeSegment(model, spec, audio, language));
+	await runOnModel(async () => {
+		const text = await decodeSegment(model, spec, audio, language);
+		await transport.sendAndFlush({ type: "transcription", id: requestId, text });
+	});
 }
 
 async function handleBatchRequest(
 	transport: SttTransport,
 	request: Extract<SttWorkerInbound, { type: "transcribe" | "download" }>,
 ): Promise<void> {
-	try {
-		if (request.type === "download") {
-			await loadModel(request.modelKey, transport, request.id);
-			transport.send({ type: "downloaded", id: request.id });
-			return;
+	await runWithCudaLeaseActivity(async () => {
+		try {
+			if (request.type === "download") {
+				await loadModel(request.modelKey, transport, request.id);
+				await transport.sendAndFlush({ type: "downloaded", id: request.id });
+				return;
+			}
+			await transcribeAudio(transport, request.id, request.modelKey, request.audio, request.language);
+		} catch (error) {
+			await transport.sendAndFlush({ type: "error", id: request.id, error: errorText(error) });
 		}
-		const text = await transcribeAudio(transport, request.id, request.modelKey, request.audio, request.language);
-		transport.send({ type: "transcription", id: request.id, text });
-	} catch (error) {
-		transport.send({ type: "error", id: request.id, error: errorText(error) });
-	}
+	});
 }
 
 // ── Live streaming sessions ─────────────────────────────────────────
@@ -477,10 +547,10 @@ interface StreamingSession {
 
 const sessions = new Map<string, StreamingSession>();
 
-function startStreamingSession(
+async function startStreamingSession(
 	transport: SttTransport,
 	request: Extract<SttWorkerInbound, { type: "stream_start" }>,
-): void {
+): Promise<void> {
 	const spec = getSttModelSpec(request.modelKey);
 	if (!spec) {
 		transport.send({ type: "error", id: request.id, error: `Unknown stt model: ${request.modelKey}` });
@@ -500,6 +570,7 @@ function startStreamingSession(
 		cancelled: false,
 		ended: false,
 	});
+	await beginCudaLeaseActivity();
 }
 
 function ingestStreamEvents(session: StreamingSession, events: EndpointerEvent[]): void {
@@ -507,6 +578,14 @@ function ingestStreamEvents(session: StreamingSession, events: EndpointerEvent[]
 		if (event.kind === "segment") session.segmentQueue.push(event.audio);
 		else session.pendingPartial = event.audio;
 	}
+}
+
+async function finishStreamingSession(session: StreamingSession, transport: SttTransport): Promise<boolean> {
+	if (!session.ended || session.cancelled || session.segmentQueue.length > 0 || session.pendingPartial) return false;
+	await transport.sendAndFlush({ type: "stream_done", id: session.id, text: session.committed.join(" ") });
+	sessions.delete(session.id);
+	await endCudaLeaseActivity();
+	return true;
 }
 
 /**
@@ -524,45 +603,55 @@ async function pumpSession(session: StreamingSession, transport: SttTransport): 
 				const audio = session.segmentQueue.shift()!;
 				// A fresh segment supersedes any queued preview for the prior one.
 				session.pendingPartial = null;
-				const text = await runOnModel(() => decodeSegment(model, session.spec, audio, session.language));
-				if (session.cancelled) return;
-				if (text.length > 0) {
-					session.committed.push(text);
-					transport.send({ type: "segment", id: session.id, index: session.segmentIndex++, text });
-				}
+				const finished = await runOnModel(async () => {
+					const text = await decodeSegment(model, session.spec, audio, session.language);
+					if (session.cancelled) return false;
+					if (text.length > 0) {
+						session.committed.push(text);
+						await transport.sendAndFlush({ type: "segment", id: session.id, index: session.segmentIndex++, text });
+					}
+					return finishStreamingSession(session, transport);
+				});
+				if (finished || session.cancelled) return;
 				continue;
 			}
 			if (session.pendingPartial) {
 				const audio = session.pendingPartial;
 				session.pendingPartial = null;
-				const text = await runOnModel(() => decodeSegment(model, session.spec, audio, session.language));
-				if (session.cancelled) return;
-				// Skip a now-stale preview if a segment finalized mid-decode.
-				if (text.length > 0 && session.segmentQueue.length === 0) {
-					transport.send({ type: "partial", id: session.id, text });
-				}
+				const finished = await runOnModel(async () => {
+					const text = await decodeSegment(model, session.spec, audio, session.language);
+					if (session.cancelled) return false;
+					// Skip a now-stale preview if a segment finalized mid-decode.
+					if (text.length > 0 && session.segmentQueue.length === 0) {
+						await transport.sendAndFlush({ type: "partial", id: session.id, text });
+					}
+					return finishStreamingSession(session, transport);
+				});
+				if (finished || session.cancelled) return;
 				continue;
 			}
 			break;
 		}
-		if (session.ended && !session.cancelled && session.segmentQueue.length === 0 && !session.pendingPartial) {
-			transport.send({ type: "stream_done", id: session.id, text: session.committed.join(" ") });
-			sessions.delete(session.id);
+		if (session.ended && !session.cancelled) {
+			await runOnModel(async () => finishStreamingSession(session, transport));
 		}
 	} catch (error) {
-		if (!session.cancelled) transport.send({ type: "error", id: session.id, error: errorText(error) });
-		sessions.delete(session.id);
+		if (!session.cancelled) {
+			await transport.sendAndFlush({ type: "error", id: session.id, error: errorText(error) });
+			sessions.delete(session.id);
+			await endCudaLeaseActivity();
+		}
 	} finally {
 		session.pumping = false;
 	}
 }
 
-function handleStreamMessage(
+async function handleStreamMessage(
 	transport: SttTransport,
 	message: Extract<SttWorkerInbound, { type: "stream_start" | "stream_audio" | "stream_stop" | "stream_cancel" }>,
-): void {
+): Promise<void> {
 	if (message.type === "stream_start") {
-		startStreamingSession(transport, message);
+		await startStreamingSession(transport, message);
 		return;
 	}
 	const session = sessions.get(message.id);
@@ -581,6 +670,7 @@ function handleStreamMessage(
 		case "stream_cancel":
 			session.cancelled = true;
 			sessions.delete(message.id);
+			await endCudaLeaseActivity();
 			return;
 	}
 }
@@ -596,7 +686,7 @@ export function startSttWorker(transport: SttTransport): void {
 				void handleBatchRequest(transport, message);
 				return;
 			default:
-				handleStreamMessage(transport, message);
+				void handleStreamMessage(transport, message);
 				return;
 		}
 	});

--- a/packages/coding-agent/src/stt/cuda-lease.ts
+++ b/packages/coding-agent/src/stt/cuda-lease.ts
@@ -1,0 +1,207 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, withFileLock } from "@oh-my-pi/pi-utils";
+import { STT_WORKER_ARG } from "./worker-config";
+const POLL_MS = 25;
+const BUSY_WAIT_MS = 15_000;
+/**
+ * Maximum time to wait for a killed worker to disappear from the process table.
+ * If the OS takes longer than this to clean up the zombie process, the claim
+ * fails and the new instance gracefully falls back to CPU execution.
+ */
+const EVICTION_WAIT_MS = 2_000;
+
+export interface CudaLeaseProcessIdentity {
+	pid: number;
+	startTimeTicks: number;
+}
+
+interface CudaLeaseOwner extends CudaLeaseProcessIdentity {
+	busy?: boolean;
+}
+
+export interface CudaLeaseHost {
+	readonly pid: number;
+	readonly busyWaitMs: number;
+	getSttWorkerIdentity(pid: number): Promise<CudaLeaseProcessIdentity | null>;
+	killSttWorker(owner: CudaLeaseProcessIdentity): Promise<boolean>;
+	wait(ms: number): Promise<void>;
+}
+
+function sameProcess(left: CudaLeaseProcessIdentity, right: CudaLeaseProcessIdentity): boolean {
+	return left.pid === right.pid && left.startTimeTicks === right.startTimeTicks;
+}
+
+/** Parse Linux `/proc/<pid>/stat` field 22 without splitting the parenthesized command name. */
+export function parseProcStatStartTime(stat: string): number | null {
+	const commandEnd = stat.lastIndexOf(") ");
+	if (commandEnd < 0) return null;
+	const fields = stat
+		.slice(commandEnd + 2)
+		.trim()
+		.split(/\s+/);
+	if (!/^[A-Za-z]$/.test(fields[0] ?? "")) return null;
+	const rawStartTime = fields[19];
+	if (!rawStartTime || !/^\d+$/.test(rawStartTime)) return null;
+	const startTimeTicks = Number(rawStartTime);
+	return Number.isSafeInteger(startTimeTicks) && startTimeTicks > 0 ? startTimeTicks : null;
+}
+
+async function readSttWorkerIdentity(pid: number): Promise<CudaLeaseProcessIdentity | null> {
+	if (pid <= 1 || process.platform !== "linux") return null;
+	try {
+		const [stat, commandLine] = await Promise.all([
+			Bun.file(`/proc/${pid}/stat`).text(),
+			Bun.file(`/proc/${pid}/cmdline`).text(),
+		]);
+		if (!commandLine.split("\0").includes(STT_WORKER_ARG)) return null;
+		const startTimeTicks = parseProcStatStartTime(stat);
+		return startTimeTicks === null ? null : { pid, startTimeTicks };
+	} catch {
+		return null;
+	}
+}
+
+const processHost: CudaLeaseHost = {
+	pid: process.pid,
+	busyWaitMs: BUSY_WAIT_MS,
+	getSttWorkerIdentity: readSttWorkerIdentity,
+	async killSttWorker(owner) {
+		const current = await readSttWorkerIdentity(owner.pid);
+		if (!current || !sameProcess(current, owner)) return false;
+		try {
+			// onnxruntime-node's finalizer can crash Bun. Match the existing
+			// worker shutdown path and let the OS reclaim CUDA without running it.
+			process.kill(owner.pid, "SIGKILL");
+		} catch (error) {
+			if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) throw error;
+		}
+		return true;
+	},
+	wait: Bun.sleep,
+};
+
+async function readOwner(leasePath: string): Promise<CudaLeaseOwner | null> {
+	try {
+		const value = (await Bun.file(leasePath).json()) as Partial<CudaLeaseOwner>;
+		if (
+			!Number.isSafeInteger(value.pid) ||
+			value.pid! <= 1 ||
+			!Number.isSafeInteger(value.startTimeTicks) ||
+			value.startTimeTicks! <= 0
+		) {
+			return null;
+		}
+		return { pid: value.pid!, startTimeTicks: value.startTimeTicks!, busy: !!value.busy };
+	} catch (error) {
+		if (isEnoent(error) || error instanceof SyntaxError) return null;
+		throw error;
+	}
+}
+
+async function writeOwner(leasePath: string, owner: CudaLeaseOwner): Promise<void> {
+	await Bun.write(leasePath, JSON.stringify(owner));
+}
+
+/**
+ * Cross-process ownership for the CUDA-backed STT worker. The most recent
+ * claimant evicts a verified idle STT worker before taking ownership. Busy
+ * owners are allowed up to 15 seconds to finish; after that, the claimant
+ * leaves them running and falls back to CPU.
+ */
+export class CudaSttLease {
+	readonly #leasePath: string;
+	readonly #host: CudaLeaseHost;
+	#identity: CudaLeaseProcessIdentity | undefined;
+
+	constructor(cacheDir: string, host: CudaLeaseHost = processHost) {
+		this.#leasePath = path.join(cacheDir, "stt-cuda-owner.json");
+		this.#host = host;
+	}
+
+	async claim(busy = false): Promise<boolean> {
+		await fs.mkdir(path.dirname(this.#leasePath), { recursive: true, mode: 0o700 });
+		const claimant = await this.#host.getSttWorkerIdentity(this.#host.pid);
+		if (!claimant) return false;
+		const busyDeadline = Date.now() + this.#host.busyWaitMs;
+		for (;;) {
+			const outcome = await withFileLock(this.#leasePath, async () => {
+				const owner = await readOwner(this.#leasePath);
+				if (owner && sameProcess(owner, claimant)) {
+					if (busy && !owner.busy) await writeOwner(this.#leasePath, { ...claimant, busy: true });
+					this.#identity = claimant;
+					return "claimed";
+				}
+				if (owner && owner.pid !== claimant.pid) {
+					const current = await this.#host.getSttWorkerIdentity(owner.pid);
+					if (current && sameProcess(current, owner)) {
+						if (owner.busy) return "busy";
+						let evicted: boolean;
+						try {
+							evicted = await this.#host.killSttWorker(owner);
+						} catch (error) {
+							if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) throw error;
+							evicted = true;
+						}
+						if (evicted) {
+							const evictionDeadline = Date.now() + EVICTION_WAIT_MS;
+							while (Date.now() < evictionDeadline) {
+								const observed = await this.#host.getSttWorkerIdentity(owner.pid);
+								if (!observed || !sameProcess(observed, owner)) break;
+								await this.#host.wait(POLL_MS);
+							}
+							const observed = await this.#host.getSttWorkerIdentity(owner.pid);
+							if (observed && sameProcess(observed, owner)) return "unavailable";
+						}
+					}
+				}
+				await writeOwner(this.#leasePath, busy ? { ...claimant, busy: true } : claimant);
+				this.#identity = claimant;
+				return "claimed";
+			});
+
+			if (outcome === "claimed") return true;
+			if (outcome === "unavailable" || Date.now() >= busyDeadline) return false;
+			await this.#host.wait(Math.min(POLL_MS, busyDeadline - Date.now()));
+		}
+	}
+
+	/** Mark this lease as busy (mid-transcription). Other instances will wait. */
+	markBusy(): Promise<boolean> {
+		return this.#writeBusyState(true);
+	}
+
+	/** Mark this lease as idle (transcription finished). */
+	markIdle(): Promise<boolean> {
+		return this.#writeBusyState(false);
+	}
+
+	async #writeBusyState(busy: boolean): Promise<boolean> {
+		const identity = this.#identity;
+		if (!identity) return false;
+		try {
+			return await withFileLock(this.#leasePath, async () => {
+				const owner = await readOwner(this.#leasePath);
+				if (!owner || !sameProcess(owner, identity)) return false;
+				await writeOwner(this.#leasePath, busy ? { ...identity, busy: true } : identity);
+				return true;
+			});
+		} catch {
+			// Lease metadata is advisory. Never reject otherwise healthy STT
+			// inference or replace a successfully computed transcript.
+			return false;
+		}
+	}
+
+	async release(): Promise<void> {
+		const identity = this.#identity;
+		if (!identity) return;
+		await withFileLock(this.#leasePath, async () => {
+			const owner = await readOwner(this.#leasePath);
+			if (owner && sameProcess(owner, identity)) {
+				await Bun.file(this.#leasePath).delete();
+			}
+			if (this.#identity === identity) this.#identity = undefined;
+		});
+	}
+}

--- a/packages/coding-agent/src/stt/worker-config.ts
+++ b/packages/coding-agent/src/stt/worker-config.ts
@@ -1,0 +1,5 @@
+/** Hidden CLI argument that dispatches the STT worker subprocess. */
+export const STT_WORKER_ARG = "__omp_worker_stt";
+
+/** Worker environment flag enabling cross-process CUDA lease eviction. */
+export const STT_CUDA_LEASE_ENV = "PI_STT_CUDA_LEASE";

--- a/packages/coding-agent/test/stt-cuda-lease.test.ts
+++ b/packages/coding-agent/test/stt-cuda-lease.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	CudaSttLease,
+	type CudaLeaseHost,
+	type CudaLeaseProcessIdentity,
+	parseProcStatStartTime,
+} from "@oh-my-pi/pi-coding-agent/stt/cuda-lease";
+
+interface TestHost extends CudaLeaseHost {
+	readonly killed: number[];
+}
+
+function identity(pid: number, startTimeTicks = pid * 100): CudaLeaseProcessIdentity {
+	return { pid, startTimeTicks };
+}
+
+function owner(pid: number, busy = false): CudaLeaseProcessIdentity & { busy?: boolean } {
+	return busy ? { ...identity(pid), busy: true } : identity(pid);
+}
+
+function createHost(pid: number, liveWorkers: Set<number>, busyWaitMs = 100): TestHost {
+	const killed: number[] = [];
+	return {
+		pid,
+		killed,
+		busyWaitMs,
+		getSttWorkerIdentity: async candidate => (liveWorkers.has(candidate) ? identity(candidate) : null),
+		async killSttWorker(candidate) {
+			const current = liveWorkers.has(candidate.pid) ? identity(candidate.pid) : null;
+			if (!current || current.startTimeTicks !== candidate.startTimeTicks) return false;
+			killed.push(candidate.pid);
+			liveWorkers.delete(candidate.pid);
+			return true;
+		},
+		wait: async () => {},
+	};
+}
+
+describe("CUDA STT lease", () => {
+	let cacheDir = "";
+
+	beforeEach(async () => {
+		cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-stt-cuda-lease-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(cacheDir, { recursive: true, force: true });
+	});
+
+	it("parses process start time when the proc stat command contains spaces and parentheses", () => {
+		const fields = ["S", ...Array.from({ length: 18 }, () => "0"), "987654", "0"];
+		expect(parseProcStatStartTime(`321 (worker (cuda) name) ${fields.join(" ")}`)).toBe(987654);
+		expect(parseProcStatStartTime("321 malformed")).toBeNull();
+	});
+
+	it("evicts the prior verified STT worker and transfers ownership to the latest claimant", async () => {
+		const liveWorkers = new Set([101, 202]);
+		const firstHost = createHost(101, liveWorkers);
+		const secondHost = createHost(202, liveWorkers);
+		const first = new CudaSttLease(cacheDir, firstHost);
+		const second = new CudaSttLease(cacheDir, secondHost);
+
+		expect(await first.claim()).toBe(true);
+		expect(await second.claim()).toBe(true);
+		expect(secondHost.killed).toEqual([101]);
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(202));
+
+		await first.release();
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(202));
+	});
+
+	it("never terminates a legacy owner without a verified process incarnation", async () => {
+		await Bun.write(path.join(cacheDir, "stt-cuda-owner.json"), JSON.stringify({ pid: 303 }));
+		const liveWorkers = new Set([303, 404]);
+		const host = createHost(404, liveWorkers);
+		const lease = new CudaSttLease(cacheDir, host);
+
+		expect(await lease.claim()).toBe(true);
+		expect(host.killed).toEqual([]);
+		expect(liveWorkers.has(303)).toBe(true);
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(404));
+	});
+
+	it("does not terminate a new STT worker that reused the recorded PID", async () => {
+		const liveWorkers = new Set([101, 202]);
+		const first = new CudaSttLease(cacheDir, createHost(101, liveWorkers));
+		expect(await first.claim()).toBe(true);
+
+		const secondHost = createHost(202, liveWorkers);
+		secondHost.getSttWorkerIdentity = async candidate => {
+			if (!liveWorkers.has(candidate)) return null;
+			return candidate === 101 ? identity(101, 999_999) : identity(candidate);
+		};
+		const second = new CudaSttLease(cacheDir, secondHost);
+
+		expect(await second.claim()).toBe(true);
+		expect(secondHost.killed).toEqual([]);
+		expect(liveWorkers.has(101)).toBe(true);
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(202));
+	});
+
+	it("treats an owner that vanishes before SIGKILL as already evicted", async () => {
+		const liveWorkers = new Set([101, 202]);
+		const first = new CudaSttLease(cacheDir, createHost(101, liveWorkers));
+		expect(await first.claim()).toBe(true);
+
+		const host = createHost(202, liveWorkers);
+		host.killSttWorker = async candidate => {
+			liveWorkers.delete(candidate.pid);
+			const error = new Error("No such process") as NodeJS.ErrnoException;
+			error.code = "ESRCH";
+			throw error;
+		};
+		const second = new CudaSttLease(cacheDir, host);
+
+		expect(await second.claim()).toBe(true);
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(202));
+	});
+
+	it("waits for a busy owner to finish before evicting", async () => {
+		const liveWorkers = new Set([101, 202]);
+		const firstHost = createHost(101, liveWorkers);
+		const first = new CudaSttLease(cacheDir, firstHost);
+		expect(await first.claim()).toBe(true);
+		expect(await first.markBusy()).toBe(true);
+
+		const ownerFile = path.join(cacheDir, "stt-cuda-owner.json");
+		expect(await Bun.file(ownerFile).json()).toEqual(owner(101, true));
+
+		let polls = 0;
+		const secondHost = createHost(202, liveWorkers, 500);
+		secondHost.wait = async () => {
+			polls++;
+			if (polls === 3) await first.markIdle();
+		};
+		const second = new CudaSttLease(cacheDir, secondHost);
+		expect(await second.claim()).toBe(true);
+		expect(polls).toBeGreaterThanOrEqual(3);
+		expect(secondHost.killed).toEqual([101]);
+		expect(await Bun.file(ownerFile).json()).toEqual(owner(202));
+	});
+
+	it("falls back without evicting when a busy owner exceeds the wait deadline", async () => {
+		const liveWorkers = new Set([101, 202]);
+		const firstHost = createHost(101, liveWorkers);
+		const first = new CudaSttLease(cacheDir, firstHost);
+		expect(await first.claim(true)).toBe(true);
+
+		const secondHost = createHost(202, liveWorkers);
+		const second = new CudaSttLease(cacheDir, secondHost);
+		expect(await second.claim()).toBe(false);
+		expect(secondHost.killed).toEqual([]);
+		expect(await Bun.file(path.join(cacheDir, "stt-cuda-owner.json")).json()).toEqual(owner(101, true));
+	});
+
+	it("makes state updates non-throwing when lease metadata becomes unavailable", async () => {
+		const host = createHost(999, new Set([999]));
+		const lease = new CudaSttLease(cacheDir, host);
+		expect(await lease.claim()).toBe(true);
+
+		await fs.rm(cacheDir, { recursive: true, force: true });
+		await Bun.write(cacheDir, "not a directory");
+
+		expect(await lease.markBusy()).toBe(false);
+		expect(await lease.markIdle()).toBe(false);
+	});
+
+	it("resolves concurrent claims cleanly for three windows", async () => {
+		const liveWorkers = new Set([10, 20, 30]);
+		const host10 = createHost(10, liveWorkers);
+		const host20 = createHost(20, liveWorkers);
+		const host30 = createHost(30, liveWorkers);
+		const lease10 = new CudaSttLease(cacheDir, host10);
+		const lease20 = new CudaSttLease(cacheDir, host20);
+		const lease30 = new CudaSttLease(cacheDir, host30);
+
+		const results = await Promise.all([lease10.claim(), lease20.claim(), lease30.claim()]);
+		expect(results).toEqual([true, true, true]);
+
+		const finalOwner = (await Bun.file(
+			path.join(cacheDir, "stt-cuda-owner.json"),
+		).json()) as CudaLeaseProcessIdentity;
+		expect([10, 20, 30]).toContain(finalOwner.pid);
+		const totalKills = host10.killed.length + host20.killed.length + host30.killed.length;
+		expect(totalKills).toBe(2);
+		expect(liveWorkers.has(finalOwner.pid)).toBe(true);
+		expect(liveWorkers.size).toBe(1);
+	});
+});


### PR DESCRIPTION
I noticed that when opening a second OMP terminal, the new instance couldn't use the GPU for STT and fell back to the slow CPU because the first terminal was still holding the VRAM. To fix this, I added a file-based lease so the most recently used terminal takes over the GPU.

I reviewed the full diff and tested it locally. This change adds the opt-in `stt.cudaLease` setting. When enabled, Linux OMP instances coordinate a single CUDA-backed STT model across processes and named profiles; a claimant waits for active transcription to finish before evicting an idle STT worker.

**Verification:**
- Launched two separate OMP terminals on Linux (RTX 3050, 4GB VRAM).
- Terminal A started transcription and allocated about 2.2GB VRAM.
- Terminal B requested STT while A was still transcribing. B waited until A emitted its transcription, then the CUDA model transferred to B.
- The evicted STT subprocess exited via `SIGKILL`; the parent OMP session remained running and can spawn a fresh worker on its next STT request.
- Verified the handoff timings via `nvidia-smi` and internal `.omp/logs`.
- Ran the focused STT/settings suites (151 tests), `bun run check:types`, LSP diagnostics, Oxlint, and the compiled `omp --smoke-test`; all passed.

Resolves #11040
Resolves #11041

---

**Architectural Note / Future Work:**
The opt-in lease mechanism is restricted to Linux (`process.platform === "linux"` and `/proc` PID verification). It targets resource-constrained GPUs such as my laptop's 4GB RTX 3050, where one Whisper Turbo pipeline consumes about 2.2GB VRAM and another process otherwise falls back to CPU.

The lease is stored in a profile-independent runtime directory, so named profiles coordinate the same GPU owner. A busy owner gets up to 15 seconds to finish; if it remains busy, the claimant preserves the active transcription and falls back to CPU rather than killing it.

This last-active-wins design is the narrowly scoped compromise for the current per-process worker architecture, but it still incurs a roughly 2.5–3.5 second CUDA/model reload during ownership transfer.

A shared, profile-independent STT daemon is the correct long-term architecture if seamless multi-session GPU sharing is required: it would retain one model and CUDA context in VRAM, serialize requests from every OMP client, and exit after the final client disconnects. That is intentionally outside this PR because it is a substantially larger subsystem change requiring a dedicated binary audio protocol, request multiplexing, cancellation and backpressure, crash recovery, lifecycle handling, packaging/smoke coverage, and prior maintainer design agreement.