### PR TITLE
fix(tui): refresh argument completions after spaces

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Extension command argument completions now refresh after typing a Space when the previous argument had no suggestions. ([#11060](https://github.com/can1357/oh-my-pi/issues/11060))
+
 ## [18.1.12] - 2026-09-06
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2271,6 +2271,10 @@ export class Editor implements Component, Focusable {
 			else if (char === "#") {
 				this.#tryTriggerAutocomplete();
 			}
+			// Argument providers may expose candidates only after a separator.
+			else if (char === " " && this.#isInSubmittedSlashCommandContext()) {
+				this.#tryTriggerAutocomplete();
+			}
 			// Also auto-trigger when typing letters/path chars in a completable context
 			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -72,6 +72,41 @@ describe("Editor async autocomplete scheduling", () => {
 	});
 });
 
+describe("Editor slash argument autocomplete", () => {
+	it("re-evaluates a closed popup after typing an argument separator", async () => {
+		const argumentPrefixes: string[] = [];
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{
+						name: "probe",
+						getArgumentCompletions(argumentPrefix) {
+							argumentPrefixes.push(argumentPrefix);
+							return /^\S+\s/.test(argumentPrefix) ? [{ value: "scope", label: "scope" }] : null;
+						},
+					},
+				],
+				"/tmp",
+			),
+		);
+
+		editor.handleInput("/");
+		await untilAutocompleteShown(editor);
+		const popupClosed = onceAutocompleteUpdate(editor);
+		for (const char of "probe a") editor.handleInput(char);
+		await popupClosed;
+		expect(editor.isShowingAutocomplete()).toBeFalse();
+		expect(argumentPrefixes).toEqual(["a"]);
+
+		const popupOpened = onceAutocompleteUpdate(editor);
+		editor.handleInput(" ");
+		await popupOpened;
+		expect(argumentPrefixes).toEqual(["a", "a "]);
+		expect(editor.isShowingAutocomplete()).toBeTrue();
+	});
+});
+
 class HashActionProvider implements AutocompleteProvider {
 	async getSuggestions(
 		lines: string[],


### PR DESCRIPTION
## Repro
Typing `/probe a`, waiting for the extension argument provider to return `null` and close the popup, then typing one Space left `/probe a ` without another provider call. Reproduced with `bun /tmp/omp-11060-editor-repro.ts`, which drives each character through `Editor.handleInput`.

## Cause
`Editor.#insertCharacter` in `packages/tui/src/components/editor.ts` only started a closed-popup autocomplete request for `/`, `@`, `#`, or word/path characters. A Space inside a submitted slash command bypassed every trigger, so the registered argument provider never saw the new argument boundary.

## Fix
- Re-trigger regular autocomplete when Space is typed in a submitted slash-command context.
- Add an editor regression test that first closes the popup on a free-form value, then types Space and verifies the provider receives the trailing-space prefix.
- Document the user-visible fix in the TUI changelog.

## Verification
`bun test packages/tui/test/editor-autocomplete-actions.test.ts` — 41 passed, 0 failed. Manual editor-path reproduction changed from `popup:false, calls:["a"]` after Space to `popup:true, calls:["a","a "]`.

Fixes #11060