### PR TITLE
fix(advisor): preserve and report deferred advice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+- Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+- Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -9,7 +9,7 @@ import type {
 } from "@oh-my-pi/pi-agent-core";
 import { escapeXmlAttribute, escapeXmlText } from "@oh-my-pi/pi-utils";
 import adviseDescription from "../prompts/advisor/advise-tool.md" with { type: "text" };
-import { normalizeAdvisorNote } from "./emission-guard";
+import { type AdvisorEmissionDecision, normalizeAdvisorNote } from "./emission-guard";
 
 const adviseSchema = type({
 	note: type("string").describe(
@@ -174,6 +174,13 @@ function advisorSeverityRank(severity: AdvisorSeverity | undefined): number {
 	return ADVISOR_SEVERITY_RANK[severity ?? "nit"];
 }
 
+const ADVISOR_RESULT_TEXT: Record<AdvisorEmissionDecision, string> = {
+	accepted: "Recorded.",
+	duplicate: "Duplicate advice ignored.",
+	rate_limited: "Rate limited — only one note accepted per update. Re-raise this note on the next update.",
+	suppressed_noise: "Ignored — advice is empty or non-actionable.",
+};
+
 export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails> {
 	readonly name = "advise";
 	readonly label = "Advise";
@@ -196,21 +203,21 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	/**
 	 * @param onAdvice Route an accepted note to the primary (channel selection +
 	 *   delivery). Never re-filters — the note already cleared `accept`.
-	 * @param accept The emission guard's noise/empty/dedupe filter plus the
-	 *   one-advise-per-update budget, consumed the moment a note is emitted
-	 *   (live or deferred). A suppressed note returns `false` without spending
-	 *   the budget, so it cannot burn an update's slot ahead of a real concern.
-	 *   Defaults to always-accept for standalone use/tests without a guard.
+	 * @param accept The emission guard's noise/empty/dedupe classification plus
+	 *   the one-advise-per-update budget, consumed the moment a note is emitted
+	 *   (live or deferred). A rejected note reports the specific reason without
+	 *   spending the budget. Defaults to accepted for standalone use/tests.
 	 */
 	constructor(
 		private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void,
-		private readonly accept: (note: string) => boolean = () => true,
+		private readonly accept: (note: string, severity?: AdviseDetails["severity"]) => AdvisorEmissionDecision = () =>
+			"accepted",
 	) {}
 
 	/**
-	 * Mark whether the next advisor prompt reviews an in-progress primary turn.
-	 * Non-blockers are withheld until a completed update so partial work does
-	 * not interrupt the primary before it can finish its planned steps.
+	 * Synchronize the primary turn state. Non-blockers are withheld while a turn
+	 * is in progress; the first completed boundary flushes them even when the
+	 * advisor runtime cannot dispatch another prompt.
 	 */
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
@@ -248,22 +255,27 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 			// reached the primary, so it never re-raised and the advice was lost.
 			const key = advisorNoteDedupeKey(args.note);
 			const pending = this.#deferredNotes.find(item => item.key === key);
+			let decision: AdvisorEmissionDecision = "accepted";
 			if (pending) {
 				// Escalating an already-queued note reuses its slot; never a new one.
 				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
 					pending.severity = args.severity;
-			} else if (this.accept(args.note)) {
-				// Reserve the update's one slot now (the emission guard filters noise
-				// and enforces the per-update budget at the moment the note is emitted,
-				// exactly like the live path); hold it for the flush. A suppressed or
-				// over-budget note fails `accept` here and is dropped without a slot.
-				this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
+			} else {
+				decision = this.accept(args.note, args.severity);
+				if (decision === "accepted") {
+					// Reserve the update's one slot now; the flush routes it without
+					// consuming a second slot.
+					this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
+				}
 			}
 			return {
 				content: [
 					{
 						type: "text",
-						text: "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point.",
+						text:
+							decision === "accepted"
+								? "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point."
+								: ADVISOR_RESULT_TEXT[decision],
 					},
 				],
 				details: { note: args.note, severity: args.severity },
@@ -279,28 +291,25 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		const key = advisorNoteDedupeKey(args.note);
 		const reservedIndex = this.#deferredNotes.findIndex(item => item.key === key);
 		if (reservedIndex !== -1) this.#deferredNotes.splice(reservedIndex, 1);
-		const delivered = this.#deliver(args.note, args.severity, reservedIndex !== -1);
+		const decision = this.#deliver(args.note, args.severity, reservedIndex !== -1);
 		return {
-			content: [{ type: "text", text: delivered ? "Recorded." : "Duplicate advice ignored." }],
+			content: [{ type: "text", text: ADVISOR_RESULT_TEXT[decision] }],
 			details: { note: args.note, severity: args.severity },
 			useless: true,
 		};
 	}
 
-	/** Run one note through the escalation-rank dedupe and, if it passes, route it
-	 *  to the primary. Returns true when the note was actually delivered. Shared by
-	 *  the live path (`execute`) and the deferred flush (`beginUpdate(false)`). */
-	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): boolean {
+	/** Run one note through the escalation-rank dedupe and emission policy before
+	 *  routing it. Returns the exact policy outcome for truthful tool feedback. */
+	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): AdvisorEmissionDecision {
 		const key = advisorNoteDedupeKey(note);
 		const rank = advisorSeverityRank(severity);
 		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
-		if (rank <= previousRank) return false;
-		// Live notes clear the emission guard here; deferred notes already cleared
-		// it when reserved, so the flush passes `alreadyAccepted` to avoid a second
-		// (budget-consuming, dedupe-rejecting) pass.
-		if (!alreadyAccepted && !this.accept(note)) return false;
+		if (rank <= previousRank) return "duplicate";
+		const decision = alreadyAccepted ? "accepted" : this.accept(note, severity);
+		if (decision !== "accepted") return decision;
 		this.#deliveredNoteSeverities.set(key, rank);
 		this.onAdvice(note, severity);
-		return true;
+		return "accepted";
 	}
 }

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -11,14 +11,10 @@
  * 114× `Stop.`, 52× `No issue; continue.`, 41× `Done.` — flooding the primary
  * transcript with `<advisory severity="blocker">Stop.</advisory>` after the
  * task was already complete. The fix is to make the rules load-bearing in code
- * instead of prose: silently drop duplicates, content-free self-talk, and
- * over-budget calls at the `enqueueAdvice` boundary so the primary stays
- * clean even when the advisor misbehaves.
- *
- * The gate is intentionally invisible to the advisor model — `AdviseTool`
- * still returns `Recorded.` for a suppressed call. Surfacing "suppressed"
- * back into advisor context risks the model rephrasing the same useless note
- * to bypass the dedupe ("Stop.", then "Halt." then "Stop now.").
+ * instead of prose: classify duplicates, content-free self-talk, and over-budget
+ * calls at the emission boundary so the primary stays clean even when the advisor
+ * misbehaves. `AdviseTool` reports the resulting decision; in particular, an
+ * actionable over-budget note is told to retry instead of being falsely recorded.
  */
 
 /**
@@ -100,6 +96,9 @@ const SUPPRESSED_NORMALIZED_PHRASES: Record<string, true> = {
  */
 const DEFAULT_HISTORY_CAPACITY = 4096;
 
+/** Why an advisor note was accepted or rejected by the emission policy. */
+export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" | "suppressed_noise";
+
 /**
  * Decides whether an advisor `advise()` call should reach the primary agent.
  *
@@ -146,25 +145,14 @@ export class AdvisorEmissionGuard {
 	}
 
 	/**
-	 * Whether the proposed note should reach the primary. On `true` the gate
-	 * has already recorded the note (consumed the per-update budget and added
-	 * it to the dedupe history) — caller delivers the note. On `false` the
-	 * caller drops it.
-	 *
-	 * The single authority for the one-advise-per-update budget: called at the
-	 * moment a note is emitted, whether it is delivered live or held for a
-	 * deferred flush. A note that fails the noise/empty/dedupe filter never
-	 * consumes the budget, so a suppressed phrase cannot burn the update's slot
-	 * ahead of a substantive concern. Empty / whitespace-only notes are
-	 * suppressed defensively even though the tool-args contract requires a
-	 * non-empty string.
+	 * Classify and reserve a proposed note. Accepted notes consume the update
+	 * budget and enter the dedupe history; rejected notes leave both unchanged.
 	 */
-	accept(note: string): boolean {
+	accept(note: string): AdvisorEmissionDecision {
 		const key = normalizeAdvisorNote(note);
-		if (!key) return false;
-		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return false;
-		if (this.#seen.has(key)) return false;
-		if (this.#consumedThisUpdate) return false;
+		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
+		if (this.#seen.has(key)) return "duplicate";
+		if (this.#consumedThisUpdate) return "rate_limited";
 		this.#consumedThisUpdate = true;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);
@@ -172,6 +160,6 @@ export class AdvisorEmissionGuard {
 			const stale = this.#seenOrder.shift();
 			if (stale !== undefined) this.#seen.delete(stale);
 		}
-		return true;
+		return "accepted";
 	}
 }

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -17,6 +17,8 @@
  * actionable over-budget note is told to retry instead of being falsely recorded.
  */
 
+import type { AdvisorSeverity } from "./advise-tool";
+
 /**
  * Case-insensitive, punctuation-folded normalization. Collapses every run of
  * non-letter / non-digit characters into a single space and trims, so
@@ -106,7 +108,9 @@ export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" 
  * dedupe (FIFO-evicted at {@link DEFAULT_HISTORY_CAPACITY}), and a per-update
  * rate limit of one accepted note per advisor model prompt. Suppressed calls
  * never consume the per-update budget — a noise call doesn't burn the slot
- * for a real concern that follows in the same update.
+ * for a real concern that follows in the same update. A `blocker` is exempt
+ * from the budget: it must always interrupt, so a lower-severity note emitted
+ * earlier in the same update can never rate-limit it out.
  *
  * Reset on advisor reset (compaction, session switch, `/new`) via
  * {@link reset}. Per-update gate is cleared at the start of every advisor
@@ -147,12 +151,14 @@ export class AdvisorEmissionGuard {
 	/**
 	 * Classify and reserve a proposed note. Accepted notes consume the update
 	 * budget and enter the dedupe history; rejected notes leave both unchanged.
+	 * A `blocker` still runs the noise and dedupe filters but bypasses the
+	 * one-note-per-update budget so it always reaches the primary.
 	 */
-	accept(note: string): AdvisorEmissionDecision {
+	accept(note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
 		const key = normalizeAdvisorNote(note);
 		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
 		if (this.#seen.has(key)) return "duplicate";
-		if (this.#consumedThisUpdate) return "rate_limited";
+		if (severity !== "blocker" && this.#consumedThisUpdate) return "rate_limited";
 		this.#consumedThisUpdate = true;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1210,7 +1210,7 @@ export class SessionAdvisors {
 	 *  AdviseTool can report the exact outcome instead of claiming every rejection
 	 *  is a duplicate. Accepted notes consume the current update's budget. */
 	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
-		const decision = advisor.emissionGuard.accept(note);
+		const decision = advisor.emissionGuard.accept(note, severity);
 		if (decision !== "accepted")
 			logger.debug("advisor advice suppressed by emission guard", { decision, severity, advisor: advisor.name });
 		return decision;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -365,9 +365,9 @@ export class SessionAdvisors {
 		this.#advisorPrimaryTurnsCompleted++;
 		for (const advisor of this.#advisors) {
 			if (advisor.runtime.disposed) continue;
-			// Primary completion owns the deferred flush. The advisor loop may be
-			// quota-paused or fail before its next dispatch boundary.
-			advisor.adviseTool.beginUpdate(false);
+			// Only the terminal primary boundary owns the deferred flush. Continuing
+			// tool turns must keep partial-work critiques withheld.
+			if (willContinue !== true) advisor.adviseTool.beginUpdate(false);
 			try {
 				advisor.runtime.onTurnEnd(messages, { willContinue });
 			} catch (error) {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -41,6 +41,7 @@ import {
 	AdviseTool,
 	type AdvisorAgent,
 	type AdvisorConfig,
+	type AdvisorEmissionDecision,
 	AdvisorEmissionGuard,
 	AdvisorLoopGuard,
 	type AdvisorMessageDetails,
@@ -364,6 +365,9 @@ export class SessionAdvisors {
 		this.#advisorPrimaryTurnsCompleted++;
 		for (const advisor of this.#advisors) {
 			if (advisor.runtime.disposed) continue;
+			// Primary completion owns the deferred flush. The advisor loop may be
+			// quota-paused or fail before its next dispatch boundary.
+			advisor.adviseTool.beginUpdate(false);
 			try {
 				advisor.runtime.onTurnEnd(messages, { willContinue });
 			} catch (error) {
@@ -839,7 +843,7 @@ export class SessionAdvisors {
 			const emissionGuard = new AdvisorEmissionGuard();
 			const adviseTool = new AdviseTool(
 				(note, severity) => this.#routeAdvice(advisorRef, note, severity),
-				note => this.#acceptAdvice(advisorRef, note),
+				(note, severity) => this.#acceptAdvice(advisorRef, note, severity),
 			);
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
@@ -1191,9 +1195,8 @@ export class SessionAdvisors {
 	 * After a deliberate user interrupt auto-resume is suppressed while idle/unwinding
 	 * (the note becomes a preserved card re-entering on resume); a live-streaming turn is
 	 * steered in directly. A plain nit always rides the non-interrupting YieldQueue
-	 * aside. Suppression by the per-advisor emission guard drops the note silently —
-	 * the model still saw `Recorded.`, so it isn't tempted to rephrase the same note
-	 * past the dedupe.
+	 * aside. The emission guard has already accepted the note; rejected calls never
+	 * enter this route and receive their specific policy outcome from `AdviseTool`.
 	 */
 	#hasTerminalTextAnswerWithoutQueuedWork(): boolean {
 		if (this.#host.agent.hasQueuedMessages() || this.#host.hasPendingNextTurnMessages()) return false;
@@ -1203,15 +1206,14 @@ export class SessionAdvisors {
 		return isTerminalTextAssistantAnswer(messages[tail]);
 	}
 
-	/** Emission-guard gate: the noise/empty/dedupe filter plus the
-	 *  one-advise-per-update budget, consumed the moment a note is emitted —
-	 *  whether it is delivered live or held for a deferred flush. A suppressed
-	 *  note never consumes the budget, so it cannot burn an update's slot ahead
-	 *  of a substantive concern. Returns whether the note may reach the primary. */
-	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): boolean {
-		if (advisor.emissionGuard.accept(note)) return true;
-		logger.debug("advisor advice suppressed by emission guard", { severity, advisor: advisor.name });
-		return false;
+	/** Emission-guard gate: classify noise, duplicates, and over-budget notes so
+	 *  AdviseTool can report the exact outcome instead of claiming every rejection
+	 *  is a duplicate. Accepted notes consume the current update's budget. */
+	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
+		const decision = advisor.emissionGuard.accept(note);
+		if (decision !== "accepted")
+			logger.debug("advisor advice suppressed by emission guard", { decision, severity, advisor: advisor.name });
+		return decision;
 	}
 
 	/** Route an already-accepted advice note to the primary. Never re-runs the

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -972,7 +972,14 @@ describe("AgentSession advisor toggle", () => {
 	});
 	it("marks structurally classified advisor usage limits", async () => {
 		const mock = createMockModel({
-			responses: [{ content: ["primary complete"] }, { content: ["primary still complete"] }],
+			responses: [
+				{ content: ["primary complete"] },
+				{
+					content: [{ type: "toolCall", id: "continuing-turn", name: "missing-tool", arguments: {} }],
+					stopReason: "toolUse",
+				},
+				{ content: ["primary still complete"] },
+			],
 		});
 		const primaryAgent = new Agent({
 			initialState: {
@@ -1034,10 +1041,18 @@ describe("AgentSession advisor toggle", () => {
 			});
 			expect(JSON.stringify(deferred.content)).toContain("Deferred");
 
-			// The quota latch prevents another advisor dispatch. Primary turn
-			// completion must still release the note into its delivery queue.
+			// The quota latch prevents another advisor dispatch. The tool boundary
+			// must keep the note out of the continuing model request; terminal
+			// completion may then release it into the primary transcript.
 			await quotaSession.prompt("Complete another primary turn");
 			await quotaSession.waitForIdle();
+			const continuingCall = mock.calls[2];
+			if (!continuingCall) throw new Error("Expected primary continuation call");
+			expect(
+				continuingCall.context.messages.some(message =>
+					JSON.stringify(message).includes("The final result still needs a regression test."),
+				),
+			).toBe(false);
 			expect(
 				quotaSession.messages.some(
 					message =>

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -971,7 +971,9 @@ describe("AgentSession advisor toggle", () => {
 		}
 	});
 	it("marks structurally classified advisor usage limits", async () => {
-		const mock = createMockModel({ responses: [{ content: ["primary complete"] }] });
+		const mock = createMockModel({
+			responses: [{ content: ["primary complete"] }, { content: ["primary still complete"] }],
+		});
 		const primaryAgent = new Agent({
 			initialState: {
 				model,
@@ -1022,6 +1024,28 @@ describe("AgentSession advisor toggle", () => {
 			// failed batch stays requeued (the quota latch makes yielded true).
 			await advisorYielded.promise;
 			unsubscribe();
+
+			const adviseTool = advisorAgent.state.tools.find(tool => tool.name === "advise");
+			if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advisor advise tool");
+			adviseTool.beginUpdate(true);
+			const deferred = await adviseTool.execute("deferred-before-quota", {
+				note: "The final result still needs a regression test.",
+				severity: "nit",
+			});
+			expect(JSON.stringify(deferred.content)).toContain("Deferred");
+
+			// The quota latch prevents another advisor dispatch. Primary turn
+			// completion must still release the note into its delivery queue.
+			await quotaSession.prompt("Complete another primary turn");
+			await quotaSession.waitForIdle();
+			expect(
+				quotaSession.messages.some(
+					message =>
+						message.role === "custom" &&
+						typeof message.content === "string" &&
+						message.content.includes("The final result still needs a regression test."),
+				),
+			).toBe(true);
 		} finally {
 			await quotaSession.dispose();
 			vi.restoreAllMocks();

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -810,10 +810,9 @@ describe("advisor", () => {
 			expect(delivered).toEqual(concerns);
 		});
 
-		it("caps a single in-progress prompt spraying distinct notes to one deferred note", async () => {
-			// A single in-progress advisor prompt that emits several distinct notes
-			// spends the update's one budget slot on the first; the rest are dropped
-			// at emission, so the flush cannot deliver an unbounded batch (#3520).
+		it("reports over-budget deferred notes and blockers as rate limited", async () => {
+			// Preserve the one-note cap from #3520, but never claim a dropped note
+			// was deferred or duplicated: the advisor must know to retry it.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
@@ -826,9 +825,18 @@ describe("advisor", () => {
 			};
 
 			beginUpdate(true);
-			await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
-			await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
-			await tool.execute("x-2", { note: "Third mid-turn concern.", severity: "concern" });
+			const accepted = await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
+			const concern = await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
+			const blocker = await tool.execute("x-2", {
+				note: "A destructive migration will drop user data.",
+				severity: "blocker",
+			});
+
+			expect(JSON.stringify(accepted.content)).toContain("Deferred");
+			expect(JSON.stringify(concern.content)).toContain("Rate limited");
+			expect(JSON.stringify(blocker.content)).toContain("Rate limited");
+			expect(JSON.stringify(blocker.content)).not.toContain("Duplicate");
+
 			beginUpdate(false);
 			expect(delivered).toEqual(["First mid-turn concern."]);
 		});

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -921,6 +921,41 @@ describe("advisor", () => {
 			expect(delivered).toEqual([{ note: escalatedNote, severity: "blocker" }]);
 		});
 
+		it("delivers a distinct blocker live after a non-blocker consumed the update budget", async () => {
+			// #11062 follow-up: a nit emitted first in an in-progress update reserves
+			// the one deferred slot. A distinct blocker that follows must still
+			// interrupt now instead of being rejected as rate-limited and dropped;
+			// the reserved nit stays queued and flushes when the turn completes.
+			const delivered: { note: string; severity?: string }[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				(note, severity) => guard.accept(note, severity),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+
+			beginUpdate(true);
+			const nit = await tool.execute("b-0", { note: "Minor naming nit.", severity: "nit" });
+			const blocker = await tool.execute("b-1", {
+				note: "Destructive migration will drop user data.",
+				severity: "blocker",
+			});
+
+			expect(JSON.stringify(nit.content)).toContain("Deferred");
+			expect(JSON.stringify(blocker.content)).toContain("Recorded.");
+			expect(delivered).toEqual([{ note: "Destructive migration will drop user data.", severity: "blocker" }]);
+
+			// The reserved nit still flushes at the completed boundary, after the blocker.
+			beginUpdate(false);
+			expect(delivered).toEqual([
+				{ note: "Destructive migration will drop user data.", severity: "blocker" },
+				{ note: "Minor naming nit.", severity: "nit" },
+			]);
+		});
+
 		it("validates parameters using ArkType", () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -60,6 +60,18 @@ describe("AdvisorEmissionGuard", () => {
 		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
 	});
 
+	it("exempts blockers from the per-update budget so they always interrupt", () => {
+		// A nit emitted first in an update must never rate-limit a blocker that
+		// follows it: blockers are the always-interrupt severity. Noise and dedupe
+		// still apply to blockers.
+		const guard = new AdvisorEmissionGuard();
+		expect(guard.accept("Minor naming nit.", "nit")).toBe("accepted");
+		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
+		// A repeat blocker is still deduped, not waved through by the exemption.
+		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("duplicate");
+		expect(guard.accept("Stop.", "blocker")).toBe("suppressed_noise");
+	});
+
 	it("does not let a suppressed call consume the per-update budget", () => {
 		// A noise call like "Stop." must never displace a real concern that
 		// follows in the same advisor model cycle.

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -32,20 +32,20 @@ describe("AdvisorEmissionGuard", () => {
 		// none of these carry a concrete reason and they cannot be acted on, so
 		// the guard suppresses them regardless of severity.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe(false);
-		expect(guard.accept("Done.")).toBe(false);
-		expect(guard.accept("No issue; continue.")).toBe(false);
-		expect(guard.accept("LGTM")).toBe(false);
-		expect(guard.accept("No further watcher input needed.")).toBe(false);
+		expect(guard.accept("Stop.")).toBe("suppressed_noise");
+		expect(guard.accept("Done.")).toBe("suppressed_noise");
+		expect(guard.accept("No issue; continue.")).toBe("suppressed_noise");
+		expect(guard.accept("LGTM")).toBe("suppressed_noise");
+		expect(guard.accept("No further watcher input needed.")).toBe("suppressed_noise");
 	});
 
 	it("dedupes by normalized text across the session, ignoring casing and trailing punctuation", () => {
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Move retries into the queue, not the request path.")).toBe(true);
+		expect(guard.accept("Move retries into the queue, not the request path.")).toBe("accepted");
 		// Same advice with different casing and trailing punctuation must NOT
 		// land twice in the primary transcript.
-		expect(guard.accept("move retries into the queue, not the request path")).toBe(false);
-		expect(guard.accept("Move retries into the queue, not the request path!")).toBe(false);
+		expect(guard.accept("move retries into the queue, not the request path")).toBe("duplicate");
+		expect(guard.accept("Move retries into the queue, not the request path!")).toBe("duplicate");
 	});
 
 	it("rate-limits to one accepted advise per advisor update cycle", () => {
@@ -53,29 +53,29 @@ describe("AdvisorEmissionGuard", () => {
 		// models violate this; the guard enforces it at the boundary so the
 		// primary transcript never receives two advisories from one model cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe(true);
-		expect(guard.accept("Second concern: wrong env var name.")).toBe(false);
+		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
+		expect(guard.accept("Second concern: wrong env var name.")).toBe("rate_limited");
 		guard.beginUpdate();
 		// New cycle: budget reset.
-		expect(guard.accept("Second concern: wrong env var name.")).toBe(true);
+		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
 	});
 
 	it("does not let a suppressed call consume the per-update budget", () => {
 		// A noise call like "Stop." must never displace a real concern that
 		// follows in the same advisor model cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe(false);
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Stop.")).toBe("suppressed_noise");
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
 	});
 
 	it("does not let a deduped call consume the per-update budget", () => {
 		// A repeat of a prior session note is dropped, but the model can still
 		// follow it with a fresh concrete concern in the same cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(false);
-		expect(guard.accept("New concern: cache eviction never fires.")).toBe(true);
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("duplicate");
+		expect(guard.accept("New concern: cache eviction never fires.")).toBe("accepted");
 	});
 
 	it("reset clears dedupe and the per-update gate so a re-primed advisor can re-raise old issues", () => {
@@ -83,10 +83,10 @@ describe("AdvisorEmissionGuard", () => {
 		// advisor is re-primed from scratch and may legitimately re-raise the
 		// same concerns — they're new context for a freshly-primed reviewer.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Race in #handleRetry.")).toBe(true);
-		expect(guard.accept("Race in #handleRetry.")).toBe(false);
+		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
+		expect(guard.accept("Race in #handleRetry.")).toBe("duplicate");
 		guard.reset();
-		expect(guard.accept("Race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
 	});
 
 	it("evicts oldest entries when dedupe history exceeds capacity", () => {
@@ -94,26 +94,26 @@ describe("AdvisorEmissionGuard", () => {
 		// bound. Pre-eviction unique notes are remembered; post-eviction the
 		// oldest one is forgotten and can resurface.
 		const guard = new AdvisorEmissionGuard({ capacity: 3 });
-		expect(guard.accept("first")).toBe(true);
+		expect(guard.accept("first")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("second")).toBe(true);
+		expect(guard.accept("second")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("third")).toBe(true);
+		expect(guard.accept("third")).toBe("accepted");
 		guard.beginUpdate();
 		// "first" still in history.
-		expect(guard.accept("first")).toBe(false);
+		expect(guard.accept("first")).toBe("duplicate");
 		guard.beginUpdate();
 		// Fourth unique entry evicts "first".
-		expect(guard.accept("fourth")).toBe(true);
+		expect(guard.accept("fourth")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("first")).toBe(true);
+		expect(guard.accept("first")).toBe("accepted");
 	});
 
 	it("rejects empty / whitespace-only notes without consuming the budget", () => {
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("")).toBe(false);
-		expect(guard.accept("   ")).toBe(false);
-		expect(guard.accept("Concrete advice.")).toBe(true);
+		expect(guard.accept("")).toBe("suppressed_noise");
+		expect(guard.accept("   ")).toBe("suppressed_noise");
+		expect(guard.accept("Concrete advice.")).toBe("accepted");
 	});
 
 	it("end-to-end: the reporter's 309-call spam log produces ≤1 accepted note across many updates", () => {
@@ -139,7 +139,7 @@ describe("AdvisorEmissionGuard", () => {
 			for (let i = 0; i < perCycle; i++) {
 				const note = stream[c * perCycle + i];
 				if (note === undefined) break;
-				if (guard.accept(note)) accepted.push(note);
+				if (guard.accept(note) === "accepted") accepted.push(note);
 			}
 		}
 		expect(accepted).toEqual(["Concrete-but-repeated nit: x"]);


### PR DESCRIPTION
## Repro

On current `main`, reserve one in-progress concern and emit a distinct blocker in the same advisor update; the blocker is not delivered and the tool falsely returns `Duplicate advice ignored.`.

```sh
bun -e 'import { AdviseTool } from "./packages/coding-agent/src/advisor/advise-tool.ts"; import { AdvisorEmissionGuard } from "./packages/coding-agent/src/advisor/emission-guard.ts"; const delivered=[]; const guard=new AdvisorEmissionGuard(); const tool=new AdviseTool((note,severity)=>delivered.push({note,severity}), note=>guard.accept(note)); tool.beginUpdate(true); guard.beginUpdate(); await tool.execute("1",{note:"First actionable concern.",severity:"concern"}); const blocker=await tool.execute("2",{note:"Destructive migration will drop user data.",severity:"blocker"}); console.log(JSON.stringify({blocker:blocker.content,delivered}));'
```

## Cause

`AdvisorEmissionGuard.accept()` collapsed noise, duplicate, and per-update budget rejection into one boolean, so `AdviseTool.execute()` could not distinguish an over-budget note from a duplicate and unconditionally claimed rejected in-progress notes were deferred. Separately, `SessionAdvisors.onPrimaryTurnEnd()` notified the advisor runtime without flushing `AdviseTool`'s accepted deferred backlog, leaving that backlog dependent on a later advisor dispatch that quota exhaustion prevents.

## Fix

- Return a typed emission decision and map duplicate, rate-limit, and noise outcomes to accurate tool feedback.
- Flush accepted deferred notes at the primary turn boundary before notifying the advisor runtime.
- Cover over-budget concern/blocker feedback and quota-paused deferred delivery with regressions; document the user-visible fix.

## Verification

`bun test packages/coding-agent/test/advisor/emission-guard.test.ts packages/coding-agent/test/advisor/advisor.test.ts packages/coding-agent/test/advisor-toggle.test.ts` — 235 passed, 0 failed.

`bun --cwd=packages/coding-agent run check` — passed.

Skipped the pre-publish gate: `bun run fix` fails identically on a clean `origin/main` checkout because `audiopus_sys` requires the unavailable `cmake` executable; TypeScript formatting completed successfully in both runs.

Fixes #11062