### PR TITLE
feat(coding-agent): add --reapply-config to adopt config model/thinking/tier on resume

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -63,8 +63,18 @@ Argument handling:
 | `--profile <name>` | Use an isolated profile for auth, sessions, settings, and caches. |
 | `--alias <name>` | Create a shell shortcut for the selected profile and exit. |
 | `--config <file>` | Load an extra `config.yml`-style overlay for this run (repeatable). |
+| `--reapply-config` | On resume, adopt the config-resolved default model, thinking level, and service tier instead of the session's own; applied per knob. Default off. |
 | `--session-dir <dir>` | Directory for session storage and lookup. |
 | `--no-session` | Don't save the session (ephemeral). |
+
+`--reapply-config` re-applies a `--config`/`--profile` overlay to a resumed
+session, which otherwise restores the model, thinking level, and service tier
+baked in at its original launch. Adoption is per knob — a value the config does
+not specify keeps the session's own. The model and thinking level are only
+adopted when no explicit `--model` is given (`--model` pins those two); the
+service tier re-applies per family regardless of `--model` (a family the config
+omits keeps the session's), and `--service-tier` still overrides it. A bare
+resume (flag off) always restores the session's own values.
 
 #### Session history
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--reapply-config` (and the `reapplyConfig` SDK option): on `--resume`, adopt the config-resolved default model, its thinking level, and service tier instead of restoring the values baked into the session at its original launch. Adoption is per-knob (and per-family for the service tier) — a value the config does not specify keeps the session's own — and the flag is off by default, so a bare resume still restores the session's model/thinking/tier. A resume that swaps the model, or falls back after a broken config default, is surfaced as a notice. Lets a `--config`/`--profile` overlay re-apply on resume.
+
+### Fixed
+
+- Fixed `--reapply-config` skipping the cold-cache discovery retry for a configured `modelRoles.default`: the retry now runs before the session-model and availability fallbacks can claim the model, so a default on a discovery-backed provider (ollama, LM Studio, llama.cpp, an openai-compat proxy) is resolved instead of silently losing to a lower-priority pick ([#11065](https://github.com/can1357/oh-my-pi/pull/11065) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
+- Fixed `--reapply-config` treating a `modelRoles.default` self alias — `*`, `@default`, or the legacy `pi/default` — as a concrete configured model; those name the default role rather than a model, so they now count as an unset knob like the bare `default` sentinel and the session's own model is restored without a bogus broken-default warning ([#11065](https://github.com/can1357/oh-my-pi/pull/11065) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
+- Extended the `--reapply-config` self-alias fix to suffixed spellings: `modelRoles.default` set to `*:low`, `@default:xhigh`, or `pi/default:max` still names the default role, so the thinking suffix is now stripped before classification and the resume keeps the session's model instead of reporting a broken config default ([#11065](https://github.com/can1357/oh-my-pi/pull/11065) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
+- Fixed the `--reapply-config` cold-cache discovery retry skipping a configured default supplied by an extension: the guard only counted config-declared discovery providers, so an extension registering its catalog through `fetchDynamicModels` was passed over when no implicit or config provider was enabled, and the resume fell back to the session's baked model ([#11065](https://github.com/can1357/oh-my-pi/pull/11065) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -32,6 +32,7 @@ export interface Args {
 	provider?: string;
 	model?: string;
 	config?: string[];
+	reapplyConfig?: boolean;
 	smol?: string;
 	slow?: string;
 	plan?: string;
@@ -264,6 +265,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.noPrewalk = true;
 		} else if (arg === "--plan-yolo") {
 			result.planYolo = true;
+		} else if (arg === "--reapply-config") {
+			result.reapplyConfig = true;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
 		} else if (arg === "--print-thoughts") {

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -307,6 +307,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--prewalk",
 	"--no-prewalk",
 	"--plan-yolo",
+	"--reapply-config",
 	"--print",
 	"--print-thoughts",
 	"--no-extensions",

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -47,6 +47,10 @@ export const launchHelp = {
 			description: "Load an extra config.yml-style overlay for this run (repeatable)",
 			multiple: true,
 		}),
+		"reapply-config": Flags.boolean({
+			description:
+				"On resume, use the config-resolved default model, thinking level, and service tier instead of restoring the session's own — applied per knob (and per family for the service tier), so anything the config does not specify keeps the session's; lets a --config/--profile overlay re-apply on resume (default off)",
+		}),
 		"add-dir": Flags.string({
 			description: "Add a workspace directory beyond the working directory (repeatable)",
 			multiple: true,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2366,6 +2366,23 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Whether {@link refresh} has any catalog left to discover: a config-declared
+	 * discovery provider, or a runtime provider an extension registered through
+	 * `fetchDynamicModels`. `refresh` covers both, but
+	 * {@link getDiscoverableProviders} only reports the config-declared half, so
+	 * a guard written against it skips the refresh for an extension-only catalog
+	 * — exactly the case whose cache is cold at session creation.
+	 */
+	hasRefreshableProviders(): boolean {
+		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
+		if (this.#discoverableProviders.some(provider => !disabledProviders.has(provider.provider))) return true;
+		for (const provider of this.#runtimeModelManagers.keys()) {
+			if (!disabledProviders.has(provider)) return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Whether `providerId` is known to the registry: it has at least one live
 	 * model, or it is configured for dynamic discovery (models.yml `discovery:`
 	 * or a runtime extension provider) and is not disabled. Discovery-only

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1059,7 +1059,7 @@ export function parseModelPattern(
 	);
 }
 
-const DEFAULT_MODEL_ROLE = "default";
+export const DEFAULT_MODEL_ROLE = "default";
 const MODEL_ROLE_ALIAS_PREFIXES = [MODEL_ROLE_ALIAS_PREFIX, LEGACY_MODEL_ROLE_ALIAS_PREFIX];
 
 export interface ModelRoleLookup {
@@ -1121,12 +1121,36 @@ export function resolveExplicitModelRole(
 	return undefined;
 }
 
+/**
+ * True when a model selector is a self alias for the default role — the bare
+ * `default` sentinel or one of its alias spellings (`*`, `@default`,
+ * `pi/default`), each optionally carrying a thinking suffix (`*:low`,
+ * `@default:xhigh`). All of them name the default role rather than a model, so
+ * {@link resolveModelRoleValue} resolves them to nothing. Callers deciding
+ * whether `modelRoles.default` actually SETS a model must ask here rather than
+ * re-spelling the list: a second copy is what let `*` and `@default` count as a
+ * configured model while the bare sentinel did not.
+ *
+ * The suffix is split off first, with the same prefix-aware split
+ * {@link resolveExplicitModelRole} uses, because the alias parser accepts a
+ * suffixed self alias as the default role. Comparing the unsplit value would
+ * call `*:low` a concrete model knob: `--reapply-config` would then take the
+ * "config named a model" path, fail to resolve the circular selector, warn
+ * about a broken default, and drop the requested tier.
+ */
+export function isDefaultModelRoleSelfAlias(value: string): boolean {
+	const { base } = splitThinkingSuffix(value, modelRoleAliasPrefixLength(value) ?? -1, MAX_THINKING_SUFFIX_OPTIONS);
+	return (
+		base === DEFAULT_MODEL_ROLE ||
+		base === formatModelRoleAlias(DEFAULT_MODEL_ROLE) ||
+		base === DEFAULT_MODEL_ROLE_ALIAS ||
+		base === `${LEGACY_MODEL_ROLE_ALIAS_PREFIX}${DEFAULT_MODEL_ROLE}`
+	);
+}
+
 function isSessionInheritedAgentPattern(value: string): boolean {
 	return (
-		value === DEFAULT_MODEL_ROLE ||
-		value === formatModelRoleAlias(DEFAULT_MODEL_ROLE) ||
-		value === DEFAULT_MODEL_ROLE_ALIAS ||
-		value === `${LEGACY_MODEL_ROLE_ALIAS_PREFIX}${DEFAULT_MODEL_ROLE}` ||
+		isDefaultModelRoleSelfAlias(value) ||
 		value === formatModelRoleAlias("task") ||
 		value === `${LEGACY_MODEL_ROLE_ALIAS_PREFIX}task`
 	);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -286,6 +286,18 @@ export interface InteractiveModeNotify {
 	message: string;
 }
 
+/**
+ * Severity for a `modelFallbackMessage`. A `--reapply-config` config *adoption*
+ * ("resumed on X from config instead of the session's Y") is the user-requested
+ * outcome of the flag, so it is informational; the flag's other notices report a
+ * model that "did not resolve", which is a genuine fallback and stays a warning,
+ * as does every non-`--reapply-config` restore failure.
+ */
+export function buildModelFallbackNotification(modelFallbackMessage: string): InteractiveModeNotify {
+	const configAdoption = modelFallbackMessage.startsWith("--reapply-config: resumed on ");
+	return { kind: configAdoption ? "info" : "warn", message: modelFallbackMessage };
+}
+
 export function buildModelScopeNotification(
 	scopedModelsForDisplay: readonly Pick<ScopedModel, "model" | "thinkingLevel" | "explicitThinkingLevel">[],
 	startupQuiet: boolean,
@@ -1101,6 +1113,9 @@ export async function buildSessionOptions(
 		autoApprove: parsed.autoApprove ?? false,
 	};
 	const restoringSession = Boolean(parsed.continue || parsed.resume || isForeignSessionImport(parsed));
+	if (parsed.reapplyConfig) {
+		options.reapplyConfig = true;
+	}
 	if (parsed.serviceTier !== undefined) {
 		options.openAIServiceTier = serviceTierSettingToTier(parsed.serviceTier) ?? null;
 	}
@@ -1142,7 +1157,12 @@ export async function buildSessionOptions(
 			parsed.systemPrompt !== undefined ||
 			parsed.appendSystemPrompt !== undefined ||
 			parsed.tools !== undefined ||
-			parsed.noTools === true;
+			parsed.noTools === true ||
+			// --reapply-config re-resolves the model / thinking level from config,
+			// so a resumed fork's request shape can change without --model or
+			// --thinking ever being passed. An explicit --prompt-cache-key still
+			// wins: that case never reaches this branch.
+			parsed.reapplyConfig === true;
 		if (!forkCacheShapeChanged && header?.providerPromptCacheKey) {
 			options.providerPromptCacheKey = header.providerPromptCacheKey;
 			options.providerPromptCacheKeySource = "fork";
@@ -2031,7 +2051,7 @@ export async function runRootCommand(
 			}
 
 			if (modelFallbackMessage) {
-				notifs.push({ kind: "warn", message: modelFallbackMessage });
+				notifs.push(buildModelFallbackNotification(modelFallbackMessage));
 			}
 
 			const modelRegistryError = modelRegistry.getError();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -69,6 +69,7 @@ import {
 	formatModelString,
 	formatModelStringWithRouting,
 	getModelMatchPreferences,
+	isDefaultModelRoleSelfAlias,
 	parseModelPattern,
 	parseModelString,
 	pickDefaultAvailableModel,
@@ -420,6 +421,22 @@ export interface CreateAgentSessionOptions {
 	thinkingLevelCeiling?: Effort;
 	/** OpenAI service-tier override for this session. `null` omits `service_tier`. */
 	openAIServiceTier?: ServiceTier | null;
+	/**
+	 * On resume, adopt the config-resolved default model, its thinking level, and
+	 * service tier instead of restoring the values baked into the session on its
+	 * original launch. Default (unset/false) preserves the resume behavior of
+	 * keeping the session's own model/thinking/tier, so a bare resume never yanks
+	 * a conversation off the model it was running. Set by the CLI `--reapply-config`
+	 * flag; SDK embedders (e.g. Compass) pass it to re-apply an updated profile on
+	 * resume. No-op on a fresh session, which already starts from config.
+	 *
+	 * Model and thinking are gated on there being no explicit `--model`: passing
+	 * `--model` pins those two and config does not override them. The service tier
+	 * is independent of `--model` — it re-applies per family regardless (a family
+	 * the config does not name keeps the session's), and the dedicated
+	 * `openAIServiceTier` / `--service-tier` override still wins over it.
+	 */
+	reapplyConfig?: boolean;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 	/** Prewalk from the starting model to a fast/cheap target at the first edit/write once the todo list exists. */
@@ -668,7 +685,14 @@ export interface CreateAgentSessionResult {
 	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
 	/** MCP manager for server lifecycle management (undefined if MCP disabled) */
 	mcpManager?: MCPManager;
-	/** Warning if session was restored with a different model than saved */
+	/**
+	 * A model-selection notice surfaced to the user. Historically a warning when a
+	 * session could not be restored on its saved model; also carries the
+	 * `--reapply-config` adoption notices (a config swap, a fallback after a broken
+	 * config default, or an unresolved double-failure), which are informational
+	 * rather than errors. Callers that distinguish severity should treat a
+	 * `--reapply-config:` prefix as informational.
+	 */
 	modelFallbackMessage?: string;
 	/** LSP servers detected for startup; warmup may continue in the background */
 	lspServers?: LspStartupServerInfo[];
@@ -1451,6 +1475,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		options.model !== undefined ||
 		options.modelPattern !== undefined ||
 		options.thinkingLevel !== undefined ||
+		options.reapplyConfig === true ||
 		options.systemPrompt !== undefined ||
 		options.customSystemPrompt !== undefined ||
 		options.appendSystemPrompt !== undefined ||
@@ -1536,6 +1561,21 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			matchPreferences: modelMatchPreferences,
 		}),
 	);
+	// `--reapply-config` (options.reapplyConfig) adopts the config-resolved default over
+	// the session's baked value ON A PER-KNOB BASIS: a knob is adopted only when
+	// config actually specifies it, otherwise the session's own value is kept.
+	// For the model that means config must NAME a default role. Mirror the
+	// resolver's own notion of "no default" (model-resolver.ts: a blank value or
+	// a default-role self alias resolves to nothing): a tombstoned/absent
+	// `modelRoles.default`, an empty string, or a self alias — `default`, `*`,
+	// `@default`, `pi/default` (an overlay that only retunes a non-default role,
+	// or only a tier) is NOT a config default, so the session model is retained
+	// rather than discarded onto an arbitrary fallback. The alias spellings come
+	// from `isDefaultModelRoleSelfAlias`, never a second list here: a copy that
+	// drifts is how `*` once counted as a configured model.
+	const normalizedDefaultRole = defaultRoleValue?.trim();
+	const hasConfigDefaultRole = normalizedDefaultRole ? !isDefaultModelRoleSelfAlias(normalizedDefaultRole) : false;
+	const adoptConfigModel = Boolean(options.reapplyConfig) && !hasExplicitModel && hasConfigDefaultRole;
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
 	let initialRetryFallback: InitialRetryFallbackState | undefined;
@@ -1543,14 +1583,17 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// initial pass here so model-dependent setup (thinking-level resolution,
 	// host preconnect) can use the restored model; extension-registered
 	// providers aren't visible yet, so we retry the preferred candidates once
-	// extensions register below.
+	// extensions register below. Under `--reapply-config` the config default wins
+	// first (the early restore + reclaim below are skipped), but these stay the
+	// fallback for when the config default resolves to nothing — a resume must
+	// never be yanked onto an arbitrary pick.
 	const sessionModelStrings =
 		!hasExplicitModel && hasExistingSession
 			? getRestorableSessionModels(existingSession.models, sessionManager.getLastModelChangeRole())
 			: [];
 	let restoredSessionModelIndex = -1;
 	let restoredSessionThinkingLevel: ConfiguredThinkingLevel | undefined;
-	if (!hasExplicitModel && !model && sessionModelStrings.length > 0) {
+	if (!hasExplicitModel && !adoptConfigModel && !model && sessionModelStrings.length > 0) {
 		logger.time("restoreSessionModel", () => {
 			let failedSessionModel: string | undefined;
 			for (let i = 0; i < sessionModelStrings.length; i++) {
@@ -1590,6 +1633,17 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			model = settingsDefaultModel;
 		});
 	}
+	// The early role resolution above ran before extension factories registered
+	// their providers (and before any cold discovery pass), so an ordered
+	// `modelRoles.default` list whose FIRST candidate lives behind such a
+	// provider resolved to a later, already-available candidate. Under
+	// `--reapply-config` that model is adopted immediately, which would leave
+	// `model` non-null and skip the post-registration retry below — resuming on
+	// the lower-priority configured fallback instead of the first configured
+	// model. Remember that the early match was not the first candidate so the
+	// retry runs anyway once providers are registered.
+	const reResolveConfigDefault =
+		adoptConfigModel && model !== undefined && (defaultRoleSpec.matchedPatternIndex ?? 0) > 0;
 
 	const taskDepth = options.taskDepth ?? 0;
 
@@ -1600,8 +1654,21 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// role reclaim so the final model's own defaults aren't masked by an earlier
 	// fallback model's.
 	const pickInitialThinkingLevel = (selectedModel: Model | undefined): ConfiguredThinkingLevel | undefined => {
+		// Adopt the config thinking level over the session's baked one whenever
+		// config actually NAMES that knob — either as an explicit selector on the
+		// default role (`:xhigh`) or as a global `defaultThinkingLevel`. Thinking
+		// is a knob of its own, so this must not be coupled to the role carrying a
+		// suffix; config that sets only `defaultThinkingLevel` still specifies the
+		// level, and `--reapply-config` must honor it. With config naming no
+		// thinking knob at all the session's own entry is kept, so the flag never
+		// silently moves the level onto a bare model default. `defaultRoleSpec` is
+		// read live — it is re-resolved post-extension for role models that
+		// register late.
+		const hasConfigThinkingLevel =
+			Boolean(defaultRoleSpec.explicitThinkingLevel) || settings.isConfigured("defaultThinkingLevel");
+		const adoptConfigThinking = Boolean(options.reapplyConfig) && !hasExplicitModel && hasConfigThinkingLevel;
 		let level = options.thinkingLevel;
-		if (level === undefined && hasExistingSession && hasThinkingEntry) {
+		if (level === undefined && hasExistingSession && hasThinkingEntry && !adoptConfigThinking) {
 			level =
 				parseConfiguredThinkingLevel(existingSession.configuredThinkingLevel) ??
 				parseThinkingLevel(existingSession.thinkingLevel);
@@ -1609,8 +1676,19 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		if (level === undefined && !hasThinkingEntry && restoredSessionThinkingLevel !== undefined) {
 			level = restoredSessionThinkingLevel;
 		}
-		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
+		if (
+			level === undefined &&
+			!hasExplicitModel &&
+			(!hasThinkingEntry || adoptConfigThinking) &&
+			defaultRoleSpec.explicitThinkingLevel
+		) {
 			level = defaultRoleSpec.thinkingLevel;
+		}
+		// The role selector carries no `:level`, but config names the knob
+		// globally. Under adoption that configured value outranks the selected
+		// model's own `defaultLevel`, which would otherwise mask it.
+		if (level === undefined && adoptConfigThinking && settings.isConfigured("defaultThinkingLevel")) {
+			level = parseConfiguredThinkingLevel(settings.get("defaultThinkingLevel"));
 		}
 		if (level === undefined && selectedModel?.thinking?.defaultLevel !== undefined) {
 			level = selectedModel.thinking.defaultLevel;
@@ -2282,7 +2360,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// downstream fallback filling `model`). Reclaim it here so resume
 		// honors the last active role in either case.
 		const sessionRetryLimit = restoredSessionModelIndex >= 0 ? restoredSessionModelIndex : sessionModelStrings.length;
-		if (!hasExplicitModel && sessionRetryLimit > 0) {
+		if (!hasExplicitModel && !adoptConfigModel && sessionRetryLimit > 0) {
 			const restoreSessionModel = (): boolean => {
 				for (let i = 0; i < sessionRetryLimit; i++) {
 					const sessionModelStr = sessionModelStrings[i];
@@ -2648,7 +2726,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Fall back to first available model with a valid API key, honoring the
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
-		if (!model && deferredModelPatterns.length === 0) {
+		if ((!model || reResolveConfigDefault) && deferredModelPatterns.length === 0) {
 			// Retry the configured default role against the current catalog,
 			// setting `model` (+ thinking level) when it resolves. Extension
 			// factories register providers AFTER the early `defaultRoleSpec`
@@ -2689,44 +2767,96 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				return true;
 			};
 
+			// Cold-cache discovery race (issues #6114, #6162): a discovery provider
+			// (models.yml `openai-models-list`, LM Studio/Ollama/llama.cpp, or an
+			// openai-compat proxy) ships no static models, so the static+cached
+			// catalog above could not see the configured default at all — even
+			// though `omp models` (which awaits discovery) lists it. Background
+			// discovery in main.ts fires only AFTER createAgentSession returns.
+			// One cache-aware pass, at most, per session creation.
+			//
+			// The guard asks `hasRefreshableProviders()`, not
+			// `getDiscoverableProviders()`: an extension supplying the configured
+			// default through `fetchDynamicModels` registers a RUNTIME provider,
+			// which the config-declared list never reports. With every
+			// implicit/config provider absent or disabled that list is empty, so
+			// gating on it would skip `refresh()` — which does cover runtime
+			// managers — and hand the resume to the baked-model fallback below.
+			let discoveryRefreshed = false;
+			const refreshDiscoveryOnce = async (): Promise<boolean> => {
+				if (discoveryRefreshed || !modelRegistry.hasRefreshableProviders()) return false;
+				discoveryRefreshed = true;
+				await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
+				return true;
+			};
+
 			await tryResolveDefaultRole();
 
+			// The configured default outranks BOTH lower-priority pickers below —
+			// the session's own baked model and the arbitrary availability pick —
+			// and each of those runs only while `model` is unset, so whichever
+			// fires first would permanently shadow the discovery retry. Take the
+			// cold-cache pass here, before either can claim `model`. It is also
+			// the only retry for an ordered role list whose FIRST candidate needs
+			// discovery: that leaves `model` set to the later candidate, which no
+			// `!model` guard downstream can revisit.
+			if (
+				!hasExplicitModel &&
+				Boolean(settings.getModelRole("default")) &&
+				(!model || (defaultRoleSpec.matchedPatternIndex ?? 0) > 0) &&
+				(await refreshDiscoveryOnce())
+			) {
+				await tryResolveDefaultRole();
+			}
+
+			// Under `--reapply-config` the early session restore was skipped so the
+			// config default could win. It didn't resolve (even post-extension), so
+			// fall back to the session's own baked model rather than an arbitrary
+			// pick — a resume must never be silently yanked onto an unrelated model.
+			if (!model && adoptConfigModel && sessionModelStrings.length > 0) {
+				logger.time("restoreSessionModelReapplyFallback", () => {
+					for (let i = 0; i < sessionModelStrings.length; i++) {
+						const parsedModel = parseModelString(sessionModelStrings[i], {
+							allowMaxSuffix: true,
+							allowAutoAlias: true,
+							isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+						});
+						if (!parsedModel) continue;
+						const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
+						if (restoredModel && hasModelAuth(restoredModel)) {
+							model = restoredModel;
+							restoredSessionModelIndex = i;
+							restoredSessionThinkingLevel = parsedModel.thinkingLevel;
+							thinkingLevel = pickInitialThinkingLevel(restoredModel);
+							autoThinking = thinkingLevel === AUTO_THINKING;
+							effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
+							effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+								autoThinking
+									? resolveProvisionalAutoLevel(restoredModel)
+									: resolveThinkingLevelForModel(restoredModel, effectiveThinkingLevel),
+							);
+							preconnectModelHost(restoredModel.baseUrl);
+							break;
+						}
+					}
+				});
+			}
 			if (!model) {
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 				let pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth), provider =>
 					modelRegistry.hasConcreteAuth(provider),
 				);
 
-				// Cold-cache discovery race (issues #6114, #6162): a discovery
-				// provider (models.yml `openai-models-list`, LM Studio/Ollama/
-				// llama.cpp, or an openai-compat proxy) ships no static models, so
-				// the static+cached catalog resolved nothing above. Background
-				// discovery in main.ts fires only AFTER createAgentSession returns,
-				// so on a cache-cold boot the configured default stays unresolved
-				// and `pick` silently degrades to an unrelated authed provider's
-				// default (#6162) or "No models available" (#6114) — even though
-				// `omp models` (which awaits discovery) lists the model. Await one
-				// cache-aware discovery pass and retry when a default role is
-				// configured (must win over `pick`) or nothing resolved at all.
-				// The common path — role already resolved, or a `pick` with no
-				// configured default — never pays for it.
-				const defaultRoleConfigured = Boolean(settings.getModelRole("default"));
-				if (
-					!hasExplicitModel &&
-					(defaultRoleConfigured || !pick) &&
-					modelRegistry.getDiscoverableProviders().length > 0
-				) {
-					await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
-					if (!(await tryResolveDefaultRole()) && !model) {
-						const refreshedCandidates = await resolveAllowedModels(
-							modelRegistry,
-							settings,
-							modelMatchPreferences,
-						);
-						pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth), provider =>
-							modelRegistry.hasConcreteAuth(provider),
-						);
-					}
+				// The configured default already took its discovery pass above, so
+				// what is left here is #6114: nothing resolved at all and the only
+				// catalog that could carry a model is a discovery provider's.
+				// `refreshDiscoveryOnce` is a no-op when that pass already ran, so
+				// the common path never pays for a second one.
+				if (!pick && !hasExplicitModel && (await refreshDiscoveryOnce())) {
+					const refreshedCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+					pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth), provider =>
+						modelRegistry.hasConcreteAuth(provider),
+					);
 				}
 
 				if (!model && pick) {
@@ -2743,6 +2873,45 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					patterns && patterns.length > 0
 						? `No model available matching enabledModels (${patterns.join(", ")}) with usable credentials. Configure auth for an allowed provider or adjust enabledModels.`
 						: "No models available. Use /login or set an API key environment variable. Then use /model to select a model.";
+			}
+		}
+
+		// `--reapply-config` user signal. The resolution above is silent, so a
+		// resume that swapped the session's model — or a broken config default
+		// that fell back to the session's own model — would give no indication
+		// the overlay was (or was not) applied. Surface one notice for whichever
+		// happened. Only under `adoptConfigModel`, so the bare-resume path keeps
+		// its exact prior message flow.
+		const bakedSessionModel = sessionModelStrings[0];
+		if (adoptConfigModel && model && bakedSessionModel) {
+			const configDefaultResolved =
+				defaultRoleSpec.model !== undefined &&
+				defaultRoleSpec.model.provider === model.provider &&
+				defaultRoleSpec.model.id === model.id;
+			if (restoredSessionModelIndex >= 0) {
+				// The post-resolution fallback restored the session's baked model:
+				// the config default named a model that did not resolve.
+				modelFallbackMessage = `--reapply-config: config default "${defaultRoleValue}" did not resolve${
+					defaultRoleSpec.warning ? ` (${defaultRoleSpec.warning})` : ""
+				}; kept the session's ${formatModelString(model)}`;
+			} else if (configDefaultResolved) {
+				// The config default resolved and won over the baked model. Notice
+				// only when it is genuinely a different model than the session ran.
+				const bakedParsed = parseModelString(bakedSessionModel, {
+					allowMaxSuffix: true,
+					allowAutoAlias: true,
+					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+				});
+				if (bakedParsed?.provider !== model.provider || bakedParsed?.id !== model.id) {
+					modelFallbackMessage = `--reapply-config: resumed on ${formatModelString(model)} from config instead of the session's ${bakedSessionModel}`;
+				}
+			} else {
+				// Neither the config default nor the session's baked model resolved,
+				// so the model came from an arbitrary availability pick. Never leave
+				// that silent — it is the case the bare-resume path warns about too.
+				modelFallbackMessage = `--reapply-config: config default "${defaultRoleValue}" did not resolve${
+					defaultRoleSpec.warning ? ` (${defaultRoleSpec.warning})` : ""
+				} and the session's ${bakedSessionModel} could not be restored; using ${formatModelString(model)}`;
 			}
 		}
 
@@ -3486,13 +3655,26 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const openaiWebsocketSetting = settings.get("providers.openaiWebsockets") ?? "off";
 		const preferOpenAICodexWebsockets =
 			openaiWebsocketSetting === "on" ? true : openaiWebsocketSetting === "off" ? false : undefined;
-		const configuredServiceTierByFamily = hasServiceTierEntry
-			? (existingSession.serviceTier ?? {})
-			: buildServiceTierByFamily(
-					settings.get("tier.openai"),
-					settings.get("tier.anthropic"),
-					settings.get("tier.google"),
-				);
+		const configServiceTierByFamily = buildServiceTierByFamily(
+			settings.get("tier.openai"),
+			settings.get("tier.anthropic"),
+			settings.get("tier.google"),
+		);
+		// Under `--reapply-config`, adopt the config tier PER FAMILY: a family the
+		// config specifies overrides the session's, a family it does not keeps the
+		// session's baked value. Config settings default every family to "none"
+		// (which `buildServiceTierByFamily` omits), so "unspecified" is exactly an
+		// absent family key. Unlike the model/thinking knobs, the tier is NOT gated
+		// on `!hasExplicitModel`: `--model` pins only the model, and the dedicated
+		// `openAIServiceTier` override below is the way to pin the tier. Without the
+		// flag, the session's tier map is restored wholesale when present, else the
+		// config map is used.
+		const configuredServiceTierByFamily =
+			options.reapplyConfig && hasServiceTierEntry
+				? { ...existingSession.serviceTier, ...configServiceTierByFamily }
+				: hasServiceTierEntry
+					? (existingSession.serviceTier ?? {})
+					: configServiceTierByFamily;
 		const initialServiceTierByFamily = { ...configuredServiceTierByFamily };
 		if (options.openAIServiceTier === null) {
 			delete initialServiceTierByFamily.openai;

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -138,6 +138,7 @@ describe("AgentSession model persistence", () => {
 	async function createStartupResumeSession(
 		targetSessionFile: string,
 		settings: Settings = Settings.isolated(),
+		extraOptions?: { reapplyConfig?: boolean; model?: Model<Api> },
 	): Promise<CreateAgentSessionResult> {
 		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir.path(), "startup"));
 		const result = await createAgentSession({
@@ -155,10 +156,508 @@ describe("AgentSession model persistence", () => {
 			enableMCP: false,
 			enableLsp: false,
 			skipPythonPreflight: true,
+			reapplyConfig: extraOptions?.reapplyConfig,
+			model: extraOptions?.model,
 		});
 		session = result.session;
 		return result;
 	}
+	async function loadOverlaySettings(overlayModelRoles: Record<string, string | null>): Promise<Settings> {
+		const overlayPath = path.join(tempDir.path(), `overlay-${Bun.nanoseconds()}.yml`);
+		const roleLines = Object.entries(overlayModelRoles)
+			.map(([role, value]) => `  ${role}: ${value === null ? "null" : value}`)
+			.join("\n");
+		await Bun.write(overlayPath, `modelRoles:\n${roleLines}\n`);
+		return Settings.loadIsolated({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			inMemory: true,
+			configFiles: [overlayPath],
+		});
+	}
+
+	async function writeThinkingModelSession(modelValueStr: string, bakedThinking: string): Promise<string> {
+		const targetSessionFile = path.join(tempDir.path(), `target-thinking-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: modelValueStr,
+					role: "default",
+				},
+				{
+					type: "thinking_level_change",
+					id: "thinking",
+					parentId: "default-model",
+					timestamp,
+					thinkingLevel: bakedThinking,
+					configured: bakedThinking,
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		return targetSessionFile;
+	}
+
+	it("adopts the config default model over the baked session model on resume with reapplyConfig", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const overlayModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		const settings = await loadOverlaySettings({ default: modelValue(overlayModel) });
+		expect(settings.getModelRoleProvenance("default")).toBe("overlay");
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(overlayModel.id);
+	});
+
+	it("restores the baked session model on a bare resume without reapplyConfig", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const overlayModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		const settings = await loadOverlaySettings({ default: modelValue(overlayModel) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(bakedModel.id);
+	});
+
+	it("adopts the config default thinking level over the baked session level on resume with reapplyConfig", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Medium);
+
+		const settings = await loadOverlaySettings({ default: `${modelValue(model)}:xhigh` });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(model.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.XHigh);
+	});
+
+	it("restores the baked session thinking level on a bare resume without reapplyConfig", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Medium);
+
+		const settings = await loadOverlaySettings({ default: `${modelValue(model)}:xhigh` });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(model.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Medium);
+	});
+
+	it("adopts a config defaultThinkingLevel with no role suffix on resume with reapplyConfig", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Medium);
+
+		// Config names the thinking knob GLOBALLY (`defaultThinkingLevel`) and the
+		// default role carries no `:level` suffix. Thinking is its own knob, so
+		// --reapply-config must honor the configured value rather than restoring
+		// the session's baked level.
+		const settings = await loadOverlaySettingsRaw(
+			`modelRoles:\n  default: ${modelValue(model)}\ndefaultThinkingLevel: ${Effort.XHigh}\n`,
+		);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(model.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.XHigh);
+	});
+
+	it("restores the baked session thinking level on a bare resume that configures defaultThinkingLevel", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Medium);
+
+		const settings = await loadOverlaySettingsRaw(
+			`modelRoles:\n  default: ${modelValue(model)}\ndefaultThinkingLevel: ${Effort.XHigh}\n`,
+		);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		// Without the flag the configured level must not reach a resumed session.
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Medium);
+	});
+
+	it("keeps the baked session thinking level when reapplyConfig names no thinking knob", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Medium);
+
+		// Config names a default role but no thinking level anywhere, so the
+		// per-knob contract keeps the session's own level — the flag must never
+		// move it onto a schema default or a bare model default.
+		const settings = await loadOverlaySettings({ default: modelValue(model) });
+		expect(settings.isConfigured("defaultThinkingLevel")).toBe(false);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Medium);
+	});
+
+	async function loadOverlaySettingsRaw(overlayYaml: string): Promise<Settings> {
+		const overlayPath = path.join(tempDir.path(), `overlay-raw-${Bun.nanoseconds()}.yml`);
+		await Bun.write(overlayPath, overlayYaml);
+		return Settings.loadIsolated({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			inMemory: true,
+			configFiles: [overlayPath],
+		});
+	}
+
+	async function writeServiceTierSession(modelValueStr: string, tier: string): Promise<string> {
+		const targetSessionFile = path.join(tempDir.path(), `target-tier-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: modelValueStr,
+					role: "default",
+				},
+				{
+					type: "service_tier_change",
+					id: "tier",
+					parentId: "default-model",
+					timestamp,
+					serviceTier: { openai: tier },
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		return targetSessionFile;
+	}
+
+	it("keeps the baked session model when reapplyConfig resolves no config default", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		// Overlay retunes only a non-default role, naming no `modelRoles.default`.
+		const settings = await loadOverlaySettings({ review: `${modelValue(bakedModel)}:xhigh` });
+		expect(settings.getModelRole("default")).toBeUndefined();
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		// The session model is retained, not discarded onto an arbitrary fallback.
+		expect(result.session.model?.id).toBe(bakedModel.id);
+	});
+
+	// `modelRoles.default` set to a self alias — `*`, `@default`, or the legacy
+	// `pi/default` — names the default role rather than a model, so the resolver
+	// resolves it to nothing. `--reapply-config` must therefore treat it as an
+	// UNSET model knob (like the bare `default` sentinel) and restore the
+	// session's model normally, instead of counting it as a configured model,
+	// discarding the session model, and reporting a broken config default.
+	for (const selfAlias of ["*", "@default", "pi/default"]) {
+		it(`treats a "${selfAlias}" default role as an unset model knob under reapplyConfig`, async () => {
+			const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+			const targetSessionFile = await writeRoleModelSession(
+				modelValue(bakedModel),
+				modelValue(bakedModel),
+				"default",
+			);
+
+			const settings = await loadOverlaySettingsRaw(`modelRoles:\n  default: "${selfAlias}"\n`);
+			expect(settings.getModelRole("default")).toBe(selfAlias);
+
+			const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+			expect(result.session.model?.id).toBe(bakedModel.id);
+			// No config default was named, so there is nothing to warn about.
+			expect(result.modelFallbackMessage).toBeUndefined();
+		});
+	}
+
+	// The same self aliases carrying a thinking suffix. The alias parser accepts
+	// these as the default role (`resolveExplicitModelRole("*:low")` -> `default`),
+	// so the selector still names the role rather than a model and still resolves
+	// to nothing. Classified on the unsplit string they look like a concrete model
+	// knob, which sends the resume down the "config named a model" path: it
+	// discards the early restore, cannot resolve the circular selector, and
+	// reports a broken config default that config never named.
+	for (const selfAlias of ["*:xhigh", "@default:low", "pi/default:max"]) {
+		it(`treats a "${selfAlias}" default role as an unset model knob under reapplyConfig`, async () => {
+			const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+			const targetSessionFile = await writeRoleModelSession(
+				modelValue(bakedModel),
+				modelValue(bakedModel),
+				"default",
+			);
+
+			const settings = await loadOverlaySettingsRaw(`modelRoles:\n  default: "${selfAlias}"\n`);
+			expect(settings.getModelRole("default")).toBe(selfAlias);
+
+			const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+			expect(result.session.model?.id).toBe(bakedModel.id);
+			expect(result.modelFallbackMessage).toBeUndefined();
+		});
+	}
+
+	it("keeps the baked session model and thinking when reapplyConfig names an unresolvable default", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(bakedModel), Effort.Medium);
+
+		// Overlay names a default that resolves to no catalog model (a typo, or a
+		// model behind a provider that never registered on this boot).
+		const settings = await loadOverlaySettings({ default: "anthropic/no-such-model-xyz:xhigh" });
+		expect(settings.getModelRole("default")).toBe("anthropic/no-such-model-xyz:xhigh");
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		// Config resolved nothing, so the resume falls back to its own baked model
+		// and thinking level — never an arbitrary pickDefaultAvailableModel choice.
+		expect(result.session.model?.id).toBe(bakedModel.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Medium);
+	});
+
+	it("keeps the baked session thinking level when reapplyConfig is combined with an explicit model", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(model), Effort.Minimal);
+
+		const settings = await loadOverlaySettings({ default: `${modelValue(model)}:xhigh` });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, {
+			reapplyConfig: true,
+			model,
+		});
+
+		// An explicit --model overrides the config default role, so reapplyConfig must
+		// not move the session's thinking level to the config selector or a model
+		// default — the session's baked level is kept.
+		expect(result.session.model?.id).toBe(model.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Minimal);
+	});
+
+	it("adopts the config service tier over the baked session tier for the same family with reapplyConfig", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeServiceTierSession(modelValue(model), "priority");
+
+		const settings = await loadOverlaySettingsRaw(
+			`modelRoles:\n  default: ${modelValue(model)}\ntier:\n  openai: flex\n`,
+		);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.serviceTierByFamily.openai).toBe("flex");
+	});
+
+	it("merges config service tier per family, keeping baked families the config omits", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		// Session baked an openai tier; config specifies only google.
+		const targetSessionFile = await writeServiceTierSession(modelValue(model), "priority");
+
+		const settings = await loadOverlaySettingsRaw(
+			`modelRoles:\n  default: ${modelValue(model)}\ntier:\n  google: flex\n`,
+		);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		// The config's google tier is adopted; the session's openai tier is kept.
+		expect(result.session.serviceTierByFamily.google).toBe("flex");
+		expect(result.session.serviceTierByFamily.openai).toBe("priority");
+	});
+
+	it("restores the baked session service tier on a bare resume without reapplyConfig", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeServiceTierSession(modelValue(model), "priority");
+
+		const settings = await loadOverlaySettings({ default: modelValue(model) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.serviceTierByFamily.openai).toBe("priority");
+	});
+
+	it("does not persist the adopted config values back as session entries on a reapplyConfig resume", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const overlayModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		const settings = await loadOverlaySettings({ default: modelValue(overlayModel) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(overlayModel.id);
+		// Adopted values are per-run intent, not written back — the branch still
+		// holds only the two fixture model_change entries (both the baked model),
+		// and the adopted overlay model is never appended, so a later bare resume
+		// still restores the session's own baked model.
+		const modelChanges = result.session.sessionManager.getBranch().filter(entry => entry.type === "model_change");
+		expect(modelChanges.map(entry => entry.model)).toEqual([modelValue(bakedModel), modelValue(bakedModel)]);
+		expect(modelChanges.some(entry => entry.model === modelValue(overlayModel))).toBe(false);
+		expect(result.session.sessionManager.getBranch().some(entry => entry.type === "thinking_level_change")).toBe(
+			false,
+		);
+	});
+
+	it("reports the model swap when reapplyConfig adopts a different config default", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const overlayModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		const settings = await loadOverlaySettings({ default: modelValue(overlayModel) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(overlayModel.id);
+		// The swap is otherwise silent, so reapplyConfig surfaces a notice naming
+		// both the adopted model and the session's own. Assert the SWAP branch, not
+		// just the operands: the broken-config branch also names both models, so a
+		// `.toContain` on the ids alone would pass on an inverted discrimination.
+		expect(result.modelFallbackMessage).toContain("resumed on");
+		expect(result.modelFallbackMessage).not.toContain("did not resolve");
+		expect(result.modelFallbackMessage).toContain(modelValue(overlayModel));
+		expect(result.modelFallbackMessage).toContain(modelValue(bakedModel));
+	});
+
+	it("stays silent when reapplyConfig adopts the same model the session already ran", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeRoleModelSession(modelValue(model), modelValue(model), "default");
+
+		const settings = await loadOverlaySettings({ default: modelValue(model) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(model.id);
+		// No swap happened, so there is nothing to report.
+		expect(result.modelFallbackMessage).toBeUndefined();
+	});
+
+	it("reports the broken config default when reapplyConfig falls back to the session model", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(bakedModel), Effort.Medium);
+
+		const settings = await loadOverlaySettings({ default: "anthropic/no-such-model-xyz:xhigh" });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(bakedModel.id);
+		// A broken config default would otherwise be an indistinguishable no-op;
+		// the notice names the unresolved default and that the session was kept.
+		// Pin arm (a): the double-failure arm (c) also opens "did not resolve", so
+		// assert the substrings unique to the fallback branch.
+		expect(result.modelFallbackMessage).toContain("did not resolve");
+		expect(result.modelFallbackMessage).toContain("anthropic/no-such-model-xyz");
+		expect(result.modelFallbackMessage).toContain("kept the session's");
+		expect(result.modelFallbackMessage).not.toContain("could not be restored");
+	});
+
+	it("keeps the baked session model when reapplyConfig names a tombstoned default", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		// A tombstoned `modelRoles.default: null` is not a config-named default, so
+		// the model knob is not adopted and the session model is retained.
+		const settings = await loadOverlaySettings({ default: null });
+		expect(settings.getModelRole("default")).toBeUndefined();
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(bakedModel.id);
+		expect(result.modelFallbackMessage).toBeUndefined();
+	});
+
+	it("keeps the baked session model and thinking when reapplyConfig names an empty default", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeThinkingModelSession(modelValue(bakedModel), Effort.Medium);
+
+		// An explicit empty-string default resolves to no model — the resolver's
+		// own "no default" case, so the model knob is not adopted and the resume
+		// keeps its own baked values with no bogus "did not resolve" notice.
+		const settings = await loadOverlaySettingsRaw(`modelRoles:\n  default: ""\n`);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(bakedModel.id);
+		expect(result.session.configuredThinkingLevel()).toBe(Effort.Medium);
+		expect(result.modelFallbackMessage).toBeUndefined();
+	});
+
+	it("keeps the baked session model when reapplyConfig names the bare default sentinel", async () => {
+		const bakedModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeRoleModelSession(modelValue(bakedModel), modelValue(bakedModel), "default");
+
+		// A literal `default` is the resolver's self-referential sentinel, not a
+		// config-named model, so it is treated as "no default": session retained,
+		// no notice.
+		const settings = await loadOverlaySettingsRaw(`modelRoles:\n  default: default\n`);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		expect(result.session.model?.id).toBe(bakedModel.id);
+		expect(result.modelFallbackMessage).toBeUndefined();
+	});
+
+	it("reports the double failure when neither the config default nor the baked session model resolves", async () => {
+		// Session baked on an unresolvable model AND overlay names an unresolvable
+		// default: the model comes from an arbitrary availability pick, which must
+		// never be silent — the same case the bare-resume path warns about.
+		const targetSessionFile = await writeRoleModelSession(
+			"anthropic/no-such-baked-model-abc",
+			"anthropic/no-such-baked-model-abc",
+			"default",
+		);
+
+		const settings = await loadOverlaySettings({ default: "anthropic/no-such-model-xyz" });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		// A model was picked (some authed default), and the notice names both the
+		// unresolved config default and the unrestorable session model.
+		expect(result.session.model).toBeDefined();
+		expect(result.modelFallbackMessage).toContain("did not resolve");
+		expect(result.modelFallbackMessage).toContain("anthropic/no-such-model-xyz");
+		expect(result.modelFallbackMessage).toContain("anthropic/no-such-baked-model-abc");
+		expect(result.modelFallbackMessage).toContain("could not be restored");
+	});
+
+	it("stays silent under reapplyConfig when the session has no baked model to swap from", async () => {
+		// A session with entries but no `model_change` (so no baked model to
+		// restore or compare against). `reapplyConfig` must not leak a notice
+		// naming a nonexistent session model — a fresh/no-model resume is a no-op.
+		const overlayModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const targetSessionFile = path.join(tempDir.path(), `target-nomodel-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "message",
+					id: "u1",
+					parentId: null,
+					timestamp,
+					message: { role: "user", content: "hi" },
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+
+		const settings = await loadOverlaySettings({ default: modelValue(overlayModel) });
+
+		const result = await createStartupResumeSession(targetSessionFile, settings, { reapplyConfig: true });
+
+		// No baked model existed, so nothing was swapped away from; the notice must
+		// not fire (and must never interpolate a bare `undefined`).
+		expect(result.modelFallbackMessage).toBeUndefined();
+	});
+
 	it("switches the active model without persisting by default", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const nextModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/flag-tables.test.ts
+++ b/packages/coding-agent/test/flag-tables.test.ts
@@ -68,6 +68,19 @@ describe("--external-thinking", () => {
 		expect(parseArgs([]).externalThinking).toBeUndefined();
 	});
 });
+
+describe("--reapply-config", () => {
+	it("enables config-model adoption without consuming the initial message", () => {
+		const result = parseArgs(["--reapply-config", "check this"]);
+
+		expect(result.reapplyConfig).toBe(true);
+		expect(result.messages).toEqual(["check this"]);
+	});
+
+	it("stays unset when omitted", () => {
+		expect(parseArgs([]).reapplyConfig).toBeUndefined();
+	});
+});
 describe("--session-dir", () => {
 	it("uses PI_CODING_AGENT_SESSION_DIR unless the CLI flag overrides it", () => {
 		const previous = Bun.env.PI_CODING_AGENT_SESSION_DIR;

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -15,6 +15,7 @@ import { getOAuthProviders, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oau
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("ModelRegistry runtime provider registration", () => {
@@ -25,6 +26,8 @@ describe("ModelRegistry runtime provider registration", () => {
 	let fetchRequests: string[];
 
 	const sourceIds = ["ext://atomic", "ext://runtime", "ext://oauth"];
+	/** Every config-declared discovery provider id, for the disable list. */
+	const scoped0Providers = (): string[] => registry.getDiscoverableProviders();
 
 	// Stub transport: reject every request so refresh("online") drives the full
 	// online discovery path with deterministic, instant failures instead of real
@@ -1378,5 +1381,41 @@ describe("ModelRegistry runtime provider registration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	// The cold-cache discovery guard in `createAgentSession` asks this predicate.
+	// `getDiscoverableProviders()` projects only the CONFIG-declared half, so an
+	// extension supplying the configured default through `fetchDynamicModels`
+	// left the guard blind: with every config provider disabled that list
+	// contributes nothing, the guard skipped the refresh that DOES cover runtime
+	// managers, and the resume fell through to the baked-model fallback.
+	test("hasRefreshableProviders counts a runtime provider when every config provider is disabled", async () => {
+		const providerName = "dynamic-refreshable-provider";
+		// Disable every config-declared discovery provider, so ONLY a runtime
+		// manager can make the registry refreshable — the exact case the guard's
+		// old `getDiscoverableProviders().length === 0` test got wrong.
+		const scoped = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: offlineFetch,
+			settings: await Settings.loadIsolated({
+				cwd: tempDir,
+				agentDir: tempDir,
+				overrides: { disabledProviders: scoped0Providers(), "compaction.enabled": false },
+			}),
+		});
+
+		expect(scoped.hasRefreshableProviders()).toBe(false);
+
+		scoped.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-responses",
+				fetchDynamicModels: async () => [{ ...baseModel, id: "dynamic-refreshable-model" }],
+			},
+			"ext://runtime",
+		);
+
+		expect(scoped.hasRefreshableProviders()).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -7,6 +7,7 @@ import {
 	expandRoleAlias,
 	extractExplicitThinkingSelector,
 	filterAvailableModelsByEnabledPatterns,
+	isDefaultModelRoleSelfAlias,
 	parseModelPattern,
 	parseModelString,
 	pickDefaultAvailableModel,
@@ -1960,6 +1961,44 @@ describe("resolveExplicitModelRole", () => {
 		expect(resolveExplicitModelRole("openai/gpt-4o:high", settings)).toBeUndefined();
 		expect(resolveExplicitModelRole("openai/gpt-4o:max", settings)).toBeUndefined();
 		expect(resolveExplicitModelRole(["openai/gpt-4o", "@reviewer:high"], settings)).toBe("reviewer");
+	});
+});
+
+describe("isDefaultModelRoleSelfAlias", () => {
+	test("classifies every bare self-alias spelling", () => {
+		expect(isDefaultModelRoleSelfAlias("default")).toBe(true);
+		expect(isDefaultModelRoleSelfAlias("@default")).toBe(true);
+		expect(isDefaultModelRoleSelfAlias(DEFAULT_MODEL_ROLE_ALIAS)).toBe(true);
+		expect(isDefaultModelRoleSelfAlias(`${LEGACY_MODEL_ROLE_ALIAS_PREFIX}default`)).toBe(true);
+	});
+
+	// The alias parser accepts a thinking suffix on every self-alias spelling
+	// (`resolveExplicitModelRole("*:low")` resolves to `default`), so the
+	// selector still names the default role and still resolves to no model. A
+	// predicate that compares the unsplit string would call `*:low` a concrete
+	// model knob and send `--reapply-config` down the "config named a model"
+	// path, where the circular selector cannot resolve.
+	test("classifies suffixed self aliases the alias parser accepts", () => {
+		for (const suffix of ["low", "xhigh", "max", "auto"]) {
+			expect(isDefaultModelRoleSelfAlias(`${DEFAULT_MODEL_ROLE_ALIAS}:${suffix}`)).toBe(true);
+			expect(isDefaultModelRoleSelfAlias(`@default:${suffix}`)).toBe(true);
+			expect(isDefaultModelRoleSelfAlias(`default:${suffix}`)).toBe(true);
+			expect(isDefaultModelRoleSelfAlias(`${LEGACY_MODEL_ROLE_ALIAS_PREFIX}default:${suffix}`)).toBe(true);
+		}
+	});
+
+	// A suffix that is not a thinking level is part of the selector, not a
+	// stripped tier — `@default:nonsense` is not the default role.
+	test("does not classify a non-thinking suffix as a self alias", () => {
+		expect(isDefaultModelRoleSelfAlias("@default:nonsense")).toBe(false);
+		expect(isDefaultModelRoleSelfAlias("*:nonsense")).toBe(false);
+	});
+
+	test("does not classify another role or a concrete model", () => {
+		expect(isDefaultModelRoleSelfAlias("@smol")).toBe(false);
+		expect(isDefaultModelRoleSelfAlias("@smol:low")).toBe(false);
+		expect(isDefaultModelRoleSelfAlias("anthropic/claude-sonnet-4-5")).toBe(false);
+		expect(isDefaultModelRoleSelfAlias("anthropic/claude-sonnet-4-5:low")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/profile-bootstrap.test.ts
+++ b/packages/coding-agent/test/profile-bootstrap.test.ts
@@ -223,6 +223,11 @@ describe("extractProfileFlags", () => {
 			profile: "work",
 			aliasName: undefined,
 		});
+		expect(extractProfileFlags(["--reapply-config", "--profile", "work"])).toEqual({
+			argv: ["--reapply-config"],
+			profile: "work",
+			aliasName: undefined,
+		});
 		expect(extractProfileFlags(["-p", "--profile", "work"])).toEqual({
 			argv: ["-p"],
 			profile: "work",

--- a/packages/coding-agent/test/reapply-config-cold-discovery-default.test.ts
+++ b/packages/coding-agent/test/reapply-config-cold-discovery-default.test.ts
@@ -1,0 +1,199 @@
+/**
+ * `--reapply-config` must give the configured `modelRoles.default` a
+ * cold-discovery retry BEFORE any lower-priority fallback claims the model.
+ *
+ * A discovery-backed provider (models.yml `discovery:`, LM Studio/Ollama/
+ * llama.cpp, an openai-compat proxy) ships no static models, so on a cache-cold
+ * boot the configured default resolves to nothing. Two lower-priority pickers
+ * sit downstream of that failure — the session's own baked model and the
+ * arbitrary availability pick — and both are reached only while `model` is
+ * still unset. So whichever one runs first permanently shadows the discovery
+ * refresh, and the resume lands on it even though `omp models` (which awaits
+ * discovery) lists the configured default.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { Api, FetchImpl, Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const OLLAMA_ENDPOINT = "http://127.0.0.1:11434";
+const DISCOVERED_MODEL = "phi3";
+
+describe("--reapply-config cold-discovery configured default", () => {
+	let tempDir: TempDir;
+	let sharedDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+	const savedOllamaEnv: Record<string, string | undefined> = {};
+
+	beforeAll(async () => {
+		sharedDir = TempDir.createSync("@omp-reapply-cold-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		sharedDir.removeSync();
+	});
+
+	beforeEach(() => {
+		// A stray ollama endpoint in the ambient environment would repoint
+		// discovery away from the mocked one and make the fetch mock throw.
+		for (const key of ["OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_CONTEXT_LENGTH"] as const) {
+			savedOllamaEnv[key] = Bun.env[key];
+			delete Bun.env[key];
+		}
+		tempDir = TempDir.createSync("@omp-reapply-cold-");
+	});
+
+	afterEach(async () => {
+		for (const key of ["OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_CONTEXT_LENGTH"] as const) {
+			const original = savedOllamaEnv[key];
+			if (original === undefined) delete Bun.env[key];
+			else Bun.env[key] = original;
+		}
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		tempDir.removeSync();
+	});
+
+	function anthropicModel(id: string): Model<Api> {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	function modelValue(model: Model<Api>): string {
+		return `${model.provider}/${model.id}`;
+	}
+
+	const mockOllamaDiscovery: FetchImpl = async input => {
+		const url = String(input);
+		if (url === `${OLLAMA_ENDPOINT}/api/tags`) {
+			return Response.json({ models: [{ name: DISCOVERED_MODEL }] });
+		}
+		if (url === `${OLLAMA_ENDPOINT}/api/show`) {
+			return Response.json({ capabilities: ["completion"] });
+		}
+		throw new Error(`Unexpected URL: ${url}`);
+	};
+
+	async function writeBakedSession(bakedModelValue: string): Promise<string> {
+		const sessionFile = path.join(tempDir.path(), `baked-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			sessionFile,
+			`${[
+				{ type: "session", version: 3, id: "baked-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: bakedModelValue,
+					role: "default",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		return sessionFile;
+	}
+
+	async function loadOverlay(defaultRole: string): Promise<Settings> {
+		const overlayPath = path.join(tempDir.path(), `overlay-${Bun.nanoseconds()}.yml`);
+		await Bun.write(overlayPath, `modelRoles:\n  default: "${defaultRole}"\n`);
+		return Settings.loadIsolated({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			inMemory: true,
+			configFiles: [overlayPath],
+		});
+	}
+
+	/**
+	 * Resume against a registry whose ollama catalog is reachable ONLY through a
+	 * discovery fetch: models.yml declares the provider with no static models and
+	 * the cache starts cold, so nothing resolves until a refresh runs.
+	 */
+	async function resume(sessionFile: string, settings: Settings): Promise<AgentSession> {
+		const modelsPath = path.join(tempDir.path(), "models.yml");
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					ollama: {
+						baseUrl: `${OLLAMA_ENDPOINT}/v1`,
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "ollama" },
+					},
+				},
+			}),
+		);
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath, { fetch: mockOllamaDiscovery });
+		const sessionManager = await SessionManager.open(sessionFile, path.join(tempDir.path(), "startup"));
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			rules: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			reapplyConfig: true,
+		});
+		session = result.session;
+		return result.session;
+	}
+
+	it("discovers the configured default instead of falling back to the session's baked model", async () => {
+		const bakedModel = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		// The only configured candidate needs discovery; the session's own model
+		// is bundled and immediately restorable, so it wins any race it is
+		// allowed to enter.
+		const settings = await loadOverlay(`ollama/${DISCOVERED_MODEL}`);
+
+		const resumed = await resume(sessionFile, settings);
+
+		expect(resumed.model?.provider).toBe("ollama");
+		expect(resumed.model?.id).toBe(DISCOVERED_MODEL);
+	});
+
+	it("discovers the first configured candidate instead of keeping the later one it matched early", async () => {
+		const bakedModel = anthropicModel("claude-opus-4-1");
+		const laterCandidate = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		// Ordered list whose first candidate needs discovery and whose second is
+		// already available: the early pass adopts index 1, which leaves `model`
+		// non-null and would otherwise skip the retry entirely.
+		const settings = await loadOverlay(`ollama/${DISCOVERED_MODEL},${modelValue(laterCandidate)}`);
+
+		const resumed = await resume(sessionFile, settings);
+
+		expect(resumed.model?.provider).toBe("ollama");
+		expect(resumed.model?.id).toBe(DISCOVERED_MODEL);
+	});
+});

--- a/packages/coding-agent/test/reapply-config-notice-severity.test.ts
+++ b/packages/coding-agent/test/reapply-config-notice-severity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { buildModelFallbackNotification } from "../src/main";
+
+describe("buildModelFallbackNotification", () => {
+	it("renders a --reapply-config adoption as informational, not a warning", () => {
+		// The documented contract on `modelFallbackMessage`: a config swap the user
+		// asked for with `--reapply-config` is the flag working, so it must not be
+		// dressed up as a warning.
+		const notify = buildModelFallbackNotification(
+			"--reapply-config: resumed on anthropic/claude-sonnet-4-5 from config instead of the session's openai/gpt-5",
+		);
+		expect(notify.kind).toBe("info");
+	});
+
+	it("keeps a --reapply-config unresolved config default as a warning", () => {
+		// Same flag, but the config named a model that did not resolve: a real
+		// fallback the user should see as a warning.
+		const notify = buildModelFallbackNotification(
+			'--reapply-config: config default "anthropic/nope" did not resolve; kept the session\'s anthropic/claude-sonnet-4-5',
+		);
+		expect(notify.kind).toBe("warn");
+	});
+
+	it("keeps a --reapply-config double failure as a warning", () => {
+		const notify = buildModelFallbackNotification(
+			'--reapply-config: config default "anthropic/nope" did not resolve and the session\'s openai/gone could not be restored; using anthropic/claude-sonnet-4-5',
+		);
+		expect(notify.kind).toBe("warn");
+	});
+
+	it("keeps an ordinary model-restore fallback as a warning", () => {
+		const notify = buildModelFallbackNotification(
+			"Could not restore the session's openai/gpt-5; using anthropic/claude-sonnet-4-5",
+		);
+		expect(notify.kind).toBe("warn");
+	});
+
+	it("classifies by prefix, so an adoption phrase quoted mid-message stays a warning", () => {
+		// The `info` downgrade is anchored to the start of the message because
+		// only `sdk.ts` emits that exact prefix. A failure notice that merely
+		// mentions the phrase must not inherit the downgrade — relaxing the match
+		// to a substring test would silence a real fallback warning.
+		const notify = buildModelFallbackNotification(
+			"Could not restore the session's openai/gpt-5 (--reapply-config: resumed on anthropic/claude-opus-4-1 from config instead of the session's x/y)",
+		);
+		expect(notify.kind).toBe("warn");
+	});
+});

--- a/packages/coding-agent/test/reapply-config-role-fallback-order.test.ts
+++ b/packages/coding-agent/test/reapply-config-role-fallback-order.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `--reapply-config` must resume on the FIRST configured `modelRoles.default`
+ * candidate, not on whichever candidate happened to be visible before extension
+ * providers registered.
+ *
+ * The startup role resolution in `sdk.ts` runs before extension factories drain
+ * their `pi.registerProvider(...)` queue into the registry. With an ordered
+ * fallback list whose first candidate lives behind such a provider, that early
+ * pass can only match a later candidate. `--reapply-config` adopts it, and the
+ * post-registration retry is gated on `!model` — so without re-resolving, the
+ * resume silently lands on the lower-priority configured fallback even though
+ * the preferred model became available moments later.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const EXTENSION_PROVIDER = "reapply-order-gw";
+const EXTENSION_MODEL = "reapply-order-model";
+
+describe("--reapply-config configured default fallback order", () => {
+	let tempDir: TempDir;
+	let sharedDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		sharedDir = TempDir.createSync("@omp-reapply-order-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		sharedDir.removeSync();
+	});
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@omp-reapply-order-");
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		tempDir.removeSync();
+	});
+
+	function anthropicModel(id: string): Model<Api> {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	function modelValue(model: Model<Api>): string {
+		return `${model.provider}/${model.id}`;
+	}
+
+	/**
+	 * Registers a provider the same way a real extension does — through the
+	 * runtime's pending-registration queue, which `sdk.ts` drains only AFTER its
+	 * early role resolution.
+	 */
+	const registerLateProvider: ExtensionFactory = pi => {
+		pi.registerProvider(EXTENSION_PROVIDER, {
+			baseUrl: "https://reapply-order.example.invalid/v1",
+			apiKey: "literal-test-key",
+			api: "openai-completions",
+			models: [
+				{
+					id: EXTENSION_MODEL,
+					name: "Reapply Order Model",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128_000,
+					maxTokens: 8192,
+				},
+			],
+		});
+	};
+
+	async function writeBakedSession(bakedModelValue: string): Promise<string> {
+		const sessionFile = path.join(tempDir.path(), `baked-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			sessionFile,
+			`${[
+				{ type: "session", version: 3, id: "baked-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: bakedModelValue,
+					role: "default",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		return sessionFile;
+	}
+
+	async function loadOverlay(defaultRole: string): Promise<Settings> {
+		const overlayPath = path.join(tempDir.path(), `overlay-${Bun.nanoseconds()}.yml`);
+		await Bun.write(overlayPath, `modelRoles:\n  default: "${defaultRole}"\n`);
+		return Settings.loadIsolated({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			inMemory: true,
+			configFiles: [overlayPath],
+		});
+	}
+
+	async function resume(sessionFile: string, settings: Settings, reapplyConfig: boolean): Promise<AgentSession> {
+		// A registry private to this resume: the extension provider registration
+		// must not leak into any other test's catalog.
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const sessionManager = await SessionManager.open(sessionFile, path.join(tempDir.path(), "startup"));
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			extensions: [registerLateProvider],
+			disableExtensionDiscovery: true,
+			skills: [],
+			rules: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			reapplyConfig,
+		});
+		session = result.session;
+		return result.session;
+	}
+
+	it("resumes on the first configured candidate once its extension provider registers", async () => {
+		const bakedModel = anthropicModel("claude-opus-4-1");
+		const laterCandidate = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		// Ordered fallback list: the FIRST candidate is behind the extension
+		// provider (invisible at early resolution), the second is bundled and
+		// already available, so the early pass matches index 1.
+		const settings = await loadOverlay(`${EXTENSION_PROVIDER}/${EXTENSION_MODEL},${modelValue(laterCandidate)}`);
+
+		const resumed = await resume(sessionFile, settings, true);
+
+		// The preferred candidate became available during extension registration,
+		// so `--reapply-config` must land on it — never on the configured fallback.
+		expect(resumed.model?.provider).toBe(EXTENSION_PROVIDER);
+		expect(resumed.model?.id).toBe(EXTENSION_MODEL);
+	});
+
+	it("still resumes on the first configured candidate when it is already available", async () => {
+		// Guards the re-resolution against regressing the ordinary case: when the
+		// early pass already matched index 0 there is nothing to re-resolve, and
+		// the adopted model must stay put.
+		const bakedModel = anthropicModel("claude-opus-4-1");
+		const firstCandidate = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		const settings = await loadOverlay(`${modelValue(firstCandidate)},${EXTENSION_PROVIDER}/${EXTENSION_MODEL}`);
+
+		const resumed = await resume(sessionFile, settings, true);
+
+		expect(resumed.model?.provider).toBe(firstCandidate.provider);
+		expect(resumed.model?.id).toBe(firstCandidate.id);
+	});
+
+	it("keeps the baked session model on a bare resume even when a later candidate matched first", async () => {
+		// Without the flag the session's own model wins regardless of how the
+		// configured role resolved, so the re-resolution must not reach this path.
+		const bakedModel = anthropicModel("claude-opus-4-1");
+		const laterCandidate = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		const settings = await loadOverlay(`${EXTENSION_PROVIDER}/${EXTENSION_MODEL},${modelValue(laterCandidate)}`);
+
+		const resumed = await resume(sessionFile, settings, false);
+
+		expect(resumed.model?.id).toBe(bakedModel.id);
+	});
+});

--- a/packages/coding-agent/test/reapply-config-runtime-provider-discovery.test.ts
+++ b/packages/coding-agent/test/reapply-config-runtime-provider-discovery.test.ts
@@ -1,0 +1,215 @@
+/**
+ * `--reapply-config` must give a configured `modelRoles.default` supplied by an
+ * EXTENSION its cold-cache discovery retry, not just one supplied by a
+ * config-declared discovery provider.
+ *
+ * An extension that registers a provider with `fetchDynamicModels` installs a
+ * RUNTIME model manager. `modelRegistry.refresh()` discovers those, but
+ * `getDiscoverableProviders()` reports only the config-declared half of the
+ * discovery surface. So with every implicit/config discovery provider disabled
+ * or absent, a guard written against that list sees an empty array and returns
+ * before the refresh can run — even though a runtime manager is registered and
+ * holds the configured default. The resume then falls through to the baked
+ * session model, which is exactly what the flag was asked to override.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const RUNTIME_PROVIDER = "reapply-runtime-gw";
+const RUNTIME_MODEL = "reapply-runtime-model";
+
+/** The implicit discovery providers the registry always adds; disabled so the
+ * config-declared discoverable list is genuinely empty. */
+const IMPLICIT_DISCOVERY_PROVIDERS = ["ollama", "llama.cpp", "lm-studio"];
+
+describe("--reapply-config runtime-provider cold discovery", () => {
+	let tempDir: TempDir;
+	let sharedDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		sharedDir = TempDir.createSync("@omp-reapply-runtime-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		sharedDir.removeSync();
+	});
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@omp-reapply-runtime-");
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		tempDir.removeSync();
+	});
+
+	function anthropicModel(id: string): Model<Api> {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	function modelValue(model: Model<Api>): string {
+		return `${model.provider}/${model.id}`;
+	}
+
+	/**
+	 * Config-declared discoverable providers for these settings, read from a
+	 * throwaway registry so the assertion never perturbs the one under test.
+	 */
+	function countConfigDiscoverableProviders(settings: Settings): number {
+		const probe = new ModelRegistry(authStorage, path.join(tempDir.path(), "probe-models.yml"), { settings });
+		return probe.getDiscoverableProviders().length;
+	}
+
+	let dynamicFetches = 0;
+
+	/**
+	 * A dynamic-ONLY provider: it declares no static `models`, so nothing exists
+	 * until a discovery pass calls `fetchDynamicModels`. Registered through the
+	 * runtime's pending-registration queue, the same path a real extension uses.
+	 */
+	const registerRuntimeProvider: ExtensionFactory = pi => {
+		pi.registerProvider(RUNTIME_PROVIDER, {
+			baseUrl: "https://reapply-runtime.example.invalid/v1",
+			apiKey: "literal-test-key",
+			api: "openai-completions",
+			fetchDynamicModels: async () => {
+				dynamicFetches += 1;
+				return [
+					{
+						id: RUNTIME_MODEL,
+						name: "Reapply Runtime Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8192,
+					},
+				];
+			},
+		});
+	};
+
+	async function writeBakedSession(bakedModelValue: string): Promise<string> {
+		const sessionFile = path.join(tempDir.path(), `baked-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			sessionFile,
+			`${[
+				{ type: "session", version: 3, id: "baked-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: bakedModelValue,
+					role: "default",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		return sessionFile;
+	}
+
+	async function loadOverlay(defaultRole: string): Promise<Settings> {
+		const overlayPath = path.join(tempDir.path(), `overlay-${Bun.nanoseconds()}.yml`);
+		await Bun.write(
+			overlayPath,
+			`modelRoles:\n  default: "${defaultRole}"\ndisabledProviders:\n${IMPLICIT_DISCOVERY_PROVIDERS.map(
+				provider => `  - "${provider}"\n`,
+			).join("")}`,
+		);
+		return Settings.loadIsolated({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			inMemory: true,
+			configFiles: [overlayPath],
+		});
+	}
+
+	async function resume(sessionFile: string, settings: Settings): Promise<AgentSession> {
+		// A registry private to this resume, with a cache DB under the per-test
+		// temp dir so the runtime catalog genuinely starts cold. `settings` is
+		// passed so the disabled implicit providers actually take effect.
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"), { settings });
+		const sessionManager = await SessionManager.open(sessionFile, path.join(tempDir.path(), "startup"));
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			extensions: [registerRuntimeProvider],
+			disableExtensionDiscovery: true,
+			skills: [],
+			rules: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			// `hasUI` keeps online runtime discovery deferred to the post-paint
+			// starter, so nothing populates the runtime catalog before the guard
+			// under test runs. Without this the background pass would mask the bug.
+			hasUI: true,
+			reapplyConfig: true,
+		});
+		session = result.session;
+		return result.session;
+	}
+
+	it("discovers an extension-supplied configured default with no config discovery providers", async () => {
+		dynamicFetches = 0;
+		const bakedModel = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		const settings = await loadOverlay(`${RUNTIME_PROVIDER}/${RUNTIME_MODEL}`);
+		// The premise of the finding: nothing config-declared is left to discover,
+		// so a guard keyed off this list short-circuits.
+		expect(countConfigDiscoverableProviders(settings)).toBe(0);
+
+		const resumed = await resume(sessionFile, settings);
+
+		expect(dynamicFetches).toBeGreaterThan(0);
+		expect(resumed.model?.provider).toBe(RUNTIME_PROVIDER);
+		expect(resumed.model?.id).toBe(RUNTIME_MODEL);
+	});
+
+	it("keeps the baked session model when the configured default is unresolvable", async () => {
+		// Guards the widened refresh against over-adopting: a refresh that
+		// discovers nothing matching must still leave the resume on its own model
+		// rather than an arbitrary pick.
+		dynamicFetches = 0;
+		const bakedModel = anthropicModel("claude-sonnet-4-5");
+		const sessionFile = await writeBakedSession(modelValue(bakedModel));
+
+		const settings = await loadOverlay(`${RUNTIME_PROVIDER}/no-such-runtime-model`);
+
+		const resumed = await resume(sessionFile, settings);
+
+		expect(resumed.model?.id).toBe(bakedModel.id);
+	});
+});

--- a/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
+++ b/packages/coding-agent/test/session-fork-prompt-cache-key.test.ts
@@ -169,6 +169,16 @@ describe("provider prompt-cache key session affinity", () => {
 				name: "tools",
 				options: { toolNames: ["read"] },
 			},
+			{
+				// `--reapply-config` re-resolves model and thinking from config, so
+				// the request shape can change with no explicit model/thinking
+				// option. `main.ts` drops the inherited key for the CLI path, but
+				// `createAgentSessionScoped` reads the header independently — so
+				// without this in the SDK check, the SDK path (and the CLI through
+				// it) kept the parent's affinity anyway.
+				name: "reapply-config",
+				options: { reapplyConfig: true },
+			},
 		];
 
 		for (const entry of cases) {
@@ -226,6 +236,55 @@ describe("provider prompt-cache key session affinity", () => {
 
 			expect(options.model).toBe(OPENAI_TEST_MODEL);
 			expect(options.providerPromptCacheKey).toBeUndefined();
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	it("drops inherited prompt-cache affinity when --reapply-config can reshape the request", async () => {
+		using tempDir = TempDir.createSync("@omp-prompt-cache-reapply-");
+		const source = await createSourceSessionFixture(tempDir, "parent-cache-session-reapply");
+		const forkedManager = await SessionManager.forkFrom(source.sourceFile, source.cwd, source.forkSessionDir);
+		const authStorage = await AuthStorage.create(tempDir.join("reapply-auth.db"));
+		authStorage.setRuntimeApiKey(OPENAI_TEST_MODEL.provider, "test-key");
+		try {
+			const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+
+			// Baseline: a bare resume of the same fork keeps the parent's key, so
+			// the fixture really does carry inheritable affinity.
+			const inherited = await buildSessionOptions(
+				parseArgs(["--cwd", source.cwd]),
+				[],
+				forkedManager,
+				modelRegistry,
+				settings,
+			);
+			expect(inherited.providerPromptCacheKey).toBe(source.sourceHeader.id);
+			expect(inherited.providerPromptCacheKeySource).toBe("fork");
+
+			// --reapply-config re-resolves model/thinking from config, so the
+			// parent's cache affinity no longer matches this request's shape.
+			const reapplied = await buildSessionOptions(
+				parseArgs(["--cwd", source.cwd, "--reapply-config"]),
+				[],
+				forkedManager,
+				modelRegistry,
+				settings,
+			);
+			expect(reapplied.providerPromptCacheKey).toBeUndefined();
+
+			// An explicit --prompt-cache-key is the user's own instruction and
+			// still wins over the reapply-driven discard.
+			const explicit = await buildSessionOptions(
+				parseArgs(["--cwd", source.cwd, "--reapply-config", "--prompt-cache-key", "pinned-affinity"]),
+				[],
+				forkedManager,
+				modelRegistry,
+				settings,
+			);
+			expect(explicit.providerPromptCacheKey).toBe("pinned-affinity");
+			expect(explicit.providerPromptCacheKeySource).toBe("explicit");
 		} finally {
 			authStorage.close();
 		}


### PR DESCRIPTION
## Problem

`--resume` restores the model, thinking level, and service tier that were baked into the session when it was created. That is right for a session you want to continue exactly as it was, but wrong when the config default has moved on: you resume an old session and silently get the old model, with no way to adopt the current config short of starting fresh and losing the history.

## Approach

Add `--reapply-config` (and the equivalent `reapplyConfig` SDK option). On resume it adopts the config-resolved default model, its thinking level, and its service tier, instead of the values baked into the session. Without the flag, behavior is unchanged.

The interesting part is what happens when config has nothing useful to say. Adopting a missing default would be worse than keeping the session value, so each of these keeps the session model and stays silent: config specifies no default, tombstones it (`null`), names an empty string, or names the bare `default` sentinel. When config names an unresolvable or typo'd default, the session value is kept and a notice explains why. A double failure — unresolvable config default *and* an unrestorable baked model — is reported naming both, rather than failing with one cause and hiding the other.

`--model` combined with `reapplyConfig` keeps the session's thinking level, since an explicit model choice shouldn't drag an unrelated thinking level along with it. Service tier merges per family.

## Verification

`bun test` over the three touched suites: **125 pass, 0 fail**.

`agent-session-model-persistence.test.ts` covers each field adopting the config value on resume with `reapplyConfig` and restoring the baked session value on a bare resume without it, plus every keep-silently case above, the keep-with-notice case, the double-failure report, the `--model` interaction, and per-family tier merging. A session with no `model_change` entry stays silent rather than emitting a notice that names a nonexistent session model.
