### PR TITLE
feat(advisor): add configurable advice budget per update (default 4)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
+- Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.
+
 ### Fixed
 
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
@@ -30,7 +34,6 @@
 - Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 - Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 - Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
-
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
 - Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+- Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
+- Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.14] - 2026-09-07
 
@@ -31,9 +32,7 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
-- Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
-- Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
-- Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
 - Advisor notes now report rate limiting accurately and deferred notes flush when the primary turn completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 - Advisor notes now report rate limiting accurately and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+- Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -177,7 +177,7 @@ function advisorSeverityRank(severity: AdvisorSeverity | undefined): number {
 const ADVISOR_RESULT_TEXT: Record<AdvisorEmissionDecision, string> = {
 	accepted: "Recorded.",
 	duplicate: "Duplicate advice ignored.",
-	rate_limited: "Rate limited — only one note accepted per update. Re-raise this note on the next update.",
+	rate_limited: "Rate limited — update advice budget reached. Re-raise this note on the next update.",
 	suppressed_noise: "Ignored — advice is empty or non-actionable.",
 };
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -9,7 +9,7 @@ import type {
 } from "@oh-my-pi/pi-agent-core";
 import { escapeXmlAttribute, escapeXmlText } from "@oh-my-pi/pi-utils";
 import adviseDescription from "../prompts/advisor/advise-tool.md" with { type: "text" };
-import { normalizeAdvisorNote } from "./emission-guard";
+import { type AdvisorEmissionDecision, normalizeAdvisorNote } from "./emission-guard";
 
 const adviseSchema = type({
 	note: type("string").describe(
@@ -174,6 +174,13 @@ function advisorSeverityRank(severity: AdvisorSeverity | undefined): number {
 	return ADVISOR_SEVERITY_RANK[severity ?? "nit"];
 }
 
+const ADVISOR_RESULT_TEXT: Record<AdvisorEmissionDecision, string> = {
+	accepted: "Recorded.",
+	duplicate: "Duplicate advice ignored.",
+	rate_limited: "Rate limited — only one note accepted per update. Re-raise this note on the next update.",
+	suppressed_noise: "Ignored — advice is empty or non-actionable.",
+};
+
 export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails> {
 	readonly name = "advise";
 	readonly label = "Advise";
@@ -196,21 +203,21 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	/**
 	 * @param onAdvice Route an accepted note to the primary (channel selection +
 	 *   delivery). Never re-filters — the note already cleared `accept`.
-	 * @param accept The emission guard's noise/empty/dedupe filter plus the
-	 *   one-advise-per-update budget, consumed the moment a note is emitted
-	 *   (live or deferred). A suppressed note returns `false` without spending
-	 *   the budget, so it cannot burn an update's slot ahead of a real concern.
-	 *   Defaults to always-accept for standalone use/tests without a guard.
+	 * @param accept The emission guard's noise/empty/dedupe classification plus
+	 *   the one-advise-per-update budget, consumed the moment a note is emitted
+	 *   (live or deferred). A rejected note reports the specific reason without
+	 *   spending the budget. Defaults to accepted for standalone use/tests.
 	 */
 	constructor(
 		private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void,
-		private readonly accept: (note: string) => boolean = () => true,
+		private readonly accept: (note: string, severity?: AdviseDetails["severity"]) => AdvisorEmissionDecision = () =>
+			"accepted",
 	) {}
 
 	/**
-	 * Mark whether the next advisor prompt reviews an in-progress primary turn.
-	 * Non-blockers are withheld until a completed update so partial work does
-	 * not interrupt the primary before it can finish its planned steps.
+	 * Synchronize the primary turn state. Non-blockers are withheld while a turn
+	 * is in progress; the first completed boundary flushes them even when the
+	 * advisor runtime cannot dispatch another prompt.
 	 */
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
@@ -248,22 +255,27 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 			// reached the primary, so it never re-raised and the advice was lost.
 			const key = advisorNoteDedupeKey(args.note);
 			const pending = this.#deferredNotes.find(item => item.key === key);
+			let decision: AdvisorEmissionDecision = "accepted";
 			if (pending) {
 				// Escalating an already-queued note reuses its slot; never a new one.
 				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
 					pending.severity = args.severity;
-			} else if (this.accept(args.note)) {
-				// Reserve the update's one slot now (the emission guard filters noise
-				// and enforces the per-update budget at the moment the note is emitted,
-				// exactly like the live path); hold it for the flush. A suppressed or
-				// over-budget note fails `accept` here and is dropped without a slot.
-				this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
+			} else {
+				decision = this.accept(args.note, args.severity);
+				if (decision === "accepted") {
+					// Reserve the update's one slot now; the flush routes it without
+					// consuming a second slot.
+					this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
+				}
 			}
 			return {
 				content: [
 					{
 						type: "text",
-						text: "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point.",
+						text:
+							decision === "accepted"
+								? "Deferred — primary is mid-turn; this note will be delivered automatically when the turn completes. Do not re-raise the same point."
+								: ADVISOR_RESULT_TEXT[decision],
 					},
 				],
 				details: { note: args.note, severity: args.severity },
@@ -279,28 +291,25 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		const key = advisorNoteDedupeKey(args.note);
 		const reservedIndex = this.#deferredNotes.findIndex(item => item.key === key);
 		if (reservedIndex !== -1) this.#deferredNotes.splice(reservedIndex, 1);
-		const delivered = this.#deliver(args.note, args.severity, reservedIndex !== -1);
+		const decision = this.#deliver(args.note, args.severity, reservedIndex !== -1);
 		return {
-			content: [{ type: "text", text: delivered ? "Recorded." : "Duplicate advice ignored." }],
+			content: [{ type: "text", text: ADVISOR_RESULT_TEXT[decision] }],
 			details: { note: args.note, severity: args.severity },
 			useless: true,
 		};
 	}
 
-	/** Run one note through the escalation-rank dedupe and, if it passes, route it
-	 *  to the primary. Returns true when the note was actually delivered. Shared by
-	 *  the live path (`execute`) and the deferred flush (`beginUpdate(false)`). */
-	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): boolean {
+	/** Run one note through the escalation-rank dedupe and emission policy before
+	 *  routing it. Returns the exact policy outcome for truthful tool feedback. */
+	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): AdvisorEmissionDecision {
 		const key = advisorNoteDedupeKey(note);
 		const rank = advisorSeverityRank(severity);
 		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
-		if (rank <= previousRank) return false;
-		// Live notes clear the emission guard here; deferred notes already cleared
-		// it when reserved, so the flush passes `alreadyAccepted` to avoid a second
-		// (budget-consuming, dedupe-rejecting) pass.
-		if (!alreadyAccepted && !this.accept(note)) return false;
+		if (rank <= previousRank) return "duplicate";
+		const decision = alreadyAccepted ? "accepted" : this.accept(note, severity);
+		if (decision !== "accepted") return decision;
 		this.#deliveredNoteSeverities.set(key, rank);
 		this.onAdvice(note, severity);
-		return true;
+		return "accepted";
 	}
 }

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -204,7 +204,7 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 * @param onAdvice Route an accepted note to the primary (channel selection +
 	 *   delivery). Never re-filters — the note already cleared `accept`.
 	 * @param accept The emission guard's noise/empty/dedupe classification plus
-	 *   the one-advise-per-update budget, consumed the moment a note is emitted
+	 *   the per-update advice budget, consumed the moment a note is emitted
 	 *   (live or deferred). A rejected note reports the specific reason without
 	 *   spending the budget. Defaults to accepted for standalone use/tests.
 	 */

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -27,6 +27,11 @@ export interface AdvisorConfig {
 	 *  stays in the roster but its runtime is never built — it shows `○` in
 	 *  the status line and `/advisor status` rather than disappearing. */
 	enabled?: boolean;
+	/**
+	 * Per-advisor maximum non-blocker advice notes accepted per advisor prompt
+	 * update (default `4`). Blockers are exempt from the budget.
+	 */
+	maxNotesPerUpdate?: number;
 }
 
 /**
@@ -48,6 +53,7 @@ export type AdvisorRuntimeStatus = "running" | "paused" | "quota_exhausted" | "e
 export interface DiscoveredAdvisors {
 	advisors: AdvisorConfig[];
 	sharedInstructions: string | undefined;
+	sharedMaxNotesPerUpdate?: number;
 }
 
 const advisorEntrySchema = type({
@@ -56,10 +62,12 @@ const advisorEntrySchema = type({
 	"tools?": "string[]",
 	"instructions?": "string",
 	"enabled?": "boolean",
+	"maxNotesPerUpdate?": "number",
 });
 
 const watchdogYamlSchema = type({
 	"instructions?": "string",
+	"maxNotesPerUpdate?": "number",
 	"advisors?": advisorEntrySchema.array(),
 });
 
@@ -139,7 +147,7 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 	const items = await collectConfigCandidates(cwd, agentDir, ["WATCHDOG.yml", "WATCHDOG.yaml"]);
 	const advisors = new Map<string, AdvisorConfig>();
 	const sharedParts: string[] = [];
-
+	let sharedMaxNotesPerUpdate: number | undefined;
 	for (const item of items) {
 		let parsed: unknown;
 		try {
@@ -163,6 +171,14 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 			if (expanded) sharedParts.push(expanded);
 		}
 
+		if (
+			typeof result.maxNotesPerUpdate === "number" &&
+			Number.isFinite(result.maxNotesPerUpdate) &&
+			result.maxNotesPerUpdate >= 1
+		) {
+			sharedMaxNotesPerUpdate = Math.trunc(result.maxNotesPerUpdate);
+		}
+
 		for (const entry of result.advisors ?? []) {
 			const slug = slugifyAdvisorName(entry.name);
 			const instructions = entry.instructions?.trim()
@@ -174,6 +190,12 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 				tools: filterAdvisorTools(entry.tools, item.path),
 				instructions,
 				enabled: entry.enabled,
+				maxNotesPerUpdate:
+					typeof entry.maxNotesPerUpdate === "number" &&
+					Number.isFinite(entry.maxNotesPerUpdate) &&
+					entry.maxNotesPerUpdate >= 1
+						? Math.trunc(entry.maxNotesPerUpdate)
+						: undefined,
 			});
 		}
 	}
@@ -181,6 +203,7 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 	return {
 		advisors: [...advisors.values()],
 		sharedInstructions: sharedParts.length > 0 ? sharedParts.join("\n\n") : undefined,
+		sharedMaxNotesPerUpdate,
 	};
 }
 
@@ -195,6 +218,7 @@ export type AdvisorConfigScope = "project" | "user";
  */
 export interface WatchdogConfigDoc {
 	instructions?: string;
+	maxNotesPerUpdate?: number;
 	advisors: AdvisorConfig[];
 }
 
@@ -260,10 +284,20 @@ export async function loadWatchdogConfigFile(filePath: string): Promise<Watchdog
 		if (a.tools !== undefined) advisor.tools = [...a.tools];
 		if (a.instructions?.trim()) advisor.instructions = a.instructions;
 		if (a.enabled !== undefined) advisor.enabled = a.enabled;
+		if (typeof a.maxNotesPerUpdate === "number" && Number.isFinite(a.maxNotesPerUpdate) && a.maxNotesPerUpdate >= 1) {
+			advisor.maxNotesPerUpdate = Math.trunc(a.maxNotesPerUpdate);
+		}
 		return advisor;
 	});
 	const doc: WatchdogConfigDoc = { advisors };
 	if (result.instructions?.trim()) doc.instructions = result.instructions;
+	if (
+		typeof result.maxNotesPerUpdate === "number" &&
+		Number.isFinite(result.maxNotesPerUpdate) &&
+		result.maxNotesPerUpdate >= 1
+	) {
+		doc.maxNotesPerUpdate = Math.trunc(result.maxNotesPerUpdate);
+	}
 	return doc;
 }
 
@@ -299,6 +333,13 @@ function appendYamlString(lines: string[], indent: string, key: string, value: s
 export function serializeWatchdogConfig(doc: WatchdogConfigDoc): string {
 	const lines: string[] = [];
 	if (doc.instructions?.trim()) appendYamlString(lines, "", "instructions", doc.instructions);
+	if (
+		typeof doc.maxNotesPerUpdate === "number" &&
+		Number.isFinite(doc.maxNotesPerUpdate) &&
+		doc.maxNotesPerUpdate >= 1
+	) {
+		lines.push(`maxNotesPerUpdate: ${Math.trunc(doc.maxNotesPerUpdate)}`);
+	}
 	if (doc.advisors.length > 0) {
 		lines.push("advisors:");
 		for (const advisor of doc.advisors) {
@@ -318,6 +359,13 @@ export function serializeWatchdogConfig(doc: WatchdogConfigDoc): string {
 				appendYamlString(lines, "    ", "instructions", advisor.instructions);
 			}
 			if (advisor.enabled !== undefined) lines.push(`    enabled: ${advisor.enabled}`);
+			if (
+				typeof advisor.maxNotesPerUpdate === "number" &&
+				Number.isFinite(advisor.maxNotesPerUpdate) &&
+				advisor.maxNotesPerUpdate >= 1
+			) {
+				lines.push(`    maxNotesPerUpdate: ${Math.trunc(advisor.maxNotesPerUpdate)}`);
+			}
 		}
 	}
 	return lines.length === 0 ? "" : `${lines.join("\n")}\n`;

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -11,14 +11,10 @@
  * 114× `Stop.`, 52× `No issue; continue.`, 41× `Done.` — flooding the primary
  * transcript with `<advisory severity="blocker">Stop.</advisory>` after the
  * task was already complete. The fix is to make the rules load-bearing in code
- * instead of prose: silently drop duplicates, content-free self-talk, and
- * over-budget calls at the `enqueueAdvice` boundary so the primary stays
- * clean even when the advisor misbehaves.
- *
- * The gate is intentionally invisible to the advisor model — `AdviseTool`
- * still returns `Recorded.` for a suppressed call. Surfacing "suppressed"
- * back into advisor context risks the model rephrasing the same useless note
- * to bypass the dedupe ("Stop.", then "Halt." then "Stop now.").
+ * instead of prose: classify duplicates, content-free self-talk, and over-budget
+ * calls at the emission boundary so the primary stays clean even when the advisor
+ * misbehaves. `AdviseTool` reports the resulting decision; in particular, an
+ * actionable over-budget note is told to retry instead of being falsely recorded.
  */
 
 /**
@@ -100,6 +96,9 @@ const SUPPRESSED_NORMALIZED_PHRASES: Record<string, true> = {
  */
 const DEFAULT_HISTORY_CAPACITY = 4096;
 
+/** Why an advisor note was accepted or rejected by the emission policy. */
+export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" | "suppressed_noise";
+
 /**
  * Decides whether an advisor `advise()` call should reach the primary agent.
  *
@@ -146,25 +145,14 @@ export class AdvisorEmissionGuard {
 	}
 
 	/**
-	 * Whether the proposed note should reach the primary. On `true` the gate
-	 * has already recorded the note (consumed the per-update budget and added
-	 * it to the dedupe history) — caller delivers the note. On `false` the
-	 * caller drops it.
-	 *
-	 * The single authority for the one-advise-per-update budget: called at the
-	 * moment a note is emitted, whether it is delivered live or held for a
-	 * deferred flush. A note that fails the noise/empty/dedupe filter never
-	 * consumes the budget, so a suppressed phrase cannot burn the update's slot
-	 * ahead of a substantive concern. Empty / whitespace-only notes are
-	 * suppressed defensively even though the tool-args contract requires a
-	 * non-empty string.
+	 * Classify and reserve a proposed note. Accepted notes consume the update
+	 * budget and enter the dedupe history; rejected notes leave both unchanged.
 	 */
-	accept(note: string): boolean {
+	accept(note: string): AdvisorEmissionDecision {
 		const key = normalizeAdvisorNote(note);
-		if (!key) return false;
-		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return false;
-		if (this.#seen.has(key)) return false;
-		if (this.#consumedThisUpdate) return false;
+		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
+		if (this.#seen.has(key)) return "duplicate";
+		if (this.#consumedThisUpdate) return "rate_limited";
 		this.#consumedThisUpdate = true;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);
@@ -172,6 +160,6 @@ export class AdvisorEmissionGuard {
 			const stale = this.#seenOrder.shift();
 			if (stale !== undefined) this.#seen.delete(stale);
 		}
-		return true;
+		return "accepted";
 	}
 }

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -98,9 +98,11 @@ const SUPPRESSED_NORMALIZED_PHRASES: Record<string, true> = {
  */
 const DEFAULT_HISTORY_CAPACITY = 4096;
 
+/** Maximum non-blocker advise notes allowed per update cycle across all configurations. */
+export const ADVISOR_MAX_BUDGET_PER_UPDATE = 32;
+
 /** Why an advisor note was accepted or rejected by the emission policy. */
 export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" | "suppressed_noise";
-
 /**
  * Decides whether an advisor `advise()` call should reach the primary agent.
  *
@@ -128,7 +130,9 @@ export class AdvisorEmissionGuard {
 		this.#capacity = opts.capacity ?? DEFAULT_HISTORY_CAPACITY;
 		const budget = opts.budgetPerUpdate;
 		this.#budgetPerUpdate =
-			typeof budget === "number" && Number.isFinite(budget) ? Math.max(1, Math.trunc(budget)) : 4;
+			typeof budget === "number" && Number.isFinite(budget)
+				? Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.max(1, Math.trunc(budget)))
+				: 4;
 	}
 
 	/**

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -17,6 +17,8 @@
  * actionable over-budget note is told to retry instead of being falsely recorded.
  */
 
+import type { AdvisorSeverity } from "./advise-tool";
+
 /**
  * Case-insensitive, punctuation-folded normalization. Collapses every run of
  * non-letter / non-digit characters into a single space and trims, so
@@ -106,7 +108,9 @@ export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" 
  * dedupe (FIFO-evicted at {@link DEFAULT_HISTORY_CAPACITY}), and a per-update
  * rate limit of one accepted note per advisor model prompt. Suppressed calls
  * never consume the per-update budget — a noise call doesn't burn the slot
- * for a real concern that follows in the same update.
+ * for a real concern that follows in the same update. A `blocker` is exempt
+ * from the budget: it must always interrupt, so a lower-severity note emitted
+ * earlier in the same update can never rate-limit it out.
  *
  * Reset on advisor reset (compaction, session switch, `/new`) via
  * {@link reset}. Per-update gate is cleared at the start of every advisor
@@ -147,12 +151,14 @@ export class AdvisorEmissionGuard {
 	/**
 	 * Classify and reserve a proposed note. Accepted notes consume the update
 	 * budget and enter the dedupe history; rejected notes leave both unchanged.
+	 * A `blocker` still runs the noise and dedupe filters but bypasses the
+	 * one-note-per-update budget so it always reaches the primary.
 	 */
-	accept(note: string): AdvisorEmissionDecision {
+	accept(note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
 		const key = normalizeAdvisorNote(note);
 		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
 		if (this.#seen.has(key)) return "duplicate";
-		if (this.#consumedThisUpdate) return "rate_limited";
+		if (severity !== "blocker" && this.#consumedThisUpdate) return "rate_limited";
 		this.#consumedThisUpdate = true;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -120,11 +120,15 @@ export class AdvisorEmissionGuard {
 	#seen = new Set<string>();
 	/** Insertion-order log to drive FIFO eviction without an extra Map. */
 	#seenOrder: string[] = [];
-	#consumedThisUpdate = false;
+	#acceptedThisUpdate = 0;
+	readonly #budgetPerUpdate: number;
 	readonly #capacity: number;
 
-	constructor(opts: { capacity?: number } = {}) {
+	constructor(opts: { capacity?: number; budgetPerUpdate?: number } = {}) {
 		this.#capacity = opts.capacity ?? DEFAULT_HISTORY_CAPACITY;
+		const budget = opts.budgetPerUpdate;
+		this.#budgetPerUpdate =
+			typeof budget === "number" && Number.isFinite(budget) ? Math.max(1, Math.trunc(budget)) : 4;
 	}
 
 	/**
@@ -136,7 +140,7 @@ export class AdvisorEmissionGuard {
 	reset(): void {
 		this.#seen.clear();
 		this.#seenOrder.length = 0;
-		this.#consumedThisUpdate = false;
+		this.#acceptedThisUpdate = 0;
 	}
 
 	/**
@@ -145,7 +149,7 @@ export class AdvisorEmissionGuard {
 	 * cycle starts with a fresh budget of one advise.
 	 */
 	beginUpdate(): void {
-		this.#consumedThisUpdate = false;
+		this.#acceptedThisUpdate = 0;
 	}
 
 	/**
@@ -158,8 +162,8 @@ export class AdvisorEmissionGuard {
 		const key = normalizeAdvisorNote(note);
 		if (!key || SUPPRESSED_NORMALIZED_PHRASES[key]) return "suppressed_noise";
 		if (this.#seen.has(key)) return "duplicate";
-		if (severity !== "blocker" && this.#consumedThisUpdate) return "rate_limited";
-		this.#consumedThisUpdate = true;
+		if (severity !== "blocker" && this.#acceptedThisUpdate >= this.#budgetPerUpdate) return "rate_limited";
+		if (severity !== "blocker") this.#acceptedThisUpdate++;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);
 		if (this.#seenOrder.length > this.#capacity) {

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -101,6 +101,8 @@ const DEFAULT_HISTORY_CAPACITY = 4096;
 /** Maximum non-blocker advise notes allowed per update cycle across all configurations. */
 export const ADVISOR_MAX_BUDGET_PER_UPDATE = 32;
 
+/** Default non-blocker advise notes allowed per update cycle when unspecified. */
+export const ADVISOR_DEFAULT_BUDGET_PER_UPDATE = 4;
 /** Why an advisor note was accepted or rejected by the emission policy. */
 export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" | "suppressed_noise";
 /**
@@ -132,7 +134,7 @@ export class AdvisorEmissionGuard {
 		this.#budgetPerUpdate =
 			typeof budget === "number" && Number.isFinite(budget)
 				? Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.max(1, Math.trunc(budget)))
-				: 4;
+				: ADVISOR_DEFAULT_BUDGET_PER_UPDATE;
 	}
 
 	/**

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -1,9 +1,10 @@
 /**
  * Per-session policy gate for advisor `advise()` calls.
  *
- * The advisor system prompt tells the watcher model:
+ * The advisor system prompt tells the watcher model a per-update advice budget
+ * (default 4 non-blockers, `blocker` exempt):
  *
- * > at most one `advise` per update
+ * > max N non-blockers/update (`blocker` exempt)
  * > NEVER repeat advice you already gave, and NEVER send the same advice twice
  *
  * Real advisor models violate this. Issue #3520 captured a session where
@@ -110,7 +111,7 @@ export type AdvisorEmissionDecision = "accepted" | "duplicate" | "rate_limited" 
  *
  * Enforces — in this order — the noise filter, session-scoped exact-text
  * dedupe (FIFO-evicted at {@link DEFAULT_HISTORY_CAPACITY}), and a per-update
- * rate limit of one accepted note per advisor model prompt. Suppressed calls
+ * budget of accepted notes per advisor model prompt. Suppressed calls
  * never consume the per-update budget — a noise call doesn't burn the slot
  * for a real concern that follows in the same update. A `blocker` is exempt
  * from the budget: it must always interrupt, so a lower-severity note emitted
@@ -152,7 +153,7 @@ export class AdvisorEmissionGuard {
 	/**
 	 * Clear the per-update rate-limit gate. Called by `AdvisorRuntime` right
 	 * before each `agent.prompt(batch)` invocation so the next advisor model
-	 * cycle starts with a fresh budget of one advise.
+	 * cycle starts with a fresh budget.
 	 */
 	beginUpdate(): void {
 		this.#acceptedThisUpdate = 0;
@@ -162,7 +163,7 @@ export class AdvisorEmissionGuard {
 	 * Classify and reserve a proposed note. Accepted notes consume the update
 	 * budget and enter the dedupe history; rejected notes leave both unchanged.
 	 * A `blocker` still runs the noise and dedupe filters but bypasses the
-	 * one-note-per-update budget so it always reaches the primary.
+	 * per-update budget so it always reaches the primary.
 	 */
 	accept(note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
 		const key = normalizeAdvisorNote(note);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -586,6 +586,25 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.maxNotesPerUpdate": {
+		type: "number",
+		default: 4,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Max Notes Per Update",
+			description:
+				"Maximum non-blocker advice notes accepted per advisor prompt update. Defaults to 4. Blockers are exempt.",
+			options: [
+				{ value: "1", label: "1 note", description: "Anti-flood (strict)." },
+				{ value: "2", label: "2 notes" },
+				{ value: "3", label: "3 notes" },
+				{ value: "4", label: "4 notes", description: "Default." },
+				{ value: "5", label: "5 notes" },
+			],
+			condition: "advisorEnabled",
+		},
+	},
 	shellPath: { type: "string", default: undefined },
 	"git.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1,3 +1,4 @@
+import { ADVISOR_DEFAULT_BUDGET_PER_UPDATE } from "../advisor/emission-guard";
 import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { SHAPE_VARIANT_NAMES } from "@oh-my-pi/snapcompact";
@@ -588,13 +589,13 @@ export const SETTINGS_SCHEMA = {
 	},
 	"advisor.maxNotesPerUpdate": {
 		type: "number",
-		default: 4,
+		default: ADVISOR_DEFAULT_BUDGET_PER_UPDATE,
 		ui: {
 			tab: "model",
 			group: "Advisor",
 			label: "Advisor Max Notes Per Update",
 			description:
-				"Maximum non-blocker advice notes accepted per advisor prompt update. Defaults to 4. Blockers are exempt.",
+				"Maximum non-blocker advice notes accepted per advisor prompt update (1–32; UI offers 1–5 quick picks). Blockers are exempt.",
 			options: [
 				{ value: "1", label: "1 note", description: "Anti-flood (strict)." },
 				{ value: "2", label: "2 notes" },

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -163,6 +163,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"advisor.enabled",
 	"advisor.syncBacklog",
 	"advisor.immuneTurns",
+	"advisor.maxNotesPerUpdate",
 	"tier.advisor",
 ];
 

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -353,7 +353,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 	}
 
 	#isBareDefaultDoc(doc: WatchdogConfigDoc): boolean {
-		if (doc.advisors.length !== 1 || doc.instructions?.trim()) return false;
+		if (doc.advisors.length !== 1 || doc.instructions?.trim() || doc.maxNotesPerUpdate !== undefined) return false;
 		const advisor = doc.advisors[0];
 		if (!advisor) return false;
 		return (
@@ -361,7 +361,8 @@ export class AdvisorConfigOverlayComponent implements Component {
 			!advisor.model?.trim() &&
 			advisor.tools === undefined &&
 			!advisor.instructions?.trim() &&
-			advisor.enabled !== false
+			advisor.enabled !== false &&
+			advisor.maxNotesPerUpdate === undefined
 		);
 	}
 

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -352,12 +352,11 @@ export class AdvisorConfigOverlayComponent implements Component {
 		if (this.#doc.advisors.length === 0) this.#doc.advisors.push({ name: "default" });
 	}
 
-	#isBareDefaultDoc(doc: WatchdogConfigDoc): boolean {
-		if (doc.advisors.length !== 1 || doc.instructions?.trim() || doc.maxNotesPerUpdate !== undefined) return false;
+	#hasSyntheticDefaultAdvisor(doc: WatchdogConfigDoc): boolean {
+		if (doc.advisors.length !== 1) return false;
 		const advisor = doc.advisors[0];
-		if (!advisor) return false;
 		return (
-			advisor.name === "default" &&
+			advisor?.name === "default" &&
 			!advisor.model?.trim() &&
 			advisor.tools === undefined &&
 			!advisor.instructions?.trim() &&
@@ -423,7 +422,8 @@ export class AdvisorConfigOverlayComponent implements Component {
 			return;
 		}
 		if (value === "save") {
-			await this.#cb.save(this.#scope, this.#isBareDefaultDoc(this.#doc) ? { advisors: [] } : this.#doc);
+			const doc = this.#hasSyntheticDefaultAdvisor(this.#doc) ? { ...this.#doc, advisors: [] } : this.#doc;
+			await this.#cb.save(this.#scope, doc);
 			this.#dirty = false;
 			this.#showList();
 			return;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -531,6 +531,12 @@ export class SelectorController {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();
 				break;
+			case "advisor.maxNotesPerUpdate":
+				if (this.ctx.session.isAdvisorEnabled()) {
+					this.ctx.session.setAdvisorEnabled(true);
+					this.ctx.ui.requestRender();
+				}
+				break;
 			case "steeringMode":
 				this.ctx.session.setSteeringMode(value as "all" | "one-at-a-time");
 				break;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -356,7 +356,11 @@ export class SelectorController {
 					// Re-discover the merged roster (project + user) so the live advisors
 					// reflect cross-level precedence, not just the edited file.
 					const discovered = await discoverAdvisorConfigs(cwd, agentDir);
-					const count = this.ctx.session.applyAdvisorConfigs(discovered.advisors, discovered.sharedInstructions);
+					const count = this.ctx.session.applyAdvisorConfigs(
+						discovered.advisors,
+						discovered.sharedInstructions,
+						discovered.sharedMaxNotesPerUpdate,
+					);
 					this.ctx.statusLine.invalidate();
 					this.ctx.showStatus(
 						count > 0

--- a/packages/coding-agent/src/prompts/advisor/system.md
+++ b/packages/coding-agent/src/prompts/advisor/system.md
@@ -17,7 +17,7 @@ Per `advise`: 2–3 tool calls. Critical bugs MAY need deeper verification befor
 </workflow>
 
 <communication>
-- Surface commentary via `advise`: max {{#if max_notes_per_update}}{{max_notes_per_update}}{{else}}4{{/if}}/update.
+- Surface commentary via `advise`: max {{#if max_notes_per_update}}{{max_notes_per_update}}{{else}}4{{/if}} non-blockers/update (`blocker` exempt).
 - Silence preferred when agent on track.
 - Address agent directly; offer alternatives, not lectures.
 - NEVER restate information agent has, including seen errors: type errors, LSP diagnostics, failed builds/tests, lint.

--- a/packages/coding-agent/src/prompts/advisor/system.md
+++ b/packages/coding-agent/src/prompts/advisor/system.md
@@ -17,7 +17,7 @@ Per `advise`: 2–3 tool calls. Critical bugs MAY need deeper verification befor
 </workflow>
 
 <communication>
-- Surface commentary via `advise`: max 1/update.
+- Surface commentary via `advise`: max {{#if max_notes_per_update}}{{max_notes_per_update}}{{else}}4{{/if}}/update.
 - Silence preferred when agent on track.
 - Address agent directly; offer alternatives, not lectures.
 - NEVER restate information agent has, including seen errors: type errors, LSP diagnostics, failed builds/tests, lint.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3719,6 +3719,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			advisorContextPrompt,
 			advisorMemoryPrompt,
 			advisorSharedInstructions: discoveredAdvisors.sharedInstructions,
+			advisorSharedMaxNotesPerUpdate: discoveredAdvisors.sharedMaxNotesPerUpdate,
 			advisorConfigs: discoveredAdvisors.advisors,
 			agent,
 			pruneToolDescriptions: inlineToolDescriptors,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -311,6 +311,8 @@ export interface AgentSessionConfig {
 	advisorWatchdogPrompt?: string;
 	/** Shared advisor instructions loaded from WATCHDOG.yml. */
 	advisorSharedInstructions?: string;
+	/** Shared advisor max notes per update loaded from WATCHDOG.yml. */
+	advisorSharedMaxNotesPerUpdate?: number;
 	/** Project context rendered for advisor sessions. */
 	advisorContextPrompt?: string;
 	/** Memory backend developer instructions rendered for advisor sessions. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1711,6 +1711,7 @@ export class AgentSession {
 			mcpResources: config.advisorMcpResources,
 			watchdogPrompt: config.advisorWatchdogPrompt,
 			sharedInstructions: config.advisorSharedInstructions,
+			sharedMaxNotesPerUpdate: config.advisorSharedMaxNotesPerUpdate,
 			contextPrompt: config.advisorContextPrompt,
 			memoryPrompt: config.advisorMemoryPrompt,
 			configs: config.advisorConfigs,
@@ -10437,8 +10438,12 @@ export class AgentSession {
 	 *
 	 * @returns the number of advisors active after the rebuild.
 	 */
-	applyAdvisorConfigs(advisors: AdvisorConfig[], sharedInstructions: string | undefined): number {
-		return this.#advisors.applyAdvisorConfigs(advisors, sharedInstructions);
+	applyAdvisorConfigs(
+		advisors: AdvisorConfig[],
+		sharedInstructions: string | undefined,
+		sharedMaxNotesPerUpdate?: number,
+	): number {
+		return this.#advisors.applyAdvisorConfigs(advisors, sharedInstructions, sharedMaxNotesPerUpdate);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1210,7 +1210,7 @@ export class SessionAdvisors {
 	 *  AdviseTool can report the exact outcome instead of claiming every rejection
 	 *  is a duplicate. Accepted notes consume the current update's budget. */
 	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
-		const decision = advisor.emissionGuard.accept(note);
+		const decision = advisor.emissionGuard.accept(note, severity);
 		if (decision !== "accepted")
 			logger.debug("advisor advice suppressed by emission guard", { decision, severity, advisor: advisor.name });
 		return decision;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -35,7 +35,7 @@ import type {
 import { isUsageLimitOutcome, resolveModelServiceTier, streamSimple } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { extractHttpStatusFromError, extractRetryHint, logger } from "@oh-my-pi/pi-utils";
+import { extractHttpStatusFromError, extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import {
 	ADVISOR_DEFAULT_TOOL_NAMES,
 	AdviseTool,
@@ -868,7 +868,7 @@ export class SessionAdvisors {
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
 			// instructions; `config.instructions` adds this advisor's specialization.
-			const systemPrompt = [advisorSystemPrompt];
+			const systemPrompt = [prompt.render(advisorSystemPrompt, { max_notes_per_update: budgetPerUpdate })];
 			if (this.#advisorContextPrompt) systemPrompt.push(this.#advisorContextPrompt);
 			if (this.#advisorMemoryPrompt) systemPrompt.push(this.#advisorMemoryPrompt);
 			if (this.#advisorWatchdogPrompt) systemPrompt.push(this.#advisorWatchdogPrompt);

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -215,6 +215,7 @@ export interface SessionAdvisorsOptions {
 	mcpResources?: CursorMcpResourceAdapter;
 	watchdogPrompt?: string;
 	sharedInstructions?: string;
+	sharedMaxNotesPerUpdate?: number;
 	contextPrompt?: string;
 	/** Active memory backend's developer instructions, wrapped for advisors. */
 	memoryPrompt?: string;
@@ -311,6 +312,7 @@ export class SessionAdvisors {
 	#advisorMcpResources: SessionAdvisorsOptions["mcpResources"];
 	#advisorWatchdogPrompt: string | undefined;
 	#advisorSharedInstructions: string | undefined;
+	#advisorSharedMaxNotesPerUpdate: number | undefined;
 	#advisorContextPrompt: string | undefined;
 	#advisorMemoryPrompt: string | undefined;
 	#advisorStreamFn: StreamFn | undefined;
@@ -348,6 +350,7 @@ export class SessionAdvisors {
 		this.#advisorMcpResources = options.mcpResources;
 		this.#advisorWatchdogPrompt = options.watchdogPrompt;
 		this.#advisorSharedInstructions = options.sharedInstructions;
+		this.#advisorSharedMaxNotesPerUpdate = options.sharedMaxNotesPerUpdate;
 		this.#advisorContextPrompt = options.contextPrompt;
 		this.#advisorMemoryPrompt = options.memoryPrompt;
 		this.#advisorConfigs = options.configs;
@@ -615,6 +618,21 @@ export class SessionAdvisors {
 		if (!Number.isFinite(immuneTurns) || immuneTurns <= 0) return 0;
 		return Math.trunc(immuneTurns);
 	}
+	#advisorMaxNotesPerUpdate(config?: AdvisorConfig): number {
+		const perAdvisor = config?.maxNotesPerUpdate;
+		if (typeof perAdvisor === "number" && Number.isFinite(perAdvisor) && perAdvisor >= 1) {
+			return Math.min(32, Math.trunc(perAdvisor));
+		}
+		const shared = this.#advisorSharedMaxNotesPerUpdate;
+		if (typeof shared === "number" && Number.isFinite(shared) && shared >= 1) {
+			return Math.min(32, Math.trunc(shared));
+		}
+		const setting = this.#host.settings.get("advisor.maxNotesPerUpdate") as number;
+		if (typeof setting === "number" && Number.isFinite(setting) && setting >= 1) {
+			return Math.min(32, Math.trunc(setting));
+		}
+		return 4;
+	}
 
 	#isAdvisorInterruptImmuneTurnActive(): boolean {
 		return isAdvisorInterruptImmuneTurnActive({
@@ -789,7 +807,8 @@ export class SessionAdvisors {
 	#advisorRuntimeSignature(config: AdvisorConfig, slug: string, model: Model, thinkingLevel: ThinkingLevel): string {
 		const tools = config.tools?.length ? config.tools.join("\u001e") : "";
 		const instructions = config.instructions?.trim() ?? "";
-		return [config.name, slug, formatModelStringWithRouting(model), thinkingLevel, tools, instructions].join(
+		const budget = this.#advisorMaxNotesPerUpdate(config);
+		return [config.name, slug, formatModelStringWithRouting(model), thinkingLevel, tools, instructions, budget].join(
 			"\u001f",
 		);
 	}
@@ -840,7 +859,8 @@ export class SessionAdvisors {
 				signature,
 			} = descriptor;
 
-			const emissionGuard = new AdvisorEmissionGuard();
+			const budgetPerUpdate = this.#advisorMaxNotesPerUpdate(config);
+			const emissionGuard = new AdvisorEmissionGuard({ budgetPerUpdate });
 			const adviseTool = new AdviseTool(
 				(note, severity) => this.#routeAdvice(advisorRef, note, severity),
 				(note, severity) => this.#acceptAdvice(advisorRef, note, severity),
@@ -1841,10 +1861,14 @@ export class SessionAdvisors {
 	 *
 	 * @returns the number of advisors active after the rebuild.
 	 */
-	applyAdvisorConfigs(advisors: AdvisorConfig[], sharedInstructions: string | undefined): number {
+	applyAdvisorConfigs(
+		advisors: AdvisorConfig[],
+		sharedInstructions: string | undefined,
+		sharedMaxNotesPerUpdate?: number,
+	): number {
 		this.#advisorConfigs = advisors;
 		this.#advisorSharedInstructions = sharedInstructions;
-		if (!this.#advisorEnabled) return 0;
+		this.#advisorSharedMaxNotesPerUpdate = sharedMaxNotesPerUpdate;
 		this.#stopAdvisorRuntime();
 		this.#buildAdvisorRuntime(true);
 		return this.#advisors.length;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -365,9 +365,9 @@ export class SessionAdvisors {
 		this.#advisorPrimaryTurnsCompleted++;
 		for (const advisor of this.#advisors) {
 			if (advisor.runtime.disposed) continue;
-			// Primary completion owns the deferred flush. The advisor loop may be
-			// quota-paused or fail before its next dispatch boundary.
-			advisor.adviseTool.beginUpdate(false);
+			// Only the terminal primary boundary owns the deferred flush. Continuing
+			// tool turns must keep partial-work critiques withheld.
+			if (willContinue !== true) advisor.adviseTool.beginUpdate(false);
 			try {
 				advisor.runtime.onTurnEnd(messages, { willContinue });
 			} catch (error) {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -41,6 +41,7 @@ import {
 	AdviseTool,
 	type AdvisorAgent,
 	type AdvisorConfig,
+	type AdvisorEmissionDecision,
 	AdvisorEmissionGuard,
 	AdvisorLoopGuard,
 	type AdvisorMessageDetails,
@@ -364,6 +365,9 @@ export class SessionAdvisors {
 		this.#advisorPrimaryTurnsCompleted++;
 		for (const advisor of this.#advisors) {
 			if (advisor.runtime.disposed) continue;
+			// Primary completion owns the deferred flush. The advisor loop may be
+			// quota-paused or fail before its next dispatch boundary.
+			advisor.adviseTool.beginUpdate(false);
 			try {
 				advisor.runtime.onTurnEnd(messages, { willContinue });
 			} catch (error) {
@@ -839,7 +843,7 @@ export class SessionAdvisors {
 			const emissionGuard = new AdvisorEmissionGuard();
 			const adviseTool = new AdviseTool(
 				(note, severity) => this.#routeAdvice(advisorRef, note, severity),
-				note => this.#acceptAdvice(advisorRef, note),
+				(note, severity) => this.#acceptAdvice(advisorRef, note, severity),
 			);
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
@@ -1191,9 +1195,8 @@ export class SessionAdvisors {
 	 * After a deliberate user interrupt auto-resume is suppressed while idle/unwinding
 	 * (the note becomes a preserved card re-entering on resume); a live-streaming turn is
 	 * steered in directly. A plain nit always rides the non-interrupting YieldQueue
-	 * aside. Suppression by the per-advisor emission guard drops the note silently —
-	 * the model still saw `Recorded.`, so it isn't tempted to rephrase the same note
-	 * past the dedupe.
+	 * aside. The emission guard has already accepted the note; rejected calls never
+	 * enter this route and receive their specific policy outcome from `AdviseTool`.
 	 */
 	#hasTerminalTextAnswerWithoutQueuedWork(): boolean {
 		if (this.#host.agent.hasQueuedMessages() || this.#host.hasPendingNextTurnMessages()) return false;
@@ -1203,15 +1206,14 @@ export class SessionAdvisors {
 		return isTerminalTextAssistantAnswer(messages[tail]);
 	}
 
-	/** Emission-guard gate: the noise/empty/dedupe filter plus the
-	 *  one-advise-per-update budget, consumed the moment a note is emitted —
-	 *  whether it is delivered live or held for a deferred flush. A suppressed
-	 *  note never consumes the budget, so it cannot burn an update's slot ahead
-	 *  of a substantive concern. Returns whether the note may reach the primary. */
-	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): boolean {
-		if (advisor.emissionGuard.accept(note)) return true;
-		logger.debug("advisor advice suppressed by emission guard", { severity, advisor: advisor.name });
-		return false;
+	/** Emission-guard gate: classify noise, duplicates, and over-budget notes so
+	 *  AdviseTool can report the exact outcome instead of claiming every rejection
+	 *  is a duplicate. Accepted notes consume the current update's budget. */
+	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): AdvisorEmissionDecision {
+		const decision = advisor.emissionGuard.accept(note);
+		if (decision !== "accepted")
+			logger.debug("advisor advice suppressed by emission guard", { decision, severity, advisor: advisor.name });
+		return decision;
 	}
 
 	/** Route an already-accepted advice note to the primary. Never re-runs the

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -38,6 +38,7 @@ import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { extractHttpStatusFromError, extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import {
 	ADVISOR_DEFAULT_TOOL_NAMES,
+	ADVISOR_MAX_BUDGET_PER_UPDATE,
 	AdviseTool,
 	type AdvisorAgent,
 	type AdvisorConfig,
@@ -621,15 +622,15 @@ export class SessionAdvisors {
 	#advisorMaxNotesPerUpdate(config?: AdvisorConfig): number {
 		const perAdvisor = config?.maxNotesPerUpdate;
 		if (typeof perAdvisor === "number" && Number.isFinite(perAdvisor) && perAdvisor >= 1) {
-			return Math.min(32, Math.trunc(perAdvisor));
+			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(perAdvisor));
 		}
 		const shared = this.#advisorSharedMaxNotesPerUpdate;
 		if (typeof shared === "number" && Number.isFinite(shared) && shared >= 1) {
-			return Math.min(32, Math.trunc(shared));
+			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(shared));
 		}
 		const setting = this.#host.settings.get("advisor.maxNotesPerUpdate") as number;
 		if (typeof setting === "number" && Number.isFinite(setting) && setting >= 1) {
-			return Math.min(32, Math.trunc(setting));
+			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(setting));
 		}
 		return 4;
 	}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -38,6 +38,7 @@ import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { extractHttpStatusFromError, extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import {
 	ADVISOR_DEFAULT_TOOL_NAMES,
+	ADVISOR_DEFAULT_BUDGET_PER_UPDATE,
 	ADVISOR_MAX_BUDGET_PER_UPDATE,
 	AdviseTool,
 	type AdvisorAgent,
@@ -620,19 +621,17 @@ export class SessionAdvisors {
 		return Math.trunc(immuneTurns);
 	}
 	#advisorMaxNotesPerUpdate(config?: AdvisorConfig): number {
-		const perAdvisor = config?.maxNotesPerUpdate;
-		if (typeof perAdvisor === "number" && Number.isFinite(perAdvisor) && perAdvisor >= 1) {
-			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(perAdvisor));
-		}
-		const shared = this.#advisorSharedMaxNotesPerUpdate;
-		if (typeof shared === "number" && Number.isFinite(shared) && shared >= 1) {
-			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(shared));
-		}
-		const setting = this.#host.settings.get("advisor.maxNotesPerUpdate") as number;
-		if (typeof setting === "number" && Number.isFinite(setting) && setting >= 1) {
-			return Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(setting));
-		}
-		return 4;
+		const clamp = (value: unknown): number | undefined =>
+			typeof value === "number" && Number.isFinite(value) && value >= 1
+				? Math.min(ADVISOR_MAX_BUDGET_PER_UPDATE, Math.trunc(value))
+				: undefined;
+
+		return (
+			clamp(config?.maxNotesPerUpdate) ??
+			clamp(this.#advisorSharedMaxNotesPerUpdate) ??
+			clamp(this.#host.settings.get("advisor.maxNotesPerUpdate")) ??
+			ADVISOR_DEFAULT_BUDGET_PER_UPDATE
+		);
 	}
 
 	#isAdvisorInterruptImmuneTurnActive(): boolean {

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -972,7 +972,14 @@ describe("AgentSession advisor toggle", () => {
 	});
 	it("marks structurally classified advisor usage limits", async () => {
 		const mock = createMockModel({
-			responses: [{ content: ["primary complete"] }, { content: ["primary still complete"] }],
+			responses: [
+				{ content: ["primary complete"] },
+				{
+					content: [{ type: "toolCall", id: "continuing-turn", name: "missing-tool", arguments: {} }],
+					stopReason: "toolUse",
+				},
+				{ content: ["primary still complete"] },
+			],
 		});
 		const primaryAgent = new Agent({
 			initialState: {
@@ -1034,10 +1041,18 @@ describe("AgentSession advisor toggle", () => {
 			});
 			expect(JSON.stringify(deferred.content)).toContain("Deferred");
 
-			// The quota latch prevents another advisor dispatch. Primary turn
-			// completion must still release the note into its delivery queue.
+			// The quota latch prevents another advisor dispatch. The tool boundary
+			// must keep the note out of the continuing model request; terminal
+			// completion may then release it into the primary transcript.
 			await quotaSession.prompt("Complete another primary turn");
 			await quotaSession.waitForIdle();
+			const continuingCall = mock.calls[2];
+			if (!continuingCall) throw new Error("Expected primary continuation call");
+			expect(
+				continuingCall.context.messages.some(message =>
+					JSON.stringify(message).includes("The final result still needs a regression test."),
+				),
+			).toBe(false);
 			expect(
 				quotaSession.messages.some(
 					message =>

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -1115,4 +1115,48 @@ describe("AgentSession advisor toggle", () => {
 		const advisor2 = session.getAdvisorAgent();
 		expect(advisor2).not.toBe(advisor1);
 	});
+
+	it("enforces precedence: per-advisor > shared WATCHDOG.yml > settings > default", async () => {
+		session.settings.set("advisor.maxNotesPerUpdate", 2);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		// 1. Per-advisor (5) overrides shared (3) and settings (2)
+		session.applyAdvisorConfigs([{ name: "Specific", maxNotesPerUpdate: 5 }], undefined, 3);
+		let advisor = session.getAdvisorAgent();
+		let tool = advisor?.state.tools?.find(t => t.name === "advise");
+		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+		tool.beginUpdate(true);
+		for (let i = 1; i <= 5; i++) {
+			const res = await tool.execute(`s-${i}`, { note: `Specific note ${i}`, severity: "concern" });
+			expect(JSON.stringify(res.content)).toContain("Deferred");
+		}
+		const s6 = await tool.execute("s-6", { note: "Specific note 6", severity: "concern" });
+		expect(JSON.stringify(s6.content)).toContain("Rate limited");
+
+		// 2. Shared (3) overrides settings (2) when per-advisor is undefined
+		session.applyAdvisorConfigs([{ name: "Inheriting" }], undefined, 3);
+		advisor = session.getAdvisorAgent();
+		tool = advisor?.state.tools?.find(t => t.name === "advise");
+		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+		tool.beginUpdate(true);
+		for (let i = 1; i <= 3; i++) {
+			const res = await tool.execute(`h-${i}`, { note: `Inheriting note ${i}`, severity: "concern" });
+			expect(JSON.stringify(res.content)).toContain("Deferred");
+		}
+		const h4 = await tool.execute("h-4", { note: "Inheriting note 4", severity: "concern" });
+		expect(JSON.stringify(h4.content)).toContain("Rate limited");
+
+		// 3. Settings (2) overrides default (4) when shared and per-advisor are undefined
+		session.applyAdvisorConfigs([{ name: "SettingsOnly" }], undefined, undefined);
+		advisor = session.getAdvisorAgent();
+		tool = advisor?.state.tools?.find(t => t.name === "advise");
+		if (!(tool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+		tool.beginUpdate(true);
+		for (let i = 1; i <= 2; i++) {
+			const res = await tool.execute(`set-${i}`, { note: `Settings note ${i}`, severity: "concern" });
+			expect(JSON.stringify(res.content)).toContain("Deferred");
+		}
+		const set3 = await tool.execute("set-3", { note: "Settings note 3", severity: "concern" });
+		expect(JSON.stringify(set3.content)).toContain("Rate limited");
+	});
 });

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -1066,4 +1066,53 @@ describe("AgentSession advisor toggle", () => {
 			vi.restoreAllMocks();
 		}
 	});
+
+	it("respects maxNotesPerUpdate configured per advisor through applyAdvisorConfigs", async () => {
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		session.applyAdvisorConfigs([{ name: "Security", maxNotesPerUpdate: 2 }], undefined);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent");
+		const adviseTool = advisor.state.tools?.find(tool => tool.name === "advise");
+		if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+
+		adviseTool.beginUpdate(true);
+		const r1 = await adviseTool.execute("1", { note: "First concern", severity: "concern" });
+		const r2 = await adviseTool.execute("2", { note: "Second concern", severity: "concern" });
+		const r3 = await adviseTool.execute("3", { note: "Third concern", severity: "concern" });
+
+		expect(JSON.stringify(r1.content)).toContain("Deferred");
+		expect(JSON.stringify(r2.content)).toContain("Deferred");
+		expect(JSON.stringify(r3.content)).toContain("Rate limited");
+	});
+
+	it("respects advisor.maxNotesPerUpdate from settings when no per-advisor budget is set", async () => {
+		session.settings.set("advisor.maxNotesPerUpdate", 3);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent");
+		const adviseTool = advisor.state.tools?.find(tool => tool.name === "advise");
+		if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advise tool");
+
+		adviseTool.beginUpdate(true);
+		const r1 = await adviseTool.execute("1", { note: "First concern", severity: "concern" });
+		const r2 = await adviseTool.execute("2", { note: "Second concern", severity: "concern" });
+		const r3 = await adviseTool.execute("3", { note: "Third concern", severity: "concern" });
+		const r4 = await adviseTool.execute("4", { note: "Fourth concern", severity: "concern" });
+
+		expect(JSON.stringify(r1.content)).toContain("Deferred");
+		expect(JSON.stringify(r2.content)).toContain("Deferred");
+		expect(JSON.stringify(r3.content)).toContain("Deferred");
+		expect(JSON.stringify(r4.content)).toContain("Rate limited");
+	});
+
+	it("rebuilds advisor runtime when maxNotesPerUpdate changes in settings", () => {
+		session.settings.set("advisor.maxNotesPerUpdate", 1);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor1 = session.getAdvisorAgent();
+
+		session.settings.set("advisor.maxNotesPerUpdate", 3);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor2 = session.getAdvisorAgent();
+		expect(advisor2).not.toBe(advisor1);
+	});
 });

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -971,7 +971,9 @@ describe("AgentSession advisor toggle", () => {
 		}
 	});
 	it("marks structurally classified advisor usage limits", async () => {
-		const mock = createMockModel({ responses: [{ content: ["primary complete"] }] });
+		const mock = createMockModel({
+			responses: [{ content: ["primary complete"] }, { content: ["primary still complete"] }],
+		});
 		const primaryAgent = new Agent({
 			initialState: {
 				model,
@@ -1022,6 +1024,28 @@ describe("AgentSession advisor toggle", () => {
 			// failed batch stays requeued (the quota latch makes yielded true).
 			await advisorYielded.promise;
 			unsubscribe();
+
+			const adviseTool = advisorAgent.state.tools.find(tool => tool.name === "advise");
+			if (!(adviseTool instanceof advisorModule.AdviseTool)) throw new Error("Expected advisor advise tool");
+			adviseTool.beginUpdate(true);
+			const deferred = await adviseTool.execute("deferred-before-quota", {
+				note: "The final result still needs a regression test.",
+				severity: "nit",
+			});
+			expect(JSON.stringify(deferred.content)).toContain("Deferred");
+
+			// The quota latch prevents another advisor dispatch. Primary turn
+			// completion must still release the note into its delivery queue.
+			await quotaSession.prompt("Complete another primary turn");
+			await quotaSession.waitForIdle();
+			expect(
+				quotaSession.messages.some(
+					message =>
+						message.role === "custom" &&
+						typeof message.content === "string" &&
+						message.content.includes("The final result still needs a regression test."),
+				),
+			).toBe(true);
 		} finally {
 			await quotaSession.dispose();
 			vi.restoreAllMocks();

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -1116,6 +1116,24 @@ describe("AgentSession advisor toggle", () => {
 		expect(advisor2).not.toBe(advisor1);
 	});
 
+	it("propagates the resolved budget into the advisor model-visible system prompt", () => {
+		// Contract: SessionAdvisors must render the resolved budget into the
+		// prompt the advisor model actually receives. If the runtime stopped
+		// supplying it, the template falls back to 4 and this fails.
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		session.applyAdvisorConfigs([{ name: "Strict", maxNotesPerUpdate: 1 }], undefined);
+		let advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent");
+		expect(advisor.state.systemPrompt.join("\n")).toContain("max 1 non-blockers/update (`blocker` exempt)");
+
+		session.settings.set("advisor.maxNotesPerUpdate", 3);
+		session.applyAdvisorConfigs([{ name: "Lenient" }], undefined, undefined);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent");
+		expect(advisor.state.systemPrompt.join("\n")).toContain("max 3 non-blockers/update (`blocker` exempt)");
+	});
+
 	it("enforces precedence: per-advisor > shared WATCHDOG.yml > settings > default", async () => {
 		session.settings.set("advisor.maxNotesPerUpdate", 2);
 		expect(session.setAdvisorEnabled(true)).toBe(true);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -810,10 +810,9 @@ describe("advisor", () => {
 			expect(delivered).toEqual(concerns);
 		});
 
-		it("caps a single in-progress prompt spraying distinct notes to one deferred note", async () => {
-			// A single in-progress advisor prompt that emits several distinct notes
-			// spends the update's one budget slot on the first; the rest are dropped
-			// at emission, so the flush cannot deliver an unbounded batch (#3520).
+		it("reports over-budget deferred notes and blockers as rate limited", async () => {
+			// Preserve the one-note cap from #3520, but never claim a dropped note
+			// was deferred or duplicated: the advisor must know to retry it.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
@@ -826,9 +825,18 @@ describe("advisor", () => {
 			};
 
 			beginUpdate(true);
-			await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
-			await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
-			await tool.execute("x-2", { note: "Third mid-turn concern.", severity: "concern" });
+			const accepted = await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
+			const concern = await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
+			const blocker = await tool.execute("x-2", {
+				note: "A destructive migration will drop user data.",
+				severity: "blocker",
+			});
+
+			expect(JSON.stringify(accepted.content)).toContain("Deferred");
+			expect(JSON.stringify(concern.content)).toContain("Rate limited");
+			expect(JSON.stringify(blocker.content)).toContain("Rate limited");
+			expect(JSON.stringify(blocker.content)).not.toContain("Duplicate");
+
 			beginUpdate(false);
 			expect(delivered).toEqual(["First mid-turn concern."]);
 		});

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -33,6 +33,8 @@ import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
 import { SecretObfuscator } from "../../src/secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../../src/session/session-history-format";
 import { YieldQueue } from "../../src/session/yield-queue";
+import { prompt } from "@oh-my-pi/pi-utils";
+import advisorSystemPrompt from "../../src/prompts/advisor/system.md" with { type: "text" };
 
 /** Poll until the drain loop reaches the asserted state — waitForCatchup
  *  releases IMMEDIATELY on advisor failure (the primary must never park on a
@@ -941,6 +943,14 @@ describe("advisor", () => {
 			await tool.execute("s-3", { note: "Note 3", severity: "concern" });
 			await tool.execute("s-4", { note: "Note 4", severity: "concern" });
 			expect(delivered).toEqual(["Note 0", "Note 1", "Note 2", "Note 3"]);
+		});
+
+		it("renders max_notes_per_update into the advisor system prompt", () => {
+			const renderedDefault = prompt.render(advisorSystemPrompt, { max_notes_per_update: 4 });
+			expect(renderedDefault).toContain("max 4/update");
+
+			const renderedStrict = prompt.render(advisorSystemPrompt, { max_notes_per_update: 1 });
+			expect(renderedStrict).toContain("max 1/update");
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {
@@ -6337,6 +6347,34 @@ describe("advisor", () => {
 			expect(text).toContain("○ Disabled");
 			// The preview of the highlighted (first) advisor shows its enabled status.
 			expect(text).toContain("● on");
+		});
+
+		it("preserves top-level maxNotesPerUpdate without stripping to an empty roster on save", async () => {
+			let savedDoc: WatchdogConfigDoc | undefined;
+			const overlay = new AdvisorConfigOverlayComponent(
+				{} as unknown as TUI,
+				{ ...deps },
+				"project",
+				{ maxNotesPerUpdate: 3, advisors: [] },
+				{
+					...callbacks,
+					save: async (_scope, doc) => {
+						savedDoc = doc;
+					},
+				},
+			);
+			overlay.render(200);
+			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\r");
+			await Promise.resolve();
+			expect(savedDoc).toBeDefined();
+			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
+			expect(savedDoc?.advisors).toHaveLength(1);
+			expect(savedDoc?.advisors[0]?.name).toBe("default");
 		});
 	});
 });

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -947,10 +947,10 @@ describe("advisor", () => {
 
 		it("renders max_notes_per_update into the advisor system prompt", () => {
 			const renderedDefault = prompt.render(advisorSystemPrompt, { max_notes_per_update: 4 });
-			expect(renderedDefault).toContain("max 4/update");
+			expect(renderedDefault).toContain("max 4 non-blockers/update (`blocker` exempt)");
 
 			const renderedStrict = prompt.render(advisorSystemPrompt, { max_notes_per_update: 1 });
-			expect(renderedStrict).toContain("max 1/update");
+			expect(renderedStrict).toContain("max 1 non-blockers/update (`blocker` exempt)");
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -814,7 +814,7 @@ describe("advisor", () => {
 			// Preserve the one-note cap from #3520, but never claim a dropped note
 			// was deferred or duplicated: the advisor must know to retry it.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard();
+			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
 			const tool = new AdviseTool(
 				note => delivered.push(note),
 				note => guard.accept(note),
@@ -839,6 +839,41 @@ describe("advisor", () => {
 
 			beginUpdate(false);
 			expect(delivered).toEqual(["First mid-turn concern."]);
+		});
+
+		it("reserves and flushes multiple deferred notes up to a configured budgetPerUpdate", async () => {
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 3 });
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				(note, severity) => guard.accept(note, severity),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+
+			beginUpdate(true);
+			const note0 = await tool.execute("c-0", { note: "First concern: missing await.", severity: "concern" });
+			const note1 = await tool.execute("c-1", { note: "Second concern: unhandled rejection.", severity: "concern" });
+			const note2 = await tool.execute("c-2", { note: "Third nit: unused import.", severity: "nit" });
+			const note3 = await tool.execute("c-3", { note: "Fourth concern: memory leak.", severity: "concern" });
+
+			expect(JSON.stringify(note0.content)).toContain("Deferred");
+			expect(JSON.stringify(note1.content)).toContain("Deferred");
+			expect(JSON.stringify(note2.content)).toContain("Deferred");
+			expect(JSON.stringify(note3.content)).toContain("Rate limited");
+
+			// Nothing delivered yet while mid-turn
+			expect(delivered).toEqual([]);
+
+			// Primary completes turn: all 3 reserved notes flush in arrival order
+			beginUpdate(false);
+			expect(delivered).toEqual([
+				"First concern: missing await.",
+				"Second concern: unhandled rejection.",
+				"Third nit: unused import.",
+			]);
 		});
 
 		it("does not let a suppressed phrase burn the deferred slot ahead of a real concern", async () => {
@@ -867,10 +902,10 @@ describe("advisor", () => {
 			expect(delivered).toEqual(["The migration drops the users table without a backup."]);
 		});
 
-		it("still caps a single model turn spraying many distinct notes to one accepted note", async () => {
-			// Live path: notes emitted in one completed-turn update stay capped at one.
+		it("still caps a single model turn spraying many distinct notes when configured with budgetPerUpdate 1", async () => {
+			// Live path: notes emitted in one completed-turn update stay capped at one when budget is 1.
 			const delivered: string[] = [];
-			const guard = new AdvisorEmissionGuard();
+			const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
 			const tool = new AdviseTool(
 				note => delivered.push(note),
 				note => guard.accept(note),
@@ -885,6 +920,27 @@ describe("advisor", () => {
 			await tool.execute("s-1", { note: "Second distinct live concern.", severity: "concern" });
 			await tool.execute("s-2", { note: "Third distinct live concern.", severity: "concern" });
 			expect(delivered).toEqual(["First distinct live concern."]);
+		});
+
+		it("accepts up to the default budget of 4 distinct live notes per completed update", async () => {
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				note => guard.accept(note),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+
+			beginUpdate(false);
+			await tool.execute("s-0", { note: "Note 0", severity: "concern" });
+			await tool.execute("s-1", { note: "Note 1", severity: "concern" });
+			await tool.execute("s-2", { note: "Note 2", severity: "concern" });
+			await tool.execute("s-3", { note: "Note 3", severity: "concern" });
+			await tool.execute("s-4", { note: "Note 4", severity: "concern" });
+			expect(delivered).toEqual(["Note 0", "Note 1", "Note 2", "Note 3"]);
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -921,6 +921,41 @@ describe("advisor", () => {
 			expect(delivered).toEqual([{ note: escalatedNote, severity: "blocker" }]);
 		});
 
+		it("delivers a distinct blocker live after a non-blocker consumed the update budget", async () => {
+			// #11062 follow-up: a nit emitted first in an in-progress update reserves
+			// the one deferred slot. A distinct blocker that follows must still
+			// interrupt now instead of being rejected as rate-limited and dropped;
+			// the reserved nit stays queued and flushes when the turn completes.
+			const delivered: { note: string; severity?: string }[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				(note, severity) => guard.accept(note, severity),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+
+			beginUpdate(true);
+			const nit = await tool.execute("b-0", { note: "Minor naming nit.", severity: "nit" });
+			const blocker = await tool.execute("b-1", {
+				note: "Destructive migration will drop user data.",
+				severity: "blocker",
+			});
+
+			expect(JSON.stringify(nit.content)).toContain("Deferred");
+			expect(JSON.stringify(blocker.content)).toContain("Recorded.");
+			expect(delivered).toEqual([{ note: "Destructive migration will drop user data.", severity: "blocker" }]);
+
+			// The reserved nit still flushes at the completed boundary, after the blocker.
+			beginUpdate(false);
+			expect(delivered).toEqual([
+				{ note: "Destructive migration will drop user data.", severity: "blocker" },
+				{ note: "Minor naming nit.", severity: "nit" },
+			]);
+		});
+
 		it("validates parameters using ArkType", () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -6402,5 +6402,32 @@ describe("advisor", () => {
 			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
 			expect(savedDoc?.advisors).toEqual([{ name: "default", instructions: "custom" }]);
 		});
+
+		it("preserves top-level instructions while stripping the synthetic default advisor on save", async () => {
+			let savedDoc: WatchdogConfigDoc | undefined;
+			const overlay = new AdvisorConfigOverlayComponent(
+				{} as unknown as TUI,
+				{ ...deps },
+				"project",
+				{ instructions: "baseline rules", advisors: [] },
+				{
+					...callbacks,
+					save: async (_scope, doc) => {
+						savedDoc = doc;
+					},
+				},
+			);
+			overlay.render(200);
+			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\r");
+			await Promise.resolve();
+			expect(savedDoc).toBeDefined();
+			expect(savedDoc?.instructions).toBe("baseline rules");
+			expect(savedDoc?.advisors).toEqual([]);
+		});
 	});
 });

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -6349,7 +6349,7 @@ describe("advisor", () => {
 			expect(text).toContain("● on");
 		});
 
-		it("preserves top-level maxNotesPerUpdate without stripping to an empty roster on save", async () => {
+		it("preserves top-level maxNotesPerUpdate while stripping the synthetic default advisor on save", async () => {
 			let savedDoc: WatchdogConfigDoc | undefined;
 			const overlay = new AdvisorConfigOverlayComponent(
 				{} as unknown as TUI,
@@ -6373,8 +6373,34 @@ describe("advisor", () => {
 			await Promise.resolve();
 			expect(savedDoc).toBeDefined();
 			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
-			expect(savedDoc?.advisors).toHaveLength(1);
-			expect(savedDoc?.advisors[0]?.name).toBe("default");
+			expect(savedDoc?.advisors).toEqual([]);
+		});
+
+		it("preserves customized default advisor and top-level maxNotesPerUpdate on save", async () => {
+			let savedDoc: WatchdogConfigDoc | undefined;
+			const overlay = new AdvisorConfigOverlayComponent(
+				{} as unknown as TUI,
+				{ ...deps },
+				"project",
+				{ maxNotesPerUpdate: 3, advisors: [{ name: "default", instructions: "custom" }] },
+				{
+					...callbacks,
+					save: async (_scope, doc) => {
+						savedDoc = doc;
+					},
+				},
+			);
+			overlay.render(200);
+			// Arrow down 4 times to "Save & apply" (advisor:0, add, shared, scope, save)
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\x1b[B");
+			overlay.handleInput("\r");
+			await Promise.resolve();
+			expect(savedDoc).toBeDefined();
+			expect(savedDoc?.maxNotesPerUpdate).toBe(3);
+			expect(savedDoc?.advisors).toEqual([{ name: "default", instructions: "custom" }]);
 		});
 	});
 });

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -33,8 +33,6 @@ import { getThemeByName, setThemeInstance } from "../../src/modes/theme/theme";
 import { SecretObfuscator } from "../../src/secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../../src/session/session-history-format";
 import { YieldQueue } from "../../src/session/yield-queue";
-import { prompt } from "@oh-my-pi/pi-utils";
-import advisorSystemPrompt from "../../src/prompts/advisor/system.md" with { type: "text" };
 
 /** Poll until the drain loop reaches the asserted state — waitForCatchup
  *  releases IMMEDIATELY on advisor failure (the primary must never park on a
@@ -943,14 +941,6 @@ describe("advisor", () => {
 			await tool.execute("s-3", { note: "Note 3", severity: "concern" });
 			await tool.execute("s-4", { note: "Note 4", severity: "concern" });
 			expect(delivered).toEqual(["Note 0", "Note 1", "Note 2", "Note 3"]);
-		});
-
-		it("renders max_notes_per_update into the advisor system prompt", () => {
-			const renderedDefault = prompt.render(advisorSystemPrompt, { max_notes_per_update: 4 });
-			expect(renderedDefault).toContain("max 4 non-blockers/update (`blocker` exempt)");
-
-			const renderedStrict = prompt.render(advisorSystemPrompt, { max_notes_per_update: 1 });
-			expect(renderedStrict).toContain("max 1 non-blockers/update (`blocker` exempt)");
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {

--- a/packages/coding-agent/test/advisor/config.test.ts
+++ b/packages/coding-agent/test/advisor/config.test.ts
@@ -350,3 +350,47 @@ describe("per-advisor enabled field", () => {
 		expect(text.match(/enabled:/g)).toHaveLength(2);
 	});
 });
+
+describe("maxNotesPerUpdate configuration", () => {
+	it("discovers shared and per-advisor maxNotesPerUpdate from WATCHDOG.yml", async () => {
+		const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-advisor-max-notes-"));
+		await fsp.mkdir(path.join(tmp, ".git"));
+		try {
+			const yaml = [
+				"maxNotesPerUpdate: 4",
+				"advisors:",
+				"  - name: High Throughput",
+				"    maxNotesPerUpdate: 5",
+				"  - name: Default Budget",
+			].join("\n");
+			await Bun.write(path.join(tmp, "WATCHDOG.yml"), yaml);
+
+			const { advisors, sharedMaxNotesPerUpdate } = await discoverAdvisorConfigs(tmp, tmp);
+			expect(sharedMaxNotesPerUpdate).toBe(4);
+			expect(advisors).toHaveLength(2);
+			expect(advisors.find(a => a.name === "High Throughput")?.maxNotesPerUpdate).toBe(5);
+			expect(advisors.find(a => a.name === "Default Budget")?.maxNotesPerUpdate).toBeUndefined();
+		} finally {
+			await fsp.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("round-trips maxNotesPerUpdate through save and load", async () => {
+		const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-advisor-max-notes-roundtrip-"));
+		try {
+			const doc: WatchdogConfigDoc = {
+				maxNotesPerUpdate: 3,
+				advisors: [{ name: "High", maxNotesPerUpdate: 5 }, { name: "Default" }],
+			};
+			const file = path.join(tmp, "WATCHDOG.yml");
+			await saveWatchdogConfigFile(file, doc);
+
+			const loaded = await loadWatchdogConfigFile(file);
+			expect(loaded.maxNotesPerUpdate).toBe(3);
+			expect(loaded.advisors[0]?.maxNotesPerUpdate).toBe(5);
+			expect(loaded.advisors[1]?.maxNotesPerUpdate).toBeUndefined();
+		} finally {
+			await fsp.rm(tmp, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { AdvisorEmissionGuard, normalizeAdvisorNote } from "../../src/advisor/emission-guard";
+import {
+	ADVISOR_MAX_BUDGET_PER_UPDATE,
+	AdvisorEmissionGuard,
+	normalizeAdvisorNote,
+} from "../../src/advisor/emission-guard";
 
 describe("normalizeAdvisorNote", () => {
 	it("collapses punctuation, casing, and surrounding whitespace into one canonical key", () => {
@@ -90,6 +94,14 @@ describe("AdvisorEmissionGuard", () => {
 		const guardNegative = new AdvisorEmissionGuard({ budgetPerUpdate: -3 });
 		expect(guardNegative.accept("First concern.", "concern")).toBe("accepted");
 		expect(guardNegative.accept("Second concern.", "concern")).toBe("rate_limited");
+	});
+
+	it("clamps budgetPerUpdate to at most ADVISOR_MAX_BUDGET_PER_UPDATE (32)", () => {
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 100 });
+		for (let i = 0; i < ADVISOR_MAX_BUDGET_PER_UPDATE; i++) {
+			expect(guard.accept(`Note ${i}`, "concern")).toBe("accepted");
+		}
+		expect(guard.accept("Note 33", "concern")).toBe("rate_limited");
 	});
 
 	it("exempts blockers from the per-update budget so they always interrupt", () => {

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -60,6 +60,18 @@ describe("AdvisorEmissionGuard", () => {
 		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
 	});
 
+	it("exempts blockers from the per-update budget so they always interrupt", () => {
+		// A nit emitted first in an update must never rate-limit a blocker that
+		// follows it: blockers are the always-interrupt severity. Noise and dedupe
+		// still apply to blockers.
+		const guard = new AdvisorEmissionGuard();
+		expect(guard.accept("Minor naming nit.", "nit")).toBe("accepted");
+		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
+		// A repeat blocker is still deduped, not waved through by the exemption.
+		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("duplicate");
+		expect(guard.accept("Stop.", "blocker")).toBe("suppressed_noise");
+	});
+
 	it("does not let a suppressed call consume the per-update budget", () => {
 		// A noise call like "Stop." must never displace a real concern that
 		// follows in the same advisor model cycle.

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -48,23 +48,55 @@ describe("AdvisorEmissionGuard", () => {
 		expect(guard.accept("Move retries into the queue, not the request path!")).toBe("duplicate");
 	});
 
-	it("rate-limits to one accepted advise per advisor update cycle", () => {
-		// The advisor system prompt says "at most one `advise` per update". Real
-		// models violate this; the guard enforces it at the boundary so the
-		// primary transcript never receives two advisories from one model cycle.
+	it("rate-limits non-blockers past the default budget of 4 per advisor update cycle", () => {
 		const guard = new AdvisorEmissionGuard();
+		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
+		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
+		expect(guard.accept("Third concern: unhandled rejection.")).toBe("accepted");
+		expect(guard.accept("Fourth concern: missing validation.")).toBe("accepted");
+		expect(guard.accept("Fifth concern: unhandled error.")).toBe("rate_limited");
+		guard.beginUpdate();
+		// New cycle: budget reset.
+		expect(guard.accept("Fifth concern: unhandled error.")).toBe("accepted");
+	});
+
+	it("supports strict 1-note rate-limiting when budgetPerUpdate is set to 1", () => {
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
 		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
 		expect(guard.accept("Second concern: wrong env var name.")).toBe("rate_limited");
 		guard.beginUpdate();
-		// New cycle: budget reset.
 		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
+	});
+
+	it("honors a configured budgetPerUpdate allowing multiple accepted non-blockers per cycle", () => {
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 3 });
+		expect(guard.accept("First concern: missing await in #handleRetry.", "concern")).toBe("accepted");
+		expect(guard.accept("Second concern: wrong env var name.", "concern")).toBe("accepted");
+		expect(guard.accept("Third nit: variable name could be clearer.", "nit")).toBe("accepted");
+		// Exceeds the configured budget of 3
+		expect(guard.accept("Fourth concern: missing error boundary.", "concern")).toBe("rate_limited");
+		// Blockers still bypass the budget
+		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
+		// Reset on next cycle
+		guard.beginUpdate();
+		expect(guard.accept("Fourth concern: missing error boundary.", "concern")).toBe("accepted");
+	});
+
+	it("clamps non-positive budgetPerUpdate to at least 1", () => {
+		const guardZero = new AdvisorEmissionGuard({ budgetPerUpdate: 0 });
+		expect(guardZero.accept("First concern.", "concern")).toBe("accepted");
+		expect(guardZero.accept("Second concern.", "concern")).toBe("rate_limited");
+
+		const guardNegative = new AdvisorEmissionGuard({ budgetPerUpdate: -3 });
+		expect(guardNegative.accept("First concern.", "concern")).toBe("accepted");
+		expect(guardNegative.accept("Second concern.", "concern")).toBe("rate_limited");
 	});
 
 	it("exempts blockers from the per-update budget so they always interrupt", () => {
 		// A nit emitted first in an update must never rate-limit a blocker that
 		// follows it: blockers are the always-interrupt severity. Noise and dedupe
 		// still apply to blockers.
-		const guard = new AdvisorEmissionGuard();
+		const guard = new AdvisorEmissionGuard({ budgetPerUpdate: 1 });
 		expect(guard.accept("Minor naming nit.", "nit")).toBe("accepted");
 		expect(guard.accept("Destructive migration will drop user data.", "blocker")).toBe("accepted");
 		// A repeat blocker is still deduped, not waved through by the exemption.

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -32,20 +32,20 @@ describe("AdvisorEmissionGuard", () => {
 		// none of these carry a concrete reason and they cannot be acted on, so
 		// the guard suppresses them regardless of severity.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe(false);
-		expect(guard.accept("Done.")).toBe(false);
-		expect(guard.accept("No issue; continue.")).toBe(false);
-		expect(guard.accept("LGTM")).toBe(false);
-		expect(guard.accept("No further watcher input needed.")).toBe(false);
+		expect(guard.accept("Stop.")).toBe("suppressed_noise");
+		expect(guard.accept("Done.")).toBe("suppressed_noise");
+		expect(guard.accept("No issue; continue.")).toBe("suppressed_noise");
+		expect(guard.accept("LGTM")).toBe("suppressed_noise");
+		expect(guard.accept("No further watcher input needed.")).toBe("suppressed_noise");
 	});
 
 	it("dedupes by normalized text across the session, ignoring casing and trailing punctuation", () => {
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Move retries into the queue, not the request path.")).toBe(true);
+		expect(guard.accept("Move retries into the queue, not the request path.")).toBe("accepted");
 		// Same advice with different casing and trailing punctuation must NOT
 		// land twice in the primary transcript.
-		expect(guard.accept("move retries into the queue, not the request path")).toBe(false);
-		expect(guard.accept("Move retries into the queue, not the request path!")).toBe(false);
+		expect(guard.accept("move retries into the queue, not the request path")).toBe("duplicate");
+		expect(guard.accept("Move retries into the queue, not the request path!")).toBe("duplicate");
 	});
 
 	it("rate-limits to one accepted advise per advisor update cycle", () => {
@@ -53,29 +53,29 @@ describe("AdvisorEmissionGuard", () => {
 		// models violate this; the guard enforces it at the boundary so the
 		// primary transcript never receives two advisories from one model cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe(true);
-		expect(guard.accept("Second concern: wrong env var name.")).toBe(false);
+		expect(guard.accept("First concern: missing await in #handleRetry.")).toBe("accepted");
+		expect(guard.accept("Second concern: wrong env var name.")).toBe("rate_limited");
 		guard.beginUpdate();
 		// New cycle: budget reset.
-		expect(guard.accept("Second concern: wrong env var name.")).toBe(true);
+		expect(guard.accept("Second concern: wrong env var name.")).toBe("accepted");
 	});
 
 	it("does not let a suppressed call consume the per-update budget", () => {
 		// A noise call like "Stop." must never displace a real concern that
 		// follows in the same advisor model cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Stop.")).toBe(false);
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Stop.")).toBe("suppressed_noise");
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
 	});
 
 	it("does not let a deduped call consume the per-update budget", () => {
 		// A repeat of a prior session note is dropped, but the model can still
 		// follow it with a fresh concrete concern in the same cycle.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe(false);
-		expect(guard.accept("New concern: cache eviction never fires.")).toBe(true);
+		expect(guard.accept("Concrete: read race in #handleRetry.")).toBe("duplicate");
+		expect(guard.accept("New concern: cache eviction never fires.")).toBe("accepted");
 	});
 
 	it("reset clears dedupe and the per-update gate so a re-primed advisor can re-raise old issues", () => {
@@ -83,10 +83,10 @@ describe("AdvisorEmissionGuard", () => {
 		// advisor is re-primed from scratch and may legitimately re-raise the
 		// same concerns — they're new context for a freshly-primed reviewer.
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("Race in #handleRetry.")).toBe(true);
-		expect(guard.accept("Race in #handleRetry.")).toBe(false);
+		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
+		expect(guard.accept("Race in #handleRetry.")).toBe("duplicate");
 		guard.reset();
-		expect(guard.accept("Race in #handleRetry.")).toBe(true);
+		expect(guard.accept("Race in #handleRetry.")).toBe("accepted");
 	});
 
 	it("evicts oldest entries when dedupe history exceeds capacity", () => {
@@ -94,26 +94,26 @@ describe("AdvisorEmissionGuard", () => {
 		// bound. Pre-eviction unique notes are remembered; post-eviction the
 		// oldest one is forgotten and can resurface.
 		const guard = new AdvisorEmissionGuard({ capacity: 3 });
-		expect(guard.accept("first")).toBe(true);
+		expect(guard.accept("first")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("second")).toBe(true);
+		expect(guard.accept("second")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("third")).toBe(true);
+		expect(guard.accept("third")).toBe("accepted");
 		guard.beginUpdate();
 		// "first" still in history.
-		expect(guard.accept("first")).toBe(false);
+		expect(guard.accept("first")).toBe("duplicate");
 		guard.beginUpdate();
 		// Fourth unique entry evicts "first".
-		expect(guard.accept("fourth")).toBe(true);
+		expect(guard.accept("fourth")).toBe("accepted");
 		guard.beginUpdate();
-		expect(guard.accept("first")).toBe(true);
+		expect(guard.accept("first")).toBe("accepted");
 	});
 
 	it("rejects empty / whitespace-only notes without consuming the budget", () => {
 		const guard = new AdvisorEmissionGuard();
-		expect(guard.accept("")).toBe(false);
-		expect(guard.accept("   ")).toBe(false);
-		expect(guard.accept("Concrete advice.")).toBe(true);
+		expect(guard.accept("")).toBe("suppressed_noise");
+		expect(guard.accept("   ")).toBe("suppressed_noise");
+		expect(guard.accept("Concrete advice.")).toBe("accepted");
 	});
 
 	it("end-to-end: the reporter's 309-call spam log produces ≤1 accepted note across many updates", () => {
@@ -139,7 +139,7 @@ describe("AdvisorEmissionGuard", () => {
 			for (let i = 0; i < perCycle; i++) {
 				const note = stream[c * perCycle + i];
 				if (note === undefined) break;
-				if (guard.accept(note)) accepted.push(note);
+				if (guard.accept(note) === "accepted") accepted.push(note);
 			}
 		}
 		expect(accepted).toEqual(["Concrete-but-repeated nit: x"]);

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -123,6 +123,22 @@ describe("selector setting side effects", () => {
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 
+	it("re-enables live advisor runtime to rebuild when advisor.maxNotesPerUpdate changes in /settings", () => {
+		const setAdvisorEnabled = vi.fn();
+		const isAdvisorEnabled = vi.fn().mockReturnValue(true);
+		const requestRender = vi.fn();
+		const controller = new SelectorController({
+			session: { setAdvisorEnabled, isAdvisorEnabled },
+			ui: { requestRender },
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("advisor.maxNotesPerUpdate", 3);
+
+		expect(isAdvisorEnabled).toHaveBeenCalledTimes(1);
+		expect(setAdvisorEnabled).toHaveBeenCalledWith(true);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
 	for (const id of ["terminal.showImages", "showImages"]) {
 		for (const visible of [false, true]) {
 			it(`updates every image owner and rebuilds the transcript when ${id}=${visible}`, () => {


### PR DESCRIPTION
## Summary

Builds upon the fixes in #11064 to introduce configurable per-update advice budgets for reasoning models, relaxing the legacy #3520 1-note-per-update clamp to a configurable default of `4`.

### Context & Motivation

In #3520, an anti-flood clamp was added to prevent budget models (specifically Moonshot Kimi k2.7) from entering degenerate repetition loops (emitting hundreds of `Stop.` / `Done.` notes). That clamp enforced a strict limit of at most 1 accepted note per advisor model update cycle.

While effective against looping budget models, this creates severe friction for frontier reasoning models (e.g. `gpt-5.6-sol`, Claude Opus):
1. **Accelerated Quota Exhaustion**: Frontier verifiers naturally identify 2–4 distinct correctness issues in a single diff inspection. Forcing them to serialize observations across separate updates causes the primary transcript to be replayed and re-prompted $ times, burning hundreds of thousands of tokens per review and rapidly triggering HTTP 429 quota exhaustion.
2. **Review Latency**: Real bugs flagged as `concern` are rate-limited out simply because another note was processed first in the turn.

### Changes

1. **`AdvisorEmissionGuard`**:
   - Replaced `#consumedThisUpdate` boolean with `#acceptedThisUpdate` counter vs `#budgetPerUpdate` (default `4`, bounded to `[1, 32]`).
   - `blocker` severity continues to bypass the budget limit and does not consume non-blocker budget slots.
2. **Settings Surface**:
   - Added `advisor.maxNotesPerUpdate` in `settings-schema.ts` (type: `number`, default: `4`, options: 1–5).
3. **`WATCHDOG.yml` Configuration**:
   - Added `maxNotesPerUpdate` to `AdvisorConfig` and top-level `watchdogYamlSchema`, preserved across discovery, loading, and serialization.
4. **Session Precedence & Runtime Signature**:
   - Precedence: per-advisor `config.maxNotesPerUpdate` > `WATCHDOG.yml` top-level `maxNotesPerUpdate` > `settings.advisor.maxNotesPerUpdate` > `4` default.
   - Included resolved budget in `#advisorRuntimeSignature` so updating the budget cleanly invalidates and rebuilds the advisor runtime.
5. **Tool Feedback**:
   - Updated rate-limited copy from hardcoded "only one note accepted..." to accurate "update advice budget reached. Re-raise this note on the next update."

### Verification

- `bun check` in `packages/coding-agent` passed (0 errors in `oxlint`, `oxfmt`, and `tsgo`).
- 309 tests passed across all advisor test suites:
  - `packages/coding-agent/test/advisor/emission-guard.test.ts`
  - `packages/coding-agent/test/advisor/advisor.test.ts`
  - `packages/coding-agent/test/advisor/config.test.ts`
  - `packages/coding-agent/test/advisor-toggle.test.ts`
  - `packages/coding-agent/test/advisor-watchdog.test.ts`

Related: #11062, #11064, #3520