### PR TITLE
fix(collab): hold guest prompts until join sync completes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a collab TUI guest running prompts against its own local model (failing with "No API key found") when typed before the host snapshot finished syncing; such prompts are now held until the join completes ([#11067](https://github.com/can1357/oh-my-pi/issues/11067)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -256,128 +256,127 @@ export class CollabGuestLink {
 	async join(link: string): Promise<void> {
 		const parsed = parseCollabLink(link);
 		if ("error" in parsed) throw new Error(parsed.error);
-		this.#roomId = parsed.roomId;
-		this.#writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
-		const key = await importRoomKey(parsed.key);
-
-		this.#returnSessionFile = this.#ctx.sessionManager.getSessionFile() ?? null;
-
-		// Mark the join in flight so the input controller holds locally-typed
-		// prompts until `collabGuest` is installed below. Without this, a prompt
-		// submitted during the snapshot sync runs on the guest's own local
-		// session and model, failing with a "No API key" error for the guest's
-		// default provider (issue #11067). Cleared in the `finally` — on both
-		// success (collabGuest takes over) and failure.
+		// Arm before the first asynchronous step: Editor does not await
+		// onSubmit, so another prompt can arrive while the room key imports.
+		// The outer finally covers key-import and all later setup failures.
 		this.#ctx.collabJoining = true;
-
-		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
-		this.#socket = socket;
-
-		const firstWelcome = Promise.withResolvers<void>();
-		let joined = false;
-		this.#joinReject = err => firstWelcome.reject(err);
-
-		const finishJoin = (): void => {
-			if (joined) return;
-			joined = true;
-			firstWelcome.resolve();
-		};
-
-		socket.onOpen = () => {
-			// (Re)connect: re-introduce ourselves; the host answers with a fresh
-			// welcome which (re)syncs the replica. Discard any partially-streamed
-			// snapshot from a prior connection: the host will resend the full
-			// chunk train.
-			this.#welcomed = false;
-			this.#pendingSnapshot = null;
-			this.#clearSnapshotProgressTimer();
-			this.#armWelcomeTimer();
-			socket.send({
-				t: "hello",
-				proto: COLLAB_PROTO,
-				name: collabDisplayName(this.#ctx),
-				writeToken: this.#writeToken,
-			});
-		};
-		socket.onFrame = frame => {
-			this.#applyChain = this.#applyChain
-				.then(async () => {
-					if (frame.t === "welcome") {
-						this.#clearWelcomeTimer();
-						this.#beginWelcome(frame, joined);
-						if (frame.entryCount === 0) {
-							await this.#finalizeSnapshot();
-							finishJoin();
-						}
-						return;
-					}
-					if (frame.t === "snapshot-chunk") {
-						const ready = this.#accumulateSnapshotChunk(frame);
-						if (ready) {
-							await this.#finalizeSnapshot();
-							finishJoin();
-						}
-						return;
-					}
-					if (frame.t === "error" && !this.#welcomed && !this.#left) {
-						// Pre-welcome errors are the host's targeted reply to our
-						// hello (e.g. protocol mismatch): no welcome will follow.
-						// Fail the join with the host's message instead of hanging
-						// until the welcome timeout.
-						this.#clearWelcomeTimer();
-						if (joined) this.#ctx.showError(`Collab host: ${frame.message}`);
-						else firstWelcome.reject(new Error(frame.message));
-						return;
-					}
-					if (!this.#welcomed || this.#left) return;
-					this.#applyFrame(frame);
-				})
-				.catch(err => {
-					logger.warn("collab guest frame apply failed", { type: frame.t, error: String(err) });
-					if (!joined && (frame.t === "welcome" || frame.t === "snapshot-chunk")) {
-						firstWelcome.reject(err instanceof Error ? err : new Error(String(err)));
-					}
-				});
-		};
-		socket.onClose = (reason, willReconnect) => {
-			this.#clearWelcomeTimer();
-			this.#clearSnapshotProgressTimer();
-			this.#flushPendingTranscripts();
-			if (this.#left) return;
-			if (!joined) {
-				firstWelcome.reject(new Error(reason));
-				return;
-			}
-			if (willReconnect) {
-				this.#ctx.showStatus(`Collab connection lost (${reason}), reconnecting…`, { dim: true });
-				return;
-			}
-			this.#ctx.showStatus(`Collab session ended (${reason})`);
-			void this.#restoreLocalSession();
-		};
-		socket.connect();
-		// Cover the connect phase too: if the relay blackholes the WebSocket
-		// handshake (no onOpen, no onClose), onOpen never arms the welcome timer,
-		// so without this the join would hang forever. onOpen re-arms (resetting
-		// the budget) once the socket actually opens.
-		this.#armWelcomeTimer();
-
 		try {
-			await firstWelcome.promise;
-		} catch (err) {
-			this.#left = true;
-			socket.close();
-			this.#socket = null;
-			throw err;
+			this.#roomId = parsed.roomId;
+			this.#writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
+			const key = await importRoomKey(parsed.key);
+
+			this.#returnSessionFile = this.#ctx.sessionManager.getSessionFile() ?? null;
+
+			const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+			this.#socket = socket;
+
+			const firstWelcome = Promise.withResolvers<void>();
+			let joined = false;
+			this.#joinReject = err => firstWelcome.reject(err);
+
+			const finishJoin = (): void => {
+				if (joined) return;
+				joined = true;
+				firstWelcome.resolve();
+			};
+
+			socket.onOpen = () => {
+				// (Re)connect: re-introduce ourselves; the host answers with a fresh
+				// welcome which (re)syncs the replica. Discard any partially-streamed
+				// snapshot from a prior connection: the host will resend the full
+				// chunk train.
+				this.#welcomed = false;
+				this.#pendingSnapshot = null;
+				this.#clearSnapshotProgressTimer();
+				this.#armWelcomeTimer();
+				socket.send({
+					t: "hello",
+					proto: COLLAB_PROTO,
+					name: collabDisplayName(this.#ctx),
+					writeToken: this.#writeToken,
+				});
+			};
+			socket.onFrame = frame => {
+				this.#applyChain = this.#applyChain
+					.then(async () => {
+						if (frame.t === "welcome") {
+							this.#clearWelcomeTimer();
+							this.#beginWelcome(frame, joined);
+							if (frame.entryCount === 0) {
+								await this.#finalizeSnapshot();
+								finishJoin();
+							}
+							return;
+						}
+						if (frame.t === "snapshot-chunk") {
+							const ready = this.#accumulateSnapshotChunk(frame);
+							if (ready) {
+								await this.#finalizeSnapshot();
+								finishJoin();
+							}
+							return;
+						}
+						if (frame.t === "error" && !this.#welcomed && !this.#left) {
+							// Pre-welcome errors are the host's targeted reply to our
+							// hello (e.g. protocol mismatch): no welcome will follow.
+							// Fail the join with the host's message instead of hanging
+							// until the welcome timeout.
+							this.#clearWelcomeTimer();
+							if (joined) this.#ctx.showError(`Collab host: ${frame.message}`);
+							else firstWelcome.reject(new Error(frame.message));
+							return;
+						}
+						if (!this.#welcomed || this.#left) return;
+						this.#applyFrame(frame);
+					})
+					.catch(err => {
+						logger.warn("collab guest frame apply failed", { type: frame.t, error: String(err) });
+						if (!joined && (frame.t === "welcome" || frame.t === "snapshot-chunk")) {
+							firstWelcome.reject(err instanceof Error ? err : new Error(String(err)));
+						}
+					});
+			};
+			socket.onClose = (reason, willReconnect) => {
+				this.#clearWelcomeTimer();
+				this.#clearSnapshotProgressTimer();
+				this.#flushPendingTranscripts();
+				if (this.#left) return;
+				if (!joined) {
+					firstWelcome.reject(new Error(reason));
+					return;
+				}
+				if (willReconnect) {
+					this.#ctx.showStatus(`Collab connection lost (${reason}), reconnecting…`, { dim: true });
+					return;
+				}
+				this.#ctx.showStatus(`Collab session ended (${reason})`);
+				void this.#restoreLocalSession();
+			};
+			socket.connect();
+			// Cover the connect phase too: if the relay blackholes the WebSocket
+			// handshake (no onOpen, no onClose), onOpen never arms the welcome timer,
+			// so without this the join would hang forever. onOpen re-arms (resetting
+			// the budget) once the socket actually opens.
+			this.#armWelcomeTimer();
+
+			try {
+				await firstWelcome.promise;
+			} catch (err) {
+				this.#left = true;
+				socket.close();
+				this.#socket = null;
+				throw err;
+			} finally {
+				this.#joinReject = null;
+				this.#clearWelcomeTimer();
+				this.#clearSnapshotProgressTimer();
+			}
+
+			this.#ctx.collabGuest = this;
+			this.#ctx.syncRunningSubagentBadge();
 		} finally {
 			this.#ctx.collabJoining = false;
-			this.#joinReject = null;
-			this.#clearWelcomeTimer();
-			this.#clearSnapshotProgressTimer();
 		}
-
-		this.#ctx.collabGuest = this;
-		this.#ctx.syncRunningSubagentBadge();
 	}
 
 	/** User-initiated leave (or post-disconnect cleanup): restore the previous session. */

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -262,6 +262,14 @@ export class CollabGuestLink {
 
 		this.#returnSessionFile = this.#ctx.sessionManager.getSessionFile() ?? null;
 
+		// Mark the join in flight so the input controller holds locally-typed
+		// prompts until `collabGuest` is installed below. Without this, a prompt
+		// submitted during the snapshot sync runs on the guest's own local
+		// session and model, failing with a "No API key" error for the guest's
+		// default provider (issue #11067). Cleared in the `finally` — on both
+		// success (collabGuest takes over) and failure.
+		this.#ctx.collabJoining = true;
+
 		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
 		this.#socket = socket;
 
@@ -362,6 +370,7 @@ export class CollabGuestLink {
 			this.#socket = null;
 			throw err;
 		} finally {
+			this.#ctx.collabJoining = false;
 			this.#joinReject = null;
 			this.#clearWelcomeTimer();
 			this.#clearSnapshotProgressTimer();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -828,6 +828,19 @@ export class InputController {
 				}
 			}
 
+			// Collab guest join still syncing: `ctx.collabGuest` is not installed
+			// until the host snapshot finishes replicating, so a prompt submitted
+			// during that window would otherwise run on the guest's own local
+			// session and model — resolving credentials the guest doesn't have and
+			// failing with "No API key found" (issue #11067). Hold the input and
+			// keep the text so the user can resend once the join completes.
+			if (this.ctx.collabJoining && !this.ctx.collabGuest) {
+				if (text || (inputImages?.length ?? 0) > 0) {
+					this.ctx.showStatus("Joining collab session — wait for the sync to finish, then resend.");
+				}
+				return;
+			}
+
 			// Collab guest: prompts execute on the host; local slash/skill/bash/
 			// python execution is host-only (builtins are gated inside
 			// executeBuiltinSlashCommand, which already consumed allowed ones).

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -835,9 +835,17 @@ export class InputController {
 			// failing with "No API key found" (issue #11067). Hold the input and
 			// keep the text so the user can resend once the join completes.
 			if (this.ctx.collabJoining && !this.ctx.collabGuest) {
-				if (text || (inputImages?.length ?? 0) > 0) {
-					this.ctx.showStatus("Joining collab session — wait for the sync to finish, then resend.");
-				}
+				this.ctx.editor.pendingImages = inputImages ? [...inputImages] : [];
+				this.ctx.editor.pendingImageLinks = inputImages
+					? inputImageLinks
+						? [...inputImageLinks]
+						: inputImages.map(() => undefined)
+					: [];
+				this.ctx.editor.imageLinks =
+					this.ctx.editor.pendingImageLinks.length > 0 ? this.ctx.editor.pendingImageLinks : undefined;
+				this.ctx.editor.setCollapsedText(text);
+				this.ctx.showStatus("Joining collab session — wait for the sync to finish, then resend.");
+				this.ctx.ui.requestRender();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -828,26 +828,10 @@ export class InputController {
 				}
 			}
 
-			// Collab guest join still syncing: `ctx.collabGuest` is not installed
-			// until the host snapshot finishes replicating, so a prompt submitted
-			// during that window would otherwise run on the guest's own local
-			// session and model — resolving credentials the guest doesn't have and
-			// failing with "No API key found" (issue #11067). Hold the input and
-			// keep the text so the user can resend once the join completes.
-			if (this.ctx.collabJoining && !this.ctx.collabGuest) {
-				this.ctx.editor.pendingImages = inputImages ? [...inputImages] : [];
-				this.ctx.editor.pendingImageLinks = inputImages
-					? inputImageLinks
-						? [...inputImageLinks]
-						: inputImages.map(() => undefined)
-					: [];
-				this.ctx.editor.imageLinks =
-					this.ctx.editor.pendingImageLinks.length > 0 ? this.ctx.editor.pendingImageLinks : undefined;
-				this.ctx.editor.setCollapsedText(text);
-				this.ctx.showStatus("Joining collab session — wait for the sync to finish, then resend.");
-				this.ctx.ui.requestRender();
-				return;
-			}
+			// Collab guest join still syncing: hold local prompts until the guest
+			// is installed (issue #11067). Covers the plain-Enter path; the queue
+			// shorthand and Ctrl+Enter follow-up paths gate at their own entrypoints.
+			if (this.#holdDuringCollabJoin(text, inputImages, inputImageLinks)) return;
 
 			// Collab guest: prompts execute on the host; local slash/skill/bash/
 			// python execution is host-only (builtins are gated inside
@@ -1341,6 +1325,30 @@ export class InputController {
 		await this.#queueForYield(text, { images, imageLinks });
 	}
 
+	/**
+	 * Hold a locally-typed prompt while a collab-guest join is still syncing.
+	 *
+	 * Between the start of `/join` and `collabGuest` being installed the session
+	 * is still the guest's own local replica, so every local prompt entrypoint
+	 * (plain Enter, `-> `/`=> ` queue shorthand, Ctrl+Enter follow-up) would run
+	 * inference against the guest's own model and credentials — failing with
+	 * "No API key found" for the guest's default provider (issue #11067). The
+	 * real editor clears its buffer before dispatch, so this restores the
+	 * submitted text and image chips and shows a hint. Returns `true` when the
+	 * caller must stop (join in flight); `false` otherwise.
+	 */
+	#holdDuringCollabJoin(text: string, images?: ImageContent[], imageLinks?: (string | undefined)[]): boolean {
+		if (!this.ctx.collabJoining || this.ctx.collabGuest) return false;
+		this.ctx.editor.pendingImages = images ? [...images] : [];
+		this.ctx.editor.pendingImageLinks = images ? (imageLinks ? [...imageLinks] : images.map(() => undefined)) : [];
+		this.ctx.editor.imageLinks =
+			this.ctx.editor.pendingImageLinks.length > 0 ? this.ctx.editor.pendingImageLinks : undefined;
+		this.ctx.editor.setCollapsedText(text);
+		this.ctx.showStatus("Joining collab session — wait for the sync to finish, then resend.");
+		this.ctx.ui.requestRender();
+		return true;
+	}
+
 	async #queueForYield(
 		text: string,
 		options: {
@@ -1349,6 +1357,9 @@ export class InputController {
 			imageLinks?: (string | undefined)[];
 		},
 	): Promise<void> {
+		// Queue shorthand (`-> `/`=> `) and `/queue` both land here before any
+		// local dispatch; hold them while a collab-guest join is still syncing.
+		if (this.#holdDuringCollabJoin(options.historyText ?? text, options.images, options.imageLinks)) return;
 		const splitMessages = splitQueuedMessages(text);
 		if (splitMessages.length === 0 && !options.images?.length) {
 			this.ctx.editor.clearDraft();
@@ -1460,6 +1471,10 @@ export class InputController {
 		const imageLinks =
 			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
 		if (!text && !images) return;
+
+		// Ctrl+Enter/Ctrl+Q follow-up bypasses the Enter submit handler entirely;
+		// hold it too while a collab-guest join is still syncing (issue #11067).
+		if (this.#holdDuringCollabJoin(text, images, imageLinks)) return;
 
 		// Focused subagent session: follow-ups go to it; non-chat input is gated.
 		if (this.ctx.focusedAgentId) {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -160,6 +160,13 @@ export interface InteractiveModeContext {
 	lspServers?: LspStartupServerInfo[];
 	collabHost?: CollabHost;
 	collabGuest?: CollabGuestLink;
+	/**
+	 * True while a `/join` is syncing the host snapshot, before `collabGuest`
+	 * is installed. During this window the session is still the guest's own
+	 * local replica: prompts must be held rather than run against the guest's
+	 * local model/credentials (issue #11067).
+	 */
+	collabJoining?: boolean;
 	eventController: EventController;
 	eventBus?: EventBus;
 	/** Root-scoped bus carrying this session tree's `task:subagent:*` frames. */

--- a/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
+++ b/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
@@ -14,13 +14,15 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
  * completes.
  *
  * Contract: while a join is in flight (`collabJoining` set, `collabGuest`
- * unset) a free-text submit must NOT reach the local session prompt; it is held
- * with a status hint. Once the join settles the flag clears and prompts flow
- * normally.
+ * unset) a free-text submit must NOT reach the local session prompt. The real
+ * editor clears its buffer before invoking `onSubmit`, so the controller must
+ * restore the submitted text and image chips while showing a status hint. Once
+ * the join settles the flag clears and prompts flow normally.
  */
 
 type FakeEditor = {
 	onSubmit?: (text: string) => Promise<void>;
+	submit(text: string): Promise<void>;
 	imageLinks?: readonly (string | undefined)[];
 	pendingImages: ImageContent[];
 	pendingImageLinks: (string | undefined)[];
@@ -41,8 +43,15 @@ function createContext() {
 	const prompt = vi.fn(async () => {});
 	const showStatus = vi.fn();
 	const addToHistory = vi.fn();
+	const requestRender = vi.fn();
 
 	const editor: FakeEditor = {
+		async submit(text: string) {
+			// Mirrors Editor.#submitValue: the visible buffer and atom table are
+			// cleared before the callback receives the expanded submission.
+			editorText = "";
+			await this.onSubmit?.(text);
+		},
 		pendingImages: [] as ImageContent[],
 		pendingImageLinks: [] as (string | undefined)[],
 		setText(text: string) {
@@ -87,7 +96,7 @@ function createContext() {
 
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
-		ui: { requestRender: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
 		session,
 		settings: session.settings,
 		sessionManager: { getSessionName: () => "named-session" } as InteractiveModeContext["sessionManager"],
@@ -128,35 +137,46 @@ function createContext() {
 		isPythonMode: false,
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, spies: { steer, prompt, showStatus } };
+	return { ctx, editor, spies: { steer, prompt, showStatus, requestRender } };
 }
 
 describe("InputController collab join window", () => {
-	it("holds a typed prompt while a collab join is still syncing", async () => {
+	it("restores typed text and image chips while a collab join is still syncing", async () => {
 		const { ctx, editor, spies } = createContext();
+		const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
+		const imageLink = "file:///tmp/collab-draft.png";
+		const text = "is agent working? [Image #1]";
 		ctx.collabJoining = true;
 		ctx.collabGuest = undefined;
+		editor.setText(text);
+		editor.pendingImages = [image];
+		editor.pendingImageLinks = [imageLink];
+		editor.imageLinks = editor.pendingImageLinks;
 		const controller = new InputController(ctx);
 		controller.setupEditorSubmitHandler();
 
-		await editor.onSubmit?.("is agent working?");
+		await editor.submit(text);
 
-		// No local inference: the prompt never touches the guest's own session.
 		expect(spies.prompt).not.toHaveBeenCalled();
 		expect(spies.steer).not.toHaveBeenCalled();
-		// The user gets a hint that the session is not ready yet.
+		expect(editor.getText()).toBe(text);
+		expect(editor.pendingImages).toEqual([image]);
+		expect(editor.pendingImageLinks).toEqual([imageLink]);
+		expect(editor.imageLinks).toEqual([imageLink]);
 		expect(spies.showStatus).toHaveBeenCalledTimes(1);
 		expect(spies.showStatus.mock.calls[0]?.[0]).toMatch(/collab/i);
+		expect(spies.requestRender).toHaveBeenCalledTimes(1);
 	});
 
 	it("runs prompts locally once the join window has closed", async () => {
 		const { ctx, editor, spies } = createContext();
 		ctx.collabJoining = false;
 		ctx.collabGuest = undefined;
+		editor.setText("is agent working?");
 		const controller = new InputController(ctx);
 		controller.setupEditorSubmitHandler();
 
-		await editor.onSubmit?.("is agent working?");
+		await editor.submit("is agent working?");
 
 		expect(spies.prompt).toHaveBeenCalledWith("is agent working?", {
 			streamingBehavior: "steer",

--- a/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
+++ b/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
@@ -28,6 +28,7 @@ type FakeEditor = {
 	pendingImageLinks: (string | undefined)[];
 	setText(text: string): void;
 	getText(): string;
+	getExpandedText(): string;
 	setCollapsedText(text: string): void;
 	composerChips(): unknown[];
 	addToHistory(text: string): void;
@@ -41,6 +42,8 @@ function createContext() {
 	let editorText = "";
 	const steer = vi.fn(async (_text: string, _images?: unknown) => {});
 	const prompt = vi.fn(async () => {});
+	const followUp = vi.fn(async () => {});
+	const startPendingSubmission = vi.fn((submission: unknown) => submission);
 	const showStatus = vi.fn();
 	const addToHistory = vi.fn();
 	const requestRender = vi.fn();
@@ -58,6 +61,9 @@ function createContext() {
 			editorText = text;
 		},
 		getText() {
+			return editorText;
+		},
+		getExpandedText() {
 			return editorText;
 		},
 		setCollapsedText(text: string) {
@@ -87,6 +93,7 @@ function createContext() {
 		settings: Settings.isolated({}),
 		steer,
 		prompt,
+		followUp,
 		maybeStartTitleGeneration: vi.fn(),
 		queuedMessageCount: 0,
 		customCommands: [],
@@ -129,6 +136,7 @@ function createContext() {
 				throw err;
 			}
 		},
+		startPendingSubmission,
 		onInputCallback: undefined,
 		updatePendingMessagesDisplay: vi.fn(),
 		flushPendingBashComponents: vi.fn(),
@@ -137,7 +145,7 @@ function createContext() {
 		isPythonMode: false,
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, spies: { steer, prompt, showStatus, requestRender } };
+	return { ctx, editor, spies: { steer, prompt, followUp, startPendingSubmission, showStatus, requestRender } };
 }
 
 describe("InputController collab join window", () => {
@@ -166,6 +174,50 @@ describe("InputController collab join window", () => {
 		expect(spies.showStatus).toHaveBeenCalledTimes(1);
 		expect(spies.showStatus.mock.calls[0]?.[0]).toMatch(/collab/i);
 		expect(spies.requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("holds a `=> ` queue-shorthand prompt while a collab join is still syncing", async () => {
+		const { ctx, editor, spies } = createContext();
+		const text = "=> investigate this";
+		ctx.collabJoining = true;
+		ctx.collabGuest = undefined;
+		editor.setText(text);
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.submit(text);
+
+		// The queue path must not reach any local dispatch during the join.
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.followUp).not.toHaveBeenCalled();
+		expect(spies.startPendingSubmission).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe(text);
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus.mock.calls[0]?.[0]).toMatch(/collab/i);
+	});
+
+	it("holds a Ctrl+Enter follow-up prompt while a collab join is still syncing", async () => {
+		const { ctx, editor, spies } = createContext();
+		const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
+		const imageLink = "file:///tmp/collab-followup.png";
+		const text = "wrap up [Image #1]";
+		ctx.collabJoining = true;
+		ctx.collabGuest = undefined;
+		editor.setText(text);
+		editor.pendingImages = [image];
+		editor.pendingImageLinks = [imageLink];
+		editor.imageLinks = editor.pendingImageLinks;
+		const controller = new InputController(ctx);
+
+		await controller.handleFollowUp();
+
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.followUp).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe(text);
+		expect(editor.pendingImages).toEqual([image]);
+		expect(editor.pendingImageLinks).toEqual([imageLink]);
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus.mock.calls[0]?.[0]).toMatch(/collab/i);
 	});
 
 	it("runs prompts locally once the join window has closed", async () => {

--- a/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
+++ b/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+/**
+ * Regression (issue #11067): `omp join` boots a full local session and only
+ * installs `ctx.collabGuest` after the host snapshot finishes replicating.
+ * A prompt typed during that sync window has no guest to forward to, so it used
+ * to run against the guest's own local model — failing with
+ * "No API key found for <guest's default provider>" even though the host owns
+ * the credential. `ctx.collabJoining` now holds such prompts until the join
+ * completes.
+ *
+ * Contract: while a join is in flight (`collabJoining` set, `collabGuest`
+ * unset) a free-text submit must NOT reach the local session prompt; it is held
+ * with a status hint. Once the join settles the flag clears and prompts flow
+ * normally.
+ */
+
+type FakeEditor = {
+	onSubmit?: (text: string) => Promise<void>;
+	imageLinks?: readonly (string | undefined)[];
+	pendingImages: ImageContent[];
+	pendingImageLinks: (string | undefined)[];
+	setText(text: string): void;
+	getText(): string;
+	setCollapsedText(text: string): void;
+	composerChips(): unknown[];
+	addToHistory(text: string): void;
+	clearDraft(historyText?: string): void;
+	setActionKeys(action: string, keys: string[]): void;
+	setCustomKeyHandler(key: string, handler: () => void): void;
+	clearCustomKeyHandlers(): void;
+};
+
+function createContext() {
+	let editorText = "";
+	const steer = vi.fn(async (_text: string, _images?: unknown) => {});
+	const prompt = vi.fn(async () => {});
+	const showStatus = vi.fn();
+	const addToHistory = vi.fn();
+
+	const editor: FakeEditor = {
+		pendingImages: [] as ImageContent[],
+		pendingImageLinks: [] as (string | undefined)[],
+		setText(text: string) {
+			editorText = text;
+		},
+		getText() {
+			return editorText;
+		},
+		setCollapsedText(text: string) {
+			editorText = text;
+		},
+		composerChips() {
+			return [];
+		},
+		addToHistory,
+		clearDraft(historyText?: string) {
+			if (historyText !== undefined) addToHistory(historyText);
+			editorText = "";
+			this.pendingImages = [];
+			this.pendingImageLinks = [];
+		},
+		setActionKeys: vi.fn(),
+		setCustomKeyHandler: vi.fn(),
+		clearCustomKeyHandlers: vi.fn(),
+	};
+
+	const session = {
+		isStreaming: false,
+		isCompacting: false,
+		isBashRunning: false,
+		isEvalRunning: false,
+		extensionRunner: undefined,
+		settings: Settings.isolated({}),
+		steer,
+		prompt,
+		maybeStartTitleGeneration: vi.fn(),
+		queuedMessageCount: 0,
+		customCommands: [],
+		promptTemplates: [],
+		getQueuedMessages: () => ({ steering: [], followUp: [] }),
+	} as unknown as InteractiveModeContext["session"];
+
+	const ctx = {
+		editor: editor as unknown as InteractiveModeContext["editor"],
+		ui: { requestRender: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		session,
+		settings: session.settings,
+		sessionManager: { getSessionName: () => "named-session" } as InteractiveModeContext["sessionManager"],
+		compactionQueuedMessages: [] as InteractiveModeContext["compactionQueuedMessages"],
+		skillCommands: new Map(),
+		fileSlashCommands: new Set<string>(),
+		locallySubmittedUserSignatures: new Set<string>(),
+		isKnownSlashCommand: () => false,
+		showStatus,
+		collabJoining: false,
+		collabGuest: undefined,
+		recordLocalSubmission(this: InteractiveModeContext, text: string, imageCount = 0) {
+			const sig = `${text}\u0000${imageCount}`;
+			this.locallySubmittedUserSignatures.add(sig);
+			return () => {
+				this.locallySubmittedUserSignatures.delete(sig);
+			};
+		},
+		async withLocalSubmission<T>(
+			this: InteractiveModeContext,
+			text: string,
+			fn: () => Promise<T>,
+			options?: { imageCount?: number },
+		): Promise<T> {
+			const dispose = this.recordLocalSubmission(text, options?.imageCount ?? 0);
+			try {
+				return await fn();
+			} catch (err) {
+				dispose();
+				throw err;
+			}
+		},
+		onInputCallback: undefined,
+		updatePendingMessagesDisplay: vi.fn(),
+		flushPendingBashComponents: vi.fn(),
+		showError: vi.fn(),
+		isBashMode: false,
+		isPythonMode: false,
+	} as unknown as InteractiveModeContext;
+
+	return { ctx, editor, spies: { steer, prompt, showStatus } };
+}
+
+describe("InputController collab join window", () => {
+	it("holds a typed prompt while a collab join is still syncing", async () => {
+		const { ctx, editor, spies } = createContext();
+		ctx.collabJoining = true;
+		ctx.collabGuest = undefined;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("is agent working?");
+
+		// No local inference: the prompt never touches the guest's own session.
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.steer).not.toHaveBeenCalled();
+		// The user gets a hint that the session is not ready yet.
+		expect(spies.showStatus).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus.mock.calls[0]?.[0]).toMatch(/collab/i);
+	});
+
+	it("runs prompts locally once the join window has closed", async () => {
+		const { ctx, editor, spies } = createContext();
+		ctx.collabJoining = false;
+		ctx.collabGuest = undefined;
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await editor.onSubmit?.("is agent working?");
+
+		expect(spies.prompt).toHaveBeenCalledWith("is agent working?", {
+			streamingBehavior: "steer",
+			images: undefined,
+		});
+		expect(spies.showStatus).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
+++ b/packages/coding-agent/test/collab/guest-join-window-prompt.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { CollabGuestLink } from "@oh-my-pi/pi-coding-agent/collab/guest";
+import { generateRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { formatCollabLink, generateRoomId } from "@oh-my-pi/pi-coding-agent/collab/protocol";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 /**
  * Regression (issue #11067): `omp join` boots a full local session and only
@@ -235,5 +242,22 @@ describe("InputController collab join window", () => {
 			images: undefined,
 		});
 		expect(spies.showStatus).not.toHaveBeenCalled();
+	});
+});
+
+describe("CollabGuestLink join guard", () => {
+	it("arms before room-key import and clears when the import fails", async () => {
+		const keyImport = Promise.withResolvers<CryptoKey>();
+		vi.spyOn(crypto.subtle, "importKey").mockReturnValueOnce(keyImport.promise);
+		const ctx = { collabJoining: false } as unknown as InteractiveModeContext;
+		const guest = new CollabGuestLink(ctx);
+		const link = formatCollabLink("https://relay.omp.test", generateRoomId(), generateRoomKey());
+
+		const join = guest.join(link);
+
+		expect(ctx.collabJoining).toBe(true);
+		keyImport.reject(new Error("room-key import failed"));
+		await expect(join).rejects.toThrow("room-key import failed");
+		expect(ctx.collabJoining).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
Join a collab session from a second machine (`omp collab` on the host prints an `omp join <link>` command; run it on the guest). While the guest is still syncing the host snapshot, type a prompt. It fails with `Error: No API key found for <provider>` naming the *guest's* default provider — even though the host owns the credential and the browser collab client on the same setup works. Reported as #11067 (guest error named `github-copilot` while the host ran `GPT-Luna`). Driving the real `InputController` + `AgentSession` in the guest's mid-join state confirms the guest's own `session.prompt` runs (`local session.prompt invoked: true`) instead of forwarding to the host.

## Cause
`omp join` boots a full local interactive session and dispatches `/join`. `CollabGuestLink.join()` (`packages/coding-agent/src/collab/guest.ts`) installs `ctx.collabGuest` only *after* the host snapshot finishes replicating. The input controller forwards prompts to the host only when `ctx.collabGuest` is set (`modes/controllers/input-controller.ts`); until then a typed prompt falls through to the guest's own local session, which resolves credentials locally via `ModelRegistry.getApiKey` and throws `No API key found for <provider>` (`session/agent-session.ts`). The web collab client has no local inference stack, so it always forwards to the host — hence the browser session works.

## Fix
- Add `ctx.collabJoining` (`modes/types.ts`), set at the start of `CollabGuestLink.join()` and cleared in the `finally` (both success and failure) just before `collabGuest` is installed.
- In `InputController`, hold a locally-typed prompt while a join is in flight (`collabJoining` set, `collabGuest` unset): show a "Joining collab session — wait for the sync to finish, then resend." status and keep the editor text, instead of routing it to the guest's own model.
- Regression test `test/collab/guest-join-window-prompt.test.ts`: a submit during the join window does not reach `session.prompt`; once the window closes, prompts flow normally.

## Verification
`bun test test/collab/ test/input-controller-orphan-submit.test.ts` → 87 pass, 0 fail (run with a writable `HOME`; two `chunked-welcome` tests otherwise fail because this sandbox's `~/.omp` is root-owned, unrelated to this change). `bun run check` (oxlint + oxfmt + tsgo) passes for `packages/coding-agent`.

Fixes #11067