### PR TITLE
fix(utils): apply dotenv launch provenance only to the live process env

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `filterChildShellEnv` applying the omp process's own launch-environment provenance (the pre-dotenv `NODE_ENV` and launcher-owned names read from `/proc/self/environ`) to caller-supplied environment objects; launch provenance now only applies when filtering the live `process.env`/`Bun.env`, and an explicit env resolves its dotenv mode from its own `NODE_ENV`.
+
 ## [18.1.11] - 2026-09-05
 
 ### Fixed

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -112,9 +112,10 @@ export function filterChildShellEnv(
 	env: Record<string, string | undefined>,
 	cwd: string = process.cwd(),
 ): Record<string, string> {
+	const runtimeLaunchEnvValues = env === Bun.env || env === process.env ? launchEnvValues : undefined;
 	const result = filterProcessEnv(env);
 	const projectEnv = parseEnvFile(path.join(cwd, ".env"));
-	const launchNodeEnv = launchEnvValues ? launchEnvValues.get("NODE_ENV") : env.NODE_ENV;
+	const launchNodeEnv = runtimeLaunchEnvValues ? runtimeLaunchEnvValues.get("NODE_ENV") : env.NODE_ENV;
 	const nodeEnvName = `.env.${launchNodeEnv || "development"}`;
 	const modeEnv = parseEnvFile(path.join(cwd, nodeEnvName));
 	const localEnv = parseEnvFile(path.join(cwd, ".env.local"));
@@ -128,7 +129,7 @@ export function filterChildShellEnv(
 	};
 	let fallbackLaunchEnv: Record<string, string> | undefined;
 	let expandedFallbackLaunchEnv: Record<string, string> | undefined;
-	if (!launchEnvValues && nodeEnvName !== ".env.development") {
+	if (!runtimeLaunchEnvValues && nodeEnvName !== ".env.development") {
 		const fallbackModeEnv = parseEnvFile(path.join(cwd, ".env.development"));
 		const fallbackModeLocalEnv = parseEnvFile(path.join(cwd, ".env.development.local"));
 		const candidate = { ...projectEnv, ...fallbackModeEnv, ...localEnv, ...fallbackModeLocalEnv };
@@ -147,7 +148,7 @@ export function filterChildShellEnv(
 	}
 	const allLaunchEnv = fallbackLaunchEnv ? { ...launchEnv, ...fallbackLaunchEnv } : launchEnv;
 	for (const key in allLaunchEnv) {
-		const launchValue = launchEnvValues?.get(key);
+		const launchValue = runtimeLaunchEnvValues?.get(key);
 		if (launchValue !== undefined) {
 			// Launcher-owned name: it keeps the launcher's own value. Bun overwrites
 			// an empty launcher value with the dotenv one, so restore the launcher
@@ -163,7 +164,7 @@ export function filterChildShellEnv(
 			}
 			continue;
 		}
-		if (launchEnvValues || projectEnvNamesLoadedByOmp.has(key)) {
+		if (runtimeLaunchEnvValues || projectEnvNamesLoadedByOmp.has(key)) {
 			// Strong provenance: the launch environment is known and this name is
 			// absent from it, or OMP itself injected the value — either way it came
 			// from a project dotenv file, not the parent shell.

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -4,7 +4,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	$envExact,
-	filterChildShellEnv,
 	filterProcessEnv,
 	getDbBusyTimeoutMs,
 	parseEnvFile,
@@ -170,38 +169,34 @@ describe("filterProcessEnv", () => {
 });
 
 describe("filterChildShellEnv", () => {
-	// filterChildShellEnv resolves the mode-local dotenv name from the *launch*
-	// NODE_ENV (on Linux, /proc/self/environ — e.g. `test` inside a parallel
-	// bun-test worker), so the fixture must target that same mode instead of
-	// assuming `development`.
-	function launchDotenvMode(): string {
-		if (process.platform === "linux") {
-			try {
-				for (const entry of fs.readFileSync("/proc/self/environ", "utf8").split("\0")) {
-					if (entry.startsWith("NODE_ENV=")) return entry.slice("NODE_ENV=".length) || "development";
-				}
-				return "development";
-			} catch {}
-		}
-		return "development";
-	}
-
-	it("drops values Bun loaded from the default mode-local dotenv file", () => {
+	it("uses the supplied mode for an isolated environment and cwd", async () => {
 		const cwd = path.dirname(writeTempEnv(""));
 		fs.writeFileSync(
-			path.join(cwd, `.env.${launchDotenvMode()}.local`),
+			path.join(cwd, ".env.development.local"),
 			"OMP_DOTENV_REPRO_MARKER=synthetic-mode-local-value\n",
 		);
+		const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+		const script = [
+			`import { filterChildShellEnv } from ${JSON.stringify(envModulePath)};`,
+			"const child = filterChildShellEnv(",
+			'  { OMP_DOTENV_REPRO_MARKER: "synthetic-mode-local-value", UNCHANGED: "parent-value" },',
+			`  ${JSON.stringify(cwd)},`,
+			");",
+			"process.stdout.write(JSON.stringify(child));",
+		].join("\n");
+		const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+			env: { ...process.env, NODE_ENV: "test", OMP_DOTENV_REPRO_MARKER: undefined },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
 
-		const child = filterChildShellEnv(
-			{
-				OMP_DOTENV_REPRO_MARKER: "synthetic-mode-local-value",
-				UNCHANGED: "parent-value",
-			},
-			cwd,
-		);
-
-		expect(child).toEqual({ UNCHANGED: "parent-value" });
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
 	});
 
 	it("uses the launch mode when dotenv changes NODE_ENV", async () => {


### PR DESCRIPTION
Split out of #9368 at @H4vC's request; independent of the async-progress stack.

`filterChildShellEnv(env, cwd)` always consulted omp's own pre-dotenv launch snapshot, even when the caller passed an explicit env. For a caller-built env that is the wrong provenance: the dotenv mode came from omp's launch `NODE_ENV` instead of the supplied env's, and names present in omp's launch env were treated as launcher-owned. Inside a bun-test worker (`NODE_ENV=test`) filtering an isolated env against a cwd with `.env.development.local` looked for `.env.test.local` and leaked the mode-local value into the child.

Now launch provenance applies only when `env` is the live `process.env`/`Bun.env` (the object Bun's dotenv loading actually mutated). Any other env resolves its mode from its own `NODE_ENV` and uses the weak-provenance path, exactly as on platforms without `/proc/self/environ`. Filtering the real process env is unchanged.

<details>
<summary>Tests</summary>

`packages/utils/test/env.test.ts` "uses the supplied mode for an isolated environment and cwd" spawns a `NODE_ENV=test` bun subprocess and asserts the `.env.development.local` marker is dropped for an explicit env; it fails against the previous implementation.

`bun test packages/utils/test/env.test.ts` → 19 pass; `bun run check` in `packages/utils` clean.
</details>
