### PR TITLE
feat(coding-agent): add prewalk restart command

### DIFF
--- a/docs/prewalk.md
+++ b/docs/prewalk.md
@@ -47,13 +47,18 @@ The switch is one-shot: after the handoff, prewalk disarms itself. The target mo
 
 ## Arm from an active session
 
-Run the slash command to arm prewalk without restarting OMP or enabling it in config:
+Run either slash command without restarting OMP:
 
 ```text
 /prewalk
+/prewalk restart
 ```
 
-`/prewalk` always targets the `@smol` role. If prewalk is already armed, the command leaves the existing target in place. After a handoff is consumed, switch to another model and run `/prewalk` again to arm another one-shot handoff. To choose a different target at startup, use `--prewalk-into`.
+`/prewalk` arms a one-shot handoff from the active model to the current `@smol` assignment.
+
+After a handoff, `/prewalk restart` immediately returns the session to the current `@default` assignment and re-arms the handoff to `@smol`. Both roles are resolved when the command runs, so the cycle is independent of concrete model names and does not alter either role's persisted configuration.
+
+If prewalk is already armed, the command leaves the existing target in place. To choose a different target at startup, use `--prewalk-into`.
 
 ## Subagent prewalk
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.
 
+### Added
+
+- Added `/prewalk restart` to return an active session to its `@default` model and re-arm the one-shot handoff to `@smol`.
+
 ### Changed
 
 - Ranged reads of text without bracket characters skip unnecessary lexical context scanning.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -327,7 +327,12 @@ import {
 	VIBE_MODE_CONTEXT_MESSAGE_TYPE,
 } from "./messages";
 import { ModelControls, type ModelControlsHost } from "./model-controls";
-import { isPrewalkPlanNudge, PrewalkCoordinator, type PrewalkCoordinatorHost } from "./prewalk";
+import {
+	isPrewalkPlanNudge,
+	PrewalkCoordinator,
+	type PrewalkCoordinatorHost,
+	type PrewalkRestartResult,
+} from "./prewalk";
 import {
 	isAdvisorCard,
 	isDisplayableQueuedMessage,
@@ -1112,6 +1117,16 @@ export class AgentSession {
 	 */
 	armPrewalk(target: Model, thinkingLevel?: ConfiguredThinkingLevel): boolean {
 		return this.#prewalk.arm(target, thinkingLevel);
+	}
+
+	/** Restore a planning model and re-arm prewalk without partially applying a rejected restart. */
+	restartPrewalk(
+		source: Model,
+		sourceThinkingLevel: ConfiguredThinkingLevel | undefined,
+		target: Model,
+		targetThinkingLevel: ConfiguredThinkingLevel | undefined,
+	): Promise<PrewalkRestartResult> {
+		return this.#prewalk.restart(source, sourceThinkingLevel, target, targetThinkingLevel);
 	}
 
 	/** Validate the active plan artifact and shape an `xd://propose` result for review-mode hosts. */

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -278,6 +278,7 @@ export class PrewalkCoordinator {
 		await this.#host.setModelTemporary(source, sourceThinkingLevel, { ephemeral: true });
 		if (!active) return this.arm(target, targetThinkingLevel) ? "armed" : "reset";
 		if (this.#isNoop(active)) {
+			this.#scrubPlanNudge();
 			this.#disarmNoop(active);
 			return "reset";
 		}
@@ -315,13 +316,15 @@ export class PrewalkCoordinator {
 		this.#host.setPlanProposalHandler(title => this.#finalizePlanYoloProposal(title));
 	}
 
-	#scrubPlanNudge(liveMessages: AgentMessage[]): void {
+	#scrubPlanNudge(liveMessages?: AgentMessage[]): void {
 		if (!this.#planInjected) return;
 		const isPlanNudge = isPrewalkPlanNudge;
-		for (let index = liveMessages.length - 1; index >= 0; index--) {
-			if (!isPlanNudge(liveMessages[index])) continue;
-			invalidateMessageCache(liveMessages[index]);
-			liveMessages.splice(index, 1);
+		if (liveMessages) {
+			for (let index = liveMessages.length - 1; index >= 0; index--) {
+				if (!isPlanNudge(liveMessages[index])) continue;
+				invalidateMessageCache(liveMessages[index]);
+				liveMessages.splice(index, 1);
+			}
 		}
 		const stateMessages = this.#host.agent.state.messages;
 		const filtered = stateMessages.filter(message => !isPlanNudge(message));

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -86,6 +86,8 @@ export interface PrewalkCoordinatorOptions {
 }
 
 /** Coordinates one-way model prewalks and automatic plan-yolo handoffs. */
+
+export type PrewalkRestartResult = "armed" | "reset" | "rejected";
 export class PrewalkCoordinator {
 	readonly #host: PrewalkCoordinatorHost;
 	#prewalk: Prewalk | undefined;
@@ -250,6 +252,36 @@ export class PrewalkCoordinator {
 			"prewalk",
 		);
 		return true;
+	}
+
+	/**
+	 * Restores the planning model and reuses or creates the requested one-shot handoff.
+	 * A different active arm rejects the restart before the current model changes.
+	 */
+	async restart(
+		source: Model,
+		sourceThinkingLevel: ConfiguredThinkingLevel | undefined,
+		target: Model,
+		targetThinkingLevel: ConfiguredThinkingLevel | undefined,
+	): Promise<PrewalkRestartResult> {
+		const active = this.#prewalk;
+		if (
+			active &&
+			(active.target.provider !== target.provider ||
+				active.target.id !== target.id ||
+				active.thinkingLevel !== targetThinkingLevel)
+		) {
+			this.arm(target, targetThinkingLevel);
+			return "rejected";
+		}
+
+		await this.#host.setModelTemporary(source, sourceThinkingLevel, { ephemeral: true });
+		if (!active) return this.arm(target, targetThinkingLevel) ? "armed" : "reset";
+		if (this.#isNoop(active)) {
+			this.#disarmNoop(active);
+			return "reset";
+		}
+		return "armed";
 	}
 
 	/** Lazily enables plan-yolo's plan phase before the first prompt is built. */

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -611,25 +611,49 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "prewalk",
 		icon: "prewalk",
-		description: "Switch to a fast/cheap model at the next action (works even without --prewalk)",
-		acpDescription: "Prewalk at the next action",
-		handle: async (_command, runtime) => {
-			const rolePattern = expandRoleAlias("@smol", runtime.settings);
-			const resolved = resolveCliModel({
-				cliModel: rolePattern,
+		description: "Arm or restart a one-shot model handoff",
+		allowArgs: true,
+		acpDescription: "Arm or restart prewalk",
+		acpInputHint: "[restart]",
+		subcommands: [{ name: "restart", description: "Return to @default and re-arm the handoff to @smol" }],
+		handle: async (command, runtime) => {
+			const arg = command.args.trim().toLowerCase();
+			if (arg && arg !== "restart") return usage("Usage: /prewalk [restart]", runtime);
+			const targetPattern = expandRoleAlias("@smol", runtime.settings);
+			const target = resolveCliModel({
+				cliModel: targetPattern,
 				modelRegistry: runtime.session.modelRegistry,
 				preferences: getModelMatchPreferences(runtime.settings),
 			});
-			if (resolved.error || !resolved.model) {
-				return usage(resolved.error ?? `Model "${rolePattern}" not found`, runtime);
+			if (target.error || !target.model) {
+				return usage(target.error ?? `Model "${targetPattern}" not found`, runtime);
 			}
-			if (!runtime.session.modelRegistry.hasConfiguredAuth(resolved.model)) {
-				return usage(`No API key for ${resolved.model.provider}/${resolved.model.id}`, runtime);
+			if (!runtime.session.modelRegistry.hasConfiguredAuth(target.model)) {
+				return usage(`No API key for ${target.model.provider}/${target.model.id}`, runtime);
 			}
-			const armed = runtime.session.armPrewalk(resolved.model, resolved.thinkingLevel);
+			let restartSource: string | undefined;
+			if (arg === "restart") {
+				const sourcePattern = expandRoleAlias("@default", runtime.settings);
+				const source = resolveCliModel({
+					cliModel: sourcePattern,
+					modelRegistry: runtime.session.modelRegistry,
+					preferences: getModelMatchPreferences(runtime.settings),
+				});
+				if (source.error || !source.model) {
+					return usage(source.error ?? `Model "${sourcePattern}" not found`, runtime);
+				}
+				if (!runtime.session.modelRegistry.hasConfiguredAuth(source.model)) {
+					return usage(`No API key for ${source.model.provider}/${source.model.id}`, runtime);
+				}
+				await runtime.session.setModelTemporary(source.model, source.thinkingLevel, { ephemeral: true });
+				restartSource = `${source.model.provider}/${source.model.id}`;
+			}
+			const armed = runtime.session.armPrewalk(target.model, target.thinkingLevel);
 			if (armed) {
 				await runtime.output(
-					`Prewalk on: switching to ${resolved.model.provider}/${resolved.model.id} at the next edit/write (todo-gated).`,
+					arg === "restart"
+						? `Prewalk restarted: using @default (${restartSource}) for planning, then switching to @smol (${target.model.provider}/${target.model.id}) at the next edit/write (todo-gated).`
+						: `Prewalk on: switching to ${target.model.provider}/${target.model.id} at the next edit/write (todo-gated).`,
 				);
 			}
 			return commandConsumed();

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -1,6 +1,5 @@
 import * as path from "node:path";
 import {
-	expandRoleAlias,
 	formatModelString,
 	getModelMatchPreferences,
 	resolveCliModel,
@@ -619,41 +618,40 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		handle: async (command, runtime) => {
 			const arg = command.args.trim().toLowerCase();
 			if (arg && arg !== "restart") return usage("Usage: /prewalk [restart]", runtime);
-			const targetPattern = expandRoleAlias("@smol", runtime.settings);
-			const target = resolveCliModel({
-				cliModel: targetPattern,
-				modelRegistry: runtime.session.modelRegistry,
-				preferences: getModelMatchPreferences(runtime.settings),
-			});
+			const target = resolveSessionModelSelector("@smol", runtime.session, runtime.settings);
 			if (target.error || !target.model) {
-				return usage(target.error ?? `Model "${targetPattern}" not found`, runtime);
+				return usage(target.error ?? 'Model "@smol" not found', runtime);
 			}
 			if (!runtime.session.modelRegistry.hasConfiguredAuth(target.model)) {
 				return usage(`No API key for ${target.model.provider}/${target.model.id}`, runtime);
 			}
-			let restartSource: string | undefined;
 			if (arg === "restart") {
-				const sourcePattern = expandRoleAlias("@default", runtime.settings);
-				const source = resolveCliModel({
-					cliModel: sourcePattern,
-					modelRegistry: runtime.session.modelRegistry,
-					preferences: getModelMatchPreferences(runtime.settings),
-				});
+				const source = resolveSessionModelSelector("@default", runtime.session, runtime.settings);
 				if (source.error || !source.model) {
-					return usage(source.error ?? `Model "${sourcePattern}" not found`, runtime);
+					return usage(source.error ?? 'Model "@default" not found', runtime);
 				}
 				if (!runtime.session.modelRegistry.hasConfiguredAuth(source.model)) {
 					return usage(`No API key for ${source.model.provider}/${source.model.id}`, runtime);
 				}
-				await runtime.session.setModelTemporary(source.model, source.thinkingLevel, { ephemeral: true });
-				restartSource = `${source.model.provider}/${source.model.id}`;
+				const result = await runtime.session.restartPrewalk(
+					source.model,
+					source.thinkingLevel,
+					target.model,
+					target.thinkingLevel,
+				);
+				if (result === "rejected") return commandConsumed();
+				const restartSource = `${source.model.provider}/${source.model.id}`;
+				await runtime.output(
+					result === "armed"
+						? `Prewalk restarted: using @default (${restartSource}) for planning, then switching to @smol (${target.model.provider}/${target.model.id}) at the next edit/write (todo-gated).`
+						: `Prewalk reset: using @default (${restartSource}); @smol resolves to the same model and thinking level, so no handoff was armed.`,
+				);
+				return commandConsumed();
 			}
 			const armed = runtime.session.armPrewalk(target.model, target.thinkingLevel);
 			if (armed) {
 				await runtime.output(
-					arg === "restart"
-						? `Prewalk restarted: using @default (${restartSource}) for planning, then switching to @smol (${target.model.provider}/${target.model.id}) at the next edit/write (todo-gated).`
-						: `Prewalk on: switching to ${target.model.provider}/${target.model.id} at the next edit/write (todo-gated).`,
+					`Prewalk on: switching to ${target.model.provider}/${target.model.id} at the next edit/write (todo-gated).`,
 				);
 			}
 			return commandConsumed();

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -708,7 +708,7 @@ describe("AgentSession prewalk", () => {
 		expect(notices.some(message => message.includes("nothing to switch"))).toBe(true);
 	});
 
-	it("/prewalk reports success only when the requested arm remains active", async () => {
+	it("/prewalk commands report success only when the requested arm becomes active", async () => {
 		const primary = modelOrThrow("claude-sonnet-4-5");
 		const target = modelOrThrow("claude-sonnet-4-6");
 
@@ -760,6 +760,30 @@ describe("AgentSession prewalk", () => {
 		settings.setModelRole("smol", `${primary.provider}/${primary.id}:medium`);
 		expect(await executeBuiltinSlashCommand("/prewalk", runtime)).toBe(true);
 		expect(showStatus).toHaveBeenCalledTimes(1);
+
+		// Restart must not move the active model when an existing arm rejects the requested target.
+		settings.setModelRole("default", `${target.provider}/${target.id}:medium`);
+		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
+		expect(session.model?.id).toBe(primary.id);
+		expect(session.getPrewalkState()?.target.id).toBe(target.id);
+		expect(showStatus).toHaveBeenCalledTimes(1);
+
+		// A matching arm remains active while restart restores the configured planning model.
+		await session.setModelTemporary(target, Effort.Medium, { ephemeral: true });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}:medium`);
+		settings.setModelRole("smol", `${target.provider}/${target.id}:medium`);
+		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
+		expect(session.model?.id).toBe(primary.id);
+		expect(session.getPrewalkState()?.target.id).toBe(target.id);
+		expect(showStatus).toHaveBeenCalledTimes(2);
+
+		// If both roles now coincide, restart resets the model and clears the obsolete matching arm.
+		settings.setModelRole("default", `${target.provider}/${target.id}:medium`);
+		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
+		expect(session.model?.id).toBe(target.id);
+		expect(session.getPrewalkState()).toBeUndefined();
+		expect(showStatus).toHaveBeenCalledTimes(3);
+		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Prewalk reset"));
 	});
 
 	it("/prewalk restart returns to @default and re-arms @smol", async () => {
@@ -792,7 +816,7 @@ describe("AgentSession prewalk", () => {
 			},
 		});
 		const settings = Settings.isolated({ "compaction.enabled": false });
-		settings.setModelRole("default", `${primary.provider}/${primary.id}:medium`);
+		settings.setModelRole("default", `anthropic/missing-model,${primary.provider}/${primary.id}:medium`);
 		settings.setModelRole("smol", `${target.provider}/${target.id}:medium`);
 		const sessionManager = SessionManager.inMemory();
 		session = new AgentSession({
@@ -824,9 +848,10 @@ describe("AgentSession prewalk", () => {
 		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
 		expect(session.model?.id).toBe(primary.id);
 		expect(session.getPrewalkState()?.target.id).toBe(target.id);
-		expect(showStatus).toHaveBeenCalledWith(
-			`Prewalk restarted: using @default (${primary.provider}/${primary.id}) for planning, then switching to @smol (${target.provider}/${target.id}) at the next edit/write (todo-gated).`,
-		);
+		expect(showStatus).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Prewalk restarted"));
+		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining(`${primary.provider}/${primary.id}`));
+		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining(`${target.provider}/${target.id}`));
 
 		await session.prompt("second task");
 		expect(requested.slice(firstRunCallCount)).toEqual([
@@ -835,6 +860,13 @@ describe("AgentSession prewalk", () => {
 			`${target.provider}/${target.id}`,
 		]);
 		expect(session.model?.id).toBe(target.id);
+
+		settings.setModelRole("smol", `${primary.provider}/${primary.id}:medium`);
+		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
+		expect(session.model?.id).toBe(primary.id);
+		expect(session.getPrewalkState()).toBeUndefined();
+		expect(showStatus).toHaveBeenCalledTimes(2);
+		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Prewalk reset"));
 	});
 
 	it("requires a fresh todo before a later explicit prewalk can hand off", async () => {

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -762,6 +762,81 @@ describe("AgentSession prewalk", () => {
 		expect(showStatus).toHaveBeenCalledTimes(1);
 	});
 
+	it("/prewalk restart returns to @default and re-arms @smol", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+		const mock = createMockModel({
+			responses: [
+				toolCall("first-todo", "todo"),
+				toolCall("first-write", "write"),
+				{ content: ["first done"] },
+				toolCall("second-todo", "todo"),
+				toolCall("second-write", "write"),
+				{ content: ["second done"] },
+			],
+		});
+		const requested: string[] = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [todoTool as AgentTool, writeTool as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (model, context, options) => {
+				requested.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}:medium`);
+		settings.setModelRole("smol", `${target.provider}/${target.id}:medium`);
+		const sessionManager = SessionManager.inMemory();
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			prewalk: { target, thinkingLevel: Effort.Medium },
+			thinkingLevel: Effort.Medium,
+		});
+
+		await session.prompt("first task");
+		expect(session.model?.id).toBe(target.id);
+		const firstRunCallCount = requested.length;
+
+		const showStatus = vi.fn();
+		const ctx = {
+			session,
+			sessionManager,
+			settings,
+			collabGuest: false,
+			showStatus,
+			editor: { setText: vi.fn() },
+			refreshSlashCommandState: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const runtime = { ctx } satisfies TuiSlashCommandRuntime;
+
+		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
+		expect(session.model?.id).toBe(primary.id);
+		expect(session.getPrewalkState()?.target.id).toBe(target.id);
+		expect(showStatus).toHaveBeenCalledWith(
+			`Prewalk restarted: using @default (${primary.provider}/${primary.id}) for planning, then switching to @smol (${target.provider}/${target.id}) at the next edit/write (todo-gated).`,
+		);
+
+		await session.prompt("second task");
+		expect(requested.slice(firstRunCallCount)).toEqual([
+			`${primary.provider}/${primary.id}`,
+			`${primary.provider}/${primary.id}`,
+			`${target.provider}/${target.id}`,
+		]);
+		expect(session.model?.id).toBe(target.id);
+	});
+
 	it("requires a fresh todo before a later explicit prewalk can hand off", async () => {
 		const primary = modelOrThrow("claude-sonnet-4-5");
 		const target = modelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -782,6 +782,9 @@ describe("AgentSession prewalk", () => {
 		expect(await executeBuiltinSlashCommand("/prewalk restart", runtime)).toBe(true);
 		expect(session.model?.id).toBe(target.id);
 		expect(session.getPrewalkState()).toBeUndefined();
+		expect(
+			agent.state.messages.some(message => message.role === "custom" && message.customType === "prewalk-plan"),
+		).toBe(false);
 		expect(showStatus).toHaveBeenCalledTimes(3);
 		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Prewalk reset"));
 	});


### PR DESCRIPTION
## What

Adds `/prewalk restart` to:

- Return the active session to its current `@default` model.
- Re-arm the one-shot prewalk handoff to the current `@smol` model.
- Resolve both roles when invoked without hard-coded model IDs.
- Preserve persisted model-role configuration.

## Why

After prewalk hands a session to `@smol`, the session remains there. Restarting the prewalk cycle previously required manual model selection or restarting OMP.

This command restores the role-based cycle directly from the active session.

## Testing

- `bun test packages/coding-agent/test/agent-session-prewalk.test.ts` — 18 passed.
- Edited implementation and test files pass oxlint.
- Type checking remains blocked by the existing missing `kitty-vt-wasm` declarations in `packages/tui/test/virtual-terminal.ts` and the resulting implicit-`any`
diagnostic.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)