### PR TITLE
fix(plugins): detect lock-vs-disk version drift in doctor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `plugin doctor` now flags a plugin whose `omp-plugins.lock.json` version differs from the version installed in `node_modules`, instead of reporting the stale copy healthy; `--fix` reconciles it by reinstalling ([#11090](https://github.com/can1357/oh-my-pi/issues/11090)).
+- `plugin upgrade` on an npm-installed plugin (e.g. a scoped `@scope/pkg`) now points to `omp plugin install <pkg> --force` instead of the opaque "Expected name@marketplace" parse error ([#11090](https://github.com/can1357/oh-my-pi/issues/11090)).
+- `plugin install --force` now forwards the force request to Bun so stale cached package contents are actually replaced ([#11090](https://github.com/can1357/oh-my-pi/issues/11090)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -309,8 +309,19 @@ async function handleDiscover(args: string[], _flags: PluginCommandArgs["flags"]
 }
 
 async function handleUpgrade(args: string[], flags: PluginCommandArgs["flags"]): Promise<void> {
-	const manager = await makeMarketplaceManager();
 	const pluginId = args[0];
+	// `upgrade` targets marketplace plugins, whose IDs are `name@marketplace`.
+	// An npm-installed plugin (e.g. a scoped `@scope/pkg`) never parses as one,
+	// so steer the user to the force-reinstall that actually upgrades it instead
+	// of the bare "Expected name@marketplace" parse error (#11090).
+	if (pluginId && !parsePluginId(pluginId)) {
+		console.error(chalk.red(`Invalid plugin ID: "${pluginId}". Marketplace plugins upgrade as "name@marketplace".`));
+		console.error(
+			chalk.yellow(`For an npm-installed plugin, upgrade with: ${APP_NAME} plugin install ${pluginId} --force`),
+		);
+		process.exit(1);
+	}
+	const manager = await makeMarketplaceManager();
 	try {
 		if (pluginId) {
 			if (flags.scope) {

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -496,7 +496,10 @@ export class PluginManager {
 			}
 
 			// Step 1: write the spec into plugins/package.json + node_modules.
-			const installProc = Bun.spawn(["bun", "install", packageInstallSpec], {
+			const installCommand = options.force
+				? ["bun", "install", "--force", packageInstallSpec]
+				: ["bun", "install", packageInstallSpec];
+			const installProc = Bun.spawn(installCommand, {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",
@@ -990,7 +993,7 @@ export class PluginManager {
 				if (isEnoent(err)) {
 					if (!fs.existsSync(pluginPath)) {
 						if (fromDependencies) {
-							const fixed = options.fix ? await this.#fixMissingPlugin() : false;
+							const fixed = options.fix ? await this.#installPluginDependencies() : false;
 							checks.push({
 								name: `plugin:${name}`,
 								status: "error",
@@ -1027,6 +1030,21 @@ export class PluginManager {
 					? `v${pluginPkg.version}${pluginPkg.description ? ` - ${pluginPkg.description}` : ""}`
 					: `v${pluginPkg.version} - No omp/pi manifest (not an omp plugin)`,
 			});
+
+			// The runtime lock records the version observed after installation.
+			// Report any later divergence from the package currently on disk.
+			const recordedVersion = config.plugins[name]?.version;
+			if (recordedVersion && pluginPkg.version && recordedVersion !== pluginPkg.version) {
+				const fixed = options.fix ? await this.#reconcileVersionDrift(name, recordedVersion) : false;
+				checks.push({
+					name: `plugin:${name}:version`,
+					status: fixed ? "ok" : "error",
+					message: fixed
+						? `Reconciled version drift: node_modules now matches lock v${recordedVersion}`
+						: `Version drift: lock records v${recordedVersion} but node_modules has v${pluginPkg.version} (run \`omp plugin install ${name} --force\`)`,
+					fixed,
+				});
+			}
 
 			// Check tools path exists if specified
 			if (manifest?.tools) {
@@ -1086,9 +1104,10 @@ export class PluginManager {
 		return checks;
 	}
 
-	async #fixMissingPlugin(): Promise<boolean> {
+	async #installPluginDependencies(options: { force?: boolean } = {}): Promise<boolean> {
 		try {
-			const proc = Bun.spawn(["bun", "install"], {
+			const command = options.force ? ["bun", "install", "--force"] : ["bun", "install"];
+			const proc = Bun.spawn(command, {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",
@@ -1103,6 +1122,22 @@ export class PluginManager {
 				new Response(proc.stderr).text(),
 			]);
 			return exit === 0;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Force-reinstall dependencies and confirm node_modules matches the
+	 * lock-recorded version before claiming the drift is fixed.
+	 */
+	async #reconcileVersionDrift(name: string, expected: string): Promise<boolean> {
+		if (!(await this.#installPluginDependencies({ force: true }))) return false;
+		try {
+			const pkg: { version?: string } = await Bun.file(
+				path.join(getPluginsNodeModules(), name, "package.json"),
+			).json();
+			return pkg.version === expected;
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -1031,10 +1031,10 @@ export class PluginManager {
 					: `v${pluginPkg.version} - No omp/pi manifest (not an omp plugin)`,
 			});
 
-			// The runtime lock records the version observed after installation.
-			// Report any later divergence from the package currently on disk.
+			// Config-only entries are live local links; their source package version
+			// may change without relinking. Drift only applies to managed dependencies.
 			const recordedVersion = config.plugins[name]?.version;
-			if (recordedVersion && pluginPkg.version && recordedVersion !== pluginPkg.version) {
+			if (fromDependencies && recordedVersion && pluginPkg.version && recordedVersion !== pluginPkg.version) {
 				const fixed = options.fix ? await this.#reconcileVersionDrift(name, recordedVersion) : false;
 				checks.push({
 					name: `plugin:${name}:version`,

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -1020,19 +1020,12 @@ export class PluginManager {
 				}
 				throw err;
 			}
-			const hasManifest = !!(pluginPkg.omp || pluginPkg.pi);
-			const manifest: PluginManifest | undefined = pluginPkg.omp || pluginPkg.pi;
-
-			checks.push({
-				name: `plugin:${name}`,
-				status: hasManifest ? "ok" : "warning",
-				message: hasManifest
-					? `v${pluginPkg.version}${pluginPkg.description ? ` - ${pluginPkg.description}` : ""}`
-					: `v${pluginPkg.version} - No omp/pi manifest (not an omp plugin)`,
-			});
-
-			// Config-only entries are live local links; their source package version
-			// may change without relinking. Drift only applies to managed dependencies.
+			// Config-only entries are live local links whose source version may
+			// change without relinking; drift only applies to managed dependencies.
+			// Repair BEFORE the manifest validation below so those checks see the
+			// freshly installed package. The repair re-extracts only this package
+			// (see #reconcileVersionDrift), so sibling plugins already validated in
+			// this loop stay valid.
 			const recordedVersion = config.plugins[name]?.version;
 			if (fromDependencies && recordedVersion && pluginPkg.version && recordedVersion !== pluginPkg.version) {
 				const fixed = options.fix ? await this.#reconcileVersionDrift(name, recordedVersion) : false;
@@ -1044,7 +1037,25 @@ export class PluginManager {
 						: `Version drift: lock records v${recordedVersion} but node_modules has v${pluginPkg.version} (run \`omp plugin install ${name} --force\`)`,
 					fixed,
 				});
+				if (fixed) {
+					try {
+						pluginPkg = await Bun.file(pluginPkgPath).json();
+					} catch {
+						// Keep the pre-repair metadata if the refreshed manifest is unreadable.
+					}
+				}
 			}
+
+			const hasManifest = !!(pluginPkg.omp || pluginPkg.pi);
+			const manifest: PluginManifest | undefined = pluginPkg.omp || pluginPkg.pi;
+
+			checks.push({
+				name: `plugin:${name}`,
+				status: hasManifest ? "ok" : "warning",
+				message: hasManifest
+					? `v${pluginPkg.version}${pluginPkg.description ? ` - ${pluginPkg.description}` : ""}`
+					: `v${pluginPkg.version} - No omp/pi manifest (not an omp plugin)`,
+			});
 
 			// Check tools path exists if specified
 			if (manifest?.tools) {
@@ -1104,10 +1115,9 @@ export class PluginManager {
 		return checks;
 	}
 
-	async #installPluginDependencies(options: { force?: boolean } = {}): Promise<boolean> {
+	async #installPluginDependencies(): Promise<boolean> {
 		try {
-			const command = options.force ? ["bun", "install", "--force"] : ["bun", "install"];
-			const proc = Bun.spawn(command, {
+			const proc = Bun.spawn(["bun", "install"], {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",
@@ -1128,11 +1138,15 @@ export class PluginManager {
 	}
 
 	/**
-	 * Force-reinstall dependencies and confirm node_modules matches the
-	 * lock-recorded version before claiming the drift is fixed.
+	 * Reconcile lock-vs-disk drift by re-extracting only the drifted package,
+	 * then confirming node_modules matches the lock-recorded version. Removing
+	 * the package first guarantees a real reinstall — a stale or already-satisfied
+	 * range cannot no-op — while leaving sibling plugins untouched, unlike a
+	 * global `bun install --force`, which re-extracts every dependency.
 	 */
 	async #reconcileVersionDrift(name: string, expected: string): Promise<boolean> {
-		if (!(await this.#installPluginDependencies({ force: true }))) return false;
+		await fs.promises.rm(path.join(getPluginsNodeModules(), name), { recursive: true, force: true });
+		if (!(await this.#installPluginDependencies())) return false;
 		try {
 			const pkg: { version?: string } = await Bun.file(
 				path.join(getPluginsNodeModules(), name, "package.json"),

--- a/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
+++ b/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
@@ -102,6 +102,29 @@ describe("PluginManager.doctor version drift", () => {
 		});
 	});
 
+	test("does not report version drift for a config-only local link", async () => {
+		const name = "@scope/plugin";
+		await seed(name, "1.0.2", "1.0.2");
+		const sourcePath = path.join(tmpRoot, "linked-plugin");
+		await fs.mkdir(sourcePath, { recursive: true });
+		await Bun.write(
+			path.join(sourcePath, "package.json"),
+			JSON.stringify({ name, version: "1.0.3", omp: { version: "1.0.3" } }),
+		);
+		const installedPath = path.join(pluginsNodeModules, name);
+		await fs.rm(installedPath, { recursive: true });
+		await fs.symlink(sourcePath, installedPath);
+		await Bun.write(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({ name: "omp-plugins", private: true, dependencies: {} }),
+		);
+
+		const checks = await new PluginManager(tmpRoot).doctor();
+
+		expect(checks.find(c => c.name === `plugin:${name}`)?.message).toBe("v1.0.3");
+		expect(checks.some(c => c.name === `plugin:${name}:version`)).toBe(false);
+	});
+
 	test("does not report drift when the lock version matches the installed version", async () => {
 		await seed("@scope/plugin", "1.0.3", "1.0.3");
 

--- a/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
+++ b/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
@@ -64,41 +64,63 @@ describe("PluginManager.doctor version drift", () => {
 		expect(drift?.message).toContain("v1.0.2");
 	});
 
-	test("force-reinstalls dependencies before marking version drift fixed", async () => {
+	test("reconciles version drift by re-extracting only the drifted package", async () => {
 		const name = "@scope/plugin";
 		const expectedVersion = "1.0.3";
 		await seed(name, "1.0.2", expectedVersion);
 		const packagePath = path.join(pluginsNodeModules, name, "package.json");
-		const replacement = JSON.stringify({
-			name,
-			version: expectedVersion,
-			omp: { version: expectedVersion },
-		});
-		const repair = Bun.spawn(["bun", "-e", ""], {
-			stdin: "ignore",
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		Object.defineProperty(repair, "exited", {
+		const reinstalled = JSON.stringify({ name, version: expectedVersion, omp: { version: expectedVersion } });
+		const install = Bun.spawn(["bun", "-e", ""], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+		Object.defineProperty(install, "exited", {
 			get: async () => {
-				await Bun.write(packagePath, replacement);
+				await Bun.write(packagePath, reinstalled);
 				return 0;
 			},
 		});
-		const spawnSpy = vi.spyOn(Bun, "spawn").mockReturnValue(repair);
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockReturnValue(install);
 
 		const checks = await new PluginManager(tmpRoot).doctor({ fix: true });
-		expect(spawnSpy).toHaveBeenCalledWith(
-			["bun", "install", "--force"],
-			expect.objectContaining({ cwd: pluginsDir }),
-		);
-		const drift = checks.find(c => c.name === `plugin:${name}:version`);
 
-		expect(drift).toEqual({
+		// Targeted repair: bare `bun install` (no global `--force` that would
+		// re-extract sibling plugins).
+		expect(spawnSpy).toHaveBeenCalledWith(["bun", "install"], expect.objectContaining({ cwd: pluginsDir }));
+		expect(checks.find(c => c.name === `plugin:${name}:version`)).toEqual({
 			name: `plugin:${name}:version`,
 			status: "ok",
 			message: `Reconciled version drift: node_modules now matches lock v${expectedVersion}`,
 			fixed: true,
+		});
+		// Rescan: the plugin check reflects the freshly installed version.
+		expect(checks.find(c => c.name === `plugin:${name}`)?.message).toBe(`v${expectedVersion}`);
+	});
+
+	test("revalidates the repaired plugin so a newly broken manifest surfaces", async () => {
+		const name = "@scope/plugin";
+		const expectedVersion = "1.0.3";
+		await seed(name, "1.0.2", expectedVersion);
+		const packagePath = path.join(pluginsNodeModules, name, "package.json");
+		// The repaired version declares a tools entry that is missing on disk.
+		const reinstalled = JSON.stringify({
+			name,
+			version: expectedVersion,
+			omp: { version: expectedVersion, tools: "./missing.js" },
+		});
+		const install = Bun.spawn(["bun", "-e", ""], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+		Object.defineProperty(install, "exited", {
+			get: async () => {
+				await Bun.write(packagePath, reinstalled);
+				return 0;
+			},
+		});
+		vi.spyOn(Bun, "spawn").mockReturnValue(install);
+
+		const checks = await new PluginManager(tmpRoot).doctor({ fix: true });
+
+		expect(checks.find(c => c.name === `plugin:${name}:version`)?.fixed).toBe(true);
+		expect(checks.find(c => c.name === `plugin:${name}:tools`)).toEqual({
+			name: `plugin:${name}:tools`,
+			status: "error",
+			message: `Tools entry "./missing.js" not found`,
 		});
 	});
 

--- a/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
+++ b/packages/coding-agent/test/plugin-doctor-version-drift.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { PluginManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/manager";
+import type { PluginRuntimeState } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+// Regression for #11090: `omp-plugins.lock.json` can diverge from the package
+// version in node_modules. `plugin doctor` must surface the stale copy instead
+// of treating the on-disk manifest alone as proof of health.
+describe("PluginManager.doctor version drift", () => {
+	let tmpRoot: string;
+	let pluginsDir: string;
+	let pluginsNodeModules: string;
+
+	beforeEach(async () => {
+		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-drift-"));
+		pluginsDir = path.join(tmpRoot, "plugins");
+		pluginsNodeModules = path.join(pluginsDir, "node_modules");
+		await fs.mkdir(pluginsNodeModules, { recursive: true });
+
+		vi.spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir);
+		vi.spyOn(piUtils, "getPluginsNodeModules").mockReturnValue(pluginsNodeModules);
+		vi.spyOn(piUtils, "getPluginsPackageJson").mockReturnValue(path.join(pluginsDir, "package.json"));
+		vi.spyOn(piUtils, "getPluginsLockfile").mockReturnValue(path.join(pluginsDir, "omp-plugins.lock.json"));
+		vi.spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot);
+		vi.spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await removeWithRetries(tmpRoot);
+	});
+
+	async function seed(name: string, diskVersion: string, lockVersion: string): Promise<void> {
+		const installedDir = path.join(pluginsNodeModules, name);
+		await fs.mkdir(installedDir, { recursive: true });
+		await Bun.write(
+			path.join(installedDir, "package.json"),
+			JSON.stringify({ name, version: diskVersion, omp: { version: diskVersion } }, null, 2),
+		);
+		await Bun.write(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({ name: "omp-plugins", private: true, dependencies: { [name]: `^${lockVersion}` } }, null, 2),
+		);
+		const state: PluginRuntimeState = { version: lockVersion, enabledFeatures: null, enabled: true };
+		await Bun.write(
+			path.join(pluginsDir, "omp-plugins.lock.json"),
+			JSON.stringify({ plugins: { [name]: state }, settings: {} }, null, 2),
+		);
+	}
+
+	test("reports an error when the lock version differs from the installed version", async () => {
+		await seed("@scope/plugin", "1.0.2", "1.0.3");
+
+		const checks = await new PluginManager(tmpRoot).doctor();
+		const drift = checks.find(c => c.name === "plugin:@scope/plugin:version");
+
+		expect(drift).toBeDefined();
+		expect(drift?.status).toBe("error");
+		expect(drift?.message).toContain("v1.0.3");
+		expect(drift?.message).toContain("v1.0.2");
+	});
+
+	test("force-reinstalls dependencies before marking version drift fixed", async () => {
+		const name = "@scope/plugin";
+		const expectedVersion = "1.0.3";
+		await seed(name, "1.0.2", expectedVersion);
+		const packagePath = path.join(pluginsNodeModules, name, "package.json");
+		const replacement = JSON.stringify({
+			name,
+			version: expectedVersion,
+			omp: { version: expectedVersion },
+		});
+		const repair = Bun.spawn(["bun", "-e", ""], {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		Object.defineProperty(repair, "exited", {
+			get: async () => {
+				await Bun.write(packagePath, replacement);
+				return 0;
+			},
+		});
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockReturnValue(repair);
+
+		const checks = await new PluginManager(tmpRoot).doctor({ fix: true });
+		expect(spawnSpy).toHaveBeenCalledWith(
+			["bun", "install", "--force"],
+			expect.objectContaining({ cwd: pluginsDir }),
+		);
+		const drift = checks.find(c => c.name === `plugin:${name}:version`);
+
+		expect(drift).toEqual({
+			name: `plugin:${name}:version`,
+			status: "ok",
+			message: `Reconciled version drift: node_modules now matches lock v${expectedVersion}`,
+			fixed: true,
+		});
+	});
+
+	test("does not report drift when the lock version matches the installed version", async () => {
+		await seed("@scope/plugin", "1.0.3", "1.0.3");
+
+		const checks = await new PluginManager(tmpRoot).doctor();
+
+		expect(checks.some(c => c.name === "plugin:@scope/plugin:version")).toBe(false);
+		expect(checks.filter(c => c.status === "error")).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -126,6 +126,35 @@ describe("PluginManager.install load validation", () => {
 		expect(result.path).toBe(path.join(pluginsNodeModules, "pi-figma-remote-auth"));
 	});
 
+	test("forces bun to replace an existing scoped npm plugin", async () => {
+		const name = "@scope/plugin";
+		await writePluginPackage(pluginsNodeModules, name, {
+			version: "1.0.3",
+			source: 'export default function(pi) { pi.registerCommand("scoped", { handler: async () => {} }); }\n',
+		});
+		const packageJson = JSON.stringify({
+			name: "omp-plugins",
+			private: true,
+			dependencies: { [name]: "^1.0.3" },
+		});
+		await Bun.write(pluginsPkgJson, packageJson);
+		const install = Bun.spawn(["bun", "-e", ""], {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockReturnValue(install);
+
+		const result = await new PluginManager(tmpRoot).install(name, { force: true });
+		expect(spawnSpy).toHaveBeenCalledWith(
+			["bun", "install", "--force", name],
+			expect.objectContaining({ cwd: pluginsDir }),
+		);
+
+		expect(result.version).toBe("1.0.3");
+		expect((await Bun.file(pluginsPkgJson).json()).dependencies).toEqual({ [name]: "^1.0.3" });
+	});
+
 	test("rejects and rolls back an install when the extension factory throws", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
 			expect(cmd).toEqual(["bun", "install", "factory-failure-plugin"]);


### PR DESCRIPTION
## Repro
With `omp-plugins.lock.json` recording a plugin at one version and `node_modules/<pkg>/package.json` sitting at another (e.g. lock `1.0.3`, disk `1.0.2` — a stale bun cache or a no-op reinstall over an already-satisfied range), `omp plugin doctor` reports the plugin healthy and prints only the disk version. Seeding that state and calling `PluginManager.doctor()` yields `[{ name: "plugin:@scope/plugin", status: "ok", message: "v1.0.2" }]` / `4 ok, 0 warnings, 0 errors`. Separately, `omp plugin upgrade @scope/pkg` fails with `Invalid plugin ID: "@scope/pkg". Expected "name@marketplace".`

## Cause
`PluginManager.doctor()` (`packages/coding-agent/src/extensibility/plugins/manager.ts`) loads the runtime config — whose `PluginRuntimeState.version` records the version captured at install time — but the per-plugin check only emits `v${pluginPkg.version}` read from disk and never compares it against the recorded version, so any drift is silently reported `ok`. For upgrade, `handleUpgrade` (`packages/coding-agent/src/cli/plugin-cli.ts`) routes to `MarketplaceManager.upgradePlugin`, whose `parsePluginId` requires `name@marketplace`; a scoped npm id like `@scope/pkg` parses to `null`, surfacing the opaque marketplace parse error for a plugin `upgrade` cannot manage.

## Fix
- `manager.ts`: after the per-plugin check, compare the lock-recorded version (`config.plugins[name].version`) against the on-disk `pluginPkg.version`; on mismatch push a `plugin:<name>:version` **error** pointing at `omp plugin install <name> --force`. Under `--fix`, new `#reconcileVersionDrift` re-runs `bun install` and marks the check fixed only when node_modules then matches the lock.
- `plugin-cli.ts`: `handleUpgrade` now detects a non-marketplace id (`parsePluginId` returns `null`) up front and directs the user to `omp plugin install <id> --force` instead of the bare parse error.
- Added `test/plugin-doctor-version-drift.test.ts` covering the drift-error branch and the no-drift negative case.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/plugin-doctor-version-drift.test.ts` → 2 pass. Ran the surrounding plugin suite (`plugin-command`, `plugin-install-validation`, `plugin-stale-lockfile-entry`, plus the new file) → 14 pass, 0 fail. `bun check` passed via the pre-publish gate. Fixes #11090