### PR TITLE
fix(tests): dispose status lines before settings teardown

### DIFF
--- a/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
+++ b/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
@@ -21,13 +21,16 @@ import {
 } from "@oh-my-pi/pi-coding-agent/collab/guest";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineTestComponents } from "../helpers/status-line";
 
+const statusLines = new StatusLineTestComponents();
 beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 });
 
@@ -130,7 +133,7 @@ describe("reconcileGuestIdleHostState", () => {
 
 describe("reconcileGuestSnapshotHostState", () => {
 	it("stops the active meter when an idle welcome snapshot finalizes after reconnect", () => {
-		const statusLine = new StatusLineComponent(makeSession());
+		const statusLine = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 10_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 		statusLine.markActivityStart();
@@ -158,7 +161,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 		// often a reconnect dropped it mid-stream — showed no spinner while the
 		// host kept working, so the loader vanished mid-turn. The host builds
 		// its `state` frame at fire time, so `isStreaming` is never stale here.
-		const statusLine = new StatusLineComponent(makeSession());
+		const statusLine = statusLines.track(new StatusLineComponent(makeSession()));
 		const markActivityStart = vi.spyOn(statusLine, "markActivityStart");
 		const ensureLoadingAnimation = mock(() => {});
 		const ctx: GuestSnapshotActivityReconcilerCtx = {
@@ -185,7 +188,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 			visibleChildren.push(workingLoader);
 		});
 		const ctx: GuestSnapshotActivityReconcilerCtx & { statusContainer: { clear: () => void } } = {
-			statusLine: new StatusLineComponent(makeSession()),
+			statusLine: statusLines.track(new StatusLineComponent(makeSession())),
 			statusContainer: {
 				clear: () => visibleChildren.splice(0),
 				disposeChildren: () => visibleChildren.splice(0),
@@ -210,7 +213,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 	it("does not start the working loader while a retry loader owns the status area", () => {
 		const ensureLoadingAnimation = mock(() => {});
 		const ctx: GuestSnapshotActivityReconcilerCtx = {
-			statusLine: new StatusLineComponent(makeSession()),
+			statusLine: statusLines.track(new StatusLineComponent(makeSession())),
 			statusContainer: { disposeChildren: () => {} },
 			loadingAnimation: undefined,
 			ensureLoadingAnimation,
@@ -224,7 +227,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 	it("does not start the working loader while an auto-compaction loader owns the status area", () => {
 		const ensureLoadingAnimation = mock(() => {});
 		const ctx: GuestSnapshotActivityReconcilerCtx = {
-			statusLine: new StatusLineComponent(makeSession()),
+			statusLine: statusLines.track(new StatusLineComponent(makeSession())),
 			statusContainer: { disposeChildren: () => {} },
 			loadingAnimation: undefined,
 			ensureLoadingAnimation,

--- a/packages/coding-agent/test/context-consolidation.test.ts
+++ b/packages/coding-agent/test/context-consolidation.test.ts
@@ -12,7 +12,9 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
+const statusLines = new StatusLineTestComponents();
 describe("Context usage consolidation", () => {
 	let sharedDir: TempDir;
 	let authStorage: AuthStorage;
@@ -50,6 +52,7 @@ describe("Context usage consolidation", () => {
 	});
 
 	afterAll(async () => {
+		statusLines.dispose();
 		authStorage.close();
 		try {
 			await sharedDir.remove();
@@ -339,7 +342,7 @@ describe("Context usage consolidation", () => {
 		const cb = computeContextBreakdown(session);
 		expect(cb.usedTokens).toBe(used!);
 
-		const sl = new StatusLineComponent(session);
+		const sl = statusLines.track(new StatusLineComponent(session));
 		expect(sl.getCachedContextBreakdown().usedTokens).toBe(used!);
 
 		const cu = session.getContextUsage();
@@ -374,7 +377,7 @@ describe("Context usage consolidation", () => {
 		sessionManager.appendMessage(assistant);
 		syncSession(session, agent);
 
-		const sl = new StatusLineComponent(session);
+		const sl = statusLines.track(new StatusLineComponent(session));
 		const initialBreakdown = sl.getCachedContextBreakdown();
 
 		const assistantExt = assistant as unknown as { thinkingSignature: string };

--- a/packages/coding-agent/test/helpers/status-line.ts
+++ b/packages/coding-agent/test/helpers/status-line.ts
@@ -1,0 +1,19 @@
+interface DisposableStatusLine {
+	dispose(): void;
+}
+
+/** Owns status-line components created by one test file so teardown cannot leak asynchronous work. */
+export class StatusLineTestComponents {
+	#components: DisposableStatusLine[] = [];
+
+	/** Tracks a component until this file's teardown. */
+	track<T extends DisposableStatusLine>(component: T): T {
+		this.#components.push(component);
+		return component;
+	}
+
+	/** Disposes every tracked component before the file resets global settings. */
+	dispose(): void {
+		for (const component of this.#components.splice(0)) component.dispose();
+	}
+}

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { createGallerySegmentContext } from "../../../../src/cli/gallery-fixtures/segments";
 import { Settings } from "../../../../src/config/settings";
 import { StatusLineComponent } from "../../../../src/modes/components/status-line/component";
@@ -6,6 +6,7 @@ import { renderSegment } from "../../../../src/modes/components/status-line/segm
 import { loadTheme } from "../../../../src/modes/theme/loader";
 import { getThemeByName, setThemeInstance, theme } from "../../../../src/modes/theme/theme";
 import type { AgentSession } from "../../../../src/session/agent-session";
+import { StatusLineTestComponents } from "../../../helpers/status-line";
 
 // The cost assertions below care about how the two costs are rendered, not about
 // terminal width. The status line also shows the cwd and git branch, so a long
@@ -14,6 +15,7 @@ import type { AgentSession } from "../../../../src/session/agent-session";
 // segment always fits, and let the width-sensitive behavior stay covered by the
 // truncation tests that target it directly.
 const WIDE_ENOUGH_FOR_COST_SEGMENT = 400;
+const statusLines = new StatusLineTestComponents();
 
 function makeSessionWithLastMessage(
 	lastMessage: unknown,
@@ -86,27 +88,35 @@ beforeAll(async () => {
 	setThemeInstance(loaded);
 });
 
+afterAll(() => {
+	statusLines.dispose();
+});
+
 describe("StatusLineComponent", () => {
 	it("fingerprints tool-call arguments containing bigint values", () => {
-		const statusLine = new StatusLineComponent(
-			makeSessionWithLastMessage({
-				role: "assistant",
-				timestamp: 1,
-				content: [
-					{
-						type: "toolCall",
-						name: "read",
-						arguments: { offset: 1n, nested: { limit: 2n } },
-					},
-				],
-			}) as unknown as AgentSession,
+		const statusLine = statusLines.track(
+			new StatusLineComponent(
+				makeSessionWithLastMessage({
+					role: "assistant",
+					timestamp: 1,
+					content: [
+						{
+							type: "toolCall",
+							name: "read",
+							arguments: { offset: 1n, nested: { limit: 2n } },
+						},
+					],
+				}) as unknown as AgentSession,
+			),
 		);
 
 		expect(statusLine.getCachedContextBreakdown()).toEqual({ usedTokens: 42, contextWindow: 128000 });
 	});
 
 	it("renders Prewalk annotation when prewalk is armed", () => {
-		const statusLine = new StatusLineComponent(makeSessionWithLastMessage(null, true) as unknown as AgentSession);
+		const statusLine = statusLines.track(
+			new StatusLineComponent(makeSessionWithLastMessage(null, true) as unknown as AgentSession),
+		);
 
 		// By default preset, 'mode' segment is included in left/right segments.
 		// Let's get the border and see if Prewalk is rendered.
@@ -117,12 +127,14 @@ describe("StatusLineComponent", () => {
 	});
 
 	it("renders startup placeholders without values from the prior session", () => {
-		const statusLine = new StatusLineComponent(
-			makeSessionWithLastMessage(null, false, {
-				cost: 2.67,
-				modelName: "Stale Model",
-				sessionName: "stale-session",
-			}) as unknown as AgentSession,
+		const statusLine = statusLines.track(
+			new StatusLineComponent(
+				makeSessionWithLastMessage(null, false, {
+					cost: 2.67,
+					modelName: "Stale Model",
+					sessionName: "stale-session",
+				}) as unknown as AgentSession,
+			),
 		);
 
 		const live = Bun.stripANSI(statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content);
@@ -166,12 +178,14 @@ describe("StatusLineComponent", () => {
 	});
 
 	it("renders primary and advisor costs separately with subscription indicator in Unicode preset", () => {
-		const statusLine = new StatusLineComponent(
-			makeSessionWithLastMessage(null, false, {
-				cost: 2.67,
-				advisorCost: 0.41,
-				usingSubscription: true,
-			}) as unknown as AgentSession,
+		const statusLine = statusLines.track(
+			new StatusLineComponent(
+				makeSessionWithLastMessage(null, false, {
+					cost: 2.67,
+					advisorCost: 0.41,
+					usingSubscription: true,
+				}) as unknown as AgentSession,
+			),
 		);
 
 		const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
@@ -179,13 +193,15 @@ describe("StatusLineComponent", () => {
 	});
 
 	it("renders advisor cost with subscription prefix when advisor is on subscription in Unicode preset", () => {
-		const statusLine = new StatusLineComponent(
-			makeSessionWithLastMessage(null, false, {
-				cost: 2.67,
-				advisorCost: 0.41,
-				usingSubscription: true,
-				advisorUsingSubscription: true,
-			}) as unknown as AgentSession,
+		const statusLine = statusLines.track(
+			new StatusLineComponent(
+				makeSessionWithLastMessage(null, false, {
+					cost: 2.67,
+					advisorCost: 0.41,
+					usingSubscription: true,
+					advisorUsingSubscription: true,
+				}) as unknown as AgentSession,
+			),
 		);
 
 		const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
@@ -198,13 +214,15 @@ describe("StatusLineComponent", () => {
 		const asciiTheme = await loadTheme("dark", { symbolPresetOverride: "ascii" });
 		setThemeInstance(asciiTheme);
 		try {
-			const statusLine = new StatusLineComponent(
-				makeSessionWithLastMessage(null, false, {
-					cost: 2.67,
-					advisorCost: 0.41,
-					usingSubscription: true,
-					advisorUsingSubscription: true,
-				}) as unknown as AgentSession,
+			const statusLine = statusLines.track(
+				new StatusLineComponent(
+					makeSessionWithLastMessage(null, false, {
+						cost: 2.67,
+						advisorCost: 0.41,
+						usingSubscription: true,
+						advisorUsingSubscription: true,
+					}) as unknown as AgentSession,
+				),
 			);
 			const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
 			expect(stripped).toContain("S2.67 + S0.41 (adv)");
@@ -214,11 +232,13 @@ describe("StatusLineComponent", () => {
 	});
 
 	it("omits advisor cost when the advisor has never been active", () => {
-		const statusLine = new StatusLineComponent(
-			makeSessionWithLastMessage(null, false, {
-				cost: 2.67,
-				usingSubscription: true,
-			}) as unknown as AgentSession,
+		const statusLine = statusLines.track(
+			new StatusLineComponent(
+				makeSessionWithLastMessage(null, false, {
+					cost: 2.67,
+					usingSubscription: true,
+				}) as unknown as AgentSession,
+			),
 		);
 
 		const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
@@ -232,13 +252,15 @@ describe("StatusLineComponent", () => {
 		const nerdTheme = await loadTheme("dark", { symbolPresetOverride: "nerd" });
 		setThemeInstance(nerdTheme);
 		try {
-			const statusLine = new StatusLineComponent(
-				makeSessionWithLastMessage(null, false, {
-					cost: 2.67,
-					advisorCost: 0.41,
-					usingSubscription: true,
-					advisorUsingSubscription: true,
-				}) as unknown as AgentSession,
+			const statusLine = statusLines.track(
+				new StatusLineComponent(
+					makeSessionWithLastMessage(null, false, {
+						cost: 2.67,
+						advisorCost: 0.41,
+						usingSubscription: true,
+						advisorUsingSubscription: true,
+					}) as unknown as AgentSession,
+				),
 			);
 			const stripped = statusLine.getTopBorder(WIDE_ENOUGH_FOR_COST_SEGMENT).content.replace(/\x1b\[[0-9;]*m/g, "");
 			expect(stripped).toContain("\u{f067a} 2.67 + \uea70 \u{f067a} 0.41");

--- a/packages/coding-agent/test/status-line-background-jobs.test.ts
+++ b/packages/coding-agent/test/status-line-background-jobs.test.ts
@@ -6,8 +6,10 @@ import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AsyncJobSnapshotItem } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
 let settingsState: SettingsTestState | undefined;
+const statusLines = new StatusLineTestComponents();
 
 beforeEach(async () => {
 	settingsState = beginSettingsTest();
@@ -16,6 +18,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+	statusLines.dispose();
 	restoreSettingsTestState(settingsState);
 	settingsState = undefined;
 });
@@ -69,7 +72,7 @@ function makeComponent(running: AsyncJobSnapshotItem[]): StatusLineComponent {
 		},
 		getContextUsage: () => undefined,
 	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
-	const component = new StatusLineComponent(session);
+	const component = statusLines.track(new StatusLineComponent(session));
 	component.updateSettings({
 		preset: "custom",
 		leftSegments: [],

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -21,7 +21,9 @@ import { initTheme, setSymbolPreset, theme } from "@oh-my-pi/pi-coding-agent/mod
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { getSessionAccentAnsi } from "@oh-my-pi/pi-coding-agent/utils/session-color";
 import { adjustHsv } from "@oh-my-pi/pi-utils";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
+const statusLines = new StatusLineTestComponents();
 beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
@@ -29,6 +31,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 });
 
@@ -118,14 +121,14 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 5000, contextWindow: 272_000, percent: 1.8 },
 		});
-		const breakdown = new StatusLineComponent(session).getCachedContextBreakdown();
+		const breakdown = statusLines.track(new StatusLineComponent(session)).getCachedContextBreakdown();
 		expect(breakdown.usedTokens).toBe(5000);
 		expect(breakdown.contextWindow).toBe(272_000);
 	});
 
 	it("memoizes: repeated redraws with no change do not re-query usage", () => {
 		const { session, usageCalls } = makeSession({ messages: [userMessage("hi")] });
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 
 		comp.getCachedContextBreakdown();
 		comp.getCachedContextBreakdown();
@@ -139,7 +142,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 100, contextWindow: 200_000, percent: 0.05 },
 		});
-		const comp = new StatusLineComponent(fake.session);
+		const comp = statusLines.track(new StatusLineComponent(fake.session));
 		expect(comp.getCachedContextBreakdown().usedTokens).toBe(100);
 
 		(fake.session.messages as unknown[]).push(assistantMessage("a reply that bumped the real prompt size"));
@@ -152,7 +155,7 @@ describe("StatusLineComponent context breakdown", () => {
 	it("re-queries when the streaming tail grows in place", () => {
 		const tail = assistantMessage("partial") as { content: { type: string; text: string }[] };
 		const { session, usageCalls } = makeSession({ messages: [userMessage("hi"), tail] });
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 
 		comp.getCachedContextBreakdown();
 		tail.content[0]!.text = "partial response that kept streaming".repeat(8);
@@ -165,7 +168,7 @@ describe("StatusLineComponent context breakdown", () => {
 		const { session, usageCalls } = makeSession({
 			messages: [userMessage("a"), userMessage("b")],
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.getCachedContextBreakdown();
 
 		(session as { messages: unknown[] }).messages = [userMessage("c"), userMessage("d")];
@@ -176,7 +179,7 @@ describe("StatusLineComponent context breakdown", () => {
 
 	it("re-queries when the model context window changes", () => {
 		const { session, usageCalls } = makeSession({ messages: [userMessage("hi")], contextWindow: 200_000 });
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.getCachedContextBreakdown();
 
 		(session.model as { contextWindow: number }).contextWindow = 400_000;
@@ -190,7 +193,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 190_000, contextWindow: 272_000, percent: 69.9 },
 		});
-		const comp = new StatusLineComponent(fake.session);
+		const comp = statusLines.track(new StatusLineComponent(fake.session));
 		expect(comp.getCachedContextBreakdown().usedTokens).toBe(190_000);
 
 		// Turn ends/aborts: the message list and last-message fingerprint are
@@ -208,21 +211,21 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("compaction summary")],
 			usage: { tokens: 1234, contextWindow: 272_000, percent: 0.45 },
 		});
-		const breakdown = new StatusLineComponent(session).getCachedContextBreakdown();
+		const breakdown = statusLines.track(new StatusLineComponent(session)).getCachedContextBreakdown();
 		expect(breakdown.usedTokens).toBe(1234);
 		expect(breakdown.contextWindow).toBe(272_000);
 	});
 
 	it("falls back to the model window with 0 tokens when usage is unavailable", () => {
 		const { session } = makeSession({ messages: [userMessage("hi")], usage: undefined, contextWindow: 128_000 });
-		const breakdown = new StatusLineComponent(session).getCachedContextBreakdown();
+		const breakdown = statusLines.track(new StatusLineComponent(session)).getCachedContextBreakdown();
 		expect(breakdown.usedTokens).toBe(0);
 		expect(breakdown.contextWindow).toBe(128_000);
 	});
 
 	it("memoizes usage queries so repeated renders query only once", () => {
 		const { session, usageCalls } = makeSession({ messages: [userMessage("hi")] });
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -242,7 +245,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi"), assistantMessage("done")],
 			usage: { tokens: 5000, contextWindow: 272_000, percent: 1.8 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["context_pct"],
@@ -260,7 +263,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("compaction summary")],
 			usage: { tokens: 1234, contextWindow: 272_000, percent: 0.45 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["context_pct"],
@@ -278,7 +281,7 @@ describe("StatusLineComponent context breakdown", () => {
 			contextWindow: 0,
 			usage: { tokens: 5000, contextWindow: 0, percent: 0 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["context_pct"],
@@ -296,7 +299,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi"), assistantMessage("done")],
 			usage: { tokens: 50_000, contextWindow: 100_000, percent: 50 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -319,7 +322,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi"), assistantMessage("done")],
 			usage: { tokens: 50_000, contextWindow: 100_000, percent: 50 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -345,7 +348,7 @@ describe("StatusLineComponent context breakdown", () => {
 		settings.override("statusLine.contextLine", "embedded");
 
 		try {
-			const comp = new StatusLineComponent(session);
+			const comp = statusLines.track(new StatusLineComponent(session));
 			const border = comp.getTopBorder(120);
 			const plain = border.content.replaceAll(/\x1b\[[0-9;]*m/g, "");
 			const percentIndex = plain.indexOf("8%");
@@ -382,7 +385,7 @@ describe("StatusLineComponent context breakdown", () => {
 		settings.override("statusLine.contextLine", "embedded");
 
 		try {
-			const comp = new StatusLineComponent(session);
+			const comp = statusLines.track(new StatusLineComponent(session));
 			const border = comp.getTopBorder(120);
 			const plain = border.content.replaceAll(/\x1b\[[0-9;]*m/g, "");
 			expect(border.width).toBe(120);
@@ -403,7 +406,7 @@ describe("StatusLineComponent context breakdown", () => {
 			usage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
 			sessionName: "28大学生AI赋能司法行政创新挑战 law agent",
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi", "model", "path", "context_pct"],
@@ -425,7 +428,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi"), assistantMessage("done")],
 			usage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi", "context_pct"],
@@ -451,7 +454,7 @@ describe("StatusLineComponent context breakdown", () => {
 		settings.override("statusLine.contextLine", "embedded");
 
 		try {
-			const comp = new StatusLineComponent(session);
+			const comp = statusLines.track(new StatusLineComponent(session));
 			const border = comp.getTopBorder(120);
 			const plain = border.content.replaceAll(/\x1b\[[0-9;]*m/g, "");
 			const windowIndex = plain.indexOf("200K");
@@ -475,7 +478,7 @@ describe("StatusLineComponent context breakdown", () => {
 			usage: { tokens: 50_000, contextWindow: 100_000, percent: 50 },
 			settings,
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -519,7 +522,7 @@ describe("StatusLineComponent context breakdown", () => {
 			settings: Settings.isolated({ "compaction.methodOrder": ["snapcompact", "soft"] }),
 			modelInput: ["text", "image"],
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -540,7 +543,7 @@ describe("StatusLineComponent context breakdown", () => {
 			usage: { tokens: 50_000, contextWindow: 100_000, percent: 50 },
 			settings: Settings.isolated({ "compaction.asyncEnabled": false }),
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -560,7 +563,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 1000, contextWindow: 100_000, percent: 1 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		expect(comp.render(80)).toHaveLength(0); // box mode: main status lives in the editor border
 
 		comp.setComposerStyle({ statusAttachment: "none", bottomBar: "full", bottomBarGap: false });
@@ -584,7 +587,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 1000, contextWindow: 100_000, percent: 1 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.setComposerStyle({ statusAttachment: "none", bottomBar: "full", bottomBarGap: true });
 		let menuOpen = true;
 		comp.setAutocompleteActiveProbe(() => menuOpen);
@@ -598,7 +601,7 @@ describe("StatusLineComponent context breakdown", () => {
 			messages: [userMessage("hi")],
 			usage: { tokens: 1000, contextWindow: 100_000, percent: 1 },
 		});
-		const comp = new StatusLineComponent(session);
+		const comp = statusLines.track(new StatusLineComponent(session));
 		comp.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],

--- a/packages/coding-agent/test/status-line-dispose-async-leak.test.ts
+++ b/packages/coding-agent/test/status-line-dispose-async-leak.test.ts
@@ -18,9 +18,11 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
 import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
 const originalProjectDir = getProjectDir();
 
@@ -36,11 +38,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+	headState = fakeRefHead;
 	defaultBranchMock = vi.fn(async () => null);
 	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
 	const gitRepository = {
 		defaultBranch: defaultBranchMock,
-		headSync: () => fakeRefHead,
+		headSync: () => headState,
 		linkedWorktree: () => null,
 	} as unknown as VcsGitRepo;
 	vi.spyOn(vcs, "git").mockReturnValue(gitRepository);
@@ -105,6 +108,13 @@ const fakeRepoInfo: VcsGitRepoInfo = {
 	repoRoot: "/fake",
 	isReftable: false,
 };
+const featureRefHead: VcsHeadState = {
+	kind: "ref",
+	branch: "feature/x",
+	refName: "refs/heads/feature/x",
+	commit: undefined,
+};
+let headState = fakeRefHead;
 
 let defaultBranchMock = vi.fn(async (): Promise<string | null> => null);
 
@@ -171,5 +181,36 @@ describe("StatusLineComponent dispose guards async callbacks", () => {
 		await Promise.resolve();
 
 		expect(onBranchChange).not.toHaveBeenCalled();
+	});
+
+	it("suppresses a pending PR lookup when tracked file teardown resets settings", async () => {
+		headState = featureRefHead;
+		defaultBranchMock.mockResolvedValue("main");
+		const ghStarted = Promise.withResolvers<void>();
+		const releaseGh = Promise.withResolvers<void>();
+		vi.spyOn(github, "run").mockImplementation(async () => {
+			ghStarted.resolve();
+			await releaseGh.promise;
+			return { exitCode: 1, stdout: "", stderr: "" };
+		});
+
+		const onBranchChange = vi.fn();
+		const components = new StatusLineTestComponents();
+		const component = components.track(new StatusLineComponent(makeSession()));
+		component.updateSettings(gitSegmentSettings);
+		component.watchBranch(onBranchChange);
+		component.getTopBorder(80);
+		await ghStarted.promise;
+		onBranchChange.mockClear();
+
+		components.dispose();
+		resetSettingsForTest();
+		releaseGh.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBranchChange).not.toHaveBeenCalled();
+		await Settings.init({ inMemory: true });
 	});
 });

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -11,8 +11,10 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { getSessionAccentAnsi, getSessionAccentHex } from "@oh-my-pi/pi-coding-agent/utils/session-color";
 import { visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
 const originalProjectDir = getProjectDir();
+const statusLines = new StatusLineTestComponents();
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -21,6 +23,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 	setProjectDir(originalProjectDir);
 });
@@ -137,7 +140,7 @@ function stripAnsi(value: string): string {
 
 describe("status line session accent", () => {
 	function buildComponent(sessionAccent: boolean) {
-		const component = new StatusLineComponent(createStatusLineSession("Named session"));
+		const component = statusLines.track(new StatusLineComponent(createStatusLineSession("Named session")));
 		component.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -206,7 +209,7 @@ describe("session_name preview-title fallback", () => {
 	});
 
 	it("right-aligns the stand-in title through the box border pipeline", () => {
-		const component = new StatusLineComponent(createStatusLineSession(""));
+		const component = statusLines.track(new StatusLineComponent(createStatusLineSession("")));
 		component.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -225,7 +228,7 @@ describe("session_name preview-title fallback", () => {
 
 describe("status line focused-agent dimming", () => {
 	it("keeps powerline end caps at full intensity while text stays dimmed", () => {
-		const component = new StatusLineComponent(createStatusLineSession("Focused session"));
+		const component = statusLines.track(new StatusLineComponent(createStatusLineSession("Focused session")));
 		component.updateSettings({
 			preset: "custom",
 			leftSegments: ["pi"],
@@ -461,7 +464,7 @@ describe("overflow: path survives before model", () => {
 
 		const modelName = `MODEL_SHOULD_DROP_${"x".repeat(24)}`;
 		const session = createStatusLineSession("overflow test", modelName);
-		const component = new StatusLineComponent(session);
+		const component = statusLines.track(new StatusLineComponent(session));
 		const pathOptions = {
 			abbreviate: false,
 			maxLength: 32,

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -11,9 +11,11 @@ import { visibleWidth } from "@oh-my-pi/pi-tui";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { removeSyncWithRetries, setProjectDir } from "@oh-my-pi/pi-utils";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
 let settingsState: SettingsTestState | undefined;
 let projectDir = "";
+const statusLines = new StatusLineTestComponents();
 
 beforeEach(async () => {
 	settingsState = beginSettingsTest();
@@ -24,6 +26,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+	statusLines.dispose();
 	restoreSettingsTestState(settingsState);
 	settingsState = undefined;
 	if (projectDir) {
@@ -71,7 +74,7 @@ function makeSession(sessionName = "Cache Session") {
 }
 
 function makeComponent(statusLineSettings: StatusLineSettings): StatusLineComponent {
-	const component = new StatusLineComponent(makeSession());
+	const component = statusLines.track(new StatusLineComponent(makeSession()));
 	component.updateSettings(statusLineSettings);
 	return component;
 }

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -17,7 +17,9 @@ import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
+const statusLines = new StatusLineTestComponents();
 beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
@@ -25,6 +27,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 });
 
@@ -139,7 +142,7 @@ describe("time_spent segment", () => {
 
 describe("StatusLineComponent active-time accounting", () => {
 	it("accumulates only across markActivityStart/markActivityEnd windows, not idle time", () => {
-		const c = new StatusLineComponent(makeSession());
+		const c = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 1_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -166,7 +169,7 @@ describe("StatusLineComponent active-time accounting", () => {
 	});
 
 	it("ticks live during an open window so the segment animates while the agent runs", () => {
-		const c = new StatusLineComponent(makeSession());
+		const c = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 2_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -178,7 +181,7 @@ describe("StatusLineComponent active-time accounting", () => {
 	});
 
 	it("is idempotent: reentrant markActivityStart and unmatched markActivityEnd never double-count", () => {
-		const c = new StatusLineComponent(makeSession());
+		const c = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 3_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -201,7 +204,7 @@ describe("StatusLineComponent active-time accounting", () => {
 	});
 
 	it("resetActiveTime resets the active accumulator for /clear and fresh-session flows", () => {
-		const c = new StatusLineComponent(makeSession());
+		const c = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 4_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -222,7 +225,7 @@ describe("StatusLineComponent active-time accounting", () => {
 	});
 
 	it("resetActiveTime also drops an in-flight window so /clear during a turn starts fresh", () => {
-		const c = new StatusLineComponent(makeSession());
+		const c = statusLines.track(new StatusLineComponent(makeSession()));
 		let now = 5_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -248,7 +251,7 @@ describe("StatusLineComponent active-time accounting", () => {
 		// keeps the leak inside the subagent's meter.
 		const main = makeSession({ isStreaming: false });
 		const sub = makeSession({ isStreaming: true });
-		const c = new StatusLineComponent(main);
+		const c = statusLines.track(new StatusLineComponent(main));
 		let now = 6_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -282,7 +285,7 @@ describe("StatusLineComponent active-time accounting", () => {
 		// it instead.
 		const main = makeSession({ isStreaming: false });
 		const sub = makeSession({ isStreaming: true });
-		const c = new StatusLineComponent(main);
+		const c = statusLines.track(new StatusLineComponent(main));
 		let now = 7_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -311,7 +314,7 @@ describe("StatusLineComponent active-time accounting", () => {
 		// would carry the previous conversation's meter into the
 		// resumed one.
 		const session = makeSession({ sessionFile: "/tmp/conv-a.jsonl" });
-		const c = new StatusLineComponent(session);
+		const c = statusLines.track(new StatusLineComponent(session));
 		let now = 8_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -339,7 +342,7 @@ describe("StatusLineComponent active-time accounting", () => {
 		// first autosave sets one. That transition is the same
 		// conversation, so accumulated active time MUST survive.
 		const session = makeSession({ sessionFile: undefined });
-		const c = new StatusLineComponent(session);
+		const c = statusLines.track(new StatusLineComponent(session));
 		let now = 9_000_000_000;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 

--- a/packages/coding-agent/test/status-line-transparent.test.ts
+++ b/packages/coding-agent/test/status-line-transparent.test.ts
@@ -3,8 +3,10 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
 const originalProjectDir = getProjectDir();
+const statusLines = new StatusLineTestComponents();
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -13,6 +15,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 	setProjectDir(originalProjectDir);
 });
@@ -52,7 +55,7 @@ function makeSession() {
 }
 
 function buildComponent(transparent: boolean) {
-	const component = new StatusLineComponent(makeSession());
+	const component = statusLines.track(new StatusLineComponent(makeSession()));
 	component.updateSettings({
 		preset: "custom",
 		leftSegments: ["pi"],

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -5,7 +5,9 @@ import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { StatusLineTestComponents } from "./helpers/status-line";
 
+const statusLines = new StatusLineTestComponents();
 beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
@@ -13,6 +15,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+	statusLines.dispose();
 	resetSettingsForTest();
 });
 
@@ -24,33 +27,35 @@ function makeComponent(
 		activeIdentity?: { accountId?: string; email?: string; projectId?: string };
 	} = {},
 ): StatusLineComponent {
-	const component = new StatusLineComponent({
-		state: { messages: [], model: { id: options.modelId, contextWindow: 1000, provider: options.provider } },
-		model: { id: options.modelId, contextWindow: 1000, provider: options.provider },
-		sessionManager: {
-			getUsageStatistics: () => ({
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				orchestrationInput: 0,
-				orchestrationOutput: 0,
-				orchestrationCacheRead: 0,
-				premiumRequests: 0,
-				cost: 0,
-			}),
-		},
-		fetchUsageReports: async () => reports,
-		modelRegistry: {
-			authStorage: {
-				getOAuthAccountIdentity: (provider: string) =>
-					provider === options.provider ? options.activeIdentity : undefined,
+	const component = statusLines.track(
+		new StatusLineComponent({
+			state: { messages: [], model: { id: options.modelId, contextWindow: 1000, provider: options.provider } },
+			model: { id: options.modelId, contextWindow: 1000, provider: options.provider },
+			sessionManager: {
+				getUsageStatistics: () => ({
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					orchestrationInput: 0,
+					orchestrationOutput: 0,
+					orchestrationCacheRead: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
 			},
-		},
-		getAsyncJobSnapshot: () => ({ running: [] }),
-		getContextUsage: () => undefined,
-	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]);
+			fetchUsageReports: async () => reports,
+			modelRegistry: {
+				authStorage: {
+					getOAuthAccountIdentity: (provider: string) =>
+						provider === options.provider ? options.activeIdentity : undefined,
+				},
+			},
+			getAsyncJobSnapshot: () => ({ running: [] }),
+			getContextUsage: () => undefined,
+		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]),
+	);
 	component.updateSettings({
 		preset: "custom",
 		leftSegments: [],
@@ -297,7 +302,7 @@ describe("usage status-line segment", () => {
 			getAsyncJobSnapshot: () => ({ running: [] }),
 			getContextUsage: () => undefined,
 		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
-		const component = new StatusLineComponent(session);
+		const component = statusLines.track(new StatusLineComponent(session));
 		component.updateSettings({
 			preset: "custom",
 			leftSegments: [],
@@ -365,7 +370,7 @@ describe("usage status-line segment", () => {
 			getAsyncJobSnapshot: () => ({ running: [] }),
 			getContextUsage: () => undefined,
 		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
-		const component = new StatusLineComponent(session);
+		const component = statusLines.track(new StatusLineComponent(session));
 		component.updateSettings({
 			preset: "custom",
 			leftSegments: [],


### PR DESCRIPTION
## Repro
A deterministic test blocks `github.run()` during `StatusLineComponent#getTopBorder()`, calls `resetSettingsForTest()` while the component remains undisposed, then releases the lookup; `cd packages/coding-agent && bun test test/status-line-undisposed-async-leak.repro.test.ts` fails with `Settings not initialized` through `#gitEnabled → #getBranchLabel → setCachedPr`.

## Cause
Ten status-line test files constructed `StatusLineComponent` instances without owning their lifecycle, then reset global settings during file teardown. A pending fire-and-forget PR lookup in `src/modes/components/status-line/component.ts` could therefore resume after teardown and read the uninitialized global settings proxy.

## Fix
- Add `StatusLineTestComponents` to track each test file’s status-line instances and dispose them before settings teardown.
- Route all constructions in the ten affected files through that lifecycle owner.
- Extend `status-line-dispose-async-leak.test.ts` with a delayed `github.run()` regression covering disposal immediately before settings reset.

## Verification
`cd packages/coding-agent && bun test test/status-line-dispose-async-leak.test.ts` passes 3/3 tests. `cd packages/coding-agent && bun run check` passes. A full `bun run test` run reported 815 passes and 50 unrelated failures, with no `Settings not initialized` failure; the remaining failures were in commit-provider, MCP, skillful, generated-file guard, and conflict-integration tests.

Fixes #11097