### PR TITLE
fix(coding-agent): preserve and advance Ask custom answers

### DIFF
--- a/docs/tools/ask.md
+++ b/docs/tools/ask.md
@@ -58,7 +58,8 @@
 - Multiple questions: returns `details.results[]`; the fallback permits arrow-key back/forward navigation, while a rich UI presents the complete form.
 - Single-select: one option or custom input.
 - Multi-select: toggled choices or custom input. In the fallback, `Done selecting` appears only when forward navigation is not active and at least one choice is selected.
-- Rich ask dialog: supports per-question headers, option previews, answer notes, and a `Chat about this` redirect.
+- Rich ask dialog: supports per-question headers, option previews, answer notes, and a `Chat about this` redirect. Submitting a nonempty custom answer advances to the next question, or to review for a single multi-select question; existing checkbox selections are preserved. A single-select question still submits immediately when it is the only question.
+- Custom editor: paste followed by Enter submits the pasted text, including when they arrive together. Submission waits for an in-flight clipboard read; cancellation discards pending clipboard delivery.
 - Selector/editor fallback: supports labels/descriptions but not headers, previews, notes, or chat redirect.
 
 ## Side Effects

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review.
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review.
+- Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -818,6 +818,11 @@ export class AskDialogComponent implements Component {
 			if (!question.multi) {
 				state.selectedOptions.clear();
 				clearNoteUnlessRow(state, rowItem.key);
+			}
+			if (question.multi && this.#questions.length === 1) {
+				this.#activeTabIndex = this.#submitTabIndex();
+				this.#submitScrollOffset = 0;
+			} else {
 				this.#advanceAfterQuestion();
 			}
 		} finally {

--- a/packages/coding-agent/src/modes/components/hook-editor.ts
+++ b/packages/coding-agent/src/modes/components/hook-editor.ts
@@ -8,6 +8,7 @@
  * - Prompt-style (ask): Enter submits, Shift+Enter inserts newline, legacy ask chrome
  */
 import { Editor, type Focusable, matchesKey, Spacer, Text, type TUI } from "@oh-my-pi/pi-tui";
+import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
 import { getEditorTheme, theme } from "../../modes/theme/theme";
 import {
 	matchesAppExternalEditor,
@@ -36,6 +37,10 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 	#onCancelCallback: () => void;
 	#tui: TUI;
 	#promptStyle: boolean;
+	#pasteHandler = new BracketedPasteHandler();
+	#pendingPastes: { settled: boolean; text: string | undefined }[] = [];
+	#submitQueued = false;
+	#disposed = false;
 	/** Focus state mirrored to the nested editor during rendering. */
 	focused = false;
 
@@ -104,6 +109,14 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#disposed) return;
+		const paste = this.#pasteHandler.process(keyData);
+		if (paste.handled) {
+			if (paste.pasteContent === undefined) return;
+			this.pasteText(paste.pasteContent);
+			if (paste.remaining.length > 0) this.handleInput(paste.remaining);
+			return;
+		}
 		if (this.#promptStyle) {
 			this.#handlePromptStyleInput(keyData);
 		} else {
@@ -111,8 +124,55 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 		}
 	}
 
-	#submitCurrentText(): void {
-		this.#onSubmitCallback(this.#editor.getExpandedText());
+	#submitCurrentText(requireText = false): void {
+		if (this.#disposed) return;
+		if (this.#pendingPastes.length > 0) {
+			this.#submitQueued = true;
+			return;
+		}
+		const text = this.#editor.getExpandedText();
+		if (requireText && text.trim().length === 0) return;
+		this.dispose();
+		this.#onSubmitCallback(text);
+	}
+
+	/** Reserve ordered clipboard delivery. Completion accepts nonempty text once, or releases on undefined. */
+	beginPaste(): (text: string | undefined) => boolean {
+		if (this.#disposed) return () => false;
+		const pending: { settled: boolean; text: string | undefined } = { settled: false, text: undefined };
+		this.#pendingPastes.push(pending);
+		return text => {
+			if (this.#disposed || pending.settled) return false;
+			pending.settled = true;
+			pending.text = text;
+			// A failed/empty read releases the wait, but must not submit an answer.
+			if (!text) this.#submitQueued = false;
+			let delivered = 0;
+			for (const paste of this.#pendingPastes) {
+				if (!paste.settled) break;
+				if (paste.text) this.#editor.pasteText(paste.text);
+				delivered++;
+			}
+			if (delivered > 0) this.#pendingPastes.splice(0, delivered);
+			if (this.#pendingPastes.length === 0 && this.#submitQueued) {
+				this.#submitQueued = false;
+				this.#submitCurrentText(true);
+			}
+			return !!text;
+		};
+	}
+
+	override dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#submitQueued = false;
+		this.#pendingPastes.length = 0;
+		super.dispose();
+	}
+
+	#cancel(): void {
+		this.dispose();
+		this.#onCancelCallback();
 	}
 
 	/** Route non-bracketed paste transports (e.g. kitty's OSC 5522 enhanced clipboard)
@@ -120,7 +180,9 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 	 *  enhanced-paste routing falls back to the main prompt editor hidden behind the
 	 *  dialog (#2127 routing contract). */
 	pasteText(text: string): void {
-		this.#editor.pasteText(text);
+		if (this.#disposed) return;
+		if (this.#pendingPastes.length > 0) this.beginPaste()(text);
+		else this.#editor.pasteText(text);
 	}
 
 	/**
@@ -140,7 +202,7 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 
 		// Prompt-style keeps Escape as an explicit cancel key and also honors app.interrupt remaps.
 		if (matchesKey(keyData, "escape") || matchesKey(keyData, "esc") || matchesAppInterrupt(keyData)) {
-			this.#onCancelCallback();
+			this.#cancel();
 			return;
 		}
 
@@ -178,7 +240,7 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 
 		// Escape to cancel
 		if (matchesAppInterrupt(keyData)) {
-			this.#onCancelCallback();
+			this.#cancel();
 			return;
 		}
 
@@ -200,7 +262,7 @@ export class HookEditorComponent extends OverlayPanel implements Focusable {
 		try {
 			this.#tui.stop();
 			const result = await openInEditor(editorCmd, currentText);
-			if (result !== null) {
+			if (!this.#disposed && result !== null) {
 				this.#editor.setText(result);
 			}
 		} finally {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -673,6 +673,7 @@ export class ExtensionUiController {
 			const finishPrompt = (value: string | undefined): void => {
 				const resolvePrompt = promptResolve;
 				promptResolve = undefined;
+				promptEditor?.dispose();
 				promptEditor = undefined;
 				restoreAskDialog();
 				resolvePrompt?.(value);
@@ -720,6 +721,7 @@ export class ExtensionUiController {
 			return () => {
 				closed = true;
 				askDialog?.dispose();
+				promptEditor?.dispose();
 				promptResolve?.(undefined);
 				promptResolve = undefined;
 				promptEditor = undefined;
@@ -1035,6 +1037,7 @@ export class ExtensionUiController {
 	 * Hide the hook editor.
 	 */
 	hideHookEditor(): void {
+		this.ctx.hookEditor?.dispose();
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.editor);
 		this.ctx.hookEditor = undefined;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -93,6 +93,8 @@ function isExpandable(obj: unknown): obj is Expandable {
 /** Minimal contract for any component that can receive a paste payload directly. */
 interface PasteTarget {
 	pasteText(text: string): void;
+	/** Reserve delivery before an async clipboard read; undefined releases it without text. */
+	beginPaste?(): (text: string | undefined) => boolean;
 }
 
 function hasPasteText(value: unknown): value is PasteTarget {
@@ -1776,6 +1778,7 @@ export class InputController {
 	}
 
 	async handleImagePaste(): Promise<boolean> {
+		let finishPaste: ((text: string | undefined) => boolean) | undefined;
 		try {
 			// When a modal paste-capable prompt (login/API-key Input) owns focus,
 			// only clipboard text may land there. Image payloads must not mutate
@@ -1784,6 +1787,7 @@ export class InputController {
 			const focusedNow = this.ctx.ui.getFocused();
 			const promptTarget =
 				focusedNow && focusedNow !== this.ctx.editor && hasPasteText(focusedNow) ? focusedNow : null;
+			finishPaste = promptTarget?.beginPaste?.();
 			// #8769: On macOS, Finder `Cmd+C` on an image file puts BOTH a
 			// `public.file-url` representation and a generated 1024x1024
 			// file-icon bitmap on the pasteboard. `arboard::get_image()`
@@ -1852,15 +1856,23 @@ export class InputController {
 				await this.handleImagePathPaste(imagePath);
 				return true;
 			}
-			// Route to the focused component when it accepts pastes (modal
-			// Input prompts), matching the enhanced-paste text path (#2127).
-			const target = promptTarget ?? this.ctx.editor;
-			target.pasteText(text);
+			// Keep the initiating prompt as the only possible modal destination.
+			if (promptTarget && this.ctx.ui.getFocused() !== promptTarget) return false;
+			if (finishPaste) {
+				const accepted = finishPaste(text);
+				finishPaste = undefined;
+				if (!accepted) return false;
+			} else {
+				const target = promptTarget ?? this.ctx.editor;
+				target.pasteText(text);
+			}
 			this.ctx.ui.requestRender();
 			return true;
 		} catch {
 			this.ctx.showStatus("Failed to read clipboard");
 			return false;
+		} finally {
+			finishPaste?.(undefined);
 		}
 	}
 

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -194,6 +194,19 @@ describe("HookEditorComponent default (hook) mode", () => {
 		expect(onCancel).not.toHaveBeenCalled();
 	});
 
+	it("treats Enter bundled after a bracketed paste as a newline in hook mode", () => {
+		const onSubmit = vi.fn();
+		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, vi.fn());
+
+		component.handleInput("\x1b[200~first\nsecond\x1b[201~\r");
+		expect(onSubmit).not.toHaveBeenCalled();
+		component.handleInput("last");
+		component.handleInput("\x11");
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith("first\nsecond\nlast");
+	});
+
 	it("cancels on Escape", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();
@@ -207,6 +220,34 @@ describe("HookEditorComponent default (hook) mode", () => {
 });
 
 describe("HookEditorComponent prompt-style mode", () => {
+	it("submits the complete pasted answer once when paste and Enter arrive together", () => {
+		const onSubmit = vi.fn();
+		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, vi.fn(), {
+			promptStyle: true,
+		});
+		const pasted = largePasteText();
+
+		component.handleInput(`\x1b[200~${pasted}\x1b[201~\r`);
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith(pasted);
+	});
+
+	it("submits only after a fragmented paste closes with a bundled Enter", () => {
+		const onSubmit = vi.fn();
+		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, vi.fn(), {
+			promptStyle: true,
+		});
+
+		component.handleInput("\x1b[200~first\n");
+		component.handleInput("second\x1b[20");
+		expect(onSubmit).not.toHaveBeenCalled();
+		component.handleInput("1~\r");
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith("first\nsecond");
+	});
+
 	it("submits on plain Enter", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -595,28 +595,63 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].note).toBeUndefined();
 	});
 
-	it("shows selected multi-select options together with custom input on Submit", async () => {
-		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("custom detail"));
+	it("saves multi-select choices and custom input, then advances exactly one question", async () => {
+		const onPrompt = vi.fn().mockResolvedValue("custom detail");
 		const onSubmit = vi.fn();
-		const questions: ExtensionAskDialogQuestion[] = [
-			{
-				id: "q1",
-				question: "Choose multiple?",
-				options: [{ label: "Option A" }, { label: "Option B" }],
-				multi: true,
-			},
-			{
-				id: "q2",
-				question: "Second question?",
-				options: [{ label: "Option C" }],
-			},
-		];
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose multiple?",
+					options: [{ label: "Option A" }, { label: "Option B" }],
+					multi: true,
+				},
+				{
+					id: "q2",
+					question: "Second question?",
+					options: [{ label: "Option C" }, { label: "Option D" }],
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
 
-		const component = new AskDialogComponent(questions, {
-			onSubmit,
-			onCancel: vi.fn(),
-			onPrompt,
-		});
+		component.handleInput(SPACE);
+		component.handleInput(DOWN);
+		component.handleInput(SPACE);
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(render(component)).toContain("Second question?");
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		expect(onSubmit).not.toHaveBeenCalled();
+		component.handleInput(ENTER);
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results).toMatchObject([
+			{ id: "q1", selectedOptions: ["Option A", "Option B"], customInput: "custom detail" },
+			{ id: "q2", selectedOptions: ["Option D"] },
+		]);
+	});
+
+	it("reviews a single multi-select custom answer and lets the user go back to edit it", async () => {
+		const onPrompt = vi.fn().mockResolvedValueOnce("first draft").mockResolvedValueOnce("revised answer");
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose multiple?",
+					options: [{ label: "Option A" }, { label: "Option B" }],
+					multi: true,
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
 
 		component.handleInput(SPACE);
 		component.handleInput(DOWN);
@@ -624,20 +659,23 @@ describe("AskDialogComponent", () => {
 		component.handleInput(ENTER);
 		await Promise.resolve();
 		await Promise.resolve();
+		expect(onSubmit).not.toHaveBeenCalled();
 
-		// Multi questions do not auto-advance after the Other prompt: still on
-		// q1, so Tab twice (q2, then Submit) to reach the review.
-		component.handleInput(TAB);
-		component.handleInput(TAB);
-		const review = render(component);
-		expect(review).toContain("Option A");
-		expect(review).toContain("custom detail");
-
+		component.handleInput(SHIFT_TAB);
+		component.handleInput(UP);
+		component.handleInput(SPACE);
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onSubmit).not.toHaveBeenCalled();
 		component.handleInput(ENTER);
 
+		expect(onPrompt).toHaveBeenCalledTimes(2);
 		expect(onSubmit).toHaveBeenCalledTimes(1);
-		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
-		expect(onSubmit.mock.calls[0][0].results[0].customInput).toBe("custom detail");
+		expect(onSubmit.mock.calls[0][0].results).toMatchObject([
+			{ id: "q1", selectedOptions: ["Option A", "Option B"], customInput: "revised answer" },
+		]);
 	});
 
 	it("multi-question, multi-select: Enter on a plain option advances, does not submit", () => {
@@ -1560,13 +1598,13 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 		expect(render(component)).toContain("my custom answer");
 
-		// Reopen Other (prefilled with the current answer) and submit an
-		// empty value: the custom answer is unselected.
+		// Return from review to edit the saved custom answer.
+		component.handleInput(SHIFT_TAB);
 		onPrompt.mockReturnValueOnce(Promise.resolve(""));
 		component.handleInput(ENTER);
 		await Promise.resolve();
 		await Promise.resolve();
-		expect(onPrompt).toHaveBeenNthCalledWith(2, expect.any(String), "my custom answer");
+		expect(onSubmit).not.toHaveBeenCalled();
 		expect(render(component)).not.toContain("my custom answer");
 
 		// Submitting confirms nothing was kept.

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
-import { Container, type OverlayOptions, setKeybindings } from "@oh-my-pi/pi-tui";
+import { type Component, Container, isFocusable, type OverlayOptions, setKeybindings } from "@oh-my-pi/pi-tui";
 import { KeybindingsManager } from "../../../src/config/keybindings";
 import type { ExtensionAskDialogQuestion, ExtensionUIContext } from "../../../src/extensibility/extensions";
 import { AskDialogComponent } from "../../../src/modes/components/ask-dialog";
 import { CustomEditor } from "../../../src/modes/components/custom-editor";
+import { HookEditorComponent } from "../../../src/modes/components/hook-editor";
 import { ExtensionUiController } from "../../../src/modes/controllers/extension-ui-controller";
+import { InputController } from "../../../src/modes/controllers/input-controller";
 import { getEditorTheme, getThemeByName, setThemeInstance } from "../../../src/modes/theme/theme";
 import type { InteractiveModeContext } from "../../../src/modes/types";
 
@@ -23,7 +25,14 @@ function makeHarness() {
 	const editorContainer = new Container();
 	editorContainer.addChild(editor);
 	const requestRender = vi.fn();
-	const setFocus = vi.fn();
+	let focused: Component | null = editor;
+	editor.focused = true;
+	const getFocused = () => focused;
+	const setFocus = vi.fn((component: Component | null) => {
+		if (focused && isFocusable(focused)) focused.focused = false;
+		focused = component;
+		if (focused && isFocusable(focused)) focused.focused = true;
+	});
 	const addAutocompleteProvider = vi.fn();
 	const fakeHandle = {
 		hide: vi.fn(),
@@ -36,9 +45,10 @@ function makeHarness() {
 		editor,
 		ui: {
 			requestRender,
+			getFocused,
 			setFocus,
 			showOverlay,
-			terminal: { rows: 40 },
+			terminal: { rows: 40, columns: 120 },
 		},
 		editorContainer,
 		session: {
@@ -51,6 +61,7 @@ function makeHarness() {
 		},
 		addAutocompleteProvider,
 		syncComposerShape: vi.fn(),
+		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
 	const controller = new ExtensionUiController(ctx);
@@ -60,10 +71,21 @@ function makeHarness() {
 		requestRender,
 		addAutocompleteProvider,
 		editorContainer,
+		getFocused,
 		setFocus,
 		showOverlay,
 		fakeHandle,
 		controller,
+		inputController: (readText: () => Promise<string>) =>
+			new InputController(ctx, { readImage: async () => null, readText }),
+		handleInput(data: string): void {
+			if (!focused?.handleInput) throw new Error("Expected a focused input component");
+			focused.handleInput(data);
+		},
+		getPrompt(): HookEditorComponent {
+			if (!(focused instanceof HookEditorComponent)) throw new Error("Expected the custom answer editor");
+			return focused;
+		},
 		async init(): Promise<ExtensionUIContext> {
 			await controller.initHooksAndCustomTools();
 			expect(uiContext).toBeDefined();
@@ -71,6 +93,137 @@ function makeHarness() {
 		},
 	};
 }
+
+describe("ExtensionUiController clipboard input", () => {
+	const questions: ExtensionAskDialogQuestion[] = [
+		{ id: "answer", question: "Choose an answer?", options: [{ label: "Default" }] },
+	];
+
+	it("waits for clipboard text before advancing the custom answer exactly once", async () => {
+		const harness = makeHarness();
+		const clipboard = Promise.withResolvers<string>();
+		const input = harness.inputController(() => clipboard.promise);
+		const pending = harness.controller.showAskDialog([
+			{ id: "first", question: "Choose several?", options: [{ label: "Alpha" }], multi: true },
+			{ id: "second", question: "Next answer?", options: [{ label: "Beta" }, { label: "Gamma" }] },
+		]);
+		harness.handleInput(" ");
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		const prompt = harness.getPrompt();
+
+		const paste = input.handleImagePaste();
+		harness.handleInput("\r");
+		harness.handleInput("\r");
+		await Promise.resolve();
+		expect(harness.getFocused()).toBe(prompt);
+
+		clipboard.resolve("clipboard answer");
+		expect(await paste).toBe(true);
+		await Promise.resolve();
+		expect(harness.getFocused()).toBeInstanceOf(AskDialogComponent);
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		harness.handleInput("\r");
+
+		expect(await pending).toMatchObject({
+			kind: "submit",
+			results: [
+				{ id: "first", selectedOptions: ["Alpha"], customInput: "clipboard answer" },
+				{ id: "second", selectedOptions: ["Gamma"], customInput: undefined },
+			],
+		});
+		expect(harness.editor.getText()).toBe("");
+		expect(harness.getFocused()).toBe(harness.editor);
+	});
+
+	it("discards a cancelled prompt's late paste after a new custom editor opens", async () => {
+		const harness = makeHarness();
+		const clipboard = Promise.withResolvers<string>();
+		const input = harness.inputController(() => clipboard.promise);
+		const pending = harness.controller.showAskDialog(questions);
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		const cancelledPrompt = harness.getPrompt();
+		const paste = input.handleImagePaste();
+		harness.handleInput("\r");
+		harness.handleInput("\x1b");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		harness.handleInput("\r");
+		const replacement = harness.getPrompt();
+		expect(replacement).not.toBe(cancelledPrompt);
+		harness.handleInput("replacement answer");
+		clipboard.resolve("stale clipboard text");
+		expect(await paste).toBe(false);
+		expect(harness.getFocused()).toBe(replacement);
+		harness.handleInput("\r");
+
+		expect(await pending).toMatchObject({
+			kind: "submit",
+			results: [{ id: "answer", selectedOptions: [], customInput: "replacement answer" }],
+		});
+		expect(harness.editor.getText()).toBe("");
+	});
+
+	it("discards an aborted Ask's late paste without touching the next Ask or hidden draft", async () => {
+		const harness = makeHarness();
+		const clipboard = Promise.withResolvers<string>();
+		const input = harness.inputController(() => clipboard.promise);
+		const abort = new AbortController();
+		const pending = harness.controller.showAskDialog(questions, { signal: abort.signal });
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		const paste = input.handleImagePaste();
+		harness.handleInput("\r");
+		abort.abort();
+		expect(await pending).toBeUndefined();
+		expect(harness.getFocused()).toBe(harness.editor);
+
+		const next = harness.controller.showAskDialog(questions);
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		const replacement = harness.getPrompt();
+		harness.handleInput("next answer");
+		clipboard.resolve("stale clipboard text");
+		expect(await paste).toBe(false);
+		expect(harness.getFocused()).toBe(replacement);
+		harness.handleInput("\r");
+
+		expect(await next).toMatchObject({
+			kind: "submit",
+			results: [{ id: "answer", selectedOptions: [], customInput: "next answer" }],
+		});
+		expect(harness.editor.getText()).toBe("");
+	});
+
+	it("keeps a failed clipboard read editable and discards its queued empty submit", async () => {
+		const harness = makeHarness();
+		const clipboard = Promise.withResolvers<string>();
+		const input = harness.inputController(() => clipboard.promise);
+		const pending = harness.controller.showAskDialog(questions);
+		harness.handleInput("\x1b[B");
+		harness.handleInput("\r");
+		const prompt = harness.getPrompt();
+		const paste = input.handleImagePaste();
+		harness.handleInput("\r");
+		await Promise.resolve();
+		clipboard.reject(new Error("Clipboard unavailable"));
+
+		expect(await paste).toBe(false);
+		expect(harness.getFocused()).toBe(prompt);
+		harness.handleInput("typed after failure");
+		await Promise.resolve();
+		expect(harness.getFocused()).toBe(prompt);
+		harness.handleInput("\r");
+		expect(await pending).toMatchObject({
+			kind: "submit",
+			results: [{ id: "answer", selectedOptions: [], customInput: "typed after failure" }],
+		});
+		expect(harness.editor.getText()).toBe("");
+	});
+});
 
 describe("ExtensionUiController editor UI", () => {
 	it("requests a render after extension pasteToEditor mutates the prompt", async () => {


### PR DESCRIPTION
## What

- Submit pasted Ask custom answers on the first Enter, including fragmented paste and paste arriving together with Enter.
- Wait for pending clipboard text before submitting, and discard late delivery after cancellation.
- Advance custom multi-select answers while preserving checked options.
- Keep the review step for a single multi-select question, with the option to go back and edit.

Existing note behavior and single-select behavior are unchanged.

## Why

Custom multi-select answers stayed on the same question, so pressing Enter again reopened the editor instead of continuing. Paste and Enter arriving together could also fail to submit, while a delayed clipboard read could write into an editor that had already closed, leaving the answer unset.

## Testing

- Coding-agent `bun check`: passed (lint, formatting, and types).
- 186 focused Ask and paste tests: passed, including regressions for bundled paste, delayed clipboard reads, cancellation, and repeated Enter.
- Actual source CLI: verified custom-answer advancement and review, and confirmed the final result retained both the pasted text and checked option.
- `git diff --check`: passed.

Full-workspace and Rust checks were not run; no Rust source changed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
