### PR TITLE
docs: clarify PR template and attribution workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## What
 
-<!-- Brief description of the change -->
+<!-- Brief description of the change. Include at least one sentence in your own words explaining what changed and why, as required by CONTRIBUTING.md. -->
 
 ## Why
 
@@ -14,4 +14,4 @@
 
 - [ ] `bun check` passes
 - [ ] Tested locally
-- [ ] CHANGELOG updated with the required link and attribution (if user-facing; add the PR number after creation)
+- [ ] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@
 
 - [ ] `bun check` passes
 - [ ] Tested locally
-- [ ] CHANGELOG updated (if user-facing)
+- [ ] CHANGELOG updated with the required link and attribution (if user-facing; add the PR number after creation)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ This repo contains multiple packages, but **`packages/coding-agent/`** is the pr
 
 ## GitHub
 
-Unless user tells you exactly what to write:
-
-- **Never comment on GitHub** (issues, PRs, discussions).
-- **Never create issues on GitHub**.
+- Before posting a GitHub comment or creating an issue, MUST show the target and proposed text and obtain user confirmation. An explicit instruction to post supplied text to a specified target already counts as confirmation.
+- A request to address or fix PR feedback permits drafting replies, not posting them without confirmation. A request only to get or check comments is read-only.
+- When authorized to resolve review feedback, MUST verify the fix, obtain approval for a factual reply citing the change and verification, and post it in the existing thread before resolving. NEVER resolve if the reply is unapproved or posting fails.
+- Permission to work on a PR does not authorize unrelated comments or issue creation.
 
 ### Pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ Unless user tells you exactly what to write:
 - **Never comment on GitHub** (issues, PRs, discussions).
 - **Never create issues on GitHub**.
 
+### Pull requests
+
+When authorized to create or edit a PR:
+
+- MUST read `.github/PULL_REQUEST_TEMPLATE.md` first and preserve its sections and checklist, including when shortening an existing description.
+- For user-facing changes, MUST follow the [Changelog](#changelog) attribution rules. After GitHub assigns the PR number, update the entry and push it before marking the changelog checklist item complete.
+- MUST read back the published PR description after creating or editing it. Check only verified checklist items; explain skipped or inapplicable checks in `Testing`.
+
 ## Code Quality
 
 - No `any` unless absolutely necessary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,11 @@ Unless user tells you exactly what to write:
 
 ### Pull requests
 
-When authorized to create or edit a PR:
+When authorized to create or edit a contributor-submitted PR, follow the checklist below. RoboOMP-managed PRs follow their dedicated workflow and enforced body format in `python/robomp/src/prompts/system_append.md` instead.
 
-- MUST read `.github/PULL_REQUEST_TEMPLATE.md` first and preserve its sections and checklist, including when shortening an existing description.
-- For user-facing changes, MUST follow the [Changelog](#changelog) attribution rules. After GitHub assigns the PR number, update the entry and push it before marking the changelog checklist item complete.
+- MUST read `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` first. Preserve the template sections and checklist, including when shortening an existing description.
+- MUST obtain at least one sentence written by the contributor in their own words explaining what changed and why, as required by `CONTRIBUTING.md`. If it is missing, ask the contributor; NEVER generate a substitute. Preserve that sentence during edits.
+- For user-facing changes, MUST follow the [Changelog](#changelog) attribution rules. Internal issue fixes keep their issue links. For external contributions, add the PR link and contributor credit after GitHub assigns the number, then push the entry before marking the changelog checklist item complete.
 - MUST read back the published PR description after creating or editing it. Check only verified checklist items; explain skipped or inapplicable checks in `Testing`.
 
 ## Code Quality


### PR DESCRIPTION
## What

- Add a short PR workflow under `AGENTS.md`'s GitHub section: read and preserve the PR template, complete changelog attribution after the PR number is assigned, and verify the published description.
- Make the existing template checkbox explicitly mention the required changelog link and attribution, including the post-creation step.

The existing attribution rules remain the source of truth. No CI checks or runtime behavior are added.

## Why

A changelog entry can exist while still missing contributor credit, and shortening a PR description can accidentally remove its required structure. The current checklist does not call out either step. These reminders put the existing requirements at the point where contributors prepare and publish a PR, without requiring a PR number before one exists.

## Testing

- `git diff --check`: passed.
- Manually checked the guidance against the existing changelog attribution rules and the PR template.
- `bun check` and runtime tests were not run: this changes only contributor instructions and the Markdown template.
- A package changelog entry is not applicable; there is no user-facing runtime change.

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated with the required link and attribution (if user-facing; add the PR number after creation)
