### PR TITLE
fix(tui): drop trailing pad from pi status segment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Unset `tiny` model roles now honor the configured `@smol` fallback in direct execution and the `/models` Roles view ([#11311](https://github.com/can1357/oh-my-pi/issues/11311)).
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 - Codex turns interrupted before terminal completion now auto-continue after resolved tool calls instead of stopping ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
+- Fixed the status line's `pi` brand/working segment double-padding the first separator, so every gap around a separator is a single space ([#11103](https://github.com/can1357/oh-my-pi/issues/11103)).
 - `/handoff` no longer leaves the TUI in a running state when completion races with delayed session events ([#11263](https://github.com/can1357/oh-my-pi/issues/11263)).
 
 ## [18.1.15] - 2026-09-08
@@ -62,9 +63,6 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
-### Fixed
-
-- Fixed the status line's `pi` brand/working segment double-padding the first separator, so every gap around a separator is a single space ([#11103](https://github.com/can1357/oh-my-pi/issues/11103)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -62,6 +62,9 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
+### Fixed
+
+- Fixed the status line's `pi` brand/working segment double-padding the first separator, so every gap around a separator is a single space ([#11103](https://github.com/can1357/oh-my-pi/issues/11103)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -147,7 +147,7 @@ const piSegment: StatusLineSegment = {
 		if (ctx.focusedAgentId) {
 			const icon = theme.icon.ghost ? `${theme.icon.ghost} ` : "";
 			return {
-				content: theme.fg("warning", `${icon}${statusValue(ctx, ctx.focusedAgentId)} `),
+				content: theme.fg("warning", `${icon}${statusValue(ctx, ctx.focusedAgentId)}`),
 				visible: true,
 			};
 		}
@@ -156,11 +156,13 @@ const piSegment: StatusLineSegment = {
 		const fgAnsi = ctx.brandFgAnsi ?? theme.getFgAnsi("dim");
 		// While a turn runs the brand icon becomes a braille spinner plus a
 		// whole-unit turn timer (port of rust omp's status-band active brand).
+		// No trailing pad: the group renderer owns inter-segment spacing, so a
+		// trailing space here would double the gap at the first separator (#11103).
 		const content =
 			ctx.turnElapsedMs != null
-				? `${brandSpinnerFrame(ctx.now?.getTime())} ${statusValue(ctx, brandTimer(ctx.turnElapsedMs))} `
+				? `${brandSpinnerFrame(ctx.now?.getTime())} ${statusValue(ctx, brandTimer(ctx.turnElapsedMs))}`
 				: theme.icon.omp
-					? `${theme.icon.omp} `
+					? theme.icon.omp
 					: "";
 		return { content: `${fgAnsi}${content}\x1b[39m`, visible: true };
 	},

--- a/packages/coding-agent/test/status-line-brand-fade.test.ts
+++ b/packages/coding-agent/test/status-line-brand-fade.test.ts
@@ -85,14 +85,14 @@ describe("status line brand fade", () => {
 		const component = makeComponent();
 		try {
 			// Idle: omp icon settled in the dim color.
-			expect(component.renderBottomBar(80, "full")).toContain(`${dimAnsi}${theme.icon.omp} `);
+			expect(component.renderBottomBar(80, "full")).toContain(`${dimAnsi}${theme.icon.omp}`);
 
 			// Turn start: the glyph becomes a spinner + whole-second timer at
 			// once, but the color starts from the on-screen dim — no instant swap.
 			component.markActivityStart();
 			now += 10;
 			const early = component.renderBottomBar(80, "full");
-			expect(early).toContain(" 0s ");
+			expect(early).toContain(" 0s");
 			expect(early).not.toContain(theme.icon.omp);
 			expect(early).toContain(dimAnsi);
 			expect(early).not.toContain(accentAnsi);
@@ -139,7 +139,7 @@ describe("status line brand fade", () => {
 			expect(mid).not.toContain(accentAnsi);
 
 			now += 300;
-			expect(component.renderBottomBar(80, "full")).toContain(`${dimAnsi}${theme.icon.omp} `);
+			expect(component.renderBottomBar(80, "full")).toContain(`${dimAnsi}${theme.icon.omp}`);
 		} finally {
 			component.dispose();
 		}

--- a/packages/coding-agent/test/status-line-segment-padding.test.ts
+++ b/packages/coding-agent/test/status-line-segment-padding.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Contract: status-line segments render unpadded and the group renderer owns
+ * all inter-segment spacing, so every separator gap is a single space. The `pi`
+ * brand segment used to carry a trailing space inside its own span, which
+ * stacked with the separator's leading space into a 2-space gap at the first
+ * separator while every later gap stayed single (#11103).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function fakeSession(): AgentSession {
+	const model = { id: "test-model", name: "Test Model", contextWindow: 200_000 };
+	const messages = [{ role: "user", content: "hi" }];
+	return {
+		messages,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		model,
+		modelRegistry: { isUsingOAuth: () => false },
+		state: { messages, model },
+		settings: undefined,
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => undefined,
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		isFastModeActive: () => false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		getContextUsage: () => ({ tokens: 1_000, contextWindow: 200_000, percent: 0.5 }),
+		contextUsageRevision: 0,
+	} as unknown as AgentSession;
+}
+
+/** `pi` + `model` bottom bar (plain dot separators) through the real pipeline. */
+function makeComponent(): StatusLineComponent {
+	const component = new StatusLineComponent(fakeSession());
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: ["pi", "model"],
+		rightSegments: [],
+		separator: "powerline-thin",
+		sessionAccent: false,
+	});
+	return component;
+}
+
+/** Spaces immediately flanking the first `·` separator in the stripped bar. */
+function firstSeparatorGap(bar: string): { before: number; after: number } {
+	const plain = bar.replace(/\x1b\[[0-9;]*m/g, "");
+	const dot = plain.indexOf("·");
+	if (dot < 0) throw new Error(`no separator in bar: ${JSON.stringify(plain)}`);
+	const before = plain.slice(0, dot).match(/ *$/)?.[0].length ?? 0;
+	const after = plain.slice(dot + 1).match(/^ */)?.[0].length ?? 0;
+	return { before, after };
+}
+
+describe("status line segment padding", () => {
+	it("keeps a single-space gap at the first separator while a turn runs", () => {
+		const now = 1_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const component = makeComponent();
+		try {
+			component.markActivityStart();
+			const bar = component.renderBottomBar(80, "full");
+			expect(firstSeparatorGap(bar)).toEqual({ before: 1, after: 1 });
+		} finally {
+			component.dispose();
+		}
+	});
+
+	it("keeps a single-space gap at the first separator when idle", () => {
+		const component = makeComponent();
+		try {
+			const bar = component.renderBottomBar(80, "full");
+			expect(firstSeparatorGap(bar)).toEqual({ before: 1, after: 1 });
+		} finally {
+			component.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With the default status-line preset during an active turn, the working-indicator (`pi`) segment renders `⠹ 4m ` — with a space on both sides inside its colored span. Because the separator emits ` · `, the gap around the first separator compounds to two spaces while every later gap stays single. Reproduced through the real segment pipeline: `bun test test/status-line-segment-padding.test.ts`, which renders `pi` + `model` and measures the spaces flanking the first `·` (2 before the fix, 1 after).

## Cause
`piSegment.render` in `packages/coding-agent/src/modes/components/status-line/segments.ts` emitted a trailing space inside its content in all three branches (working `⠹ 4m `, idle `π `, and the focused-agent branch). Every other segment renders unpadded. The group renderer in `component.ts` (`renderGroup`) owns inter-segment spacing — it joins parts with ` <sep> ` and wraps the group in ` … ` — so the pi segment's own trailing space stacked with the separator's leading space into a 2-space gap at the first separator.

## Fix
- Remove the trailing space from all three `piSegment` branches so the separator owns all spacing, matching every other segment.
- Added `test/status-line-segment-padding.test.ts`: renders `pi` + `model` through the real component and asserts a single-space gap on both sides of the first separator, working and idle.
- Updated `test/status-line-brand-fade.test.ts`: its color-fade assertions incidentally encoded the old trailing space; they now match the unpadded span.

## Verification
`bun test test/status-line-segment-padding.test.ts test/status-line-brand-fade.test.ts` → 4 pass, 0 fail. The `bun check` pre-publish gate passed on push. Fixes #11103