### PR TITLE
fix(coding-agent): resolve the Antigravity image model from account discovery

### DIFF
--- a/packages/catalog/src/discovery/antigravity.ts
+++ b/packages/catalog/src/discovery/antigravity.ts
@@ -1,4 +1,5 @@
 import { type } from "@oh-my-pi/omptype";
+import type { FetchImpl } from "@oh-my-pi/pi-utils";
 import { collapseVariants, type VariantCollapseTable } from "../compat/collapse";
 import type { ModelSpec } from "../types";
 import { discoveryFetch, toPositiveNumber } from "../utils";
@@ -6,6 +7,7 @@ import { ensureAntigravityVersion, getAntigravityUserAgent } from "../wire/gemin
 
 export const ANTIGRAVITY_PRIMARY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 export const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+export const DEFAULT_ANTIGRAVITY_IMAGE_MODEL = "gemini-3-pro-image";
 const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [ANTIGRAVITY_PRIMARY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
 
@@ -51,6 +53,7 @@ export interface AntigravityDiscoveryAgentModelSort {
 export interface AntigravityDiscoveryApiResponse {
 	models?: Record<string, AntigravityDiscoveryApiModel>;
 	agentModelSorts?: AntigravityDiscoveryAgentModelSort[];
+	imageGenerationModelIds?: string[];
 }
 const AntigravityDiscoveryApiModelSchema = type({
 	"displayName?": type("unknown").pipe(value => (typeof value === "string" ? value : undefined)),
@@ -123,6 +126,9 @@ const AntigravityDiscoveryApiResponseSchema = type({
 		}
 		return result;
 	}),
+	"imageGenerationModelIds?": type("unknown").pipe(value =>
+		Array.isArray(value) ? value.filter((modelId): modelId is string => typeof modelId === "string") : undefined,
+	),
 });
 /**
  * Options for fetching Antigravity discovery models.
@@ -139,7 +145,7 @@ export interface FetchAntigravityDiscoveryModelsOptions {
 	/** Optional abort signal for request cancellation. */
 	signal?: AbortSignal;
 	/** Optional fetch implementation override for tests. */
-	fetcher?: typeof fetch;
+	fetcher?: FetchImpl;
 	/**
 	 * Hand collapse table to apply to the discovered list. Defaults to the
 	 * Antigravity (budget-transport) table; `googleGeminiCli` passes the
@@ -157,6 +163,92 @@ export interface FetchAntigravityDiscoveryModelsOptions {
 export async function fetchAntigravityDiscoveryModels(
 	options: FetchAntigravityDiscoveryModelsOptions,
 ): Promise<ModelSpec<"google-gemini-cli">[] | null> {
+	const discovered = await fetchAntigravityDiscoveryResponse(options);
+	if (!discovered) {
+		return null;
+	}
+
+	const models: ModelSpec<"google-gemini-cli">[] = [];
+
+	for (const [modelId, model] of Object.entries(discovered.payload.models ?? {})) {
+		if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId)) {
+			continue;
+		}
+		if (model.isInternal === true) {
+			continue;
+		}
+
+		const supportsImages = model.supportsImages === true;
+		models.push({
+			id: modelId,
+			name: model.displayName || modelId,
+			api: "google-gemini-cli",
+			provider: "google-antigravity",
+			baseUrl: discovered.endpoint,
+			reasoning: model.supportsThinking === true,
+			input: supportsImages ? ["text", "image"] : ["text"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: toPositiveNumber(model.maxTokens, DEFAULT_CONTEXT_WINDOW),
+			maxTokens: toPositiveNumber(model.maxOutputTokens, DEFAULT_MAX_TOKENS),
+		});
+	}
+
+	// Collapse effort-tier variants at the source so runtime discovery,
+	// the gemini-cli re-provision, and the catalog generator all see
+	// logical ids only.
+	const collapsed = collapseVariants(
+		models,
+		options.collapseTable === undefined ? undefined : { table: options.collapseTable },
+	);
+	collapsed.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+	return collapsed;
+}
+
+/** What one Antigravity endpoint said about image generation. */
+export interface AntigravityImageModel {
+	/** Endpoint that answered. */
+	endpoint: string;
+	/**
+	 * Advertised image model, or null when that endpoint answered and
+	 * advertised none. Callers need the distinction: an endpoint that never
+	 * answered may still serve a different roster, while one that answered
+	 * without image models has given a definitive answer.
+	 */
+	model: string | null;
+}
+
+/**
+ * Resolves what an Antigravity account's endpoint advertises for image
+ * generation. Returns null only when no endpoint answered at all.
+ *
+ * Prefers the default image model when the account still carries it, and
+ * otherwise takes the first advertised image generation model.
+ */
+export async function fetchAntigravityImageModel(
+	options: FetchAntigravityDiscoveryModelsOptions,
+): Promise<AntigravityImageModel | null> {
+	const discovered = await fetchAntigravityDiscoveryResponse(options);
+	if (!discovered) return null;
+	const usable = (discovered.payload.imageGenerationModelIds ?? []).filter(id => id.length > 0);
+	const model = usable.includes(DEFAULT_ANTIGRAVITY_IMAGE_MODEL)
+		? DEFAULT_ANTIGRAVITY_IMAGE_MODEL
+		: (usable[0] ?? null);
+	return { endpoint: discovered.endpoint, model };
+}
+
+interface AntigravityDiscoveryResponse {
+	payload: AntigravityDiscoveryApiResponse;
+	endpoint: string;
+}
+
+async function fetchAntigravityDiscoveryResponse(
+	options: FetchAntigravityDiscoveryModelsOptions,
+): Promise<AntigravityDiscoveryResponse | null> {
 	if (options.userAgent === undefined) {
 		await ensureAntigravityVersion(options.fetcher ?? fetch, options.signal);
 	}
@@ -179,7 +271,10 @@ export async function fetchAntigravityDiscoveryModels(
 				body: JSON.stringify({}),
 				signal: options.signal,
 			});
-		} catch {
+		} catch (error) {
+			if (options.signal?.aborted) {
+				throw error;
+			}
 			continue;
 		}
 
@@ -190,54 +285,17 @@ export async function fetchAntigravityDiscoveryModels(
 		let payload: unknown;
 		try {
 			payload = await response.json();
-		} catch {
+		} catch (error) {
+			if (options.signal?.aborted) {
+				throw error;
+			}
 			continue;
 		}
 
 		const parsed = parseAntigravityDiscoveryResponse(payload);
-		if (!parsed) {
-			continue;
+		if (parsed) {
+			return { payload: parsed, endpoint };
 		}
-
-		const models: ModelSpec<"google-gemini-cli">[] = [];
-
-		for (const [modelId, model] of Object.entries(parsed.models ?? {})) {
-			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId)) {
-				continue;
-			}
-			if (model.isInternal === true) {
-				continue;
-			}
-
-			const supportsImages = model.supportsImages === true;
-			models.push({
-				id: modelId,
-				name: model.displayName || modelId,
-				api: "google-gemini-cli",
-				provider: "google-antigravity",
-				baseUrl: endpoint,
-				reasoning: model.supportsThinking === true,
-				input: supportsImages ? ["text", "image"] : ["text"],
-				cost: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-				},
-				contextWindow: toPositiveNumber(model.maxTokens, DEFAULT_CONTEXT_WINDOW),
-				maxTokens: toPositiveNumber(model.maxOutputTokens, DEFAULT_MAX_TOKENS),
-			});
-		}
-
-		// Collapse effort-tier variants at the source so runtime discovery,
-		// the gemini-cli re-provision, and the catalog generator all see
-		// logical ids only.
-		const collapsed = collapseVariants(
-			models,
-			options.collapseTable === undefined ? undefined : { table: options.collapseTable },
-		);
-		collapsed.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
-		return collapsed;
 	}
 
 	return null;

--- a/packages/catalog/test/compat-collapse.test.ts
+++ b/packages/catalog/test/compat-collapse.test.ts
@@ -17,7 +17,9 @@ import {
 import { stripThinkingVariantSuffix } from "@oh-my-pi/pi-catalog/compat/taxonomy";
 import {
 	ANTIGRAVITY_PRIMARY_ENDPOINT,
+	DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
 	fetchAntigravityDiscoveryModels,
+	fetchAntigravityImageModel,
 } from "@oh-my-pi/pi-catalog/discovery/antigravity";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
@@ -1545,6 +1547,64 @@ describe("antigravity discovery collapsing", () => {
 		expect(discoveryUrl).toBeDefined();
 		expect(discoveryUrl).toContain(ANTIGRAVITY_PRIMARY_ENDPOINT);
 		expect(models?.[0]?.baseUrl).toBe(ANTIGRAVITY_PRIMARY_ENDPOINT);
+	});
+
+	it("discovers the advertised image model and endpoint", async () => {
+		const imagePayload = {
+			...payload,
+			imageGenerationModelIds: ["gemini-3.1-flash-image"],
+		};
+		const imageFetcher = Object.assign(
+			() => Promise.resolve(new Response(JSON.stringify(imagePayload), { status: 200 })),
+			{ preconnect: fetch.preconnect },
+		);
+
+		const target = await fetchAntigravityImageModel({
+			token: "t",
+			fetcher: imageFetcher,
+		});
+
+		expect(target).toEqual({
+			model: "gemini-3.1-flash-image",
+			endpoint: ANTIGRAVITY_PRIMARY_ENDPOINT,
+		});
+	});
+
+	it("prefers the default image model when multiple image models are advertised", async () => {
+		const imagePayload = {
+			...payload,
+			imageGenerationModelIds: ["gemini-3.1-flash-image", DEFAULT_ANTIGRAVITY_IMAGE_MODEL],
+		};
+		const imageFetcher = Object.assign(
+			() => Promise.resolve(new Response(JSON.stringify(imagePayload), { status: 200 })),
+			{ preconnect: fetch.preconnect },
+		);
+
+		const target = await fetchAntigravityImageModel({
+			token: "t",
+			fetcher: imageFetcher,
+		});
+
+		expect(target).toEqual({
+			model: DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
+			endpoint: ANTIGRAVITY_PRIMARY_ENDPOINT,
+		});
+	});
+
+	it("reports the answering endpoint with a null model when it advertises no image roster", async () => {
+		const imageFetcher = Object.assign(
+			() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 })),
+			{ preconnect: fetch.preconnect },
+		);
+
+		const target = await fetchAntigravityImageModel({
+			token: "t",
+			fetcher: imageFetcher,
+		});
+
+		// Distinct from null, which means no endpoint answered at all: a caller
+		// failing over needs to tell "answered, has nothing" from "unreachable".
+		expect(target).toEqual({ model: null, endpoint: ANTIGRAVITY_PRIMARY_ENDPOINT });
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Antigravity image generation now uses the connected account's advertised image model instead of silently falling back after a stale-model 404 ([#11107](https://github.com/can1357/oh-my-pi/pull/11107) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -13,6 +13,11 @@ import {
 } from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import {
+	type AntigravityImageModel,
+	DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
+	fetchAntigravityImageModel,
+} from "@oh-my-pi/pi-catalog/discovery/antigravity";
+import {
 	applyCodexResidencyHeader,
 	CODEX_BASE_URL,
 	getCodexAccountId,
@@ -42,7 +47,6 @@ import { resolveReadPath } from "./path-utils";
 
 const DEFAULT_MODEL = "gemini-3-pro-image-preview";
 const DEFAULT_OPENROUTER_MODEL = "google/gemini-3-pro-image-preview";
-const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3-pro-image";
 const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image";
 const DEFAULT_DEEPINFRA_IMAGE_MODEL = "black-forest-labs/FLUX-2-pro";
 const DEEPINFRA_IMAGES_URL = "https://api.deepinfra.com/v1/openai/images/generations";
@@ -595,7 +599,7 @@ async function findAntigravityCredentials(
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
 	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity", sessionId, {
-		modelId: DEFAULT_ANTIGRAVITY_MODEL,
+		modelId: DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
 	});
 	if (!apiKey) return null;
 
@@ -607,6 +611,195 @@ async function findAntigravityCredentials(
 		apiKey: parsed.accessToken,
 		projectId: parsed.projectId,
 	};
+}
+function resolveAntigravityEndpoints(): string[] {
+	try {
+		const mode = settings.get("providers.antigravityEndpoint");
+		if (mode === "production") return [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
+		if (mode === "sandbox") return [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
+	} catch {
+		// Settings unavailable; fall through to the auto-failover pair.
+	}
+	return [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
+}
+
+const ANTIGRAVITY_DISCOVERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Antigravity generation plan for one credential: endpoints in preference
+ * order plus the model each endpoint advertises.
+ *
+ * The model is per endpoint, not per account. A roster is served by the
+ * endpoint that advertised it, so reusing production's model id against
+ * sandbox can be rejected by a perfectly healthy sandbox and defeat the
+ * failover it exists for.
+ */
+type AntigravityEndpointDiscovery =
+	| { status: "unattempted" }
+	| { status: "model"; model: string }
+	| { status: "empty" }
+	| { status: "failed" };
+
+interface AntigravityImageTarget {
+	endpoints: string[];
+	/** Discovery state per endpoint, distinguishing unattempted, successful, empty, and failed. */
+	discoveryByEndpoint: Map<string, AntigravityEndpointDiscovery>;
+	/** Used for an endpoint that advertises nothing reachable. */
+	fallbackModel: string;
+}
+
+/**
+ * One discovery probe against one endpoint. `deadline` lets a caller bound a
+ * whole walk rather than each hop, so a stalled route cannot multiply the
+ * budget; a real caller abort still propagates instead of being read as
+ * discovery unavailability.
+ */
+async function discoverAntigravityImageModel(
+	bearer: string,
+	endpoint: string,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+	deadline?: AbortSignal,
+): Promise<AntigravityImageModel | null> {
+	if (signal?.aborted) signal.throwIfAborted();
+	try {
+		const timeoutSignal = deadline ?? AbortSignal.timeout(ANTIGRAVITY_DISCOVERY_TIMEOUT_MS);
+		const discoverySignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+		// Already spent: issuing a request under a dead signal buys nothing and
+		// leaves a fetch that may never settle.
+		if (discoverySignal.aborted) {
+			if (signal?.aborted) signal.throwIfAborted();
+			return null;
+		}
+		return await fetchAntigravityImageModel({
+			token: bearer,
+			endpoint,
+			userAgent: getAntigravityUserAgent(),
+			signal: discoverySignal,
+			fetcher: fetchImpl,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		// Timed out or failed; treat as discovery unavailable at this endpoint.
+		return null;
+	} finally {
+		if (signal?.aborted) signal.throwIfAborted();
+	}
+}
+
+/**
+ * Resolves the Antigravity generation plan for the account behind `bearer`,
+ * memoized per bearer. `withAuth` can rotate to a sibling account mid-request;
+ * each account carries its own image roster, so the plan MUST be resolved for
+ * the credential actually in hand, not the initial one.
+ *
+ * The walk is explicit rather than delegated, and one deadline covers all of
+ * it. Only endpoints that definitively answered with an empty roster or a model
+ * are pinned: an endpoint where discovery failed, timed out, or was never asked
+ * stays unresolved so a later failover can discover its roster instead of
+ * generating with a model it may not serve.
+ */
+async function resolveAntigravityImageTarget(
+	bearer: string,
+	cache: Map<string, AntigravityImageTarget>,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<AntigravityImageTarget> {
+	if (signal?.aborted) signal.throwIfAborted();
+	const cached = cache.get(bearer);
+	if (cached) return cached;
+
+	const endpoints = resolveAntigravityEndpoints();
+	const discoveryByEndpoint = new Map<string, AntigravityEndpointDiscovery>();
+	for (const endpoint of endpoints) {
+		discoveryByEndpoint.set(endpoint, { status: "unattempted" });
+	}
+	const deadline = AbortSignal.timeout(ANTIGRAVITY_DISCOVERY_TIMEOUT_MS);
+	let ordered = endpoints;
+	for (const endpoint of endpoints) {
+		// Deadline already spent, so this endpoint is never asked anything. It
+		// stays unattempted so a later failover can discover its own roster rather
+		// than generating with a model another endpoint advertised.
+		if (deadline.aborted) break;
+		const discovered = await discoverAntigravityImageModel(bearer, endpoint, fetchImpl, signal, deadline);
+		// An endpoint that answered and reported no image model records an empty
+		// roster so it pins the fallback model without re-probing. A failed or
+		// timed-out discovery records failure so the first generation attempt
+		// uses the fallback directly while a later failover rediscovers it.
+		if (!discovered) {
+			discoveryByEndpoint.set(endpoint, { status: "failed" });
+			continue;
+		}
+		if (discovered.model === null) {
+			discoveryByEndpoint.set(endpoint, { status: "empty" });
+			continue;
+		}
+		discoveryByEndpoint.set(endpoint, { status: "model", model: discovered.model });
+		ordered = [discovered.endpoint, ...endpoints.filter(other => other !== discovered.endpoint)];
+		break;
+	}
+	const target: AntigravityImageTarget = {
+		endpoints: ordered,
+		discoveryByEndpoint,
+		fallbackModel: DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
+	};
+	cache.set(bearer, target);
+	return target;
+}
+
+async function probeEndpointModel(
+	target: AntigravityImageTarget,
+	endpoint: string,
+	bearer: string,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<string> {
+	const discovered = await discoverAntigravityImageModel(bearer, endpoint, fetchImpl, signal);
+	if (!discovered) {
+		target.discoveryByEndpoint.set(endpoint, { status: "failed" });
+		return target.fallbackModel;
+	}
+	if (discovered.model === null) {
+		target.discoveryByEndpoint.set(endpoint, { status: "empty" });
+		return target.fallbackModel;
+	}
+	target.discoveryByEndpoint.set(endpoint, { status: "model", model: discovered.model });
+	return discovered.model;
+}
+
+/**
+ * The model to generate with at `endpoint`.
+ *
+ * An endpoint is in one of four states:
+ * - unattempted: discovered on first use.
+ * - model: already answered with an advertised model; reused directly.
+ * - empty: definitively answered with no image roster; uses fallback model without re-probing.
+ * - failed: discovery timed out or failed. On the first generation attempt,
+ *   uses fallback model without re-probing or adding a second deadline;
+ *   on a later failover return, rediscovers the endpoint in case it recovered.
+ */
+async function resolveAntigravityModelAt(
+	target: AntigravityImageTarget,
+	endpoint: string,
+	bearer: string,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+	isFailover = false,
+): Promise<string> {
+	const state = target.discoveryByEndpoint.get(endpoint) ?? { status: "unattempted" };
+	switch (state.status) {
+		case "model":
+			return state.model;
+		case "empty":
+			return target.fallbackModel;
+		case "failed":
+			if (!isFailover) {
+				return target.fallbackModel;
+			}
+			return probeEndpointModel(target, endpoint, bearer, fetchImpl, signal);
+		case "unattempted":
+			return probeEndpointModel(target, endpoint, bearer, fetchImpl, signal);
+	}
 }
 
 async function findXAIImageCredentials(modelRegistry?: ModelRegistry): Promise<ImageApiKey | null> {
@@ -1263,7 +1456,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						provider === "openai" || provider === "openai-codex"
 							? (apiKey.model?.id ?? "gpt")
 							: provider === "antigravity"
-								? DEFAULT_ANTIGRAVITY_MODEL
+								? DEFAULT_ANTIGRAVITY_IMAGE_MODEL
 								: provider === "openrouter"
 									? DEFAULT_OPENROUTER_MODEL
 									: provider === "xai"
@@ -1345,9 +1538,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						}
 
 						const prompt = assemblePrompt(params);
+						const imageTargetCache = new Map<string, AntigravityImageTarget>();
+						let usedModel = DEFAULT_ANTIGRAVITY_IMAGE_MODEL;
 						const antigravityKey: ApiKey = ctx.modelRegistry.resolver("google-antigravity", {
 							sessionId,
-							modelId: DEFAULT_ANTIGRAVITY_MODEL,
+							modelId: DEFAULT_ANTIGRAVITY_IMAGE_MODEL,
 						});
 
 						const response = await withAuth(
@@ -1359,27 +1554,13 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								const rotated = parseAntigravityCredentials(key);
 								const bearer = rotated?.accessToken ?? key;
 								const projectId = rotated?.projectId ?? apiKey.projectId!;
-								const requestBody = buildAntigravityRequest(
-									prompt,
-									model,
-									projectId,
-									params.aspect_ratio,
-									params.image_size,
-									resolvedImages,
+								const target = await resolveAntigravityImageTarget(
+									bearer,
+									imageTargetCache,
+									fetchImpl,
+									requestSignal,
 								);
-
-								let endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-								try {
-									const mode = settings.get("providers.antigravityEndpoint");
-									if (mode === "production") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
-									} else if (mode === "sandbox") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-									}
-								} catch {
-									// Ignored
-								}
-
+								const endpoints = target.endpoints;
 								let resp: Response | undefined;
 								let lastError: Error | undefined;
 
@@ -1387,6 +1568,26 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 									const endpoint = endpoints[i];
 									const isLastEndpoint = i === endpoints.length - 1;
 									try {
+										// Resolved here rather than once above: each endpoint
+										// serves the roster it advertised, so a failover has to
+										// carry that endpoint's model.
+										const model = await resolveAntigravityModelAt(
+											target,
+											endpoint,
+											bearer,
+											fetchImpl,
+											requestSignal,
+											i > 0,
+										);
+										usedModel = model;
+										const requestBody = buildAntigravityRequest(
+											prompt,
+											model,
+											projectId,
+											params.aspect_ratio,
+											params.image_size,
+											resolvedImages,
+										);
 										resp = await fetchImpl(`${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
 											method: "POST",
 											headers: {
@@ -1450,7 +1651,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								content: [{ type: "text", text: `No image data returned.${messageText}` }],
 								details: {
 									provider,
-									model,
+									model: usedModel,
 									imageCount: 0,
 									imagePaths: [],
 									images: [],
@@ -1463,10 +1664,15 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const imagePaths = await saveImagesToTemp(parsed.images);
 
 						return {
-							content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
+							content: [
+								{
+									type: "text",
+									text: buildResponseSummary(provider, usedModel, imagePaths, responseText),
+								},
+							],
 							details: {
 								provider,
-								model,
+								model: usedModel,
 								imageCount: parsed.images.length,
 								imagePaths,
 								images: parsed.images,

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, afterEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, describe, expect, it, spyOn } from "bun:test";
 import type { Model } from "@oh-my-pi/pi-ai";
+import { DEFAULT_ANTIGRAVITY_IMAGE_MODEL } from "@oh-my-pi/pi-catalog/discovery/antigravity";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import type { ReadonlySessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -769,12 +770,702 @@ describe("imageGenTool", () => {
 		const result = await imageGenTool.execute("call-fallback-xai", { subject: "a cat" }, undefined, ctx);
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
+		// Neither endpoint advertises an image roster here, so discovery probes
+		// both looking for one before generation settles on the fallback.
 		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
 			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
 			"https://api.x.ai/v1/images/generations",
 		]);
 		expect(result.details?.provider).toBe("xai");
 	});
+	it("generates with the image model the Antigravity account actually serves", async () => {
+		// This account serves gemini-3.1-flash-image; the historical default wire
+		// id is not an entity on the project, so assuming it 404s and the image
+		// silently comes from a different provider instead.
+		setImageProviderOrder(["antigravity", "xai"]);
+		const requestUrls: string[] = [];
+		let generationModel: string | undefined;
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.includes(":fetchAvailableModels")) {
+				return Response.json({ imageGenerationModelIds: ["gemini-3.1-flash-image"] });
+			}
+			if (url.includes("streamGenerateContent")) {
+				generationModel = (JSON.parse(String(init?.body)) as { model?: string }).model;
+				if (generationModel !== "gemini-3.1-flash-image") {
+					return Response.json({ error: { message: "Requested entity was not found." } }, { status: 404 });
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("antigravity-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-served-model", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(generationModel).toBe("gemini-3.1-flash-image");
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3.1-flash-image");
+		expect(result.details?.imageCount).toBe(1);
+		// Antigravity served it, so xAI is never asked.
+		expect(requestUrls.some(url => url.startsWith("https://api.x.ai/"))).toBe(false);
+	});
+
+	it("keeps the default Antigravity image model when discovery is unavailable", async () => {
+		setImageProviderOrder(["antigravity"]);
+		let generationModel: string | undefined;
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			if (url.includes(":fetchAvailableModels")) {
+				return new Response("Forbidden", { status: 403 });
+			}
+			if (url.includes("streamGenerateContent")) {
+				generationModel = (JSON.parse(String(init?.body)) as { model?: string }).model;
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("default-model-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-default-model", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(generationModel).toBe("gemini-3-pro-image");
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3-pro-image");
+	});
+
+	it("falls over to the sandbox generation endpoint when production answers 403 in auto mode", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request, _init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.includes(":fetchAvailableModels")) {
+				if (url.startsWith("https://daily-cloudcode-pa.googleapis.com/")) {
+					return new Response(JSON.stringify({ error: { message: "forbidden on prod" } }), {
+						status: 403,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(JSON.stringify({ imageGenerationModelIds: ["gemini-3.1-flash-image"] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (url.includes("streamGenerateContent")) {
+				if (url.startsWith("https://daily-cloudcode-pa.googleapis.com/")) {
+					return new Response(JSON.stringify({ error: { message: "forbidden on prod generation" } }), {
+						status: 403,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("sandbox-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-prod-403-sandbox", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3.1-flash-image");
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+	});
+
+	it("rediscovers the model when generation fails over to another endpoint", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const generationModels: Record<string, string> = {};
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			const isProd = url.startsWith("https://daily-cloudcode-pa.googleapis.com/");
+			if (url.includes(":fetchAvailableModels")) {
+				// Each endpoint advertises its own roster; production is tried
+				// first and answers, so its model is the one pinned initially.
+				return Response.json({
+					imageGenerationModelIds: [isProd ? "gemini-3-prod-image" : "gemini-3-sandbox-image"],
+				});
+			}
+			if (url.includes("streamGenerateContent")) {
+				const body = JSON.parse(String(init?.body)) as { model?: string };
+				generationModels[isProd ? "prod" : "sandbox"] = body.model ?? "";
+				if (isProd) {
+					// Retryable, so generation fails over to the next endpoint.
+					return Response.json({ error: { message: "slow down" } }, { status: 429 });
+				}
+				if (body.model !== "gemini-3-sandbox-image") {
+					return Response.json({ error: { message: `unknown model ${body.model}` } }, { status: 404 });
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("sandbox-failover-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-failover-model", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(result.details?.provider).toBe("antigravity");
+		// The failover generated with sandbox's own advertised model, not
+		// production's, and the reported model is the one that served.
+		expect(generationModels.prod).toBe("gemini-3-prod-image");
+		expect(generationModels.sandbox).toBe("gemini-3-sandbox-image");
+		expect(result.details?.model).toBe("gemini-3-sandbox-image");
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+	});
+
+	it("keeps probing when an endpoint answers with no image roster and prefers the sibling that has one", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		let generationModel: string | undefined;
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			const isProd = url.startsWith("https://daily-cloudcode-pa.googleapis.com/");
+			if (url.includes(":fetchAvailableModels")) {
+				// Production answers, but this account has no image roster there.
+				return isProd ? Response.json({}) : Response.json({ imageGenerationModelIds: ["gemini-3-sandbox-image"] });
+			}
+			if (url.includes("streamGenerateContent")) {
+				const body = JSON.parse(String(init?.body)) as { model?: string };
+				generationModel = body.model;
+				if (isProd) {
+					// An unadvertised model 404s, and the generation loop does not
+					// fail over on 404, so stopping the walk at production would
+					// have stranded the request here.
+					return Response.json({ error: { message: `unknown model ${body.model}` } }, { status: 404 });
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("sibling-roster-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-sibling-roster", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(result.details?.provider).toBe("antigravity");
+		expect(generationModel).toBe("gemini-3-sandbox-image");
+		expect(result.details?.model).toBe("gemini-3-sandbox-image");
+		// Generation went straight to the endpoint that advertised a roster.
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+	});
+
+	it("pins the default model without re-probing when all endpoints answer with an empty roster", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const generationModels: Record<string, string> = {};
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			const isProd = url.startsWith("https://daily-cloudcode-pa.googleapis.com/");
+			if (url.includes(":fetchAvailableModels")) {
+				// Both endpoints answer with an empty roster.
+				return Response.json({});
+			}
+			if (url.includes("streamGenerateContent")) {
+				const body = JSON.parse(String(init?.body)) as { model?: string };
+				generationModels[isProd ? "prod" : "sandbox"] = body.model ?? "";
+				if (isProd) {
+					// Production generation fails with a retryable rate limit.
+					return Response.json({ error: { message: "rate limited" } }, { status: 429 });
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("empty-roster-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-ag-all-empty", { subject: "a fox" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(generationModels.prod).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+		expect(generationModels.sandbox).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+		// Preflight probed both endpoints; neither re-probed on generation or failover.
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+	});
+
+	it("leaves an endpoint whose discovery failed unresolved so failover rediscovers it", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const generationModels: Record<string, string> = {};
+		let prodDiscoveryAttempts = 0;
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			const isProd = url.startsWith("https://daily-cloudcode-pa.googleapis.com/");
+			if (url.includes(":fetchAvailableModels")) {
+				if (isProd) {
+					prodDiscoveryAttempts++;
+					if (prodDiscoveryAttempts === 1) {
+						// Transient failure on production discovery.
+						return Response.json({ error: { message: "internal error" } }, { status: 500 });
+					}
+					// Once healthy, production advertises its own image model.
+					return Response.json({ imageGenerationModelIds: ["gemini-3-prod-image"] });
+				}
+				// Sandbox discovery succeeds during the initial walk.
+				return Response.json({ imageGenerationModelIds: ["gemini-3-sandbox-image"] });
+			}
+			if (url.includes("streamGenerateContent")) {
+				const body = JSON.parse(String(init?.body)) as { model?: string };
+				generationModels[isProd ? "prod" : "sandbox"] = body.model ?? "";
+				if (!isProd) {
+					// Sandbox generation hits a retryable rate limit.
+					return Response.json({ error: { message: "rate limited" } }, { status: 429 });
+				}
+				// Production serves only its advertised model; the default model 404s.
+				if (body.model !== "gemini-3-prod-image") {
+					return Response.json({ error: { message: `unknown model ${body.model}` } }, { status: 404 });
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("rediscovered-prod-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute(
+			"call-ag-failed-discovery-failover",
+			{ subject: "a fox" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(generationModels.sandbox).toBe("gemini-3-sandbox-image");
+		expect(generationModels.prod).toBe("gemini-3-prod-image");
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3-prod-image");
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+	});
+
+	it("leaves an endpoint the timed-out walk never probed discoverable at failover", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const generationModels: Record<string, string> = {};
+		let prodDiscoveryAttempts = 0;
+		// One deadline covers the whole discovery walk, so a stall on the first
+		// endpoint cuts it short before the second is ever asked anything.
+		const walkDeadline = new AbortController();
+		const nativeTimeout = AbortSignal.timeout;
+		let firstWalkProbe = true;
+		const timeoutSpy = spyOn(AbortSignal, "timeout").mockImplementation(ms => {
+			if (ms !== 10_000) return nativeTimeout(ms);
+			if (firstWalkProbe) {
+				firstWalkProbe = false;
+				queueMicrotask(() => walkDeadline.abort(new DOMException("The operation timed out.", "TimeoutError")));
+				return walkDeadline.signal;
+			}
+			// The per-endpoint probe a failover makes gets a live budget again.
+			return nativeTimeout(ms);
+		});
+
+		try {
+			const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+				const url = input.toString();
+				requestUrls.push(url);
+				const isProd = url.startsWith("https://daily-cloudcode-pa.googleapis.com/");
+				if (url.includes(":fetchAvailableModels")) {
+					if (isProd) {
+						prodDiscoveryAttempts++;
+						// Stalls until the walk deadline fires.
+						const { promise, reject } = Promise.withResolvers<Response>();
+						init?.signal?.addEventListener("abort", () => {
+							reject(init.signal?.reason ?? new DOMException("The operation timed out.", "TimeoutError"));
+						});
+						return promise;
+					}
+					return Response.json({ imageGenerationModelIds: ["gemini-3-sandbox-image"] });
+				}
+				if (url.includes("streamGenerateContent")) {
+					const body = JSON.parse(String(init?.body)) as { model?: string };
+					generationModels[isProd ? "prod" : "sandbox"] = body.model ?? "";
+					if (isProd) {
+						return Response.json({ error: { message: "slow down" } }, { status: 429 });
+					}
+					if (body.model !== "gemini-3-sandbox-image") {
+						return Response.json({ error: { message: `unknown model ${body.model}` } }, { status: 404 });
+					}
+					return new Response(
+						`data: ${JSON.stringify({
+							response: {
+								candidates: [
+									{
+										content: {
+											parts: [
+												{
+													inlineData: {
+														data: Buffer.from("unprobed-failover-image").toString("base64"),
+														mimeType: "image/png",
+													},
+												},
+											],
+										},
+									},
+								],
+							},
+						})}\n\n`,
+						{ status: 200, headers: { "content-type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected provider request: ${url}`);
+			}) as unknown as typeof fetch;
+			const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+			const result = await imageGenTool.execute("call-ag-unprobed", { subject: "a fox" }, undefined, ctx);
+			generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+			// Production stalled so it generates with the fallback, and sandbox
+			// was never probed by the walk, so the failover discovers its roster
+			// instead of reusing production's guess.
+			expect(generationModels.prod).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+			expect(generationModels.sandbox).toBe("gemini-3-sandbox-image");
+			expect(result.details?.provider).toBe("antigravity");
+			expect(result.details?.model).toBe("gemini-3-sandbox-image");
+			expect(prodDiscoveryAttempts).toBe(1);
+			expect(requestUrls.filter(url => url.includes(":fetchAvailableModels"))).toEqual([
+				"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+				"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+			]);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("falls through to the fallback model when discovery preflight times out", async () => {
+		setImageProviderOrder(["antigravity"]);
+		let generationModel: string | undefined;
+		const timeoutController = new AbortController();
+		const nativeTimeout = AbortSignal.timeout;
+		let sawDiscoveryTimeout = false;
+		const timeoutSpy = spyOn(AbortSignal, "timeout").mockImplementation(ms => {
+			if (ms !== 10_000) return nativeTimeout(ms);
+			sawDiscoveryTimeout = true;
+			queueMicrotask(() => timeoutController.abort(new DOMException("The operation timed out.", "TimeoutError")));
+			return timeoutController.signal;
+		});
+
+		try {
+			const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+				const url = input.toString();
+				if (url.includes(":fetchAvailableModels")) {
+					const { promise, reject } = Promise.withResolvers<Response>();
+					init?.signal?.addEventListener("abort", () => {
+						reject(init.signal?.reason ?? new DOMException("The operation timed out.", "TimeoutError"));
+					});
+					return promise;
+				}
+				if (url.includes("streamGenerateContent")) {
+					generationModel = (JSON.parse(String(init?.body)) as { model?: string }).model;
+					return new Response(
+						`data: ${JSON.stringify({
+							response: {
+								candidates: [
+									{
+										content: {
+											parts: [
+												{
+													inlineData: {
+														data: Buffer.from("timeout-fallback-image").toString("base64"),
+														mimeType: "image/png",
+													},
+												},
+											],
+										},
+									},
+								],
+							},
+						})}\n\n`,
+						{ status: 200, headers: { "content-type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected provider request: ${url}`);
+			}) as unknown as typeof fetch;
+			const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+			const result = await imageGenTool.execute("call-ag-timeout-fallback", { subject: "a fox" }, undefined, ctx);
+			generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+			expect(sawDiscoveryTimeout).toBe(true);
+			// Asserted against the catalog constant, not a literal: the fallback
+			// and the discovery preference are the same value by construction,
+			// so they cannot drift apart when the catalog default changes.
+			expect(generationModel).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+			expect(result.details?.provider).toBe("antigravity");
+			expect(result.details?.model).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("uses the fallback model on the first generation attempt without a second discovery request when preflight times out", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		let generationModel: string | undefined;
+		const walkDeadline = new AbortController();
+		const secondDeadline = new AbortController();
+		const nativeTimeout = AbortSignal.timeout;
+		let firstWalkProbe = true;
+		const timeoutSpy = spyOn(AbortSignal, "timeout").mockImplementation(ms => {
+			if (ms !== 10_000) return nativeTimeout(ms);
+			if (firstWalkProbe) {
+				firstWalkProbe = false;
+				queueMicrotask(() => walkDeadline.abort(new DOMException("The operation timed out.", "TimeoutError")));
+				return walkDeadline.signal;
+			}
+			queueMicrotask(() => secondDeadline.abort(new DOMException("The operation timed out.", "TimeoutError")));
+			return secondDeadline.signal;
+		});
+
+		try {
+			const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+				const url = input.toString();
+				requestUrls.push(url);
+				if (url.includes(":fetchAvailableModels")) {
+					const { promise, reject } = Promise.withResolvers<Response>();
+					init?.signal?.addEventListener("abort", () => {
+						reject(init.signal?.reason ?? new DOMException("The operation timed out.", "TimeoutError"));
+					});
+					return promise;
+				}
+				if (url.includes("streamGenerateContent")) {
+					generationModel = (JSON.parse(String(init?.body)) as { model?: string }).model;
+					return new Response(
+						`data: ${JSON.stringify({
+							response: {
+								candidates: [
+									{
+										content: {
+											parts: [
+												{
+													inlineData: {
+														data: Buffer.from("timeout-no-reprobe-image").toString("base64"),
+														mimeType: "image/png",
+													},
+												},
+											],
+										},
+									},
+								],
+							},
+						})}\n\n`,
+						{ status: 200, headers: { "content-type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected provider request: ${url}`);
+			}) as unknown as typeof fetch;
+			const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+			const result = await imageGenTool.execute("call-ag-timeout-no-reprobe", { subject: "a fox" }, undefined, ctx);
+			generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+			expect(generationModel).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+			expect(result.details?.provider).toBe("antigravity");
+			expect(result.details?.model).toBe(DEFAULT_ANTIGRAVITY_IMAGE_MODEL);
+			expect(requestUrls).toEqual([
+				"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+				"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			]);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("propagates caller cancellation during discovery preflight", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const callerController = new AbortController();
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			if (url.includes(":fetchAvailableModels")) {
+				const { promise, reject } = Promise.withResolvers<Response>();
+				init?.signal?.addEventListener("abort", () => {
+					reject(init.signal?.reason ?? new DOMException("The user aborted a request.", "AbortError"));
+				});
+				queueMicrotask(() => callerController.abort(new DOMException("Operation cancelled by user", "AbortError")));
+				return promise;
+			}
+			throw new Error(`Unexpected request after abort: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		await expect(
+			imageGenTool.execute("call-ag-caller-abort", { subject: "a fox" }, undefined, ctx, callerController.signal),
+		).rejects.toThrow();
+	});
+
 	it("skips active providers that do not support the requested aspect ratio", async () => {
 		const requestUrls: string[] = [];
 		const fetchMock = (async (input: string | URL | Request) => {


### PR DESCRIPTION
## What

`generate_image` never produces an image through Antigravity. It silently serves a different provider and reports that provider's name as if nothing went wrong. Fixes #11106.

The cause is one hardcoded wire model id:

```ts
const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3-pro-image";
```

Not every account carries that id. Mine reports:

```json
"imageGenerationModelIds": ["gemini-3.1-flash-image"]
```

The request 404s, the `catch` classifies it as a `ProviderHttpError`, pushes it onto `failures`, and continues down the provider order. Since `failures` only surfaces in the `AggregateError` when *every* provider fails, any later working provider hides it entirely.

Both probes below hit the same endpoint the tool uses (`POST /v1internal:streamGenerateContent?alt=sse`), with the same stored `google-antigravity` OAuth credential, seconds apart:

| model | result |
|---|---|
| `gemini-3-pro-image` | **HTTP 404** `Requested entity was not found.` |
| `gemini-3.1-flash-image` | **HTTP 200**, 949 KB `inlineData` image/jpeg |

So the credential, endpoint, request envelope, `responseModalities` and quota were all fine. Only the model id was wrong.

## Change

- Added `resolveAntigravityImageModel()`, which asks the account's own `POST /v1internal:fetchAvailableModels` for `imageGenerationModelIds` and uses what the account actually serves. It prefers `DEFAULT_ANTIGRAVITY_MODEL` when the account still carries it, so accounts working today keep the same model, and falls back to that constant when discovery is unavailable.
- Discovery runs inside the `withAuth` callback, so it uses the same (possibly rotated) bearer that generates the image rather than the initial seed.
- Hoisted endpoint selection into `resolveAntigravityEndpoints()` so discovery and generation share it, honoring `providers.antigravityEndpoint`.
- Both Antigravity result payloads and the response summary now report the model actually requested instead of the constant.

Discovery is best effort and never fails the request: a transport error tries the failover endpoint, a non-ok response (a sandbox-only credential answers 403 on the primary) tries the next, and an endpoint that answers without naming an image model ends the loop rather than getting probed twice. Aborts propagate.

This adds one small POST per Antigravity image request. That seemed the right trade against a 3-minute image timeout, and it avoids a cached model id going stale when an account's image models change. Happy to memoize per project if you'd rather.

## Note on #5218 / #5443

#5218 reported this same path and named the symptom: *"When the Antigravity image endpoint returns 404, the tool fails."* It was closed by #5443, which made the tool continue to the next credentialed provider after an image-provider HTTP failure. That fixed the traversal but left the 404 in place, converting a loud failure into a silent reroute. This PR fixes the 404 itself.

Not addressed here, and worth a separate decision: when a **concrete, explicitly requested** provider is skipped or fails, the result text still attributes the image to whichever provider answered, with nothing in the logs. On this desk, requesting each of the seven providers with an identical prompt produced `openai-codex` and `xai` served correctly and the other five silently rerouted to `xai`. A caller cannot currently tell a working provider from a broken one.

## Testing

- `bun test packages/coding-agent/test/tools/image-gen.test.ts` — 18 pass / 0 fail.
- Added **"generates with the image model the Antigravity account actually serves"**: discovery names `gemini-3.1-flash-image`, the mock 404s anything else, and the test asserts the generation request carried that model, that `details.provider` is `antigravity`, and that xAI is never called. It **fails on unmodified `main`** with `Unexpected provider request: https://api.x.ai/v1/images/generations`, which is exactly the production symptom.
- Added **"keeps the default Antigravity image model when discovery is unavailable"**: discovery 403s and generation still runs on `gemini-3-pro-image`. This one passes before and after, guarding the fallback against regression.
- Updated **"falls back to xAI after an earlier provider HTTP failure"** for the added discovery probe in its expected request sequence. It also fails on unmodified `main`, confirming the sequence assertion is real.
- `bun run check:ts` — clean across the workspace.
- `bun run fmt:ts` — clean.
- `bun test packages/coding-agent/test/tools` — 2033 pass / 162 fail. Unmodified `main` in this same worktree is 2031 pass / 162 fail, so the failure set is unchanged and environmental in this checkout; the delta is my two new tests.
- CHANGELOG updated under `[Unreleased]`.

---

## Update: rebased and review feedback addressed

Rebased onto `main` (`8fad7f1006`) as a single commit. The 694 intervening commits absorbed neither this fix nor #11108, and the sandbox-endpoint mismatch flagged on `7832412298` is gone: the resolved target now carries the endpoint that served it, and that endpoint goes first in the failover order, so a sandbox-only credential answering 403 on production no longer blocks generation.

Discovery outcomes are now three states rather than two (`image-gen.ts:713-729`). An endpoint that answered with no image models pins the default so it is not re-probed; an endpoint whose discovery failed or timed out is left unresolved so a later failover rediscovers it instead of posting an unsupported model to a now-healthy endpoint. Discovery remains best-effort and never fails the request, bounded by its own `AbortSignal.timeout(10_000)` composed with the caller's signal.

**Testing on this head:** `bun run check:ts` exits 0. `bun test packages/coding-agent/test/tools/image-gen.test.ts` 25 pass / 0 fail, `packages/catalog/test/compat-collapse.test.ts` 69 pass / 0 fail. Each new case fails against the unfixed source; the failed-discovery one falls through to the next provider entirely (`Unexpected provider request: https://api.x.ai/v1/images/generations`).

On the overlap with #11108: that PR fixes the same symptom through the shared catalog path but halts when an endpoint advertises no image models, tracks one model rather than a model per endpoint on failover, and has no discovery deadline. This branch now routes through the same `packages/catalog/src/discovery/antigravity.ts` client rather than a second one. If you would rather take #11108 and have me rebase the endpoint-tracking and deadline work on top of it, say so and I will.
