### PR TITLE
fix(tools): use advertised Antigravity image models

### DIFF
--- a/packages/catalog/src/discovery/antigravity.ts
+++ b/packages/catalog/src/discovery/antigravity.ts
@@ -1,4 +1,5 @@
 import { type } from "@oh-my-pi/omptype";
+import type { FetchImpl } from "@oh-my-pi/pi-utils";
 import { collapseVariants, type VariantCollapseTable } from "../compat/collapse";
 import type { ModelSpec } from "../types";
 import { discoveryFetch, toPositiveNumber } from "../utils";
@@ -51,6 +52,7 @@ export interface AntigravityDiscoveryAgentModelSort {
 export interface AntigravityDiscoveryApiResponse {
 	models?: Record<string, AntigravityDiscoveryApiModel>;
 	agentModelSorts?: AntigravityDiscoveryAgentModelSort[];
+	imageGenerationModelIds?: string[];
 }
 const AntigravityDiscoveryApiModelSchema = type({
 	"displayName?": type("unknown").pipe(value => (typeof value === "string" ? value : undefined)),
@@ -123,6 +125,9 @@ const AntigravityDiscoveryApiResponseSchema = type({
 		}
 		return result;
 	}),
+	"imageGenerationModelIds?": type("unknown").pipe(value =>
+		Array.isArray(value) ? value.filter((modelId): modelId is string => typeof modelId === "string") : undefined,
+	),
 });
 /**
  * Options for fetching Antigravity discovery models.
@@ -139,7 +144,7 @@ export interface FetchAntigravityDiscoveryModelsOptions {
 	/** Optional abort signal for request cancellation. */
 	signal?: AbortSignal;
 	/** Optional fetch implementation override for tests. */
-	fetcher?: typeof fetch;
+	fetcher?: FetchImpl;
 	/**
 	 * Hand collapse table to apply to the discovered list. Defaults to the
 	 * Antigravity (budget-transport) table; `googleGeminiCli` passes the
@@ -157,6 +162,78 @@ export interface FetchAntigravityDiscoveryModelsOptions {
 export async function fetchAntigravityDiscoveryModels(
 	options: FetchAntigravityDiscoveryModelsOptions,
 ): Promise<ModelSpec<"google-gemini-cli">[] | null> {
+	const discovered = await fetchAntigravityDiscoveryResponse(options);
+	if (!discovered) {
+		return null;
+	}
+
+	const models: ModelSpec<"google-gemini-cli">[] = [];
+	const apiModels = discovered.payload.models;
+	if (apiModels) {
+		for (const modelId in apiModels) {
+			const model = apiModels[modelId];
+			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId)) {
+				continue;
+			}
+			if (model.isInternal === true) {
+				continue;
+			}
+
+			const supportsImages = model.supportsImages === true;
+			models.push({
+				id: modelId,
+				name: model.displayName || modelId,
+				api: "google-gemini-cli",
+				provider: "google-antigravity",
+				baseUrl: discovered.endpoint,
+				reasoning: model.supportsThinking === true,
+				input: supportsImages ? ["text", "image"] : ["text"],
+				cost: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+				},
+				contextWindow: toPositiveNumber(model.maxTokens, DEFAULT_CONTEXT_WINDOW),
+				maxTokens: toPositiveNumber(model.maxOutputTokens, DEFAULT_MAX_TOKENS),
+			});
+		}
+	}
+
+	// Collapse effort-tier variants at the source so runtime discovery,
+	// the gemini-cli re-provision, and the catalog generator all see
+	// logical ids only.
+	const collapsed = collapseVariants(
+		models,
+		options.collapseTable === undefined ? undefined : { table: options.collapseTable },
+	);
+	collapsed.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+	return collapsed;
+}
+
+/** Advertised image model and serving endpoint for one Antigravity account. */
+export interface AntigravityImageModel {
+	id: string;
+	endpoint: string;
+}
+
+/** Resolves the first image-generation model advertised by an Antigravity account. */
+export async function fetchAntigravityImageModel(
+	options: FetchAntigravityDiscoveryModelsOptions,
+): Promise<AntigravityImageModel | null> {
+	const discovered = await fetchAntigravityDiscoveryResponse(options);
+	const id = discovered?.payload.imageGenerationModelIds?.find(modelId => modelId.length > 0);
+	return id && discovered ? { id, endpoint: discovered.endpoint } : null;
+}
+
+interface AntigravityDiscoveryResponse {
+	payload: AntigravityDiscoveryApiResponse;
+	endpoint: string;
+}
+
+async function fetchAntigravityDiscoveryResponse(
+	options: FetchAntigravityDiscoveryModelsOptions,
+): Promise<AntigravityDiscoveryResponse | null> {
 	if (options.userAgent === undefined) {
 		await ensureAntigravityVersion(options.fetcher ?? fetch, options.signal);
 	}
@@ -195,49 +272,9 @@ export async function fetchAntigravityDiscoveryModels(
 		}
 
 		const parsed = parseAntigravityDiscoveryResponse(payload);
-		if (!parsed) {
-			continue;
+		if (parsed) {
+			return { payload: parsed, endpoint };
 		}
-
-		const models: ModelSpec<"google-gemini-cli">[] = [];
-
-		for (const [modelId, model] of Object.entries(parsed.models ?? {})) {
-			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId)) {
-				continue;
-			}
-			if (model.isInternal === true) {
-				continue;
-			}
-
-			const supportsImages = model.supportsImages === true;
-			models.push({
-				id: modelId,
-				name: model.displayName || modelId,
-				api: "google-gemini-cli",
-				provider: "google-antigravity",
-				baseUrl: endpoint,
-				reasoning: model.supportsThinking === true,
-				input: supportsImages ? ["text", "image"] : ["text"],
-				cost: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-				},
-				contextWindow: toPositiveNumber(model.maxTokens, DEFAULT_CONTEXT_WINDOW),
-				maxTokens: toPositiveNumber(model.maxOutputTokens, DEFAULT_MAX_TOKENS),
-			});
-		}
-
-		// Collapse effort-tier variants at the source so runtime discovery,
-		// the gemini-cli re-provision, and the catalog generator all see
-		// logical ids only.
-		const collapsed = collapseVariants(
-			models,
-			options.collapseTable === undefined ? undefined : { table: options.collapseTable },
-		);
-		collapsed.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
-		return collapsed;
 	}
 
 	return null;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Antigravity image generation now uses the image model advertised for the connected account instead of silently falling back after a stale-model 404 ([#11106](https://github.com/can1357/oh-my-pi/issues/11106)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -631,6 +631,45 @@ function resolveAntigravityEndpoints(): string[] {
 	return [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
 }
 
+/** Advertised Antigravity image model plus the endpoints to reach it, per account. */
+interface AntigravityImageTarget {
+	model: string;
+	endpoints: string[];
+}
+
+/**
+ * Resolves the image model and serving endpoint advertised for the account
+ * behind `bearer`, memoized per bearer. `withAuth` can rotate to a sibling
+ * account mid-request; each account carries its own image roster, so the target
+ * MUST be resolved for the credential actually in hand, not the initial one.
+ * Falls back to {@link DEFAULT_ANTIGRAVITY_MODEL} and the default endpoint order
+ * when discovery is unavailable.
+ */
+async function resolveAntigravityImageTarget(
+	bearer: string,
+	cache: Map<string, AntigravityImageTarget>,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<AntigravityImageTarget> {
+	const cached = cache.get(bearer);
+	if (cached) return cached;
+
+	const endpoints = resolveAntigravityEndpoints();
+	const advertised = await fetchAntigravityImageModel({
+		token: bearer,
+		endpoint: endpoints.length === 1 ? endpoints[0] : undefined,
+		userAgent: getAntigravityUserAgent(),
+		signal,
+		fetcher: fetchImpl,
+	});
+	const target: AntigravityImageTarget = {
+		model: advertised?.id ?? DEFAULT_ANTIGRAVITY_MODEL,
+		endpoints: advertised ? [advertised.endpoint] : endpoints,
+	};
+	cache.set(bearer, target);
+	return target;
+}
+
 async function findXAIImageCredentials(modelRegistry?: ModelRegistry): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
 		const creds = await resolveXAIHttpCredentials(modelRegistry);
@@ -1281,23 +1320,14 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 				const provider = apiKey.provider;
 				try {
-					let antigravityEndpoints: string[] | undefined;
 					let model: string;
 					if (provider === "openai" || provider === "openai-codex") {
 						model = apiKey.model?.id ?? "gpt";
 					} else if (provider === "antigravity") {
-						antigravityEndpoints = resolveAntigravityEndpoints();
-						const advertised = await fetchAntigravityImageModel({
-							token: apiKey.apiKey,
-							endpoint: antigravityEndpoints.length === 1 ? antigravityEndpoints[0] : undefined,
-							userAgent: getAntigravityUserAgent(),
-							signal: requestSignal,
-							fetcher: fetchImpl,
-						});
-						if (advertised) {
-							antigravityEndpoints = [advertised.endpoint];
-						}
-						model = advertised?.id ?? DEFAULT_ANTIGRAVITY_MODEL;
+						// The real model is resolved per credential inside withAuth (a
+						// rotated sibling account may advertise a different roster); this
+						// seed only hints credential resolution and the fallback path.
+						model = DEFAULT_ANTIGRAVITY_MODEL;
 					} else if (provider === "openrouter") {
 						model = DEFAULT_OPENROUTER_MODEL;
 					} else if (provider === "xai") {
@@ -1385,6 +1415,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 							sessionId,
 							modelId: model,
 						});
+						// withAuth may rotate to a sibling account after a 401/403/quota
+						// failure; resolve each account's advertised image target once and
+						// reuse it across that credential's endpoint retries.
+						const imageTargetCache = new Map<string, AntigravityImageTarget>();
+						let usedModel = model;
 
 						const response = await withAuth(
 							antigravityKey,
@@ -1395,16 +1430,23 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								const rotated = parseAntigravityCredentials(key);
 								const bearer = rotated?.accessToken ?? key;
 								const projectId = rotated?.projectId ?? apiKey.projectId!;
+								const target = await resolveAntigravityImageTarget(
+									bearer,
+									imageTargetCache,
+									fetchImpl,
+									requestSignal,
+								);
+								usedModel = target.model;
 								const requestBody = buildAntigravityRequest(
 									prompt,
-									model,
+									target.model,
 									projectId,
 									params.aspect_ratio,
 									params.image_size,
 									resolvedImages,
 								);
 
-								const endpoints = antigravityEndpoints ?? resolveAntigravityEndpoints();
+								const endpoints = target.endpoints;
 
 								let resp: Response | undefined;
 								let lastError: Error | undefined;
@@ -1476,7 +1518,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								content: [{ type: "text", text: `No image data returned.${messageText}` }],
 								details: {
 									provider,
-									model,
+									model: usedModel,
 									imageCount: 0,
 									imagePaths: [],
 									images: [],
@@ -1489,10 +1531,12 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const imagePaths = await saveImagesToTemp(parsed.images);
 
 						return {
-							content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, usedModel, imagePaths, responseText) },
+							],
 							details: {
 								provider,
-								model,
+								model: usedModel,
 								imageCount: parsed.images.length,
 								imagePaths,
 								images: parsed.images,

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -662,10 +662,14 @@ async function resolveAntigravityImageTarget(
 		signal,
 		fetcher: fetchImpl,
 	});
-	const target: AntigravityImageTarget = {
-		model: advertised?.id ?? DEFAULT_ANTIGRAVITY_MODEL,
-		endpoints: advertised ? [advertised.endpoint] : endpoints,
-	};
+	const target: AntigravityImageTarget = advertised
+		? {
+				model: advertised.id,
+				// Keep the discovered endpoint first but retain the other configured
+				// fallbacks so generation retries (429/5xx/network) still fail over.
+				endpoints: [advertised.endpoint, ...endpoints.filter(endpoint => endpoint !== advertised.endpoint)],
+			}
+		: { model: DEFAULT_ANTIGRAVITY_MODEL, endpoints };
 	cache.set(bearer, target);
 	return target;
 }

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -12,6 +12,7 @@ import {
 	withAuth,
 } from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { fetchAntigravityImageModel } from "@oh-my-pi/pi-catalog/discovery/antigravity";
 import {
 	applyCodexResidencyHeader,
 	CODEX_BASE_URL,
@@ -60,12 +61,22 @@ const IMAGE_SYSTEM_INSTRUCTION =
 export type { ImageProvider } from "./image-providers";
 export type ImageProviderPreference = ImageProvider | "auto";
 
-interface ImageApiKey {
-	provider: ImageProvider;
+interface ImageApiKeyBase {
 	apiKey: ApiKey;
-	projectId?: string;
 	model?: Model;
 }
+
+interface AntigravityImageApiKey extends ImageApiKeyBase {
+	provider: "antigravity";
+	apiKey: string;
+	projectId: string;
+}
+
+interface OtherImageApiKey extends ImageApiKeyBase {
+	provider: Exclude<ImageProvider, "antigravity">;
+}
+
+type ImageApiKey = AntigravityImageApiKey | OtherImageApiKey;
 
 const COMMON_IMAGE_ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as const;
 const XAI_IMAGE_ASPECT_RATIOS = [...COMMON_IMAGE_ASPECT_RATIOS, "3:2", "2:3"] as const;
@@ -592,9 +603,7 @@ async function findAntigravityCredentials(
 	modelRegistry: ModelRegistry,
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
-	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity", sessionId, {
-		modelId: DEFAULT_ANTIGRAVITY_MODEL,
-	});
+	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity", sessionId);
 	if (!apiKey) return null;
 
 	const parsed = parseAntigravityCredentials(apiKey);
@@ -605,6 +614,21 @@ async function findAntigravityCredentials(
 		apiKey: parsed.accessToken,
 		projectId: parsed.projectId,
 	};
+}
+
+function resolveAntigravityEndpoints(): string[] {
+	try {
+		const mode = settings.get("providers.antigravityEndpoint");
+		if (mode === "production") {
+			return [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
+		}
+		if (mode === "sandbox") {
+			return [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
+		}
+	} catch {
+		// Use the default fallback order when settings are unavailable.
+	}
+	return [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
 }
 
 async function findXAIImageCredentials(modelRegistry?: ModelRegistry): Promise<ImageApiKey | null> {
@@ -888,7 +912,7 @@ function isOpenAIHostedImageModel(model: Model | undefined): model is Model {
 	return modelId.startsWith("gpt-") || modelId === "o3" || modelId.startsWith("o3-");
 }
 
-function getOpenAIHostedImageProvider(model: Model): ImageProvider {
+function getOpenAIHostedImageProvider(model: Model): "openai" | "openai-codex" {
 	return model.api === "openai-codex-responses" || model.provider === "openai-codex" ? "openai-codex" : "openai";
 }
 
@@ -1257,18 +1281,32 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 				const provider = apiKey.provider;
 				try {
-					const model =
-						provider === "openai" || provider === "openai-codex"
-							? (apiKey.model?.id ?? "gpt")
-							: provider === "antigravity"
-								? DEFAULT_ANTIGRAVITY_MODEL
-								: provider === "openrouter"
-									? DEFAULT_OPENROUTER_MODEL
-									: provider === "xai"
-										? DEFAULT_XAI_IMAGE_MODEL
-										: provider === "deepinfra"
-											? DEFAULT_DEEPINFRA_IMAGE_MODEL
-											: DEFAULT_MODEL;
+					let antigravityEndpoints: string[] | undefined;
+					let model: string;
+					if (provider === "openai" || provider === "openai-codex") {
+						model = apiKey.model?.id ?? "gpt";
+					} else if (provider === "antigravity") {
+						antigravityEndpoints = resolveAntigravityEndpoints();
+						const advertised = await fetchAntigravityImageModel({
+							token: apiKey.apiKey,
+							endpoint: antigravityEndpoints.length === 1 ? antigravityEndpoints[0] : undefined,
+							userAgent: getAntigravityUserAgent(),
+							signal: requestSignal,
+							fetcher: fetchImpl,
+						});
+						if (advertised) {
+							antigravityEndpoints = [advertised.endpoint];
+						}
+						model = advertised?.id ?? DEFAULT_ANTIGRAVITY_MODEL;
+					} else if (provider === "openrouter") {
+						model = DEFAULT_OPENROUTER_MODEL;
+					} else if (provider === "xai") {
+						model = DEFAULT_XAI_IMAGE_MODEL;
+					} else if (provider === "deepinfra") {
+						model = DEFAULT_DEEPINFRA_IMAGE_MODEL;
+					} else {
+						model = DEFAULT_MODEL;
+					}
 					const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
 					if (
 						params.aspect_ratio &&
@@ -1345,7 +1383,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const prompt = assemblePrompt(params);
 						const antigravityKey: ApiKey = ctx.modelRegistry.resolver("google-antigravity", {
 							sessionId,
-							modelId: DEFAULT_ANTIGRAVITY_MODEL,
+							modelId: model,
 						});
 
 						const response = await withAuth(
@@ -1366,17 +1404,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 									resolvedImages,
 								);
 
-								let endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-								try {
-									const mode = settings.get("providers.antigravityEndpoint");
-									if (mode === "production") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
-									} else if (mode === "sandbox") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-									}
-								} catch {
-									// Ignored
-								}
+								const endpoints = antigravityEndpoints ?? resolveAntigravityEndpoints();
 
 								let resp: Response | undefined;
 								let lastError: Error | undefined;

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -816,6 +816,64 @@ describe("imageGenTool", () => {
 		expect(result.details?.model).toBe("gemini-3.1-flash-image");
 	});
 
+	it("fails over to the sandbox endpoint in auto mode after a production 5xx", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			if (url.includes(":fetchAvailableModels")) {
+				requestUrls.push(url);
+				return new Response(JSON.stringify({ imageGenerationModelIds: ["gemini-3.1-flash-image"] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (url.includes("streamGenerateContent")) {
+				requestUrls.push(url);
+				if (url.startsWith("https://daily-cloudcode-pa.googleapis.com/")) {
+					return new Response(JSON.stringify({ error: { message: "backend unavailable" } }), {
+						status: 503,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("sandbox-antigravity-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-antigravity-failover", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			"https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3.1-flash-image");
+	});
+
 	it("re-discovers the image model when withAuth rotates to a sibling Antigravity account", async () => {
 		setImageProviderOrder(["antigravity", "xai"]);
 		const credsA = JSON.stringify({ token: "token-A", projectId: "proj-A" });

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -816,6 +816,102 @@ describe("imageGenTool", () => {
 		expect(result.details?.model).toBe("gemini-3.1-flash-image");
 	});
 
+	it("re-discovers the image model when withAuth rotates to a sibling Antigravity account", async () => {
+		setImageProviderOrder(["antigravity", "xai"]);
+		const credsA = JSON.stringify({ token: "token-A", projectId: "proj-A" });
+		const credsB = JSON.stringify({ token: "token-B", projectId: "proj-B" });
+		const streamAttempts: Array<{ token: string; model: string }> = [];
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			const auth = new Headers(init?.headers).get("authorization");
+			if (url.includes(":fetchAvailableModels")) {
+				// Account A still carries the legacy pro model; the rotated sibling B
+				// only advertises the flash model.
+				const modelId = auth === "Bearer token-B" ? "gemini-3.1-flash-image" : "gemini-3-pro-image";
+				return new Response(JSON.stringify({ imageGenerationModelIds: [modelId] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (url.includes("streamGenerateContent")) {
+				const token = auth?.replace("Bearer ", "") ?? "";
+				const request = JSON.parse(String(init?.body)) as { model?: string };
+				streamAttempts.push({ token, model: request.model ?? "" });
+				// Account A is out of quota, forcing withAuth to rotate to sibling B.
+				if (token === "token-A") {
+					return new Response(JSON.stringify({ error: { message: "quota exhausted" } }), {
+						status: 403,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				// Sibling B only serves its advertised model.
+				if (request.model !== "gemini-3.1-flash-image") {
+					return new Response(JSON.stringify({ error: { message: "Requested entity was not found." } }), {
+						status: 404,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("sibling-antigravity-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected provider request: ${url}`);
+		}) as unknown as typeof fetch;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => undefined,
+				getApiKeyForProvider: async (provider: string) => (provider === "google-antigravity" ? credsA : undefined),
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: () => false,
+					rotateSessionCredential: async () => false,
+				},
+				resolver: (provider: string) =>
+					provider === "google-antigravity"
+						? (rctx: { lastChance?: boolean }) => (rctx.lastChance ? credsB : credsA)
+						: () => "test-xai-token",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-antigravity-rotation", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(streamAttempts).toEqual([
+			{ token: "token-A", model: "gemini-3-pro-image" },
+			{ token: "token-B", model: "gemini-3.1-flash-image" },
+		]);
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3.1-flash-image");
+	});
+
 	it("falls back to xAI after an earlier provider HTTP failure", async () => {
 		const requestUrls: string[] = [];
 		const fetchMock = (async (input: string | URL | Request) => {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -748,6 +748,74 @@ describe("imageGenTool", () => {
 		expect(result.details?.provider).toBe("xai");
 	});
 
+	it("uses the Antigravity image model advertised for the account", async () => {
+		setImageProviderOrder(["antigravity", "xai"]);
+		const requestUrls: string[] = [];
+		const requestedModels: string[] = [];
+		const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.includes(":fetchAvailableModels")) {
+				return new Response(JSON.stringify({ imageGenerationModelIds: ["gemini-3.1-flash-image"] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (url.includes("streamGenerateContent")) {
+				const request = JSON.parse(String(init?.body)) as { model?: string };
+				if (request.model) requestedModels.push(request.model);
+				if (request.model !== "gemini-3.1-flash-image") {
+					return new Response(JSON.stringify({ error: { message: "Requested entity was not found." } }), {
+						status: 404,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [
+											{
+												inlineData: {
+													data: Buffer.from("advertised-antigravity-image").toString("base64"),
+													mimeType: "image/png",
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("unexpected-xai-fallback").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute(
+			"call-advertised-antigravity-model",
+			{ subject: "a cat" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+		]);
+		expect(requestedModels).toEqual(["gemini-3.1-flash-image"]);
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3.1-flash-image");
+	});
+
 	it("falls back to xAI after an earlier provider HTTP failure", async () => {
 		const requestUrls: string[] = [];
 		const fetchMock = (async (input: string | URL | Request) => {
@@ -770,6 +838,7 @@ describe("imageGenTool", () => {
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
 		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
 			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
 			"https://api.x.ai/v1/images/generations",
 		]);


### PR DESCRIPTION
## Repro
On current main, an Antigravity account advertising only `gemini-3.1-flash-image` receives a generation request for the hardcoded `gemini-3-pro-image`; the modeled 404 is then hidden by fallback to xAI. Reproduced with `bun test packages/coding-agent/test/tools/image-gen.test.ts` before the fix (16 passed, 1 failed).

## Cause
`packages/coding-agent/src/tools/image-gen.ts` selected `DEFAULT_ANTIGRAVITY_MODEL` without consulting the account roster, while `packages/catalog/src/discovery/antigravity.ts` parsed `fetchAvailableModels` but discarded its `imageGenerationModelIds` field.

## Fix
- Parse and expose the first account-advertised Antigravity image model with the endpoint that served the roster.
- Resolve that target before image generation, while retaining `gemini-3-pro-image` only when discovery is unavailable.
- Add a regression covering the stale-model 404 and cross-provider reroute, plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/image-gen.test.ts packages/catalog/test/compat-collapse.test.ts` passes: 83 tests, 425 assertions. `bun run check:ts` passes across all workspaces. Skipped the full pre-publish gate because its Rust formatting half fails before project code while building `audiopus_sys`: this workstation has no `cmake`; no Rust files changed.

Fixes #11106