### PR TITLE
test(utils): replace flaky incoming-json wall-clock budget with a scan counter

### DIFF
--- a/packages/utils/test/incoming-json.test.ts
+++ b/packages/utils/test/incoming-json.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { IncomingDoc, IncomingJsonError } from "@oh-my-pi/pi-utils/incoming-json";
 import { JsonLexer } from "@oh-my-pi/pi-utils/json-lexer";
 import { parseJsonWithRepair } from "@oh-my-pi/pi-utils/json-parse";
@@ -431,8 +431,15 @@ describe("incoming JSON cursors", () => {
 		// constant number of reads per element, so total reads stay O(n); a
 		// regression that re-lexed every earlier element would make it O(n²).
 		// Operation count is deterministic, unlike a timing bound that a loaded
-		// CI runner inflates past any threshold (#11109).
-		const peek = spyOn(JsonLexer.prototype, "peek");
+		// CI runner inflates past any threshold (#11109). A scalar counter, not
+		// a call-recording spy: retaining a mock entry per ~840k reads would be
+		// the allocation-heavy flake this test removes.
+		const originalPeek = JsonLexer.prototype.peek;
+		let reads = 0;
+		JsonLexer.prototype.peek = function (this: JsonLexer): number {
+			reads++;
+			return originalPeek.call(this);
+		};
 		try {
 			for (let i = 0; i < count; i++) {
 				feed.push(`{"n":${i}},`);
@@ -445,9 +452,9 @@ describe("incoming JSON cursors", () => {
 			expect(sum).toBe((count * (count - 1)) / 2);
 			// ~42 reads/element in practice; the ceiling only has to sit below the
 			// quadratic blow-up (~count/2 reads/element) to catch a rescan.
-			expect(peek.mock.calls.length).toBeLessThan(count * 250);
+			expect(reads).toBeLessThan(count * 250);
 		} finally {
-			peek.mockRestore();
+			JsonLexer.prototype.peek = originalPeek;
 		}
 	}, 30_000);
 });

--- a/packages/utils/test/incoming-json.test.ts
+++ b/packages/utils/test/incoming-json.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { IncomingDoc, IncomingJsonError } from "@oh-my-pi/pi-utils/incoming-json";
+import { JsonLexer } from "@oh-my-pi/pi-utils/json-lexer";
 import { parseJsonWithRepair } from "@oh-my-pi/pi-utils/json-parse";
 
 /** Whether `promise` is still unsettled after the microtask queue and one macrotask drain. */
@@ -426,16 +427,27 @@ describe("incoming JSON cursors", () => {
 		const items = doc.root().object().key("items").array();
 		feed.push('{"items":[');
 		let sum = 0;
-		const started = performance.now();
-		for (let i = 0; i < count; i++) {
-			feed.push(`{"n":${i}},`);
-			const element = await items.next();
-			sum += await element!.object().key("n").number();
+		// Count lexer reads rather than wall-clock time: a resumed scan does a
+		// constant number of reads per element, so total reads stay O(n); a
+		// regression that re-lexed every earlier element would make it O(n²).
+		// Operation count is deterministic, unlike a timing bound that a loaded
+		// CI runner inflates past any threshold (#11109).
+		const peek = spyOn(JsonLexer.prototype, "peek");
+		try {
+			for (let i = 0; i < count; i++) {
+				feed.push(`{"n":${i}},`);
+				const element = await items.next();
+				sum += await element!.object().key("n").number();
+			}
+			feed.push("]}");
+			feed.finish();
+			expect(await items.next()).toBeUndefined();
+			expect(sum).toBe((count * (count - 1)) / 2);
+			// ~42 reads/element in practice; the ceiling only has to sit below the
+			// quadratic blow-up (~count/2 reads/element) to catch a rescan.
+			expect(peek.mock.calls.length).toBeLessThan(count * 250);
+		} finally {
+			peek.mockRestore();
 		}
-		feed.push("]}");
-		feed.finish();
-		expect(await items.next()).toBeUndefined();
-		expect(sum).toBe((count * (count - 1)) / 2);
-		expect(performance.now() - started).toBeLessThan(2_000);
-	});
+	}, 30_000);
 });


### PR DESCRIPTION
## Repro
The `incoming JSON cursors > iterates a large nested array without rescanning earlier elements` test (`packages/utils/test/incoming-json.test.ts`) wraps a 20,000-element awaited iteration in `expect(performance.now() - started).toBeLessThan(2_000)`. Wall time there is dominated by 20k microtask hops, not the scan work the assertion means to bound, so a loaded CI runner pushes it past 2s and fails (job 101601811883, received 2159.55ms). Running the loop while a CPU-bound background task saturates the event loop reproduces it deterministically: `wall=177534.6ms peeks=840019 perElement=42.0 wallBudget(<2000ms)=FAIL` — wall explodes while the actual scan work is unchanged.

## Cause
The resume path in `packages/utils/src/incoming-json.ts` (`ContainerIndex.frontier`, `selectValue`/`selectIndex`) keeps total lexer work linear: each `items.next()` jumps to the cached frontier instead of re-lexing earlier elements, so the loop does a constant ~42 `JsonLexer.peek()` reads per element regardless of machine load. The 2s wall-clock ceiling was a proxy for that O(n) guarantee, but it measures scheduler contention, not lexer work, making it non-deterministic on shared runners.

## Fix
- Drop the `performance.now()` / `toBeLessThan(2_000)` probe.
- Spy on `JsonLexer.prototype.peek` and assert total reads stay `< count * 250`. Correct O(n) resume yields ~42 reads/element (840,019 total); an O(n²) rescan regression would be ~count/2 reads/element (~8.4e9) — three orders of magnitude of separation, and the count is invariant across load.
- Restore the spy in a `finally` so the test is full-suite-safe.
- Give the test an explicit 30s timeout so the default per-test deadline also cannot fire under load.

## Verification
`bun test test/incoming-json.test.ts` in `packages/utils` — 23 pass, 0 fail. Repro script confirms `peeks=840019` is invariant while wall time varies with contention. `bun run fix` + `bun check` pass via the push gate.

Fixes #11109