### PR TITLE
fix(tui): guard synchronized output terminal identity

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Tabby CMD sessions enabling synchronized output from a spoofed `WT_SESSION`, which caused streaming repaints to overlap when Tabby's terminal chain mishandled DEC 2026.
+
 ## [18.1.12] - 2026-09-06
 
 ### Fixed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -307,9 +307,11 @@ export function isWindowsTerminalPreviewSixelSupported(
 	env: NodeJS.ProcessEnv = Bun.env,
 	platform: NodeJS.Platform = process.platform,
 ): boolean {
-	if (platform !== "win32") return false;
-	if (!env.WT_SESSION) return false;
-	if (env.TERM_PROGRAM && env.TERM_PROGRAM.toLowerCase() !== "windows_terminal") {
+	if (
+		platform !== "win32" ||
+		!env.WT_SESSION ||
+		(env.TERM_PROGRAM && env.TERM_PROGRAM.toLowerCase() !== "windows_terminal")
+	) {
 		return false;
 	}
 	const version = parseMajorMinorVersion(env.TERM_PROGRAM_VERSION);
@@ -368,7 +370,7 @@ export function shouldEnableSynchronizedOutputByDefault(
 	if (override !== null) return override;
 
 	if (advertisesSynchronizedOutput(env.TERM_FEATURES)) return true;
-	if (env.WT_SESSION) return true;
+	if (env.WT_SESSION && (!env.TERM_PROGRAM || env.TERM_PROGRAM.toLowerCase() === "windows_terminal")) return true;
 	if (isInsideHerdr(env)) return true;
 
 	// Risky multiplexers start off even when an inner terminal id leaks through:

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -92,12 +92,20 @@ describe("shouldEnableSynchronizedOutputByDefault", () => {
 		}
 	});
 
-	it("enables sync in Windows Terminal / WSL via WT_SESSION regardless of terminal id", () => {
+	it("enables sync only when WT_SESSION does not contradict the terminal identity", () => {
 		expect(shouldEnableSynchronizedOutputByDefault({ WT_SESSION: "abc" }, "trueColor")).toBe(true);
-		// WSL shape: Linux + WT_SESSION + COLORTERM=truecolor collapses to trueColor id.
-		expect(shouldEnableSynchronizedOutputByDefault({ WT_SESSION: "abc", COLORTERM: "truecolor" }, "trueColor")).toBe(
-			true,
-		);
+		expect(
+			shouldEnableSynchronizedOutputByDefault(
+				{ WT_SESSION: "abc", TERM_PROGRAM: "Windows_Terminal", COLORTERM: "truecolor" },
+				"trueColor",
+			),
+		).toBe(true);
+		expect(
+			shouldEnableSynchronizedOutputByDefault(
+				{ WT_SESSION: "0", TERM_PROGRAM: "Tabby", COLORTERM: "truecolor" },
+				"trueColor",
+			),
+		).toBe(false);
 	});
 
 	it("enables sync when TERM_FEATURES advertises the Sy capability, even through SSH/mux", () => {


### PR DESCRIPTION
## Repro
On current `main`, the reporter's Tabby CMD environment is misclassified by running `bun -e 'import { shouldEnableSynchronizedOutputByDefault as enabled } from "./packages/tui/src/terminal-capabilities.ts"; console.log(enabled({ TERM: "xterm-256color", COLORTERM: "truecolor", TERM_PROGRAM: "Tabby", WT_SESSION: "0" }, "trueColor"));'`: it prints `true`, enabling DEC 2026 wrappers despite the explicit Tabby identity.

## Cause
`shouldEnableSynchronizedOutputByDefault()` in `packages/tui/src/terminal-capabilities.ts` treated every non-empty `WT_SESSION` as authoritative, unlike the existing SIXEL capability path, so Tabby's `WT_SESSION=0` compatibility variable overrode `TERM_PROGRAM=Tabby`. The reported DECRPM status-0 exception is already limited to Herdr by `TUI.start()` in `packages/tui/src/tui.ts`; that runtime path was not broadened.

## Fix
- Cross-check `TERM_PROGRAM` before using `WT_SESSION` to enable synchronized output, while preserving Windows Terminal and WSL sessions where `TERM_PROGRAM` is absent.
- Add the Tabby CMD environment as a regression case and retain the Windows Terminal cases.
- Document the user-visible fix in the TUI changelog.

## Verification
`bun test packages/tui/test/terminal-capabilities.test.ts packages/tui/test/herdr-sync-output.test.ts` passes 56 tests with 0 failures. Re-running the one-line Tabby policy reproduction prints `false`. The pre-publish `bun run fix` and `bun check` gate passed during branch publication.

Fixes #11110