### PR TITLE
fix(coding-agent): Show jj bookmark/change label in colocated workspaces

### DIFF
--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -91,9 +91,20 @@ impl CancelToken {
 	/// Create a new cancel token from optional timeout and abort signal.
 	pub fn new(timeout_ms: Option<u32>, signal: Option<Unknown>) -> Self {
 		let mut result = Self { core: core_cancel::CancelToken::new(timeout_ms) };
+		let aborted = signal
+			.as_ref()
+			.and_then(|value| value.coerce_to_object().ok())
+			.and_then(|object| object.get_named_property::<bool>("aborted").ok())
+			.unwrap_or(false);
 		if let Some(signal) = signal.and_then(|value| AbortSignal::from_unknown(value).ok()) {
 			let abort_token = result.emplace_abort_token();
-			signal.on_abort(move || abort_token.abort(AbortReason::Signal));
+			// An already-fired signal never invokes on_abort again: honor its
+			// current state, or pre-cancelled work would run to completion.
+			if aborted {
+				abort_token.abort(AbortReason::Signal);
+			} else {
+				signal.on_abort(move || abort_token.abort(AbortReason::Signal));
+			}
 		}
 		result
 	}

--- a/crates/pi-natives/src/vcs.rs
+++ b/crates/pi-natives/src/vcs.rs
@@ -495,6 +495,15 @@ pub fn vcs_discover(env: Env, dir: String) -> Result<Option<VcsRepo>> {
 		.map_err(|err| rich_error(env, err))
 }
 
+/// Discover the repository presenting a directory: equal-root jj+git ties
+/// prefer Jujutsu. Git-safe automation must keep using [`vcs_discover`].
+#[napi]
+pub fn vcs_discover_for_display(env: Env, dir: String) -> Result<Option<VcsRepo>> {
+	pi_vcs::detect_for_display(Path::new(&dir))
+		.map(|repo| repo.map(|inner| VcsRepo { inner }))
+		.map_err(|err| rich_error(env, err))
+}
+
 #[napi]
 impl VcsRepo {
 	/// Backend kind (`"git"` or `"jj"`).

--- a/crates/pi-vcs/src/jj/mod.rs
+++ b/crates/pi-vcs/src/jj/mod.rs
@@ -76,7 +76,10 @@ impl JjWorkspace {
 /// Resolve the `.jj/repo` directory for `root`, or `None` when `root` is not
 /// a workspace. jj marks a workspace via `.jj/repo`: a directory in the
 /// default workspace, or a FILE (created by `jj workspace add`) whose contents
-/// are a path — relative to `.jj` — to the default workspace's repo dir.
+/// are a path — relative to `.jj` — to the default workspace's repo dir. A
+/// file indirection whose target is missing (stale linked marker) or is not
+/// a directory is NOT a workspace: returning `None` lets discovery continue
+/// upward instead of preferring an unusable handle forever.
 fn resolve_repo_dir(root: &Path) -> Option<PathBuf> {
 	let jj_dir = root.join(".jj");
 	let repo_path = jj_dir.join("repo");
@@ -92,5 +95,9 @@ fn resolve_repo_dir(root: &Path) -> Option<PathBuf> {
 	if target.is_empty() {
 		return None;
 	}
-	Some(crate::git::normalize_path(&jj_dir.join(target)))
+	let resolved = crate::git::normalize_path(&jj_dir.join(target));
+	std::fs::metadata(&resolved)
+		.ok()
+		.filter(|target_meta| target_meta.is_dir())
+		.map(|_| resolved)
 }

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -446,6 +446,37 @@ mod tests {
 	}
 
 	#[test]
+	fn stale_linked_marker_falls_back_to_git() {
+		// Stale linked-workspace pointer plus a usable equal-root Git
+		// checkout: both detectors must prefer Git over the unusable
+		// handle, in every root ordering.
+		let temp = tempfile::tempdir().unwrap();
+		init_git(temp.path());
+		fs::create_dir_all(temp.path().join(".jj")).unwrap();
+		fs::write(temp.path().join(".jj/repo"), "../elsewhere\n").unwrap();
+		assert!(matches!(detect(temp.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(
+			detect_for_display(temp.path()).unwrap(),
+			Some(Repo::Git(_))
+		));
+
+		// A pointer at an existing file is not a repo dir either.
+		let file_target = tempfile::tempdir().unwrap();
+		init_git(file_target.path());
+		fs::create_dir_all(file_target.path().join(".jj")).unwrap();
+		fs::write(file_target.path().join("not-a-repo"), "junk\n").unwrap();
+		fs::write(file_target.path().join(".jj/repo"), "../not-a-repo\n").unwrap();
+		assert!(matches!(
+			detect(file_target.path()).unwrap(),
+			Some(Repo::Git(_))
+		));
+		assert!(matches!(
+			detect_for_display(file_target.path()).unwrap(),
+			Some(Repo::Git(_))
+		));
+	}
+
+	#[test]
 	fn git_uncommitted_diff_matches_both_unborn_head_comparisons() {
 		let temp = tempfile::tempdir().unwrap();
 		init_git(temp.path());

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -447,18 +447,30 @@ mod tests {
 
 	#[test]
 	fn stale_linked_marker_falls_back_to_git() {
+		// Stale marker nested inside an outer Git checkout: discovery must
+		// skip the unusable handle and continue upward to Git. Pre-fix both
+		// detectors preferred the stale handle here (the inner jj root
+		// counts as a strict descendant of the outer git root), so this
+		// case guards the changed fallback path in each detector.
+		let outer = tempfile::tempdir().unwrap();
+		init_git(outer.path());
+		let inner = outer.path().join("sub");
+		fs::create_dir_all(inner.join(".jj")).unwrap();
+		fs::write(inner.join(".jj/repo"), "../elsewhere\n").unwrap();
+		assert!(matches!(detect(&inner).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(&inner).unwrap(), Some(Repo::Git(_))));
+
 		// Stale linked-workspace pointer plus a usable equal-root Git
 		// checkout: both detectors must prefer Git over the unusable
-		// handle, in every root ordering.
+		// handle. (On an equal-root tie `detect` already preferred Git
+		// pre-fix via its tie-break; only the display assertion guards
+		// there.)
 		let temp = tempfile::tempdir().unwrap();
 		init_git(temp.path());
 		fs::create_dir_all(temp.path().join(".jj")).unwrap();
 		fs::write(temp.path().join(".jj/repo"), "../elsewhere\n").unwrap();
 		assert!(matches!(detect(temp.path()).unwrap(), Some(Repo::Git(_))));
-		assert!(matches!(
-			detect_for_display(temp.path()).unwrap(),
-			Some(Repo::Git(_))
-		));
+		assert!(matches!(detect_for_display(temp.path()).unwrap(), Some(Repo::Git(_))));
 
 		// A pointer at an existing file is not a repo dir either.
 		let file_target = tempfile::tempdir().unwrap();
@@ -466,14 +478,8 @@ mod tests {
 		fs::create_dir_all(file_target.path().join(".jj")).unwrap();
 		fs::write(file_target.path().join("not-a-repo"), "junk\n").unwrap();
 		fs::write(file_target.path().join(".jj/repo"), "../not-a-repo\n").unwrap();
-		assert!(matches!(
-			detect(file_target.path()).unwrap(),
-			Some(Repo::Git(_))
-		));
-		assert!(matches!(
-			detect_for_display(file_target.path()).unwrap(),
-			Some(Repo::Git(_))
-		));
+		assert!(matches!(detect(file_target.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(file_target.path()).unwrap(), Some(Repo::Git(_))));
 	}
 
 	#[test]

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -282,6 +282,28 @@ pub fn detect(dir: &Path) -> Result<Option<Repo>> {
 	}
 }
 
+/// Detect which VCS should present `dir` in human-facing surfaces.
+///
+/// Same as [`detect`], except equal-root jj+git ties prefer Jujutsu:
+/// colocated workspaces resolve to [`Repo::Jj`]. A strictly deeper nested
+/// git checkout still wins (it is the tree the user works in), and
+/// [`is_pure_jj`] keeps using [`detect`], so git-mutating automation policy
+/// is unchanged. Existing [`Repo`] dispatch serves both detectors without a
+/// colocated variant: presentation reads label/status through the returned
+/// backend, while automation keeps the [`detect`] result.
+pub fn detect_for_display(dir: &Path) -> Result<Option<Repo>> {
+	let jj = jj::JjWorkspace::discover(dir)?;
+	let Some(jj) = jj else {
+		return Ok(git::GitRepo::discover(dir)?.map(|repo| Repo::Git(Arc::new(repo))));
+	};
+	match git::GitRepo::discover(dir)? {
+		Some(repo) if is_strict_descendant(repo.root(), jj.root()) => {
+			Ok(Some(Repo::Git(Arc::new(repo))))
+		},
+		_ => Ok(Some(Repo::Jj(Arc::new(jj)))),
+	}
+}
+
 /// Detect a "pure" Jujutsu workspace — one where git-mutating automation has
 /// no safe target because jj is the nearest (or only) VCS ancestor.
 ///
@@ -376,7 +398,51 @@ mod tests {
 			.unwrap()
 			.uncommitted_diff(&[])
 			.unwrap();
+
 		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn display_prefers_jj_on_equal_root_ties() {
+		let temp = tempfile::tempdir().unwrap();
+		init_git(temp.path());
+		fs::create_dir_all(temp.path().join(".jj/repo")).unwrap();
+		assert!(matches!(detect(temp.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(temp.path()).unwrap(), Some(Repo::Jj(_))));
+	}
+
+	#[test]
+	fn display_matches_detect_for_pure_and_nested_roots() {
+		// Pure git.
+		let git_dir = tempfile::tempdir().unwrap();
+		init_git(git_dir.path());
+		assert!(matches!(detect(git_dir.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(git_dir.path()).unwrap(), Some(Repo::Git(_))));
+
+		// Pure jj.
+		let jj_dir = tempfile::tempdir().unwrap();
+		fs::create_dir_all(jj_dir.path().join(".jj/repo")).unwrap();
+		assert!(matches!(detect(jj_dir.path()).unwrap(), Some(Repo::Jj(_))));
+		assert!(matches!(detect_for_display(jj_dir.path()).unwrap(), Some(Repo::Jj(_))));
+
+		// Nested git checkout under an outer jj workspace: the strictly
+		// deeper git root still wins in both detectors.
+		let outer = tempfile::tempdir().unwrap();
+		fs::create_dir_all(outer.path().join(".jj/repo")).unwrap();
+		let inner = outer.path().join("sub");
+		fs::create_dir_all(&inner).unwrap();
+		init_git(&inner);
+		assert!(matches!(detect(&inner).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(&inner).unwrap(), Some(Repo::Git(_))));
+
+		// Jj nested inside an unrelated git checkout: the deeper root wins
+		// in both detectors.
+		let git_outer = tempfile::tempdir().unwrap();
+		init_git(git_outer.path());
+		let jj_inner = git_outer.path().join("sub");
+		fs::create_dir_all(jj_inner.join(".jj/repo")).unwrap();
+		assert!(matches!(detect(&jj_inner).unwrap(), Some(Repo::Jj(_))));
+		assert!(matches!(detect_for_display(&jj_inner).unwrap(), Some(Repo::Jj(_))));
 	}
 
 	#[test]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- In colocated jj-git workspaces, the status line and legacy footer now show the Jujutsu bookmark/change label and working-copy status instead of a detached git HEAD. Git-backed automation still resolves these directories to Git ([#11071](https://github.com/can1357/oh-my-pi/issues/11071)).
+- In colocated jj-git workspaces, the status line and legacy footer now show the Jujutsu bookmark/change label and working-copy status instead of a detached git HEAD. Git-backed automation still resolves these directories to Git ([#11071](https://github.com/can1357/oh-my-pi/issues/11071), [#11113](https://github.com/can1357/oh-my-pi/pull/11113) by [@boazy](https://github.com/boazy)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- In colocated jj-git workspaces, the status line and legacy footer now show the Jujutsu bookmark/change label and working-copy status instead of a detached git HEAD. Git-backed automation still resolves these directories to Git ([#11071](https://github.com/can1357/oh-my-pi/issues/11071)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -11,8 +11,8 @@ import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
-/** Minimum interval between watcher-install attempts for one target. */
-const FOOTER_WATCH_RETRY_TTL_MS = 5000;
+/** Minimum interval between display-backend syncs (re-discovery walks). */
+const FOOTER_DISPLAY_SYNC_TTL_MS = 5000;
 
 /**
  * Footer component that shows pwd, token stats, and context usage
@@ -27,10 +27,9 @@ export class FooterComponent implements Component {
 	// changes under it (late colocation), the watcher is rebound.
 	#watchedTarget: string | null = null;
 
-	// Last watcher-install attempt, bounding retries for a persistently
-	// failing target (see rebind below).
-	#watchAttemptTarget: string | null = null;
-	#watchAttemptAt = 0;
+	// Last display-backend sync, bounding re-discovery walks past the
+	// initial setup.
+	#lastDisplayCheckAt = 0;
 	#onBranchChange: (() => void) | null = null;
 	#disposed = false;
 	#autoCompactEnabled: boolean = true;
@@ -86,10 +85,22 @@ export class FooterComponent implements Component {
 		}
 	}
 
-	// Rebind the watcher when the display backend changed under it (late
-	// colocation): without this, jj-only label changes never clear the
-	// cached git branch, which has no polling TTL.
-	#rebindWatcherIfTargetChanged(repository: VcsRepo): void {
+	// Revalidate the display backend on a bounded cadence rather than every
+	// frame: a re-discovery walk runs at most once per TTL, and cached
+	// renders do no VCS discovery. Late colocation rebinds the watcher here;
+	// the TTL-less branch cache is cleared on change so jj-only label
+	// updates flow from then on.
+	#syncDisplayWatcher(): void {
+		const now = Date.now();
+		if (now - this.#lastDisplayCheckAt < FOOTER_DISPLAY_SYNC_TTL_MS) return;
+		this.#lastDisplayCheckAt = now;
+		let repository: VcsRepo | null;
+		try {
+			repository = vcs.repoForDisplay(getProjectDir());
+		} catch {
+			return;
+		}
+		if (!repository) return;
 		let target: string | null;
 		try {
 			target = repository.watchTarget();
@@ -97,13 +108,6 @@ export class FooterComponent implements Component {
 			return;
 		}
 		if (target === this.#watchedTarget && this.#gitUnwatch) return;
-		// Retry a failed install past the TTL, and handle the initial
-		// no-watcher case explicitly: without this bound the check below
-		// would attempt every render while broken.
-		const now = Date.now();
-		if (target === this.#watchAttemptTarget && now - this.#watchAttemptAt < FOOTER_WATCH_RETRY_TTL_MS) return;
-		this.#watchAttemptTarget = target;
-		this.#watchAttemptAt = now;
 		// Install before disposing: a failed replacement keeps existing
 		// coverage instead of leaving none.
 		try {
@@ -115,7 +119,7 @@ export class FooterComponent implements Component {
 			this.#gitUnwatch = unwatch;
 			this.#watchedTarget = target;
 		} catch {
-			// Silently fail if we can't watch
+			// Silently fail if we can't watch; the next TTL window retries.
 		}
 		this.#invalidateBranch();
 	}
@@ -147,6 +151,10 @@ export class FooterComponent implements Component {
 	 */
 	#getCurrentBranch(): string | null {
 		if (!settings.get("git.enabled")) return null;
+		this.#syncDisplayWatcher();
+		if (this.#cachedBranch !== undefined) {
+			return this.#cachedBranch;
+		}
 		const repository = (() => {
 			try {
 				return vcs.repoForDisplay(getProjectDir());
@@ -157,10 +165,6 @@ export class FooterComponent implements Component {
 		if (!repository) {
 			this.#cachedBranch = null;
 			return null;
-		}
-		this.#rebindWatcherIfTargetChanged(repository);
-		if (this.#cachedBranch !== undefined) {
-			return this.#cachedBranch;
 		}
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,6 +8,7 @@ import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
+import { colocatedJjWorkspace } from "./status-line/git-utils";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
 /**
@@ -121,6 +122,33 @@ export class FooterComponent implements Component {
 				this.#branchResolve = request;
 				void repository
 					.label(request.signal)
+					.then(label => {
+						if (this.#disposed || this.#branchGeneration !== generation) return;
+						const changed = this.#cachedBranch !== label;
+						this.#cachedBranch = label;
+						if (changed) this.#onBranchChange?.();
+					})
+					.catch(() => {
+						if (this.#disposed || this.#branchGeneration !== generation) return;
+						this.#cachedBranch = null;
+					})
+					.finally(() => {
+						if (this.#branchResolve === request) this.#branchResolve = undefined;
+					});
+			}
+			return this.#cachedBranch ?? null;
+		}
+		// Colocated jj-git checkout: jj owns the working-copy label even though
+		// `detect()` resolves the directory to Git (same root-equality
+		// predicate as the status line, independent of git HEAD state).
+		const colocatedJj = colocatedJjWorkspace(getProjectDir(), repository);
+		if (colocatedJj) {
+			if (!this.#branchResolve) {
+				const request = new AbortController();
+				const generation = this.#branchGeneration;
+				this.#branchResolve = request;
+				void colocatedJj
+					.workingCopyLabel(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
 						const changed = this.#cachedBranch !== label;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -87,10 +87,23 @@ export class FooterComponent implements Component {
 		} catch {
 			return;
 		}
-		if (target !== this.#watchedTarget) {
-			this.#setupGitWatcher();
-			this.#invalidateBranch();
+		if (target === this.#watchedTarget) return;
+		// Install before disposing: a failed replacement keeps existing
+		// coverage instead of leaving none. The attempt is recorded per
+		// target value, so a persistently failing install does not retry
+		// every render; the next target move tries again.
+		try {
+			const unwatch = vcs.watch(repository, () => {
+				this.#invalidateBranch();
+				this.#onBranchChange?.();
+			});
+			this.#gitUnwatch?.();
+			this.#gitUnwatch = unwatch;
+		} catch {
+			// Silently fail if we can't watch
 		}
+		this.#watchedTarget = target;
+		this.#invalidateBranch();
 	}
 
 	/**
@@ -145,8 +158,9 @@ export class FooterComponent implements Component {
 					.label(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
-						const changed = this.#cachedBranch !== label;
-						this.#cachedBranch = label;
+						const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
+						const changed = this.#cachedBranch !== clean;
+						this.#cachedBranch = clean;
 						if (changed) this.#onBranchChange?.();
 					})
 					.catch(() => {

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -263,10 +263,11 @@ export class FooterComponent implements Component {
 			})
 			.catch((error: unknown) => {
 				if (this.#disposed || this.#branchGeneration !== generation) return;
-				// Transient cancellations keep today's sticky null rather
-				// than failing over: the store may merely be slow.
+				// Transient retries must not clobber an installed fallback
+				// with null (and seed sticky null only initially): either
+				// way the visible frame is unchanged, so no repaint.
 				if (isTransientVcsError(error)) {
-					this.#cachedBranch = null;
+					if (!this.#fallbackRepo) this.#cachedBranch = null;
 					return;
 				}
 				const fallback = this.#gitFallback(repository);

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -33,6 +33,11 @@ export class FooterComponent implements Component {
 	// the jj target, preserving repair detection through the label path.
 	#fallbackUnwatch: (() => void) | null = null;
 	#fallbackWatchedTarget: string | null = null;
+	// Operational git repo the cached branch falls back to (null when no
+	// fallback is active). Recorded independently of watcher success so a
+	// failed watcher install neither loses the fallback nor disables its
+	// re-probe; the watcher itself stays optional coverage.
+	#fallbackRepo: VcsRepo | null = null;
 
 	// Last display-backend sync, bounding re-discovery walks past the
 	// initial setup.
@@ -126,10 +131,17 @@ export class FooterComponent implements Component {
 		}
 		if (target === this.#watchedTarget && this.#gitUnwatch) {
 			// A cached fallback never re-issues the label on its own, so a
-			// repaired store would stick on git forever: re-probe jj here,
-			// bounded by this TTL plus the in-flight guard. A still-broken
-			// store fails silently back into the same fallback.
-			if (this.#fallbackWatchedTarget !== null && !repository.asGit()) this.#requestJjLabel(repository);
+			// repaired store would stick on git forever: retry both recovery
+			// paths on this cadence — the jj re-probe (repair detection)
+			// and the git watcher install (a previous install may have
+			// thrown). Each is self-guarding: the probe needs no in-flight
+			// load, the install is skipped while its target is already
+			// watched, and a still-broken store fails silently back into
+			// the same fallback.
+			if (this.#fallbackRepo !== null && !repository.asGit()) {
+				this.#requestJjLabel(repository);
+				this.#watchFallback(this.#fallbackRepo);
+			}
 			return;
 		}
 		// Install before disposing: a failed replacement keeps existing
@@ -143,6 +155,7 @@ export class FooterComponent implements Component {
 			this.#gitUnwatch = unwatch;
 			this.#watchedTarget = target;
 			this.#releaseFallbackWatch();
+			this.#fallbackRepo = null;
 		} catch {
 			// Silently fail if we can't watch; the next TTL window retries.
 		}
@@ -158,6 +171,7 @@ export class FooterComponent implements Component {
 		this.#branchResolve = undefined;
 		this.#gitUnwatch?.();
 		this.#gitUnwatch = null;
+		this.#fallbackRepo = null;
 		this.#releaseFallbackWatch();
 	}
 
@@ -241,6 +255,7 @@ export class FooterComponent implements Component {
 			.then(label => {
 				if (this.#disposed || this.#branchGeneration !== generation) return;
 				this.#releaseFallbackWatch();
+				this.#fallbackRepo = null;
 				const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
 				const changed = this.#cachedBranch !== clean;
 				this.#cachedBranch = clean;
@@ -251,6 +266,7 @@ export class FooterComponent implements Component {
 				const fallback = this.#gitFallback(repository);
 				const changed = this.#cachedBranch !== fallback.branch;
 				this.#cachedBranch = fallback.branch;
+				this.#fallbackRepo = fallback.repo;
 				this.#watchFallback(fallback.repo);
 				if (changed) this.#onBranchChange?.();
 			})

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,7 +8,7 @@ import { settings } from "../../config/settings";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
-import { sanitizeStatusText } from "../shared";
+import { isTransientVcsError, sanitizeStatusText } from "../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
 /** Minimum interval between display-backend syncs (re-discovery walks). */
@@ -261,8 +261,14 @@ export class FooterComponent implements Component {
 				this.#cachedBranch = clean;
 				if (changed) this.#onBranchChange?.();
 			})
-			.catch(() => {
+			.catch((error: unknown) => {
 				if (this.#disposed || this.#branchGeneration !== generation) return;
+				// Transient cancellations keep today's sticky null rather
+				// than failing over: the store may merely be slow.
+				if (isTransientVcsError(error)) {
+					this.#cachedBranch = null;
+					return;
+				}
 				const fallback = this.#gitFallback(repository);
 				const changed = this.#cachedBranch !== fallback.branch;
 				this.#cachedBranch = fallback.branch;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -155,6 +155,24 @@ export class FooterComponent implements Component {
 		this.#branchResolve = undefined;
 		this.#cachedBranch = undefined;
 	}
+	/**
+	 * Branch of the operational git checkout for a display whose jj label
+	 * failed to load. Only resolves in the colocated layout (same root):
+	 * pure-jj and nested layouts have no usable fallback and keep today's
+	 * null. Never throws.
+	 */
+	#operationalGitBranch(display: VcsRepo): string | null {
+		try {
+			const operational = vcs.repo(getProjectDir());
+			if (operational?.kind() !== "git" || operational.root() !== display.root()) return null;
+			const gitRepository = operational.asGit();
+			const headState = gitRepository?.headSync();
+			if (!headState) return null;
+			return headState.kind === "ref" ? (headState.branch ?? headState.refName ?? "HEAD") : "detached";
+		} catch {
+			return null;
+		}
+	}
 
 	/**
 	 * Get the current branch, bookmark, or change-id label.
@@ -193,7 +211,7 @@ export class FooterComponent implements Component {
 					})
 					.catch(() => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
-						this.#cachedBranch = null;
+						this.#cachedBranch = this.#operationalGitBranch(repository);
 					})
 					.finally(() => {
 						if (this.#branchResolve === request) this.#branchResolve = undefined;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -27,6 +27,13 @@ export class FooterComponent implements Component {
 	// changes under it (late colocation), the watcher is rebound.
 	#watchedTarget: string | null = null;
 
+	// Fallback watcher for a retired jj display: while the cached branch
+	// comes from the operational git repo, this follows its HEAD so git
+	// moves invalidate the fallback. The display watcher above stays on
+	// the jj target, preserving repair detection through the label path.
+	#fallbackUnwatch: (() => void) | null = null;
+	#fallbackWatchedTarget: string | null = null;
+
 	// Last display-backend sync, bounding re-discovery walks past the
 	// initial setup.
 	#lastDisplayCheckAt = 0;
@@ -128,6 +135,7 @@ export class FooterComponent implements Component {
 			this.#gitUnwatch?.();
 			this.#gitUnwatch = unwatch;
 			this.#watchedTarget = target;
+			this.#releaseFallbackWatch();
 		} catch {
 			// Silently fail if we can't watch; the next TTL window retries.
 		}
@@ -143,6 +151,7 @@ export class FooterComponent implements Component {
 		this.#branchResolve = undefined;
 		this.#gitUnwatch?.();
 		this.#gitUnwatch = null;
+		this.#releaseFallbackWatch();
 	}
 
 	invalidate(): void {
@@ -156,22 +165,58 @@ export class FooterComponent implements Component {
 		this.#cachedBranch = undefined;
 	}
 	/**
-	 * Branch of the operational git checkout for a display whose jj label
-	 * failed to load. Only resolves in the colocated layout (same root):
-	 * pure-jj and nested layouts have no usable fallback and keep today's
-	 * null. Never throws.
+	 * Operational git fallback for a display whose jj label failed to load:
+	 * branch plus the repo to watch for HEAD moves. Only resolves in the
+	 * colocated layout (same root): pure-jj and nested layouts have no
+	 * usable fallback and keep today's null. Never throws.
 	 */
-	#operationalGitBranch(display: VcsRepo): string | null {
+	#gitFallback(display: VcsRepo): { branch: string | null; repo: VcsRepo | null } {
 		try {
 			const operational = vcs.repo(getProjectDir());
-			if (operational?.kind() !== "git" || operational.root() !== display.root()) return null;
-			const gitRepository = operational.asGit();
-			const headState = gitRepository?.headSync();
-			if (!headState) return null;
-			return headState.kind === "ref" ? (headState.branch ?? headState.refName ?? "HEAD") : "detached";
+			if (operational?.kind() !== "git" || operational.root() !== display.root()) {
+				return { branch: null, repo: null };
+			}
+			const headState = operational.asGit()?.headSync();
+			if (!headState) return { branch: null, repo: operational };
+			const branch = headState.kind === "ref" ? (headState.branch ?? headState.refName ?? "HEAD") : "detached";
+			return { branch, repo: operational };
 		} catch {
-			return null;
+			return { branch: null, repo: null };
 		}
+	}
+
+	/**
+	 * Follow the fallback repo's HEAD so a later `git switch` invalidates
+	 * the cached fallback branch. Target-keyed: reuses the live watcher
+	 * when the repo is unchanged, releases nothing on install failure.
+	 */
+	#watchFallback(repo: VcsRepo | null): void {
+		if (!repo) return;
+		let target: string | null = null;
+		try {
+			target = repo.watchTarget();
+		} catch {
+			target = null;
+		}
+		if (target === null || target === this.#fallbackWatchedTarget) return;
+		this.#releaseFallbackWatch();
+		try {
+			const unwatch = vcs.watch(repo, () => {
+				this.#invalidateBranch();
+				this.#onBranchChange?.();
+			});
+			this.#fallbackUnwatch = unwatch;
+			this.#fallbackWatchedTarget = target;
+		} catch {
+			// Silently fail if we can't watch; the cached fallback stays
+			// until the next invalidation from elsewhere.
+		}
+	}
+
+	#releaseFallbackWatch(): void {
+		this.#fallbackUnwatch?.();
+		this.#fallbackUnwatch = null;
+		this.#fallbackWatchedTarget = null;
 	}
 
 	/**
@@ -204,6 +249,7 @@ export class FooterComponent implements Component {
 					.label(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
+						this.#releaseFallbackWatch();
 						const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
 						const changed = this.#cachedBranch !== clean;
 						this.#cachedBranch = clean;
@@ -211,7 +257,11 @@ export class FooterComponent implements Component {
 					})
 					.catch(() => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
-						this.#cachedBranch = this.#operationalGitBranch(repository);
+						const fallback = this.#gitFallback(repository);
+						const changed = this.#cachedBranch !== fallback.branch;
+						this.#cachedBranch = fallback.branch;
+						this.#watchFallback(fallback.repo);
+						if (changed) this.#onBranchChange?.();
 					})
 					.finally(() => {
 						if (this.#branchResolve === request) this.#branchResolve = undefined;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,7 +8,6 @@ import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
-import { colocatedJjWorkspace } from "./status-line/git-utils";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
 /**
@@ -58,7 +57,7 @@ export class FooterComponent implements Component {
 		this.#gitUnwatch = null;
 
 		if (!settings.get("git.enabled")) return;
-		const repository = vcs.repo(getProjectDir());
+		const repository = vcs.repoForDisplay(getProjectDir());
 		if (!repository) return;
 
 		try {
@@ -104,7 +103,7 @@ export class FooterComponent implements Component {
 
 		const repository = (() => {
 			try {
-				return vcs.repo(getProjectDir());
+				return vcs.repoForDisplay(getProjectDir());
 			} catch {
 				return null;
 			}
@@ -122,33 +121,6 @@ export class FooterComponent implements Component {
 				this.#branchResolve = request;
 				void repository
 					.label(request.signal)
-					.then(label => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						const changed = this.#cachedBranch !== label;
-						this.#cachedBranch = label;
-						if (changed) this.#onBranchChange?.();
-					})
-					.catch(() => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						this.#cachedBranch = null;
-					})
-					.finally(() => {
-						if (this.#branchResolve === request) this.#branchResolve = undefined;
-					});
-			}
-			return this.#cachedBranch ?? null;
-		}
-		// Colocated jj-git checkout: jj owns the working-copy label even though
-		// `detect()` resolves the directory to Git (same root-equality
-		// predicate as the status line, independent of git HEAD state).
-		const colocatedJj = colocatedJjWorkspace(getProjectDir(), repository);
-		if (colocatedJj) {
-			if (!this.#branchResolve) {
-				const request = new AbortController();
-				const generation = this.#branchGeneration;
-				this.#branchResolve = request;
-				void colocatedJj
-					.workingCopyLabel(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
 						const changed = this.#cachedBranch !== label;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -124,7 +124,14 @@ export class FooterComponent implements Component {
 		} catch {
 			return;
 		}
-		if (target === this.#watchedTarget && this.#gitUnwatch) return;
+		if (target === this.#watchedTarget && this.#gitUnwatch) {
+			// A cached fallback never re-issues the label on its own, so a
+			// repaired store would stick on git forever: re-probe jj here,
+			// bounded by this TTL plus the in-flight guard. A still-broken
+			// store fails silently back into the same fallback.
+			if (this.#fallbackWatchedTarget !== null && !repository.asGit()) this.#requestJjLabel(repository);
+			return;
+		}
 		// Install before disposing: a failed replacement keeps existing
 		// coverage instead of leaving none.
 		try {
@@ -220,6 +227,38 @@ export class FooterComponent implements Component {
 	}
 
 	/**
+	 * Issue one async jj label load, dropping superseded completions by
+	 * launch generation. Shared by the cache-miss path and the fallback
+	 * re-probe; never issues while another load is in flight.
+	 */
+	#requestJjLabel(repository: VcsRepo): void {
+		if (this.#branchResolve) return;
+		const request = new AbortController();
+		const generation = this.#branchGeneration;
+		this.#branchResolve = request;
+		void repository
+			.label(request.signal)
+			.then(label => {
+				if (this.#disposed || this.#branchGeneration !== generation) return;
+				this.#releaseFallbackWatch();
+				const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
+				const changed = this.#cachedBranch !== clean;
+				this.#cachedBranch = clean;
+				if (changed) this.#onBranchChange?.();
+			})
+			.catch(() => {
+				if (this.#disposed || this.#branchGeneration !== generation) return;
+				const fallback = this.#gitFallback(repository);
+				const changed = this.#cachedBranch !== fallback.branch;
+				this.#cachedBranch = fallback.branch;
+				this.#watchFallback(fallback.repo);
+				if (changed) this.#onBranchChange?.();
+			})
+			.finally(() => {
+				if (this.#branchResolve === request) this.#branchResolve = undefined;
+			});
+	}
+	/**
 	 * Get the current branch, bookmark, or change-id label.
 	 */
 	#getCurrentBranch(): string | null {
@@ -242,30 +281,7 @@ export class FooterComponent implements Component {
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
 			if (!this.#branchResolve) {
-				const request = new AbortController();
-				const generation = this.#branchGeneration;
-				this.#branchResolve = request;
-				void repository
-					.label(request.signal)
-					.then(label => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						this.#releaseFallbackWatch();
-						const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
-						const changed = this.#cachedBranch !== clean;
-						this.#cachedBranch = clean;
-						if (changed) this.#onBranchChange?.();
-					})
-					.catch(() => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						const fallback = this.#gitFallback(repository);
-						const changed = this.#cachedBranch !== fallback.branch;
-						this.#cachedBranch = fallback.branch;
-						this.#watchFallback(fallback.repo);
-						if (changed) this.#onBranchChange?.();
-					})
-					.finally(() => {
-						if (this.#branchResolve === request) this.#branchResolve = undefined;
-					});
+				this.#requestJjLabel(repository);
 			}
 			return this.#cachedBranch ?? null;
 		}

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -1,5 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { type Component, padding, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
@@ -18,6 +19,10 @@ export class FooterComponent implements Component {
 	#branchResolve: AbortController | undefined;
 	#branchGeneration = 0;
 	#gitUnwatch: (() => void) | null = null;
+
+	// Watch target the installed watcher follows; when the display backend
+	// changes under it (late colocation), the watcher is rebound.
+	#watchedTarget: string | null = null;
 	#onBranchChange: (() => void) | null = null;
 	#disposed = false;
 	#autoCompactEnabled: boolean = true;
@@ -61,12 +66,30 @@ export class FooterComponent implements Component {
 		if (!repository) return;
 
 		try {
+			this.#watchedTarget = repository.watchTarget();
 			this.#gitUnwatch = vcs.watch(repository, () => {
 				this.#invalidateBranch();
 				this.#onBranchChange?.();
 			});
 		} catch {
 			// Silently fail if we can't watch
+		}
+	}
+
+	// Rebind the watcher when the display backend changed under it (late
+	// colocation): without this, jj-only label changes never clear the
+	// cached git branch, which has no polling TTL.
+	#rebindWatcherIfTargetChanged(repository: VcsRepo): void {
+		if (!this.#gitUnwatch) return;
+		let target: string | null;
+		try {
+			target = repository.watchTarget();
+		} catch {
+			return;
+		}
+		if (target !== this.#watchedTarget) {
+			this.#setupGitWatcher();
+			this.#invalidateBranch();
 		}
 	}
 
@@ -97,10 +120,6 @@ export class FooterComponent implements Component {
 	 */
 	#getCurrentBranch(): string | null {
 		if (!settings.get("git.enabled")) return null;
-		if (this.#cachedBranch !== undefined) {
-			return this.#cachedBranch;
-		}
-
 		const repository = (() => {
 			try {
 				return vcs.repoForDisplay(getProjectDir());
@@ -112,7 +131,10 @@ export class FooterComponent implements Component {
 			this.#cachedBranch = null;
 			return null;
 		}
-
+		this.#rebindWatcherIfTargetChanged(repository);
+		if (this.#cachedBranch !== undefined) {
+			return this.#cachedBranch;
+		}
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
 			if (!this.#branchResolve) {

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -11,6 +11,9 @@ import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
+/** Minimum interval between watcher-install attempts for one target. */
+const FOOTER_WATCH_RETRY_TTL_MS = 5000;
+
 /**
  * Footer component that shows pwd, token stats, and context usage
  */
@@ -23,6 +26,11 @@ export class FooterComponent implements Component {
 	// Watch target the installed watcher follows; when the display backend
 	// changes under it (late colocation), the watcher is rebound.
 	#watchedTarget: string | null = null;
+
+	// Last watcher-install attempt, bounding retries for a persistently
+	// failing target (see rebind below).
+	#watchAttemptTarget: string | null = null;
+	#watchAttemptAt = 0;
 	#onBranchChange: (() => void) | null = null;
 	#disposed = false;
 	#autoCompactEnabled: boolean = true;
@@ -66,11 +74,13 @@ export class FooterComponent implements Component {
 		if (!repository) return;
 
 		try {
-			this.#watchedTarget = repository.watchTarget();
-			this.#gitUnwatch = vcs.watch(repository, () => {
+			const target = repository.watchTarget();
+			const unwatch = vcs.watch(repository, () => {
 				this.#invalidateBranch();
 				this.#onBranchChange?.();
 			});
+			this.#gitUnwatch = unwatch;
+			this.#watchedTarget = target;
 		} catch {
 			// Silently fail if we can't watch
 		}
@@ -80,18 +90,22 @@ export class FooterComponent implements Component {
 	// colocation): without this, jj-only label changes never clear the
 	// cached git branch, which has no polling TTL.
 	#rebindWatcherIfTargetChanged(repository: VcsRepo): void {
-		if (!this.#gitUnwatch) return;
 		let target: string | null;
 		try {
 			target = repository.watchTarget();
 		} catch {
 			return;
 		}
-		if (target === this.#watchedTarget) return;
+		if (target === this.#watchedTarget && this.#gitUnwatch) return;
+		// Retry a failed install past the TTL, and handle the initial
+		// no-watcher case explicitly: without this bound the check below
+		// would attempt every render while broken.
+		const now = Date.now();
+		if (target === this.#watchAttemptTarget && now - this.#watchAttemptAt < FOOTER_WATCH_RETRY_TTL_MS) return;
+		this.#watchAttemptTarget = target;
+		this.#watchAttemptAt = now;
 		// Install before disposing: a failed replacement keeps existing
-		// coverage instead of leaving none. The attempt is recorded per
-		// target value, so a persistently failing install does not retry
-		// every render; the next target move tries again.
+		// coverage instead of leaving none.
 		try {
 			const unwatch = vcs.watch(repository, () => {
 				this.#invalidateBranch();
@@ -99,10 +113,10 @@ export class FooterComponent implements Component {
 			});
 			this.#gitUnwatch?.();
 			this.#gitUnwatch = unwatch;
+			this.#watchedTarget = target;
 		} catch {
 			// Silently fail if we can't watch
 		}
-		this.#watchedTarget = target;
 		this.#invalidateBranch();
 	}
 

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -100,7 +100,17 @@ export class FooterComponent implements Component {
 		} catch {
 			return;
 		}
-		if (!repository) return;
+		if (!repository) {
+			// No repository: drop stale branch/watcher state rather than
+			// retaining the previous backend's label and coverage.
+			if (this.#cachedBranch !== undefined || this.#gitUnwatch || this.#branchResolve) {
+				this.#gitUnwatch?.();
+				this.#gitUnwatch = null;
+				this.#watchedTarget = null;
+				this.#invalidateBranch();
+			}
+			return;
+		}
 		let target: string | null;
 		try {
 			target = repository.watchTarget();

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -536,6 +536,8 @@ export class StatusLineComponent implements Component {
 	#prLookupInFlight = false;
 	#defaultBranch?: string;
 	#defaultBranchCwd: string | undefined = undefined;
+	#defaultBranchRepoId: string | null | undefined = undefined;
+	#defaultBranchGeneration = 0;
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
 
@@ -666,10 +668,23 @@ export class StatusLineComponent implements Component {
 		cache.displayRepositoryCheckedAt = now;
 		if (cache.displayRepository && prevTarget !== displayWatchTarget(cache.displayRepository)) {
 			// The backend or head target changed (late colocation,
-			// late-appearing repo, redirected `.git`): rebuild both targets
-			// so jj-only changes invalidate from now on, and drop the
-			// previous backend's cached branch/PR state — the new watcher
-			// only reports future moves, never the current one.
+			// late-appearing repo, redirected `.git`): the operational handle
+			// snapshots git_dir/head_path at discovery, so re-discover it
+			// before rebuilding watchers — otherwise PR/status keep querying
+			// the old repo. Then drop the previous backend's cached
+			// branch/PR/default-branch state (bumping the generation so an
+			// in-flight default-branch lookup cannot repopulate it); a fresh
+			// watcher only reports future moves, never the current one.
+			try {
+				cache.repository = vcs.repo(cache.effectiveGitCwd);
+				cache.repositoryCheckedAt = now;
+			} catch {
+				// Keep the stale handle; the next change retries.
+			}
+			this.#defaultBranch = undefined;
+			this.#defaultBranchCwd = undefined;
+			this.#defaultBranchRepoId = undefined;
+			this.#defaultBranchGeneration++;
 			this.#setupGitWatcher();
 			this.invalidateGitCaches();
 		}
@@ -1275,18 +1290,20 @@ export class StatusLineComponent implements Component {
 		return this.#cachedBranch ?? null;
 	}
 
-	#isDefaultBranch(branch: string, effectiveGitCwd: string): boolean {
-		if (this.#defaultBranchCwd !== effectiveGitCwd) {
+	#isDefaultBranch(branch: string, effectiveGitCwd: string, repoId: string | null): boolean {
+		if (this.#defaultBranchCwd !== effectiveGitCwd || this.#defaultBranchRepoId !== repoId) {
 			this.#defaultBranch = undefined;
 			this.#defaultBranchCwd = effectiveGitCwd;
+			this.#defaultBranchRepoId = repoId;
 		}
 
 		if (this.#defaultBranch === undefined) {
 			this.#defaultBranch = "main";
 			const lookupCwd = effectiveGitCwd;
+			const generation = this.#defaultBranchGeneration;
 			(async () => {
 				const resolved = await vcs.git(lookupCwd)?.defaultBranch();
-				if (this.#disposed || this.#defaultBranchCwd !== lookupCwd) return;
+				if (this.#disposed || this.#defaultBranchCwd !== lookupCwd || this.#defaultBranchGeneration !== generation) return;
 				if (resolved) {
 					this.#defaultBranch = resolved;
 					if (this.#onBranchChange) {
@@ -1387,8 +1404,9 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		if (this.#resolveRepository(activeRepoCache)?.kind() !== "git") return null;
-		const branch = this.#getBranchLabel(activeRepoCache, this.#resolveRepository(activeRepoCache));
+		const operational = this.#resolveRepository(activeRepoCache);
+		if (operational?.kind() !== "git") return null;
+		const branch = this.#getBranchLabel(activeRepoCache, operational);
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 
 		if (canReuseCachedPr(this.#cachedPr, this.#cachedPrContext, currentContext)) {
@@ -1404,7 +1422,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		// Don't look up if detached, default branch, or already in flight.
-		if (branch === "detached" || this.#isDefaultBranch(branch, gitCwd) || this.#prLookupInFlight) {
+		if (branch === "detached" || this.#isDefaultBranch(branch, gitCwd, displayWatchTarget(operational)) || this.#prLookupInFlight) {
 			return stalePr ?? null;
 		}
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
@@ -278,6 +279,17 @@ function displayWatchTarget(repository: VcsRepo | null): string | null {
 	}
 }
 
+/**
+ * Whether the workspace behind a cached display handle still exists,
+ * probed through its head watch target (one stat, no repository walk).
+ */
+function displayWatchTargetAlive(repository: VcsRepo): boolean {
+	try {
+		return existsSync(repository.watchTarget());
+	} catch {
+		return false;
+	}
+}
 /**
  * Project + worktree-dir names when `cwd` is a linked git worktree, else null.
  * The project name comes from the shared primary checkout; bare-repo worktrees
@@ -601,7 +613,7 @@ export class StatusLineComponent implements Component {
 			// the cache without a render-path walk.
 			const fresh = now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS;
 			const stable = cache.displayRepository.kind() !== "git" || cache.repository?.kind() !== "git";
-			if (fresh || stable) return cache.displayRepository;
+			if (fresh || (stable && displayWatchTargetAlive(cache.displayRepository))) return cache.displayRepository;
 		} else if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) {
 			return null;
 		}
@@ -1114,8 +1126,12 @@ export class StatusLineComponent implements Component {
 			(async () => {
 				let next: string | null = null;
 				try {
-					next =
+					const raw =
 						(await repository.label(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
+					// Repository-controlled jj metadata can carry control
+					// characters; sanitize at the cache boundary (the git segment
+					// renders the label verbatim).
+					next = raw === null ? null : sanitizeStatusText(raw);
 				} catch {
 					next = null;
 				} finally {
@@ -1238,6 +1254,7 @@ export class StatusLineComponent implements Component {
 		unstaged: number;
 		untracked: number;
 	} | null {
+
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
@@ -1246,10 +1263,12 @@ export class StatusLineComponent implements Component {
 		// Colocated workspaces present the jj label, but status counts come
 		// from the operational git status: the jj status path reads the last
 		// snapshotted commit and misses live working-copy edits until the next
-		// jj operation, while snapshotting from render is off the table. (A jj
-		// display paired with a git operational repo implies equal roots.)
+		// jj operation, while snapshotting from render is off the table.
+		// Equal roots mean colocation; with different roots the jj workspace
+		// is nested inside a stale cached git repo and keeps pure-jj behavior.
 		const operational = display.kind() === "jj" ? this.#resolveRepository(activeRepoCache) : null;
-		const repository = operational?.kind() === "git" ? operational : display;
+		const colocated = operational?.kind() === "git" && operational.root() === display.root();
+		const repository = colocated ? operational : display;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
 				return this.#cachedJjStatus;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -720,14 +720,32 @@ export class StatusLineComponent implements Component {
 		}
 		const prevTarget = displayWatchTarget(cache.displayRepository);
 		let display: VcsRepo | null;
+		let discoveryFailed = false;
 		try {
 			display = vcs.repoForDisplay(cache.effectiveGitCwd);
 		} catch {
 			display = null;
+			discoveryFailed = true;
 		}
-		cache.displayRepository = display ?? cache.repository;
+		if (display) {
+			cache.displayRepository = display;
+		} else if (discoveryFailed || !cache.displayRepository) {
+			// Discovery threw (transient I/O), or this is the first
+			// resolution: keep the stale handle, falling back to
+			// operational. A transient failure must not read as removal.
+			cache.displayRepository ??= cache.repository;
+		} else {
+			// Authoritative null rediscovery: confirm through the operational
+			// detector before dropping the stale handle. A lone display blip
+			// while operational still resolves (racing mutation, skewed
+			// detectors) keeps today's behavior; only agreement means
+			// removal, and the target change below then invalidates caches
+			// and rebuilds watchers.
+			this.#refreshOperational(cache);
+			if (!cache.repository) cache.displayRepository = null;
+		}
 		cache.displayRepositoryCheckedAt = now;
-		if (cache.displayRepository && prevTarget !== displayWatchTarget(cache.displayRepository)) {
+		if ((cache.displayRepository || prevTarget) && prevTarget !== displayWatchTarget(cache.displayRepository)) {
 			// The backend or head target changed (late colocation,
 			// late-appearing repo, redirected `.git`): refresh the operational
 			// handle too — it snapshots git_dir/head_path at discovery — then

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -868,9 +868,10 @@ export class StatusLineComponent implements Component {
 		// branch/PR cache instead of leaving it on the old branch.
 		const operationalForWatch = this.#resolveRepository(activeRepoCache);
 		if (operationalForWatch && operationalForWatch.kind() === "git") {
-			const operationalGitRoot = operationalForWatch.root();
-			const displayGitRoot = repository.kind() === "git" ? repository.root() : null;
-			if (operationalGitRoot !== displayGitRoot) {
+			// Dedupe by watched target, not root: same-root handles can still
+			// follow different head targets, and dropping .git/HEAD coverage
+			// would blind the git branch/PR cache.
+			if (displayWatchTarget(operationalForWatch) !== displayWatchTarget(repository)) {
 				try {
 					const unwatchOperational = vcs.watch(operationalForWatch, () => {
 						if (this.#disposed || this.#operationalGitUnwatch !== unwatchOperational) return;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -613,7 +613,13 @@ export class StatusLineComponent implements Component {
 			// the cache without a render-path walk.
 			const fresh = now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS;
 			const stable = cache.displayRepository.kind() !== "git" || cache.repository?.kind() !== "git";
-			if (fresh || (stable && displayWatchTargetAlive(cache.displayRepository))) return cache.displayRepository;
+			if (fresh) return cache.displayRepository;
+			// A live workspace needs no walk, but the timestamp must still
+			// advance — otherwise every render past the TTL stats again.
+			if (stable && displayWatchTargetAlive(cache.displayRepository)) {
+				cache.displayRepositoryCheckedAt = now;
+				return cache.displayRepository;
+			}
 		} else if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) {
 			return null;
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -26,7 +26,7 @@ import { withTimeoutSignal } from "../../../utils/fetch-timeout";
 import { GH_COMMAND_TIMEOUT_MS, github } from "../../../utils/github";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { calculateTokensPerSecond } from "../../../utils/token-rate";
-import { sanitizeStatusText } from "../../shared";
+import { isTransientVcsError, sanitizeStatusText } from "../../shared";
 import { theme } from "../../theme/theme";
 import { type CompactionBoundaries, computeCompactionBoundaries } from "../../utils/context-usage";
 import {
@@ -1287,8 +1287,7 @@ export class StatusLineComponent implements Component {
 	 */
 	#jjLabelLoadFailed(activeRepoCache: ActiveRepoCache, repository: VcsRepo, generation: number, error: unknown): void {
 		if (this.#disposed || this.#jjCacheGeneration !== generation) return;
-		const name = (error as { name?: unknown } | null)?.name;
-		if (name === "AbortError" || name === "TimeoutError") return;
+		if (isTransientVcsError(error)) return;
 		const target = displayWatchTarget(repository);
 		if (target === null || !this.#colocatedGitRepo(activeRepoCache, repository)) return;
 		if (this.#jjLabelFailedTarget === target) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -562,6 +562,11 @@ export class StatusLineComponent implements Component {
 	#cachedPr: { number: number; url: string } | null | undefined = undefined;
 	#cachedPrContext: PrCacheContext | undefined = undefined;
 	#prLookupInFlight = false;
+	// Generation of the in-flight PR lookup's repository. Bumped on every
+	// repository-target change so a superseded lookup can neither block the
+	// new repository's slot nor commit its result. Mirrors
+	// #defaultBranchGeneration / #branchCacheGeneration.
+	#prLookupGeneration = 0;
 	#defaultBranch?: string;
 	#defaultBranchCwd: string | undefined = undefined;
 	#defaultBranchRepoId: string | null | undefined = undefined;
@@ -757,9 +762,16 @@ export class StatusLineComponent implements Component {
 		this.#defaultBranchCwd = undefined;
 		this.#defaultBranchRepoId = undefined;
 		this.#defaultBranchGeneration++;
+		this.#prLookupGeneration++;
 		this.#setupGitWatcher();
 		this.invalidateGitCaches();
 		this.#cachedPr = null;
+		// Retire a superseded lookup's slot: its `github.run` may stay pending
+		// up to GH_COMMAND_TIMEOUT_MS, and the new repository must start its
+		// own lookup immediately. The stale completion is dropped by the
+		// generation check in `#lookupPr`, and its finally-block no longer
+		// clears a slot it no longer owns.
+		this.#prLookupInFlight = false;
 		this.#gitStatusInFlight = undefined;
 		this.#cachedGitStatus = null;
 		this.#cachedGitStatusCwd = undefined;
@@ -1517,6 +1529,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		this.#prLookupInFlight = true;
+		const lookupGeneration = this.#prLookupGeneration;
 		const lookupContext = currentContext;
 		const lookupCwd = gitCwd;
 
@@ -1524,6 +1537,7 @@ export class StatusLineComponent implements Component {
 		(async () => {
 			// Helper: only write cache if branch/repo context hasn't changed since launch
 			const setCachedPr = (value: { number: number; url: string } | null) => {
+				if (lookupGeneration !== this.#prLookupGeneration) return;
 				const latestActiveRepoCache = this.#resolveActiveRepoCache();
 				if (latestActiveRepoCache.effectiveGitCwd !== lookupCwd) return;
 				const latestBranch = this.#getBranchLabel(
@@ -1564,7 +1578,7 @@ export class StatusLineComponent implements Component {
 				if (this.#disposed) return;
 				setCachedPr(null);
 			} finally {
-				this.#prLookupInFlight = false;
+				if (this.#prLookupGeneration === lookupGeneration) this.#prLookupInFlight = false;
 				if (!this.#disposed && this.#onBranchChange) {
 					this.#onBranchChange();
 				}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -244,6 +244,8 @@ interface ActiveRepoCache {
 	displayRepository: VcsRepo | null;
 	displayRepositoryCheckedAt: number;
 	repositoryCheckedAt: number;
+	/** Operational re-discovery failed mid-rebind; retry through the accessor. */
+	operationalRefreshNeeded: boolean;
 	/** Project + worktree dir name when `projectDir` is a linked worktree, else null. */
 	worktree: WorktreeContext | null;
 }
@@ -426,6 +428,7 @@ export class StatusLineComponent implements Component {
 	#cachedBranch: string | null | undefined = undefined;
 	#cachedBranchRepoId: string | null | undefined = undefined;
 	#cachedBranchCwd: string | undefined = undefined;
+	#cachedBranchTarget: string | null | undefined = undefined;
 	// In-flight reftable resolve slot. Ownership is the launch id, not the cwd:
 	// two live resolves can share a cwd string across an invalidation, and a
 	// stale one must never free (or poison) a slot it no longer owns.
@@ -624,17 +627,24 @@ export class StatusLineComponent implements Component {
 			displayRepository,
 			displayRepositoryCheckedAt: Date.now(),
 			repositoryCheckedAt: Date.now(),
+			operationalRefreshNeeded: false,
 			worktree,
 		};
 		return this.#activeRepoCache;
 	}
 
 	#resolveRepository(cache: ActiveRepoCache): VcsRepo | null {
-		if (cache.repository) return cache.repository;
+		if (cache.repository && !cache.operationalRefreshNeeded) return cache.repository;
 		const now = Date.now();
-		if (now - cache.repositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return null;
-		cache.repository = vcs.repo(cache.effectiveGitCwd);
-		cache.repositoryCheckedAt = now;
+		if (now - cache.repositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return cache.repository;
+		try {
+			cache.repository = vcs.repo(cache.effectiveGitCwd);
+			cache.repositoryCheckedAt = now;
+			cache.operationalRefreshNeeded = false;
+		} catch {
+			// Keep the stale handle (or null); the next window retries.
+			cache.repositoryCheckedAt = now;
+		}
 		return cache.repository;
 	}
 
@@ -678,8 +688,10 @@ export class StatusLineComponent implements Component {
 			try {
 				cache.repository = vcs.repo(cache.effectiveGitCwd);
 				cache.repositoryCheckedAt = now;
+				cache.operationalRefreshNeeded = false;
 			} catch {
-				// Keep the stale handle; the next change retries.
+				// Keep the stale handle; the accessor retries it on a cadence.
+				cache.operationalRefreshNeeded = true;
 			}
 			this.#defaultBranch = undefined;
 			this.#defaultBranchCwd = undefined;
@@ -1125,6 +1137,7 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranch = undefined;
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedBranchCwd = undefined;
+		this.#cachedBranchTarget = undefined;
 		// Abort before releasing the in-flight slot. Releasing alone would allow
 		// repeated invalidations to fan out still-running git subprocesses.
 		this.#branchResolveActive?.controller.abort();
@@ -1209,10 +1222,19 @@ export class StatusLineComponent implements Component {
 			})();
 			return this.#cachedJjBranch;
 		}
+		// The branch cache is keyed by watch target as well as cwd: display
+		// and operational reads can resolve different repos for one cwd
+		// after a redirect, and must never serve each other's labels.
+		const branchTarget = displayWatchTarget(repository);
 		const fallbackCacheExpired =
 			this.#gitWatcherUnavailable &&
 			(this.#branchLastFetch === undefined || Date.now() - this.#branchLastFetch >= WATCHER_FAILURE_POLL_TTL_MS);
-		if (this.#cachedBranch !== undefined && this.#cachedBranchCwd === gitCwd && !fallbackCacheExpired) {
+		if (
+			this.#cachedBranch !== undefined &&
+			this.#cachedBranchCwd === gitCwd &&
+			this.#cachedBranchTarget === branchTarget &&
+			!fallbackCacheExpired
+		) {
 			return this.#cachedBranch;
 		}
 
@@ -1224,7 +1246,9 @@ export class StatusLineComponent implements Component {
 		const repoInfo = vcs.gitInfo(gitCwd);
 		if (repoInfo?.isReftable) {
 			if (this.#branchResolveActive !== undefined) {
-				return this.#branchResolveActive.cwd === gitCwd && this.#cachedBranchCwd === gitCwd
+				return this.#branchResolveActive.cwd === gitCwd &&
+					this.#cachedBranchCwd === gitCwd &&
+					this.#cachedBranchTarget === branchTarget
 					? (this.#cachedBranch ?? null)
 					: null;
 			}
@@ -1263,6 +1287,7 @@ export class StatusLineComponent implements Component {
 				const prev = this.#cachedBranchCwd === gitCwd ? this.#cachedBranch : undefined;
 				this.#cachedBranchCwd = gitCwd;
 				this.#cachedBranchRepoId = repoId;
+				this.#cachedBranchTarget = branchTarget;
 				this.#cachedBranch = next;
 				this.#branchLastFetch = Date.now();
 				if (prev !== next && this.#onBranchChange) this.#onBranchChange();
@@ -1281,6 +1306,7 @@ export class StatusLineComponent implements Component {
 		const gitHeadPath = repoInfo?.headPath ?? null;
 		this.#cachedBranchCwd = gitCwd;
 		this.#cachedBranchRepoId = gitHeadPath;
+		this.#cachedBranchTarget = branchTarget;
 		this.#branchLastFetch = Date.now();
 		if (!head) {
 			this.#cachedBranch = null;
@@ -2037,6 +2063,7 @@ export class StatusLineComponent implements Component {
 					displayRepository: null,
 					displayRepositoryCheckedAt: Date.now(),
 					repositoryCheckedAt: Date.now(),
+					operationalRefreshNeeded: false,
 					worktree: null,
 				};
 		const gitBranch = includeGit || includePr ? this.#getBranchLabel(activeRepoCache) : null;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -5,7 +5,7 @@ import {
 	getAntigravityCounterKeyForModel,
 	scopeAntigravityLimitsForModel,
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
-import type { VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -33,7 +33,13 @@ import {
 	type CodexResetUsageSnapshot,
 	detectCodexResetFireworks,
 } from "../codex-reset-fireworks";
-import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
+import {
+	canReuseCachedPr,
+	colocatedJjWorkspace,
+	createPrCacheContext,
+	isSamePrCacheContext,
+	type PrCacheContext,
+} from "./git-utils";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -1027,6 +1033,13 @@ export class StatusLineComponent implements Component {
 			})();
 			return this.#cachedJjBranch;
 		}
+		// Colocated jj-git checkout: jj owns the working-copy label even though
+		// `detect()` resolves the directory to Git. The predicate is root
+		// equality (see colocatedJjWorkspace), independent of git HEAD state.
+		const colocatedJj = colocatedJjWorkspace(gitCwd, repository);
+		if (colocatedJj) {
+			return this.#colocatedJjBranchLabel(gitCwd, colocatedJj);
+		}
 
 		const fallbackCacheExpired =
 			this.#gitWatcherUnavailable &&
@@ -1107,6 +1120,52 @@ export class StatusLineComponent implements Component {
 		}
 		this.#cachedBranch = head.kind === "ref" ? (head.branch ?? head.refName ?? "HEAD") : "detached";
 		return this.#cachedBranch ?? null;
+	}
+
+	/**
+	 * Working-copy label for a colocated jj-git checkout.
+	 *
+	 * Mirrors the pure-jj fetch above (same throttle state, same invalidation
+	 * lifecycle): the render path never blocks, the first paint returns the
+	 * cached label, and the resolve requests a repaint on change. The result
+	 * is mirrored into the git-branch cache so PR and default-branch lookups
+	 * follow the displayed jj bookmark.
+	 */
+	#colocatedJjBranchLabel(gitCwd: string, jj: VcsJjWorkspace): string | null {
+		if (this.#jjBranchActive || Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS) {
+			return this.#cachedJjBranch;
+		}
+		const request: JjResolveRequest = {
+			id: ++this.#jjResolveSeq,
+			controller: new AbortController(),
+		};
+		this.#jjBranchActive = request;
+		const generation = this.#jjCacheGeneration;
+		(async () => {
+			let next: string | null = null;
+			try {
+				next =
+					(await jj.workingCopyLabel(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
+			} catch {
+				next = null;
+			} finally {
+				if (this.#jjBranchActive?.id === request.id) this.#jjBranchActive = undefined;
+				if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
+			}
+			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
+			const changed = next !== this.#cachedJjBranch;
+			this.#cachedJjBranch = next;
+			this.#cachedBranchCwd = gitCwd;
+			try {
+				this.#cachedBranchRepoId = vcs.gitInfo(gitCwd)?.headPath ?? null;
+			} catch {
+				this.#cachedBranchRepoId = null;
+			}
+			this.#cachedBranch = next;
+			this.#branchLastFetch = Date.now();
+			if (changed) this.#onBranchChange?.();
+		})();
+		return this.#cachedJjBranch;
 	}
 
 	#isDefaultBranch(branch: string, effectiveGitCwd: string): boolean {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -674,18 +674,8 @@ export class StatusLineComponent implements Component {
 		const now = Date.now();
 		if (now - cache.repositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return cache.repository;
 		try {
-			const prevTarget = displayWatchTarget(cache.repository);
-			cache.repository = vcs.repo(cache.effectiveGitCwd);
-			cache.repositoryCheckedAt = now;
-			cache.operationalRefreshNeeded = false;
-			if (prevTarget !== displayWatchTarget(cache.repository)) {
-				// Operational identity changed outside a display rebind:
-				// drop default-branch state so a stale in-flight lookup
-				// cannot repopulate it.
-			this.#defaultBranch = undefined;
-			this.#defaultBranchCwd = undefined;
-			this.#defaultBranchRepoId = undefined;
-			this.#defaultBranchGeneration++;
+			if (this.#refreshOperational(cache)) {
+				this.#handleRepositoryTargetChanged();
 			}
 		} catch {
 			// Keep the stale handle (or null); the next window retries.
@@ -706,6 +696,12 @@ export class StatusLineComponent implements Component {
 			if (fresh) return cache.displayRepository;
 			// A live workspace needs no walk, but the timestamp must still
 			// advance — otherwise every render past the TTL stats again.
+			// The operational handle is revalidated here as well: it snapshots
+			// git_dir/head_path at discovery and can move under a stable
+			// display (colocated git redirect with untouched jj).
+			if (stable && cache.displayRepository.kind() === "jj" && this.#refreshOperational(cache)) {
+				this.#handleRepositoryTargetChanged();
+			}
 			if (
 				stable &&
 				!(cache.displayRepository.kind() === "jj" &&
@@ -729,42 +725,56 @@ export class StatusLineComponent implements Component {
 		cache.displayRepositoryCheckedAt = now;
 		if (cache.displayRepository && prevTarget !== displayWatchTarget(cache.displayRepository)) {
 			// The backend or head target changed (late colocation,
-			// late-appearing repo, redirected `.git`): the operational handle
-			// snapshots git_dir/head_path at discovery, so re-discover it
-			// before rebuilding watchers — otherwise PR/status keep querying
-			// the old repo. Then drop the previous backend's cached
-			// branch/PR/default-branch state (bumping the generation so an
-			// in-flight default-branch lookup cannot repopulate it); a fresh
-			// watcher only reports future moves, never the current one.
-			try {
-				cache.repository = vcs.repo(cache.effectiveGitCwd);
-				cache.repositoryCheckedAt = now;
-				cache.operationalRefreshNeeded = false;
-			} catch {
-				// Keep the stale handle; the accessor retries it on a cadence.
-				cache.operationalRefreshNeeded = true;
-			}
-			this.#defaultBranch = undefined;
-			this.#defaultBranchCwd = undefined;
-			this.#defaultBranchRepoId = undefined;
-			this.#defaultBranchGeneration++;
-			this.#setupGitWatcher();
-			// The PR payload itself (not just its context) belongs to the old
-			// repo: on a default branch no replacement lookup ever runs, so
-			// retaining it would display it indefinitely. Generic activity
-			// invalidation deliberately keeps stale-visible until resolved.
-			this.#cachedPr = null;
-			// Git status requests/cache are keyed by cwd alone: drop them here
-			// or the old repo's pending completion publishes A's counts for B
-			// (or blocks B while hung). Ordinary HEAD moves keep the 1s-stale
-			// cache; only a target change resets.
-			this.#gitStatusInFlight = undefined;
-			this.#cachedGitStatus = null;
-			this.#cachedGitStatusCwd = undefined;
-			this.#gitStatusLastFetch = 0;
-			this.invalidateGitCaches();
+			// late-appearing repo, redirected `.git`): refresh the operational
+			// handle too — it snapshots git_dir/head_path at discovery — then
+			// drop the previous backend's cached state and rebuild watchers.
+			// A fresh watcher only reports future moves, never the current one.
+			this.#refreshOperational(cache);
+			this.#handleRepositoryTargetChanged();
 		}
 		return cache.displayRepository;
+	}
+
+	/**
+	 * Re-resolve the operational handle, reporting identity change.
+	 * GitRepo snapshots git_dir/head_path at discovery, so a same-cwd
+	 * redirect strands PR/status/watchers on the old repo unless something
+	 * re-checks. Failures keep the stale handle and flag a retry; success
+	 * clears the flag. Callers gate frequency (TTL windows). Never throws.
+	 */
+	#refreshOperational(cache: ActiveRepoCache): boolean {
+		let prevTarget: string | null = null;
+		try {
+			prevTarget = displayWatchTarget(cache.repository);
+			const fresh = vcs.repo(cache.effectiveGitCwd);
+			cache.repository = fresh;
+			cache.repositoryCheckedAt = Date.now();
+			cache.operationalRefreshNeeded = false;
+		} catch {
+			cache.repositoryCheckedAt = Date.now();
+			cache.operationalRefreshNeeded = true;
+			return false;
+		}
+		return prevTarget !== displayWatchTarget(cache.repository);
+	}
+
+	/**
+	 * Applied when display or operational identity moved: drop all
+	 * backend-derived caches (branch/PR/default/status), bump generations so
+	 * in-flight work cannot repopulate them, and rebuild both watchers.
+	 */
+	#handleRepositoryTargetChanged(): void {
+		this.#defaultBranch = undefined;
+		this.#defaultBranchCwd = undefined;
+		this.#defaultBranchRepoId = undefined;
+		this.#defaultBranchGeneration++;
+		this.#setupGitWatcher();
+		this.invalidateGitCaches();
+		this.#cachedPr = null;
+		this.#gitStatusInFlight = undefined;
+		this.#cachedGitStatus = null;
+		this.#cachedGitStatusCwd = undefined;
+		this.#gitStatusLastFetch = 0;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -280,12 +280,15 @@ function displayWatchTarget(repository: VcsRepo | null): string | null {
 }
 
 /**
- * Whether the workspace behind a cached display handle still exists,
- * probed through its head watch target (one stat, no repository walk).
+ * Whether the workspace behind a cached display handle still exists: the
+ * local `.jj` marker must be present as well as the shared head watch
+ * target (two stats, no repository walk). Linked workspaces keep only an
+ * indirection locally while the shared target outlives them, so the target
+ * alone cannot prove the workspace is still there.
  */
-function displayWatchTargetAlive(repository: VcsRepo): boolean {
+function displayWorkspaceAlive(repository: VcsRepo): boolean {
 	try {
-		return fs.existsSync(repository.watchTarget());
+		return fs.existsSync(path.join(repository.root(), ".jj")) && fs.existsSync(repository.watchTarget());
 	} catch {
 		return false;
 	}
@@ -621,7 +624,7 @@ export class StatusLineComponent implements Component {
 			if (fresh) return cache.displayRepository;
 			// A live workspace needs no walk, but the timestamp must still
 			// advance — otherwise every render past the TTL stats again.
-			if (stable && displayWatchTargetAlive(cache.displayRepository)) {
+			if (stable && displayWorkspaceAlive(cache.displayRepository)) {
 				cache.displayRepositoryCheckedAt = now;
 				return cache.displayRepository;
 			}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -5,7 +5,7 @@ import {
 	getAntigravityCounterKeyForModel,
 	scopeAntigravityLimitsForModel,
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
-import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -33,13 +33,7 @@ import {
 	type CodexResetUsageSnapshot,
 	detectCodexResetFireworks,
 } from "../codex-reset-fireworks";
-import {
-	canReuseCachedPr,
-	colocatedJjWorkspace,
-	createPrCacheContext,
-	isSamePrCacheContext,
-	type PrCacheContext,
-} from "./git-utils";
+import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -246,6 +240,8 @@ interface ActiveRepoCache {
 	activeRepo: ActiveRepoContext | null;
 	effectiveGitCwd: string;
 	repository: VcsRepo | null;
+	displayRepository: VcsRepo | null;
+	displayRepositoryCheckedAt: number;
 	repositoryCheckedAt: number;
 	/** Project + worktree dir name when `projectDir` is a linked worktree, else null. */
 	worktree: WorktreeContext | null;
@@ -540,6 +536,18 @@ export class StatusLineComponent implements Component {
 		const activeRepo = projectRepository ? null : resolveActiveRepoContextSync(projectDir);
 		const effectiveGitCwd = activeRepo?.repoRoot ?? projectDir;
 		const repository = projectRepository ?? (activeRepo ? vcs.repo(effectiveGitCwd) : null);
+		// Presentation follows a second detector whose only policy difference
+		// is preferring jj on equal-root ties (see detect_for_display);
+		// automation keeps `repository` above. A failed display lookup (or a
+		// caller that only stubs the operational detector) degrades to the
+		// operational repository rather than hiding the segment.
+		let displayRepository: VcsRepo | null;
+		try {
+			displayRepository = vcs.repoForDisplay(effectiveGitCwd);
+		} catch {
+			displayRepository = null;
+		}
+		displayRepository ??= repository;
 		// Only collapse the bare-cwd case: a single-direct-child-repo context
 		// (activeRepo set) renders `<parent> ↳ <child>`, which we leave intact.
 		const worktree = activeRepo ? null : resolveWorktreeContext(effectiveGitCwd);
@@ -548,6 +556,8 @@ export class StatusLineComponent implements Component {
 			activeRepo,
 			effectiveGitCwd,
 			repository,
+			displayRepository,
+			displayRepositoryCheckedAt: Date.now(),
 			repositoryCheckedAt: Date.now(),
 			worktree,
 		};
@@ -561,6 +571,21 @@ export class StatusLineComponent implements Component {
 		cache.repository = vcs.repo(cache.effectiveGitCwd);
 		cache.repositoryCheckedAt = now;
 		return cache.repository;
+	}
+
+	#resolveDisplayRepository(cache: ActiveRepoCache): VcsRepo | null {
+		if (cache.displayRepository) return cache.displayRepository;
+		const now = Date.now();
+		if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return null;
+		let display: VcsRepo | null;
+		try {
+			display = vcs.repoForDisplay(cache.effectiveGitCwd);
+		} catch {
+			display = null;
+		}
+		cache.displayRepository = display ?? cache.repository;
+		cache.displayRepositoryCheckedAt = now;
+		return cache.displayRepository;
 	}
 
 	/**
@@ -777,7 +802,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		const activeRepoCache = this.#resolveActiveRepoCache();
-		const repository = this.#resolveRepository(activeRepoCache);
+		const repository = this.#resolveDisplayRepository(activeRepoCache);
 		if (!repository) {
 			// There is no path to watch yet. Cache the negative result only for the
 			// fallback poll interval so a later `git init` becomes visible without
@@ -998,11 +1023,15 @@ export class StatusLineComponent implements Component {
 		this.#jjStatusActive?.controller.abort();
 		this.#jjStatusActive = undefined;
 	}
-	#getBranchLabel(activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache()): string | null {
+	#getBranchLabel(
+		activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache(),
+		// Presentation defaults to the display detector; PR lookup passes the
+		// operational repository so a jj label never becomes a GitHub head.
+		repository: VcsRepo | null = this.#resolveDisplayRepository(activeRepoCache),
+	): string | null {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) return null;
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
@@ -1033,14 +1062,6 @@ export class StatusLineComponent implements Component {
 			})();
 			return this.#cachedJjBranch;
 		}
-		// Colocated jj-git checkout: jj owns the working-copy label even though
-		// `detect()` resolves the directory to Git. The predicate is root
-		// equality (see colocatedJjWorkspace), independent of git HEAD state.
-		const colocatedJj = colocatedJjWorkspace(gitCwd, repository);
-		if (colocatedJj) {
-			return this.#colocatedJjBranchLabel(gitCwd, colocatedJj);
-		}
-
 		const fallbackCacheExpired =
 			this.#gitWatcherUnavailable &&
 			(this.#branchLastFetch === undefined || Date.now() - this.#branchLastFetch >= WATCHER_FAILURE_POLL_TTL_MS);
@@ -1122,52 +1143,6 @@ export class StatusLineComponent implements Component {
 		return this.#cachedBranch ?? null;
 	}
 
-	/**
-	 * Working-copy label for a colocated jj-git checkout.
-	 *
-	 * Mirrors the pure-jj fetch above (same throttle state, same invalidation
-	 * lifecycle): the render path never blocks, the first paint returns the
-	 * cached label, and the resolve requests a repaint on change. The result
-	 * is mirrored into the git-branch cache so PR and default-branch lookups
-	 * follow the displayed jj bookmark.
-	 */
-	#colocatedJjBranchLabel(gitCwd: string, jj: VcsJjWorkspace): string | null {
-		if (this.#jjBranchActive || Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS) {
-			return this.#cachedJjBranch;
-		}
-		const request: JjResolveRequest = {
-			id: ++this.#jjResolveSeq,
-			controller: new AbortController(),
-		};
-		this.#jjBranchActive = request;
-		const generation = this.#jjCacheGeneration;
-		(async () => {
-			let next: string | null = null;
-			try {
-				next =
-					(await jj.workingCopyLabel(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
-			} catch {
-				next = null;
-			} finally {
-				if (this.#jjBranchActive?.id === request.id) this.#jjBranchActive = undefined;
-				if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
-			}
-			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
-			const changed = next !== this.#cachedJjBranch;
-			this.#cachedJjBranch = next;
-			this.#cachedBranchCwd = gitCwd;
-			try {
-				this.#cachedBranchRepoId = vcs.gitInfo(gitCwd)?.headPath ?? null;
-			} catch {
-				this.#cachedBranchRepoId = null;
-			}
-			this.#cachedBranch = next;
-			this.#branchLastFetch = Date.now();
-			if (changed) this.#onBranchChange?.();
-		})();
-		return this.#cachedJjBranch;
-	}
-
 	#isDefaultBranch(branch: string, effectiveGitCwd: string): boolean {
 		if (this.#defaultBranchCwd !== effectiveGitCwd) {
 			this.#defaultBranch = undefined;
@@ -1199,7 +1174,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveRepository(activeRepoCache);
+		const repository = this.#resolveDisplayRepository(activeRepoCache);
 		if (!repository) return null;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
@@ -1271,7 +1246,7 @@ export class StatusLineComponent implements Component {
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
 		if (this.#resolveRepository(activeRepoCache)?.kind() !== "git") return null;
-		const branch = this.#getBranchLabel(activeRepoCache);
+		const branch = this.#getBranchLabel(activeRepoCache, this.#resolveRepository(activeRepoCache));
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 
 		if (canReuseCachedPr(this.#cachedPr, this.#cachedPrContext, currentContext)) {
@@ -1301,7 +1276,10 @@ export class StatusLineComponent implements Component {
 			const setCachedPr = (value: { number: number; url: string } | null) => {
 				const latestActiveRepoCache = this.#resolveActiveRepoCache();
 				if (latestActiveRepoCache.effectiveGitCwd !== lookupCwd) return;
-				const latestBranch = this.#getBranchLabel(latestActiveRepoCache);
+				const latestBranch = this.#getBranchLabel(
+					latestActiveRepoCache,
+					this.#resolveRepository(latestActiveRepoCache),
+				);
 				const latestContext = latestBranch
 					? createPrCacheContext(latestBranch, this.#cachedBranchRepoId ?? null)
 					: undefined;
@@ -1896,6 +1874,8 @@ export class StatusLineComponent implements Component {
 					activeRepo: null,
 					effectiveGitCwd: projectDir,
 					repository: null,
+					displayRepository: null,
+					displayRepositoryCheckedAt: Date.now(),
 					repositoryCheckedAt: Date.now(),
 					worktree: null,
 				};

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -592,6 +592,10 @@ export class StatusLineComponent implements Component {
 		} else if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) {
 			return null;
 		}
+		const prevBackend =
+			cache.displayRepository !== null
+				? `${cache.displayRepository.kind()}:${cache.displayRepository.root()}`
+				: null;
 		let display: VcsRepo | null;
 		try {
 			display = vcs.repoForDisplay(cache.effectiveGitCwd);
@@ -600,6 +604,15 @@ export class StatusLineComponent implements Component {
 		}
 		cache.displayRepository = display ?? cache.repository;
 		cache.displayRepositoryCheckedAt = now;
+		if (cache.displayRepository && this.#gitUnwatch) {
+			const nextBackend = `${cache.displayRepository.kind()}:${cache.displayRepository.root()}`;
+			if (prevBackend !== nextBackend) {
+				// The backend changed under an installed watcher (late
+				// colocation): rebind both targets so jj-only changes
+				// invalidate from now on.
+				this.#setupGitWatcher();
+			}
+		}
 		return cache.displayRepository;
 	}
 
@@ -1218,8 +1231,15 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveDisplayRepository(activeRepoCache);
-		if (!repository) return null;
+		const display = this.#resolveDisplayRepository(activeRepoCache);
+		if (!display) return null;
+		// Colocated workspaces present the jj label, but status counts come
+		// from the operational git status: the jj status path reads the last
+		// snapshotted commit and misses live working-copy edits until the next
+		// jj operation, while snapshotting from render is off the table. (A jj
+		// display paired with a git operational repo implies equal roots.)
+		const operational = display.kind() === "jj" ? this.#resolveRepository(activeRepoCache) : null;
+		const repository = operational?.kind() === "git" ? operational : display;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
 				return this.#cachedJjStatus;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -666,11 +666,12 @@ export class StatusLineComponent implements Component {
 		cache.displayRepositoryCheckedAt = now;
 		if (cache.displayRepository && prevTarget !== displayWatchTarget(cache.displayRepository)) {
 			// The backend or head target changed (late colocation,
-			// late-appearing repo): rebuild both targets so jj-only changes
-			// invalidate from now on. Re-resolution itself is TTL-gated and
-			// the display poll covers branch reads, so a failed rebuild
-			// retries on the next change rather than storming.
+			// late-appearing repo, redirected `.git`): rebuild both targets
+			// so jj-only changes invalidate from now on, and drop the
+			// previous backend's cached branch/PR state — the new watcher
+			// only reports future moves, never the current one.
 			this.#setupGitWatcher();
+			this.invalidateGitCaches();
 		}
 		return cache.displayRepository;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -698,6 +698,11 @@ export class StatusLineComponent implements Component {
 			this.#defaultBranchRepoId = undefined;
 			this.#defaultBranchGeneration++;
 			this.#setupGitWatcher();
+			// The PR payload itself (not just its context) belongs to the old
+			// repo: on a default branch no replacement lookup ever runs, so
+			// retaining it would display it indefinitely. Generic activity
+			// invalidation deliberately keeps stale-visible until resolved.
+			this.#cachedPr = null;
 			this.invalidateGitCaches();
 		}
 		return cache.displayRepository;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
@@ -285,7 +285,7 @@ function displayWatchTarget(repository: VcsRepo | null): string | null {
  */
 function displayWatchTargetAlive(repository: VcsRepo): boolean {
 	try {
-		return existsSync(repository.watchTarget());
+		return fs.existsSync(repository.watchTarget());
 	} catch {
 		return false;
 	}
@@ -422,6 +422,11 @@ export class StatusLineComponent implements Component {
 	#branchCacheGeneration = 0;
 
 	#gitUnwatch: (() => void) | null = null;
+
+	// Reentrancy guard: display revalidation inside this setup can re-enter
+	// here on a backend change; the outer call installs the fresh pair as it
+	// continues, so the nested call is a no-op.
+	#setupGitWatcherActive = false;
 	// Operational-git head watcher, installed only when the display backend
 	// differs (colocated jj): a direct `git switch` moves .git/HEAD without
 	// touching jj op heads, so the display watcher alone cannot invalidate
@@ -848,6 +853,16 @@ export class StatusLineComponent implements Component {
 	}
 
 	#setupGitWatcher(): void {
+		if (this.#setupGitWatcherActive) return;
+		this.#setupGitWatcherActive = true;
+		try {
+			this.#setupGitWatcherInner();
+		} finally {
+			this.#setupGitWatcherActive = false;
+		}
+	}
+
+	#setupGitWatcherInner(): void {
 		this.#retireGitWatcher();
 		this.#gitWatcherUnavailable = false;
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -857,8 +857,10 @@ export class StatusLineComponent implements Component {
 					});
 					this.#operationalGitUnwatch = unwatchOperational;
 				} catch {
-					// Display-watcher coverage remains; PR state then refreshes
-					// on the next poll/cwd change instead.
+					// Fall back to polling for the operational branch: without
+					// this, the cached git branch would stay stale indefinitely
+					// while the display watcher reports healthy.
+					this.#gitWatcherUnavailable = true;
 				}
 			}
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -280,18 +280,42 @@ function displayWatchTarget(repository: VcsRepo | null): string | null {
 }
 
 /**
- * Whether the workspace behind a cached display handle still exists: the
- * local `.jj` marker must be present as well as the shared head watch
- * target (two stats, no repository walk). Linked workspaces keep only an
- * indirection locally while the shared target outlives them, so the target
- * alone cannot prove the workspace is still there.
+ * Local `.jj/repo` marker state, mirroring `pi-vcs` workspace discovery:
+ * a directory in the default workspace, or a file (created by
+ * `jj workspace add`) pointing at the shared repo.
  */
-function displayWorkspaceAlive(repository: VcsRepo): boolean {
+function jjMarkerState(root: string): "primary" | "linked" | "gone" {
 	try {
-		return fs.existsSync(path.join(repository.root(), ".jj")) && fs.existsSync(repository.watchTarget());
+		const marker = fs.statSync(path.join(root, ".jj", "repo"));
+		if (marker.isDirectory()) return "primary";
+		return marker.isFile() ? "linked" : "gone";
+	} catch {
+		return "gone";
+	}
+}
+
+/**
+ * Whether the shared head watch target of a cached display handle still exists.
+ */
+function displayTargetAlive(repository: VcsRepo): boolean {
+	try {
+		return fs.existsSync(repository.watchTarget());
 	} catch {
 		return false;
 	}
+}
+
+/**
+ * Whether a cached display handle is safe to keep without re-discovery.
+ * Directory-backed primary jj workspaces stay cached while marker+target
+ * exist; file-backed linked workspaces share their watch target with the
+ * primary, so they re-resolve every window. (Git/git pairs never reach
+ * here: colocation can appear mid-session.)
+ */
+function keepCachedDisplay(repository: VcsRepo): boolean {
+	if (repository.kind() !== "jj") return true;
+	if (jjMarkerState(repository.root()) !== "primary") return false;
+	return displayTargetAlive(repository);
 }
 /**
  * Project + worktree-dir names when `cwd` is a linked git worktree, else null.
@@ -624,7 +648,7 @@ export class StatusLineComponent implements Component {
 			if (fresh) return cache.displayRepository;
 			// A live workspace needs no walk, but the timestamp must still
 			// advance — otherwise every render past the TTL stats again.
-			if (stable && displayWorkspaceAlive(cache.displayRepository)) {
+			if (stable && keepCachedDisplay(cache.displayRepository)) {
 				cache.displayRepositoryCheckedAt = now;
 				return cache.displayRepository;
 			}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1353,7 +1353,13 @@ export class StatusLineComponent implements Component {
 				// request is still current: a superseded resolve must neither
 				// publish its label (below) nor clear a failure the newer
 				// generation recorded for the same target.
-				if (loaded && displayWatchTarget(repository) === this.#jjLabelFailedTarget) this.#jjLabelFailedTarget = null;
+				if (loaded && displayWatchTarget(repository) === this.#jjLabelFailedTarget) {
+					this.#jjLabelFailedTarget = null;
+					// Presentation changes even when the loaded label equals
+					// the stale cache (healthy null after a failure): the
+					// frame still shows the git fallback, so repaint anyway.
+					this.#onBranchChange?.();
+				}
 				const changed = next !== this.#cachedJjBranch;
 				this.#cachedJjBranch = next;
 				if (changed) this.#onBranchChange?.();

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -310,31 +310,20 @@ function displayTargetAlive(repository: VcsRepo): boolean {
 /**
  * Whether a git checkout rooted strictly below `jjRoot` now contains `cwd`:
  * nested checkouts take precedence for dirs inside them, so the display must
- * re-resolve. Each level reuses the central detector (marker validity matches
- * discovery exactly), bounded to the nesting depth. Root comparison is
- * lexical; symlinked layouts conservatively keep caching, as does anything
- * unexpected.
+ * re-resolve. One central discovery call from `cwd` (never per-level walks,
+ * which would repeat the upward search per directory), validated exactly
+ * like any other discovery. Root comparison is lexical; symlinked layouts
+ * conservatively keep caching, as does anything unexpected.
  */
 function nestedGitAppeared(cwd: string, jjRoot: string): boolean {
 	try {
-		let dir = path.resolve(cwd);
+		const dir = path.resolve(cwd);
 		const stop = path.resolve(jjRoot);
-		for (;;) {
-			if (dir === stop) return false;
-			if (!dir.startsWith(stop + path.sep)) return false;
-			// Reuse the central detector per level instead of stat-ing `.git`
-			// directly, so marker validity matches discovery exactly and the
-			// two cannot drift. Root comparison is lexical; symlinked layouts
-			// conservatively keep caching.
-			try {
-				if (vcs.git(dir)?.info().repoRoot === dir) return true;
-			} catch {
-				// Unreadable level; keep climbing.
-			}
-			const parent = path.dirname(dir);
-			if (parent === dir) return false;
-			dir = parent;
-		}
+		if (dir === stop || !dir.startsWith(stop + path.sep)) return false;
+		const found = vcs.git(dir);
+		if (!found) return false;
+		const foundRoot = path.resolve(found.info().repoRoot);
+		return foundRoot !== stop && foundRoot.startsWith(stop + path.sep);
 	} catch {
 		return false;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -666,9 +666,19 @@ export class StatusLineComponent implements Component {
 		const now = Date.now();
 		if (now - cache.repositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return cache.repository;
 		try {
+			const prevTarget = displayWatchTarget(cache.repository);
 			cache.repository = vcs.repo(cache.effectiveGitCwd);
 			cache.repositoryCheckedAt = now;
 			cache.operationalRefreshNeeded = false;
+			if (prevTarget !== displayWatchTarget(cache.repository)) {
+				// Operational identity changed outside a display rebind:
+				// drop default-branch state so a stale in-flight lookup
+				// cannot repopulate it.
+			this.#defaultBranch = undefined;
+			this.#defaultBranchCwd = undefined;
+			this.#defaultBranchRepoId = undefined;
+			this.#defaultBranchGeneration++;
+			}
 		} catch {
 			// Keep the stale handle (or null); the next window retries.
 			cache.repositoryCheckedAt = now;
@@ -1364,10 +1374,11 @@ export class StatusLineComponent implements Component {
 		if (this.#defaultBranch === undefined) {
 			this.#defaultBranch = "main";
 			const lookupCwd = effectiveGitCwd;
+			const lookupRepoId = repoId;
 			const generation = this.#defaultBranchGeneration;
 			(async () => {
 				const resolved = await vcs.git(lookupCwd)?.defaultBranch();
-				if (this.#disposed || this.#defaultBranchCwd !== lookupCwd || this.#defaultBranchGeneration !== generation) return;
+				if (this.#disposed || this.#defaultBranchCwd !== lookupCwd || this.#defaultBranchRepoId !== lookupRepoId || this.#defaultBranchGeneration !== generation) return;
 				if (resolved) {
 					this.#defaultBranch = resolved;
 					if (this.#onBranchChange) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -395,7 +395,13 @@ export class StatusLineComponent implements Component {
 	// dropped rather than overwrite the value the newer resolve committed.
 	// Mirrors #jjCacheGeneration / #getBranchLabel in this file.
 	#branchCacheGeneration = 0;
+
 	#gitUnwatch: (() => void) | null = null;
+	// Operational-git head watcher, installed only when the display backend
+	// differs (colocated jj): a direct `git switch` moves .git/HEAD without
+	// touching jj op heads, so the display watcher alone cannot invalidate
+	// the git branch/PR cache.
+	#operationalGitUnwatch: (() => void) | null = null;
 	#gitWatcherUnavailable = false;
 	#onBranchChange: (() => void) | null = null;
 	#disposed = false;
@@ -574,9 +580,18 @@ export class StatusLineComponent implements Component {
 	}
 
 	#resolveDisplayRepository(cache: ActiveRepoCache): VcsRepo | null {
-		if (cache.displayRepository) return cache.displayRepository;
 		const now = Date.now();
-		if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return null;
+		if (cache.displayRepository) {
+			// A plain git checkout can gain colocation mid-session
+			// (`jj git init --colocate`) without changing cwd: revalidate
+			// git/git pairs at the failure-poll cadence, otherwise serve
+			// the cache without a render-path walk.
+			const fresh = now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS;
+			const stable = cache.displayRepository.kind() !== "git" || cache.repository?.kind() !== "git";
+			if (fresh || stable) return cache.displayRepository;
+		} else if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) {
+			return null;
+		}
 		let display: VcsRepo | null;
 		try {
 			display = vcs.repoForDisplay(cache.effectiveGitCwd);
@@ -823,12 +838,39 @@ export class StatusLineComponent implements Component {
 		} catch {
 			this.#gitWatcherUnavailable = true;
 		}
+
+		// Colocated workspaces present through jj, but PR/default-branch state
+		// still derives from the operational git repository: retain its head
+		// target too whenever it differs from the display target, so a direct
+		// `git switch` (valid: colocation stays Git-safe) invalidates the git
+		// branch/PR cache instead of leaving it on the old branch.
+		const operationalForWatch = this.#resolveRepository(activeRepoCache);
+		if (operationalForWatch && operationalForWatch.kind() === "git") {
+			const operationalGitRoot = operationalForWatch.root();
+			const displayGitRoot = repository.kind() === "git" ? repository.root() : null;
+			if (operationalGitRoot !== displayGitRoot) {
+				try {
+					const unwatchOperational = vcs.watch(operationalForWatch, () => {
+						if (this.#disposed || this.#operationalGitUnwatch !== unwatchOperational) return;
+						this.invalidateGitCaches();
+						this.#onBranchChange?.();
+					});
+					this.#operationalGitUnwatch = unwatchOperational;
+				} catch {
+					// Display-watcher coverage remains; PR state then refreshes
+					// on the next poll/cwd change instead.
+				}
+			}
+		}
 	}
 
 	#retireGitWatcher(): void {
 		const unwatch = this.#gitUnwatch;
 		this.#gitUnwatch = null;
 		unwatch?.();
+		const unwatchOperational = this.#operationalGitUnwatch;
+		this.#operationalGitUnwatch = null;
+		unwatchOperational?.();
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -308,6 +308,34 @@ function displayTargetAlive(repository: VcsRepo): boolean {
 }
 
 /**
+ * Whether a `.git` entry appeared on the path from `cwd` up to (excluding)
+ * `jjRoot` since discovery: a nested git checkout takes precedence for
+ * dirs inside it, so the display must re-resolve. Bounded to the nesting
+ * depth — no full repository walk. Anything unexpected means keep caching.
+ */
+function nestedGitAppeared(cwd: string, jjRoot: string): boolean {
+	try {
+		let dir = path.resolve(cwd);
+		const stop = path.resolve(jjRoot);
+		for (;;) {
+			if (dir === stop) return false;
+			if (!dir.startsWith(stop + path.sep)) return false;
+			try {
+				fs.statSync(path.join(dir, ".git"));
+				return true;
+			} catch {
+				// Absent at this level; keep climbing.
+			}
+			const parent = path.dirname(dir);
+			if (parent === dir) return false;
+			dir = parent;
+		}
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Whether a cached display handle is safe to keep without re-discovery.
  * Directory-backed primary jj workspaces stay cached while marker+target
  * exist; file-backed linked workspaces share their watch target with the
@@ -660,7 +688,12 @@ export class StatusLineComponent implements Component {
 			if (fresh) return cache.displayRepository;
 			// A live workspace needs no walk, but the timestamp must still
 			// advance — otherwise every render past the TTL stats again.
-			if (stable && keepCachedDisplay(cache.displayRepository)) {
+			if (
+				stable &&
+				!(cache.displayRepository.kind() === "jj" &&
+					nestedGitAppeared(cache.effectiveGitCwd, cache.displayRepository.root())) &&
+				keepCachedDisplay(cache.displayRepository)
+			) {
 				cache.displayRepositoryCheckedAt = now;
 				return cache.displayRepository;
 			}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -308,10 +308,12 @@ function displayTargetAlive(repository: VcsRepo): boolean {
 }
 
 /**
- * Whether a `.git` entry appeared on the path from `cwd` up to (excluding)
- * `jjRoot` since discovery: a nested git checkout takes precedence for
- * dirs inside it, so the display must re-resolve. Bounded to the nesting
- * depth — no full repository walk. Anything unexpected means keep caching.
+ * Whether a git checkout rooted strictly below `jjRoot` now contains `cwd`:
+ * nested checkouts take precedence for dirs inside them, so the display must
+ * re-resolve. Each level reuses the central detector (marker validity matches
+ * discovery exactly), bounded to the nesting depth. Root comparison is
+ * lexical; symlinked layouts conservatively keep caching, as does anything
+ * unexpected.
  */
 function nestedGitAppeared(cwd: string, jjRoot: string): boolean {
 	try {
@@ -320,11 +322,14 @@ function nestedGitAppeared(cwd: string, jjRoot: string): boolean {
 		for (;;) {
 			if (dir === stop) return false;
 			if (!dir.startsWith(stop + path.sep)) return false;
+			// Reuse the central detector per level instead of stat-ing `.git`
+			// directly, so marker validity matches discovery exactly and the
+			// two cannot drift. Root comparison is lexical; symlinked layouts
+			// conservatively keep caching.
 			try {
-				fs.statSync(path.join(dir, ".git"));
-				return true;
+				if (vcs.git(dir)?.info().repoRoot === dir) return true;
 			} catch {
-				// Absent at this level; keep climbing.
+				// Unreadable level; keep climbing.
 			}
 			const parent = path.dirname(dir);
 			if (parent === dir) return false;
@@ -545,7 +550,10 @@ export class StatusLineComponent implements Component {
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
 	#cachedGitStatusCwd: string | undefined = undefined;
 	#gitStatusLastFetch = 0;
-	#gitStatusInFlightCwd: string | undefined = undefined;
+	// In-flight git status request: object identity (not cwd) owns the slot,
+	// so a superseded completion can neither publish nor release another
+	// request's state. Mirrors the reftable/jj request-id pattern.
+	#gitStatusInFlight: { cwd: string } | undefined = undefined;
 	#cachedJjBranch: string | null = null;
 	#jjBranchLastFetch = 0;
 	#jjResolveSeq = 0;
@@ -746,6 +754,14 @@ export class StatusLineComponent implements Component {
 			// retaining it would display it indefinitely. Generic activity
 			// invalidation deliberately keeps stale-visible until resolved.
 			this.#cachedPr = null;
+			// Git status requests/cache are keyed by cwd alone: drop them here
+			// or the old repo's pending completion publishes A's counts for B
+			// (or blocks B while hung). Ordinary HEAD moves keep the 1s-stale
+			// cache; only a target change resets.
+			this.#gitStatusInFlight = undefined;
+			this.#cachedGitStatus = null;
+			this.#cachedGitStatusCwd = undefined;
+			this.#gitStatusLastFetch = 0;
 			this.invalidateGitCaches();
 		}
 		return cache.displayRepository;
@@ -1440,14 +1456,15 @@ export class StatusLineComponent implements Component {
 			return this.#cachedJjStatus;
 		}
 
-		if (this.#gitStatusInFlightCwd !== undefined) {
+		if (this.#gitStatusInFlight) {
 			return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
 		}
 		if (this.#cachedGitStatusCwd === gitCwd && Date.now() - this.#gitStatusLastFetch < 1000) {
 			return this.#cachedGitStatus;
 		}
 
-		this.#gitStatusInFlightCwd = gitCwd;
+		const statusRequest = { cwd: gitCwd };
+		this.#gitStatusInFlight = statusRequest;
 
 		(async () => {
 			let nextStatus: { staged: number; unstaged: number; untracked: number } | null = null;
@@ -1456,19 +1473,18 @@ export class StatusLineComponent implements Component {
 			} catch {
 				nextStatus = null;
 			} finally {
-				if (this.#gitStatusInFlightCwd === gitCwd) {
+				if (this.#gitStatusInFlight === statusRequest) {
 					const prev = this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
 					this.#cachedGitStatus = nextStatus;
 					this.#cachedGitStatusCwd = gitCwd;
 					this.#gitStatusLastFetch = Date.now();
-					this.#gitStatusInFlightCwd = undefined;
+					this.#gitStatusInFlight = undefined;
 					if (!this.#disposed && this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(nextStatus)) {
 						this.#onBranchChange();
 					}
 				}
 			}
 		})();
-
 		return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -266,6 +266,19 @@ interface WorktreeContext {
 }
 
 /**
+ * Watch target identifying a display backend, or null when unreadable.
+ * Compared across revalidation so a backend *or* target change rebinds the
+ * watchers: same-kind/same-root handles can still move head targets.
+ */
+function displayWatchTarget(repository: VcsRepo | null): string | null {
+	try {
+		return repository?.watchTarget() ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Project + worktree-dir names when `cwd` is a linked git worktree, else null.
  * The project name comes from the shared primary checkout; bare-repo worktrees
  * resolve to the shared `foo.git` dir, so a trailing `.git` is stripped.
@@ -592,10 +605,7 @@ export class StatusLineComponent implements Component {
 		} else if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) {
 			return null;
 		}
-		const prevBackend =
-			cache.displayRepository !== null
-				? `${cache.displayRepository.kind()}:${cache.displayRepository.root()}`
-				: null;
+		const prevTarget = displayWatchTarget(cache.displayRepository);
 		let display: VcsRepo | null;
 		try {
 			display = vcs.repoForDisplay(cache.effectiveGitCwd);
@@ -605,11 +615,10 @@ export class StatusLineComponent implements Component {
 		cache.displayRepository = display ?? cache.repository;
 		cache.displayRepositoryCheckedAt = now;
 		if (cache.displayRepository && this.#gitUnwatch) {
-			const nextBackend = `${cache.displayRepository.kind()}:${cache.displayRepository.root()}`;
-			if (prevBackend !== nextBackend) {
-				// The backend changed under an installed watcher (late
-				// colocation): rebind both targets so jj-only changes
-				// invalidate from now on.
+			// The backend or head target changed under an installed watcher
+			// (late colocation): rebind both targets so jj-only changes
+			// invalidate from now on.
+			if (prevTarget !== displayWatchTarget(cache.displayRepository)) {
 				this.#setupGitWatcher();
 			}
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -626,13 +626,13 @@ export class StatusLineComponent implements Component {
 		}
 		cache.displayRepository = display ?? cache.repository;
 		cache.displayRepositoryCheckedAt = now;
-		if (cache.displayRepository && this.#gitUnwatch) {
-			// The backend or head target changed under an installed watcher
-			// (late colocation): rebind both targets so jj-only changes
-			// invalidate from now on.
-			if (prevTarget !== displayWatchTarget(cache.displayRepository)) {
-				this.#setupGitWatcher();
-			}
+		if (cache.displayRepository && prevTarget !== displayWatchTarget(cache.displayRepository)) {
+			// The backend or head target changed (late colocation,
+			// late-appearing repo): rebuild both targets so jj-only changes
+			// invalidate from now on. Re-resolution itself is TTL-gated and
+			// the display poll covers branch reads, so a failed rebuild
+			// retries on the next change rather than storming.
+			this.#setupGitWatcher();
 		}
 		return cache.displayRepository;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -729,20 +729,16 @@ export class StatusLineComponent implements Component {
 		}
 		if (display) {
 			cache.displayRepository = display;
-		} else if (discoveryFailed || !cache.displayRepository) {
-			// Discovery threw (transient I/O), or this is the first
-			// resolution: keep the stale handle, falling back to
-			// operational. A transient failure must not read as removal.
+		} else if (discoveryFailed) {
+			// Discovery threw (transient I/O): keep the stale handle,
+			// falling back to operational on first resolution. A transient
+			// failure must not read as repository removal.
 			cache.displayRepository ??= cache.repository;
 		} else {
-			// Authoritative null rediscovery: confirm through the operational
-			// detector before dropping the stale handle. A lone display blip
-			// while operational still resolves (racing mutation, skewed
-			// detectors) keeps today's behavior; only agreement means
-			// removal, and the target change below then invalidates caches
-			// and rebuilds watchers.
-			this.#refreshOperational(cache);
-			if (!cache.repository) cache.displayRepository = null;
+			// Authoritative null rediscovery: the repository was removed.
+			// Drop the stale handle so its branch stops rendering; the
+			// target change below invalidates caches and rebuilds watchers.
+			cache.displayRepository = null;
 		}
 		cache.displayRepositoryCheckedAt = now;
 		if ((cache.displayRepository || prevTarget) && prevTarget !== displayWatchTarget(cache.displayRepository)) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -550,6 +550,14 @@ export class StatusLineComponent implements Component {
 	#cachedJjStatus: { staged: number; unstaged: number; untracked: number } | null = null;
 	#jjStatusLastFetch = 0;
 	#jjStatusActive: JjResolveRequest | undefined = undefined;
+	// Watch target of a jj display handle whose label load genuinely rejected,
+	// with the rejection timestamp. While set, presentation serves the
+	// colocated operational git branch instead of a permanently-null jj
+	// label, re-probing jj at the refresh cadence so a repaired workspace
+	// recovers without a restart. Only set for real backend rejections —
+	// never aborts/timeouts, never healthy nulls.
+	#jjLabelFailedTarget: string | null = null;
+	#jjLabelFailedAt = 0;
 	// Bumped on every jj-cache reset — a cwd switch (#applyCwdChange) or a HEAD /
 	// bookmark move (#invalidateGitCaches). An in-flight jj query captures this
 	// at launch; a mismatch on resolve means the caches were reset underneath it
@@ -698,8 +706,10 @@ export class StatusLineComponent implements Component {
 			}
 			if (
 				stable &&
-				!(cache.displayRepository.kind() === "jj" &&
-					nestedGitAppeared(cache.effectiveGitCwd, cache.displayRepository.root())) &&
+				!(
+					cache.displayRepository.kind() === "jj" &&
+					nestedGitAppeared(cache.effectiveGitCwd, cache.displayRepository.root())
+				) &&
 				keepCachedDisplay(cache.displayRepository)
 			) {
 				cache.displayRepositoryCheckedAt = now;
@@ -1254,6 +1264,48 @@ export class StatusLineComponent implements Component {
 		this.#jjStatusActive?.controller.abort();
 		this.#jjStatusActive = undefined;
 	}
+	/**
+	 * Record a genuine jj label load rejection for a colocated display so
+	 * presentation serves the operational git branch until jj loads again.
+	 * Only genuine backend rejections retire the handle: deliberate aborts
+	 * (reset/dispose) and command timeouts are transient, and a healthy
+	 * null (no bookmark) must keep showing jj-empty, never git.
+	 */
+	#jjLabelLoadFailed(activeRepoCache: ActiveRepoCache, repository: VcsRepo, generation: number, error: unknown): void {
+		if (this.#disposed || this.#jjCacheGeneration !== generation) return;
+		const name = (error as { name?: unknown } | null)?.name;
+		if (name === "AbortError" || name === "TimeoutError") return;
+		const target = displayWatchTarget(repository);
+		if (target === null || !this.#colocatedGitRepo(activeRepoCache, repository)) return;
+		if (this.#jjLabelFailedTarget === target) {
+			this.#jjLabelFailedAt = Date.now();
+			return;
+		}
+		this.#jjLabelFailedTarget = target;
+		this.#jjLabelFailedAt = Date.now();
+		this.#onBranchChange?.();
+	}
+
+	/**
+	 * Operational git handle when `display` is a jj workspace colocated on
+	 * the same root (mirrors the status path's colocation rule), else null.
+	 * Pure-jj and nested layouts have no usable fallback and keep today's
+	 * null behavior.
+	 */
+	#colocatedGitRepo(activeRepoCache: ActiveRepoCache, display: VcsRepo): VcsRepo | null {
+		const operational = this.#resolveRepository(activeRepoCache);
+		return operational?.kind() === "git" && operational.root() === display.root() ? operational : null;
+	}
+
+	/**
+	 * Operational git branch for a retired jj display. Served from the
+	 * separate branch-cache slot (keyed by the git watch target), so jj and
+	 * git labels never clobber each other.
+	 */
+	#colocatedGitBranch(activeRepoCache: ActiveRepoCache, display: VcsRepo): string | null {
+		const gitRepo = this.#colocatedGitRepo(activeRepoCache, display);
+		return gitRepo ? this.#getBranchLabel(activeRepoCache, gitRepo) : this.#cachedJjBranch;
+	}
 	#getBranchLabel(
 		activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache(),
 		// Presentation defaults to the display detector; PR lookup passes the
@@ -1266,8 +1318,11 @@ export class StatusLineComponent implements Component {
 		if (!repository) return null;
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
-			if (this.#jjBranchActive || Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS) {
-				return this.#cachedJjBranch;
+			const labelTarget = displayWatchTarget(repository);
+			const labelFailed = labelTarget !== null && labelTarget === this.#jjLabelFailedTarget;
+			const labelProbeDue = labelFailed && Date.now() - this.#jjLabelFailedAt >= JJ_REFRESH_TTL_MS;
+			if (this.#jjBranchActive || (!labelProbeDue && Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS)) {
+				return labelFailed ? this.#colocatedGitBranch(activeRepoCache, repository) : this.#cachedJjBranch;
 			}
 			const request: JjResolveRequest = {
 				id: ++this.#jjResolveSeq,
@@ -1284,8 +1339,13 @@ export class StatusLineComponent implements Component {
 					// characters; sanitize at the cache boundary (the git segment
 					// renders the label verbatim).
 					next = raw === null ? null : sanitizeStatusText(raw);
-				} catch {
+					// A successful load clears the failure marker: the handle
+					// is usable again (repaired workspace), so presentation
+					// returns to jj on the repaint below.
+					if (displayWatchTarget(repository) === this.#jjLabelFailedTarget) this.#jjLabelFailedTarget = null;
+				} catch (error) {
 					next = null;
+					this.#jjLabelLoadFailed(activeRepoCache, repository, generation, error);
 				} finally {
 					if (this.#jjBranchActive?.id === request.id) this.#jjBranchActive = undefined;
 					if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
@@ -1295,7 +1355,7 @@ export class StatusLineComponent implements Component {
 				this.#cachedJjBranch = next;
 				if (changed) this.#onBranchChange?.();
 			})();
-			return this.#cachedJjBranch;
+			return labelFailed ? this.#colocatedGitBranch(activeRepoCache, repository) : this.#cachedJjBranch;
 		}
 		// The branch cache is keyed by watch target as well as cwd: display
 		// and operational reads can resolve different repos for one cwd
@@ -1405,7 +1465,13 @@ export class StatusLineComponent implements Component {
 			const generation = this.#defaultBranchGeneration;
 			(async () => {
 				const resolved = await vcs.git(lookupCwd)?.defaultBranch();
-				if (this.#disposed || this.#defaultBranchCwd !== lookupCwd || this.#defaultBranchRepoId !== lookupRepoId || this.#defaultBranchGeneration !== generation) return;
+				if (
+					this.#disposed ||
+					this.#defaultBranchCwd !== lookupCwd ||
+					this.#defaultBranchRepoId !== lookupRepoId ||
+					this.#defaultBranchGeneration !== generation
+				)
+					return;
 				if (resolved) {
 					this.#defaultBranch = resolved;
 					if (this.#onBranchChange) {
@@ -1422,7 +1488,6 @@ export class StatusLineComponent implements Component {
 		unstaged: number;
 		untracked: number;
 	} | null {
-
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
@@ -1524,7 +1589,11 @@ export class StatusLineComponent implements Component {
 		}
 
 		// Don't look up if detached, default branch, or already in flight.
-		if (branch === "detached" || this.#isDefaultBranch(branch, gitCwd, displayWatchTarget(operational)) || this.#prLookupInFlight) {
+		if (
+			branch === "detached" ||
+			this.#isDefaultBranch(branch, gitCwd, displayWatchTarget(operational)) ||
+			this.#prLookupInFlight
+		) {
 			return stalePr ?? null;
 		}
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1332,6 +1332,7 @@ export class StatusLineComponent implements Component {
 			const generation = this.#jjCacheGeneration;
 			(async () => {
 				let next: string | null = null;
+				let loaded = false;
 				try {
 					const raw =
 						(await repository.label(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
@@ -1339,10 +1340,7 @@ export class StatusLineComponent implements Component {
 					// characters; sanitize at the cache boundary (the git segment
 					// renders the label verbatim).
 					next = raw === null ? null : sanitizeStatusText(raw);
-					// A successful load clears the failure marker: the handle
-					// is usable again (repaired workspace), so presentation
-					// returns to jj on the repaint below.
-					if (displayWatchTarget(repository) === this.#jjLabelFailedTarget) this.#jjLabelFailedTarget = null;
+					loaded = true;
 				} catch (error) {
 					next = null;
 					this.#jjLabelLoadFailed(activeRepoCache, repository, generation, error);
@@ -1351,6 +1349,11 @@ export class StatusLineComponent implements Component {
 					if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
 				}
 				if (this.#jjCacheGeneration !== generation || this.#disposed) return;
+				// A successful load clears the failure marker only when this
+				// request is still current: a superseded resolve must neither
+				// publish its label (below) nor clear a failure the newer
+				// generation recorded for the same target.
+				if (loaded && displayWatchTarget(repository) === this.#jjLabelFailedTarget) this.#jjLabelFailedTarget = null;
 				const changed = next !== this.#cachedJjBranch;
 				this.#cachedJjBranch = next;
 				if (changed) this.#onBranchChange?.();

--- a/packages/coding-agent/src/modes/components/status-line/git-utils.ts
+++ b/packages/coding-agent/src/modes/components/status-line/git-utils.ts
@@ -1,32 +1,3 @@
-import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
-import * as vcs from "@oh-my-pi/pi-natives/vcs";
-
-/**
- * Jujutsu workspace colocated with the checkout `repository` was discovered
- * from (same root), or null.
- *
- * `detect()` still resolves colocated directories to Git (git automation is
- * safe there), so presentation code must ask jj directly through the
- * independent `vcs.jj()` discovery. The predicate is root equality — not git
- * HEAD state: detached is valid in ordinary Git, and a colocated checkout
- * can have an attached HEAD. A jj workspace at a *different* root (e.g. a
- * nested git checkout under an outer jj tree) is not colocation: the git
- * branch stays authoritative there.
- */
-export function colocatedJjWorkspace(dir: string, repository: VcsRepo): VcsJjWorkspace | null {
-	let jj: VcsJjWorkspace | null;
-	try {
-		jj = vcs.jj(dir);
-	} catch {
-		return null;
-	}
-	if (!jj) return null;
-	try {
-		return jj.root() === repository.root() ? jj : null;
-	} catch {
-		return null;
-	}
-}
 /**
  * Extract "owner/repo" from a GitHub remote URL.
  * Handles HTTPS, SSH (scp-style), and git:// protocols.

--- a/packages/coding-agent/src/modes/components/status-line/git-utils.ts
+++ b/packages/coding-agent/src/modes/components/status-line/git-utils.ts
@@ -1,3 +1,32 @@
+import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+/**
+ * Jujutsu workspace colocated with the checkout `repository` was discovered
+ * from (same root), or null.
+ *
+ * `detect()` still resolves colocated directories to Git (git automation is
+ * safe there), so presentation code must ask jj directly through the
+ * independent `vcs.jj()` discovery. The predicate is root equality — not git
+ * HEAD state: detached is valid in ordinary Git, and a colocated checkout
+ * can have an attached HEAD. A jj workspace at a *different* root (e.g. a
+ * nested git checkout under an outer jj tree) is not colocation: the git
+ * branch stays authoritative there.
+ */
+export function colocatedJjWorkspace(dir: string, repository: VcsRepo): VcsJjWorkspace | null {
+	let jj: VcsJjWorkspace | null;
+	try {
+		jj = vcs.jj(dir);
+	} catch {
+		return null;
+	}
+	if (!jj) return null;
+	try {
+		return jj.root() === repository.root() ? jj : null;
+	} catch {
+		return null;
+	}
+}
 /**
  * Extract "owner/repo" from a GitHub remote URL.
  * Handles HTTPS, SSH (scp-style), and git:// protocols.

--- a/packages/coding-agent/src/modes/shared.ts
+++ b/packages/coding-agent/src/modes/shared.ts
@@ -32,3 +32,20 @@ export function getTabBarTheme(): TabBarTheme {
 }
 
 export { parseCommandArgs } from "../utils/command-args";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// VCS Errors
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Whether a VCS binding rejection is a transient cancellation rather than a
+ * genuine backend failure. The native `repo_blocking` wrapper checks the
+ * abort/timeout signal before the task begins and rejects with
+ * `{ name: "VcsError", code: "Canceled" }`; DOM `AbortError`/`TimeoutError`
+ * cover non-native paths. Callers use this to choose retry-later (throttled
+ * null) over fail-over (fallback presentation).
+ */
+export function isTransientVcsError(error: unknown): boolean {
+	const details = error as { name?: unknown; code?: unknown } | null | undefined;
+	return details?.name === "AbortError" || details?.name === "TimeoutError" || details?.code === "Canceled";
+}

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -103,6 +103,8 @@ describe("FooterComponent display detector", () => {
 			watchTargets.push(repo.watchTarget());
 			return () => {};
 		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
 
 		const onBranchChange = vi.fn();
 		const component = new FooterComponent(makeSession());
@@ -111,6 +113,8 @@ describe("FooterComponent display detector", () => {
 		expect(component.render(80).join("\n")).toContain("(main)");
 
 		colocated = true;
+		// Past the sync cadence the new backend is observed.
+		now += 6_000;
 		component.render(80);
 		await flush();
 		const content = component.render(80).join("\n");
@@ -146,6 +150,8 @@ describe("FooterComponent display detector", () => {
 		// The replacement throws: the label still recovers through the
 		// re-read, and the old watcher is retained.
 		colocated = true;
+		// Past the sync cadence the new backend is observed.
+		now += 6_000;
 		component.render(80);
 		await flush();
 		let content = component.render(80).join("\n");

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -121,4 +121,49 @@ describe("FooterComponent display detector", () => {
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
 		component.dispose();
 	});
+
+	it("keeps the old watcher when the replacement fails to install", async () => {
+		const root = "/repo/footer-watch-failure";
+		const git = gitDisplay(root, "main");
+		const jj = jjDisplay(root, async () => `recovered-${String.fromCharCode(7)}mark`);
+		let colocated = false;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (colocated ? jj : git));
+		const watchTargets: string[] = [];
+		let failJjWatch = true;
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			if (repo.kind() === "jj" && failJjWatch) throw new Error("no watch");
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		expect(component.render(80).join("\n")).toContain("(main)");
+
+		// The replacement throws: the label still recovers through the
+		// re-read, and the old watcher is retained.
+		colocated = true;
+		component.render(80);
+		await flush();
+		let content = component.render(80).join("\n");
+		expect(content).toContain("(recovered-");
+		expect(content).not.toContain(String.fromCharCode(7));
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`]);
+
+		// No per-render retry storm while the target is unchanged.
+		component.render(80);
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`]);
+
+		// The next target move retries the install.
+		failJjWatch = false;
+		colocated = false;
+		content = component.render(80).join("\n");
+		expect(content).toContain("(main)");
+		colocated = true;
+		component.render(80);
+		await flush();
+		expect(component.render(80).join("\n")).toContain("(recovered-");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -176,4 +176,50 @@ describe("FooterComponent display detector", () => {
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
 		component.dispose();
 	});
+
+	it("clears the branch and watcher when discovery finds no repository", async () => {
+		const root = "/repo/footer-vanish";
+		const jjHeads = `${root}/.jj/repo/op_heads/heads`;
+		const jj = jjDisplay(root, async () => "gone-bookmark");
+		const git = gitDisplay(root, "main");
+		let mode: "git" | "jj" | "none" = "git";
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (mode === "git" ? git : mode === "jj" ? jj : null));
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		expect(component.render(80).join("\n")).toContain("(main)");
+
+		// Become colocated, then vanish entirely: the bookmark must go
+		// away rather than linger with dead coverage.
+		mode = "jj";
+		now += 6_000;
+		component.render(80);
+		await flush();
+		expect(component.render(80).join("\n")).toContain("(gone-bookmark)");
+		mode = "none";
+		now += 6_000;
+		component.render(80);
+		await flush();
+		let content = component.render(80).join("\n");
+		expect(content).not.toContain("(gone-bookmark)");
+		expect(content).not.toContain("(main)");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, jjHeads]);
+
+		// Reappearing re-installs from a clean slate.
+		mode = "jj";
+		now += 6_000;
+		component.render(80);
+		await flush();
+		content = component.render(80).join("\n");
+		expect(content).toContain("(gone-bookmark)");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, jjHeads, jjHeads]);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #11071 follow-up: when a plain git checkout gains colocation mid-session,
+ * the legacy footer must rebind its watcher from `.git/HEAD` to the jj
+ * operation-head target — otherwise jj-only label changes never clear the
+ * cached git branch, which has no polling TTL.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { FooterComponent } from "@oh-my-pi/pi-coding-agent/modes/components/footer";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getContextUsage: () => undefined,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "footer-colocated test",
+			getEntries: () => [],
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof FooterComponent>[0];
+}
+
+function gitDisplay(root: string, branch: string): VcsRepo {
+	const handle = {
+		headSync: (): VcsHeadState => ({ kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined }),
+	} as unknown as VcsGitRepo;
+	return {
+		kind: () => "git",
+		asGit: () => handle,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => `${root}/.git/HEAD`,
+	} as unknown as VcsRepo;
+}
+
+function jjDisplay(root: string, label: () => Promise<string | null>): VcsRepo {
+	return {
+		kind: () => "jj",
+		asGit: () => null,
+		asJj: () => ({}) as never,
+		root: () => root,
+		watchTarget: () => `${root}/.jj/repo/op_heads/heads`,
+		label,
+	} as unknown as VcsRepo;
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("FooterComponent display detector", () => {
+	it("rebinds the watcher and label when colocation appears after setup", async () => {
+		const root = "/repo/footer-colocate";
+		const git = gitDisplay(root, "main");
+		const jj = jjDisplay(root, async () => "footer-bookmark");
+		let colocated = false;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (colocated ? jj : git));
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+
+		const onBranchChange = vi.fn();
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(onBranchChange);
+
+		expect(component.render(80).join("\n")).toContain("(main)");
+
+		colocated = true;
+		component.render(80);
+		await flush();
+		const content = component.render(80).join("\n");
+		expect(content).toContain("(footer-bookmark)");
+		expect(content).not.toContain("(main)");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
+		component.dispose();
+	});
+});

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -95,7 +95,7 @@ describe("FooterComponent display detector", () => {
 	it("rebinds the watcher and label when colocation appears after setup", async () => {
 		const root = "/repo/footer-colocate";
 		const git = gitDisplay(root, "main");
-		const jj = jjDisplay(root, async () => "footer-bookmark");
+		const jj = jjDisplay(root, async () => `footer-${String.fromCharCode(7)}bookmark`);
 		let colocated = false;
 		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (colocated ? jj : git));
 		const watchTargets: string[] = [];
@@ -114,7 +114,9 @@ describe("FooterComponent display detector", () => {
 		component.render(80);
 		await flush();
 		const content = component.render(80).join("\n");
-		expect(content).toContain("(footer-bookmark)");
+		expect(content).toContain("(footer-");
+		expect(content).toContain("bookmark)");
+		expect(content).not.toContain(String.fromCharCode(7));
 		expect(content).not.toContain("(main)");
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
 		component.dispose();

--- a/packages/coding-agent/test/footer-colocated-jj.test.ts
+++ b/packages/coding-agent/test/footer-colocated-jj.test.ts
@@ -122,7 +122,7 @@ describe("FooterComponent display detector", () => {
 		component.dispose();
 	});
 
-	it("keeps the old watcher when the replacement fails to install", async () => {
+	it("retries the install on the unchanged target after a transient failure", async () => {
 		const root = "/repo/footer-watch-failure";
 		const git = gitDisplay(root, "main");
 		const jj = jjDisplay(root, async () => `recovered-${String.fromCharCode(7)}mark`);
@@ -130,11 +130,14 @@ describe("FooterComponent display detector", () => {
 		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (colocated ? jj : git));
 		const watchTargets: string[] = [];
 		let failJjWatch = true;
-		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+		const watchMock = vi.spyOn(vcs, "watch");
+		watchMock.mockImplementation(((repo: VcsRepo) => {
 			if (repo.kind() === "jj" && failJjWatch) throw new Error("no watch");
 			watchTargets.push(repo.watchTarget());
 			return () => {};
 		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
 
 		const component = new FooterComponent(makeSession());
 		component.watchBranch(() => {});
@@ -149,21 +152,22 @@ describe("FooterComponent display detector", () => {
 		expect(content).toContain("(recovered-");
 		expect(content).not.toContain(String.fromCharCode(7));
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`]);
+		expect(watchMock).toHaveBeenCalledTimes(2);
 
 		// No per-render retry storm while the target is unchanged.
 		component.render(80);
+		expect(watchMock).toHaveBeenCalledTimes(2);
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`]);
 
-		// The next target move retries the install.
+		// The transient failure clears while staying colocated: past the TTL
+		// the same target is retried, the jj watcher installs, and refresh works.
 		failJjWatch = false;
-		colocated = false;
-		content = component.render(80).join("\n");
-		expect(content).toContain("(main)");
-		colocated = true;
+		now += 6_000;
 		component.render(80);
 		await flush();
-		expect(component.render(80).join("\n")).toContain("(recovered-");
-		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
+		content = component.render(80).join("\n");
+		expect(content).toContain("(recovered-");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`]);
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Footer twin of the status-line jj label fallback: a colocated workspace
+ * whose jj store is corrupt rejects `label()` while the operational git
+ * checkout at the same root is fully usable. The footer must render the
+ * git branch instead of a permanent null. Pure-jj (or nested) layouts have
+ * no fallback target and keep today's null behavior without throwing.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { FooterComponent } from "@oh-my-pi/pi-coding-agent/modes/components/footer";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getContextUsage: () => undefined,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "footer-label-fallback test",
+			getEntries: () => [],
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof FooterComponent>[0];
+}
+
+function gitRepo(root: string, branch: string): VcsRepo {
+	const handle = {
+		headSync: (): VcsHeadState => ({ kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined }),
+	} as unknown as VcsGitRepo;
+	return {
+		kind: () => "git",
+		asGit: () => handle,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => `${root}/.git/HEAD`,
+	} as unknown as VcsRepo;
+}
+
+function corruptJj(root: string, label: () => Promise<string | null>): VcsRepo {
+	return {
+		kind: () => "jj",
+		asGit: () => null,
+		asJj: () => ({}) as never,
+		root: () => root,
+		watchTarget: () => `${root}/.jj/repo/op_heads/heads`,
+		label,
+	} as unknown as VcsRepo;
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("FooterComponent jj label fallback", () => {
+	it("renders the colocated git branch when the jj label load rejects", async () => {
+		const root = "/repo/footer-label-fallback";
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
+		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			expect(label).toHaveBeenCalledTimes(1);
+
+			// The fallback is cached: no per-render retry storm.
+			component.render(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(1);
+		} finally {
+			component.dispose();
+		}
+	});
+
+	it("keeps null without throwing when no git fallback exists", async () => {
+		const root = "/repo/footer-label-no-fallback";
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(null);
+		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).not.toContain("feature/f");
+		} finally {
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -273,9 +273,19 @@ describe("FooterComponent jj label fallback", () => {
 	});
 	it("keeps null on native cancellation instead of failing over", async () => {
 		const root = "/repo/footer-fallback-transient";
-		const label = vi
-			.fn<() => Promise<string | null>>()
-			.mockRejectedValue(Object.assign(new Error("operation canceled"), { name: "VcsError", code: "Canceled" }));
+		// Real transient path: a native handle failing its pre-start
+		// heartbeat for an aborted signal (no repo I/O runs). Deterministic:
+		// CancelToken honors already-fired signals, so no worker race.
+		const nativeRepo = vcs.repo(import.meta.dir);
+		if (!nativeRepo) throw new Error("expected a git checkout above the test dir");
+		const stop = new AbortController();
+		stop.abort();
+		const pending: Promise<string | null>[] = [];
+		const label = vi.fn<() => Promise<string | null>>(() => {
+			const promise = nativeRepo.label(stop.signal).then(label => label ?? null);
+			pending.push(promise);
+			return promise;
+		});
 		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
 		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
 		const watchKinds: string[] = [];
@@ -283,16 +293,79 @@ describe("FooterComponent jj label fallback", () => {
 			watchKinds.push(repo.kind());
 			return () => {};
 		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		async function settleNative(): Promise<void> {
+			await Promise.allSettled(pending);
+			pending.length = 0;
+			await flush();
+		}
 
 		const component = new FooterComponent(makeSession());
 		component.watchBranch(() => {});
 		try {
 			component.render(80);
-			await flush();
+			await settleNative();
 			// A mere timeout must not fail over to git: sticky null, and
 			// no fallback watcher installed.
 			expect(component.render(80).join("\n")).not.toContain("(feature/f)");
 			expect(watchKinds).toEqual(["jj"]);
+
+			// Past the cadence the footer still holds its sticky null: no
+			// retry storm, no wedged slot, still no failover.
+			now += 6_000;
+			component.render(80);
+			await settleNative();
+			expect(label.mock.calls.length).toBe(1);
+			expect(component.render(80).join("\n")).not.toContain("(feature/f)");
+		} finally {
+			component.dispose();
+		}
+	});
+	it("preserves the fallback across a transient retry", async () => {
+		const root = "/repo/footer-fallback-transient-retry";
+		// Real transient path (as above): pre-aborted heartbeat rejection.
+		const nativeRepo = vcs.repo(import.meta.dir);
+		if (!nativeRepo) throw new Error("expected a git checkout above the test dir");
+		const stop = new AbortController();
+		stop.abort();
+		const pending: Promise<string | null>[] = [];
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
+		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		async function settleNative(): Promise<void> {
+			await Promise.allSettled(pending);
+			pending.length = 0;
+			await flush();
+		}
+
+		const component = new FooterComponent(makeSession());
+		const onBranchChange = vi.fn();
+		component.watchBranch(onBranchChange);
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			onBranchChange.mockClear();
+
+			// A TTL re-probe that cancels must leave the installed
+			// fallback (and its frame) untouched, without repainting.
+			label.mockImplementation(() => {
+				const promise = nativeRepo.label(stop.signal).then(label => label ?? null);
+				pending.push(promise);
+				return promise;
+			});
+			const callsBefore = label.mock.calls.length;
+			now += 6_000;
+			component.render(80);
+			await settleNative();
+			// The re-probe really ran (not a vacuous pass on a stuck cache).
+			expect(label.mock.calls.length).toBeGreaterThan(callsBefore);
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			expect(onBranchChange).not.toHaveBeenCalled();
 		} finally {
 			component.dispose();
 		}

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -149,16 +149,20 @@ describe("FooterComponent jj label fallback", () => {
 		let gitBranch = "feature/f";
 		const git = gitRepo(root, "feature/f");
 		const gitHandle = git.asGit();
-		if (gitHandle) gitHandle.headSync = () => ({ kind: "ref", branch: gitBranch, refName: `refs/heads/${gitBranch}`, commit: undefined });
+		if (gitHandle)
+			gitHandle.headSync = () => ({
+				kind: "ref",
+				branch: gitBranch,
+				refName: `refs/heads/${gitBranch}`,
+				commit: undefined,
+			});
 		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
 		vi.spyOn(vcs, "repo").mockReturnValue(git);
 		const watchers: { kind: string; fire: () => void }[] = [];
-		vi.spyOn(vcs, "watch").mockImplementation(
-			((repo: VcsRepo, fire: () => void) => {
-				watchers.push({ kind: repo.kind(), fire });
-				return () => {};
-			}) as unknown as typeof vcs.watch,
-		);
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo, fire: () => void) => {
+			watchers.push({ kind: repo.kind(), fire });
+			return () => {};
+		}) as unknown as typeof vcs.watch);
 
 		const component = new FooterComponent(makeSession());
 		component.watchBranch(() => {});
@@ -177,6 +181,49 @@ describe("FooterComponent jj label fallback", () => {
 			component.render(80);
 			await flush();
 			expect(component.render(80).join("\n")).toContain("(feature/g2)");
+		} finally {
+			component.dispose();
+		}
+	});
+	it("re-probes jj on a bounded cadence while the fallback holds", async () => {
+		const root = "/repo/footer-fallback-reprobe";
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
+		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			expect(label).toHaveBeenCalledTimes(1);
+
+			// Within the cadence nothing re-issues: no per-render storm.
+			now += 1_000;
+			component.render(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(1);
+
+			// Past the cadence exactly one re-probe runs. A still-broken
+			// store fails silently back into the same fallback.
+			now += 5_000;
+			component.render(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(2);
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+
+			// A repaired store recovers without a restart.
+			label.mockResolvedValue("fixed-j");
+			now += 5_000;
+			component.render(80);
+			await flush();
+			const content = component.render(80).join("\n");
+			expect(content).toContain("(fixed-j)");
+			expect(content).not.toContain("(feature/f)");
 		} finally {
 			component.dispose();
 		}

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -228,4 +228,47 @@ describe("FooterComponent jj label fallback", () => {
 			component.dispose();
 		}
 	});
+	it("re-probes and recovers when the fallback watcher install throws", async () => {
+		const root = "/repo/footer-fallback-watch-throw";
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			// The git fallback target cannot be watched here, but the
+			// jj display target can: fallback must not depend on the
+			// install succeeding.
+			if (repo.kind() === "git") throw new Error("no watch");
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			expect(watchTargets).toEqual([`${root}/.jj/repo/op_heads/heads`]);
+
+			// Past the cadence the jj re-probe runs even though no git
+			// watcher could be installed.
+			now += 6_000;
+			component.render(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(2);
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+
+			// A repaired store still recovers.
+			label.mockResolvedValue("fixed-j");
+			now += 6_000;
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(fixed-j)");
+		} finally {
+			component.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -271,4 +271,30 @@ describe("FooterComponent jj label fallback", () => {
 			component.dispose();
 		}
 	});
+	it("keeps null on native cancellation instead of failing over", async () => {
+		const root = "/repo/footer-fallback-transient";
+		const label = vi
+			.fn<() => Promise<string | null>>()
+			.mockRejectedValue(Object.assign(new Error("operation canceled"), { name: "VcsError", code: "Canceled" }));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(gitRepo(root, "feature/f"));
+		const watchKinds: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchKinds.push(repo.kind());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			// A mere timeout must not fail over to git: sticky null, and
+			// no fallback watcher installed.
+			expect(component.render(80).join("\n")).not.toContain("(feature/f)");
+			expect(watchKinds).toEqual(["jj"]);
+		} finally {
+			component.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/footer-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-fallback.test.ts
@@ -101,8 +101,16 @@ describe("FooterComponent jj label fallback", () => {
 		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
 
 		const component = new FooterComponent(makeSession());
-		component.watchBranch(() => {});
+		const onBranchChange = vi.fn();
+		component.watchBranch(onBranchChange);
 		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			expect(label).toHaveBeenCalledTimes(1);
+			// The fallback is a real change (undefined -> branch): it must
+			// repaint, or an idle footer keeps the old/empty frame.
+			expect(onBranchChange).toHaveBeenCalledTimes(1);
 			component.render(80);
 			await flush();
 			expect(component.render(80).join("\n")).toContain("(feature/f)");
@@ -130,6 +138,45 @@ describe("FooterComponent jj label fallback", () => {
 			component.render(80);
 			await flush();
 			expect(component.render(80).join("\n")).not.toContain("feature/f");
+		} finally {
+			component.dispose();
+		}
+	});
+
+	it("follows git HEAD moves while jj stays broken", async () => {
+		const root = "/repo/footer-fallback-watch";
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		let gitBranch = "feature/f";
+		const git = gitRepo(root, "feature/f");
+		const gitHandle = git.asGit();
+		if (gitHandle) gitHandle.headSync = () => ({ kind: "ref", branch: gitBranch, refName: `refs/heads/${gitBranch}`, commit: undefined });
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(corruptJj(root, label));
+		vi.spyOn(vcs, "repo").mockReturnValue(git);
+		const watchers: { kind: string; fire: () => void }[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(
+			((repo: VcsRepo, fire: () => void) => {
+				watchers.push({ kind: repo.kind(), fire });
+				return () => {};
+			}) as unknown as typeof vcs.watch,
+		);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/f)");
+			// Both backends watched: git for the fallback, jj so a repair
+			// still invalidates through the label path.
+			expect(watchers.map(watcher => watcher.kind).sort()).toEqual(["git", "jj"]);
+
+			// A later `git switch` invalidates the cached fallback even
+			// though the jj target never changed.
+			gitBranch = "feature/g2";
+			watchers.find(watcher => watcher.kind === "git")?.fire();
+			component.render(80);
+			await flush();
+			expect(component.render(80).join("\n")).toContain("(feature/g2)");
 		} finally {
 			component.dispose();
 		}

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -657,4 +657,128 @@ describe("StatusLineComponent display detector", () => {
 		expect(watchTargets).toEqual([targetA, targetB, targetA]);
 		component.dispose();
 	});
+
+	it("looks up PRs against the new default after a redirect", async () => {
+		const root = "/repo/retarget-defaults";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const repoA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const repoB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "repo").mockImplementation(() => (moved ? repoB : repoA));
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+		// Same branch name, different defaults: only the default cache
+		// decides whether the lookup fires.
+		let defaultName = "main";
+		vi.spyOn(vcs, "git").mockImplementation(() => ({
+			defaultBranch: async () => defaultName,
+			linkedWorktree: () => null,
+		}) as unknown as VcsGitRepo);
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(run).not.toHaveBeenCalled();
+
+		// Same cwd, new repo with a different default: the lookup follows it.
+		moved = true;
+		defaultName = "trunk";
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(component.getTopBorder(80).content).toContain("#7");
+		component.dispose();
+	});
+
+	it("drops an in-flight default-branch lookup across a redirect", async () => {
+		const root = "/repo/retarget-inflight";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const repoA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("feature")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const repoB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		const firstDefault = Promise.withResolvers<string | null>();
+		const secondDefault = Promise.withResolvers<string | null>();
+		let defaultCalls = 0;
+		vi.spyOn(vcs, "git").mockImplementation(
+			(() => ({
+				defaultBranch: () => (++defaultCalls === 1 ? firstDefault.promise : secondDefault.promise),
+				linkedWorktree: () => null,
+			}) as unknown as VcsGitRepo),
+		);
+		vi.spyOn(vcs, "repo").mockImplementation(() => (moved ? repoB : repoA));
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValueOnce({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" })
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":8,"url":"https://example.test/x/8"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+
+		// Redirect while the first default lookup is still in flight, then
+		// let the stale resolve land: it must not repopulate the cache.
+		moved = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		firstDefault.resolve("main");
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+
+		// The fresh lookup for the new repo commits instead.
+		secondDefault.resolve("trunk");
+		await flush();
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(2);
+		expect(component.getTopBorder(80).content).toContain("#8");
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -851,4 +851,55 @@ describe("StatusLineComponent display detector", () => {
 		expect(component.getTopBorder(80).content).toContain("#7");
 		component.dispose();
 	});
+
+	it("drops the cached PR when redirecting onto a default branch", async () => {
+		const root = "/repo/retarget-pr";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const repoA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("feature")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const repoB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		vi.spyOn(vcs, "repo").mockImplementation(() => (moved ? repoB : repoA));
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("#7");
+		expect(run).toHaveBeenCalledTimes(1);
+
+		// Redirect onto repo B's default branch: no replacement lookup runs,
+		// so repo A's PR must vanish rather than linger.
+		moved = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		const content = component.getTopBorder(80).content;
+		expect(content).not.toContain("#7");
+		expect(run).toHaveBeenCalledTimes(1);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -604,4 +604,57 @@ describe("StatusLineComponent display detector", () => {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
 	});
+
+	it("drops the cached branch when the display target is redirected", async () => {
+		const root = "/repo/retarget";
+		const targetA = `${root}/.git/HEAD`;
+		const targetB = `${root}/.git/refs/heads/other`;
+		const gitA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("branch-a")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const gitB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("branch-b")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const operational = operationalGit(root, headFor("branch-a"));
+		mockRepos(operational, gitA, root);
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		let moved = false;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? gitB : gitA));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("branch-a");
+
+		// The `.git` pointer moves with the cwd unchanged: the rebind
+		// installs the new target and the stale branch must not survive it,
+		// since a fresh watcher never reports the current state.
+		moved = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("branch-b");
+		expect(content).not.toContain("branch-a");
+		expect(watchTargets).toEqual([targetA, targetB, targetA]);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1,22 +1,23 @@
 /**
  * #11071: a colocated jj-git checkout resolved to Git in `detect()`, so the
- * status line showed the git HEAD ("detached" in practice, or a stale git
- * branch) instead of the active jj bookmark/change id.
+ * status line showed the git HEAD ("detached" in practice) instead of the
+ * active jj bookmark/change id.
  *
- * `detect()` intentionally still resolves colocated directories to Git (git
- * automation is safe there). Presentation instead consults the independent
- * `vcs.jj()` discovery and prefers the jj label when both discoveries share
- * the same root — regardless of git HEAD state. A jj workspace at a
- * different root (nested git under an outer jj tree) keeps the git branch,
- * and ordinary git without jj keeps "detached".
+ * Presentation now follows a second detector, `vcs.repoForDisplay()`, whose
+ * only policy difference is preferring jj on equal-root ties; automation
+ * keeps `vcs.repo()`. The component (and legacy footer) split accordingly:
+ * branch label, status counts, and the head watcher come from the display
+ * repository, while PR lookup keeps resolving the operational git branch —
+ * a jj bookmark/change id must never become a GitHub head.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 
 type GitStatus = { staged: number; unstaged: number; untracked: number };
@@ -55,7 +56,7 @@ function makeSession() {
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		modelRegistry: { isUsingOAuth: () => false },
 		sessionManager: {
-			getSessionName: () => "colocated-jj test",
+			getSessionName: () => "display-detector test",
 			getUsageStatistics: () => ({
 				input: 0,
 				output: 0,
@@ -68,20 +69,11 @@ function makeSession() {
 	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
 }
 
-const attachedHead: VcsHeadState = {
-	kind: "ref",
-	branch: "git-branch-name",
-	refName: "refs/heads/git-branch-name",
-	commit: undefined,
-};
+function headFor(branch: string): VcsHeadState {
+	return { kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined };
+}
 const detachedHead: VcsHeadState = { kind: "detached" };
 
-function jjWorkspace(root: string, workingCopyLabel: () => Promise<string | null>): VcsJjWorkspace {
-	return {
-		root: () => root,
-		workingCopyLabel,
-	} as unknown as VcsJjWorkspace;
-}
 function repoInfoFor(root: string): VcsGitRepoInfo {
 	return {
 		commonDir: `${root}/.git`,
@@ -93,7 +85,7 @@ function repoInfoFor(root: string): VcsGitRepoInfo {
 	};
 }
 
-function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
+function gitHandle(head: VcsHeadState | null): VcsGitRepo {
 	return {
 		headSync: () => head,
 		linkedWorktree: () => null,
@@ -101,14 +93,31 @@ function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
 	} as unknown as VcsGitRepo;
 }
 
-function unifiedGit(repository: VcsGitRepo, root: string): VcsRepo {
+function gitWithDefaultBranch(branch: string): VcsGitRepo {
+	return { defaultBranch: async () => branch, linkedWorktree: () => null } as unknown as VcsGitRepo;
+}
+
+function operationalGit(root: string, head: VcsHeadState | null): VcsRepo {
+	const handle = gitHandle(head);
 	return {
 		kind: () => "git",
-		asGit: () => repository,
+		asGit: () => handle,
 		asJj: () => null,
 		root: () => root,
 		watchTarget: () => `${root}/.git/HEAD`,
-		statusSummary: (signal?: AbortSignal) => repository.statusSummary(signal),
+		statusSummary: (signal?: AbortSignal) => handle.statusSummary(signal),
+	} as unknown as VcsRepo;
+}
+
+function displayJj(root: string, label: () => Promise<string | null>, status: GitStatus): VcsRepo {
+	return {
+		kind: () => "jj",
+		asGit: () => null,
+		asJj: () => ({}) as never,
+		root: () => root,
+		watchTarget: () => `${root}/.jj/repo/op_heads/heads`,
+		label,
+		statusSummary: async () => status,
 	} as unknown as VcsRepo;
 }
 
@@ -120,22 +129,36 @@ const gitSegment: StatusLineSettings = {
 	sessionAccent: false,
 	transparent: false,
 };
+const gitPrSegments: StatusLineSettings = {
+	...gitSegment,
+	leftSegments: ["git", "pr"],
+};
 
 async function flush(): Promise<void> {
 	await Promise.resolve();
 	await Promise.resolve();
 	await Promise.resolve();
+	await Promise.resolve();
 }
 
-describe("StatusLineComponent colocated jj-git label", () => {
-	it("prefers the jj bookmark over an attached git HEAD when roots match", async () => {
+function mockRepos(operational: VcsRepo, display: VcsRepo, root: string): void {
+	vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+	vi.spyOn(vcs, "git").mockReturnValue(null);
+	vi.spyOn(vcs, "repo").mockReturnValue(operational);
+	vi.spyOn(vcs, "repoForDisplay").mockReturnValue(display);
+}
+
+describe("StatusLineComponent display detector", () => {
+	it("shows the jj bookmark and jj status with the jj watch target when colocated", async () => {
 		const root = "/repo/colocated";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
-		const label = Promise.withResolvers<string | null>();
-		const workingCopyLabel = vi.fn(() => label.promise);
-		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace(root, workingCopyLabel));
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => "my-bookmark", { staged: 1, unstaged: 2, untracked: 3 });
+		mockRepos(operational, display, root);
+		let watched: VcsRepo | null = null;
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watched = repo;
+			return () => {};
+		}) as unknown as typeof vcs.watch);
 
 		const onBranchChange = vi.fn();
 		const component = new StatusLineComponent(makeSession());
@@ -143,47 +166,86 @@ describe("StatusLineComponent colocated jj-git label", () => {
 		component.watchBranch(onBranchChange);
 
 		component.getTopBorder(80);
-		expect(workingCopyLabel).toHaveBeenCalled();
-
-		label.resolve("my-bookmark");
 		await flush();
 
+		expect(vcs.repoForDisplay).toHaveBeenCalled();
 		expect(onBranchChange).toHaveBeenCalled();
 		expect(component.getTopBorder(80).content).toContain("my-bookmark");
+		expect((watched as VcsRepo | null)?.watchTarget()).toBe(`${root}/.jj/repo/op_heads/heads`);
 		component.dispose();
 	});
 
 	it("keeps the git branch for a nested git checkout under an outer jj workspace", async () => {
 		const root = "/repo/nested";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
-		const workingCopyLabel = vi.fn(async (): Promise<string | null> => "outer-bookmark");
-		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace("/outer", workingCopyLabel));
+		const operational = operationalGit(root, headFor("git-branch-name"));
+		mockRepos(operational, operationalGit(root, headFor("git-branch-name")), root);
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSegment);
 		component.watchBranch(() => {});
 
+		component.getTopBorder(80);
 		await flush();
-		expect(workingCopyLabel).not.toHaveBeenCalled();
 		expect(component.getTopBorder(80).content).toContain("git-branch-name");
 		component.dispose();
 	});
 
 	it("keeps detached for ordinary git with no jj workspace", async () => {
 		const root = "/repo/plain";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(detachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(detachedHead, root), root));
-		vi.spyOn(vcs, "jj").mockReturnValue(null);
+		const operational = operationalGit(root, detachedHead);
+		mockRepos(operational, operationalGit(root, detachedHead), root);
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSegment);
 		component.watchBranch(() => {});
 
+		component.getTopBorder(80);
 		await flush();
 		expect(component.getTopBorder(80).content).toContain("detached");
+		component.dispose();
+	});
+
+	it("does not send the jj bookmark to PR lookup when the git branch is default", async () => {
+		const root = "/repo/colocated-pr";
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => "feature-x", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		const run = vi.spyOn(github, "run").mockResolvedValue({ exitCode: 0, stdout: "{}", stderr: "" });
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+
+		expect(component.getTopBorder(80).content).toContain("feature-x");
+		expect(run).not.toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("still looks up PRs by the operational git branch when it is not default", async () => {
+		const root = "/repo/colocated-pr-live";
+		const operational = operationalGit(root, headFor("git-branch-name"));
+		const display = displayJj(root, async () => "feature-x", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0]?.[1]).toEqual(["pr", "view", "--json", "number,url"]);
+		expect(component.getTopBorder(80).content).toContain("feature-x");
+		expect(component.getTopBorder(80).content).toContain("#7");
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -300,4 +300,44 @@ describe("StatusLineComponent display detector", () => {
 		expect(component.getTopBorder(80).content).toContain("late-bookmark");
 		component.dispose();
 	});
+
+	it("polls the operational branch when its watcher fails to install", async () => {
+		const root = "/repo/watch-failure";
+		let current = headFor("branch-a");
+		const liveHandle = { ...gitHandle(headFor("branch-a")), headSync: () => current };
+		const operational = {
+			...operationalGit(root, headFor("branch-a")),
+			asGit: () => liveHandle,
+		} as unknown as VcsRepo;
+		const display = displayJj(root, async () => "feature-x", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		// The display watcher installs; the operational one throws.
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			if (repo.kind() === "git") throw new Error("no watcher");
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+
+		// A git switch moves .git/HEAD with no watcher to fire it; past the
+		// poll cadence the lookup follows the new branch instead of the cache.
+		current = headFor("branch-b");
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(2);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #11071: a colocated jj-git checkout resolved to Git in `detect()`, so the
+ * status line showed the git HEAD ("detached" in practice, or a stale git
+ * branch) instead of the active jj bookmark/change id.
+ *
+ * `detect()` intentionally still resolves colocated directories to Git (git
+ * automation is safe there). Presentation instead consults the independent
+ * `vcs.jj()` discovery and prefers the jj label when both discoveries share
+ * the same root — regardless of git HEAD state. A jj workspace at a
+ * different root (nested git under an outer jj tree) keeps the git branch,
+ * and ordinary git without jj keeps "detached".
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+type GitStatus = { staged: number; unstaged: number; untracked: number };
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "colocated-jj test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+const attachedHead: VcsHeadState = {
+	kind: "ref",
+	branch: "git-branch-name",
+	refName: "refs/heads/git-branch-name",
+	commit: undefined,
+};
+const detachedHead: VcsHeadState = { kind: "detached" };
+
+function jjWorkspace(root: string, workingCopyLabel: () => Promise<string | null>): VcsJjWorkspace {
+	return {
+		root: () => root,
+		workingCopyLabel,
+	} as unknown as VcsJjWorkspace;
+}
+function repoInfoFor(root: string): VcsGitRepoInfo {
+	return {
+		commonDir: `${root}/.git`,
+		gitDir: `${root}/.git`,
+		gitEntryPath: `${root}/.git`,
+		headPath: `${root}/.git/HEAD`,
+		repoRoot: root,
+		isReftable: false,
+	};
+}
+
+function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
+	return {
+		headSync: () => head,
+		linkedWorktree: () => null,
+		statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	} as unknown as VcsGitRepo;
+}
+
+function unifiedGit(repository: VcsGitRepo, root: string): VcsRepo {
+	return {
+		kind: () => "git",
+		asGit: () => repository,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => `${root}/.git/HEAD`,
+		statusSummary: (signal?: AbortSignal) => repository.statusSummary(signal),
+	} as unknown as VcsRepo;
+}
+
+const gitSegment: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["git"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("StatusLineComponent colocated jj-git label", () => {
+	it("prefers the jj bookmark over an attached git HEAD when roots match", async () => {
+		const root = "/repo/colocated";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
+		const label = Promise.withResolvers<string | null>();
+		const workingCopyLabel = vi.fn(() => label.promise);
+		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace(root, workingCopyLabel));
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80);
+		expect(workingCopyLabel).toHaveBeenCalled();
+
+		label.resolve("my-bookmark");
+		await flush();
+
+		expect(onBranchChange).toHaveBeenCalled();
+		expect(component.getTopBorder(80).content).toContain("my-bookmark");
+		component.dispose();
+	});
+
+	it("keeps the git branch for a nested git checkout under an outer jj workspace", async () => {
+		const root = "/repo/nested";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
+		const workingCopyLabel = vi.fn(async (): Promise<string | null> => "outer-bookmark");
+		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace("/outer", workingCopyLabel));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		await flush();
+		expect(workingCopyLabel).not.toHaveBeenCalled();
+		expect(component.getTopBorder(80).content).toContain("git-branch-name");
+		component.dispose();
+	});
+
+	it("keeps detached for ordinary git with no jj workspace", async () => {
+		const root = "/repo/plain";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(detachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(detachedHead, root), root));
+		vi.spyOn(vcs, "jj").mockReturnValue(null);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("detached");
+		component.dispose();
+	});
+});

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -438,11 +438,12 @@ describe("StatusLineComponent display detector", () => {
 		component.getTopBorder(80);
 		await flush();
 		const content = component.getTopBorder(80).content;
+		const ESC = String.fromCharCode(27);
 		expect(content).toContain("evil-");
 		expect(content).toContain("bookmark");
-		// The raw erase-display payload is gone (theme ANSI aside, which is
-		// emitted by the renderer itself, not the label).
-		expect(content).not.toContain("[2J");
+		// The repository-controlled erase-display payload is gone, while the
+		// renderer's own theme ANSI (also ESC-led) still styles the frame.
+		expect(content.includes(`${ESC}[2J`)).toBe(false);
 		component.dispose();
 	});
 

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -154,9 +154,11 @@ describe("StatusLineComponent display detector", () => {
 		const operational = operationalGit(root, headFor("main"));
 		const display = displayJj(root, async () => "my-bookmark", { staged: 1, unstaged: 2, untracked: 3 });
 		mockRepos(operational, display, root);
-		let watched: VcsRepo | null = null;
-		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
-			watched = repo;
+		const watched: VcsRepo[] = [];
+		const watchCallbacks = new Map<string, () => void>();
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo, onChange: () => void) => {
+			watched.push(repo);
+			watchCallbacks.set(repo.watchTarget(), onChange);
 			return () => {};
 		}) as unknown as typeof vcs.watch);
 
@@ -170,8 +172,22 @@ describe("StatusLineComponent display detector", () => {
 
 		expect(vcs.repoForDisplay).toHaveBeenCalled();
 		expect(onBranchChange).toHaveBeenCalled();
-		expect(component.getTopBorder(80).content).toContain("my-bookmark");
-		expect((watched as VcsRepo | null)?.watchTarget()).toBe(`${root}/.jj/repo/op_heads/heads`);
+		// Both head targets are watched: jj op heads for the label/status,
+		// .git/HEAD so a direct git switch invalidates the git branch/PR cache.
+		expect(watched.map(repo => repo.watchTarget()).sort()).toEqual(
+			[`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`].sort(),
+		);
+		// The 1/2/3 counts come from the jj double (the git double reports zeros).
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("my-bookmark");
+		expect(content).toContain("*2");
+		expect(content).toContain("+1");
+		expect(content).toContain("?3");
+		// Firing the operational watcher requests a repaint even though jj
+		// op heads never moved.
+		onBranchChange.mockClear();
+		watchCallbacks.get(`${root}/.git/HEAD`)?.();
+		expect(onBranchChange).toHaveBeenCalled();
 		component.dispose();
 	});
 
@@ -179,6 +195,11 @@ describe("StatusLineComponent display detector", () => {
 		const root = "/repo/nested";
 		const operational = operationalGit(root, headFor("git-branch-name"));
 		mockRepos(operational, operationalGit(root, headFor("git-branch-name")), root);
+		const watched: VcsRepo[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watched.push(repo);
+			return () => {};
+		}) as unknown as typeof vcs.watch);
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSegment);
@@ -187,6 +208,8 @@ describe("StatusLineComponent display detector", () => {
 		component.getTopBorder(80);
 		await flush();
 		expect(component.getTopBorder(80).content).toContain("git-branch-name");
+		// One backend, one target: no redundant operational watcher.
+		expect(watched.map(repo => repo.watchTarget())).toEqual([`${root}/.git/HEAD`]);
 		component.dispose();
 	});
 
@@ -246,6 +269,35 @@ describe("StatusLineComponent display detector", () => {
 		expect(run.mock.calls[0]?.[1]).toEqual(["pr", "view", "--json", "number,url"]);
 		expect(component.getTopBorder(80).content).toContain("feature-x");
 		expect(component.getTopBorder(80).content).toContain("#7");
+		component.dispose();
+	});
+
+	it("picks up colocation that appears after the first paint", async () => {
+		const root = "/repo/late-colocate";
+		const operational = operationalGit(root, headFor("git-branch-name"));
+		const jjDisplay = displayJj(root, async () => "late-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+		const gitDisplay = operationalGit(root, headFor("git-branch-name"));
+		mockRepos(operational, gitDisplay, root);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		let displayCalls = 0;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (displayCalls++ === 0 ? gitDisplay : jjDisplay));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("git-branch-name");
+
+		// Past the revalidation cadence the display detector observes the
+		// new jj workspace and the label switches to the bookmark.
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		expect(displayCalls).toBeGreaterThan(1);
+		expect(component.getTopBorder(80).content).toContain("late-bookmark");
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -781,4 +781,74 @@ describe("StatusLineComponent display detector", () => {
 		expect(component.getTopBorder(80).content).toContain("#8");
 		component.dispose();
 	});
+
+	it("retries operational re-discovery after a rebind failure", async () => {
+		const root = "/repo/refresh-retry";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const repoA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const repoB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("branch-b")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		let failRepo = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		const repoSpy = vi.spyOn(vcs, "repo");
+		repoSpy.mockImplementation(() => {
+			if (failRepo) throw new Error("no repo");
+			return moved ? repoB : repoA;
+		});
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).not.toContain("branch-b");
+		expect(run).not.toHaveBeenCalled();
+
+		// The target moves but operational re-discovery throws: the display
+		// recovers while PR state stays on the stale handle.
+		moved = true;
+		failRepo = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("branch-b");
+		expect(run).not.toHaveBeenCalled();
+		const callsAfterFailure = repoSpy.mock.calls.length;
+
+		// Same target, no storm: renders inside the window do not retry.
+		component.getTopBorder(80);
+		expect(repoSpy.mock.calls.length).toBe(callsAfterFailure);
+
+		// Past the window with the failure cleared, the same target retries
+		// through the accessor and the lookup follows the new branch.
+		failRepo = false;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(component.getTopBorder(80).content).toContain("#7");
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -554,13 +554,16 @@ describe("StatusLineComponent display detector", () => {
 		component.dispose();
 	});
 
-	it("falls back when a linked workspace loses its local marker", async () => {
-		const shared = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-shared-"));
+	it("falls back when a linked workspace marker is redirected", async () => {
+		const primary = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-primary-"));
 		const ws = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-linked-"));
-		const heads = path.join(shared, "op_heads", "heads");
+		const repoDir = path.join(primary, ".jj", "repo");
+		const heads = path.join(repoDir, "op_heads", "heads");
 		fs.mkdirSync(heads, { recursive: true });
-		// Linked-workspace layout: only an indirection locally, heads shared.
-		fs.writeFileSync(path.join(ws, ".jj"), `repo: ${path.join("..", "shared")}\n`);
+		// Real secondary layout: `.jj/repo` is a file pointing at the shared
+		// repo dir, while the watch target lives in that shared repo.
+		fs.mkdirSync(path.join(ws, ".jj"), { recursive: true });
+		fs.writeFileSync(path.join(ws, ".jj", "repo"), `${path.relative(path.join(ws, ".jj"), repoDir)}\n`);
 		try {
 			const operational = operationalGit(ws, headFor("main"));
 			const linked = {
@@ -587,9 +590,9 @@ describe("StatusLineComponent display detector", () => {
 			await flush();
 			expect(component.getTopBorder(80).content).toContain("linked-bookmark");
 
-			// The local marker goes away while the shared target survives:
-			// past the cadence the display still falls back to re-discovery.
-			fs.rmSync(path.join(ws, ".jj"), { force: true });
+			// Redirect the marker while the shared target survives: a bare
+			// target check would keep the stale handle forever.
+			fs.writeFileSync(path.join(ws, ".jj", "repo"), "/nonexistent/elsewhere\n");
 			now += 6_000;
 			component.getTopBorder(80);
 			await flush();
@@ -597,7 +600,7 @@ describe("StatusLineComponent display detector", () => {
 			expect(component.getTopBorder(80).content).not.toContain("linked-bookmark");
 			component.dispose();
 		} finally {
-			fs.rmSync(shared, { recursive: true, force: true });
+			fs.rmSync(primary, { recursive: true, force: true });
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1093,4 +1093,73 @@ describe("StatusLineComponent display detector", () => {
 		expect(content).not.toContain("*9");
 		component.dispose();
 	});
+
+	it("follows an operational move under a stable jj display", async () => {
+		const root = "/repo/stable-op-move";
+		const jjHeads = `${root}/.jj/repo/op_heads/heads`;
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const display = {
+			kind: () => "jj",
+			asGit: () => null,
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => jjHeads,
+			label: async () => "stable-bookmark",
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const opA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const opB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("branch-b")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 1, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		vi.spyOn(vcs, "repo").mockImplementation(() => (moved ? opB : opA));
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(display);
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("stable-bookmark");
+		expect(run).not.toHaveBeenCalled();
+
+		// The git side redirects with the jj workspace untouched: the stable
+		// display stays, but PR/status/watchers follow the new operational repo.
+		moved = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("stable-bookmark");
+		expect(content).toContain("+1");
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(content).toContain("#7");
+		expect(watchTargets).toEqual([jjHeads, targetA, jjHeads, targetB]);
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -11,6 +11,9 @@
  * a jj bookmark/change id must never become a GitHub head.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
@@ -201,6 +204,29 @@ describe("StatusLineComponent display detector", () => {
 		onBranchChange.mockClear();
 		watchCallbacks.get(`${root}/.git/HEAD`)?.();
 		expect(onBranchChange).toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("uses jj status for a nested jj workspace inside a cached git repo", async () => {
+		const outer = "/outer";
+		const inner = "/outer/sub";
+		const operational = operationalGit(outer, headFor("main"));
+		const display = displayJj(inner, async () => "inner-bookmark", { staged: 7, unstaged: 8, untracked: 9 });
+		mockRepos(operational, display, inner);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		// Different roots mean nesting, not colocation: the jj label shows,
+		// but counts come from the jj backend rather than the outer git repo.
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("inner-bookmark");
+		expect(content).toContain("*8");
+		expect(content).toContain("+7");
+		expect(content).toContain("?9");
 		component.dispose();
 	});
 
@@ -397,5 +423,98 @@ describe("StatusLineComponent display detector", () => {
 		await flush();
 		expect(run).toHaveBeenCalledTimes(2);
 		component.dispose();
+	});
+
+	it("sanitizes control characters from the jj label", async () => {
+		const root = "/repo/sanitize";
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => `evil-${String.fromCharCode(27)}[2J-bookmark`, { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("evil-");
+		expect(content).toContain("bookmark");
+		// The raw erase-display payload is gone (theme ANSI aside, which is
+		// emitted by the renderer itself, not the label).
+		expect(content).not.toContain("[2J");
+		component.dispose();
+	});
+
+	it("falls back to re-discovery when the jj workspace vanishes", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "omp-jj-vanish-"));
+		const heads = join(dir, ".jj", "repo", "op_heads", "heads");
+		mkdirSync(heads, { recursive: true });
+		try {
+			const operational = operationalGit(dir, headFor("main"));
+			const jjGone = displayJj(dir, async () => "gone-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+			const gitAgain = operationalGit(dir, headFor("main"));
+			mockRepos(operational, jjGone, dir);
+			let now = Date.now();
+			vi.spyOn(Date, "now").mockImplementation(() => now);
+			let displayCalls = 0;
+			vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (++displayCalls === 1 ? jjGone : gitAgain));
+
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => {});
+
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("gone-bookmark");
+
+			// The workspace vanishes; past the cadence the display falls
+			// back to re-discovery and the git branch returns.
+			rmSync(join(dir, ".jj"), { recursive: true, force: true });
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("main");
+			expect(component.getTopBorder(80).content).not.toContain("gone-bookmark");
+			component.dispose();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a live jj workspace without re-discovery walks", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "omp-jj-alive-"));
+		const heads = join(dir, ".jj", "repo", "op_heads", "heads");
+		mkdirSync(heads, { recursive: true });
+		try {
+			const operational = operationalGit(dir, headFor("main"));
+			const display = displayJj(dir, async () => "steady-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+			mockRepos(operational, display, dir);
+			let now = Date.now();
+			vi.spyOn(Date, "now").mockImplementation(() => now);
+			let displayCalls = 0;
+			vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => {
+				displayCalls++;
+				return display;
+			});
+
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => {});
+
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("steady-bookmark");
+
+			// Past the cadence the live watch target short-circuits: no walk.
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(displayCalls).toBe(1);
+			expect(component.getTopBorder(80).content).toContain("steady-bookmark");
+			component.dispose();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -957,4 +957,81 @@ describe("StatusLineComponent display detector", () => {
 			fs.rmSync(outer, { recursive: true, force: true });
 		}
 	});
+
+	it("drops a stale lookup when delayed discovery swaps the repo", async () => {
+		const root = "/repo/retarget-swapbump";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const repoA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("feature")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		const repoB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("branch-b")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		let failRepo = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		const staleOne = Promise.withResolvers<string | null>();
+		const staleTwo = Promise.withResolvers<string | null>();
+		const freshThree = Promise.withResolvers<string | null>();
+		let defaultCalls = 0;
+		vi.spyOn(vcs, "git").mockImplementation(
+			(() => ({
+				defaultBranch: () => {
+					defaultCalls++;
+					return defaultCalls === 1 ? staleOne.promise : defaultCalls === 2 ? staleTwo.promise : freshThree.promise;
+				},
+				linkedWorktree: () => null,
+			}) as unknown as VcsGitRepo),
+		);
+		vi.spyOn(vcs, "repo").mockImplementation(() => {
+			if (failRepo) throw new Error("no repo");
+			return moved ? repoB : repoA;
+		});
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValueOnce({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" })
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":8,"url":"https://example.test/x/8"}', stderr: "" });
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(1);
+
+		// Move with a failing refresh (stale handle kept, retry flagged),
+		// then recover through the accessor: the swap bumps past the
+		// second lookup, which must never commit even though it resolves.
+		moved = true;
+		failRepo = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		failRepo = false;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		staleOne.resolve("main");
+		staleTwo.resolve("branch-b");
+		await flush();
+		component.getTopBorder(80);
+		await flush();
+		expect(run).toHaveBeenCalledTimes(3);
+		expect(component.getTopBorder(80).content).toContain("#8");
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -321,6 +321,42 @@ describe("StatusLineComponent display detector", () => {
 		component.dispose();
 	});
 
+	it("rebinds watchers when the head target moves without a backend change", async () => {
+		const root = "/repo/target-move";
+		const operational = operationalGit(root, headFor("main"));
+		const before = operationalGit(root, headFor("main"));
+		const after = {
+			...operationalGit(root, headFor("main")),
+			watchTarget: () => `${root}/.git/refs/heads/main`,
+		} as unknown as VcsRepo;
+		mockRepos(operational, before, root);
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const movedAt = now + 6_000;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (now >= movedAt ? after : before));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("main");
+
+		// Same kind, same root, new head target: the watcher follows it.
+		now = movedAt;
+		component.getTopBorder(80);
+		await flush();
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.git/refs/heads/main`]);
+		expect(component.getTopBorder(80).content).toContain("main");
+		component.dispose();
+	});
+
 	it("polls the operational branch when its watcher fails to install", async () => {
 		const root = "/repo/watch-failure";
 		let current = headFor("branch-a");

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1162,4 +1162,53 @@ describe("StatusLineComponent display detector", () => {
 		expect(watchTargets).toEqual([jjHeads, targetA, jjHeads, targetB]);
 		component.dispose();
 	});
+
+	it("probes nested checkouts with one discovery call", async () => {
+		const outer = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-deep-"));
+		const cwd = path.join(outer, "a", "b", "c");
+		fs.mkdirSync(cwd, { recursive: true });
+		const heads = path.join(outer, ".jj", "repo", "op_heads", "heads");
+		fs.mkdirSync(heads, { recursive: true });
+		const previousDir = getProjectDir();
+		setProjectDir(cwd);
+		try {
+			const jjBase = displayJj(outer, async () => "deep-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+			const display = { ...jjBase, watchTarget: () => heads } as unknown as VcsRepo;
+			const operational = {
+				kind: () => "jj",
+				asGit: () => null,
+				asJj: () => null,
+				root: () => outer,
+				watchTarget: () => heads,
+				statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+			} as unknown as VcsRepo;
+			mockRepos(operational, display, cwd);
+			let gitCalls = 0;
+			vi.spyOn(vcs, "git").mockImplementation(() => {
+				gitCalls++;
+				return null;
+			});
+			let now = Date.now();
+			vi.spyOn(Date, "now").mockImplementation(() => now);
+
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => {});
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("deep-bookmark");
+			const before = gitCalls;
+			// Past the cadence a four-level nesting costs one discovery
+			// call, not one per level.
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(gitCalls - before).toBeLessThanOrEqual(1);
+			expect(component.getTopBorder(80).content).toContain("deep-bookmark");
+			component.dispose();
+		} finally {
+			setProjectDir(previousDir);
+			fs.rmSync(outer, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -97,8 +97,16 @@ function gitWithDefaultBranch(branch: string): VcsGitRepo {
 	return { defaultBranch: async () => branch, linkedWorktree: () => null } as unknown as VcsGitRepo;
 }
 
-function operationalGit(root: string, head: VcsHeadState | null): VcsRepo {
-	const handle = gitHandle(head);
+function operationalGit(
+	root: string,
+	head: VcsHeadState | null,
+	status: GitStatus = { staged: 0, unstaged: 0, untracked: 0 },
+): VcsRepo {
+	const handle = {
+		headSync: () => head,
+		linkedWorktree: () => null,
+		statusSummary: async (): Promise<GitStatus | null> => status,
+	} as unknown as VcsGitRepo;
 	return {
 		kind: () => "git",
 		asGit: () => handle,
@@ -149,10 +157,10 @@ function mockRepos(operational: VcsRepo, display: VcsRepo, root: string): void {
 }
 
 describe("StatusLineComponent display detector", () => {
-	it("shows the jj bookmark and jj status with the jj watch target when colocated", async () => {
+	it("shows the jj bookmark with live git status when colocated", async () => {
 		const root = "/repo/colocated";
-		const operational = operationalGit(root, headFor("main"));
-		const display = displayJj(root, async () => "my-bookmark", { staged: 1, unstaged: 2, untracked: 3 });
+		const operational = operationalGit(root, headFor("main"), { staged: 1, unstaged: 2, untracked: 3 });
+		const display = displayJj(root, async () => "my-bookmark", { staged: 7, unstaged: 8, untracked: 9 });
 		mockRepos(operational, display, root);
 		const watched: VcsRepo[] = [];
 		const watchCallbacks = new Map<string, () => void>();
@@ -183,6 +191,11 @@ describe("StatusLineComponent display detector", () => {
 		expect(content).toContain("*2");
 		expect(content).toContain("+1");
 		expect(content).toContain("?3");
+		// Counts come from the live operational git status, not the
+		// snapshot-bound jj status.
+		expect(content).not.toContain("*8");
+		expect(content).not.toContain("+7");
+		expect(content).not.toContain("?9");
 		// Firing the operational watcher requests a repaint even though jj
 		// op heads never moved.
 		onBranchChange.mockClear();
@@ -278,6 +291,11 @@ describe("StatusLineComponent display detector", () => {
 		const jjDisplay = displayJj(root, async () => "late-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
 		const gitDisplay = operationalGit(root, headFor("git-branch-name"));
 		mockRepos(operational, gitDisplay, root);
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
 		let now = Date.now();
 		vi.spyOn(Date, "now").mockImplementation(() => now);
 		let displayCalls = 0;
@@ -298,6 +316,8 @@ describe("StatusLineComponent display detector", () => {
 		await flush();
 		expect(displayCalls).toBeGreaterThan(1);
 		expect(component.getTopBorder(80).content).toContain("late-bookmark");
+		// The backend swap rebound the watcher from .git/HEAD to jj op heads.
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`, `${root}/.git/HEAD`]);
 		component.dispose();
 	});
 

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -352,8 +352,10 @@ describe("StatusLineComponent display detector", () => {
 		now = movedAt;
 		component.getTopBorder(80);
 		await flush();
-		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.git/refs/heads/main`]);
 		expect(component.getTopBorder(80).content).toContain("main");
+		// Both watchers rebound: display follows the new target while
+		// operational .git/HEAD coverage is retained.
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.git/refs/heads/main`, `${root}/.git/HEAD`]);
 		component.dispose();
 	});
 

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -11,9 +11,9 @@
  * a jj bookmark/change id must never become a GitHub head.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
@@ -448,9 +448,9 @@ describe("StatusLineComponent display detector", () => {
 	});
 
 	it("falls back to re-discovery when the jj workspace vanishes", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "omp-jj-vanish-"));
-		const heads = join(dir, ".jj", "repo", "op_heads", "heads");
-		mkdirSync(heads, { recursive: true });
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-vanish-"));
+		const heads = path.join(dir, ".jj", "repo", "op_heads", "heads");
+		fs.mkdirSync(heads, { recursive: true });
 		try {
 			const operational = operationalGit(dir, headFor("main"));
 			const jjGone = displayJj(dir, async () => "gone-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
@@ -471,7 +471,7 @@ describe("StatusLineComponent display detector", () => {
 
 			// The workspace vanishes; past the cadence the display falls
 			// back to re-discovery and the git branch returns.
-			rmSync(join(dir, ".jj"), { recursive: true, force: true });
+			fs.rmSync(path.join(dir, ".jj"), { recursive: true, force: true });
 			now += 6_000;
 			component.getTopBorder(80);
 			await flush();
@@ -479,14 +479,14 @@ describe("StatusLineComponent display detector", () => {
 			expect(component.getTopBorder(80).content).not.toContain("gone-bookmark");
 			component.dispose();
 		} finally {
-			rmSync(dir, { recursive: true, force: true });
+			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	});
 
 	it("keeps a live jj workspace without re-discovery walks", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "omp-jj-alive-"));
-		const heads = join(dir, ".jj", "repo", "op_heads", "heads");
-		mkdirSync(heads, { recursive: true });
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-alive-"));
+		const heads = path.join(dir, ".jj", "repo", "op_heads", "heads");
+		fs.mkdirSync(heads, { recursive: true });
 		try {
 			const operational = operationalGit(dir, headFor("main"));
 			const display = displayJj(dir, async () => "steady-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
@@ -515,7 +515,42 @@ describe("StatusLineComponent display detector", () => {
 			expect(component.getTopBorder(80).content).toContain("steady-bookmark");
 			component.dispose();
 		} finally {
-			rmSync(dir, { recursive: true, force: true });
+			fs.rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("installs one watcher pair when setup re-enters on a backend change", async () => {
+		const root = "/repo/reentrant-setup";
+		const operational = operationalGit(root, headFor("main"));
+		const gitDisplay = operationalGit(root, headFor("main"));
+		const jjDisplay = displayJj(root, async () => "reentrant-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, gitDisplay, root);
+		const watchTargets: string[] = [];
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watchTargets.push(repo.watchTarget());
+			return () => {};
+		}) as unknown as typeof vcs.watch);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const movedAt = now + 6_000;
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (now >= movedAt ? jjDisplay : gitDisplay));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("main");
+
+		// Past the cadence the detector observes colocation; re-running
+		// setup re-enters it through revalidation, and the guard leaves a
+		// single pair installed instead of leaking a duplicate.
+		now = movedAt;
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("reentrant-bookmark");
+		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`, `${root}/.git/HEAD`]);
+		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -934,6 +934,10 @@ describe("StatusLineComponent display detector", () => {
 			vi.spyOn(Date, "now").mockImplementation(() => now);
 			let nested = false;
 			vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (nested ? nestedGit : jjLive));
+			// The probe reuses central discovery per level: only the new
+			// nested checkout validates.
+			const gitAtSub = { info: () => ({ repoRoot: sub }) } as unknown as VcsGitRepo;
+			vi.spyOn(vcs, "git").mockImplementation(((dir: string) => (dir === sub && nested ? gitAtSub : null)) as unknown as typeof vcs.git);
 
 			const component = new StatusLineComponent(makeSession());
 			component.updateSettings(gitSegment);
@@ -1032,6 +1036,61 @@ describe("StatusLineComponent display detector", () => {
 		await flush();
 		expect(run).toHaveBeenCalledTimes(3);
 		expect(component.getTopBorder(80).content).toContain("#8");
+		component.dispose();
+	});
+
+	it("drops a pending status fetch when the target moves", async () => {
+		const root = "/repo/status-redirect";
+		const targetA = `${root}/.git-a/HEAD`;
+		const targetB = `${root}/.git-b/HEAD`;
+		const oldStatus = Promise.withResolvers<GitStatus | null>();
+		const dispA = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetA,
+			statusSummary: () => oldStatus.promise,
+		} as unknown as VcsRepo;
+		const dispB = {
+			kind: () => "git",
+			asGit: () => gitHandle(headFor("main")),
+			asJj: () => null,
+			root: () => root,
+			watchTarget: () => targetB,
+			statusSummary: async (): Promise<GitStatus | null> => ({ staged: 1, unstaged: 2, untracked: 3 }),
+		} as unknown as VcsRepo;
+		let moved = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(null);
+		vi.spyOn(vcs, "repo").mockReturnValue(dispA);
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? dispB : dispA));
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+		component.getTopBorder(80);
+		await flush();
+
+		// Move past the cadence with A's fetch still pending: B launches
+		// immediately instead of waiting on it.
+		moved = true;
+		now += 6_000;
+		component.getTopBorder(80);
+		await flush();
+		let content = component.getTopBorder(80).content;
+		expect(content).toContain("*2");
+		expect(content).not.toContain("*9");
+
+		// The stale completion lands late and must neither publish nor
+		// release the new request's slot.
+		oldStatus.resolve({ staged: 9, unstaged: 9, untracked: 9 });
+		await flush();
+		content = component.getTopBorder(80).content;
+		expect(content).toContain("*2");
+		expect(content).not.toContain("*9");
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -553,4 +553,52 @@ describe("StatusLineComponent display detector", () => {
 		expect(watchTargets).toEqual([`${root}/.git/HEAD`, `${root}/.jj/repo/op_heads/heads`, `${root}/.git/HEAD`]);
 		component.dispose();
 	});
+
+	it("falls back when a linked workspace loses its local marker", async () => {
+		const shared = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-shared-"));
+		const ws = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-linked-"));
+		const heads = path.join(shared, "op_heads", "heads");
+		fs.mkdirSync(heads, { recursive: true });
+		// Linked-workspace layout: only an indirection locally, heads shared.
+		fs.writeFileSync(path.join(ws, ".jj"), `repo: ${path.join("..", "shared")}\n`);
+		try {
+			const operational = operationalGit(ws, headFor("main"));
+			const linked = {
+				kind: () => "jj",
+				asGit: () => null,
+				asJj: () => ({}) as never,
+				root: () => ws,
+				watchTarget: () => heads,
+				label: async () => "linked-bookmark",
+				statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+			} as unknown as VcsRepo;
+			const gitAgain = operationalGit(ws, headFor("main"));
+			mockRepos(operational, linked, ws);
+			let now = Date.now();
+			vi.spyOn(Date, "now").mockImplementation(() => now);
+			let displayCalls = 0;
+			vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (++displayCalls === 1 ? linked : gitAgain));
+
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => {});
+
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("linked-bookmark");
+
+			// The local marker goes away while the shared target survives:
+			// past the cadence the display still falls back to re-discovery.
+			fs.rmSync(path.join(ws, ".jj"), { force: true });
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("main");
+			expect(component.getTopBorder(80).content).not.toContain("linked-bookmark");
+			component.dispose();
+		} finally {
+			fs.rmSync(shared, { recursive: true, force: true });
+			fs.rmSync(ws, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -902,4 +902,59 @@ describe("StatusLineComponent display detector", () => {
 		expect(run).toHaveBeenCalledTimes(1);
 		component.dispose();
 	});
+
+	it("observes a nested git checkout created under a cached jj workspace", async () => {
+		const outer = fs.mkdtempSync(path.join(os.tmpdir(), "omp-jj-outer-"));
+		const sub = path.join(outer, "sub");
+		fs.mkdirSync(sub, { recursive: true });
+		const heads = path.join(outer, ".jj", "repo", "op_heads", "heads");
+		fs.mkdirSync(heads, { recursive: true });
+		const previousDir = getProjectDir();
+		setProjectDir(sub);
+		try {
+			const jjBase = displayJj(outer, async () => "outer-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
+			// displayJj hardcodes a fake watch target; point it at the real one.
+			const jjLive = { ...jjBase, watchTarget: () => heads } as unknown as VcsRepo;
+			const operationalJj = {
+				kind: () => "jj",
+				asGit: () => null,
+				asJj: () => null,
+				root: () => outer,
+				watchTarget: () => heads,
+				statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+			} as unknown as VcsRepo;
+			const nestedGit = operationalGit(sub, headFor("nested-branch"));
+			mockRepos(operationalJj, jjLive, sub);
+			const watchTargets: string[] = [];
+			vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+				watchTargets.push(repo.watchTarget());
+				return () => {};
+			}) as unknown as typeof vcs.watch);
+			let now = Date.now();
+			vi.spyOn(Date, "now").mockImplementation(() => now);
+			let nested = false;
+			vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (nested ? nestedGit : jjLive));
+
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => {});
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("outer-bookmark");
+
+			// A nested git checkout appears below the cached jj root: past
+			// the cadence it takes precedence for dirs inside it.
+			fs.mkdirSync(path.join(sub, ".git"), { recursive: true });
+			nested = true;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("nested-branch");
+			expect(watchTargets).toContain(`${sub}/.git/HEAD`);
+			component.dispose();
+		} finally {
+			setProjectDir(previousDir);
+			fs.rmSync(outer, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/status-line-display-removal.test.ts
+++ b/packages/coding-agent/test/status-line-display-removal.test.ts
@@ -1,0 +1,212 @@
+/**
+ * When re-discovery authoritatively returns null (the repository was
+ * removed — e.g. a worktree `.git` pointer retargeted at a missing
+ * directory), the stale display handle must be dropped rather than
+ * served forever. Discovery *exceptions* (transient I/O) still keep the
+ * stale handle; only a successful null means removal. A reappearing
+ * repository is picked back up on cadence.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+const root = "/repo/display-removal";
+const targetA = `${root}/.git/HEAD`;
+
+function headFor(branch: string): VcsHeadState {
+	return { kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined };
+}
+
+const fakeRepoInfo: VcsGitRepoInfo = {
+	commonDir: `${root}/.git`,
+	gitDir: `${root}/.git`,
+	gitEntryPath: `${root}/.git`,
+	headPath: targetA,
+	repoRoot: root,
+	isReftable: false,
+};
+
+const gitSettings: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["git"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "display-removal test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				orchestrationCacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function gitRepo(): VcsRepo {
+	const handle = {
+		defaultBranch: async () => "main",
+		headSync: () => headFor("feature/a"),
+		linkedWorktree: () => null,
+		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	} as unknown as VcsGitRepo;
+	return {
+		kind: () => "git",
+		asGit: () => handle,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => targetA,
+		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	} as unknown as VcsRepo;
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("StatusLineComponent display removal", () => {
+	it("drops the stale handle when rediscovery returns null, and recovers on return", async () => {
+		const repo = gitRepo();
+		let displayRepo: VcsRepo | null = repo;
+		let opRepo: VcsRepo | null = repo;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+		vi.spyOn(vcs, "git").mockReturnValue(repo.asGit());
+		vi.spyOn(vcs, "repo").mockImplementation(() => opRepo);
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => displayRepo);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+
+			// The repository is removed: both detectors authoritatively
+			// return null. The old branch must stop rendering.
+			displayRepo = null;
+			opRepo = null;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).not.toContain("feature/a");
+
+			// A reappearing repository is picked back up on cadence.
+			displayRepo = repo;
+			opRepo = repo;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+		} finally {
+			component.dispose();
+		}
+	});
+
+	it("keeps the handle when only display blips but operational resolves", async () => {
+		const repo = gitRepo();
+		let displayRepo: VcsRepo | null = repo;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+		vi.spyOn(vcs, "git").mockReturnValue(repo.asGit());
+		vi.spyOn(vcs, "repo").mockReturnValue(repo);
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => displayRepo);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+
+			// A lone display null while operational resolves (racing
+			// mutation, skewed detectors) must not nuke the handle.
+			displayRepo = null;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+		} finally {
+			component.dispose();
+		}
+	});
+	it("keeps the stale handle when discovery throws", async () => {
+		const repo = gitRepo();
+		let failDiscovery = false;
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+		vi.spyOn(vcs, "git").mockReturnValue(repo.asGit());
+		vi.spyOn(vcs, "repo").mockReturnValue(repo);
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => {
+			if (failDiscovery) throw new Error("transient I/O");
+			return repo;
+		});
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+
+			failDiscovery = true;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/a");
+		} finally {
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-display-removal.test.ts
+++ b/packages/coding-agent/test/status-line-display-removal.test.ts
@@ -152,34 +152,6 @@ describe("StatusLineComponent display removal", () => {
 		}
 	});
 
-	it("keeps the handle when only display blips but operational resolves", async () => {
-		const repo = gitRepo();
-		let displayRepo: VcsRepo | null = repo;
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
-		vi.spyOn(vcs, "git").mockReturnValue(repo.asGit());
-		vi.spyOn(vcs, "repo").mockReturnValue(repo);
-		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => displayRepo);
-		let now = Date.now();
-		vi.spyOn(Date, "now").mockImplementation(() => now);
-
-		const component = new StatusLineComponent(makeSession());
-		component.updateSettings(gitSettings);
-		try {
-			component.getTopBorder(80);
-			await flush();
-			expect(component.getTopBorder(80).content).toContain("feature/a");
-
-			// A lone display null while operational resolves (racing
-			// mutation, skewed detectors) must not nuke the handle.
-			displayRepo = null;
-			now += 6_000;
-			component.getTopBorder(80);
-			await flush();
-			expect(component.getTopBorder(80).content).toContain("feature/a");
-		} finally {
-			component.dispose();
-		}
-	});
 	it("keeps the stale handle when discovery throws", async () => {
 		const repo = gitRepo();
 		let failDiscovery = false;

--- a/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
@@ -202,4 +202,34 @@ describe("StatusLineComponent jj label fallback", () => {
 			component.dispose();
 		}
 	});
+
+	it("repaints when recovery yields a healthy null label", async () => {
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		mockBackends(label);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		const onBranchChange = vi.fn();
+		component.updateSettings(gitSettings);
+		component.watchBranch(onBranchChange);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/g");
+			onBranchChange.mockClear();
+
+			// The store is repaired but holds no bookmark: the load succeeds
+			// with null, presentation returns to jj-empty, and the frame
+			// must repaint even though no cached value changed.
+			label.mockResolvedValue(null);
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(onBranchChange).toHaveBeenCalled();
+			expect(component.getTopBorder(80).content).not.toContain("feature/g");
+		} finally {
+			component.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
@@ -177,10 +177,13 @@ describe("StatusLineComponent jj label fallback", () => {
 		}
 	});
 
-	it("does not retire the handle on abort/timeout rejections", async () => {
+	it("does not retire the handle on native cancellation", async () => {
+		// The binding's actual timeout shape: repo_blocking rejects with
+		// { name: "VcsError", code: "Canceled" } when the signal fires
+		// before the native task begins — not a DOM TimeoutError.
 		const label = vi
 			.fn<() => Promise<string | null>>()
-			.mockRejectedValue(Object.assign(new Error("slow store"), { name: "TimeoutError" }));
+			.mockRejectedValue(Object.assign(new Error("operation canceled"), { name: "VcsError", code: "Canceled" }));
 		mockBackends(label);
 		let now = Date.now();
 		vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
@@ -86,6 +86,7 @@ async function flush(): Promise<void> {
 	await Promise.resolve();
 }
 
+
 function mockBackends(label: () => Promise<string | null>) {
 	const gitHandle = {
 		defaultBranch: async () => "main",
@@ -178,27 +179,42 @@ describe("StatusLineComponent jj label fallback", () => {
 	});
 
 	it("does not retire the handle on native cancellation", async () => {
-		// The binding's actual timeout shape: repo_blocking rejects with
-		// { name: "VcsError", code: "Canceled" } when the signal fires
-		// before the native task begins — not a DOM TimeoutError.
-		const label = vi
-			.fn<() => Promise<string | null>>()
-			.mockRejectedValue(Object.assign(new Error("operation canceled"), { name: "VcsError", code: "Canceled" }));
+		// Real failure path: a native handle failing its pre-start heartbeat
+		// for an aborted signal (no repo I/O runs) rejects with the binding's
+		// VcsError/code Canceled shape. Deterministic: CancelToken honors
+		// already-fired signals, so no worker race is involved.
+		const nativeRepo = vcs.repo(import.meta.dir);
+		if (!nativeRepo) throw new Error("expected a git checkout above the test dir");
+		const stop = new AbortController();
+		stop.abort();
+		const pending: Promise<string | null>[] = [];
+		const label = vi.fn<() => Promise<string | null>>(() => {
+			const promise = nativeRepo.label(stop.signal).then(label => label ?? null);
+			pending.push(promise);
+			return promise;
+		});
 		mockBackends(label);
 		let now = Date.now();
 		vi.spyOn(Date, "now").mockImplementation(() => now);
+		// Await the native settlement itself (event loop), then drain the
+		// component continuations — no wall-clock guessing.
+		async function settleNative(): Promise<void> {
+			await Promise.allSettled(pending);
+			pending.length = 0;
+			await flush();
+		}
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSettings);
 		try {
 			component.getTopBorder(80);
-			await flush();
+			await settleNative();
 			// Transient timeout: keep the (empty) jj presentation and retry
 			// on cadence rather than failing over to git.
 			expect(component.getTopBorder(80).content).not.toContain("feature/g");
 			now += 6_000;
 			component.getTopBorder(80);
-			await flush();
+			await settleNative();
 			expect(label.mock.calls.length).toBeGreaterThanOrEqual(2);
 			expect(component.getTopBorder(80).content).not.toContain("feature/g");
 		} finally {

--- a/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
+++ b/packages/coding-agent/test/status-line-jj-label-fallback.test.ts
@@ -1,0 +1,205 @@
+/**
+ * When a colocated jj workspace's store is corrupt, `detect_for_display`
+ * still prefers the jj handle (previously the operational detector chose
+ * equal-root Git, so the git branch always rendered). The jj label load
+ * then rejects on every refresh while the usable git branch stays hidden.
+ *
+ * Contract: a genuine jj label rejection (not an abort/timeout, not a
+ * healthy null) retires that display handle to the already-discovered
+ * operational git repo and repaints, so the git branch renders. The
+ * retirement is keyed by watch target and re-probes jj at the refresh
+ * cadence, so a repaired workspace recovers without a restart.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+const root = "/repo/jj-label-fallback";
+const jjTarget = `${root}/.jj/repo/op_heads/heads`;
+const gitTarget = `${root}/.git/HEAD`;
+
+function headFor(branch: string): VcsHeadState {
+	return { kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined };
+}
+
+const fakeRepoInfo: VcsGitRepoInfo = {
+	commonDir: `${root}/.git`,
+	gitDir: `${root}/.git`,
+	gitEntryPath: `${root}/.git`,
+	headPath: gitTarget,
+	repoRoot: root,
+	isReftable: false,
+};
+
+const gitSettings: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["git"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "jj-label-fallback test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				orchestrationCacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function mockBackends(label: () => Promise<string | null>) {
+	const gitHandle = {
+		defaultBranch: async () => "main",
+		headSync: () => headFor("feature/g"),
+		linkedWorktree: () => null,
+		statusSummary: async () => ({ staged: 1, unstaged: 2, untracked: 3 }),
+	} as unknown as VcsGitRepo;
+	const git = {
+		kind: () => "git",
+		asGit: () => gitHandle,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => gitTarget,
+		statusSummary: async () => ({ staged: 1, unstaged: 2, untracked: 3 }),
+	} as unknown as VcsRepo;
+	const jj = {
+		kind: () => "jj",
+		asGit: () => null,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => jjTarget,
+		label,
+		statusSummary: async (): Promise<{ staged: number; unstaged: number; untracked: number } | null> => {
+			throw new Error("store gone");
+		},
+	} as unknown as VcsRepo;
+	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+	vi.spyOn(vcs, "git").mockReturnValue(gitHandle);
+	vi.spyOn(vcs, "repo").mockReturnValue(git);
+	vi.spyOn(vcs, "repoForDisplay").mockReturnValue(jj);
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+beforeEach(() => {});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("StatusLineComponent jj label fallback", () => {
+	it("serves the colocated git branch while the jj label load rejects", async () => {
+		const label = vi.fn<() => Promise<string | null>>().mockRejectedValue(new Error("store gone"));
+		mockBackends(label);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(component.getTopBorder(80).content).toContain("feature/g");
+			expect(label).toHaveBeenCalledTimes(1);
+
+			// No hot loop: within the refresh window no new load is issued.
+			now += 1_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(1);
+			expect(component.getTopBorder(80).content).toContain("feature/g");
+
+			// Past the window exactly one bounded re-probe runs, still
+			// serving git while jj stays broken (no null flash).
+			now += 5_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(label).toHaveBeenCalledTimes(2);
+			expect(component.getTopBorder(80).content).toContain("feature/g");
+
+			// A repaired workspace recovers without a restart.
+			label.mockResolvedValue("fixed-bookmark");
+			now += 5_000;
+			component.getTopBorder(80);
+			await flush();
+			const content = component.getTopBorder(80).content;
+			expect(content).toContain("fixed-bookmark");
+			expect(content).not.toContain("feature/g");
+		} finally {
+			component.dispose();
+		}
+	});
+
+	it("does not retire the handle on abort/timeout rejections", async () => {
+		const label = vi
+			.fn<() => Promise<string | null>>()
+			.mockRejectedValue(Object.assign(new Error("slow store"), { name: "TimeoutError" }));
+		mockBackends(label);
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			// Transient timeout: keep the (empty) jj presentation and retry
+			// on cadence rather than failing over to git.
+			expect(component.getTopBorder(80).content).not.toContain("feature/g");
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(label.mock.calls.length).toBeGreaterThanOrEqual(2);
+			expect(component.getTopBorder(80).content).not.toContain("feature/g");
+		} finally {
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-pr-lookup-swap.test.ts
+++ b/packages/coding-agent/test/status-line-pr-lookup-swap.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression: a same-cwd repository swap while `github.run()` was pending
+ * retired the cached PR but left `#prLookupInFlight` set, so the new
+ * repository's `#lookupPr` early-returned null and its PR stayed hidden
+ * until the superseded run settled (up to GH_COMMAND_TIMEOUT_MS — five
+ * minutes).
+ *
+ * Contract: `#handleRepositoryTargetChanged` bumps `#prLookupGeneration`
+ * and retires the slot, so the new repository starts its own lookup on
+ * the next paint; the stale completion is dropped by the generation check
+ * (on top of the existing cwd/context guards) and must not clear the new
+ * lookup's slot in its finally-block.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+const root = "/fake";
+const targetA = `${root}/.git-a/HEAD`;
+const targetB = `${root}/.git-b/HEAD`;
+
+function headFor(branch: string): VcsHeadState {
+	return { kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined };
+}
+
+const fakeRepoInfo: VcsGitRepoInfo = {
+	commonDir: `${root}/.git`,
+	gitDir: `${root}/.git`,
+	gitEntryPath: `${root}/.git`,
+	headPath: `${root}/.git/HEAD`,
+	repoRoot: root,
+	isReftable: false,
+};
+
+function gitHandleFor(branch: string): VcsGitRepo {
+	return {
+		// Sync seed "main" keeps `#isDefaultBranch` false for feature branches.
+		defaultBranch: async () => "main",
+		headSync: () => headFor(branch),
+		linkedWorktree: () => null,
+	} as unknown as VcsGitRepo;
+}
+
+function repoFor(branch: string, target: string): VcsRepo {
+	return {
+		kind: () => "git",
+		asGit: () => gitHandleFor(branch),
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => target,
+		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	} as unknown as VcsRepo;
+}
+
+const gitPrSettings: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["pr"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "pr-lookup-swap test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				orchestrationCacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+beforeEach(() => {
+	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("StatusLineComponent PR lookup across repository swaps", () => {
+	it("starts a new lookup after a same-cwd swap and drops the stale result", async () => {
+		const repoA = repoFor("feature/x", targetA);
+		const repoB = repoFor("feature/y", targetB);
+		let moved = false;
+		vi.spyOn(vcs, "git").mockImplementation(() => gitHandleFor(moved ? "feature/y" : "feature/x"));
+		vi.spyOn(vcs, "repo").mockImplementation(() => (moved ? repoB : repoA));
+		vi.spyOn(vcs, "repoForDisplay").mockImplementation(() => (moved ? repoB : repoA));
+
+		const staleGate = Promise.withResolvers<void>();
+		const run = vi.spyOn(github, "run").mockImplementation(async () => {
+			if (run.mock.calls.length === 1) {
+				// The superseded lookup stays pending across the swap.
+				await staleGate.promise;
+				return { exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" };
+			}
+			return { exitCode: 0, stdout: '{"number":8,"url":"https://example.test/x/8"}', stderr: "" };
+		});
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSettings);
+		try {
+			component.getTopBorder(80);
+			await flush();
+			expect(run).toHaveBeenCalledTimes(1);
+
+			// Same cwd, new repository target: the next paint must start
+			// the new repository's lookup instead of waiting out the old one.
+			moved = true;
+			now += 6_000;
+			component.getTopBorder(80);
+			await flush();
+			expect(run).toHaveBeenCalledTimes(2);
+
+			// The superseded completion must not publish under the new repo.
+			staleGate.resolve();
+			await flush();
+			const content = component.getTopBorder(80).content;
+			expect(content).toContain("#8");
+			expect(content).not.toContain("#7");
+		} finally {
+			staleGate.resolve();
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -149,6 +149,16 @@ beforeEach(() => {
 	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
 	vi.spyOn(vcs, "git").mockReturnValue(fakeRepository);
 	vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepository);
+	// Presentation now resolves a second handle: forward to the operational
+	// double's current implementation without recording an extra `repo` call,
+	// so these scenarios keep display == operational (pure git / pure jj)
+	// while call-count assertions on the operational detector keep meaning.
+	const operational = vi.spyOn(vcs, "repo") as unknown as {
+		getMockImplementation(): ((dir: string) => VcsRepo | null) | undefined;
+	};
+	vi.spyOn(vcs, "repoForDisplay").mockImplementation(
+		(dir: string) => operational.getMockImplementation()?.(dir) ?? null,
+	);
 });
 
 function useReftable(info: Partial<VcsGitRepoInfo> = {}): void {

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -148,7 +148,7 @@ beforeEach(() => {
 	jjControls.label.mockReset().mockResolvedValue(null);
 	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
 	vi.spyOn(vcs, "git").mockReturnValue(fakeRepository);
-	vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepository);
+	vi.spyOn(vcs, "repo").mockImplementation(() => fakeVcsRepository);
 	// Presentation now resolves a second handle: forward to the operational
 	// double's current implementation without recording an extra `repo` call,
 	// so these scenarios keep display == operational (pure git / pure jj)
@@ -211,7 +211,7 @@ describe("StatusLineComponent repaints when an async VCS fetch resolves", () => 
 		gitControls.headSync.mockReturnValue(null); // no git branch -> jj overlay
 		gitControls.defaultBranch.mockReturnValue(Promise.withResolvers<string | null>().promise);
 		gitControls.statusSummary.mockReturnValue(Promise.withResolvers<GitStatus | null>().promise); // isolate the jj fire
-		vi.spyOn(vcs, "repo").mockReturnValue(fakeJjRepository);
+		vi.spyOn(vcs, "repo").mockImplementation(() => fakeJjRepository);
 		const label = Promise.withResolvers<string | null>();
 		jjControls.label.mockReturnValue(label.promise);
 
@@ -235,7 +235,7 @@ describe("StatusLineComponent repaints when an async VCS fetch resolves", () => 
 		gitControls.headSync.mockReturnValue(null); // no git -> jj repo
 		gitControls.defaultBranch.mockReturnValue(Promise.withResolvers<string | null>().promise);
 		gitControls.statusSummary.mockReturnValue(Promise.withResolvers<GitStatus | null>().promise);
-		vi.spyOn(vcs, "repo").mockReturnValue(fakeJjRepository);
+		vi.spyOn(vcs, "repo").mockImplementation(() => fakeJjRepository);
 		jjControls.label.mockReturnValue(Promise.withResolvers<string | null>().promise); // isolate the status fire
 		const status = Promise.withResolvers<GitStatus | null>();
 		jjControls.statusSummary.mockReturnValue(status.promise);
@@ -531,7 +531,7 @@ describe("StatusLineComponent VCS watcher and jj request lifecycle", () => {
 		gitControls.headSync.mockReturnValue(null);
 		gitControls.defaultBranch.mockReturnValue(Promise.withResolvers<string | null>().promise);
 		gitControls.statusSummary.mockReturnValue(Promise.withResolvers<GitStatus | null>().promise);
-		vi.spyOn(vcs, "repo").mockReturnValue(fakeJjRepository);
+		vi.spyOn(vcs, "repo").mockImplementation(() => fakeJjRepository);
 
 		const labelRequests: Array<{ signal: AbortSignal; resolve: (value: string | null) => void }> = [];
 		jjControls.label.mockImplementation(signal => {

--- a/packages/coding-agent/test/transient-vcs-error.test.ts
+++ b/packages/coding-agent/test/transient-vcs-error.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Contract for {@link isTransientVcsError}: which rejection shapes count as
+ * a transient cancellation (retry-later) versus a genuine backend failure
+ * (fail-over). The native shape mirrors `repo_blocking`'s `rich_error`
+ * mapping (`{ name: "VcsError", code: <Error::kind> }`); note the binding
+ * spells cancellation with one L (`Canceled`), so the napi `Status`
+ * spelling (`Cancelled`) must NOT match.
+ */
+import { describe, expect, it } from "bun:test";
+import { isTransientVcsError } from "@oh-my-pi/pi-coding-agent/modes/shared";
+
+describe("isTransientVcsError", () => {
+	it("treats the native cancellation shape as transient", () => {
+		expect(isTransientVcsError({ name: "VcsError", code: "Canceled" })).toBe(true);
+	});
+
+	it("treats DOM abort/timeout names as transient", () => {
+		expect(isTransientVcsError({ name: "AbortError" })).toBe(true);
+		expect(isTransientVcsError({ name: "TimeoutError" })).toBe(true);
+	});
+
+	it("treats genuine backend failures as non-transient", () => {
+		expect(isTransientVcsError({ name: "VcsError", code: "Backend" })).toBe(false);
+		expect(isTransientVcsError({ name: "VcsError", code: "Io" })).toBe(false);
+		// One L is ours; two Ls is not.
+		expect(isTransientVcsError({ name: "VcsError", code: "Cancelled" })).toBe(false);
+		expect(isTransientVcsError(new Error("store gone"))).toBe(false);
+		expect(isTransientVcsError(null)).toBe(false);
+		expect(isTransientVcsError(undefined)).toBe(false);
+	});
+});

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `vcsDiscoverForDisplay` (`repoForDisplay`): like repository discovery, but equal-root jj+git ties prefer Jujutsu for display surfaces. Git-safe automation must keep using `vcsDiscover` ([#11071](https://github.com/can1357/oh-my-pi/issues/11071)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `vcsDiscoverForDisplay` (`repoForDisplay`): like repository discovery, but equal-root jj+git ties prefer Jujutsu for display surfaces. Git-safe automation must keep using `vcsDiscover` ([#11071](https://github.com/can1357/oh-my-pi/issues/11071)).
+- Added `vcsDiscoverForDisplay` (`repoForDisplay`): like repository discovery, but equal-root jj+git ties prefer Jujutsu for display surfaces. Git-safe automation must keep using `vcsDiscover` ([#11071](https://github.com/can1357/oh-my-pi/issues/11071), [#11113](https://github.com/can1357/oh-my-pi/pull/11113) by [@boazy](https://github.com/boazy)).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -2778,6 +2778,12 @@ export interface VcsDiffOptions {
 /** Discover the repository owning a directory. */
 export declare function vcsDiscover(dir: string): VcsRepo | null
 
+/**
+ * Discover the repository presenting a directory: equal-root jj+git ties
+ * prefer Jujutsu. Git-safe automation must keep using [`vcs_discover`].
+ */
+export declare function vcsDiscoverForDisplay(dir: string): VcsRepo | null
+
 /** Clone a Git repository. */
 export declare function vcsGitClone(url: string, target: string, options: VcsCloneOptions, signal?: unknown | undefined | null): Promise<void>
 

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -113,6 +113,7 @@ export const supportsLanguage = nativeBindings.supportsLanguage;
 export const truncateToWidth = nativeBindings.truncateToWidth;
 export const vcsDetachGitDir = nativeBindings.vcsDetachGitDir;
 export const vcsDiscover = nativeBindings.vcsDiscover;
+export const vcsDiscoverForDisplay = nativeBindings.vcsDiscoverForDisplay;
 export const vcsGitClone = nativeBindings.vcsGitClone;
 export const vcsGitDiscover = nativeBindings.vcsGitDiscover;
 export const vcsGitRepoInfo = nativeBindings.vcsGitRepoInfo;

--- a/packages/natives/native/vcs.d.ts
+++ b/packages/natives/native/vcs.d.ts
@@ -47,6 +47,8 @@ export declare function isEmptyCherryPick(error: unknown): error is VcsError & {
 export declare function git(dir: string): VcsGitRepo | null;
 /** Discover the repository owning `dir`; `null` outside any repository. */
 export declare function repo(dir: string): VcsRepo | null;
+/** Like {@link repo}, but equal-root jj+git ties prefer Jujutsu for display. Git-safe automation must keep using {@link repo}. */
+export declare function repoForDisplay(dir: string): VcsRepo | null;
 
 /** Like {@link repo}, asserting any requested backend capabilities. */
 export declare function require(dir: string, ...features: VcsFeature[]): VcsRepo;

--- a/packages/natives/native/vcs.js
+++ b/packages/natives/native/vcs.js
@@ -41,6 +41,11 @@ export function repo(dir) {
 	return api().vcsDiscover(dir);
 }
 
+/** Like {@link repo}, but equal-root jj+git ties prefer Jujutsu for display. Git-safe automation must keep using {@link repo}. */
+export function repoForDisplay(dir) {
+	return api().vcsDiscoverForDisplay(dir);
+}
+
 /** Like {@link repo}, asserting any requested backend capabilities. */
 export function require(dir, ...features) {
 	const discovered = repo(dir);


### PR DESCRIPTION
Fixes #11071.

## Problem
In a colocated jj-git workspace, `detect()` resolves to `Repo::Git`, so the status line and footer read git HEAD — almost always detached — instead of the active jj bookmark/change id.

## Approach: second detector, display/operation split
- `crates/pi-vcs`: new `detect_for_display()` differs from `detect()` in exactly one policy — equal-root jj+git ties prefer JJ. Strictly deeper nested git still wins either direction, and `is_pure_jj()` keeps using `detect()`, so git-mutating automation policy (#1939) is unchanged. No `Colocated` variant; existing `Repo` dispatch serves both detectors.
- `crates/pi-natives` + wrappers: exposed as `vcsDiscoverForDisplay` / `vcs.repoForDisplay()` (bindings regenerated). Automation keeps `vcsDiscover` / `vcs.repo()`.
- Status line and legacy footer present the branch label through the display repository (jj bookmark/change id when colocated). Status counts stay on the live operational git status: the jj status path reads the last snapshotted commit and misses working-copy edits until the next jj operation, while snapshotting from render is off the table — so counts behave exactly as before this PR.
- A failed display lookup degrades to the operational repository rather than hiding the segment, and git/git display pairs revalidate at the failure-poll cadence so mid-session `jj git init --colocate` is picked up. On a backend change both watchers rebind (status line) and the footer watcher rebinds with its cache cleared, so jj-only changes invalidate from then on.
- PR lookup and default-branch state keep resolving the **operational** git branch (`#getBranchLabel` takes an optional repository override defaulting to display), so a jj bookmark/change id can never become a GitHub head query.
- Watchers: the display target is watched as before, plus the operational `.git/HEAD` target whenever it differs (colocated), so a direct `git switch` invalidates the git branch/PR cache; both retire together, and a failed operational watch falls back to polling instead of going stale.

## Alternatives considered
- **Uncollapsed `Repo::ColocatedJj` enum** (issue thread): principled end state, but forces a per-method backend policy across ~20 `Repo` dispatch methods plus the N-API/TS surface. This keeps the narrow safety boundary instead.
- **Flipping `detect()` to JJ**: rejected — would reclassify colocated as pure jj and disable Git-backed automation guards.
- **Detached-HEAD as the trigger**: rejected — mislabels plain-git detached checkouts and misses colocated checkouts with an attached HEAD. The predicate is root equality throughout.

## Verification
- Rust: equal-root tie prefers JJ while `detect()` stays Git; pure git/jj and both nesting directions agree across detectors (`cargo test -p pi-vcs`: 43 pass including the 2 new tests; 13 git/jj CLI-output comparisons fail identically on the clean tree — environment drift).
- TS: 7 colocated status-line tests (bookmark over attached HEAD, live git counts distinguished from the snapshot-bound jj counts, nested-git keeps git branch, plain detached unchanged, dual-watcher targets + operational-fire repaint, single watcher for pure git, PR lookup silent on default branch despite bookmark, PR lookup live by operational branch, watch-failure poll fallback, late-colocation pickup with watcher rebind) plus a footer rebind test (watcher + label follow late colocation); full status-line suite green with no weakened expectations.
- `cargo check -p pi-natives`, `tsgo --noEmit`, `oxlint`, `oxfmt --check` clean. Changelogs added for both touched packages.