### PR TITLE
docs(browser): clarify tab.evaluate string semantics

### DIFF
--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -11,7 +11,7 @@ Drive real Chromium tabs from JavaScript or Python Eval with the global `browser
   - Inspection: `observe`, `ariaSnapshot`, `screenshot`, `extract`.
   - Interaction: `click`, `type`, `fill`, `press`, `scroll`, `drag`, `scrollIntoView`, `select`, `uploadFile`.
   - Waiting: `waitFor`, `waitForSelector`, `waitForUrl`.
-  - Page execution: `evaluate`. `tab.evaluate(string)` runs in the page's global context; wrap it in a function or IIFE to use `return`.
+  - Page execution: `evaluate`. `tab.evaluate(string)` evaluates the string as a page-global expression; top-level `return` is invalid. Pass a function or invoke an IIFE string to use `return`.
 - `tab.id(n)` / `tab.ref("e5")` return `BrowserElement` handles supporting `click`, `type`, `fill`, `press`, `hover`, `focus`, `select`, `uploadFile`, `scrollIntoView`, `boundingBox`, `isVisible`, `isHidden`, and `evaluate`. A string passed to `BrowserElement.evaluate` is a function expression invoked with the element as its first argument.
 - JavaScript `await tab.run(fnOrCode, { args?, timeout? })` runs a function or code string. Functions receive `{ tab, page, browser, wait, assert }`; cell closures are not captured. Plain data, functions, and `RegExp` values are supported in `args`.
 - Python `await tab.run(code, timeout=…)` accepts a JavaScript code string only. Direct Python helpers use the same method names; keyword arguments become a trailing JavaScript options object.

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -11,7 +11,7 @@ Drive real Chromium tabs from JavaScript or Python Eval with the global `browser
   - Inspection: `observe`, `ariaSnapshot`, `screenshot`, `extract`.
   - Interaction: `click`, `type`, `fill`, `press`, `scroll`, `drag`, `scrollIntoView`, `select`, `uploadFile`.
   - Waiting: `waitFor`, `waitForSelector`, `waitForUrl`.
-  - Page execution: `evaluate`.
+  - Page execution: `evaluate`. `tab.evaluate(string)` runs in the page's global context; wrap it in a function or IIFE to use `return`.
 - `tab.id(n)` / `tab.ref("e5")` return `BrowserElement` handles supporting `click`, `type`, `fill`, `press`, `hover`, `focus`, `select`, `uploadFile`, `scrollIntoView`, `boundingBox`, `isVisible`, `isHidden`, and `evaluate`. A string passed to `BrowserElement.evaluate` is a function expression invoked with the element as its first argument.
 - JavaScript `await tab.run(fnOrCode, { args?, timeout? })` runs a function or code string. Functions receive `{ tab, page, browser, wait, assert }`; cell closures are not captured. Plain data, functions, and `RegExp` values are supported in `args`.
 - Python `await tab.run(code, timeout=…)` accepts a JavaScript code string only. Direct Python helpers use the same method names; keyword arguments become a trailing JavaScript options object.


### PR DESCRIPTION
## What

Clarifies how `tab.evaluate` handles string input and how to use `return` correctly.

## Why

The previous description could mislead agents into treating string input as a function body and using an invalid top-level `return`.

Fixes #10592

## Testing
- Ran `bun check`; all checks passed.
- Ran `bun scripts/format-prompts.ts --check` from `packages/coding-agent`; all prompt files are formatted.
- Confirmed that the assembled browser prelude includes the clarification.
- Confirmed that `tab.evaluate("1 + 2")` returns `3`, a top-level `return` raises `SyntaxError: Illegal return statement`, and an IIFE containing `return` succeeds.
- No runtime behavior was changed.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not applicable: documentation-only clarification)
