### PR TITLE
test(mcp): event-gate the reauth manual-input claim instead of a wall-clock budget

### DIFF
--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -867,11 +867,20 @@ describe("/mcp auth commands", () => {
 		});
 
 		const { controller, ctx, showError, showStatus, editor, oauthManualInput } = createController(authStorage);
+		// Event-gate the claim instead of polling to a wall-clock deadline: on a
+		// loaded runner the old 1s budget could expire before the flow claimed the
+		// manual-input slot, and the assertion below then read `undefined` from a
+		// slot that was merely late. Resolving off `tryClaimInput` itself makes the
+		// wait bounded by the event it is actually waiting for.
+		const claimed = Promise.withResolvers<void>();
+		const tryClaimInput = oauthManualInput.tryClaimInput.bind(oauthManualInput);
+		vi.spyOn(oauthManualInput, "tryClaimInput").mockImplementation(providerId => {
+			const result = tryClaimInput(providerId);
+			if (result) claimed.resolve();
+			return result;
+		});
 		const firstReauth = controller.handle("/mcp reauth envserver");
-		const claimDeadline = Date.now() + 1_000;
-		while (!oauthManualInput.hasPending() && Date.now() < claimDeadline) {
-			await Bun.sleep(10);
-		}
+		await claimed.promise;
 		expect(oauthManualInput.pendingProviderId).toBe("mcp");
 
 		const replacementReauth = new MCPCommandController(ctx).handle("/mcp reauth envserver");


### PR DESCRIPTION
`reauth supersedes an unfinished MCP OAuth flow` in `test/mcp-command-reauth.test.ts` waits for the OAuth flow to claim the manual-input slot by polling against a 1s wall-clock budget, then asserts on the pending provider id:

```ts
const claimDeadline = Date.now() + 1_000;
while (!oauthManualInput.hasPending() && Date.now() < claimDeadline) {
    await Bun.sleep(10);
}
expect(oauthManualInput.pendingProviderId).toBe("mcp");
```

A runner slower than that budget leaves the loop with nothing claimed and asserts against `undefined`, so the test reports on machine load rather than on behavior. It failed a CI run of mine this way, in a bucket whose PR touched no `mcp` or `oauth` file.

The wait now resolves off `tryClaimInput` itself, so it is bounded by the event it is actually waiting for and carries no timing assumption. No production code changes.

Verification: the failure signature reproduces on demand by starving the budget to `Date.now() + 0` — *Expected: "mcp"*, *Received: undefined*, matching the CI log exactly. With the event gate the whole file passes 18/0.

Two nearby `Bun.sleep(2_000)` races in the same test are load-bearing timeouts rather than correctness gates, so I left them alone; they fail loudly with their own message instead of via a misleading assertion.