### PR TITLE
fix(session): repair interrupted tail when forking a live /tan parent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tan` forking a mid-turn parent leaving the clone showing the parent's in-flight tool call as its own unresolved work: the fork now pairs the parent's unresolved tool call with a synthetic aborted result so the clone inherits a terminal, well-formed transcript ([#11118](https://github.com/can1357/oh-my-pi/issues/11118)).
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -129,6 +129,11 @@ export class TanCommandController {
 				// context; its cost must reflect its own work, not the parent's
 				// accumulated spend that session cost is otherwise derived from.
 				resetInheritedCost: true,
+				// The parent may be mid-turn: pair any tool call it left unresolved
+				// with a synthetic aborted result so the clone inherits a terminal
+				// transcript instead of rendering the parent's in-flight call as its
+				// own pending work (issue #11118).
+				repairInterruptedTail: true,
 			});
 
 			jobId = manager.register(

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2866,7 +2866,6 @@ export class SessionManager {
 		const sourceHeader = sourceEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		const history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
 		if (options?.resetInheritedCost) SessionManager.#resetInheritedUsageCost(history);
-		if (options?.repairInterruptedTail) SessionManager.#repairForkedInterruptedTail(history);
 		manager.#resetToNewSession(
 			{
 				parentSession: sourceHeader?.id,
@@ -2886,6 +2885,10 @@ export class SessionManager {
 		manager.#entries = history;
 		manager.#index.rebuild(history);
 		manager.sanitizeLoadedOpenAIResponsesReplayMetadata();
+		if (options?.repairInterruptedTail) {
+			SessionManager.#repairForkedInterruptedTail(history, manager.#index.pathTo());
+			manager.#index.rebuild(history);
+		}
 		manager.#forceFileCreation = true;
 		await manager.#rewriteAtomically();
 		if (options?.copyArtifacts !== false) {
@@ -2910,7 +2913,7 @@ export class SessionManager {
 	}
 
 	/**
-	 * Pair any tool calls the forked history's final assistant turn left
+	 * Pair any tool calls the forked active branch's final assistant turn left
 	 * unresolved with synthetic aborted results, in place.
 	 *
 	 * A `/tan` fork of a *live* parent is taken while the parent may be mid-turn
@@ -2923,20 +2926,24 @@ export class SessionManager {
 	 * orphan `tool_use` into the model. Synthesizing the same `assistant_stop_
 	 * aborted` results the agent loop records for an interrupted turn makes the
 	 * forked transcript terminal and well-formed before the clone is prompted.
+	 *
+	 * Assistant turns and results on sibling branches are excluded: the clone
+	 * consumes only the root-to-active-leaf path.
 	 */
-	static #repairForkedInterruptedTail(history: SessionEntry[]): void {
-		let assistantIndex = -1;
-		for (let i = history.length - 1; i >= 0; i--) {
-			const entry = history[i]!;
+	static #repairForkedInterruptedTail(history: SessionEntry[], branch: readonly SessionEntry[]): void {
+		const leaf = branch.at(-1);
+		if (!leaf) return;
+		let assistant: AssistantMessage | undefined;
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i]!;
 			if (entry.type === "message" && entry.message.role === "assistant") {
-				assistantIndex = i;
+				assistant = entry.message;
 				break;
 			}
 		}
-		if (assistantIndex < 0) return;
-		const assistant = (history[assistantIndex] as SessionMessageEntry).message as AssistantMessage;
+		if (!assistant) return;
 		const pairedResultIds = new Set<string>();
-		for (const entry of history) {
+		for (const entry of branch) {
 			if (entry.type === "message" && entry.message.role === "toolResult")
 				pairedResultIds.add(entry.message.toolCallId);
 		}
@@ -2946,9 +2953,9 @@ export class SessionManager {
 		);
 		if (dangling.length === 0) return;
 		const usedIds = new Set(history.map(entry => entry.id));
-		// Chain the synthetic results after the current branch leaf so they sit
-		// alongside any results the parent already recorded for this turn.
-		let parentId = history[history.length - 1]!.id;
+		// Chain the synthetic results after the active leaf so they extend the
+		// selected branch without mutating or depending on sibling paths.
+		let parentId = leaf.id;
 		for (const call of dangling) {
 			const id = generateId(usedIds);
 			usedIds.add(id);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type {
+	AssistantMessage,
 	ImageContent,
 	Message,
 	MessageAttribution,
@@ -8,6 +9,7 @@ import type {
 	TextContent,
 	Usage,
 } from "@oh-my-pi/pi-ai";
+import { createSyntheticToolResultMessage } from "@oh-my-pi/pi-agent-core";
 import {
 	directoryIsEnterable,
 	getBlobsDir,
@@ -2850,6 +2852,7 @@ export class SessionManager {
 			suppressBreadcrumb?: boolean;
 			sessionFile?: string;
 			resetInheritedCost?: boolean;
+			repairInterruptedTail?: boolean;
 		},
 	): Promise<SessionManager> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
@@ -2863,6 +2866,7 @@ export class SessionManager {
 		const sourceHeader = sourceEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		const history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
 		if (options?.resetInheritedCost) SessionManager.#resetInheritedUsageCost(history);
+		if (options?.repairInterruptedTail) SessionManager.#repairForkedInterruptedTail(history);
 		manager.#resetToNewSession(
 			{
 				parentSession: sourceHeader?.id,
@@ -2903,6 +2907,61 @@ export class SessionManager {
 	 */
 	static #resetInheritedUsageCost(history: SessionEntry[]): void {
 		for (const entry of history) resetUsageCost(entryUsage(entry));
+	}
+
+	/**
+	 * Pair any tool calls the forked history's final assistant turn left
+	 * unresolved with synthetic aborted results, in place.
+	 *
+	 * A `/tan` fork of a *live* parent is taken while the parent may be mid-turn
+	 * — its last assistant turn emitted a tool call whose `toolResult` is
+	 * delivered only to the parent. {@link createInterruptedTurnAbortMessage}
+	 * cannot repair this: it requires a persisted `session_exit` after the tail,
+	 * which a running parent never wrote. Left unpaired, the clone renders the
+	 * parent's in-flight tool call as its own perpetually pending work (the
+	 * transcript keeps dangling calls while the clone streams) and replays an
+	 * orphan `tool_use` into the model. Synthesizing the same `assistant_stop_
+	 * aborted` results the agent loop records for an interrupted turn makes the
+	 * forked transcript terminal and well-formed before the clone is prompted.
+	 */
+	static #repairForkedInterruptedTail(history: SessionEntry[]): void {
+		let assistantIndex = -1;
+		for (let i = history.length - 1; i >= 0; i--) {
+			const entry = history[i]!;
+			if (entry.type === "message" && entry.message.role === "assistant") {
+				assistantIndex = i;
+				break;
+			}
+		}
+		if (assistantIndex < 0) return;
+		const assistant = (history[assistantIndex] as SessionMessageEntry).message as AssistantMessage;
+		const pairedResultIds = new Set<string>();
+		for (const entry of history) {
+			if (entry.type === "message" && entry.message.role === "toolResult")
+				pairedResultIds.add(entry.message.toolCallId);
+		}
+		const dangling = assistant.content.filter(
+			(block): block is Extract<AssistantMessage["content"][number], { type: "toolCall" }> =>
+				block.type === "toolCall" && !pairedResultIds.has(block.id),
+		);
+		if (dangling.length === 0) return;
+		const usedIds = new Set(history.map(entry => entry.id));
+		// Chain the synthetic results after the current branch leaf so they sit
+		// alongside any results the parent already recorded for this turn.
+		let parentId = history[history.length - 1]!.id;
+		for (const call of dangling) {
+			const id = generateId(usedIds);
+			usedIds.add(id);
+			const entry: SessionMessageEntry = {
+				type: "message",
+				id,
+				parentId,
+				timestamp: nowIso(),
+				message: createSyntheticToolResultMessage(call, "aborted"),
+			};
+			history.push(entry);
+			parentId = id;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -231,6 +231,7 @@ describe("TanCommandController", () => {
 				suppressBreadcrumb: true,
 				sessionFile: expect.stringMatching(/Tan-.+\.jsonl$/),
 				resetInheritedCost: true,
+				repairInterruptedTail: true,
 			},
 		);
 		expect(harness.register).toHaveBeenCalledWith("task", "/tan write the release note", expect.any(Function), {

--- a/packages/coding-agent/test/session/session-manager-fork.test.ts
+++ b/packages/coding-agent/test/session/session-manager-fork.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { isSyntheticToolResultMessage } from "@oh-my-pi/pi-agent-core";
+import { collectPendingToolCalls } from "@oh-my-pi/pi-coding-agent/session/exit-diagnostics";
 import {
 	CURRENT_SESSION_VERSION,
+	type SessionEntry,
 	type SessionHeader,
 	type SessionMessageEntry,
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -45,6 +48,12 @@ async function createSessionWithArtifacts(root: string): Promise<{
 	await Bun.write(path.join(sourceArtifactsDir, "1.read.log"), "tool output");
 	await Bun.write(path.join(sourceArtifactsDir, "nested", "result.txt"), "nested output");
 	return { cwd, sessionDir, sourceFile, sourceArtifactsDir };
+}
+
+/** Load a session file's transcript entries, dropping the non-entry session header. */
+async function loadHistory(file: string): Promise<SessionEntry[]> {
+	const entries = await loadEntriesFromFile(file);
+	return entries.filter((entry): entry is SessionEntry => entry.type !== "session");
 }
 
 describe("SessionManager.forkFrom", () => {
@@ -243,5 +252,148 @@ describe("SessionManager.forkFrom", () => {
 		expect(resetMessage.usage.input).toBe(100);
 		expect(resetMessage.usage.output).toBe(50);
 		expect(resetMessage.usage.totalTokens).toBe(165);
+	});
+
+	it("pairs an unresolved tool call with a synthetic aborted result only when repair is requested", async () => {
+		using tempDir = TempDir.createSync("@omp-session-fork-repair-");
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		await fs.mkdir(sessionDir, { recursive: true });
+		const sourceFile = path.join(sessionDir, "source.jsonl");
+		const timestamp = new Date().toISOString();
+		const header: SessionHeader = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: "live-parent",
+			timestamp,
+			cwd,
+		};
+		// Parent is mid-turn: the assistant emitted a tool call whose result was
+		// delivered only to the parent, so the forked tail is non-terminal.
+		const assistant = {
+			type: "message",
+			id: "m1",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "toolu_live", name: "bash", arguments: { command: "sleep 40" } }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+				usage: {
+					input: 10,
+					output: 5,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 15,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+		};
+		await Bun.write(sourceFile, `${JSON.stringify(header)}\n${JSON.stringify(assistant)}\n`);
+
+		const untouched = await SessionManager.forkFrom(
+			sourceFile,
+			cwd,
+			path.join(tempDir.path(), "untouched"),
+			undefined,
+			{
+				suppressBreadcrumb: true,
+			},
+		);
+		const untouchedEntries = await loadHistory(untouched.getSessionFile()!);
+		expect(collectPendingToolCalls(untouchedEntries).map(call => call.toolCallId)).toEqual(["toolu_live"]);
+
+		const repaired = await SessionManager.forkFrom(
+			sourceFile,
+			cwd,
+			path.join(tempDir.path(), "repaired"),
+			undefined,
+			{
+				suppressBreadcrumb: true,
+				repairInterruptedTail: true,
+			},
+		);
+		const repairedEntries = await loadHistory(repaired.getSessionFile()!);
+		expect(collectPendingToolCalls(repairedEntries)).toEqual([]);
+		const result = repairedEntries.find(
+			(entry): entry is SessionMessageEntry => entry.type === "message" && entry.message.role === "toolResult",
+		);
+		if (!result || result.message.role !== "toolResult") throw new Error("expected a synthetic tool result");
+		expect(result.message.toolCallId).toBe("toolu_live");
+		expect(result.message.isError).toBe(true);
+		expect(isSyntheticToolResultMessage(result.message)).toBe(true);
+	});
+
+	it("leaves an already-terminal tail untouched when repair is requested", async () => {
+		using tempDir = TempDir.createSync("@omp-session-fork-terminal-");
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		await fs.mkdir(sessionDir, { recursive: true });
+		const sourceFile = path.join(sessionDir, "source.jsonl");
+		const timestamp = new Date().toISOString();
+		const header: SessionHeader = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: "settled-parent",
+			timestamp,
+			cwd,
+		};
+		const assistant = {
+			type: "message",
+			id: "m1",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "toolu_done", name: "bash", arguments: { command: "echo hi" } }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+				usage: {
+					input: 10,
+					output: 5,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 15,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+		};
+		const toolResult = {
+			type: "message",
+			id: "m2",
+			parentId: "m1",
+			timestamp,
+			message: {
+				role: "toolResult",
+				toolCallId: "toolu_done",
+				toolName: "bash",
+				content: [{ type: "text", text: "hi" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		};
+		await Bun.write(
+			sourceFile,
+			`${JSON.stringify(header)}\n${JSON.stringify(assistant)}\n${JSON.stringify(toolResult)}\n`,
+		);
+
+		const forked = await SessionManager.forkFrom(sourceFile, cwd, path.join(tempDir.path(), "fork"), undefined, {
+			suppressBreadcrumb: true,
+			repairInterruptedTail: true,
+		});
+		const forkedEntries = await loadHistory(forked.getSessionFile()!);
+		const messageEntries = forkedEntries.filter(entry => entry.type === "message");
+		expect(messageEntries).toHaveLength(2);
+		expect(collectPendingToolCalls(forkedEntries)).toEqual([]);
+		expect(forkedEntries.some(entry => entry.type === "message" && isSyntheticToolResultMessage(entry.message))).toBe(
+			false,
+		);
 	});
 });

--- a/packages/coding-agent/test/session/session-manager-fork.test.ts
+++ b/packages/coding-agent/test/session/session-manager-fork.test.ts
@@ -328,6 +328,110 @@ describe("SessionManager.forkFrom", () => {
 		expect(isSyntheticToolResultMessage(result.message)).toBe(true);
 	});
 
+	it("repairs only the active branch when sibling paths contain assistants and results", async () => {
+		using tempDir = TempDir.createSync("@omp-session-fork-branch-repair-");
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		await fs.mkdir(sessionDir, { recursive: true });
+		const sourceFile = path.join(sessionDir, "source.jsonl");
+		const timestamp = new Date().toISOString();
+		const header: SessionHeader = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: "branched-parent",
+			timestamp,
+			cwd,
+		};
+		const usage = {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 15,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		const activeAssistant = {
+			type: "message",
+			id: "active-assistant",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "toolu_active", name: "bash", arguments: { command: "sleep 40" } }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+				usage,
+			},
+		};
+		const siblingResult = {
+			type: "message",
+			id: "sibling-result",
+			parentId: "active-assistant",
+			timestamp,
+			message: {
+				role: "toolResult",
+				toolCallId: "toolu_active",
+				toolName: "bash",
+				content: [{ type: "text", text: "completed on abandoned branch" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		};
+		const siblingAssistant = {
+			type: "message",
+			id: "sibling-assistant",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "toolu_sibling", name: "read", arguments: { path: "old.txt" } }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+				usage,
+			},
+		};
+		const activeLeaf = {
+			type: "message",
+			id: "active-leaf",
+			parentId: "active-assistant",
+			timestamp,
+			message: { role: "user", content: "continue on this branch", timestamp: Date.now() },
+		};
+		await Bun.write(
+			sourceFile,
+			`${JSON.stringify(header)}\n${JSON.stringify(activeAssistant)}\n${JSON.stringify(siblingResult)}\n${JSON.stringify(siblingAssistant)}\n${JSON.stringify(activeLeaf)}\n`,
+		);
+
+		const forked = await SessionManager.forkFrom(sourceFile, cwd, path.join(tempDir.path(), "fork"), undefined, {
+			suppressBreadcrumb: true,
+			repairInterruptedTail: true,
+		});
+		const branch = forked.getBranch();
+		expect(collectPendingToolCalls(branch)).toEqual([]);
+		const syntheticResults = branch.filter(
+			(entry): entry is SessionMessageEntry =>
+				entry.type === "message" && isSyntheticToolResultMessage(entry.message),
+		);
+		expect(syntheticResults).toHaveLength(1);
+		const result = syntheticResults[0]!.message;
+		if (result.role !== "toolResult") throw new Error("expected a synthetic tool result");
+		expect(result.toolCallId).toBe("toolu_active");
+		expect(
+			(await loadHistory(forked.getSessionFile()!)).some(
+				entry =>
+					entry.type === "message" &&
+					isSyntheticToolResultMessage(entry.message) &&
+					entry.message.toolCallId === "toolu_sibling",
+			),
+		).toBe(false);
+	});
+
 	it("leaves an already-terminal tail untouched when repair is requested", async () => {
 		using tempDir = TempDir.createSync("@omp-session-fork-terminal-");
 		const cwd = path.join(tempDir.path(), "project");


### PR DESCRIPTION
## Repro
Run `/tan <task>` while the main agent is mid-turn on a long-running tool call (e.g. a ~40s `bash`), then open the new tan in the Agent Hub. The tan renders the parent's in-flight tool call as its own unresolved work. Distilled to a fork of a session whose tail is an assistant `tool_call` with no matching `toolResult`:

```
clone pending tool calls: [{"toolName":"bash","toolCallId":"toolu_live","args":{"command":"sleep 40"}}]
clone transcript tail role: assistant
clone tail still renders an unresolved tool call: true
```

## Cause
`TanCommandController.start` (`packages/coding-agent/src/modes/controllers/tan-command-controller.ts`) flushes the parent and calls `SessionManager.forkFrom` with no turn-boundary guard, so a mid-turn parent's final assistant `tool_call` — whose `toolResult` is delivered only to the parent — is copied verbatim into the clone. The existing repair, `createInterruptedTurnAbortMessage` (`session/exit-diagnostics.ts`), only fires when a persisted `session_exit` follows the non-terminal tail; a running parent never wrote one, so `tailIndex > exitIndex` and the orphan survives. While the clone streams (compaction, then its own prompt) `keepDanglingToolCalls` renders that unpaired call as pending, and `buildSessionContext` would replay it to the model as an orphan `tool_use`.

## Fix
- `SessionManager.forkFrom` gains a `repairInterruptedTail` option; when set, `#repairForkedInterruptedTail` pairs the forked history's final assistant turn's unresolved tool calls with `createSyntheticToolResultMessage(call, "aborted")` — the same `assistant_stop_aborted` synthetic results the agent loop records for an interrupted turn — chained after the branch leaf, so the forked transcript is terminal and well-formed before the clone is prompted.
- `TanCommandController.start` passes `repairInterruptedTail: true` on its fork.
- Regression tests in `session-manager-fork.test.ts`: a mid-turn fork pairs the orphan only when repair is requested (no-op flag leaves it dangling), and an already-terminal tail is left untouched (no spurious synthetic result).

Scope note: the reported ~77s stall is the pre-turn auto-compaction of the inherited ~135k-token context, inherent to forking a session that large (the pressure #3718 surfaces as a crash) and out of scope here; this PR fixes the orphan-tool-call defect and the malformed forked transcript.

## Verification
`bun test test/session/session-manager-fork.test.ts test/modes/controllers/tan-command-controller.test.ts test/session-exit-diagnostics.test.ts test/slash-commands/tan.test.ts` — 35 pass, 0 fail. `bun run check:types` clean; full `bun check` gate passed on push. Also confirmed against a distilled repro that the repaired fork reports zero pending tool calls and a synthetic aborted `toolResult` tail.

Fixes #11118