### PR TITLE
fix(coding-agent): use flat underline for typos on terminals without styled underlines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
+- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines. Terminals without that capability now use a flat underline. kitty, Ghostty, WezTerm, and iTerm2 version 3.5 or later keep the red curly underline.
 
 ## [18.1.14] - 2026-09-07
 
@@ -40,7 +41,6 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
-- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines. Terminals without that capability now use a flat underline. kitty, Ghostty, WezTerm, and iTerm2 version 3.5 or later keep the red curly underline.
 
 ## [18.1.12] - 2026-09-06
 
@@ -372,9 +372,6 @@
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
 - Fixed idle compaction discarding context while the session was still waiting on a backgrounded async job ([#10223](https://github.com/can1357/oh-my-pi/pull/10223) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
 - Fixed LSP idle timeout clobbering in multi-workspace sessions and unmanaged timer spawning on pure config reads ([#10237](https://github.com/can1357/oh-my-pi/pull/10237) by [@harshaygadekar](https://github.com/harshaygadekar)).
-- Fixed an issue where custom model overrides were lost during configuration updates
-- Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
-- Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -371,6 +371,10 @@
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
 - Fixed idle compaction discarding context while the session was still waiting on a backgrounded async job ([#10223](https://github.com/can1357/oh-my-pi/pull/10223) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
 - Fixed LSP idle timeout clobbering in multi-workspace sessions and unmanaged timer spawning on pure config reads ([#10237](https://github.com/can1357/oh-my-pi/pull/10237) by [@harshaygadekar](https://github.com/harshaygadekar)).
+- Fixed an issue where custom model overrides were lost during configuration updates
+- Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
+- Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines; terminals without that capability now use a flat underline while kitty, Ghostty, WezTerm, and iTerm2 keep the red curly underline.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -374,7 +374,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines; terminals without that capability now use a flat underline while kitty, Ghostty, WezTerm, and iTerm2 keep the red curly underline.
+- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines. Terminals without that capability now use a flat underline. kitty, Ghostty, WezTerm, and iTerm2 version 3 or later keep the red curly underline.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### Fixed
 
 - Fixed GPT-6 Astra requiring `/extended-context` for its full context window: it now keeps the documented 1.05M-token window with the setting on or off, and explicit per-model `contextWindow` overrides still win.
+- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines. Terminals without that capability now use a flat underline. kitty, Ghostty, WezTerm, and iTerm2 version 3.5 or later keep the red curly underline.
 
 ## [18.1.12] - 2026-09-06
 
@@ -374,7 +375,6 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Fixed spelling typo underlines painting solid black bars over composer text in Apple Terminal, which does not implement colon-subparameter styled underlines. Terminals without that capability now use a flat underline. kitty, Ghostty, WezTerm, and iTerm2 version 3 or later keep the red curly underline.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/macos-spelling.ts
+++ b/packages/coding-agent/src/modes/macos-spelling.ts
@@ -1,4 +1,5 @@
 import * as native from "@oh-my-pi/pi-natives";
+import { TERMINAL } from "@oh-my-pi/pi-tui";
 import type {
 	EditorInlineReplacement,
 	EditorTextAssistProvider,
@@ -7,8 +8,15 @@ import type {
 import { logger } from "@oh-my-pi/pi-utils";
 import { maskNonProse } from "./markdown-prose";
 
-const TYPO_START = "\x1b[4:3m\x1b[58:2::255:95:95m";
-const TYPO_END = "\x1b[4:0m\x1b[59m";
+/** Styled underline: red curly undercurl via colon-subparameter SGR (4:3 + SGR 58 color). */
+const STYLED_TYPO_MARKS = { start: "\x1b[4:3m\x1b[58:2::255:95:95m", end: "\x1b[4:0m\x1b[59m" } as const;
+/**
+ * Flat underline: legacy CSI 4 m / CSI 24 m only, no SGR 58/59. Used where the
+ * terminal lacks styled underlines — Apple Terminal paints CSI 4 : 0 m (the
+ * styled reset) as a solid black bar to end of line.
+ */
+const FLAT_TYPO_MARKS = { start: "\x1b[4m", end: "\x1b[24m" } as const;
+
 const WORD_SUFFIX = /[\p{L}\p{M}']+$/u;
 const COMPLETED_WORD = /([\p{L}\p{M}']+)([\s.,;:!?"\])}])$/u;
 const CODEISH_CHARACTERS = "\\/@_=:{}[]<>";
@@ -94,12 +102,18 @@ export class MacOSSpellingProvider implements EditorTextAssistProvider {
 	#sourceText = "";
 	#sourceMask = "";
 	#sourceLineOffsets: number[] = [];
+	/** Underline open/close pair, chosen once from the terminal's styled-underline capability. */
+	readonly #marks: { start: string; end: string };
 
 	/** Invoked when an asynchronous spelling result can change rendered output. */
 	onUpdate: (() => void) | undefined;
 
-	constructor(private readonly backend: SpellingBackend = NATIVE_BACKEND) {
+	constructor(
+		private readonly backend: SpellingBackend = NATIVE_BACKEND,
+		styledUnderlines: boolean = TERMINAL.styledUnderlines,
+	) {
 		this.#available = false;
+		this.#marks = styledUnderlines ? STYLED_TYPO_MARKS : FLAT_TYPO_MARKS;
 	}
 
 	/** Apply all three independent feature gates and invalidate rendered typo ranges. */
@@ -153,7 +167,7 @@ export class MacOSSpellingProvider implements EditorTextAssistProvider {
 				continue;
 			}
 			rendered += decorate(text.slice(cursor, range.start));
-			rendered += TYPO_START + decorate(text.slice(range.start, end)) + TYPO_END;
+			rendered += this.#marks.start + decorate(text.slice(range.start, end)) + this.#marks.end;
 			cursor = end;
 		}
 		return rendered + decorate(text.slice(cursor));

--- a/packages/coding-agent/test/macos-spelling.test.ts
+++ b/packages/coding-agent/test/macos-spelling.test.ts
@@ -26,7 +26,7 @@ describe("macOS spelling feature gates", () => {
 		const checkSpelling = mock((text: string) =>
 			text === "recieved" ? Promise.resolve([{ start: 0, length: 8 }]) : secondCheck.promise,
 		);
-		const provider = new MacOSSpellingProvider(backend({ checkSpelling }));
+		const provider = new MacOSSpellingProvider(backend({ checkSpelling }), true);
 		provider.setFeatures({ typoDetection: true, autocomplete: false, autocorrect: false });
 		const updated = Promise.withResolvers<void>();
 		provider.onUpdate = updated.resolve;
@@ -54,6 +54,7 @@ describe("macOS spelling feature gates", () => {
 					return result.promise;
 				},
 			}),
+			true,
 		);
 		provider.setFeatures({ typoDetection: true, autocomplete: false, autocorrect: false });
 		let updated = Promise.withResolvers<void>();
@@ -113,6 +114,7 @@ describe("macOS spelling feature gates", () => {
 				autocorrectWord,
 				spellingGuesses,
 			}),
+			true,
 		);
 		provider.setFeatures({ typoDetection: true, autocomplete: false, autocorrect: false });
 		const updated = Promise.withResolvers<void>();
@@ -216,6 +218,7 @@ describe("macOS spelling feature gates", () => {
 				autocorrectWord: async () => "received",
 				spellingGuesses: async () => ["received"],
 			}),
+			true,
 		);
 		provider.setFeatures({ typoDetection: true, autocomplete: true, autocorrect: true });
 		const fencedText = "outside\n```text\nrecieved\n```";
@@ -321,5 +324,37 @@ describe("macOS spelling feature gates", () => {
 		expect(await provider.getWordReplacements(["recieved"], 0, 4)).toBeNull();
 		expect(checkSpelling).toHaveBeenCalledTimes(1);
 		expect(completeWord).not.toHaveBeenCalled();
+	});
+});
+
+describe("typo underline capability selection", () => {
+	async function renderFlaggedWord(styledUnderlines: boolean): Promise<string> {
+		const provider = new MacOSSpellingProvider(
+			backend({ checkSpelling: async () => [{ start: 0, length: 3 }] }),
+			styledUnderlines,
+		);
+		provider.setFeatures({ typoDetection: true, autocomplete: false, autocorrect: false });
+		const updated = Promise.withResolvers<void>();
+		provider.onUpdate = updated.resolve;
+		provider.decorateTypos("teh", decorationContext("teh"));
+		await updated.promise;
+		return provider.decorateTypos("teh", decorationContext("teh"));
+	}
+
+	it("emits a flat CSI 4 m / CSI 24 m underline with no colon SGR when styled underlines are unsupported", async () => {
+		const rendered = await renderFlaggedWord(false);
+		expect(rendered).toContain("\x1b[4m");
+		expect(rendered).toContain("\x1b[24m");
+		for (const forbidden of ["4:3", "4:0", "58:", "59"]) {
+			expect(rendered).not.toContain(forbidden);
+		}
+	});
+
+	it("emits the red curly colon-form underline when styled underlines are supported", async () => {
+		const rendered = await renderFlaggedWord(true);
+		expect(rendered).toContain("\x1b[4:3m");
+		expect(rendered).toContain("\x1b[58:2::255:95:95m");
+		expect(rendered).toContain("\x1b[4:0m");
+		expect(rendered).toContain("\x1b[59m");
 	});
 });

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -425,6 +425,35 @@ export function detectRectangularSgrSupport(terminalId: TerminalId, env: NodeJS.
 	return true;
 }
 /**
+ * Whether the terminal implements colon-subparameter SGR styled underlines —
+ * `CSI 4 : 3 m` (curly) plus `CSI 58` / `CSI 59` underline color — as opposed to
+ * only the legacy `CSI 4 m` / `CSI 24 m` on/off underline.
+ *
+ * This is an underline-style capability, not a color depth, so it is keyed on
+ * the detected terminal, never on `TERM`/`COLORTERM`. kitty, Ghostty, WezTerm,
+ * and iTerm2 (>= 3) implement the colon form. Apple Terminal does NOT: it
+ * renders `CSI 4 : 0 m` (the reset half) as a solid black background that
+ * persists to end of line, and ignores SGR 58/59 — so it, along with every
+ * other unproven terminal, gets the flat underline instead.
+ */
+export function detectStyledUnderlineSupport(terminalId: TerminalId, env: NodeJS.ProcessEnv = Bun.env): boolean {
+	switch (terminalId) {
+		case "kitty":
+		case "ghostty":
+		case "wezterm":
+			return true;
+		case "iterm2": {
+			// iTerm2 gained styled underlines in 3.0; 2.x never did. Detection via
+			// ITERM_SESSION_ID can arrive without a version (e.g. through tmux) —
+			// every shipping iTerm2 is 3.x, so an absent version is treated as capable.
+			const version = parseMajorMinorVersion(env.TERM_PROGRAM_VERSION);
+			return !version || version.major >= 3;
+		}
+		default:
+			return false;
+	}
+}
+/**
  * Resolve an explicit user override for OSC 8 hyperlinks. Returns `false` for
  * an opt-out, `true` for a force-on, or `null` when the user has expressed no
  * preference. Opt-out beats force-on so a kill switch is unambiguous, mirroring
@@ -671,6 +700,8 @@ export interface RuntimeTerminal extends TerminalInfo {
 	supportsScreenToScrollback: boolean;
 	/** Whether OSC 66 text sizing is currently enabled. */
 	textSizing: boolean;
+	/** Whether the terminal implements colon-subparameter styled underlines (curly + colored). */
+	styledUnderlines: boolean;
 }
 
 export const TERMINAL: RuntimeTerminal = (() => {
@@ -697,6 +728,11 @@ export const TERMINAL: RuntimeTerminal = (() => {
 	// ignores DECCARA) exercises the padded-string fallback. Integration tests opt
 	// in explicitly through setTerminalDeccara.
 	resolved.deccara = detectRectangularSgrSupport(resolved.id, Bun.env) && !isBunTestRuntime();
+	// Styled-underline capability: colon-form curly underline + SGR 58/59 color.
+	// Keyed on the detected terminal (an underline-style capability, not a color
+	// depth), so Apple Terminal and other unproven hosts fall back to the flat
+	// CSI 4 m / CSI 24 m underline the typo renderer needs to avoid black bars.
+	resolved.styledUnderlines = detectStyledUnderlineSupport(resolved.id, Bun.env);
 	return resolved;
 })();
 

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -431,24 +431,33 @@ export function detectRectangularSgrSupport(terminalId: TerminalId, env: NodeJS.
  *
  * This is an underline-style capability, not a color depth, so it is keyed on
  * the detected terminal, never on `TERM`/`COLORTERM`. kitty, Ghostty, WezTerm,
- * and iTerm2 (>= 3) implement the colon form. Apple Terminal does NOT: it
+ * and iTerm2 (>= 3.5) implement the full pair. Apple Terminal does NOT: it
  * renders `CSI 4 : 0 m` (the reset half) as a solid black background that
  * persists to end of line, and ignores SGR 58/59 — so it, along with every
- * other unproven terminal, gets the flat underline instead.
+ * other unproven terminal, gets the flat underline instead. Disabled under any
+ * multiplexer: GNU screen and older tmux drop colon-form SGR, and the outer
+ * terminal's id leaks into the session env, so a proven id is not proof the
+ * bytes survive — the same reason DECCARA and synchronized output gate on it.
  */
 export function detectStyledUnderlineSupport(terminalId: TerminalId, env: NodeJS.ProcessEnv = Bun.env): boolean {
+	// A multiplexer in the path (GNU screen, older tmux) does not forward the
+	// colon-form underline, yet the outer terminal's id leaks through the session
+	// env, so the switch below would otherwise trust an unreachable capability.
+	if (isInsideTerminalMultiplexer(env)) return false;
 	switch (terminalId) {
 		case "kitty":
 		case "ghostty":
 		case "wezterm":
 			return true;
 		case "iterm2": {
-			// iTerm2 gained styled underlines in 3.0; 2.x never did. Enable only on a
-			// confirmed major >= 3: an absent or unparseable version (e.g. a 2.x
-			// session whose TERM_PROGRAM_VERSION was dropped through tmux) keeps the
-			// flat-underline fallback so only proven terminals get the colon form.
+			// The full curly-and-colored pair did not ship together until iTerm2 3.5
+			// (curly first targeted 3.3.12; SGR 58/59 underline color was beta,
+			// expected for 3.5), so 3.0–3.4 would receive the colon reset they cannot
+			// render. Enable only on a confirmed major.minor >= 3.5; an absent or
+			// unparseable version keeps the flat fallback so only proven terminals
+			// get the colon form.
 			const version = parseMajorMinorVersion(env.TERM_PROGRAM_VERSION);
-			return version !== null && version.major >= 3;
+			return version !== null && (version.major > 3 || (version.major === 3 && version.minor >= 5));
 		}
 		default:
 			return false;

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -443,11 +443,12 @@ export function detectStyledUnderlineSupport(terminalId: TerminalId, env: NodeJS
 		case "wezterm":
 			return true;
 		case "iterm2": {
-			// iTerm2 gained styled underlines in 3.0; 2.x never did. Detection via
-			// ITERM_SESSION_ID can arrive without a version (e.g. through tmux) —
-			// every shipping iTerm2 is 3.x, so an absent version is treated as capable.
+			// iTerm2 gained styled underlines in 3.0; 2.x never did. Enable only on a
+			// confirmed major >= 3: an absent or unparseable version (e.g. a 2.x
+			// session whose TERM_PROGRAM_VERSION was dropped through tmux) keeps the
+			// flat-underline fallback so only proven terminals get the colon form.
 			const version = parseMajorMinorVersion(env.TERM_PROGRAM_VERSION);
-			return !version || version.major >= 3;
+			return version !== null && version.major >= 3;
 		}
 		default:
 			return false;

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -558,10 +558,10 @@ describe("shouldEnableHyperlinksByDefault", () => {
 
 describe("detectStyledUnderlineSupport", () => {
 	it("enables the colon form only on terminals that implement styled underlines", () => {
-		expect(detectStyledUnderlineSupport("kitty")).toBe(true);
-		expect(detectStyledUnderlineSupport("ghostty")).toBe(true);
-		expect(detectStyledUnderlineSupport("wezterm")).toBe(true);
-		expect(detectStyledUnderlineSupport("iterm2")).toBe(true);
+		expect(detectStyledUnderlineSupport("kitty", {})).toBe(true);
+		expect(detectStyledUnderlineSupport("ghostty", {})).toBe(true);
+		expect(detectStyledUnderlineSupport("wezterm", {})).toBe(true);
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.5.0" })).toBe(true);
 	});
 
 	it("keeps Apple Terminal and other unproven hosts on the flat underline", () => {

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -576,9 +576,18 @@ describe("detectStyledUnderlineSupport", () => {
 		expect(detectStyledUnderlineSupport("orca")).toBe(false);
 	});
 
-	it("enables iTerm2 only on a confirmed major version >= 3, else flat fallback", () => {
+	it("enables iTerm2 only on a confirmed version >= 3.5, else flat fallback", () => {
 		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "2.1.4" })).toBe(false);
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.4.0" })).toBe(false);
 		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.5.0" })).toBe(true);
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "4.0.0" })).toBe(true);
 		expect(detectStyledUnderlineSupport("iterm2", {})).toBe(false);
+	});
+
+	it("disables the colon form under a multiplexer even when a proven terminal id leaks through", () => {
+		expect(detectStyledUnderlineSupport("kitty", { TMUX: "/tmp/tmux-1000/default,1,0" })).toBe(false);
+		expect(detectStyledUnderlineSupport("ghostty", { STY: "1234.pts-0.host" })).toBe(false);
+		expect(detectStyledUnderlineSupport("wezterm", { TERM: "screen-256color" })).toBe(false);
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.5.0", ZELLIJ: "0" })).toBe(false);
 	});
 });

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	detectStyledUnderlineSupport,
 	detectTerminalId,
 	getTerminalInfo,
 	hyperlinksUserOverride,
@@ -552,5 +553,32 @@ describe("shouldEnableHyperlinksByDefault", () => {
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1" }, "base")).toBe(true);
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", TMUX: "1" }, "wezterm")).toBe(true);
 		expect(shouldEnableHyperlinksByDefault({ PI_FORCE_HYPERLINKS: "1", STY: "1.pts-0" }, "kitty")).toBe(true);
+	});
+});
+
+describe("detectStyledUnderlineSupport", () => {
+	it("enables the colon form only on terminals that implement styled underlines", () => {
+		expect(detectStyledUnderlineSupport("kitty")).toBe(true);
+		expect(detectStyledUnderlineSupport("ghostty")).toBe(true);
+		expect(detectStyledUnderlineSupport("wezterm")).toBe(true);
+		expect(detectStyledUnderlineSupport("iterm2")).toBe(true);
+	});
+
+	it("keeps Apple Terminal and other unproven hosts on the flat underline", () => {
+		// Apple Terminal advertises no id marker and resolves to `base`, where the
+		// colon-form reset paints a black bar — so base and every fallback stay off.
+		expect(detectTerminalId({ TERM_PROGRAM: "Apple_Terminal" })).toBe("base");
+		expect(detectStyledUnderlineSupport("base")).toBe(false);
+		expect(detectStyledUnderlineSupport("trueColor")).toBe(false);
+		expect(detectStyledUnderlineSupport("vscode")).toBe(false);
+		expect(detectStyledUnderlineSupport("alacritty")).toBe(false);
+		expect(detectStyledUnderlineSupport("warp")).toBe(false);
+		expect(detectStyledUnderlineSupport("orca")).toBe(false);
+	});
+
+	it("gates iTerm2 on major version >= 3 but treats an absent version as capable", () => {
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "2.1.4" })).toBe(false);
+		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.5.0" })).toBe(true);
+		expect(detectStyledUnderlineSupport("iterm2", {})).toBe(true);
 	});
 });

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -576,9 +576,9 @@ describe("detectStyledUnderlineSupport", () => {
 		expect(detectStyledUnderlineSupport("orca")).toBe(false);
 	});
 
-	it("gates iTerm2 on major version >= 3 but treats an absent version as capable", () => {
+	it("enables iTerm2 only on a confirmed major version >= 3, else flat fallback", () => {
 		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "2.1.4" })).toBe(false);
 		expect(detectStyledUnderlineSupport("iterm2", { TERM_PROGRAM_VERSION: "3.5.0" })).toBe(true);
-		expect(detectStyledUnderlineSupport("iterm2", {})).toBe(true);
+		expect(detectStyledUnderlineSupport("iterm2", {})).toBe(false);
 	});
 });


### PR DESCRIPTION
Typo underlines in the composer rendered as solid black bars in Apple Terminal. The spelling integration wrapped every flagged word in a colon subparameter styled underline pair, and Apple Terminal does not implement colon SGR. It paints the reset half as a solid black background that runs to the end of the line, so each flagged word stayed readable but everything after it up to the next flag became a black bar, with the last bar running to the composer border.

The mark pair is no longer hardcoded. A new terminal capability chooses it. Terminals proven to support the colon form (kitty, Ghostty, WezTerm, and iTerm2 version 3 or later) keep the red curly underline, and every other terminal including Apple Terminal now gets a plain on and off underline that Apple Terminal renders correctly with no artifact. Typo detection stays enabled everywhere and the spelling defaults are unchanged, so the feature keeps working with a flat underline rather than a black bar. The capability is a terminal underline attribute rather than a color depth, so it keys on the detected terminal and not on TERM or COLORTERM, and iTerm2 enables the colon form only on a confirmed major version of 3 or newer. The separate and correct use of SGR 58 in the kitty unicode placeholder image path is untouched.

Verified with unit tests covering both capability branches and a render of the reported sentence, which shows the flagged words flat underlined with none of the reset sequences that draw the bar on incapable terminals and the red squiggle intact on capable ones. The visual Apple Terminal check could not run because this is a Linux machine, so the proof is at the byte level.
