### PR TITLE
fix(ai): retry Copilot Supported-values none rejection; normalize Cur…

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fixed reasoning-off requests (e.g. GitHub Copilot `gpt-6-astra`) surfacing `400 Unsupported value: 'none' … Supported values are: …` instead of retrying at the lowest allowed effort: the reasoning-effort fallback now recognizes `Supported values` phrasing.
-- Fixed Cursor GPT off-tier requests sending raw `-none` sibling ids (e.g. `gpt-5.6-sol-none-fast`), which the Run endpoint rejects; they now normalize to the base model id with no reasoning parameter, matching every other effort tier.
+- Fixed reasoning-off requests (e.g. GitHub Copilot `gpt-6-astra`) surfacing `400 Unsupported value: 'none' … Supported values are: …` instead of retrying at the lowest allowed effort: the reasoning-effort fallback now recognizes `Supported values` phrasing ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
+- Fixed Cursor GPT off-tier requests sending raw `-none` sibling ids (e.g. `gpt-5.6-sol-none-fast`), which the Run endpoint rejects; they now normalize to the base model id with no reasoning parameter, matching every other effort tier ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed reasoning-off requests (e.g. GitHub Copilot `gpt-6-astra`) surfacing `400 Unsupported value: 'none' … Supported values are: …` instead of retrying at the lowest allowed effort: the reasoning-effort fallback now recognizes `Supported values` phrasing.
+- Fixed Cursor GPT off-tier requests sending raw `-none` sibling ids (e.g. `gpt-5.6-sol-none-fast`), which the Run endpoint rejects; they now normalize to the base model id with no reasoning parameter, matching every other effort tier.
+
 ## [18.1.12] - 2026-09-06
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import http2 from "node:http2";
+import { splitCursorEffortSuffix } from "@oh-my-pi/pi-catalog/compat/collapse";
 import { classifyModel } from "@oh-my-pi/pi-catalog/compat/taxonomy";
 import type {
 	ConversationStep,
@@ -5259,19 +5260,19 @@ function resolveCursorWireModel(
 	if (wireMode === "discovered") return { modelId: wireModelId, parameters: [] };
 	// Cursor's fast lane follows the effort token (`-high-fast`), while the
 	// standard lane ends at it (`-high`). Preserve the lane in the base id.
-	const match = /^(.*)-(none|extra-high|minimal|low|medium|high|xhigh|max)(-fast)?$/.exec(wireModelId);
-	const base = match?.[1];
-	const tier = match?.[2];
-	const lane = match?.[3] ?? "";
-	if (base && tier && classifyModel("cursor", base).class === "openai") {
-		if (tier === "none") {
+	// Tier vocabulary comes from the catalog (`splitCursorEffortSuffix`), so
+	// KDL tier corrections govern the Run request too.
+	const split = splitCursorEffortSuffix(wireModelId);
+	const base = split?.baseId;
+	if (base && split && classifyModel("cursor", base).class === "openai") {
+		const lane = split.fast ? "-fast" : "";
+		if (split.tier === "none") {
 			return { modelId: `${base}${lane}`, parameters: [] };
 		}
-		const effort = tier === "extra-high" ? "xhigh" : tier;
-		if ((THINKING_EFFORTS as readonly string[]).includes(effort)) {
+		if ((THINKING_EFFORTS as readonly string[]).includes(split.tier)) {
 			return {
 				modelId: `${base}${lane}`,
-				parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: effort })],
+				parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: split.tier })],
 			};
 		}
 	}

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1,8 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import http2 from "node:http2";
-import { splitCursorEffortSuffix } from "@oh-my-pi/pi-catalog/compat/collapse";
-import { classifyModel } from "@oh-my-pi/pi-catalog/compat/taxonomy";
+import { classifyModel, collapseVariantId } from "@oh-my-pi/pi-catalog/compat/taxonomy";
 import type {
 	ConversationStep,
 	CursorRule,
@@ -5237,7 +5236,8 @@ function extractImages(content: (TextContent | ImageContent)[]) {
  * The Run endpoint rejects a sibling slug as the wire `model_id` with
  * `resource_exhausted` (errorId 528384); the official `cursor-agent` splits the
  * slug into its base model id plus a `reasoning` effort parameter. Mirror that
- * for OpenAI-family ids: strip a trailing effort tier and emit
+ * for OpenAI-family ids: split the tier with the compiled catalog policy
+ * (`collapseVariantId`, KDL suffix/lane rules) and emit
  * `{ id: "reasoning", value: <effort> }`. The off tier (`-none`) is a sibling
  * slug too, so it normalizes to the bare (lane-preserving) base with no
  * reasoning parameter instead of going out raw.
@@ -5258,21 +5258,21 @@ function resolveCursorWireModel(
 } {
 	const wireModelId = requestModelId ?? model.requestModelId ?? model.id;
 	if (wireMode === "discovered") return { modelId: wireModelId, parameters: [] };
-	// Cursor's fast lane follows the effort token (`-high-fast`), while the
-	// standard lane ends at it (`-high`). Preserve the lane in the base id.
-	// Tier vocabulary comes from the catalog (`splitCursorEffortSuffix`), so
-	// KDL tier corrections govern the Run request too.
-	const split = splitCursorEffortSuffix(wireModelId);
-	const base = split?.baseId;
-	if (base && split && classifyModel("cursor", base).class === "openai") {
-		const lane = split.fast ? "-fast" : "";
-		if (split.tier === "none") {
-			return { modelId: `${base}${lane}`, parameters: [] };
+	// `collapseVariantId` keeps the lane in the logical id (`-high-fast` →
+	// base `-fast`) and decodes the KDL effort (`-none` → `off`).
+	const collapsed = collapseVariantId("cursor", wireModelId);
+	const effort = collapsed.effort;
+	const base = effort !== undefined ? collapsed.logicalId : undefined;
+	if (effort !== undefined && base && classifyModel("cursor", base).class === "openai") {
+		if (effort === "off") {
+			return { modelId: base, parameters: [] };
 		}
-		if ((THINKING_EFFORTS as readonly string[]).includes(split.tier)) {
+		if ((THINKING_EFFORTS as readonly string[]).includes(effort)) {
 			return {
-				modelId: `${base}${lane}`,
-				parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: split.tier })],
+				modelId: base,
+				parameters: [
+					create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: collapsed.effort }),
+				],
 			};
 		}
 	}

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -5237,7 +5237,9 @@ function extractImages(content: (TextContent | ImageContent)[]) {
  * `resource_exhausted` (errorId 528384); the official `cursor-agent` splits the
  * slug into its base model id plus a `reasoning` effort parameter. Mirror that
  * for OpenAI-family ids: strip a trailing effort tier and emit
- * `{ id: "reasoning", value: <effort> }`.
+ * `{ id: "reasoning", value: <effort> }`. The off tier (`-none`) is a sibling
+ * slug too, so it normalizes to the bare (lane-preserving) base with no
+ * reasoning parameter instead of going out raw.
  *
  * Non-OpenAI ids pass through unchanged — Cursor-native ids (`composer-*`,
  * `cursor-grok-*`, `default`) carry no effort suffix, and Claude/other siblings
@@ -5257,19 +5259,21 @@ function resolveCursorWireModel(
 	if (wireMode === "discovered") return { modelId: wireModelId, parameters: [] };
 	// Cursor's fast lane follows the effort token (`-high-fast`), while the
 	// standard lane ends at it (`-high`). Preserve the lane in the base id.
-	const match = /^(.*)-(minimal|low|medium|high|xhigh|max)(-fast)?$/.exec(wireModelId);
+	const match = /^(.*)-(none|extra-high|minimal|low|medium|high|xhigh|max)(-fast)?$/.exec(wireModelId);
 	const base = match?.[1];
-	const effort = match?.[2];
-	if (
-		base &&
-		effort &&
-		(THINKING_EFFORTS as readonly string[]).includes(effort) &&
-		classifyModel("cursor", base).class === "openai"
-	) {
-		return {
-			modelId: `${base}${match[3] ?? ""}`,
-			parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: effort })],
-		};
+	const tier = match?.[2];
+	const lane = match?.[3] ?? "";
+	if (base && tier && classifyModel("cursor", base).class === "openai") {
+		if (tier === "none") {
+			return { modelId: `${base}${lane}`, parameters: [] };
+		}
+		const effort = tier === "extra-high" ? "xhigh" : tier;
+		if ((THINKING_EFFORTS as readonly string[]).includes(effort)) {
+			return {
+				modelId: `${base}${lane}`,
+				parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: effort })],
+			};
+		}
 	}
 	// A bare `composer-2.5` id resolves to the Fast variant server-side
 	// (can1357/oh-my-pi#9012). Pin the Standard tier explicitly; `-fast`

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -828,11 +828,16 @@ const streamOpenAICompletionsOnce = (
 					attemptedReasoningEffortFallbacks.add(retryMarker);
 					requestReasoningEffortFallbacks.set(activeReasoningEffortFallbackKey, reasoningEffortFallback);
 					openaiStream = await createCompletionsStream();
-					rememberOpenAIReasoningEffortFallback(
-						providerSessionState,
-						activeReasoningEffortFallbackKey,
-						reasoningEffortFallback,
-					);
+					// Explicit-disable fallbacks stay per-request so a reasoning-off
+					// side request cannot downgrade later normal turns sharing
+					// the session state.
+					if (!(options?.disableReasoning === true && options.reasoning === undefined)) {
+						rememberOpenAIReasoningEffortFallback(
+							providerSessionState,
+							activeReasoningEffortFallbackKey,
+							reasoningEffortFallback,
+						);
+					}
 				} else if (
 					model.compat.retryWithoutStrictOnGrammarError &&
 					!disableStrictTools &&

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -816,10 +816,15 @@ const streamOpenAICompletionsOnce = (
 				openaiStream = await createCompletionsStream();
 			} catch (error) {
 				const capturedErrorResponse = error instanceof OpenAIHttpError ? error.captured : undefined;
+				// A caller disable with a retained effort preference is still an
+				// explicit disable: without this, a fieldless rejection of the
+				// resulting `none` resolves to a delete-effort retry that gets
+				// cached and strips later enabled turns.
+				const isExplicitDisable = options?.disableReasoning === true;
 				const reasoningEffortFallback =
 					activeReasoningEffortFallbackKey && activeRequestParams && !requestSignal.aborted
 						? resolveOpenAIReasoningEffortFallback(error, capturedErrorResponse, activeRequestParams, {
-								explicitDisable: options?.disableReasoning === true && options.reasoning === undefined,
+								explicitDisable: isExplicitDisable,
 							})
 						: undefined;
 				if (reasoningEffortFallback !== undefined && activeReasoningEffortFallbackKey) {
@@ -831,7 +836,7 @@ const streamOpenAICompletionsOnce = (
 					// Explicit-disable fallbacks stay per-request so a reasoning-off
 					// side request cannot downgrade later normal turns sharing
 					// the session state.
-					if (!(options?.disableReasoning === true && options.reasoning === undefined)) {
+					if (!isExplicitDisable) {
 						rememberOpenAIReasoningEffortFallback(
 							providerSessionState,
 							activeReasoningEffortFallbackKey,

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -183,9 +183,11 @@ function collectMessageParts(error: unknown, captured: CapturedHttpErrorResponse
  * Text that identifies a 400 as being about the reasoning-effort field.
  * OpenAI-compatible gateways (cliproxy, …) never name the field — they reject
  * the value alone with `level "none" not supported, valid levels: low, …` — so
- * the allowed-level phrasing counts as a mention too.
+ * the allowed-level phrasing counts as a mention too. GitHub Copilot phrases
+ * the same rejection with `Supported values are: …`, so value lists count too.
  */
-const REASONING_EFFORT_FIELD_PATTERN = /reasoning[_. ]effort|reasoning value|(?:valid|supported|allowed) levels?/i;
+const REASONING_EFFORT_FIELD_PATTERN =
+	/reasoning[_. ]effort|reasoning value|(?:valid|supported|allowed) (?:levels?|values?)/i;
 
 function mentionsReasoningEffort(error: unknown, captured: CapturedHttpErrorResponse | undefined): boolean {
 	const param = capturedStringField(captured, "param");

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -202,6 +202,68 @@ function mentionsReasoningEffort(error: unknown, captured: CapturedHttpErrorResp
 	);
 }
 
+/** Which request field a rejection attributes itself to, parsed once. */
+type EffortRejectionField = "reasoning-effort" | "other" | "unknown";
+
+/**
+ * Parsed attribution of a 400/422, in precedence order: the structured error
+ * field first, the message verdict second, bare vocabulary last. New server
+ * wordings extend these parsers; the decision in
+ * {@link isInvalidReasoningEffortError} stays fixed.
+ */
+interface EffortRejectionSignal {
+	/** Authoritative attribution: explicit `param`, else message content, else unknown. */
+	field: EffortRejectionField;
+	/** The message names the reasoning-effort option without a verdict. */
+	namesFieldInMessage: boolean;
+	/** The message carries a fielded rejection verdict (any word order). */
+	messageVerdict: boolean;
+	/** The message lists allowed tiers in gateway levels vocabulary. */
+	listsLevels: boolean;
+	/** The rejected effort is quoted next to a rejection verdict. */
+	rejectedMatches: boolean;
+}
+
+const EFFORT_FIELD_PATTERN = /reasoning[_. ]effort|reasoning value/i;
+const ALLOWED_LEVELS_PATTERN = /(?:valid|supported|allowed) levels?/i;
+
+/** Fielded rejection verdicts in any word order: verdict-first, field-first, or bare mention plus verdict. */
+function messageCarriesEffortVerdict(message: string): boolean {
+	return (
+		/invalid[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(message) ||
+		/(?:reasoning[_. ]effort|reasoning value)[^\n]*(?:invalid|unsupported|not supported|not permitted|must be|expected|unknown|unexpected|unrecognized)/i.test(
+			message,
+		) ||
+		/(?:unsupported|not supported|not permitted|unknown|unexpected|unrecognized|extra)[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(
+			message,
+		)
+	);
+}
+
+function parseEffortRejectionSignal(
+	message: string,
+	captured: CapturedHttpErrorResponse | undefined,
+	currentEffort: string,
+): EffortRejectionSignal {
+	const namesFieldInMessage = EFFORT_FIELD_PATTERN.test(message);
+	const param = capturedStringField(captured, "param") ?? "";
+	const quoted = `["'\`]${escapeRegExp(currentEffort)}["'\`]`;
+	return {
+		field:
+			namesFieldInMessage || EFFORT_FIELD_PATTERN.test(param)
+				? "reasoning-effort"
+				: param.trim() !== ""
+					? "other"
+					: "unknown",
+		namesFieldInMessage,
+		messageVerdict: messageCarriesEffortVerdict(message),
+		listsLevels: ALLOWED_LEVELS_PATTERN.test(message),
+		rejectedMatches:
+			new RegExp(`(?:invalid|unsupported|not supported)[^\\n]*${quoted}`, "i").test(message) ||
+			new RegExp(`${quoted}[^\\n]*(?:invalid|unsupported|not supported)`, "i").test(message),
+	};
+}
+
 function isInvalidReasoningEffortError(
 	error: unknown,
 	captured: CapturedHttpErrorResponse | undefined,
@@ -212,40 +274,15 @@ function isInvalidReasoningEffortError(
 	if (!mentionsReasoningEffort(error, captured)) return false;
 	const message = collectMessageParts(error, captured);
 	if (/reasoning[_ ]content/i.test(message) && !REASONING_EFFORT_FIELD_PATTERN.test(message)) return false;
-	if (/invalid[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(message)) return true;
-	if (
-		/(?:reasoning[_. ]effort|reasoning value)[^\n]*(?:invalid|unsupported|not supported|not permitted|must be|expected|unknown|unexpected|unrecognized)/i.test(
-			message,
-		)
-	) {
-		return true;
-	}
-	if (
-		/(?:unsupported|not supported|not permitted|unknown|unexpected|unrecognized|extra)[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(
-			message,
-		)
-	) {
-		return true;
-	}
-	// Gateways put the rejected value first (`level "none" not supported`), the
-	// official API puts the verdict first (`Unsupported value: 'none'`). A
-	// levels-list (`valid levels: …`) is gateway-effort vocabulary, so a
-	// fieldless match stays trusted there; a bare values-list is shared with
-	// sibling tier-valued fields (e.g. text verbosity), so without a field
-	// naming only the reasoning-off value is trusted.
-	const namesField = /reasoning[_. ]effort|reasoning value/i.test(message);
-	const listsLevels = /(?:valid|supported|allowed) levels?/i.test(message);
-	// An explicit error param naming another field defeats the fieldless
-	// heuristic entirely: e.g. `tool_choice: "none"` rejected with its own
-	// Supported-values list must not trigger a reasoning-effort retry.
-	const errorParam = capturedStringField(captured, "param") ?? "";
-	if (errorParam !== "" && !/reasoning[_. ]effort|reasoning value/i.test(errorParam) && !namesField) return false;
-	if (currentEffort.toLowerCase() !== "none" && !namesField && !listsLevels) return false;
-	const quoted = `["'\`]${escapeRegExp(currentEffort)}["'\`]`;
-	return (
-		new RegExp(`(?:invalid|unsupported|not supported)[^\\n]*${quoted}`, "i").test(message) ||
-		new RegExp(`${quoted}[^\\n]*(?:invalid|unsupported|not supported)`, "i").test(message)
-	);
+	const signal = parseEffortRejectionSignal(message, captured, currentEffort);
+	// Precedence is fixed: an explicit foreign field defeats the heuristic,
+	// a fielded verdict always qualifies, and fieldless values-lists are
+	// trusted only for the reasoning-off value (levels vocabulary is
+	// gateway-effort dialect, so it stays trusted for every tier).
+	if (signal.field === "other" && !signal.namesFieldInMessage) return false;
+	if (signal.messageVerdict) return true;
+	if (currentEffort.toLowerCase() !== "none" && !signal.namesFieldInMessage && !signal.listsLevels) return false;
+	return signal.rejectedMatches;
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -228,7 +228,11 @@ function isInvalidReasoningEffortError(
 		return true;
 	}
 	// Gateways put the rejected value first (`level "none" not supported`), the
-	// official API puts the verdict first (`Unsupported value: 'none'`).
+	// official API puts the verdict first (`Unsupported value: 'none'`). Without
+	// a field naming, only the reasoning-off value is trusted: sibling
+	// tier-valued fields (e.g. text verbosity) share the low..max vocabulary,
+	// so a non-none match cannot establish which field was rejected.
+	if (currentEffort.toLowerCase() !== "none") return false;
 	const quoted = `["'\`]${escapeRegExp(currentEffort)}["'\`]`;
 	return (
 		new RegExp(`(?:invalid|unsupported|not supported)[^\\n]*${quoted}`, "i").test(message) ||

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -235,6 +235,11 @@ function isInvalidReasoningEffortError(
 	// naming only the reasoning-off value is trusted.
 	const namesField = /reasoning[_. ]effort|reasoning value/i.test(message);
 	const listsLevels = /(?:valid|supported|allowed) levels?/i.test(message);
+	// An explicit error param naming another field defeats the fieldless
+	// heuristic entirely: e.g. `tool_choice: "none"` rejected with its own
+	// Supported-values list must not trigger a reasoning-effort retry.
+	const errorParam = capturedStringField(captured, "param") ?? "";
+	if (errorParam !== "" && !/reasoning[_. ]effort|reasoning value/i.test(errorParam) && !namesField) return false;
 	if (currentEffort.toLowerCase() !== "none" && !namesField && !listsLevels) return false;
 	const quoted = `["'\`]${escapeRegExp(currentEffort)}["'\`]`;
 	return (

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -228,11 +228,14 @@ function isInvalidReasoningEffortError(
 		return true;
 	}
 	// Gateways put the rejected value first (`level "none" not supported`), the
-	// official API puts the verdict first (`Unsupported value: 'none'`). Without
-	// a field naming, only the reasoning-off value is trusted: sibling
-	// tier-valued fields (e.g. text verbosity) share the low..max vocabulary,
-	// so a non-none match cannot establish which field was rejected.
-	if (currentEffort.toLowerCase() !== "none") return false;
+	// official API puts the verdict first (`Unsupported value: 'none'`). A
+	// levels-list (`valid levels: …`) is gateway-effort vocabulary, so a
+	// fieldless match stays trusted there; a bare values-list is shared with
+	// sibling tier-valued fields (e.g. text verbosity), so without a field
+	// naming only the reasoning-off value is trusted.
+	const namesField = /reasoning[_. ]effort|reasoning value/i.test(message);
+	const listsLevels = /(?:valid|supported|allowed) levels?/i.test(message);
+	if (currentEffort.toLowerCase() !== "none" && !namesField && !listsLevels) return false;
 	const quoted = `["'\`]${escapeRegExp(currentEffort)}["'\`]`;
 	return (
 		new RegExp(`(?:invalid|unsupported|not supported)[^\\n]*${quoted}`, "i").test(message) ||

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -591,11 +591,20 @@ const streamOpenAIResponsesOnce = (
 					try {
 						openaiStream = await openResponsesStream(chained.params);
 						if (pendingReasoningEffortFallback) {
-							rememberOpenAIReasoningEffortFallback(
-								providerSessionState,
-								pendingReasoningEffortFallback.key,
-								pendingReasoningEffortFallback.fallback,
-							);
+							// Explicit-disable fallbacks (none -> lowest allowed) are
+							// per-request: persisting them under the model key would
+							// silently downgrade later normal turns sharing the
+							// session state. Keep them in the per-request map only.
+							const isExplicitDisable =
+								options?.forceReasoningOff === true ||
+								(options?.disableReasoning === true && options.reasoning === undefined);
+							if (!isExplicitDisable) {
+								rememberOpenAIReasoningEffortFallback(
+									providerSessionState,
+									pendingReasoningEffortFallback.key,
+									pendingReasoningEffortFallback.fallback,
+								);
+							}
 							pendingReasoningEffortFallback = undefined;
 						}
 						break;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -594,10 +594,11 @@ const streamOpenAIResponsesOnce = (
 							// Explicit-disable fallbacks (none -> lowest allowed) are
 							// per-request: persisting them under the model key would
 							// silently downgrade later normal turns sharing the
-							// session state. Keep them in the per-request map only.
+							// session state. A retained effort preference does not
+							// make the disable less explicit. Keep them in the
+							// per-request map only.
 							const isExplicitDisable =
-								options?.forceReasoningOff === true ||
-								(options?.disableReasoning === true && options.reasoning === undefined);
+								options?.forceReasoningOff === true || options?.disableReasoning === true;
 							if (!isExplicitDisable) {
 								rememberOpenAIReasoningEffortFallback(
 									providerSessionState,
@@ -614,8 +615,7 @@ const streamOpenAIResponsesOnce = (
 							activeReasoningEffortFallbackKey && activeRequestParams && !requestSignal.aborted
 								? resolveOpenAIReasoningEffortFallback(error, capturedErrorResponse, activeRequestParams, {
 										explicitDisable:
-											options?.forceReasoningOff === true ||
-											(options?.disableReasoning === true && options.reasoning === undefined),
+											options?.forceReasoningOff === true || options?.disableReasoning === true,
 									})
 								: undefined;
 						if (reasoningEffortFallback !== undefined && activeReasoningEffortFallbackKey) {

--- a/packages/ai/test/cursor-effort-routing.test.ts
+++ b/packages/ai/test/cursor-effort-routing.test.ts
@@ -73,7 +73,10 @@ describe("cursor effort routing", () => {
 			blobStore: new Map(),
 		});
 		const run = decodeRunRequest(requestBytes).value;
-		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra-none");
-		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra-none");
+		// The routed off-tier sibling still normalizes: suffixed sibling ids
+		// trigger Cursor's 528384, so -none goes out as the bare base id.
+		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra");
+		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra");
+		expect(run.requestedModel.parameters).toEqual([]);
 	});
 });

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -52,6 +52,14 @@ describe("Cursor requestedModel wire shape", () => {
 		]);
 	});
 
+	it("maps the extra-high sibling to the xhigh reasoning parameter", async () => {
+		const payload = await capture(cursorModel("gpt-5.6-sol-extra-high"));
+		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol");
+		expect(payload.requestedModel?.parameters).toEqual([
+			expect.objectContaining({ id: "reasoning", value: "xhigh" }),
+		]);
+	});
+
 	it("normalizes an off-tier sibling to the base id with no parameters", async () => {
 		const payload = await capture(cursorModel("gpt-5.6-sol-none"));
 		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol");

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -52,6 +52,20 @@ describe("Cursor requestedModel wire shape", () => {
 		]);
 	});
 
+	it("normalizes an off-tier sibling to the base id with no parameters", async () => {
+		const payload = await capture(cursorModel("gpt-5.6-sol-none"));
+		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol");
+	});
+
+	it("normalizes a fast-lane off-tier sibling preserving the lane", async () => {
+		const payload = await capture(cursorModel("gpt-5.6-sol-none-fast"));
+		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol-fast");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol-fast");
+	});
+
 	it("leaves Cursor-native ids untouched with no parameters", async () => {
 		const payload = await capture(cursorModel("cursor-composer-2.5"));
 		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5");

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -120,6 +120,21 @@ function unsupportedLevelResponse(value: string): Response {
 	});
 }
 
+/**
+ * GitHub Copilot-style rejection: the field is never named and the allowed
+ * list is phrased as `Supported values are: …` (e.g. gpt-6-astra refusing
+ * `reasoning.effort: "none"`).
+ */
+function copilotUnsupportedValueResponse(value: string, modelId: string): Response {
+	const message =
+		`Unsupported value: '${value}' is not supported with the '${modelId}' model. ` +
+		`Supported values are: 'low', 'medium', 'high', 'xhigh', and 'max'.`;
+	return new Response(JSON.stringify({ error: { message, type: "invalid_request_body" } }), {
+		status: 400,
+		headers: { "content-type": "application/json" },
+	});
+}
+
 function summaryReasoningErrorResponse(): Response {
 	return new Response(
 		JSON.stringify({
@@ -409,6 +424,30 @@ describe("OpenAI reasoning effort fallback retry", () => {
 				const body = parseJsonBody(init);
 				bodies.push(body);
 				return bodies.length === 1 ? unsupportedLevelResponse("none") : createResponsesSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			forceReasoningOff: true,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual(["none", "low"]);
+	});
+
+	it("clamps a Copilot Supported-values rejection of reasoning-off to the lowest allowed level", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(init);
+				bodies.push(body);
+				return bodies.length === 1
+					? copilotUnsupportedValueResponse("none", "gpt-6-astra")
+					: createResponsesSseResponse();
 			},
 			{ preconnect: fetch.preconnect },
 		);

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -149,6 +149,19 @@ function summaryReasoningErrorResponse(): Response {
 }
 
 /**
+ * Rejection aimed at a sibling tier-valued field: the current reasoning
+ * effort is quoted, but the verdict is about text verbosity. Must not
+ * trigger a reasoning-effort retry.
+ */
+function unsupportedVerbosityResponse(): Response {
+	const message = "Unsupported value: 'high' for text verbosity. Supported values are: 'low', 'medium'.";
+	return new Response(JSON.stringify({ error: { message, type: "invalid_request_body" } }), {
+		status: 400,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/**
  * Ninfer-style strict kwargs whitelist: the server rejects the
  * `chat_template_kwargs.reasoning_effort` spelling itself, not the value.
  */
@@ -461,6 +474,27 @@ describe("OpenAI reasoning effort fallback retry", () => {
 
 		expect(result.stopReason).toBe("stop");
 		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual(["none", "low"]);
+	});
+
+	it("does not retry a Supported-values rejection aimed at another field", async () => {
+		let attempts = 0;
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+				attempts += 1;
+				return unsupportedVerbosityResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(400);
+		expect(attempts).toBe(1);
 	});
 
 	it("does not retry unrelated reasoning parameter errors", async () => {

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -497,6 +497,27 @@ describe("OpenAI reasoning effort fallback retry", () => {
 		expect(attempts).toBe(1);
 	});
 
+	it("still remaps a fieldless levels-list rejection for a real effort tier", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(_init);
+				bodies.push(body);
+				return bodies.length === 1 ? unsupportedLevelResponse("xhigh") : createResponsesSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "xhigh",
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual(["xhigh", "max"]);
+	});
+
 	it("does not retry unrelated reasoning parameter errors", async () => {
 		let attempts = 0;
 		const fetchMock: FetchImpl = Object.assign(

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -236,6 +236,34 @@ function createCompletionsModel(): Model<"openai-completions"> {
 	});
 }
 
+/**
+ * First-party OpenAI 5.6 model: disabled reasoning goes out as wire `none`
+ * (`reasoning-disable-mode: none-effort`), unlike the default lowest-effort dialects.
+ */
+function createNoneEffortCompletionsModel(): Model<"openai-completions"> {
+	return buildModel({
+		id: "gpt-5.6-none-effort-test",
+		name: "None Effort Test",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		compat: {
+			thinkingFormat: "openai",
+			supportsReasoningParams: true,
+			supportsReasoningEffort: true,
+		},
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	});
+}
+
 function createResponsesModel(): Model<"openai-responses"> {
 	return buildModel({
 		id: "fallback-responses-reasoner",
@@ -511,6 +539,47 @@ describe("OpenAI reasoning effort fallback retry", () => {
 			"low",
 			"high",
 		]);
+	});
+
+	it("retries a disabled-with-effort none rejection at lowest without poisoning later turns", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(init);
+				bodies.push(body);
+				if (body.reasoning_effort === "none") {
+					const message =
+						"Unsupported value: 'none' is not supported. Supported values are: 'low', 'medium', 'high'.";
+					return new Response(JSON.stringify({ error: { message, type: "invalid_request_body" } }), {
+						status: 400,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return createChatSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const disabled = await streamOpenAICompletions(createNoneEffortCompletionsModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			disableReasoning: true,
+			providerSessionState,
+		}).result();
+		expect(disabled.stopReason).toBe("stop");
+
+		const enabled = await streamOpenAICompletions(createNoneEffortCompletionsModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			providerSessionState,
+		}).result();
+		expect(enabled.stopReason).toBe("stop");
+		// Explicit disable retries at the lowest allowed tier (not a field
+		// delete), and nothing cached may strip the later enabled turn.
+		expect(bodies.map(body => body.reasoning_effort)).toEqual(["none", "low", "high"]);
 	});
 
 	it("does not retry a Supported-values rejection aimed at another field", async () => {

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -504,6 +504,32 @@ describe("OpenAI reasoning effort fallback retry", () => {
 		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual(["none", "low"]);
 	});
 
+	it("does not retry when the error param names another none-valued field", async () => {
+		let attempts = 0;
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+				attempts += 1;
+				const message = "Unsupported value: 'none' is not supported. Supported values are: 'auto', 'required'.";
+				return new Response(
+					JSON.stringify({ error: { message, param: "tool_choice", type: "invalid_request_error" } }),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				);
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			forceReasoningOff: true,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(400);
+		expect(attempts).toBe(1);
+	});
+
 	it("does not leak an explicit-disable fallback into later normal turns", async () => {
 		const bodies: Record<string, unknown>[] = [];
 		const providerSessionState = new Map<string, ProviderSessionState>();

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -476,6 +476,43 @@ describe("OpenAI reasoning effort fallback retry", () => {
 		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual(["none", "low"]);
 	});
 
+	it("does not leak an explicit-disable fallback into later normal turns", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(init);
+				bodies.push(body);
+				const effort = (body.reasoning as { effort?: string } | undefined)?.effort;
+				if (effort === "none") return copilotUnsupportedValueResponse("none", "gpt-6-astra");
+				return createResponsesSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const off = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			forceReasoningOff: true,
+			providerSessionState,
+		}).result();
+		expect(off.stopReason).toBe("stop");
+
+		const normal = await streamOpenAIResponses(createMaxLadderResponsesModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "high",
+			providerSessionState,
+		}).result();
+		expect(normal.stopReason).toBe("stop");
+		expect(bodies.map(body => (body.reasoning as { effort?: string } | undefined)?.effort)).toEqual([
+			"none",
+			"low",
+			"high",
+		]);
+	});
+
 	it("does not retry a Supported-values rejection aimed at another field", async () => {
 		let attempts = 0;
 		const fetchMock: FetchImpl = Object.assign(

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -27,10 +27,6 @@
 	- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
 	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 	- Made extended-context catalog rebuilds faster by resolving each model's maximum window once per process ([#11039](https://github.com/can1357/oh-my-pi/pull/11039) by [@H4vC](https://github.com/H4vC)).
-   - Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
-   - Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
-   - Fixed GPT-6 Astra compacting early at a 272K-token window with its full window gated behind `/extended-context`: it now defaults to the documented 1.05M-token window.
-   - Made extended-context catalog rebuilds faster by resolving each model's maximum window once per process ([#11039](https://github.com/can1357/oh-my-pi/pull/11039) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Codex Astra using its larger window without opt-in; its default is 272K and Extended Context enables at least the documented 1.05M window.
+- Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07
 
@@ -26,6 +27,10 @@
 	- Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
 	- Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 	- Made extended-context catalog rebuilds faster by resolving each model's maximum window once per process ([#11039](https://github.com/can1357/oh-my-pi/pull/11039) by [@H4vC](https://github.com/H4vC)).
+   - Fixed GPT-6 Astra requests through GitHub Copilot failing with an unsupported endpoint error ([#10874](https://github.com/can1357/oh-my-pi/pull/10874) by [@xpcmdshell](https://github.com/xpcmdshell)).
+   - Fixed GPT-6 Astra showing as free with a 272K-token window in the OpenAI Codex catalog by applying its documented pricing; `/extended-context` enables the wire-advertised 872K-token maximum ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
+   - Fixed GPT-6 Astra compacting early at a 272K-token window with its full window gated behind `/extended-context`: it now defaults to the documented 1.05M-token window.
+   - Made extended-context catalog rebuilds faster by resolving each model's maximum window once per process ([#11039](https://github.com/can1357/oh-my-pi/pull/11039) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Codex Astra using its larger window without opt-in; its default is 272K and Extended Context enables at least the documented 1.05M window.
+- Fixed Codex Astra using its larger window without opt-in; its default is 272K and Extended Context enables at least the documented 1.05M window ([#11126](https://github.com/can1357/oh-my-pi/pull/11126) by [@H4vC](https://github.com/H4vC)).
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07

--- a/packages/catalog/src/compat/collapse.ts
+++ b/packages/catalog/src/compat/collapse.ts
@@ -338,8 +338,7 @@ function buildCompiledTables(): Readonly<Record<string, VariantCollapseTable>> {
 	return tables;
 }
 
-/** Effort tier decoded from a Cursor sibling slug (`-extra-high` normalizes to `xhigh`; `-none` is the off tier). */
-export type CursorTierToken = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+type CursorTierToken = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 interface CursorTierMember<TSpec extends VariantSpecLike> {
 	baseId: string;
@@ -361,29 +360,6 @@ const CURSOR_TIER_BY_TOKEN: Readonly<Record<string, CursorTierToken | undefined>
 	xhigh: "xhigh",
 	max: "max",
 };
-
-/** Split of a Cursor per-effort sibling slug into logical base, effort tier, and SKU lane. */
-export interface CursorEffortSuffix {
-	baseId: string;
-	tier: CursorTierToken;
-	/** True for the parallel `-fast` SKU lane (`-high-fast`); the lane stays in the logical id. */
-	fast: boolean;
-}
-
-/**
- * Split a Cursor per-effort sibling slug (`gpt-5.6-sol-high-fast`) into its
- * logical base, effort tier, and SKU lane. Shared with the cursor-agent
- * transport so the Run wire mapping tracks the catalog tier vocabulary
- * instead of duplicating it.
- */
-export function splitCursorEffortSuffix(id: string): CursorEffortSuffix | undefined {
-	const match = CURSOR_TIER_ID_PATTERN.exec(id);
-	if (!match) return undefined;
-	const tier = CURSOR_TIER_BY_TOKEN[match[2] ?? ""];
-	const baseId = match[1];
-	if (!baseId || !tier) return undefined;
-	return { baseId, tier, fast: match[3] !== undefined };
-}
 
 /** Whether an existing logical row already routes every live member in `members`. */
 function collapsedCursorLogicalMatches<TSpec extends VariantSpecLike>(

--- a/packages/catalog/src/compat/collapse.ts
+++ b/packages/catalog/src/compat/collapse.ts
@@ -338,7 +338,8 @@ function buildCompiledTables(): Readonly<Record<string, VariantCollapseTable>> {
 	return tables;
 }
 
-type CursorTierToken = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+/** Effort tier decoded from a Cursor sibling slug (`-extra-high` normalizes to `xhigh`; `-none` is the off tier). */
+export type CursorTierToken = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 interface CursorTierMember<TSpec extends VariantSpecLike> {
 	baseId: string;
@@ -360,6 +361,29 @@ const CURSOR_TIER_BY_TOKEN: Readonly<Record<string, CursorTierToken | undefined>
 	xhigh: "xhigh",
 	max: "max",
 };
+
+/** Split of a Cursor per-effort sibling slug into logical base, effort tier, and SKU lane. */
+export interface CursorEffortSuffix {
+	baseId: string;
+	tier: CursorTierToken;
+	/** True for the parallel `-fast` SKU lane (`-high-fast`); the lane stays in the logical id. */
+	fast: boolean;
+}
+
+/**
+ * Split a Cursor per-effort sibling slug (`gpt-5.6-sol-high-fast`) into its
+ * logical base, effort tier, and SKU lane. Shared with the cursor-agent
+ * transport so the Run wire mapping tracks the catalog tier vocabulary
+ * instead of duplicating it.
+ */
+export function splitCursorEffortSuffix(id: string): CursorEffortSuffix | undefined {
+	const match = CURSOR_TIER_ID_PATTERN.exec(id);
+	if (!match) return undefined;
+	const tier = CURSOR_TIER_BY_TOKEN[match[2] ?? ""];
+	const baseId = match[1];
+	if (!baseId || !tier) return undefined;
+	return { baseId, tier, fast: match[3] !== undefined };
+}
 
 /** Whether an existing logical row already routes every live member in `members`. */
 function collapsedCursorLogicalMatches<TSpec extends VariantSpecLike>(

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -92,9 +92,15 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 			// switching `COPILOT_GITHUB_TOKEN` to a different account misses the
 			// prior endpoint's cache and re-runs discovery instead of hitting the
 			// stale host and 403ing (PR #8510 review).
+			// v2: rows cached before the cross-provider routing strip inherit
+			// Cursor collapsed-family wire ids (e.g. enterprise-only
+			// `gpt-5.6-sol-fast` pinned to `-none-fast`); use a fresh namespace
+			// so they refetch instead of serving the poisoned rows. Listing ids
+			// cannot cover this class — any enterprise-only sibling can carry
+			// another provider's routing — so version the namespace instead.
 			const baseUrl = options.baseUrl ?? PERSONAL_GITHUB_COPILOT_BASE_URL;
 			const scope = `${options.apiKey ?? ""}\u0000${baseUrl}`;
-			return `github-copilot:models-v1:${Bun.hash(scope).toString(36)}`;
+			return `github-copilot:models-v2:${Bun.hash(scope).toString(36)}`;
 		}
 		case "openrouter":
 			return "openrouter:pseudo-api";

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6080,9 +6080,6 @@ const COPILOT_CACHE_INVALIDATED_MODEL_IDS = [
 	"grok-4.6",
 	"grok-4.6-1m",
 	"mai-code-1-flash-picker",
-	// Enterprise-only Cursor-family id: caches written before the
-	// cross-provider routing strip pin every request to `-none-fast`.
-	"gpt-5.6-sol-fast",
 ];
 
 function inferCopilotApi(modelId: string): Api {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6380,11 +6380,17 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 											}
 										: {}),
 								};
-						const defaultCost = copilotTierCost(tokenPrices.defaultTier);
-						if (defaultCost) {
-							// Cache writes are not reported per tier; retain the bundled provider rate.
-							base.cost = { ...defaultCost, cacheWrite: base.cost.cacheWrite };
+						// Cross-provider fallback references (e.g. a Cursor
+						// collapsed family for an enterprise-only sibling id)
+						// carry provider-specific wire routing that must not
+						// transfer: the off-tier `requestModelId` pin would send
+						// every Copilot request under the `-none` sibling id
+						// regardless of thinking level.
+						if (reference && reference.provider !== "github-copilot") {
+							delete base.requestModelId;
+							if (base.thinking) delete base.thinking.effortRouting;
 						}
+						const defaultCost = copilotTierCost(tokenPrices.defaultTier);
 						const variant = createCopilotLongContextVariant(
 							base,
 							contextWindow,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6388,9 +6388,19 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						// regardless of thinking level.
 						if (reference && reference.provider !== "github-copilot") {
 							delete base.requestModelId;
-							if (base.thinking) delete base.thinking.effortRouting;
+							if (base.thinking) {
+								// `base` is a shallow copy of the shared global
+								// reference: clone before deleting or the bundled
+								// entry loses its routing process-wide.
+								base.thinking = { ...base.thinking };
+								delete base.thinking.effortRouting;
+							}
 						}
 						const defaultCost = copilotTierCost(tokenPrices.defaultTier);
+						if (defaultCost) {
+							// Cache writes are not reported per tier; retain the bundled provider rate.
+							base.cost = { ...defaultCost, cacheWrite: base.cost.cacheWrite };
+						}
 						const variant = createCopilotLongContextVariant(
 							base,
 							contextWindow,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6080,6 +6080,9 @@ const COPILOT_CACHE_INVALIDATED_MODEL_IDS = [
 	"grok-4.6",
 	"grok-4.6-1m",
 	"mai-code-1-flash-picker",
+	// Enterprise-only Cursor-family id: caches written before the
+	// cross-provider routing strip pin every request to `-none-fast`.
+	"gpt-5.6-sol-fast",
 ];
 
 function inferCopilotApi(modelId: string): Api {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -524,7 +524,6 @@ describe("github copilot model limits mapping", () => {
 	it("refetches a cached enterprise sibling still pinned to -none-fast", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-solfast-cache-"));
 		const cacheDbPath = path.join(tempDir, "models.db");
-		const cacheProviderId = "github-copilot-solfast-cache-test";
 		try {
 			const poisoned: ModelSpec<"openai-responses"> = {
 				id: "gpt-5.6-sol-fast",
@@ -575,37 +574,26 @@ describe("github copilot model limits mapping", () => {
 					},
 				);
 			});
-			// Seed the poisoned row through the previous fingerprint (drop list
-			// without sol-fast) while keeping the real restore options: the
-			// written cache is fully usable, so only the fingerprint migration
-			// can force the refetch — the upgraded-installation scenario.
+			// Seed the poisoned row under the previous cache namespace, mirroring
+			// exactly what a pre-fix binary wrote: same DB, same credential scope,
+			// v1 scheme. The v2 namespace must orphan it and force a refetch.
+			const previousNamespace = `github-copilot:models-v1:${Bun.hash("copilot-test-key\0https://api.githubcopilot.com").toString(36)}`;
 			const oldManager = createModelManager({
 				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
-				dropCachedModelIdsOnStaticMismatch: [
-					"gpt-6-astra",
-					"gpt-6-astra-1m",
-					"grok-4.5",
-					"grok-4.5-1m",
-					"grok-4.6",
-					"grok-4.6-1m",
-					"mai-code-1-flash-picker",
-				],
-				cacheProviderId,
+				cacheProviderId: previousNamespace,
 				cacheDbPath,
 				fetchDynamicModels: async () => [poisoned],
 			});
 			await oldManager.refresh("online");
-
 			const manager = createModelManager({
 				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
-				cacheProviderId,
 				cacheDbPath,
 			});
 			const { models } = await manager.refresh("online-if-uncached");
 			const model = models.find(candidate => candidate.id === "gpt-5.6-sol-fast");
 
-			// The fingerprint migration must refetch instead of serving the
-			// poisoned cache row; the remapped row carries no off-tier pin.
+			// The v2 namespace orphans the poisoned v1 row, forcing a refetch;
+			// the remapped row carries no off-tier pin.
 			expect(fetchMock).toHaveBeenCalled();
 			expect(model?.api).toBe("openai-responses");
 			expect(model).not.toHaveProperty("requestModelId");

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -6,6 +6,7 @@ import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { createModelManager } from "@oh-my-pi/pi-catalog/model-manager";
 import { getBundledModel, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { githubCopilotModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import { COPILOT_API_HEADERS } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 function getHeaderValue(headers: unknown, key: string): string | undefined {
@@ -515,6 +516,100 @@ describe("github copilot model limits mapping", () => {
 			// so it stays dropped.
 			expect(models.find(candidate => candidate.id === "grok-4.5")?.api).toBe("openai-responses");
 			expect(models.find(candidate => candidate.id === "grok-4.5-1m")).toBeUndefined();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refetches a cached enterprise sibling still pinned to -none-fast", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-solfast-cache-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const cacheProviderId = "github-copilot-solfast-cache-test";
+		try {
+			const poisoned: ModelSpec<"openai-responses"> = {
+				id: "gpt-5.6-sol-fast",
+				name: "GPT-5.6 Sol Fast (Internal only)",
+				api: "openai-responses",
+				provider: "github-copilot",
+				baseUrl: "https://api.githubcopilot.com",
+				reasoning: true,
+				requestModelId: "gpt-5.6-sol-none-fast",
+				// Faithful to a real pre-fix mapper row: headers present, so the
+				// header-restore path cannot force the refetch by itself and only
+				// the fingerprint migration distinguishes fixed from broken.
+				headers: { ...COPILOT_API_HEADERS },
+				thinking: {
+					mode: "effort",
+					efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+					effortRouting: {
+						off: "gpt-5.6-sol-none-fast",
+						[Effort.Low]: "gpt-5.6-sol-low-fast",
+						[Effort.Medium]: "gpt-5.6-sol-medium-fast",
+						[Effort.High]: "gpt-5.6-sol-high-fast",
+						[Effort.XHigh]: "gpt-5.6-sol-xhigh-fast",
+						[Effort.Max]: "gpt-5.6-sol-max-fast",
+					},
+				},
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1_050_000,
+				maxTokens: 128_000,
+			};
+			const fetchMock = vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "gpt-5.6-sol-fast",
+								name: "GPT-5.6 Sol Fast (Internal only)",
+								capabilities: {
+									type: "chat",
+									limits: { max_context_window_tokens: 1_050_000, max_output_tokens: 128_000 },
+								},
+							},
+						],
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			});
+			// Seed the poisoned row through the previous fingerprint (drop list
+			// without sol-fast) while keeping the real restore options: the
+			// written cache is fully usable, so only the fingerprint migration
+			// can force the refetch — the upgraded-installation scenario.
+			const oldManager = createModelManager({
+				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
+				dropCachedModelIdsOnStaticMismatch: [
+					"gpt-6-astra",
+					"gpt-6-astra-1m",
+					"grok-4.5",
+					"grok-4.5-1m",
+					"grok-4.6",
+					"grok-4.6-1m",
+					"mai-code-1-flash-picker",
+				],
+				cacheProviderId,
+				cacheDbPath,
+				fetchDynamicModels: async () => [poisoned],
+			});
+			await oldManager.refresh("online");
+
+			const manager = createModelManager({
+				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
+				cacheProviderId,
+				cacheDbPath,
+			});
+			const { models } = await manager.refresh("online-if-uncached");
+			const model = models.find(candidate => candidate.id === "gpt-5.6-sol-fast");
+
+			// The fingerprint migration must refetch instead of serving the
+			// poisoned cache row; the remapped row carries no off-tier pin.
+			expect(fetchMock).toHaveBeenCalled();
+			expect(model?.api).toBe("openai-responses");
+			expect(model).not.toHaveProperty("requestModelId");
+			expect(model?.thinking?.effortRouting).toBeUndefined();
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -114,6 +114,11 @@ describe("github copilot model limits mapping", () => {
 						type: "chat",
 						limits: { max_context_window_tokens: 1_050_000, max_output_tokens: 128_000 },
 					},
+					billing: {
+						token_prices: {
+							default: { context_max: 200_000, input_price: 234, output_price: 1234, cache_price: 56 },
+						},
+					},
 				},
 			],
 		});
@@ -123,7 +128,13 @@ describe("github copilot model limits mapping", () => {
 		// off-tier requestModelId pin and effort routing must not transfer or
 		// every request goes out as gpt-5.6-sol-none-fast regardless of effort.
 		expect(sol).not.toHaveProperty("requestModelId");
-		expect(sol?.thinking?.effortRouting).toBeUndefined();
+		// The discovered default-tier prices still apply on the reference branch.
+		expect(sol?.cost).toMatchObject({ input: 2.34, output: 12.34, cacheRead: 0.56 });
+		// The strip must not mutate the shared bundled Cursor entry the global
+		// reference points at: it keeps its routing for Cursor consumers.
+		expect(getBundledModels("cursor").find(m => m.id === "gpt-5.6-sol-fast")?.thinking?.effortRouting).toMatchObject({
+			off: "gpt-5.6-sol-none-fast",
+		});
 	});
 	it("does not reuse another token's authoritative cache after COPILOT_GITHUB_TOKEN switches", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-token-switch-"));

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -104,6 +104,27 @@ describe("github copilot model limits mapping", () => {
 		expect(models).toEqual([]);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
+	it("drops cross-provider wire routing from enterprise-only sibling ids", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "gpt-5.6-sol-fast",
+					name: "GPT-5.6 Sol Fast (Internal only)",
+					capabilities: {
+						type: "chat",
+						limits: { max_context_window_tokens: 1_050_000, max_output_tokens: 128_000 },
+					},
+				},
+			],
+		});
+		const sol = models.find(m => m.id === "gpt-5.6-sol-fast");
+		expect(sol?.api).toBe("openai-responses");
+		// The global fallback reference is the Cursor collapsed family; its
+		// off-tier requestModelId pin and effort routing must not transfer or
+		// every request goes out as gpt-5.6-sol-none-fast regardless of effort.
+		expect(sol).not.toHaveProperty("requestModelId");
+		expect(sol?.thinking?.effortRouting).toBeUndefined();
+	});
 	it("does not reuse another token's authoritative cache after COPILOT_GITHUB_TOKEN switches", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-token-switch-"));
 		const cacheDbPath = path.join(tempDir, "models.db");


### PR DESCRIPTION
What

- openai-reasoning-fallback.ts: the 400-is-about-reasoning-effort gate now also matches Supported/Allowed/Valid values
  phrasing, not just levels. Copilot rejects reasoning.effort: "none" with Unsupported value: 'none' … Supported values
  are: …, which previously slipped past the fallback so the request 400d instead of retrying.
- cursor.ts (resolveCursorWireModel): off-tier siblings (-none, -none-fast) now normalize to the lane-preserving base id
  with no reasoning parameter, like every other tier. Previously they went out raw, and the Run endpoint rejects sibling
  slugs with 528384.
- Updated one stale test expectation (cursor-effort-routing), added regression tests (Copilot-style rejection → none→low
  retry; -none/-none-fast normalization).

Why

Two live failures, both static-only (no Copilot/Cursor account to repro against):
1. github-copilot/gpt-6-astra (and sol) 400 on reasoning-off requests — the fallback designed for exactly this case
   never fired on Copilot's wording.
2. Cursor gpt-5.6-sol-fast with thinking off sent gpt-5.6-sol-none-fast raw — a sibling slug, rejected per the
   transport's own documented 528384 behavior. Same reason an xhigh session could still emit a -none id: any request
   where effort resolves to undefined (thinking Off/Inherit, force-off side requests, or a model object without the
   ladder) lands on the off route.

Testing

- New regression tests fail pre-fix (verified gate old-pattern miss + raw -none passthrough) and pass post-fix.
- bun test on 8 reasoning-related suites: 56 pass / 0 fail (openai-reasoning-effort-fallback, cursor-requested-model,
  cursor-effort-routing, cursor-wire-model-fallback, cursor-on-payload, openai-configuration-update,
  openai-responses-sampling-params, requires-effort).
- bun check clean. No live-account verification possible — Copilot/Cursor paths validated via mocked-400 retry test and
  wire-shape assertions only.