### PR TITLE
fix(ai): exempt structured content from thinking-loop heuristics

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Thinking-loop guard no longer discards a legitimate final answer whose tail is homogeneous structured data (a markdown table or JSON array of same-shape rows): such content is exempted from the near-duplicate/lexical heuristics, which are meant for reasoning prose ([#11129](https://github.com/can1357/oh-my-pi/issues/11129)).
+
 ## [18.1.12] - 2026-09-06
 
 ### Added

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -99,6 +99,11 @@ const LEX_STALL_MIN_RUN = 8;
 /** Structural punctuation that dominates tables / JSON / code but is rare in
  *  prose. Used to score a segment's prose-likeness. */
 const STRUCTURAL_PUNCT = /[|{}[\]"`:;,/=<>#]/u;
+/** A quoted `"key":` pair — the shape of a JSON/object record field. Present in
+ *  structured output regardless of how long the key name is, and essentially
+ *  absent from prose; used to recognize JSON independently of {@link proseRatio}.
+ *  Global flag: collected with matchAll, never used with the stateful test(). */
+const JSON_KEY_FIELD = /"[^"\n]{1,200}"\s*:/g;
 /** Minimum fraction of prose characters (Unicode letters + whitespace, versus
  *  structural punctuation) a segment must reach to feed the near-duplicate and
  *  lexical-stall heuristics. Homogeneous structured output — a markdown table of
@@ -247,10 +252,11 @@ export class ThinkingLoopDetector {
 		// legitimate answer content, not a reasoning loop, yet consecutive rows
 		// normalize to near-identical trigrams (their varying data is numeric,
 		// which normalizeSegment drops) and would falsely trip the cluster path.
-		// Exempt low-prose segments from the semantic heuristics; a NEW output
-		// block also breaks any in-progress prose stall. Verbatim structured loops
-		// are still caught by the exact suffix-cycle detector in push()/flush().
-		if (proseRatio(segment) < SEGMENT_MIN_PROSE_RATIO) {
+		// Exempt it two ways: by shape (JSON/table recognized regardless of key
+		// length) and by a low prose ratio (punctuation-heavy data generally). A
+		// NEW output block also breaks any in-progress prose stall. Verbatim
+		// structured loops are still caught by the exact suffix-cycle detector.
+		if (isStructuredSegment(segment) || proseRatio(segment) < SEGMENT_MIN_PROSE_RATIO) {
 			this.#lexStallRun = 0;
 			return null;
 		}
@@ -596,6 +602,27 @@ function proseRatio(segment: string): number {
 	}
 	const denom = prose + structural;
 	return denom === 0 ? 1 : prose / denom;
+}
+
+/** True when a segment is structured data — a JSON value/record or a markdown
+ *  table — rather than reasoning prose, recognized by shape so it holds even
+ *  when long descriptive key names push {@link proseRatio} above its threshold
+ *  (issue #11132 review). Complements the prose-ratio check, which catches other
+ *  punctuation-heavy data (CSV, code). */
+function isStructuredSegment(segment: string): boolean {
+	const trimmed = segment.trim();
+	// A JSON object/array value, whole or force-flush-chunked.
+	if (/^[{[]/.test(trimmed) && /[}\]]$/.test(trimmed)) return true;
+	// Two or more named fields: the shape of a record, independent of key length.
+	if ((segment.match(JSON_KEY_FIELD)?.length ?? 0) >= 2) return true;
+	// Markdown table: most non-blank lines are multi-column pipe rows.
+	const lines = segment.split("\n").filter(line => line.trim() !== "");
+	if (lines.length >= 2) {
+		let pipeRows = 0;
+		for (const line of lines) if ((line.match(/\|/g)?.length ?? 0) >= 2) pipeRows++;
+		if (pipeRows >= Math.ceil(lines.length * 0.6)) return true;
+	}
+	return false;
 }
 
 /** Word-trigram shingle set of a normalized segment. */

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -99,11 +99,11 @@ const LEX_STALL_MIN_RUN = 8;
 /** Structural punctuation that dominates tables / JSON / code but is rare in
  *  prose. Used to score a segment's prose-likeness. */
 const STRUCTURAL_PUNCT = /[|{}[\]"`:;,/=<>#]/u;
-/** A quoted `"key":` pair — the shape of a JSON/object record field. Present in
- *  structured output regardless of how long the key name is, and essentially
- *  absent from prose; used to recognize JSON independently of {@link proseRatio}.
- *  Global flag: collected with matchAll, never used with the stateful test(). */
-const JSON_KEY_FIELD = /"(?:\\.|[^"\\\n])*"\s*:/g;
+/** A JSON record field prefixed by the record/field delimiter (`{` or `,`).
+ *  Requiring that structure keeps prose mentions such as `"status":` from
+ *  masquerading as record fields. Global flag: collected with matchAll, never
+ *  used with the stateful test(). */
+const JSON_KEY_FIELD = /(?:^|[{,])\s*"(?:\\.|[^"\\\n])*"\s*:/gm;
 /** Minimum fraction of prose characters (Unicode letters + whitespace, versus
  *  structural punctuation) a segment must reach to feed the near-duplicate and
  *  lexical-stall heuristics. Homogeneous structured output — a markdown table of
@@ -611,10 +611,18 @@ function proseRatio(segment: string): number {
  *  punctuation-heavy data (CSV, code). */
 function isStructuredSegment(segment: string): boolean {
 	const trimmed = segment.trim();
-	// A JSON object/array value, whole or force-flush-chunked.
+	// A complete JSON object/array value.
 	if (/^[{[]/.test(trimmed) && /[}\]]$/.test(trimmed)) return true;
-	// Two or more named fields: the shape of a record, independent of key length.
-	if ((segment.match(JSON_KEY_FIELD)?.length ?? 0) >= 2) return true;
+	// A force-flushed partial record: at least two delimiter-prefixed fields whose
+	// syntax dominates the chunk. Incidental inline JSON inside a prose paragraph
+	// leaves most of the segment outside these matches and must remain analyzable.
+	let fields = 0;
+	let fieldChars = 0;
+	for (const match of segment.matchAll(JSON_KEY_FIELD)) {
+		fields++;
+		fieldChars += match[0].length;
+	}
+	if (fields >= 2 && fieldChars * 2 >= trimmed.length) return true;
 	// Markdown table: most non-blank lines are multi-column pipe rows.
 	const lines = segment.split("\n").filter(line => line.trim() !== "");
 	if (lines.length >= 2) {

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -96,6 +96,21 @@ const LEX_STALL_NOVELTY_FLOOR = 0.2;
  *  the real reasoning-summarizer loop sustains far longer runs (10+). */
 const LEX_STALL_MIN_RUN = 8;
 
+/** Structural punctuation that dominates tables / JSON / code but is rare in
+ *  prose. Used to score a segment's prose-likeness. */
+const STRUCTURAL_PUNCT = /[|{}[\]"`:;,/=<>#]/u;
+/** Minimum fraction of prose characters (Unicode letters + whitespace, versus
+ *  structural punctuation) a segment must reach to feed the near-duplicate and
+ *  lexical-stall heuristics. Homogeneous structured output — a markdown table of
+ *  ids/URLs, a JSON array of same-shape rows — scores far below this (~0.7–0.8)
+ *  because its varying data is numeric (dropped by {@link normalizeSegment}) and
+ *  its skeleton is punctuation; those rows are legitimate answer content, not a
+ *  reasoning loop, so they are exempted. Reasoning prose in any script (Unicode
+ *  letters count, so CJK stays prose) scores ~0.95+. Calibrated to sit between
+ *  the two clusters with margin (issue #11129). Exact suffix-cycle detection is
+ *  unaffected — a verbatim structured loop is still caught. */
+const SEGMENT_MIN_PROSE_RATIO = 0.85;
+
 /** A concrete reference the model is actually reasoning about: a code span, a
  *  file extension / dotted member, a multi-segment path, or a snake/camel/Pascal
  *  identifier. A segment that introduces a NEW one resets the lexical-stall run —
@@ -227,6 +242,18 @@ export class ThinkingLoopDetector {
 		const segment = raw.replace(/^[ \t]*#{1,6}[ \t].*$/gm, "").replace(/^[ \t]*\*{2,3}.+?\*{2,3}[ \t]*$/gm, "");
 		const normalized = normalizeSegment(segment);
 		if (normalized.length < SEGMENT_MIN_NORM_CHARS) return null;
+
+		// Homogeneous structured output (markdown table, JSON array, code) is
+		// legitimate answer content, not a reasoning loop, yet consecutive rows
+		// normalize to near-identical trigrams (their varying data is numeric,
+		// which normalizeSegment drops) and would falsely trip the cluster path.
+		// Exempt low-prose segments from the semantic heuristics; a NEW output
+		// block also breaks any in-progress prose stall. Verbatim structured loops
+		// are still caught by the exact suffix-cycle detector in push()/flush().
+		if (proseRatio(segment) < SEGMENT_MIN_PROSE_RATIO) {
+			this.#lexStallRun = 0;
+			return null;
+		}
 
 		// (a) Near-duplicate trigram cluster: the same paragraph reused with
 		// cosmetic wording drift (high word-trigram overlap).
@@ -552,6 +579,23 @@ function normalizeSegment(segment: string): string {
 		.filter(token => /[a-z]/.test(token))
 		.join(" ")
 		.trim();
+}
+
+/** Fraction of a segment's classified characters that are prose (Unicode letters
+ *  or whitespace) rather than structural punctuation ({@link STRUCTURAL_PUNCT}).
+ *  Digits and other characters are ignored so that data identifiers (numeric ids,
+ *  hex) tilt the score toward neither side. Returns 1 for a segment with no
+ *  classified characters. Used to spare tables / JSON / code from the reasoning
+ *  heuristics (see {@link SEGMENT_MIN_PROSE_RATIO}). */
+function proseRatio(segment: string): number {
+	let prose = 0;
+	let structural = 0;
+	for (const ch of segment) {
+		if (/\s/.test(ch) || /\p{L}/u.test(ch)) prose++;
+		else if (STRUCTURAL_PUNCT.test(ch)) structural++;
+	}
+	const denom = prose + structural;
+	return denom === 0 ? 1 : prose / denom;
 }
 
 /** Word-trigram shingle set of a normalized segment. */

--- a/packages/ai/src/utils/thinking-loop.ts
+++ b/packages/ai/src/utils/thinking-loop.ts
@@ -103,7 +103,7 @@ const STRUCTURAL_PUNCT = /[|{}[\]"`:;,/=<>#]/u;
  *  structured output regardless of how long the key name is, and essentially
  *  absent from prose; used to recognize JSON independently of {@link proseRatio}.
  *  Global flag: collected with matchAll, never used with the stateful test(). */
-const JSON_KEY_FIELD = /"[^"\n]{1,200}"\s*:/g;
+const JSON_KEY_FIELD = /"(?:\\.|[^"\\\n])*"\s*:/g;
 /** Minimum fraction of prose characters (Unicode letters + whitespace, versus
  *  structural punctuation) a segment must reach to feed the near-duplicate and
  *  lexical-stall heuristics. Homogeneous structured output — a markdown table of

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -263,6 +263,51 @@ function longKeyJsonAnswer(n: number): string {
 	return `Here is the requested account data:\n\n${objs.join("\n\n")}`;
 }
 
+/** Compact JSON whose fields exceed the detector's force-flush chunk size when
+ *  combined, with each individual key longer than 200 characters. The chunks
+ *  remain JSON records regardless of key length and must never enter the prose
+ *  similarity heuristics (issue #11132 review). */
+function oversizedKeyJsonAnswer(n: number): string {
+	const keyPrefix = [
+		"very",
+		"long",
+		"descriptive",
+		"customer",
+		"account",
+		"identifier",
+		"for",
+		"cross",
+		"region",
+		"enterprise",
+		"reporting",
+		"workflow",
+		"with",
+		"historical",
+		"billing",
+		"context",
+		"and",
+		"primary",
+		"ledger",
+		"reconciliation",
+		"metadata",
+		"for",
+		"compliance",
+		"export",
+		"sequence",
+		"including",
+		"audited",
+		"ownership",
+		"attribution",
+		"details",
+	].join("_");
+	const rows = Array.from(
+		{ length: n },
+		(_, i) =>
+			`{"${keyPrefix}_primary":${1000 + i},"${keyPrefix}_secondary":${2000 + i},"${keyPrefix}_tertiary":${3000 + i}}`,
+	);
+	return `[${rows.join(",")}]`;
+}
+
 describe("ThinkingLoopDetector", () => {
 	test("trips on a tight near-duplicate paragraph loop via the trigram path", () => {
 		// High word-trigram overlap: the cluster check claims it before the lexical
@@ -354,6 +399,10 @@ describe("ThinkingLoopDetector", () => {
 		// Long key names push the prose ratio above its threshold, so the JSON must
 		// be recognized by shape rather than by the letter-to-punctuation ratio.
 		expect(feed(longKeyJsonAnswer(12))).toBeNull();
+	});
+
+	test("does not trip on compact JSON fields longer than 200 characters", () => {
+		expect(feed(oversizedKeyJsonAnswer(12))).toBeNull();
 	});
 
 	test("still trips on a reasoning-prose loop even when it follows structured output", () => {

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -250,6 +250,19 @@ function structuredListAnswer(n: number): string {
 	return rows.join("\n");
 }
 
+/** Blank-line-separated JSON objects with long descriptive key names and numeric
+ *  values. The long keys inflate the prose ratio above its threshold, so this
+ *  shape must be recognized as structured by JSON shape, not by that ratio
+ *  (issue #11132 review). Answer content, not a reasoning loop — must never trip. */
+function longKeyJsonAnswer(n: number): string {
+	const objs = Array.from(
+		{ length: n },
+		(_, i) =>
+			`{\n  "very_long_descriptive_customer_account_identifier": ${1000 + i},\n  "very_long_descriptive_customer_account_balance_amount": ${5000 + i}\n}`,
+	);
+	return `Here is the requested account data:\n\n${objs.join("\n\n")}`;
+}
+
 describe("ThinkingLoopDetector", () => {
 	test("trips on a tight near-duplicate paragraph loop via the trigram path", () => {
 		// High word-trigram overlap: the cluster check claims it before the lexical
@@ -335,6 +348,12 @@ describe("ThinkingLoopDetector", () => {
 		// is numeric ids/URLs. Their low prose ratio exempts them from the semantic
 		// heuristics, so the complete answer commits instead of being discarded.
 		expect(feed(structuredListAnswer(33))).toBeNull();
+	});
+
+	test("does not trip on JSON objects with long descriptive keys (issue #11132 review)", () => {
+		// Long key names push the prose ratio above its threshold, so the JSON must
+		// be recognized by shape rather than by the letter-to-punctuation ratio.
+		expect(feed(longKeyJsonAnswer(12))).toBeNull();
 	});
 
 	test("still trips on a reasoning-prose loop even when it follows structured output", () => {

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -308,6 +308,17 @@ function oversizedKeyJsonAnswer(n: number): string {
 	return `[${rows.join(",")}]`;
 }
 
+/** A genuine near-identical reasoning loop that discusses an inline JSON
+ *  example. The object is incidental prose payload, not the surrounding segment
+ *  structure, so it must not exempt the paragraph from semantic detection. */
+function embeddedRecordProseLoop(paragraphs: number): string {
+	return Array.from(
+		{ length: paragraphs },
+		(_, i) =>
+			`I am still reviewing the same payload example {"status": ${i}, "message": ${i}} without making progress. The record fields remain incidental to this repeated reasoning paragraph, and I keep restating the same inspection instead of acting.`,
+	).join("\n\n");
+}
+
 describe("ThinkingLoopDetector", () => {
 	test("trips on a tight near-duplicate paragraph loop via the trigram path", () => {
 		// High word-trigram overlap: the cluster check claims it before the lexical
@@ -403,6 +414,10 @@ describe("ThinkingLoopDetector", () => {
 
 	test("does not trip on compact JSON fields longer than 200 characters", () => {
 		expect(feed(oversizedKeyJsonAnswer(12))).toBeNull();
+	});
+
+	test("still trips on looping prose with an embedded JSON object", () => {
+		expect(feed(embeddedRecordProseLoop(12))).not.toBeNull();
 	});
 
 	test("still trips on a reasoning-prose loop even when it follows structured output", () => {

--- a/packages/ai/test/thinking-loop.test.ts
+++ b/packages/ai/test/thinking-loop.test.ts
@@ -230,6 +230,26 @@ function perFileTemplates(): string {
 		.join("\n\n");
 }
 
+/** A legitimate final answer whose tail is homogeneous structured data: a
+ *  markdown table plus a JSON trailer, both with `n` same-shape rows whose only
+ *  variation is numeric ids/URLs. Normalization drops those numbers, so the rows
+ *  collapse to near-identical trigrams — the issue #11129 false-positive shape.
+ *  This is answer content, not a reasoning loop, and must never trip. */
+function structuredListAnswer(n: number): string {
+	const rows = ["Here are the generated test cases:\n", "| case_id | case_name | case_url |", "| --- | --- | --- |"];
+	for (let i = 0; i < n; i++) {
+		const id = 35350 + i;
+		rows.push(`| ${id} | case ${i + 1} | https://example.com/#/CaseEdit?fs_id=${id} |`);
+	}
+	const cases = Array.from(
+		{ length: n },
+		(_, i) =>
+			`{"case_id": ${35350 + i}, "case_name": "case ${i + 1}", "case_url": "https://example.com/#/CaseEdit?fs_id=${35350 + i}", "case_sheet": 0}`,
+	);
+	rows.push("", `[TA_CASES]#{"cases": [${cases.join(", ")}]}`);
+	return rows.join("\n");
+}
+
 describe("ThinkingLoopDetector", () => {
 	test("trips on a tight near-duplicate paragraph loop via the trigram path", () => {
 		// High word-trigram overlap: the cluster check claims it before the lexical
@@ -308,6 +328,19 @@ describe("ThinkingLoopDetector", () => {
 		// Below the repeated-char floor: a brief on-purpose repeat is not a loop.
 		const detector = new ThinkingLoopDetector();
 		expect(detector.push("🌊 ".repeat(26))).toBeNull();
+	});
+
+	test("does not trip on a homogeneous markdown table + JSON-array answer (issue #11129)", () => {
+		// 33 same-shape table rows and 33 same-shape JSON items whose only variation
+		// is numeric ids/URLs. Their low prose ratio exempts them from the semantic
+		// heuristics, so the complete answer commits instead of being discarded.
+		expect(feed(structuredListAnswer(33))).toBeNull();
+	});
+
+	test("still trips on a reasoning-prose loop even when it follows structured output", () => {
+		// The structured-data exemption must not blind the detector to a genuine
+		// near-duplicate prose loop that arrives after a table.
+		expect(feed(`${structuredListAnswer(6)}\n\n\n${nearDuplicateLoop(12)}`)).not.toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Repro
Driving `withThinkingLoopGuard` for a deepseek-class model and streaming a legitimate final answer — a 33-row markdown table plus the requested `[TA_CASES]#{...}` JSON trailer of 33 same-shape items — as visible `text_delta` trips the guard with `Thinking loop detected: the model repeated near-identical content (4 near-identical segments within the last 16)`, exactly the message from the issue. The model is not looping; the answer is complete and correct. In `--mode json` the discarded attempt was auto-retried up to `maxAttempts`, re-streaming the same ~6.6 KB report 9-10 times.

## Cause
`ThinkingLoopDetector` in `packages/ai/src/utils/thinking-loop.ts` force-flushes wall-of-text content (no blank-line boundaries) into `SEGMENT_CHAR_CAP`-sized chunks and runs the near-duplicate word-trigram cluster over them. `normalizeSegment` drops digits, so consecutive table rows / JSON items — whose only variation is numeric ids and URLs — normalize to near-identical trigrams and reach the 4-segment cluster threshold. Those heuristics were calibrated on reasoning prose; homogeneous structured data is legitimate answer content, not a reasoning loop.

## Fix
- Add `proseRatio()` scoring a segment's prose-likeness: Unicode letters + whitespace versus JSON/table punctuation (`STRUCTURAL_PUNCT`), ignoring digits so data identifiers tilt neither side. CJK and other scripts count as prose.
- In `#consumeSegment`, skip segments below `SEGMENT_MIN_PROSE_RATIO` (0.85) before the near-duplicate and lexical-stall paths, and reset any in-progress prose stall on a structured block.
- Exact suffix-cycle detection is untouched, so a verbatim structured loop is still caught; reasoning-prose loops (including after a table) still trip.

## Verification
`bun test packages/ai/test/thinking-loop.test.ts` -> 43 pass / 0 fail, including two new regression tests: a homogeneous markdown-table + JSON-array answer no longer trips, and a reasoning-prose loop following structured output still trips. The end-to-end guard repro that failed before the fix now commits the answer cleanly (`stopReason=stop`). Fixes #11129