### PR TITLE
fix(changelog): skip thematic breaks and gate unreleased notes by con…

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
+- The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
 
 ## [18.1.12] - 2026-09-06
 

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -130,6 +130,10 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 			} else if (bullet.indent > listIndent) {
 				// Deeper than the block's first item: absorbed into the item above, not a separate change.
 				continue;
+			} else if (bullet.marker !== listMarker) {
+				// A different delimiter starts a new list: adopt its first item as reference.
+				listIndent = bullet.indent;
+				listMarker = bullet.marker;
 			}
 			categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
 			changeCount++;

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -90,27 +90,37 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 	for (const entry of entries) {
 		let category = UNCATEGORIZED_CHANGELOG_CATEGORY;
 		// Indent and marker of the first item of the open list block. The renderer absorbs every
-		// whitespace-indented line into the open item, so only an unindented line
-		// (paragraph, heading, fence, ...) closes the block — plus a differently marked
-		// thematic break at or above the open indent, which lexes as `hr`. Blank lines never do.
+		// whitespace-indented line into the open item, so an unindented line (paragraph, heading,
+		// fence, ...) closes the block — as does a blank-separated line at or above the open
+		// indent, which the blank lookahead detaches from the item. Blank lines never do alone.
 		let listIndent: number | undefined;
 		let listMarker: string | undefined;
+		// Whether the previous line was blank: only then does an indented line end the block.
+		let sawBlank = false;
 		for (const line of entry.content.split("\n")) {
 			const heading = line.match(/^###\s+(.+?)\s*$/);
 			if (heading) {
 				category = heading[1] ?? UNCATEGORIZED_CHANGELOG_CATEGORY;
 				listIndent = undefined;
 				listMarker = undefined;
+				sawBlank = false;
+				continue;
+			}
+			if (/^\s*$/.test(line)) {
+				sawBlank = true;
 				continue;
 			}
 			const bullet = changelogBullet(line);
 			if (bullet === undefined) {
-				// An unindented block boundary ends the open item, so a later indented
-				// bullet opens a new top-level list instead of nesting under the old one.
-				if (!/^\s*$/.test(line) && changelogLineIndent(line) === 0) {
+				// A block boundary ends the open item, so a later indented bullet opens a new
+				// top-level list instead of nesting under the old one: always at column zero,
+				// and at any indent at or above the open list when blank-separated.
+				const indent = changelogLineIndent(line);
+				if (indent === 0 || (sawBlank && listIndent !== undefined && indent <= listIndent)) {
 					listIndent = undefined;
 					listMarker = undefined;
 				}
+				sawBlank = false;
 				continue;
 			}
 			if (isHr(line) && bullet.marker !== listMarker) {
@@ -120,8 +130,10 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 					listIndent = undefined;
 					listMarker = undefined;
 				}
+				sawBlank = false;
 				continue;
 			}
+			sawBlank = false;
 			if (listIndent === undefined) {
 				// With no list open, four columns of indent is an indented code block, not a list item.
 				if (bullet.indent >= 4) continue;

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -112,6 +112,16 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 			}
 			const bullet = changelogBullet(line);
 			if (bullet === undefined) {
+				if (isHr(line)) {
+					// Breaks without a list marker (`_ _ _`, `***`): always `hr`, never an
+					// item. Ends the block like a differently marked break.
+					if (listIndent === undefined || changelogLineIndent(line) <= listIndent) {
+						listIndent = undefined;
+						listMarker = undefined;
+					}
+					sawBlank = false;
+					continue;
+				}
 				// A block boundary ends the open item, so a later indented bullet opens a new
 				// top-level list instead of nesting under the old one: always at column zero,
 				// and at any indent at or above the open list when blank-separated.

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { getLastChangelogVersionPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { isHr } from "@oh-my-pi/pi-utils/marked";
 import type { BunFile } from "bun";
 import bundledChangelogPath from "../../CHANGELOG.md" with { type: "file" };
 import type { SettingValue } from "../config/settings";
@@ -73,9 +74,6 @@ function changelogLineIndent(line: string): number {
 	return indent;
 }
 
-/** Thematic breaks (`* * *`, `- - -`) render as `hr`, never as list items — unless the run uses the open list's own marker, in which case the lexer keeps it as an item. Mirrors `isHr` plus the same-delimiter continuation in `parseList` (`packages/utils/src/marked/core.ts`). */
-const CHANGELOG_THEMATIC_BREAK = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
-
 /** A Markdown list bullet's indent columns and marker, or undefined when the line opens no list item. Tabs advance to the next 4-column stop. */
 function changelogBullet(line: string): { indent: number; marker: string } | undefined {
 	const match = line.match(/^([ \t]*)([-+*])[ \t]+\S/);
@@ -115,8 +113,8 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 				}
 				continue;
 			}
-			if (CHANGELOG_THEMATIC_BREAK.test(line) && bullet.marker !== listMarker) {
-				// Renders as `hr`, not a list item: ends the block when at or above the open
+			if (isHr(line) && bullet.marker !== listMarker) {
+				// Shared `hr` grammar with the renderer: ends the block when at or above the open
 				// indent. A deeper break is absorbed into the open item, so the block stays open.
 				if (listIndent === undefined || changelogLineIndent(line) <= listIndent) {
 					listIndent = undefined;

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { getLastChangelogVersionPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
-import { isHr } from "@oh-my-pi/pi-utils/marked";
+import { Lexer } from "@oh-my-pi/pi-utils/marked";
 import type { BunFile } from "bun";
 import bundledChangelogPath from "../../CHANGELOG.md" with { type: "file" };
 import type { SettingValue } from "../config/settings";
@@ -63,102 +63,30 @@ function emptyStartupSelection(persistCurrentVersion: boolean): StartupChangelog
 /** Bucket for release bullets written above any `###` category heading, so the breakdown never loses them. */
 const UNCATEGORIZED_CHANGELOG_CATEGORY = "Other";
 
-/** Leading indent columns of a line. Tabs advance to the next 4-column stop. */
-function changelogLineIndent(line: string): number {
-	let indent = 0;
-	for (const char of line) {
-		if (char === " ") indent += 1;
-		else if (char === "\t") indent += 4 - (indent % 4);
-		else break;
-	}
-	return indent;
-}
-
-/** A Markdown list bullet's indent columns and marker, or undefined when the line opens no list item. Tabs advance to the next 4-column stop. */
-function changelogBullet(line: string): { indent: number; marker: string } | undefined {
-	const match = line.match(/^([ \t]*)([-+*])[ \t]+\S/);
-	if (!match) return undefined;
-	return { indent: changelogLineIndent(match[1] ?? ""), marker: match[2] ?? "" };
-}
-
 function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 	changeCount: number;
 	categoryCounts: Record<string, number>;
 } {
 	const categoryCounts: Record<string, number> = {};
 	let changeCount = 0;
+
 	for (const entry of entries) {
 		let category = UNCATEGORIZED_CHANGELOG_CATEGORY;
-		// Indent and marker of the first item of the open list block. The renderer absorbs every
-		// whitespace-indented line into the open item, so an unindented line (paragraph, heading,
-		// fence, ...) closes the block — as does a blank-separated line at or above the open
-		// indent, which the blank lookahead detaches from the item. Blank lines never do alone.
-		let listIndent: number | undefined;
-		let listMarker: string | undefined;
-		// Whether the previous line was blank: only then does an indented line end the block.
-		let sawBlank = false;
-		for (const line of entry.content.split("\n")) {
-			const heading = line.match(/^###\s+(.+?)\s*$/);
-			if (heading) {
-				category = heading[1] ?? UNCATEGORIZED_CHANGELOG_CATEGORY;
-				listIndent = undefined;
-				listMarker = undefined;
-				sawBlank = false;
+		// Count what the renderer shows: top-level list items per `###` section, straight
+		// from the shared lexer. There is no parallel list grammar left here to drift.
+		for (const token of Lexer.lex(entry.content)) {
+			if (token.type === "heading" && token.depth === 3) {
+				const name = token.text.trim();
+				category = name === "" ? UNCATEGORIZED_CHANGELOG_CATEGORY : name;
 				continue;
 			}
-			if (/^\s*$/.test(line)) {
-				sawBlank = true;
-				continue;
+			if (token.type !== "list") continue;
+			for (const item of token.items) {
+				// A bare marker renders an empty item; it announces no change.
+				if (!item.task && item.text.trim() === "") continue;
+				categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
+				changeCount++;
 			}
-			const bullet = changelogBullet(line);
-			if (bullet === undefined) {
-				if (isHr(line)) {
-					// Breaks without a list marker (`_ _ _`, `***`): always `hr`, never an
-					// item. Ends the block like a differently marked break.
-					if (listIndent === undefined || changelogLineIndent(line) <= listIndent) {
-						listIndent = undefined;
-						listMarker = undefined;
-					}
-					sawBlank = false;
-					continue;
-				}
-				// A block boundary ends the open item, so a later indented bullet opens a new
-				// top-level list instead of nesting under the old one: always at column zero,
-				// and at any indent at or above the open list when blank-separated.
-				const indent = changelogLineIndent(line);
-				if (indent === 0 || (sawBlank && listIndent !== undefined && indent <= listIndent)) {
-					listIndent = undefined;
-					listMarker = undefined;
-				}
-				sawBlank = false;
-				continue;
-			}
-			if (isHr(line) && bullet.marker !== listMarker) {
-				// Shared `hr` grammar with the renderer: ends the block when at or above the open
-				// indent. A deeper break is absorbed into the open item, so the block stays open.
-				if (listIndent === undefined || changelogLineIndent(line) <= listIndent) {
-					listIndent = undefined;
-					listMarker = undefined;
-				}
-				sawBlank = false;
-				continue;
-			}
-			sawBlank = false;
-			if (listIndent === undefined) {
-				// With no list open, four columns of indent is an indented code block, not a list item.
-				if (bullet.indent >= 4) continue;
-				listIndent = bullet.indent;
-				listMarker = bullet.marker;
-			} else if (bullet.indent > listIndent) {
-				// Deeper than the block's first item: absorbed into the item above, not a separate change.
-				continue;
-			} else if (bullet.marker !== listMarker) {
-				// A different delimiter starts a new list: adopt its first item as reference.
-				listIndent = bullet.indent;
-				listMarker = bullet.marker;
-			}
-			categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
-			changeCount++;
 		}
 	}
 

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -73,11 +73,14 @@ function changelogLineIndent(line: string): number {
 	return indent;
 }
 
-/** Indent columns of a Markdown list bullet, or undefined when the line opens no list item. Tabs advance to the next 4-column stop. */
-function changelogBulletIndent(line: string): number | undefined {
-	const match = line.match(/^([ \t]*)[-+*][ \t]+\S/);
+/** Thematic breaks (`* * *`, `- - -`) render as `hr`, never as list items — unless the run uses the open list's own marker, in which case the lexer keeps it as an item. Mirrors `isHr` plus the same-delimiter continuation in `parseList` (`packages/utils/src/marked/core.ts`). */
+const CHANGELOG_THEMATIC_BREAK = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
+
+/** A Markdown list bullet's indent columns and marker, or undefined when the line opens no list item. Tabs advance to the next 4-column stop. */
+function changelogBullet(line: string): { indent: number; marker: string } | undefined {
+	const match = line.match(/^([ \t]*)([-+*])[ \t]+\S/);
 	if (!match) return undefined;
-	return changelogLineIndent(match[1] ?? "");
+	return { indent: changelogLineIndent(match[1] ?? ""), marker: match[2] ?? "" };
 }
 
 function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
@@ -86,32 +89,45 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 } {
 	const categoryCounts: Record<string, number> = {};
 	let changeCount = 0;
-
 	for (const entry of entries) {
 		let category = UNCATEGORIZED_CHANGELOG_CATEGORY;
-		// Indent of the first item of the open list block. The renderer absorbs every
+		// Indent and marker of the first item of the open list block. The renderer absorbs every
 		// whitespace-indented line into the open item, so only an unindented line
 		// (paragraph, heading, fence, ...) closes the block. Blank lines never do.
 		let listIndent: number | undefined;
+		let listMarker: string | undefined;
 		for (const line of entry.content.split("\n")) {
 			const heading = line.match(/^###\s+(.+?)\s*$/);
 			if (heading) {
 				category = heading[1] ?? UNCATEGORIZED_CHANGELOG_CATEGORY;
 				listIndent = undefined;
+				listMarker = undefined;
 				continue;
 			}
-			const indent = changelogBulletIndent(line);
-			if (indent === undefined) {
+			const bullet = changelogBullet(line);
+			if (bullet === undefined) {
 				// An unindented block boundary ends the open item, so a later indented
 				// bullet opens a new top-level list instead of nesting under the old one.
-				if (!/^\s*$/.test(line) && changelogLineIndent(line) === 0) listIndent = undefined;
+				if (!/^\s*$/.test(line) && changelogLineIndent(line) === 0) {
+					listIndent = undefined;
+					listMarker = undefined;
+				}
+				continue;
+			}
+			if (CHANGELOG_THEMATIC_BREAK.test(line) && bullet.marker !== listMarker) {
+				// Renders as `hr`, not a list item: ends the block like any unindented boundary.
+				if (changelogLineIndent(line) === 0) {
+					listIndent = undefined;
+					listMarker = undefined;
+				}
 				continue;
 			}
 			if (listIndent === undefined) {
 				// With no list open, four columns of indent is an indented code block, not a list item.
-				if (indent >= 4) continue;
-				listIndent = indent;
-			} else if (indent > listIndent) {
+				if (bullet.indent >= 4) continue;
+				listIndent = bullet.indent;
+				listMarker = bullet.marker;
+			} else if (bullet.indent > listIndent) {
 				// Deeper than the block's first item: absorbed into the item above, not a separate change.
 				continue;
 			}

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -93,7 +93,8 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 		let category = UNCATEGORIZED_CHANGELOG_CATEGORY;
 		// Indent and marker of the first item of the open list block. The renderer absorbs every
 		// whitespace-indented line into the open item, so only an unindented line
-		// (paragraph, heading, fence, ...) closes the block. Blank lines never do.
+		// (paragraph, heading, fence, ...) closes the block — plus a differently marked
+		// thematic break at or above the open indent, which lexes as `hr`. Blank lines never do.
 		let listIndent: number | undefined;
 		let listMarker: string | undefined;
 		for (const line of entry.content.split("\n")) {
@@ -115,8 +116,9 @@ function summarizeChangelogEntries(entries: readonly ChangelogEntry[]): {
 				continue;
 			}
 			if (CHANGELOG_THEMATIC_BREAK.test(line) && bullet.marker !== listMarker) {
-				// Renders as `hr`, not a list item: ends the block like any unindented boundary.
-				if (changelogLineIndent(line) === 0) {
+				// Renders as `hr`, not a list item: ends the block when at or above the open
+				// indent. A deeper break is absorbed into the open item, so the block stays open.
+				if (listIndent === undefined || changelogLineIndent(line) <= listIndent) {
 					listIndent = undefined;
 					listMarker = undefined;
 				}

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -203,34 +203,48 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts.Other).toBe(1);
 	});
 
-	test("unreleased section has no bullet the startup notice would misread", async () => {
-		const changelog = await Bun.file(shippedChangelogPath).text();
-		const unreleasedStart = changelog.indexOf("## [Unreleased]");
-		expect(unreleasedStart).toBeGreaterThanOrEqual(0);
-		const rest = changelog.slice(unreleasedStart + "## [Unreleased]".length);
-		const nextRelease = rest.indexOf("\n## ");
-		const unreleased = nextRelease === -1 ? rest : rest.slice(0, nextRelease);
+	test("does not count a thematic break as a change", () => {
+		const selection = summarize(`
+### Fixed
 
-		const misread: string[] = [];
-		let sawHeading = false;
-		let sawTopLevelBullet = false;
-		for (const line of unreleased.split("\n")) {
-			if (/^###\s/.test(line)) {
-				sawHeading = true;
-				sawTopLevelBullet = false;
-				continue;
-			}
-			if (/^[-+*][ \t]+\S/.test(line)) {
-				if (!sawHeading) misread.push(`above any heading: ${line.slice(0, 60)}`);
-				sawTopLevelBullet = true;
-				continue;
-			}
-			// An indented bullet with no shallower bullet above it renders as a code block, not a change.
-			if (/^[ \t]+[-+*][ \t]+\S/.test(line) && !sawTopLevelBullet) {
-				misread.push(`indented into a code block: ${line.trim().slice(0, 60)}`);
-			}
-		}
+- First fix.
 
-		expect(misread).toEqual([]);
+* * *
+
+- Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("counts a separator run that continues the open list", () => {
+		// The renderer lexes `- - -` with the open list's own marker as an item, not `hr`.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+- - -
+- Second fix.
+`);
+
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
+	});
+
+	test("announces unreleased-shaped notes truthfully", () => {
+		const selection = summarize(`
+- Uncategorized note.
+
+### Fixed
+
+   - Indented fix.
+- Ordinary fix.
+`);
+
+		const breakdown = Object.values(selection.categoryCounts).reduce((total, count) => total + count, 0);
+		expect(selection.changeCount).toBe(breakdown);
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Other: 1, Fixed: 2 });
 	});
 });

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -232,6 +232,36 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
 	});
 
+	test("restarts the list after an indented thematic break", () => {
+		// The renderer lexes the `* * *` run as `hr`, closing the open list, so the
+		// deeper bullet below it opens a new top-level list instead of nesting.
+		const selection = summarize(`
+### Fixed
+
+ - First fix.
+ * * *
+  - Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("keeps the list open across a deeper thematic break", () => {
+		// Indented past the open item, the break run is absorbed into the item above,
+		// so the bullet below it stays nested rather than starting a new list.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+   * * *
+  - nested detail
+`);
+
+		expect(selection.changeCount).toBe(1);
+		expect(selection.categoryCounts).toEqual({ Fixed: 1 });
+	});
+
 	test("refreshes the tracked marker when the list changes delimiters", () => {
 		// The renderer starts a new `*` list at the second line, so the run below it
 		// is an item of that list — not `hr` against the stale `-` marker.

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -304,6 +304,42 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
 	});
 
+	test("restarts the list after a blank-separated indented paragraph", () => {
+		// The blank lookahead detaches the paragraph from the open item, so the deeper
+		// bullet below it opens a new top-level list instead of nesting under the old one.
+		const selection = summarize(`
+### Fixed
+
+  - First fix.
+ * Second fix.
+
+ Paragraph.
+
+  * Third fix.
+`);
+
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
+	});
+
+	test("keeps the list open across a blank-separated deep continuation", () => {
+		// Past the open indent the continuation stays absorbed, so the bullet below it
+		// is still nested — resetting on any blank-separated line would overcount here.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+
+  Continued description.
+  - nested detail
+
+- Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
 	test("announces unreleased-shaped notes truthfully", () => {
 		const selection = summarize(`
 - Uncategorized note.

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -384,6 +384,52 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
 	});
 
+	test("restarts the list after an indented blockquote", () => {
+		// The blockquote closes the open list, so the deeper bullet below it opens a new
+		// top-level list instead of nesting under the old one.
+		const selection = summarize(`
+### Fixed
+
+  - First fix.
+ + Second fix.
+ > Quote.
+  - Third fix.
+`);
+
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
+	});
+
+	test("does not count bullets inside a fenced code block", () => {
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+
+\`\`\`
+- not a change
+\`\`\`
+
+- Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("counts ordered list items like unordered ones", () => {
+		// The renderer shows them as list items, so the announced count includes them.
+		const selection = summarize(`
+### Fixed
+
+1. First fix.
+2. Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
 	test("announces unreleased-shaped notes truthfully", () => {
 		const selection = summarize(`
 - Uncategorized note.

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -232,6 +232,48 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
 	});
 
+	test("refreshes the tracked marker when the list changes delimiters", () => {
+		// The renderer starts a new `*` list at the second line, so the run below it
+		// is an item of that list — not `hr` against the stale `-` marker.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+* Second fix.
+* * *
+`);
+
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
+	});
+
+	test("treats a break with a stale marker as a separator", () => {
+		// The second line opens a `*` list, so the `- - -` run below renders as `hr`.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+* Second fix.
+- - -
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("adopts the new list indent on delimiter change", () => {
+		const selection = summarize(`
+### Fixed
+
+  - First fix.
+  * Second fix.
+ - Third fix.
+`);
+
+		expect(selection.changeCount).toBe(3);
+		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
+	});
+
 	test("announces unreleased-shaped notes truthfully", () => {
 		const selection = summarize(`
 - Uncategorized note.

--- a/packages/coding-agent/test/utils/changelog-summary.test.ts
+++ b/packages/coding-agent/test/utils/changelog-summary.test.ts
@@ -304,6 +304,50 @@ An intervening paragraph closes the list.
 		expect(selection.categoryCounts).toEqual({ Fixed: 3 });
 	});
 
+	test("restarts the list after an underscore thematic break", () => {
+		// `_ _ _` never parses as a list bullet, but the renderer still lexes it as `hr`
+		// and closes the list — the deeper bullet below opens a new top-level list.
+		const selection = summarize(`
+### Fixed
+
+ - First fix.
+ _ _ _
+  - Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("restarts the list after a spaceless thematic break", () => {
+		// `***` carries no list marker either, yet still renders as `hr`.
+		const selection = summarize(`
+### Fixed
+
+ - First fix.
+ ***
+  - Second fix.
+`);
+
+		expect(selection.changeCount).toBe(2);
+		expect(selection.categoryCounts).toEqual({ Fixed: 2 });
+	});
+
+	test("keeps the list open across a deeper underscore break", () => {
+		// Past the open indent the break is absorbed into the item above, so the
+		// bullet below it stays nested rather than starting a new list.
+		const selection = summarize(`
+### Fixed
+
+- First fix.
+   _ _ _
+  - nested detail
+`);
+
+		expect(selection.changeCount).toBe(1);
+		expect(selection.categoryCounts).toEqual({ Fixed: 1 });
+	});
+
 	test("restarts the list after a blank-separated indented paragraph", () => {
 		// The blank lookahead detaches the paragraph from the open item, so the deeper
 		// bullet below it opens a new top-level list instead of nesting under the old one.

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -711,7 +711,8 @@ function isFence(line: string): RegExpExecArray | null {
 function isHeading(line: string): boolean {
 	return /^ {0,3}#{1,6}(?:\s|$)/.test(line);
 }
-function isHr(line: string): boolean {
+/** Shared thematic-break predicate: the startup changelog counter reuses it, so announced counts never drift from rendered output. */
+export function isHr(line: string): boolean {
 	return /^ {0,3}((?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})(?:\n|$)$/.test(line);
 }
 function isList(line: string): RegExpExecArray | null {

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -711,8 +711,7 @@ function isFence(line: string): RegExpExecArray | null {
 function isHeading(line: string): boolean {
 	return /^ {0,3}#{1,6}(?:\s|$)/.test(line);
 }
-/** Shared thematic-break predicate: the startup changelog counter reuses it, so announced counts never drift from rendered output. */
-export function isHr(line: string): boolean {
+function isHr(line: string): boolean {
 	return /^ {0,3}((?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})(?:\n|$)$/.test(line);
 }
 function isList(line: string): RegExpExecArray | null {


### PR DESCRIPTION
What

- Startup-notice counter skips standalone * * * / - - - runs: the renderer lexes them as hr, but the bullet regex
  counted them as changes. Exclusion is marker-aware — a run using the open list's own marker still counts, since
  parseList keeps it as an item (verified by probe).
- Replaces the Unreleased source-format gate test with a fixture through selectStartupChangelog: the gate flagged
  uncategorized bullets and 1–3-space indented openers that the parser supports by design, so it could go red on valid
  input.
- CHANGELOG [Unreleased] entry (one line, user-facing).

Why

Post-merge Codex review on #11070: P2 thematic-break inflation (changelog.ts:78), P1 gate false-positives on supported
formatting (changelog-summary.test.ts:230). PR itself is merged — this is the follow-up.

Testing

- Differential check of the counter against the repo's own Lexer (packages/utils/src/marked/core.ts): 11/11 synthetic
  shapes identical (breaks, same-marker continuation, nesting, dedents, lazy/continuation lines) and 0/59 shipped
  releases differ.
- tsgo --noEmit clean, oxlint clean; oxfmt --check diffs are pre-existing released lines only (verified the new lines
  are clean; running it would rewrite immutable history).
- Full bun test not run on this box (missing pi_natives binary — needs a bazel build); the 17 tests in
  changelog-summary.test.ts are covered by CI.

────────────────────────────────────────────────────────────────────────────────

- bun check passes (needs CI — natives binary unavailable locally)
- Tested locally
- CHANGELOG updated (if user-facing)