### PR TITLE
fix(tui): preserve in-flight tools across turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Hub wait cards keep repainting across turn boundaries until their foreground call finishes.
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -352,28 +352,44 @@ export class EventController {
 		this.#lastReadGroup = undefined;
 	}
 	/** Freeze foreground tool cards once no live agent turn can complete them. */
-	#sealAbandonedForegroundTools(): void {
-		const background = new Set<ToolExecutionHandle>();
+	#sealAbandonedForegroundTools({ preserveInFlight = false }: { preserveInFlight?: boolean } = {}): void {
+		const retained = new Set<ToolExecutionHandle>();
 		for (const toolCallId of this.#backgroundTaskCallIds) {
 			const component = this.ctx.pendingTools.get(toolCallId);
-			if (component) background.add(component);
+			if (component) retained.add(component);
+		}
+		if (preserveInFlight) {
+			for (const toolCallId of this.#executionStartedCallIds) {
+				const component = this.ctx.pendingTools.get(toolCallId);
+				if (component) retained.add(component);
+			}
 		}
 		for (const component of this.#toolTimelineComponents.values()) {
 			if (
 				(component instanceof ToolExecutionComponent || component instanceof ReadToolGroupComponent) &&
-				!background.has(component)
+				!retained.has(component)
 			) {
 				component.seal();
 			}
 		}
 		for (const [toolCallId, component] of this.ctx.pendingTools) {
-			if (this.#backgroundTaskCallIds.has(toolCallId)) continue;
+			if (
+				this.#backgroundTaskCallIds.has(toolCallId) ||
+				(preserveInFlight && this.#executionStartedCallIds.has(toolCallId))
+			) {
+				continue;
+			}
 			component.seal();
 			this.ctx.pendingTools.delete(toolCallId);
 		}
 		this.#backgroundTaskCallIds = new Set(
 			Array.from(this.#backgroundTaskCallIds).filter(toolCallId => this.ctx.pendingTools.has(toolCallId)),
 		);
+		if (preserveInFlight) {
+			this.#executionStartedCallIds = new Set(
+				Array.from(this.#executionStartedCallIds).filter(toolCallId => this.ctx.pendingTools.has(toolCallId)),
+			);
+		}
 		this.#finalizeAbandonedPostToolSegments();
 	}
 	/**
@@ -836,16 +852,14 @@ export class EventController {
 			this.#turnStartedAt = undefined;
 		}
 		this.#clearApprovalPreviewGates();
-		// A new turn cannot inherit a foreground tool execution. A dropped
-		// agent_end (for example after a renderer exception) otherwise leaves a
-		// live-only tool card without a persisted result; ordered transcript
-		// retirement then remains pinned behind that invisible stale card.
-		this.#sealAbandonedForegroundTools();
+		// Seal stale previews from the prior turn, but keep executions live until
+		// their tool_execution_end. Session events can cross a turn boundary, and
+		// dropping an executing card here would swallow its later updates and result.
+		this.#sealAbandonedForegroundTools({ preserveInFlight: true });
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
 		this.#pendingStreamPreviews.clear();
 		this.#retractedToolCallIds.clear();
-		this.#executionStartedCallIds.clear();
 		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();

--- a/packages/coding-agent/test/modes/controllers/event-controller-task-async-updates.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-task-async-updates.test.ts
@@ -1,5 +1,5 @@
 /**
- * Contracts: final async `task` snapshots vs. the tool call's own lifecycle.
+ * Contracts: async tool snapshots and foreground execution lifecycle.
  *
  * A `task` call with background jobs streams `tool_execution_update` frames
  * whose `details.async.state` can settle ("completed"/"failed") at any time
@@ -12,12 +12,16 @@
  *    real result never rendered — the "disappearing task call").
  * 2. A final async frame arriving AFTER an end that parked the block as
  *    background ("running") finalizes and untracks it.
+ * 3. An execution that crosses `agent_start` stays live until its own end, so
+ *    subsequent progress and the terminal result continue repainting the card.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { CoordinationDetails } from "@oh-my-pi/pi-coding-agent/tools/hub/types";
 import type { TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { BashToolDetails } from "@oh-my-pi/pi-coding-agent/tools/bash";
 import { createInteractiveModeContext } from "../../helpers/interactive-mode-context";
@@ -37,6 +41,16 @@ function bashResult(text: string) {
 		async: { state: "running", jobId: "bash-1", type: "bash" },
 	};
 	return { content: [{ type: "text" as const, text }], details };
+}
+
+function hubResult(status: "running" | "completed", durationMs: number): AgentToolResult<CoordinationDetails> {
+	return {
+		content: [{ type: "text", text: `${status} hub wait` }],
+		details: {
+			op: "wait",
+			jobs: [{ id: "Job1", type: "task", status, label: "Long task", durationMs }],
+		},
+	};
 }
 
 describe("EventController async update finalization", () => {
@@ -100,6 +114,50 @@ describe("EventController async update finalization", () => {
 			isError: false,
 		});
 		expect(pendingTools.has("tc-task")).toBe(false);
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+	});
+
+	it("keeps an executing foreground card live across the next agent turn", async () => {
+		const { controller, pendingTools } = createFixture();
+		await controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: "tc-hub",
+			toolName: "hub",
+			args: { op: "wait" },
+		});
+		const component = pendingTools.get("tc-hub");
+		if (!component) throw new Error("expected pending Hub card");
+		sealed.push(component);
+
+		await controller.handleEvent({
+			type: "tool_execution_update",
+			toolCallId: "tc-hub",
+			toolName: "hub",
+			args: { op: "wait" },
+			partialResult: hubResult("running", 757_000),
+		});
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("12m37s");
+
+		await controller.handleEvent({ type: "agent_start" });
+		expect(pendingTools.get("tc-hub")).toBe(component);
+
+		await controller.handleEvent({
+			type: "tool_execution_update",
+			toolCallId: "tc-hub",
+			toolName: "hub",
+			args: { op: "wait" },
+			partialResult: hubResult("running", 900_000),
+		});
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("15m");
+
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "tc-hub",
+			toolName: "hub",
+			result: hubResult("completed", 901_000),
+			isError: false,
+		});
+		expect(pendingTools.has("tc-hub")).toBe(false);
 		expect(component.isTranscriptBlockFinalized()).toBe(true);
 	});
 


### PR DESCRIPTION
## Repro
A focused `EventController` sequence starts a foreground `hub wait`, renders a `12m37s` progress update, dispatches `agent_start` before `tool_execution_end`, then sends another update and the terminal result. Before the fix, `bun test packages/coding-agent/test/modes/controllers/event-controller-task-async-updates.test.ts` failed because `pendingTools.get("tc-hub")` became `undefined` immediately after `agent_start`.

## Cause
`EventController.#handleAgentStart` called `#sealAbandonedForegroundTools` without distinguishing stale previews from calls tracked by `#executionStartedCallIds`, then cleared that execution set. The sweep sealed and deleted an executing card from `pendingTools`, so `#handleToolExecutionUpdate` and `#handleToolExecutionEnd` silently lost the component.

## Fix
- Preserve execution-started foreground components when the agent-start sweep seals stale prior-turn previews.
- Retain only execution IDs that still have a pending component, while terminal agent-end cleanup continues sealing genuinely abandoned calls.
- Add a Hub wait regression proving elapsed progress and the terminal result survive the turn boundary.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/controllers/event-controller-task-async-updates.test.ts packages/coding-agent/test/modes/controllers/event-controller-superseded-agent-end.test.ts packages/coding-agent/test/modes/controllers/event-controller-toolcall-finalize.test.ts` — 14 passed, 0 failed. The focused test was rerun after formatting — 6 passed, 0 failed. The publish gate completed `bun run fix` and `bun check` before push.

Fixes #11136