### PR TITLE
fix(cli): reap orphaned IPC subprocess workers when parent terminates

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -332,30 +332,27 @@ async function runIpcSubprocessWorker<In, Out>(
 	if (process.platform === "win32" && initialParentPid <= 0) {
 		shutdown();
 	} else if (initialParentPid > 0) {
-		let nativesAvailable = false;
 		let parentProcess: Process | null = null;
 		let runningStatus: ProcessStatus | undefined;
 		try {
 			if (!process.env.PI_TEST_NO_NATIVES) {
 				const natives = await import("@oh-my-pi/pi-natives");
-				nativesAvailable = true;
 				parentProcess = natives.Process.fromPid(initialParentPid);
 				runningStatus = natives.ProcessStatus.Running;
 			}
 		} catch {}
-
-		// If the native addon is available and Process.fromPid returned null,
-		// the parent process handle could not be opened because the parent has
-		// already terminated. Treat null as dead at boot to prevent PID reuse.
-		if (nativesAvailable && !parentProcess) {
-			shutdown();
-		}
 
 		// Note on container environments (Docker/Kubernetes): omp often runs as
 		// PID 1, so workers start with process.ppid === 1. Treating ppid <= 1 as
 		// an orphan at boot would break containerized workers. Instead, we allow
 		// PID 1 to boot normally and detect post-spawn reparenting dynamically via
 		// `process.ppid !== initialParentPid`.
+		//
+		// Note on Linux seccomp/kernels: On hosts where pidfd_open is blocked or
+		// unavailable (e.g. pre-5.3 kernels, restrictive seccomp), Process.fromPid
+		// returns null even when the parent is alive. We treat null as the native
+		// handle being unavailable and fall through to the isParentAlive() check
+		// rather than assuming null means dead at boot.
 		const isParentAlive = (): boolean => {
 			if (process.ppid !== initialParentPid) {
 				return false;

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -15,7 +15,7 @@ try {
  * lightweight CLI runner from pi-utils.
  */
 import { parentPort } from "node:worker_threads";
-import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
+import type { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { CliConfig, CommandMetadata } from "@oh-my-pi/pi-utils/cli";
 import {
 	APP_NAME,
@@ -325,24 +325,31 @@ async function runIpcSubprocessWorker<In, Out>(
 			};
 		},
 	});
-	let parentWatchdog: ReturnType<typeof setInterval> | undefined;
-	const parentPid = process.ppid;
-	if (process.platform === "win32" && parentPid <= 0) {
+	let parentWatchdog: NodeJS.Timeout | undefined;
+	const initialParentPid = process.ppid;
+	const isOrphanPid = (pid: number): boolean => pid <= (process.platform === "win32" ? 0 : 1);
+	if (isOrphanPid(initialParentPid)) {
 		shutdown();
-	} else if (parentPid > 0 && (process.platform === "win32" || parentPid > 1)) {
+	} else {
 		let parentProcess: Process | null = null;
+		let runningStatus: ProcessStatus | undefined;
 		try {
-			parentProcess = Process.fromPid(parentPid);
+			const natives = await import("@oh-my-pi/pi-natives");
+			parentProcess = natives.Process.fromPid(initialParentPid);
+			runningStatus = natives.ProcessStatus.Running;
 		} catch {}
 
 		const isParentAlive = (): boolean => {
-			if (parentProcess) {
+			if (process.ppid !== initialParentPid || isOrphanPid(process.ppid)) {
+				return false;
+			}
+			if (parentProcess && runningStatus !== undefined) {
 				try {
-					return parentProcess.status() === ProcessStatus.Running;
+					return parentProcess.status() === runningStatus;
 				} catch {}
 			}
 			try {
-				process.kill(parentPid, 0);
+				process.kill(initialParentPid, 0);
 				return true;
 			} catch (err: unknown) {
 				return (err as NodeJS.ErrnoException)?.code === "EPERM";

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -15,6 +15,7 @@ try {
  * lightweight CLI runner from pi-utils.
  */
 import { parentPort } from "node:worker_threads";
+import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { CliConfig, CommandMetadata } from "@oh-my-pi/pi-utils/cli";
 import {
 	APP_NAME,
@@ -282,6 +283,9 @@ async function runIpcSubprocessWorker<In, Out>(
 	// always spawns us that way. If it's missing, the parent vanished and
 	// there's no one to talk to.
 	const ipcSend = (): IpcSend | undefined => (process as NodeJS.Process & { send?: IpcSend }).send;
+	if (!ipcSend()) {
+		shutdown();
+	}
 	const send = (message: Out): void => {
 		const sender = ipcSend();
 		if (!sender) {
@@ -321,6 +325,47 @@ async function runIpcSubprocessWorker<In, Out>(
 			};
 		},
 	});
+	let parentWatchdog: ReturnType<typeof setInterval> | undefined;
+	const parentPid = process.ppid;
+	if (process.platform === "win32" && parentPid <= 0) {
+		shutdown();
+	} else if (parentPid > 0 && (process.platform === "win32" || parentPid > 1)) {
+		let parentProcess: Process | null = null;
+		try {
+			parentProcess = Process.fromPid(parentPid);
+		} catch {}
+
+		const isParentAlive = (): boolean => {
+			if (parentProcess) {
+				try {
+					return parentProcess.status() === ProcessStatus.Running;
+				} catch {}
+			}
+			try {
+				process.kill(parentPid, 0);
+				return true;
+			} catch (err: unknown) {
+				return (err as NodeJS.ErrnoException)?.code === "EPERM";
+			}
+		};
+
+		if (!isParentAlive()) {
+			shutdown();
+		} else {
+			if (parentProcess) {
+				void parentProcess.waitForExit().then(
+					() => shutdown(),
+					() => shutdown(),
+				);
+			}
+			parentWatchdog = setInterval(() => {
+				if (!isParentAlive()) {
+					shutdown();
+				}
+			}, 1000);
+			parentWatchdog.unref();
+		}
+	}
 	const keepalive = setInterval(() => {}, 2 ** 30);
 	// Parent went away (crashed, SIGKILL, etc.) — commit suicide so we don't
 	// linger as an orphan. SIGKILL via `process.kill` keeps us symmetrical with
@@ -330,6 +375,7 @@ async function runIpcSubprocessWorker<In, Out>(
 		await shuttingDown;
 	} finally {
 		clearInterval(keepalive);
+		if (parentWatchdog) clearInterval(parentWatchdog);
 	}
 	process.kill(process.pid, "SIGKILL");
 }

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -327,10 +327,9 @@ async function runIpcSubprocessWorker<In, Out>(
 	});
 	let parentWatchdog: NodeJS.Timeout | undefined;
 	const initialParentPid = process.ppid;
-	const isOrphanPid = (pid: number): boolean => pid <= (process.platform === "win32" ? 0 : 1);
-	if (isOrphanPid(initialParentPid)) {
+	if (process.platform === "win32" && initialParentPid <= 0) {
 		shutdown();
-	} else {
+	} else if (initialParentPid > 0) {
 		let parentProcess: Process | null = null;
 		let runningStatus: ProcessStatus | undefined;
 		try {
@@ -340,7 +339,7 @@ async function runIpcSubprocessWorker<In, Out>(
 		} catch {}
 
 		const isParentAlive = (): boolean => {
-			if (process.ppid !== initialParentPid || isOrphanPid(process.ppid)) {
+			if (process.ppid !== initialParentPid) {
 				return false;
 			}
 			if (parentProcess && runningStatus !== undefined) {

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -284,6 +284,8 @@ async function runIpcSubprocessWorker<In, Out>(
 	// there's no one to talk to.
 	const ipcSend = (): IpcSend | undefined => (process as NodeJS.Process & { send?: IpcSend }).send;
 	if (!ipcSend()) {
+		// Intentional fall-through: shutdown() only resolves the promise;
+		// the await + SIGKILL tail below is what actually exits.
 		shutdown();
 	}
 	const send = (message: Out): void => {
@@ -330,14 +332,30 @@ async function runIpcSubprocessWorker<In, Out>(
 	if (process.platform === "win32" && initialParentPid <= 0) {
 		shutdown();
 	} else if (initialParentPid > 0) {
+		let nativesAvailable = false;
 		let parentProcess: Process | null = null;
 		let runningStatus: ProcessStatus | undefined;
 		try {
-			const natives = await import("@oh-my-pi/pi-natives");
-			parentProcess = natives.Process.fromPid(initialParentPid);
-			runningStatus = natives.ProcessStatus.Running;
+			if (!process.env.PI_TEST_NO_NATIVES) {
+				const natives = await import("@oh-my-pi/pi-natives");
+				nativesAvailable = true;
+				parentProcess = natives.Process.fromPid(initialParentPid);
+				runningStatus = natives.ProcessStatus.Running;
+			}
 		} catch {}
 
+		// If the native addon is available and Process.fromPid returned null,
+		// the parent process handle could not be opened because the parent has
+		// already terminated. Treat null as dead at boot to prevent PID reuse.
+		if (nativesAvailable && !parentProcess) {
+			shutdown();
+		}
+
+		// Note on container environments (Docker/Kubernetes): omp often runs as
+		// PID 1, so workers start with process.ppid === 1. Treating ppid <= 1 as
+		// an orphan at boot would break containerized workers. Instead, we allow
+		// PID 1 to boot normally and detect post-spawn reparenting dynamically via
+		// `process.ppid !== initialParentPid`.
 		const isParentAlive = (): boolean => {
 			if (process.ppid !== initialParentPid) {
 				return false;

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -93,6 +93,78 @@ describe("worker selector dispatch", () => {
 		}
 		expect(running).toBe(false);
 	});
+
+	it("reaps orphaned IPC worker using fallback watchdog when native process handles are unavailable", async () => {
+		const repoRoot = path.resolve(__dirname, "../../..");
+		const parent = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"-e",
+				`
+				const child = Bun.spawn({
+					cmd: [process.execPath, "packages/coding-agent/src/cli.ts", "__omp_worker_js_eval_process"],
+					cwd: ${JSON.stringify(repoRoot)},
+					env: { ...process.env, PI_TEST_NO_NATIVES: "1" },
+					ipc(msg) {},
+					serialization: "advanced",
+					windowsHide: true,
+					stdin: "ignore",
+					stdout: "ignore",
+					stderr: "ignore",
+				});
+				console.log("CHILD_PID:" + child.pid);
+				setTimeout(() => process.exit(0), 500);
+				`,
+			],
+			cwd: repoRoot,
+			stdout: "pipe",
+		});
+
+		const text = await new Response(parent.stdout).text();
+		const match = text.match(/CHILD_PID:(\d+)/);
+		expect(match).not.toBeNull();
+		const childPid = Number(match?.[1]);
+		expect(childPid).toBeGreaterThan(0);
+
+		await parent.exited;
+
+		let running = isPidRunning(childPid);
+		for (let i = 0; i < 30 && running; i++) {
+			await Bun.sleep(100);
+			running = isPidRunning(childPid);
+		}
+		expect(running).toBe(false);
+	});
+
+	it("does not treat PID 1 as an immediate orphan at boot in container environments", async () => {
+		const repoRoot = path.resolve(__dirname, "../../..");
+		const childScript = `
+			Object.defineProperty(process, "ppid", { value: 1, configurable: true });
+			process.env.PI_TEST_NO_NATIVES = "1";
+			const originalKill = process.kill;
+			process.kill = (pid, sig) => {
+				if (pid === 1 && sig === 0) return true;
+				return originalKill.call(process, pid, sig);
+			};
+			const { runCli } = await import("./packages/coding-agent/src/cli.ts");
+			await runCli(["__omp_worker_js_eval_process"]);
+		`;
+
+		const child = Bun.spawn({
+			cmd: [process.execPath, "-e", childScript],
+			cwd: repoRoot,
+			ipc() {},
+			serialization: "advanced",
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+
+		await Bun.sleep(400);
+		const alive = !child.killed && child.exitCode === null;
+		child.kill("SIGKILL");
+		expect(alive).toBe(true);
+	});
 });
 
 describe("computer worker entry", () => {

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -1,4 +1,6 @@
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { isPidRunning } from "@oh-my-pi/pi-utils/procmgr";
 import { runCli } from "../src/cli";
 import * as computerWorkerEntry from "../src/tools/computer/worker-entry";
 
@@ -34,6 +36,62 @@ describe("worker selector dispatch", () => {
 		expect(process.exitCode).toBe(0);
 		expect(stdout).toHaveBeenCalled();
 		expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("unknown worker selector"));
+	});
+
+	it("exits promptly when an IPC worker selector is launched without an IPC channel", async () => {
+		const proc = Bun.spawn({
+			cmd: [process.execPath, "packages/coding-agent/src/cli.ts", "__omp_worker_js_eval_process"],
+			cwd: path.resolve(__dirname, "../../.."),
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const exited = await Promise.race([proc.exited.then(() => true), Bun.sleep(2000).then(() => false)]);
+		if (!exited) {
+			proc.kill("SIGKILL");
+		}
+		expect(exited).toBe(true);
+	});
+
+	it("reaps orphaned IPC worker when parent process terminates", async () => {
+		const repoRoot = path.resolve(__dirname, "../../..");
+		const parent = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"-e",
+				`
+				const child = Bun.spawn({
+					cmd: [process.execPath, "packages/coding-agent/src/cli.ts", "__omp_worker_js_eval_process"],
+					cwd: ${JSON.stringify(repoRoot)},
+					ipc(msg) {},
+					serialization: "advanced",
+					windowsHide: true,
+					stdin: "ignore",
+					stdout: "ignore",
+					stderr: "ignore",
+				});
+				console.log("CHILD_PID:" + child.pid);
+				setTimeout(() => process.exit(0), 500);
+				`,
+			],
+			cwd: repoRoot,
+			stdout: "pipe",
+		});
+
+		const text = await new Response(parent.stdout).text();
+		const match = text.match(/CHILD_PID:(\d+)/);
+		expect(match).not.toBeNull();
+		const childPid = Number(match?.[1]);
+		expect(childPid).toBeGreaterThan(0);
+
+		await parent.exited;
+
+		let running = isPidRunning(childPid);
+		for (let i = 0; i < 30 && running; i++) {
+			await Bun.sleep(100);
+			running = isPidRunning(childPid);
+		}
+		expect(running).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -87,9 +87,17 @@ describe("worker selector dispatch", () => {
 		await parent.exited;
 
 		let running = isPidRunning(childPid);
-		for (let i = 0; i < 30 && running; i++) {
-			await Bun.sleep(100);
-			running = isPidRunning(childPid);
+		try {
+			for (let i = 0; i < 30 && running; i++) {
+				await Bun.sleep(100);
+				running = isPidRunning(childPid);
+			}
+		} finally {
+			if (running) {
+				try {
+					process.kill(childPid, "SIGKILL");
+				} catch {}
+			}
 		}
 		expect(running).toBe(false);
 	});
@@ -105,7 +113,7 @@ describe("worker selector dispatch", () => {
 					cmd: [process.execPath, "packages/coding-agent/src/cli.ts", "__omp_worker_js_eval_process"],
 					cwd: ${JSON.stringify(repoRoot)},
 					env: { ...process.env, PI_TEST_NO_NATIVES: "1" },
-					ipc(msg) {},
+					ipc() {},
 					serialization: "advanced",
 					windowsHide: true,
 					stdin: "ignore",
@@ -129,9 +137,17 @@ describe("worker selector dispatch", () => {
 		await parent.exited;
 
 		let running = isPidRunning(childPid);
-		for (let i = 0; i < 30 && running; i++) {
-			await Bun.sleep(100);
-			running = isPidRunning(childPid);
+		try {
+			for (let i = 0; i < 30 && running; i++) {
+				await Bun.sleep(100);
+				running = isPidRunning(childPid);
+			}
+		} finally {
+			if (running) {
+				try {
+					process.kill(childPid, "SIGKILL");
+				} catch {}
+			}
 		}
 		expect(running).toBe(false);
 	});


### PR DESCRIPTION
Fixes #10537

### Summary

When the parent agent process exits or crashes unexpectedly, child IPC workers such as `__omp_worker_js_eval_process`, `__omp_worker_stt`, and `__omp_worker_tts` can get orphaned and stay alive in the background. On Windows especially, this leads to multiple zombie `bun.exe` processes accumulating with `ParentProcessId = 0`, consuming several hundred megabytes of RAM and dozens of threads until system resource exhaustion kicks in.

This happens because `runIpcSubprocessWorker` keeps an active event loop interval and relies entirely on Node/Bun's `disconnect` event to terminate. If the parent dies abruptly or named pipes close without firing `disconnect`, the worker never knows the parent is gone and stays alive indefinitely. Additionally, if an IPC worker is invoked without an IPC channel, it never shuts down and hangs on the keepalive loop.

### Changes

- **Bail early without IPC**: Immediately trigger shutdown if `process.send` is not present at startup instead of waiting forever on an idle interval.
- **Parent liveness tracking**:
  - Check `process.ppid` when the worker boots. If the parent has already exited, terminate right away.
  - Asynchronously monitor parent process termination using native process handles (`Process.waitForExit()`).
  - Add a lightweight, unreferenced fallback watchdog that periodically confirms the parent process is still running.
  - Automatically terminate the worker (`SIGKILL`) as soon as the parent process is no longer detected.
- **Automated tests**:
  - Verified that running an IPC worker selector without IPC exits immediately.
  - Verified that spawned worker subprocesses are cleanly reaped when the parent process exits or terminates.
