### PR TITLE
test(mcp): replace the remaining wall-clock gates in the reauth tests with sync points

### DIFF
--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -47,6 +47,33 @@ function restoreEnvValue(name: string, value: string | undefined): void {
 	Bun.env[name] = value;
 	process.env[name] = value;
 }
+/**
+ * Resolve when the controller installs its `editor.onEscape` hook.
+ *
+ * The hook is installed part-way through an async flow, so a test that needs
+ * it has to wait. Polling to a wall-clock deadline would make that wait a
+ * timing budget rather than a synchronisation point: on a loaded runner the
+ * deadline can expire before correct code has installed the hook, and the
+ * assertion then fails on a value that was merely late. Intercepting the
+ * assignment bounds the wait by the event it is actually waiting for, leaving
+ * `bun test --timeout` as the only backstop for a genuine hang.
+ */
+function whenEscapeInstalled(editor: { onEscape?: (() => void) | undefined }): Promise<void> {
+	const installed = Promise.withResolvers<void>();
+	let current = editor.onEscape;
+	if (typeof current === "function") installed.resolve();
+	Object.defineProperty(editor, "onEscape", {
+		configurable: true,
+		enumerable: true,
+		get: () => current,
+		set: (value: (() => void) | undefined) => {
+			current = value;
+			if (typeof value === "function") installed.resolve();
+		},
+	});
+	return installed.promise;
+}
+
 function createController(authStorage: AuthStorage, mcpManagerOverrides: McpManagerOverrides = {}) {
 	const prepareConfig = vi.fn(async (config: MCPServerConfig) => config);
 	const mcpManager = createMcpManagerStub({ prepareConfig, ...mcpManagerOverrides });
@@ -809,27 +836,21 @@ describe("/mcp auth commands", () => {
 
 		const { controller, showError, showStatus, editor } = createController(authStorage);
 
+		// Gate on #handleOAuthFlow installing its editor.onEscape hook.
+		const escapeInstalled = whenEscapeInstalled(editor);
 		const reauthPromise = controller.handle("/mcp reauth envserver");
-
-		// Wait for #handleOAuthFlow to install its editor.onEscape hook.
-		const deadline = Date.now() + 1_000;
-		while (typeof editor.onEscape !== "function" && Date.now() < deadline) {
-			await Bun.sleep(10);
-		}
+		await escapeInstalled;
 		expect(typeof editor.onEscape).toBe("function");
 
 		const installedEscape = editor.onEscape;
 		editor.onEscape?.();
 
-		// Cancellation must resolve the reauth promise promptly (well under the
-		// 5-minute production timeout); a 2s race exposes a hung flow as a test
-		// failure rather than a suite hang.
-		await Promise.race([
-			reauthPromise,
-			Bun.sleep(2_000).then(() => {
-				throw new Error("reauth did not resolve within 2s of Esc");
-			}),
-		]);
+		// Cancellation must resolve the reauth promise (well under the 5-minute
+		// production timeout). Awaited directly rather than raced against a 2s
+		// timer: a hung flow is already a failure via `bun test --timeout`, which
+		// reports the test name, whereas a wall-clock race also fails correct code
+		// that merely resolved late on a loaded runner.
+		await reauthPromise;
 
 		expect(showError).not.toHaveBeenCalled();
 		expect(showStatus).toHaveBeenCalledWith(expect.stringMatching(/cancel/i));
@@ -884,19 +905,9 @@ describe("/mcp auth commands", () => {
 		expect(oauthManualInput.pendingProviderId).toBe("mcp");
 
 		const replacementReauth = new MCPCommandController(ctx).handle("/mcp reauth envserver");
-		await Promise.race([
-			replacementReauth,
-			Bun.sleep(2_000).then(() => {
-				throw new Error("replacement reauth did not resolve within 2s");
-			}),
-		]);
+		await replacementReauth;
 		if (oauthManualInput.hasPending()) editor.onEscape?.();
-		await Promise.race([
-			firstReauth,
-			Bun.sleep(2_000).then(() => {
-				throw new Error("superseded reauth did not resolve within 2s");
-			}),
-		]);
+		await firstReauth;
 
 		expect(loginAttempt).toBe(2);
 		expect(showError).not.toHaveBeenCalled();
@@ -919,20 +930,13 @@ describe("/mcp auth commands", () => {
 		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockReturnValue(Promise.withResolvers<never>().promise);
 		const { controller, showError, showStatus, editor } = createController(authStorage);
 
+		const escapeInstalled = whenEscapeInstalled(editor);
 		const reauthPromise = controller.handle("/mcp reauth envserver");
-		const deadline = Date.now() + 1_000;
-		while (typeof editor.onEscape !== "function" && Date.now() < deadline) {
-			await Bun.sleep(10);
-		}
+		await escapeInstalled;
 		expect(typeof editor.onEscape).toBe("function");
 		editor.onEscape?.();
 
-		await Promise.race([
-			reauthPromise,
-			Bun.sleep(2_000).then(() => {
-				throw new Error("reauth did not resolve within 2s of pre-wait Esc");
-			}),
-		]);
+		await reauthPromise;
 
 		expect(showError).not.toHaveBeenCalled();
 		expect(showStatus).toHaveBeenCalledWith(expect.stringMatching(/cancel/i));


### PR DESCRIPTION
`mcp-command-reauth.test.ts` still gated assertions on wall-clock budgets after #11117 fixed the manual-input claim. Two remaining patterns fail correct code on a loaded runner:

- Both Esc tests polled for `editor.onEscape` against a `Date.now() + 1_000` deadline. If the flow installs the hook later than 1s, `expect(typeof editor.onEscape).toBe("function")` reads `undefined` from a hook that was merely late.
- Four awaits were `Promise.race`d against `Bun.sleep(2_000)`, so a flow that resolved late failed as "did not resolve within 2s".

This replaces both with synchronisation points:

- `whenEscapeInstalled()` intercepts the `editor.onEscape` assignment via a property setter, so the wait is bounded by the event it is actually waiting for.
- The four races become plain awaits. A genuinely hung flow is still a failure through `bun test --timeout`, which reports the test name; unlike a wall-clock race it does not also fail a slow-but-correct flow.

No production code changes — test file only.

Verified the gates actually gate rather than resolving eagerly: resolving `whenEscapeInstalled` before the install gives 16 pass / 2 fail (both Esc tests), versus 18 pass / 0 fail as written. `oxfmt --check`, `oxlint`, and `tsc --noEmit` are clean.
