### PR TITLE
fix(coding-agent): discover --plugin-dir agents without claude opt-in

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
 - Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body ([#11159](https://github.com/can1357/oh-my-pi/pull/11159) by [@H4vC](https://github.com/H4vC)).
+- Fixed `--plugin-dir` and omp-installed plugin agents no longer being discovered when the foreign `claude-plugins` source is disabled; user-scope plugin agent roots are now gated by origin like their skills ([#11151](https://github.com/can1357/oh-my-pi/issues/11151)).
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -105,12 +105,18 @@ export async function discoverAgents(
 		orderedDirs.push({ dir: path.join(root.path, "agents"), source: root.level });
 	}
 
-	// Load agents from Claude Code marketplace plugins (respects disabledProviders and opt-in)
+	// Load agents from Claude Code marketplace plugins (respects disabledProviders and opt-in).
+	// User-scope roots whose origin is not the foreign ~/.claude/plugins tree (omp's own
+	// installs and `--plugin-dir` roots) survive the claude-plugins opt-in gate, mirroring
+	// isSourceEnabled in extensibility/skills.ts (#10743). Without this, `--plugin-dir` and
+	// omp-installed agents are dropped at user scope whenever the Claude source is disabled.
 	const claudePluginsUserEnabled = isUserSourceEnabled("claude-plugins") || isUserSourceEnabled("claude");
 	const { roots: pluginRoots } = isProviderEnabled("claude-plugins")
 		? await listClaudePluginRoots(home, resolvedCwd)
 		: { roots: [] };
-	const filteredPluginRoots = claudePluginsUserEnabled ? pluginRoots : pluginRoots.filter(r => r.scope === "project");
+	const filteredPluginRoots = pluginRoots.filter(
+		r => r.scope === "project" || claudePluginsUserEnabled || r.origin !== "claude",
+	);
 	const sortedPluginRoots = [...filteredPluginRoots].sort((a, b) => {
 		if (a.scope === b.scope) return 0;
 		return a.scope === "project" ? -1 : 1;

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -8,6 +8,7 @@ import {
 	clearOmpExtensionCliRoots,
 	injectOmpExtensionCliRoots,
 } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
+import { clearClaudePluginRootsCache, injectPluginDirRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -70,6 +71,8 @@ describe("discoverAgents", () => {
 	afterEach(async () => {
 		enableProvider("omp-plugins");
 		clearOmpExtensionCliRoots();
+		await injectPluginDirRoots(tempHome, []);
+		clearClaudePluginRootsCache();
 		clearFsCache();
 		await removeWithRetries(tempHome);
 	});
@@ -170,5 +173,25 @@ describe("discoverAgents", () => {
 
 		expect(names).toContain("explicit-agent");
 		expect(names).not.toEqual(expect.arrayContaining(["stale-agent", "settings-agent", "loom-verify-spec"]));
+	});
+
+	test("discovers agents from a --plugin-dir root with the foreign claude-plugins opt-in off (#11151)", async () => {
+		// `--plugin-dir` roots ride the shared plugin registry as user-scope, origin
+		// "plugin-dir" entries. The claude-plugins foreign opt-in is off by default, so
+		// gating user-scope roots purely on scope (as before) dropped these agents.
+		const pluginDir = path.join(tempHome, "my-plugin");
+		await fs.mkdir(path.join(pluginDir, "agents"), { recursive: true });
+		await fs.writeFile(
+			path.join(pluginDir, "agents", "plugin-dir-agent.md"),
+			["---", "name: plugin-dir-agent", "description: agent shipped in a --plugin-dir plugin.", "---", "body"].join(
+				"\n",
+			),
+		);
+		await injectPluginDirRoots(tempHome, [pluginDir], projectDir);
+
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).toContain("plugin-dir-agent");
 	});
 });


### PR DESCRIPTION
## Repro
A plugin directory passed via `--plugin-dir` containing an `agents/` folder yields only the bundled agents; the plugin's agent is never discovered. Reproduced with a test that injects a `--plugin-dir` root and calls `discoverAgents` with the default (off) `claude-plugins` foreign opt-in: `bun test packages/coding-agent/test/task/discovery.test.ts`.

## Cause
`--plugin-dir` roots are injected into the shared plugin registry as user-scope entries with `origin: "plugin-dir"` (`src/discovery/plugin-dir-roots.ts`, `buildPluginDirRoot`). `discoverAgents` in `src/task/discovery.ts` gated plugin roots purely by scope — `claudePluginsUserEnabled ? pluginRoots : pluginRoots.filter(r => r.scope === "project")` — so with the foreign `claude-plugins` user source disabled (the default), every user-scope root was dropped, including omp's own and `--plugin-dir` installs. Skill discovery already handles this via an origin-aware gate added in #10743 (`src/extensibility/skills.ts`, `isSourceEnabled`); agent discovery was never updated to match.

## Fix
- `src/task/discovery.ts`: keep a user-scope plugin root when the claude-plugins opt-in is on OR its `origin` is not `claude` (i.e. omp/`plugin-dir` installs), mirroring `skills.ts`.
- `test/task/discovery.test.ts`: added a regression test injecting a `--plugin-dir` root and asserting its agent is discovered with the foreign opt-in off; reset injected roots in `afterEach`.
- `CHANGELOG.md`: noted the fix under Unreleased.

## Verification
`bun test packages/coding-agent/test/task/discovery.test.ts packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts` — 9 pass, 0 fail. The pre-publish `bun run fix` + `bun check` gate passed on push.

Fixes #11151