### PR TITLE
Fix/codex faithful context window

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -624,9 +624,9 @@ read:
 
 ### Context, compaction, and memory
 
-	`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 1,050,000-token window, or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again. On `openai-codex`, an explicit override still clamps to the server-honored ceiling (`min(override, maximum)`, mirroring Codex's `model_context_window`), so it cannot widen past the documented maximum.
+	`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 922,000-token input window (1.05M total context with 128K output), or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again. On `openai-codex`, an explicit override still clamps to the server-honored ceiling (`min(override, maximum)`, mirroring Codex's `model_context_window`), so it cannot widen past the documented maximum.
 
-Compaction headroom is separate from this opt-in. With the default 15% reserve, Astra’s documented extended window has an auto-compaction threshold of 892,500 tokens. A larger window can consume more usage even when there is no additional long-context pricing multiplier.
+	Compaction headroom is separate from this opt-in. With the default 15% reserve, Astra's documented extended window has an auto-compaction threshold of 783,700 tokens. A larger window can consume more usage even when there is no additional long-context pricing multiplier.
 
 ```yaml
 extendedContext: false

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -624,9 +624,9 @@ read:
 
 ### Context, compaction, and memory
 
-	`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 922,000-token input window (1.05M total context with 128K output), or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again. On `openai-codex`, an explicit override still clamps to the server-honored ceiling (`min(override, maximum)`, mirroring Codex's `model_context_window`), so it cannot widen past the documented maximum.
+`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 922,000-token input window (1.05M total context with 128K output), or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again. On `openai-codex`, an explicit override still clamps to the server-honored ceiling (`min(override, maximum)`, mirroring Codex's `model_context_window`), so it cannot widen past the documented maximum.
 
-	Compaction headroom is separate from this opt-in. With the default 15% reserve, Astra's documented extended window has an auto-compaction threshold of 783,700 tokens. A larger window can consume more usage even when there is no additional long-context pricing multiplier.
+Compaction headroom is separate from this opt-in. With the default 15% reserve, Astra's documented extended window has an auto-compaction threshold of 783,700 tokens. A larger window can consume more usage even when there is no additional long-context pricing multiplier.
 
 ```yaml
 extendedContext: false

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -624,7 +624,7 @@ read:
 
 ### Context, compaction, and memory
 
-`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 1,050,000-token window, or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again.
+	`/extended-context on` opts in to larger context windows; `/extended-context off` restores standard windows and premium-pricing caps. For `openai-codex/gpt-6-astra` and its `-wm` route, off uses 272,000 tokens and on uses the documented 1,050,000-token window, or a higher discovered maximum. The curated maximum corrects stale lower discovery values. Explicit per-model `contextWindow` overrides in `models.yml` take precedence in both modes; remove an override if you want the toggle to control that model again. On `openai-codex`, an explicit override still clamps to the server-honored ceiling (`min(override, maximum)`, mirroring Codex's `model_context_window`), so it cannot widen past the documented maximum.
 
 Compaction headroom is separate from this opt-in. With the default 15% reserve, Astra’s documented extended window has an auto-compaction threshold of 892,500 tokens. A larger window can consume more usage even when there is no additional long-context pricing multiplier.
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context.
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes.
 - Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Codex Astra using its larger window without opt-in; its default is 272K and Extended Context enables at least the documented 1.05M window ([#11126](https://github.com/can1357/oh-my-pi/pull/11126) by [@H4vC](https://github.com/H4vC)).
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context.
 - Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixed
 
-- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes.
-- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes (by [@H4vC](https://github.com/H4vC)).
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context (by [@H4vC](https://github.com/H4vC)).
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex (by [@H4vC](https://github.com/H4vC)).
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Fixed
 
-- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes (by [@H4vC](https://github.com/H4vC)).
-- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context (by [@H4vC](https://github.com/H4vC)).
-- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex (by [@H4vC](https://github.com/H4vC)).
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Fixed Codex Astra using its larger window without opt-in; its default is 272K and Extended Context enables at least the documented 1.05M window ([#11126](https://github.com/can1357/oh-my-pi/pull/11126) by [@H4vC](https://github.com/H4vC)).
 - Fixed GitHub Copilot enterprise-only model ids inheriting another provider's wire routing (e.g. `gpt-5.6-sol-fast` pinning every request to the `-none` sibling id regardless of thinking level) ([#11128](https://github.com/can1357/oh-my-pi/pull/11128) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -267,6 +267,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 		shape: "scalar",
 		values: ["freeform", "function"],
 	},
+	"clamp-context-override": { key: "clampContextOverride", set: "catalog", shape: "scalar" },
 	"context-promotion-target": { key: "contextPromotionTarget", set: "catalog", shape: "scalar" },
 	"context-window-floor": { key: "contextWindowFloor", set: "catalog", shape: "scalar" },
 	"cost-patch": { key: "costPatch", set: "catalog", shape: "object" },

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -31,24 +31,6 @@ export function resolveMaxContextWindow(model: Model): number | undefined {
 }
 
 /**
- * Codex-faithful resolution (openai/codex `ModelInfo::resolved_context_window`
- * in `protocol/src/openai_models.rs`): prefers `context_window`, falls back
- * to `max_context_window`. Upstream treats `max_context_window` as the ceiling
- * for config overrides, not as an alternate window.
- */
-export function codexResolvedContextWindow(model: Model): number | undefined {
-	const current = model.contextWindow;
-	if (typeof current === "number" && Number.isFinite(current) && current > 0) {
-		return current;
-	}
-	const maximum = model.maxContextWindow;
-	if (typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0) {
-		return maximum;
-	}
-	return undefined;
-}
-
-/**
  * Override ceiling for Codex models. Upstream clamps `model_context_window`
  * to `min(override, max_context_window)` (`with_config_overrides` in
  * `models-manager/src/model_info.rs`); the ceiling here is stale-aware — the

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -62,6 +62,15 @@ export function codexOverrideCeiling(model: Model): number | undefined {
 }
 
 /**
+ * Whether explicit context-window overrides for this model clamp to the
+ * server-honored ceiling. KDL-owned (`clamp-context-override`): branching on
+ * it here keeps provider deployment contracts out of TypeScript.
+ */
+export function clampsContextOverride(model: Model): boolean {
+	return resolveModelPolicy(toModelSpec(model)).catalog.clampContextOverride === true;
+}
+
+/**
  * Clamp a requested Codex context window to the override ceiling, mirroring
  * upstream. Returns the request unchanged when no ceiling applies or it
  * already fits.

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -54,7 +54,10 @@ export function clampsContextOverride(model: Model): boolean {
 
 /**
  * Clamp a requested Codex context window to the override ceiling, mirroring
- * upstream. Returns the request unchanged when no ceiling applies or it
+ * upstream. `model` is the pre-override model: the ceiling never shrinks the
+ * request below the window that already works, so a stale-low live maximum
+ * (e.g. 128K base with a 64K advertised maximum) cannot punish an explicit
+ * override. Returns the request unchanged when no ceiling applies or it
  * already fits.
  */
 export function clampCodexContextWindow(model: Model, requested: number): number {
@@ -65,5 +68,7 @@ export function clampCodexContextWindow(model: Model, requested: number): number
 	if (ceiling === undefined || requested <= ceiling) {
 		return requested;
 	}
-	return ceiling;
+	const current = model.contextWindow;
+	const floor = typeof current === "number" && Number.isFinite(current) && current > 0 ? current : 0;
+	return Math.min(requested, Math.max(ceiling, floor));
 }

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -52,10 +52,10 @@ export function codexResolvedContextWindow(model: Model): number | undefined {
  * Override ceiling for Codex models. Upstream clamps `model_context_window`
  * to `min(override, max_context_window)` (`with_config_overrides` in
  * `models-manager/src/model_info.rs`); the ceiling here is stale-aware — the
- * curated maximum corrects a lower server value (Astra reports 272K/872K,
- * documented 1.05M) while a higher live maximum still wins. No curated or
- * live maximum means no ceiling: overrides pass through, matching upstream's
- * unclamped branch.
+ * curated maximum corrects a lower server value (Astra reports a stale 872K
+ * maximum; OpenAI documents at most 922K input) while a higher live maximum
+ * still wins. No curated or live maximum means no ceiling: overrides pass
+ * through, matching upstream's unclamped branch.
  */
 export function codexOverrideCeiling(model: Model): number | undefined {
 	return resolveMaxContextWindow(model);

--- a/packages/catalog/src/compat/context-window.ts
+++ b/packages/catalog/src/compat/context-window.ts
@@ -29,3 +29,50 @@ export function resolveMaxContextWindow(model: Model): number | undefined {
 	}
 	return curated ?? undefined;
 }
+
+/**
+ * Codex-faithful resolution (openai/codex `ModelInfo::resolved_context_window`
+ * in `protocol/src/openai_models.rs`): prefers `context_window`, falls back
+ * to `max_context_window`. Upstream treats `max_context_window` as the ceiling
+ * for config overrides, not as an alternate window.
+ */
+export function codexResolvedContextWindow(model: Model): number | undefined {
+	const current = model.contextWindow;
+	if (typeof current === "number" && Number.isFinite(current) && current > 0) {
+		return current;
+	}
+	const maximum = model.maxContextWindow;
+	if (typeof maximum === "number" && Number.isFinite(maximum) && maximum > 0) {
+		return maximum;
+	}
+	return undefined;
+}
+
+/**
+ * Override ceiling for Codex models. Upstream clamps `model_context_window`
+ * to `min(override, max_context_window)` (`with_config_overrides` in
+ * `models-manager/src/model_info.rs`); the ceiling here is stale-aware — the
+ * curated maximum corrects a lower server value (Astra reports 272K/872K,
+ * documented 1.05M) while a higher live maximum still wins. No curated or
+ * live maximum means no ceiling: overrides pass through, matching upstream's
+ * unclamped branch.
+ */
+export function codexOverrideCeiling(model: Model): number | undefined {
+	return resolveMaxContextWindow(model);
+}
+
+/**
+ * Clamp a requested Codex context window to the override ceiling, mirroring
+ * upstream. Returns the request unchanged when no ceiling applies or it
+ * already fits.
+ */
+export function clampCodexContextWindow(model: Model, requested: number): number {
+	if (!Number.isFinite(requested) || requested <= 0) {
+		return requested;
+	}
+	const ceiling = codexOverrideCeiling(model);
+	if (ceiling === undefined || requested <= ceiling) {
+		return requested;
+	}
+	return ceiling;
+}

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:39",
+				"source": "providers/openai-codex.kdl:41",
 				"providers": [
 					"openai-codex"
 				],
@@ -10624,7 +10624,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:56",
+				"source": "providers/openai-codex.kdl:58",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10644,7 +10644,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:61",
+				"source": "providers/openai-codex.kdl:63",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10660,7 +10660,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:64",
+				"source": "providers/openai-codex.kdl:66",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10676,7 +10676,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:69",
+				"source": "providers/openai-codex.kdl:71",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10695,7 +10695,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:81",
+				"source": "providers/openai-codex.kdl:83",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10721,7 +10721,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:87",
+				"source": "providers/openai-codex.kdl:89",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10747,7 +10747,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:79",
+				"source": "providers/openai-codex.kdl:81",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10764,7 +10764,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:97",
+				"source": "providers/openai-codex.kdl:99",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10784,7 +10784,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:103",
+				"source": "providers/openai-codex.kdl:105",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10800,7 +10800,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:106",
+				"source": "providers/openai-codex.kdl:108",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10816,7 +10816,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:112",
+				"source": "providers/openai-codex.kdl:114",
 				"providers": [
 					"openai-codex"
 				],
@@ -10837,7 +10837,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:121",
+				"source": "providers/openai-codex.kdl:123",
 				"providers": [
 					"openai-codex"
 				],
@@ -10862,7 +10862,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:130",
+				"source": "providers/openai-codex.kdl:132",
 				"providers": [
 					"openai-codex"
 				],
@@ -10883,7 +10883,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:141",
+				"source": "providers/openai-codex.kdl:143",
 				"providers": [
 					"openai-codex"
 				],
@@ -11160,7 +11160,28 @@
 				}
 			},
 			{
-				"source": "providers/openai.kdl:77",
+				"source": "providers/openai.kdl:79",
+				"providers": [
+					"openai"
+				],
+				"models": [
+					{
+						"kind": "glob",
+						"value": "gpt-6-astra*"
+					}
+				],
+				"catalog": {
+					"longContext": {
+						"inputThreshold": 272000,
+						"input": 20,
+						"output": 75,
+						"cacheRead": 2,
+						"cacheWrite": 25
+					}
+				}
+			},
+			{
+				"source": "providers/openai.kdl:90",
 				"providers": [
 					"openai"
 				],

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10544,7 +10544,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:16",
+				"source": "providers/openai-codex.kdl:21",
 				"providers": [
 					"openai-codex"
 				],
@@ -10568,7 +10568,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:24",
+				"source": "providers/openai-codex.kdl:29",
 				"providers": [
 					"openai-codex"
 				],
@@ -10592,7 +10592,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:41",
+				"source": "providers/openai-codex.kdl:46",
 				"providers": [
 					"openai-codex"
 				],
@@ -10624,7 +10624,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:58",
+				"source": "providers/openai-codex.kdl:63",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10644,7 +10644,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:63",
+				"source": "providers/openai-codex.kdl:68",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10660,7 +10660,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:66",
+				"source": "providers/openai-codex.kdl:71",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10676,7 +10676,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:71",
+				"source": "providers/openai-codex.kdl:76",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10695,7 +10695,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:83",
+				"source": "providers/openai-codex.kdl:88",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10721,7 +10721,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:89",
+				"source": "providers/openai-codex.kdl:94",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10747,7 +10747,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:81",
+				"source": "providers/openai-codex.kdl:86",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10764,7 +10764,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:99",
+				"source": "providers/openai-codex.kdl:104",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10784,7 +10784,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:105",
+				"source": "providers/openai-codex.kdl:110",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10800,7 +10800,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:108",
+				"source": "providers/openai-codex.kdl:113",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10816,7 +10816,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:114",
+				"source": "providers/openai-codex.kdl:119",
 				"providers": [
 					"openai-codex"
 				],
@@ -10837,7 +10837,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:123",
+				"source": "providers/openai-codex.kdl:128",
 				"providers": [
 					"openai-codex"
 				],
@@ -10862,7 +10862,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:132",
+				"source": "providers/openai-codex.kdl:137",
 				"providers": [
 					"openai-codex"
 				],
@@ -10883,7 +10883,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:143",
+				"source": "providers/openai-codex.kdl:148",
 				"providers": [
 					"openai-codex"
 				],
@@ -10917,7 +10917,8 @@
 					"serviceTierCost": {
 						"flex": 0.5,
 						"priority": 2
-					}
+					},
+					"clampContextOverride": true
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10592,7 +10592,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:37",
+				"source": "providers/openai-codex.kdl:39",
 				"providers": [
 					"openai-codex"
 				],
@@ -10620,11 +10620,11 @@
 					"limitsPatch": {
 						"contextWindow": 272000
 					},
-					"maxContextWindow": 1050000
+					"maxContextWindow": 922000
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:54",
+				"source": "providers/openai-codex.kdl:56",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10644,7 +10644,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:59",
+				"source": "providers/openai-codex.kdl:61",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10660,7 +10660,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:62",
+				"source": "providers/openai-codex.kdl:64",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10676,7 +10676,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:67",
+				"source": "providers/openai-codex.kdl:69",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10695,7 +10695,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:79",
+				"source": "providers/openai-codex.kdl:81",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10721,7 +10721,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:85",
+				"source": "providers/openai-codex.kdl:87",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10747,7 +10747,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:77",
+				"source": "providers/openai-codex.kdl:79",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10764,7 +10764,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:95",
+				"source": "providers/openai-codex.kdl:97",
 				"class": "openai",
 				"providers": [
 					"openai-codex"
@@ -10784,7 +10784,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:101",
+				"source": "providers/openai-codex.kdl:103",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10800,7 +10800,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:104",
+				"source": "providers/openai-codex.kdl:106",
 				"class": "unknown",
 				"providers": [
 					"openai-codex"
@@ -10816,7 +10816,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:110",
+				"source": "providers/openai-codex.kdl:112",
 				"providers": [
 					"openai-codex"
 				],
@@ -10837,7 +10837,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:119",
+				"source": "providers/openai-codex.kdl:121",
 				"providers": [
 					"openai-codex"
 				],
@@ -10862,7 +10862,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:128",
+				"source": "providers/openai-codex.kdl:130",
 				"providers": [
 					"openai-codex"
 				],
@@ -10883,7 +10883,7 @@
 				}
 			},
 			{
-				"source": "providers/openai-codex.kdl:139",
+				"source": "providers/openai-codex.kdl:141",
 				"providers": [
 					"openai-codex"
 				],

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -32,7 +32,9 @@ provider "openai-codex" {
 	// Codex reports a 272K default and a stale 872K maximum for Astra. Keep
 	// the default explicit so cached 1.05M rows from #11089 cannot bypass the
 	// opt-in; the curated maximum is applied only with extended context on.
-	// The documented total window is 1.05M (922K input plus 128K output).
+	// OpenAI documents 1.05M total context with at most 922K input and 128K
+	// output, so the input ceiling is 922K — not the total. A higher live
+	// maximum still wins as the ceiling.
 	// Codex pricing remains exempt from the API long-context multiplier.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
 		cost-patch {
@@ -48,7 +50,7 @@ provider "openai-codex" {
 		limits-patch {
 			context-window 272000
 		}
-		max-context-window 1050000
+		max-context-window 922000
 	}
 	class "openai" {
 		revision ">=5.3 <5.7" {

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -9,6 +9,11 @@ provider "openai-codex" {
 	// Harmony-protocol leak detection/mitigation applies to every Codex model,
 	// current and future; replaces the provider check in harmony-leak.ts.
 	harmony-leak-mitigation #true
+	// Every Codex SKU clamps explicit context-window overrides to the
+	// server-honored ceiling (`min(override, max)`, mirroring upstream
+	// `with_config_overrides`); models without a curated or live maximum
+	// pass through. Replaces the provider check in model-registry.ts.
+	clamp-context-override #true
 	// Subscription (Codex) discovery reports no pricing; the curated Daybreak
 	// aliases carry the standard GPT-5.6 Sol/Cyber API list price so cost
 	// display reads as API-equivalent spend. The `-wm` worker sibling bills

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -35,7 +35,9 @@ provider "openai-codex" {
 	// OpenAI documents 1.05M total context with at most 922K input and 128K
 	// output, so the input ceiling is 922K — not the total. A higher live
 	// maximum still wins as the ceiling.
-	// Codex pricing remains exempt from the API long-context multiplier.
+	// Subscription credit-equivalent pricing: no per-token billing, free cache
+	// writes, exempt from the API long-context multiplier. The first-party API
+	// route bills the documented >272K tier instead — see providers/openai.kdl.
 	models "gpt-6-astra" "gpt-6-astra-wm" {
 		cost-patch {
 			input 10.0

--- a/packages/catalog/src/compat/rules/providers/openai.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai.kdl
@@ -72,6 +72,19 @@ provider "openai" {
 			cache-write 5.0
 		}
 	}
+	// Astra API route bills the documented long-context tier above 272K input:
+	// 2x input and cache rates, 1.5x output for the full request; cache writes
+	// stay 1.25x the long input rate (25.0). The Codex subscription route stays
+	// exempt (credit-equivalent, free cache writes) — see openai-codex.kdl.
+	models "gpt-6-astra*" {
+		long-context-cost {
+			input-threshold 272000
+			input 20.0
+			output 75.0
+			cache-read 2.0
+			cache-write 25.0
+		}
+	}
 	// residue: the bare Daybreak rolling aliases pin the documented 5.6-gen
 	// wire restrictions without carrying the gpt- prefix identity.
 	models "daybreak-blue-latest" "daybreak-red-latest" {

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -56,6 +56,16 @@ test("clamps Codex overrides to the stale-aware ceiling", () => {
 	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 1_200_000 }, 2_000_000)).toBe(1_200_000);
 });
 
+test("never clamps below the working window on a stale-low maximum", () => {
+	const legacy = bundledLegacy();
+	// 128K base with a 64K advertised maximum: the ceiling is discredited,
+	// so an explicit override falls back to the working window.
+	const stale = { ...legacy, contextWindow: 128_000, maxContextWindow: 64_000 };
+	expect(codexOverrideCeiling(stale)).toBe(64_000);
+	expect(clampCodexContextWindow(stale, 200_000)).toBe(128_000);
+	expect(clampCodexContextWindow(stale, 100_000)).toBe(100_000);
+});
+
 test("leaves models without a ceiling unclamped", () => {
 	const legacy = bundledLegacy();
 	expect(codexOverrideCeiling({ ...legacy, maxContextWindow: undefined })).toBeUndefined();

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test";
-import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
+import {
+	clampCodexContextWindow,
+	codexOverrideCeiling,
+	codexResolvedContextWindow,
+	resolveMaxContextWindow,
+} from "@oh-my-pi/pi-catalog/compat/context-window";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
-
 function bundledAstra() {
 	const astra = getBundledModels("openai-codex").find(model => model.id === "gpt-6-astra");
 	if (!astra) throw new Error("Expected bundled Astra model");
@@ -39,4 +43,28 @@ test("leaves models without a curated maximum to the live value or undefined", (
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: undefined })).toBeUndefined();
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: 0 })).toBeUndefined();
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: Number.NaN })).toBeUndefined();
+});
+
+test("prefers context_window over max_context_window like upstream resolved", () => {
+	const astra = bundledAstra();
+	expect(codexResolvedContextWindow({ ...astra, maxContextWindow: 872_000 })).toBe(272_000);
+	expect(codexResolvedContextWindow({ ...astra, contextWindow: null, maxContextWindow: 872_000 })).toBe(872_000);
+	expect(codexResolvedContextWindow({ ...astra, contextWindow: null, maxContextWindow: undefined })).toBeUndefined();
+});
+
+test("clamps Codex overrides to the stale-aware ceiling", () => {
+	const astra = bundledAstra();
+	// Stale 872K server maximum: curated 1.05M is the ceiling.
+	expect(codexOverrideCeiling({ ...astra, maxContextWindow: 872_000 })).toBe(1_050_000);
+	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 872_000 }, 2_000_000)).toBe(1_050_000);
+	// Fitting requests pass through untouched.
+	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 872_000 }, 400_000)).toBe(400_000);
+	// A higher live maximum still wins as the ceiling.
+	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 1_200_000 }, 2_000_000)).toBe(1_200_000);
+});
+
+test("leaves models without a ceiling unclamped", () => {
+	const legacy = bundledLegacy();
+	expect(codexOverrideCeiling({ ...legacy, maxContextWindow: undefined })).toBeUndefined();
+	expect(clampCodexContextWindow({ ...legacy, maxContextWindow: undefined }, 2_000_000)).toBe(2_000_000);
 });

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -20,7 +20,7 @@ function bundledLegacy() {
 
 test("corrects a stale live maximum up to the curated window", () => {
 	const astra = bundledAstra();
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: 872_000 })).toBe(1_050_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: 872_000 })).toBe(922_000);
 });
 
 test("keeps a higher live maximum above the curated window", () => {
@@ -30,9 +30,9 @@ test("keeps a higher live maximum above the curated window", () => {
 
 test("falls back to the curated window when the live maximum is missing or invalid", () => {
 	const astra = bundledAstra();
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: undefined })).toBe(1_050_000);
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: 0 })).toBe(1_050_000);
-	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(1_050_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: undefined })).toBe(922_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: 0 })).toBe(922_000);
+	expect(resolveMaxContextWindow({ ...astra, maxContextWindow: Number.NaN })).toBe(922_000);
 });
 
 test("leaves models without a curated maximum to the live value or undefined", () => {
@@ -54,9 +54,9 @@ test("prefers context_window over max_context_window like upstream resolved", ()
 
 test("clamps Codex overrides to the stale-aware ceiling", () => {
 	const astra = bundledAstra();
-	// Stale 872K server maximum: curated 1.05M is the ceiling.
-	expect(codexOverrideCeiling({ ...astra, maxContextWindow: 872_000 })).toBe(1_050_000);
-	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 872_000 }, 2_000_000)).toBe(1_050_000);
+	// Stale 872K server maximum: the curated 922K input cap is the ceiling.
+	expect(codexOverrideCeiling({ ...astra, maxContextWindow: 872_000 })).toBe(922_000);
+	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 872_000 }, 2_000_000)).toBe(922_000);
 	// Fitting requests pass through untouched.
 	expect(clampCodexContextWindow({ ...astra, maxContextWindow: 872_000 }, 400_000)).toBe(400_000);
 	// A higher live maximum still wins as the ceiling.

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import {
 	clampCodexContextWindow,
+	clampsContextOverride,
 	codexOverrideCeiling,
 	codexResolvedContextWindow,
 	resolveMaxContextWindow,
@@ -67,4 +68,16 @@ test("leaves models without a ceiling unclamped", () => {
 	const legacy = bundledLegacy();
 	expect(codexOverrideCeiling({ ...legacy, maxContextWindow: undefined })).toBeUndefined();
 	expect(clampCodexContextWindow({ ...legacy, maxContextWindow: undefined }, 2_000_000)).toBe(2_000_000);
+});
+
+test("reads the override-clamp contract from KDL policy, not provider ids", () => {
+	const astra = bundledAstra();
+	const legacy = bundledLegacy();
+	// Provider-wide Codex semantics: every Codex SKU clamps, on any route.
+	expect(clampsContextOverride(astra)).toBe(true);
+	expect(clampsContextOverride({ ...legacy, maxContextWindow: 640_000 })).toBe(true);
+	expect(clampsContextOverride({ ...legacy, id: "gpt-5.5-wm" })).toBe(true);
+	// Other providers never clamp, even with a live maximum present.
+	expect(clampsContextOverride({ ...legacy, provider: "openai" })).toBe(false);
+	expect(clampsContextOverride({ ...legacy, provider: "openrouter", maxContextWindow: 640_000 })).toBe(false);
 });

--- a/packages/catalog/test/context-window.test.ts
+++ b/packages/catalog/test/context-window.test.ts
@@ -3,7 +3,6 @@ import {
 	clampCodexContextWindow,
 	clampsContextOverride,
 	codexOverrideCeiling,
-	codexResolvedContextWindow,
 	resolveMaxContextWindow,
 } from "@oh-my-pi/pi-catalog/compat/context-window";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
@@ -44,13 +43,6 @@ test("leaves models without a curated maximum to the live value or undefined", (
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: undefined })).toBeUndefined();
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: 0 })).toBeUndefined();
 	expect(resolveMaxContextWindow({ ...legacy, maxContextWindow: Number.NaN })).toBeUndefined();
-});
-
-test("prefers context_window over max_context_window like upstream resolved", () => {
-	const astra = bundledAstra();
-	expect(codexResolvedContextWindow({ ...astra, maxContextWindow: 872_000 })).toBe(272_000);
-	expect(codexResolvedContextWindow({ ...astra, contextWindow: null, maxContextWindow: 872_000 })).toBe(872_000);
-	expect(codexResolvedContextWindow({ ...astra, contextWindow: null, maxContextWindow: undefined })).toBeUndefined();
 });
 
 test("clamps Codex overrides to the stale-aware ceiling", () => {

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -265,6 +265,26 @@ describe("generated model policies", () => {
 		expect(models[2]?.cost.longContext).toBeUndefined();
 	});
 
+	it("bills Astra API long-context above 272K while the sub route stays exempt", () => {
+		const models = [
+			createSpec({ id: "gpt-6-astra", api: "openai-responses", provider: "openai" }),
+			createSpec({ id: "gpt-6-astra", api: "openai-codex-responses", provider: "openai-codex" }),
+			// Third-party carriers of the same id must not inherit the tier.
+			createSpec({ id: "gpt-6-astra", api: "openai-completions", provider: "openrouter" }),
+		].map(model => buildGenerated(model));
+
+		expect(models[0]?.cost.longContext).toMatchObject({
+			inputThreshold: 272_000,
+			input: 20,
+			output: 75,
+			cacheRead: 2,
+			cacheWrite: 25,
+		});
+		expect(models[1]?.cost.longContext).toBeUndefined();
+		expect(models[1]?.cost).toMatchObject({ cacheWrite: 0 });
+		expect(models[2]?.cost.longContext).toBeUndefined();
+	});
+
 	it("pins Claude Mythos 5 first-party Anthropic catalog metadata", () => {
 		const model = buildGenerated(
 			createSpec({

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
-- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
-- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context.
-- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes.
-- Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in.
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex (by [@H4vC](https://github.com/H4vC)).
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context (by [@H4vC](https://github.com/H4vC)).
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes (by [@H4vC](https://github.com/H4vC)).
+- Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in (by [@H4vC](https://github.com/H4vC)).
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
 - Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
 - Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context.
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes.
 - Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
 - Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context.
 - Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
-- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex (by [@H4vC](https://github.com/H4vC)).
-- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context (by [@H4vC](https://github.com/H4vC)).
-- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes (by [@H4vC](https://github.com/H4vC)).
-- Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in (by [@H4vC](https://github.com/H4vC)).
+- Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Fixed Astra's extended window over-advertising input by 128K; it now uses the documented 922K input cap inside the 1.05M total context ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Bills Astra API requests above 272K input at the documented 2x input / 1.5x output long-context tier; the Codex subscription route stays exempt with free cache writes ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
+- Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in ([#11157](https://github.com/can1357/oh-my-pi/pull/11157) by [@H4vC](https://github.com/H4vC)).
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.
 - Fixed Codex Astra retaining its larger window after disabling Extended Context, including cached models; explicit model overrides still take precedence.
 - Fixed explicit Codex context-window overrides widening past the server-honored maximum; they now clamp to the documented ceiling like upstream Codex.
+- Fixed Extended Context silently enabling without a settings source (SDK embedding, early boot); it now matches the off default until opted in.
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -188,14 +188,16 @@ function getDisabledProviderIdsFromSettings(settingsInstance?: Settings): Set<st
 
 /**
  * Whether extended context windows are enabled: advertised maximum windows
- * plus premium long-context tiers. Defaults to true when no settings source
- * is available (SDK embedding, early boot).
+ * plus premium long-context tiers. Matches the schema default (`false`) when
+ * no settings source is available (SDK embedding without settings, early
+ * boot): callers get default windows until they opt in, never silently
+ * elevated ones.
  */
 function isExtendedContextEnabledFromSettings(settingsInstance?: Settings): boolean {
 	try {
 		return (settingsInstance ?? settings).get("extendedContext");
 	} catch {
-		return true;
+		return false;
 	}
 }
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -17,7 +17,7 @@ import type {
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { collapseBuiltVariants } from "@oh-my-pi/pi-catalog/compat/collapse";
-import { resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
+import { clampCodexContextWindow, resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
 import { applyCatalogMetrics, CatalogMetricsIndex } from "@oh-my-pi/pi-catalog/identity/metrics";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import {
@@ -2123,7 +2123,21 @@ export class ModelRegistry {
 			if (!providerOverrides) return model;
 			const override = resolveModelOverrideWithAliases(providerOverrides, model, hasLiveModel);
 			if (!override) return model;
-			return applyModelOverride(model, override);
+			const overridden = applyModelOverride(model, override);
+			// Codex-faithful ceiling (openai/codex `with_config_overrides`):
+			// an explicit `model_context_window` clamps to the server-honored
+			// maximum instead of widening without bound. Base catalog windows
+			// are untouched — upstream only clamps config overrides.
+			if (
+				overridden.provider !== "openai-codex" ||
+				overridden.contextWindow === null ||
+				override.contextWindow === undefined
+			) {
+				return overridden;
+			}
+			const clamped = clampCodexContextWindow(overridden, overridden.contextWindow);
+			if (clamped === overridden.contextWindow) return overridden;
+			return applyModelOverride(overridden, { contextWindow: clamped });
 		});
 	}
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -17,7 +17,11 @@ import type {
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { collapseBuiltVariants } from "@oh-my-pi/pi-catalog/compat/collapse";
-import { clampCodexContextWindow, resolveMaxContextWindow } from "@oh-my-pi/pi-catalog/compat/context-window";
+import {
+	clampCodexContextWindow,
+	clampsContextOverride,
+	resolveMaxContextWindow,
+} from "@oh-my-pi/pi-catalog/compat/context-window";
 import { applyCatalogMetrics, CatalogMetricsIndex } from "@oh-my-pi/pi-catalog/identity/metrics";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import {
@@ -2126,14 +2130,15 @@ export class ModelRegistry {
 			const override = resolveModelOverrideWithAliases(providerOverrides, model, hasLiveModel);
 			if (!override) return model;
 			const overridden = applyModelOverride(model, override);
-			// Codex-faithful ceiling (openai/codex `with_config_overrides`):
-			// an explicit `model_context_window` clamps to the server-honored
-			// maximum instead of widening without bound. Base catalog windows
-			// are untouched — upstream only clamps config overrides.
+			// KDL-owned override ceiling (`clamp-context-override`, mirroring
+			// openai/codex `with_config_overrides`): an explicit context window
+			// clamps to the server-honored maximum instead of widening without
+			// bound. Base catalog windows are untouched — upstream only clamps
+			// config overrides.
 			if (
-				overridden.provider !== "openai-codex" ||
+				override.contextWindow === undefined ||
 				overridden.contextWindow === null ||
-				override.contextWindow === undefined
+				!clampsContextOverride(overridden)
 			) {
 				return overridden;
 			}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1999,7 +1999,7 @@ export class ModelRegistry {
 		return models.map(model => {
 			const override = resolveModelOverrideWithAliases(overrides, model, hasLiveModel);
 			if (!override) return model;
-			return applyModelOverride(model, override);
+			return this.#applyModelOverrideWithClamp(model, override);
 		});
 	}
 
@@ -2129,24 +2129,33 @@ export class ModelRegistry {
 			if (!providerOverrides) return model;
 			const override = resolveModelOverrideWithAliases(providerOverrides, model, hasLiveModel);
 			if (!override) return model;
-			const overridden = applyModelOverride(model, override);
-			// KDL-owned override ceiling (`clamp-context-override`, mirroring
-			// openai/codex `with_config_overrides`): an explicit context window
-			// clamps to the server-honored maximum instead of widening without
-			// bound. Base catalog windows are untouched — upstream only clamps
-			// config overrides.
-			if (
-				override.contextWindow === undefined ||
-				overridden.contextWindow === null ||
-				!clampsContextOverride(overridden)
-			) {
-				return overridden;
-			}
-			const clamped = clampCodexContextWindow(model, overridden.contextWindow);
-			if (clamped === overridden.contextWindow) return overridden;
-			return applyModelOverride(overridden, { contextWindow: clamped });
+			return this.#applyModelOverrideWithClamp(model, override);
 		});
 	}
+
+	/**
+	 * Applies one explicit model override, clamping KDL-governed
+	 * (`clamp-context-override`) context windows to the server-honored maximum
+	 * instead of widening without bound — mirroring openai/codex
+	 * `with_config_overrides`. `model` is the pre-override row, so the ceiling
+	 * never shrinks the request below the window that already works. Shared by
+	 * every override pass (cache load and composition): overrides apply on
+	 * both, so the clamp must hold on both.
+	 */
+	#applyModelOverrideWithClamp(model: Model<Api>, override: ModelOverride): Model<Api> {
+		const overridden = applyModelOverride(model, override);
+		if (
+			override.contextWindow === undefined ||
+			overridden.contextWindow === null ||
+			!clampsContextOverride(overridden)
+		) {
+			return overridden;
+		}
+		const clamped = clampCodexContextWindow(model, overridden.contextWindow);
+		if (clamped === overridden.contextWindow) return overridden;
+		return applyModelOverride(overridden, { contextWindow: clamped });
+	}
+
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
 		const extendedContext = isExtendedContextEnabledFromSettings(this.#settings);
 		return models.map(model => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2142,7 +2142,7 @@ export class ModelRegistry {
 			) {
 				return overridden;
 			}
-			const clamped = clampCodexContextWindow(overridden, overridden.contextWindow);
+			const clamped = clampCodexContextWindow(model, overridden.contextWindow);
 			if (clamped === overridden.contextWindow) return overridden;
 			return applyModelOverride(overridden, { contextWindow: clamped });
 		});

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1726,6 +1726,14 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
 		});
 
+		test("keeps bundled Astra at its default window without a settings source", () => {
+			// `beforeEach` leaves global settings uninitialized, so this
+			// reaches the no-settings fallback: it must match the schema
+			// default (off), never silently elevated windows.
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(272_000);
+		});
+
 		test("preserves an explicit Astra context override across extended context toggles", async () => {
 			writeRawModelsJson({
 				"openai-codex": { modelOverrides: { "gpt-6-astra": { contextWindow: 400_000 } } },

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1743,6 +1743,17 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(400_000);
 		});
 
+		test("clamps an explicit Astra override to the Codex ceiling", async () => {
+			writeRawModelsJson({
+				"openai-codex": { modelOverrides: { "gpt-6-astra": { contextWindow: 2_000_000 } } },
+			});
+			const testSettings = Settings.isolated({ extendedContext: true });
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			// Explicit intent wins over the toggle, but upstream never honors
+			// more than the server ceiling (curated 1.05M here).
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+		});
+
 		test("restores the opt-in for cached Astra and worker rows with stale or invalid maxima", async () => {
 			const testSettings = Settings.isolated();
 			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1718,7 +1718,7 @@ describe("ModelRegistry", () => {
 
 			testSettings.set("extendedContext", true);
 			await registry.reapplyModelPolicies();
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(922_000);
 			expect(registry.find("openai-codex", "gpt-5.5")?.contextWindow).toBe(272_000);
 
 			testSettings.set("extendedContext", false);
@@ -1750,8 +1750,8 @@ describe("ModelRegistry", () => {
 			const testSettings = Settings.isolated({ extendedContext: true });
 			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
 			// Explicit intent wins over the toggle, but upstream never honors
-			// more than the server ceiling (curated 1.05M here).
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			// more than the server ceiling (curated 922K input cap here).
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(922_000);
 		});
 
 		test("restores the opt-in for cached Astra and worker rows with stale or invalid maxima", async () => {
@@ -1778,7 +1778,7 @@ describe("ModelRegistry", () => {
 			testSettings.set("extendedContext", true);
 			await registry.reapplyModelPolicies();
 			for (const id of ["gpt-6-astra", "gpt-6-astra-wm"]) {
-				expect(registry.find("openai-codex", id)?.contextWindow).toBe(1_050_000);
+				expect(registry.find("openai-codex", id)?.contextWindow).toBe(922_000);
 			}
 
 			testSettings.set("extendedContext", false);
@@ -1801,7 +1801,7 @@ describe("ModelRegistry", () => {
 
 			writeModelCache("openai-codex", Date.now(), [{ ...astra, maxContextWindow: 872_000 }], true, "", dbPath);
 			await registry.reapplyModelPolicies();
-			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(1_050_000);
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(922_000);
 		});
 
 		test("restores a discovered maximum from cache ahead of the default on each toggle", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1762,6 +1762,29 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(922_000);
 		});
 
+		test("clamps a cached Astra row already carrying the applied override", async () => {
+			writeRawModelsJson({
+				"openai-codex": { modelOverrides: { "gpt-6-astra": { contextWindow: 2_000_000 } } },
+			});
+			const testSettings = Settings.isolated({ extendedContext: true });
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });
+			const astra = registry.find("openai-codex", "gpt-6-astra");
+			if (!astra) throw new Error("Expected bundled Astra model");
+			// Wire-value row, as discovery persists it; the cache loader
+			// applies the models.yml override before composition sees it, so
+			// the clamp must hold on every override pass, not just the last.
+			writeModelCache(
+				"openai-codex",
+				Date.now(),
+				[{ ...astra, contextWindow: 272_000, maxContextWindow: 872_000 }],
+				true,
+				"",
+				path.join(tempDir, "models.db"),
+			);
+			await registry.reapplyModelPolicies();
+			expect(registry.find("openai-codex", "gpt-6-astra")?.contextWindow).toBe(922_000);
+		});
+
 		test("restores the opt-in for cached Astra and worker rows with stale or invalid maxima", async () => {
 			const testSettings = Settings.isolated();
 			const registry = new ModelRegistry(authStorage, modelsJsonPath, { settings: testSettings });


### PR DESCRIPTION
What

Maps Codex Astra to the documented values on fix/codex-faithful-context-window (4 commits):

- Explicit models.yml contextWindow overrides on openai-codex clamp to min(override, ceiling) like upstream with_config_overrides; base
  catalog windows untouched. New codexResolvedContextWindow / codexOverrideCeiling / clampCodexContextWindow helpers in
  compat/context-window.ts.
- Extended window corrected from the 1.05M total to the documented 922K max input (128K output separate): KDL max-context-window 922000 +
  regenerated rules.json. Extended off stays 272K; on yields 922K (higher live maxima still win).
- extendedContext no-settings fallback now matches the schema default (off) instead of silently elevating.
- Pricing split per the rate docs: sub route keeps cache-write 0 with no long-context tier; new openai-provider Astra long-context-cost tier
  (272K threshold → 20.0 / 75.0 / 2.0 / 25.0).

Why

Three sources disagreed and the code picked the wrong number from the right comment: OpenAI documents 1.05M total / 922K max input / 128K max
output (model page (https://developers.openai.com/api/docs/models/gpt-6-astra), corroborated by models.dev openai +
azure/copilot/vercel/openrouter entries), Codex ships stale 272K/872K wire values (its own bundled models.json), and OMP advertised the total
as the input budget — letting 922K–1.05M prompts skip compaction and fail upstream. The Enterprise rate card
(https://help.openai.com/en/articles/20001415-chatgpt-rate-card-enterprise-token-based-pricing) confirms the Codex long-context exception (no
multiplier, no cache-write charge) and the API 2x/1.5x tier, so each route now bills its own documented shape.

Testing

- Fresh-process probes: off 272K / on 922K; no-settings source 272K.
- packages/catalog/test/{context-window,codex-discovery,generated-policies}.test.ts — 54 + 30 pass; model-registry.test.ts — 105 pass;
  agent-session-concurrent — 24 pass.
- Full catalog suite: 889 pass, 2 fail in issue-8867-repro.test.ts (SQLite self-heal) — fails on clean baseline too. One sdk-model-selection
  EBUSY temp-cleanup flake also reproduces on baseline.

────────────────────────────────────────────────────────────

- bun check passes
- Tested locally
- CHANGELOG updated (if user-facing)