### PR TITLE
fix(utils): tolerate an already-closed handle in checkpointWal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
+- Fixed one failed `AgentStorage.close()` poisoning every later close in the process: the throw happened before `instances.clear()`, so the registry kept a dead handle and each subsequent close re-closed it. Each instance now closes inside its own `try` and the registry clear runs in a `finally`.
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -419,12 +419,28 @@ FROM model_usage_legacy
 		);
 	}
 
-	/** Flushes deferred writes, closes every process-wide database, and permits reopening them. */
+	/**
+	 * Flushes deferred writes, closes every process-wide database, and permits
+	 * reopening them.
+	 *
+	 * One instance that cannot close must not orphan the registry: leaving a
+	 * closed handle in `instances` makes every later `close()` fail the same way,
+	 * so a single bad teardown poisons the rest of the process.
+	 */
 	static close(): void {
-		for (const storage of instances.values()) storage.#close();
-		instances.clear();
-		cancelExitCleanup?.();
-		cancelExitCleanup = undefined;
+		try {
+			for (const storage of instances.values()) {
+				try {
+					storage.#close();
+				} catch (err) {
+					logger.warn("agent storage close failed", { error: err });
+				}
+			}
+		} finally {
+			instances.clear();
+			cancelExitCleanup?.();
+			cancelExitCleanup = undefined;
+		}
 	}
 
 	#close(): void {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `checkpointWal` throwing on an already-closed database handle. Every caller runs it from a `close()` path, where a closed handle has nothing left to flush — SQLite checkpoints on close — but Bun >=1.4 raises `Database has closed` from `db.run()` after `close()` where earlier versions tolerated it. Added `isClosedDatabaseError` beside the existing busy and corruption classifiers; real statement errors still propagate.
+
 ## [18.1.13] - 2026-09-07
 
 ### Fixed

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -9,9 +9,29 @@
  */
 import type { Database } from "bun:sqlite";
 
-/** Checkpoints committed WAL frames without waiting for concurrent readers. */
+/**
+ * Checkpoints committed WAL frames without waiting for concurrent readers.
+ *
+ * A closed handle is a no-op, not an error: SQLite checkpoints on close, so
+ * there is nothing left to flush. `bun:sqlite` ≥ 1.4 throws
+ * `Database has closed` here where earlier versions tolerated it, and every
+ * caller runs this from a `close()` path — one that throws leaves the caller's
+ * own teardown half-done.
+ */
 export function checkpointWal(db: Database): void {
-	db.run("PRAGMA wal_checkpoint(PASSIVE)");
+	try {
+		db.run("PRAGMA wal_checkpoint(PASSIVE)");
+	} catch (err) {
+		if (!isClosedDatabaseError(err)) throw err;
+	}
+}
+
+/**
+ * `bun:sqlite`'s "already closed" guard. It carries no result code — the handle
+ * never reached SQLite — so this matches the message rather than a `code`.
+ */
+export function isClosedDatabaseError(err: unknown): boolean {
+	return err instanceof Error && err.message.includes("Database has closed");
 }
 
 /**

--- a/packages/utils/test/sqlite.test.ts
+++ b/packages/utils/test/sqlite.test.ts
@@ -1,0 +1,50 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { checkpointWal, isClosedDatabaseError, isSqliteBusyError } from "@oh-my-pi/pi-utils/sqlite";
+
+describe("checkpointWal", () => {
+	it("flushes an open database", () => {
+		const db = new Database(":memory:");
+		db.run("create table t(x)");
+		expect(() => checkpointWal(db)).not.toThrow();
+		db.close();
+	});
+
+	it("is a no-op on a closed handle", () => {
+		// Every caller runs this from a `close()` path. `bun:sqlite` >= 1.4 throws
+		// `Database has closed` where earlier versions tolerated it, and a throw
+		// here left the caller's teardown half-done — in `AgentStorage.close()`
+		// that orphaned the instance registry and broke every later close.
+		const db = new Database(":memory:");
+		db.close();
+		expect(() => checkpointWal(db)).not.toThrow();
+	});
+
+	it("still surfaces a real failure", () => {
+		const db = new Database(":memory:");
+		// A statement error is not a closed handle and must not be swallowed.
+		expect(() => db.run("PRAGMA nonsense_pragma_that_errors(")).toThrow();
+		db.close();
+	});
+});
+
+describe("isClosedDatabaseError", () => {
+	it("recognizes bun's closed-handle guard, which carries no result code", () => {
+		const db = new Database(":memory:");
+		db.close();
+		let caught: unknown;
+		try {
+			db.run("select 1");
+		} catch (err) {
+			caught = err;
+		}
+		expect(isClosedDatabaseError(caught)).toBe(true);
+		// It has no SQLite result code, so the busy classifier must not claim it.
+		expect(isSqliteBusyError(caught)).toBe(false);
+	});
+
+	it("rejects unrelated errors", () => {
+		expect(isClosedDatabaseError(new Error("disk I/O error"))).toBe(false);
+		expect(isClosedDatabaseError("Database has closed")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

`checkpointWal` no longer throws when handed an already-closed SQLite handle, and one failed `AgentStorage.close()` no longer poisons every later close in the process.

Two defects on the same path:

1. **`packages/utils/src/sqlite.ts`** — every caller runs `checkpointWal` from a `close()` path, and a closed handle has nothing left to flush because SQLite checkpoints on close. Bun >=1.4 raises `Database has closed` from `db.run()` after `close()` where earlier versions tolerated it, so the checkpoint became a hard error. Added `isClosedDatabaseError` beside the existing `isSqliteBusyError`/`isSqliteCorruptionError` classifiers and made the checkpoint treat a closed handle as a no-op. Real statement errors still propagate.

2. **`packages/coding-agent/src/session/agent-storage.ts`** — `AgentStorage.close()` iterated the process-wide instance registry and threw before reaching `instances.clear()`. The registry then kept a closed handle, so every later `close()` re-closed a dead one and threw again. Each instance now closes inside its own `try`, and the registry clear runs in a `finally`.

The second is the multiplier: one bad teardown becomes a failure in every later test that touches storage.

## Why

> **@blyzer — replace this line with your own sentence before review.** CONTRIBUTING requires a human-written explanation and a generated summary does not satisfy it.

The repo declares `"bun": ">=1.3.14"`, so this triggers on a supported Bun version. On Bun 1.4.0 it makes a large part of the `coding-agent` suite unusable as a signal: a single poisoned teardown cascades into every later test that opens agent storage.

## Testing

Bun 1.4.0, macOS 15.6 (arm64).

**The underlying Bun behavior change, minimally:**

```bash
bun -e 'const { Database } = await import("bun:sqlite");
const db = new Database(":memory:");
db.close();
try { db.run("PRAGMA wal_checkpoint(PASSIVE)"); console.log("tolerated"); }
catch (e) { console.log("throws:", e.message); }'
# Bun 1.4.0 -> throws: Database has closed
```

**Reproducing the cascade, then confirming it is gone.** `test/settings-manager.test.ts` is the clearest victim: it passes in isolation and fails wholesale in the full run, which is what identifies cross-file state pollution rather than a broken test.

```bash
cd packages/coding-agent
bun test test/settings-manager.test.ts   # 118 pass, 0 fail — isolated, before and after
bun test                                  # the cascade only appears here
```

Full `coding-agent` suite, measured on identical trees on the same machine — `main` versus that same commit plus this branch (14494 tests, 1422 files each):

| tree | failures | occurrences of `checkpointWal` in the output |
| --- | --- | --- |
| `main` | **176** across 17 files | 338 |
| `main` + this branch | **7** across 5 files | **0** |

169 failures cleared, every one sharing a single stack: `Database has closed` at `checkpointWal (packages/utils/src/sqlite.ts)` reached through `AgentStorage#close` / `close (session/agent-storage.ts:435)`.

No remaining failure stack mentions any file this branch touches. The 7 that are left, all pre-existing:

| count | file | cause |
| --- | --- | --- |
| 2 | `test/bash-acp-terminal.test.ts` | Not that test: an undisposed `StatusLineComponent`'s in-flight `gh pr view` throws `Settings not initialized` after another file's settings teardown, and Bun blames whichever test is running. Passes 10/10 in isolation. Reported separately as #11097 |
| 2 | `test/tools/web-search-exa.test.ts` | Wall-clock assertions on cancellation promptness; 50/50 pass in isolation |
| 1 | `test/bench-auth-fallback.test.ts` | `Agent error: model unreachable` after a 5s deadline — needs live model credentials |
| 1 | `test/skillful-toggle.test.ts` | Pre-existing; identical count on two bases 158 commits apart |
| 1 | `test/session-fork-prompt-cache-key.test.ts` | Pre-existing; same |

I established that baseline by re-running the suite with my own test file parked — the count went *up*, not down.

**Guard against over-catching.** A classifier that swallowed everything would be worse than the bug, so `packages/utils/test/sqlite.test.ts` (5 new tests) pins that a real `disk I/O error` is still *not* classified as a closed-handle error, alongside the closed-handle and busy cases.

```bash
cd packages/utils && bun test test/sqlite.test.ts   # 5 pass, 0 fail
cd packages/utils && bun test                        # 911 pass, 0 fail
```

Rebased on `main` at `3b2c31cdc3` (18.1.13); one commit, no merges.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
