### PR TITLE
fix(coding-agent): keep mid-turn steers from replacing the /loop prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
+- Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body.
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fixed `/copy` link captions showing Markdown delimiters for formatted labels and splitting across two rows for multiline labels ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
-- Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body.
+- Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body ([#11159](https://github.com/can1357/oh-my-pi/pull/11159) by [@H4vC](https://github.com/H4vC)).
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -306,7 +306,8 @@ export async function submitInteractiveInput(
 	mode: Pick<
 		InteractiveMode,
 		"markPendingSubmissionStarted" | "finishPendingSubmission" | "showError" | "checkShutdownRequested"
-	>,
+	> &
+		Partial<Pick<InteractiveMode, "loopPrompt" | "pauseLoop">>,
 	session: Pick<AgentSession, "prompt" | "promptCustomMessage" | "isStreaming">,
 	input: SubmittedUserInput,
 ): Promise<void> {
@@ -355,7 +356,11 @@ export async function submitInteractiveInput(
 				userInitiated: input.userInitiated,
 			});
 		} else {
-			await session.prompt(input.text, { images: input.images, streamingBehavior });
+			const forwarded = await session.prompt(input.text, { images: input.images, streamingBehavior });
+			// Dispatch consumed the body locally (void custom command) instead of
+			// starting a turn: when it is the armed loop body, park the loop rather
+			// than resubmitting a local action after every yield.
+			if (!forwarded && mode.loopPrompt === input.text) mode.pauseLoop?.();
 		}
 	} catch (error: unknown) {
 		const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -356,10 +356,17 @@ export async function submitInteractiveInput(
 				userInitiated: input.userInitiated,
 			});
 		} else {
-			const forwarded = await session.prompt(input.text, { images: input.images, streamingBehavior });
-			// Dispatch consumed the body locally (void custom command) instead of
-			// starting a turn: when it is the armed loop body, park the loop rather
-			// than resubmitting a local action after every yield.
+			let forwarded = false;
+			try {
+				forwarded = await session.prompt(input.text, { images: input.images, streamingBehavior });
+			} catch (error: unknown) {
+				mode.showError(error instanceof Error ? error.message : "Unknown error occurred");
+			}
+			// Dispatch consumed the body locally (void custom command) or rejected
+			// instead of starting a turn: when it is the armed loop body, park the
+			// loop rather than resubmitting a failed or local-only body after
+			// every yield. A failed body degrades to idle like any other
+			// submission failure instead of error-looping.
 			if (!forwarded && mode.loopPrompt === input.text) mode.pauseLoop?.();
 		}
 	} catch (error: unknown) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -943,13 +943,6 @@ export class InputController {
 				return;
 			}
 
-			// An inline `/loop` body arms the loop only after surviving
-			// local-command dispatch: a body like `!echo hi` is consumed by its
-			// command branch without submitting a turn, and recording it would
-			// report a running loop that never starts. (The compaction branch
-			// above arms separately so queued bodies keep the explicit prompt.)
-			if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
-
 			// If streaming, use prompt() with steer behavior
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing
 			if (this.ctx.session.isStreaming) {
@@ -969,10 +962,12 @@ export class InputController {
 						() => this.ctx.session.prompt(text, { streamingBehavior: "steer", images }),
 						{ imageCount: images?.length ?? 0 },
 					);
-					// A steer consumed locally (void custom command) starts no turn:
-					// when it is the armed inline loop body, park the loop instead
-					// of resubmitting a local action once the turn ends.
-					if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
+					// An inline `/loop` body arms the loop only after dispatch
+					// confirms it was forwarded: arming before the await would
+					// retain a body whose dispatch rejects, resubmitting a failed
+					// prompt after every yield. A rejection leaves prior loop
+					// state untouched, so the previous body (if any) survives.
+					if (submittedMode === "loop" && forwarded) this.ctx.setLoopPrompt(text);
 				} catch (error) {
 					// Don't lose the queued steer draft: restore images then the collapsed
 					// text so chip tokens (and band cards) survive the retry.
@@ -990,13 +985,14 @@ export class InputController {
 				this.ctx.ui.requestRender();
 				return;
 			}
-
 			// Normal message submission
-			// While loop mode is on, an idle user-typed prompt becomes the new loop
-			// prompt that auto-resubmits after each yield. This sits after the
-			// compaction, extension-command, and streaming-steer early returns so
-			// those one-off inputs never replace the loop body.
-			if (this.ctx.loopModeEnabled) {
+			// While loop mode is on, an idle user-typed prompt handed to the input
+			// waiter becomes the new loop prompt that auto-resubmits after each
+			// yield. This sits after the compaction, extension-command, and
+			// streaming-steer early returns so those one-off inputs never replace
+			// the loop body. The waiter-less direct path below arms only after its
+			// own dispatch succeeds, so a rejection never retains a failed body.
+			if (this.ctx.loopModeEnabled && this.ctx.onInputCallback) {
 				this.ctx.setLoopPrompt(text);
 			}
 			// First, move any pending bash components to chat
@@ -1047,8 +1043,10 @@ export class InputController {
 							imageCount: images?.length ?? 0,
 						},
 					);
-					// Same locally-consumed guard as the streaming branch above.
-					if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
+					// No waiter took this submission, so the idle block above did not
+					// arm it: record it as the loop body only after dispatch
+					// confirms it was forwarded, mirroring the streaming branch.
+					if (forwarded) this.ctx.setLoopPrompt(text);
 				} catch (error) {
 					// Don't lose the message: hand images then collapsed text back to the
 					// editor so the user can retry (e.g. prompt dispatch rejecting an

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -913,7 +913,12 @@ export class InputController {
 			if (this.ctx.session.isCompacting) {
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 				this.ctx.queueCompactionMessage(text, "steer", images);
-				if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
+				// An inline `/loop` body queued here arms the loop only when it is
+				// an actual model prompt. Skill/bash/python bodies never reach this
+				// branch, but an extension-command body would otherwise be retained
+				// as loopPrompt while the drain executes it locally — and idle
+				// submissions never arm commands.
+				if (submittedMode === "loop" && !this.#isLocalExtensionCommand(text)) this.ctx.setLoopPrompt(text);
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -909,12 +909,6 @@ export class InputController {
 				}
 			}
 
-			// While loop mode is on, every user-typed prompt becomes the new loop
-			// prompt that auto-resubmits after each yield.
-			if (this.ctx.loopModeEnabled) {
-				this.ctx.setLoopPrompt(text);
-			}
-
 			// Queue input during compaction
 			if (this.ctx.session.isCompacting) {
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
@@ -980,6 +974,13 @@ export class InputController {
 			}
 
 			// Normal message submission
+			// While loop mode is on, an idle user-typed prompt becomes the new loop
+			// prompt that auto-resubmits after each yield. This sits after the
+			// compaction, extension-command, and streaming-steer early returns so
+			// those one-off inputs never replace the loop body.
+			if (this.ctx.loopModeEnabled) {
+				this.ctx.setLoopPrompt(text);
+			}
 			// First, move any pending bash components to chat
 			this.ctx.flushPendingBashComponents();
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -964,11 +964,15 @@ export class InputController {
 				// typed since queuing intact. Same protection as #783, applied to
 				// the streaming/queue path.
 				try {
-					await this.ctx.withLocalSubmission(
+					const forwarded = await this.ctx.withLocalSubmission(
 						text,
 						() => this.ctx.session.prompt(text, { streamingBehavior: "steer", images }),
 						{ imageCount: images?.length ?? 0 },
 					);
+					// A steer consumed locally (void custom command) starts no turn:
+					// when it is the armed inline loop body, park the loop instead
+					// of resubmitting a local action once the turn ends.
+					if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
 				} catch (error) {
 					// Don't lose the queued steer draft: restore images then the collapsed
 					// text so chip tokens (and band cards) survive the retry.
@@ -1036,13 +1040,15 @@ export class InputController {
 				this.ctx.editor.pendingImageLinks = [];
 				this.#maybeStartTitleGeneration(text);
 				try {
-					await this.ctx.withLocalSubmission(
+					const forwarded = await this.ctx.withLocalSubmission(
 						text,
 						() => this.ctx.session.prompt(text, { streamingBehavior: "steer", images }),
 						{
 							imageCount: images?.length ?? 0,
 						},
 					);
+					// Same locally-consumed guard as the streaming branch above.
+					if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
 				} catch (error) {
 					// Don't lose the message: hand images then collapsed text back to the
 					// editor so the user can retry (e.g. prompt dispatch rejecting an

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -827,6 +827,11 @@ export class InputController {
 					// "/loop 10 fix bug" rather than just "fix bug".
 					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
 					text = slashResult;
+					// An inline `/loop` prompt must stick even when the streaming
+					// or compaction branches below return early: otherwise the
+					// prompt is sent once as a steer while loopPrompt stays unset
+					// and loop mode idles instead of repeating it.
+					if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
 				}
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -827,11 +827,6 @@ export class InputController {
 					// "/loop 10 fix bug" rather than just "fix bug".
 					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
 					text = slashResult;
-					// An inline `/loop` prompt must stick even when the streaming
-					// or compaction branches below return early: otherwise the
-					// prompt is sent once as a steer while loopPrompt stays unset
-					// and loop mode idles instead of repeating it.
-					if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
 				}
 			}
 
@@ -918,8 +913,10 @@ export class InputController {
 			if (this.ctx.session.isCompacting) {
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 				this.ctx.queueCompactionMessage(text, "steer", images);
+				if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
 				return;
 			}
+
 			// Extension commands are local actions. Execute them before the normal
 			// submission path creates an optimistic user message; otherwise a
 			// consumed command remains rendered like a prompt sent to the model.
@@ -940,6 +937,13 @@ export class InputController {
 				}
 				return;
 			}
+
+			// An inline `/loop` body arms the loop only after surviving
+			// local-command dispatch: a body like `!echo hi` is consumed by its
+			// command branch without submitting a turn, and recording it would
+			// report a running loop that never starts. (The compaction branch
+			// above arms separately so queued bodies keep the explicit prompt.)
+			if (submittedMode === "loop") this.ctx.setLoopPrompt(text);
 
 			// If streaming, use prompt() with steer behavior
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -986,13 +986,13 @@ export class InputController {
 				return;
 			}
 			// Normal message submission
-			// While loop mode is on, an idle user-typed prompt handed to the input
-			// waiter becomes the new loop prompt that auto-resubmits after each
-			// yield. This sits after the compaction, extension-command, and
-			// streaming-steer early returns so those one-off inputs never replace
-			// the loop body. The waiter-less direct path below arms only after its
-			// own dispatch succeeds, so a rejection never retains a failed body.
-			if (this.ctx.loopModeEnabled && this.ctx.onInputCallback) {
+			// While loop mode is on, an idle user-typed prompt becomes the new loop
+			// prompt that auto-resubmits after each yield. This arms synchronously,
+			// before any await: arming after a turn-length dispatch would race the
+			// reschedule timer and strand the waiter. Non-forward outcomes (local
+			// consume, rejection) park the loop at their own dispatch sites, so a
+			// failed body degrades to idle instead of looping errors.
+			if (this.ctx.loopModeEnabled) {
 				this.ctx.setLoopPrompt(text);
 			}
 			// First, move any pending bash components to chat
@@ -1043,10 +1043,10 @@ export class InputController {
 							imageCount: images?.length ?? 0,
 						},
 					);
-					// No waiter took this submission, so the idle block above did not
-					// arm it: record it as the loop body only after dispatch
-					// confirms it was forwarded, mirroring the streaming branch.
-					if (forwarded) this.ctx.setLoopPrompt(text);
+					// The idle block above already armed this body synchronously.
+					// A locally-consumed dispatch starts no turn: park the armed
+					// loop instead of resubmitting a local action on next idle.
+					if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
 				} catch (error) {
 					// Don't lose the message: hand images then collapsed text back to the
 					// editor so the user can retry (e.g. prompt dispatch rejecting an
@@ -1060,6 +1060,9 @@ export class InputController {
 					}
 					this.ctx.editor.setCollapsedText(text);
 					this.ctx.showError(error instanceof Error ? error.message : String(error));
+					// Dispatch rejected after the body was armed: park it so the
+					// failed prompt is not resubmitted on next idle.
+					if (this.ctx.loopPrompt === text) this.ctx.pauseLoop();
 				}
 				this.ctx.updatePendingMessagesDisplay();
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -1111,6 +1111,15 @@ export class UiHelpers {
 		);
 	}
 
+	/**
+	 * Park the loop when drain dispatch consumes the armed body locally (void
+	 * custom command) instead of starting a turn. The drain otherwise discards
+	 * prompt()'s result, and the next idle tick would resubmit a local action.
+	 */
+	#parkLoopOnLocalConsume(text: string, forwarded: boolean): void {
+		if (!forwarded && this.ctx.loopPrompt === text) this.ctx.pauseLoop();
+	}
+
 	async #deliverQueuedMessage(message: CompactionQueuedMessage): Promise<void> {
 		if (
 			await invokeSkillCommandFromText(this.ctx, message.text, message.mode, {
@@ -1122,7 +1131,8 @@ export class UiHelpers {
 			return;
 		}
 		if (this.ctx.isKnownSlashCommand(message.text)) {
-			await this.ctx.session.prompt(message.text);
+			const forwarded = await this.ctx.session.prompt(message.text);
+			this.#parkLoopOnLocalConsume(message.text, forwarded);
 			return;
 		}
 		await this.ctx.withLocalSubmission(
@@ -1192,7 +1202,8 @@ export class UiHelpers {
 			}
 			if (firstPromptIndex === -1) {
 				for (const message of queuedMessages) {
-					await this.ctx.session.prompt(message.text);
+					const forwarded = await this.ctx.session.prompt(message.text);
+					this.#parkLoopOnLocalConsume(message.text, forwarded);
 				}
 				return;
 			}

--- a/packages/coding-agent/test/compaction-flush-loop.test.ts
+++ b/packages/coding-agent/test/compaction-flush-loop.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+
+beforeAll(() => {
+	initTheme();
+});
+
+function makeCtx(initialQueue: CompactionQueuedMessage[], loopPrompt: string | undefined) {
+	let currentLoopPrompt = loopPrompt;
+	const pauseLoop = mock(() => {
+		currentLoopPrompt = undefined;
+	});
+	// Mirror AgentSession.prompt: a void custom command is consumed locally
+	// (false) instead of starting a turn (true).
+	const prompt = mock(async (text: string): Promise<boolean> => text !== "/void-cmd");
+	const ctx = {
+		session: {
+			prompt,
+			promptCustomMessage: mock(async () => true),
+			clearQueue: () => ({ steering: [], followUp: [] }),
+		},
+		compactionQueuedMessages: [...initialQueue],
+		skillCommands: new Map(),
+		fileSlashCommands: new Set<string>(),
+		locallySubmittedUserSignatures: new Set<string>(),
+		isKnownSlashCommand: (text: string) => text === "/void-cmd",
+		recordLocalSubmission: () => () => {},
+		withLocalSubmission: async (_text: string, fn: () => Promise<unknown>) => fn(),
+		updatePendingMessagesDisplay: mock(() => {}),
+		showError: mock((_msg: string) => {}),
+		showStatus: mock((_msg: string) => {}),
+		get loopPrompt() {
+			return currentLoopPrompt;
+		},
+		set loopPrompt(value: string | undefined) {
+			currentLoopPrompt = value;
+		},
+		pauseLoop,
+	} as unknown as InteractiveModeContext;
+	return {
+		ctx,
+		prompt,
+		pauseLoop,
+		getLoopPrompt: () => currentLoopPrompt,
+	};
+}
+
+describe("flushCompactionQueue loop parking", () => {
+	test("all-slash drain parks the loop when the body is consumed locally", async () => {
+		const queued: CompactionQueuedMessage[] = [{ text: "/void-cmd", mode: "steer" }];
+		const { ctx, prompt, pauseLoop, getLoopPrompt } = makeCtx(queued, "/void-cmd");
+
+		await new UiHelpers(ctx).flushCompactionQueue({ willRetry: false });
+
+		expect(prompt).toHaveBeenCalledWith("/void-cmd");
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
+	});
+
+	test("pre-command drain parks the loop when the body is consumed locally", async () => {
+		const queued: CompactionQueuedMessage[] = [
+			{ text: "/void-cmd", mode: "steer" },
+			{ text: "plain follow-up", mode: "followUp" },
+		];
+		const { ctx, pauseLoop, getLoopPrompt } = makeCtx(queued, "/void-cmd");
+
+		await new UiHelpers(ctx).flushCompactionQueue({ willRetry: false });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
+	});
+
+	test("drain keeps the loop armed when the body starts a turn", async () => {
+		const queued: CompactionQueuedMessage[] = [{ text: "plain body", mode: "steer" }];
+		const { ctx, pauseLoop, getLoopPrompt } = makeCtx(queued, "plain body");
+
+		await new UiHelpers(ctx).flushCompactionQueue({ willRetry: false });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("plain body");
+	});
+});

--- a/packages/coding-agent/test/compaction-flush-loop.test.ts
+++ b/packages/coding-agent/test/compaction-flush-loop.test.ts
@@ -7,14 +7,22 @@ beforeAll(() => {
 	initTheme();
 });
 
-function makeCtx(initialQueue: CompactionQueuedMessage[], loopPrompt: string | undefined) {
+function makeCtx(
+	initialQueue: CompactionQueuedMessage[],
+	loopPrompt: string | undefined,
+	promptBehavior: "forward" | "consume" | "throw" = "consume",
+) {
 	let currentLoopPrompt = loopPrompt;
 	const pauseLoop = mock(() => {
 		currentLoopPrompt = undefined;
 	});
 	// Mirror AgentSession.prompt: a void custom command is consumed locally
 	// (false) instead of starting a turn (true).
-	const prompt = mock(async (text: string): Promise<boolean> => text !== "/void-cmd");
+	const prompt = mock(async (text: string): Promise<boolean> => {
+		if (promptBehavior === "throw") throw new Error("attachment too large");
+		if (promptBehavior === "forward") return true;
+		return text !== "/void-cmd";
+	});
 	const ctx = {
 		session: {
 			prompt,
@@ -84,5 +92,20 @@ describe("flushCompactionQueue loop parking", () => {
 
 		expect(pauseLoop).not.toHaveBeenCalled();
 		expect(getLoopPrompt()).toBe("plain body");
+	});
+
+	test("failed drain restores the queue and leaves loop state alone", async () => {
+		const queued: CompactionQueuedMessage[] = [{ text: "queued body", mode: "steer" }];
+		const { ctx, pauseLoop, getLoopPrompt } = makeCtx(queued, "queued body", "throw");
+
+		await new UiHelpers(ctx).flushCompactionQueue({ willRetry: false });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// The message stays queued for retry; loop parking happens when the
+		// main turn later observes the rejection, not in the drain.
+		expect(ctx.compactionQueuedMessages).toEqual(queued);
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("queued body");
 	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -6,8 +6,17 @@ type Spy = Mock<(...args: unknown[]) => unknown>;
 function createLoopContext(options: {
 	isStreaming: boolean;
 	isCompacting?: boolean;
+	extensionCommandNames?: string[];
 	onInputCallback?: (...args: never[]) => void;
 }) {
+	const extensionCommandNames = options.extensionCommandNames ?? [];
+	const extensionRunner =
+		extensionCommandNames.length > 0
+			? {
+					hasHandlers: () => false,
+					getCommand: (name: string) => (extensionCommandNames.includes(name) ? {} : undefined),
+				}
+			: undefined;
 	let loopPrompt: string | undefined = "original loop prompt";
 	const setLoopPrompt = vi.fn((prompt: string) => {
 		loopPrompt = prompt;
@@ -33,7 +42,7 @@ function createLoopContext(options: {
 			isBashRunning: false,
 			isEvalRunning: false,
 			queuedMessageCount: 0,
-			extensionRunner: undefined,
+			extensionRunner,
 			customCommands: [],
 			promptTemplates: [],
 			prompt,
@@ -145,6 +154,25 @@ describe("loop mode interjections", () => {
 		await ctx.editor.onSubmit?.("/loop 3 !echo hi");
 
 		expect(handleBashCommand).toHaveBeenCalledWith("echo hi", false);
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
+	});
+
+	it("does not arm the loop when the compacted body is a local command", async () => {
+		const { ctx, setLoopPrompt, getLoopPrompt, queueCompactionMessage } = createLoopContext({
+			isStreaming: false,
+			isCompacting: true,
+			extensionCommandNames: ["ext-cmd"],
+		});
+		// Mirror handleLoopCommand: enabling loop mode hands the inline body
+		// back to the dispatcher, where it queues for compaction.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "/ext-cmd args");
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 /ext-cmd args");
+
+		expect(queueCompactionMessage).toHaveBeenCalledTimes(1);
 		expect(setLoopPrompt).not.toHaveBeenCalled();
 		expect(getLoopPrompt()).toBe("original loop prompt");
 	});

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -203,7 +203,7 @@ describe("loop mode interjections", () => {
 		expect(getLoopPrompt()).toBe("original loop prompt");
 	});
 
-	it("leaves the loop untouched when a direct submission is consumed locally", async () => {
+	it("parks the loop when a direct submission is consumed locally", async () => {
 		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: false });
 		prompt.mockResolvedValueOnce(false);
 		const controller = new InputController(ctx);
@@ -212,9 +212,9 @@ describe("loop mode interjections", () => {
 		await ctx.editor.onSubmit?.("/void-cmd");
 
 		expect(prompt).toHaveBeenCalledTimes(1);
-		expect(setLoopPrompt).not.toHaveBeenCalled();
-		expect(pauseLoop).not.toHaveBeenCalled();
-		expect(getLoopPrompt()).toBe("original loop prompt");
+		expect(setLoopPrompt).toHaveBeenCalledWith("/void-cmd");
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
 	});
 
 	it("arms a direct submission after dispatch succeeds", async () => {
@@ -248,7 +248,7 @@ describe("loop mode interjections", () => {
 		expect(showError).toHaveBeenCalledWith("attachment too large");
 	});
 
-	it("keeps the prior body when a direct submission is rejected", async () => {
+	it("parks the loop when a direct submission is rejected", async () => {
 		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt, showError } = createLoopContext({
 			isStreaming: false,
 		});
@@ -258,9 +258,9 @@ describe("loop mode interjections", () => {
 
 		await ctx.editor.onSubmit?.("direct body");
 
-		expect(setLoopPrompt).not.toHaveBeenCalled();
-		expect(pauseLoop).not.toHaveBeenCalled();
-		expect(getLoopPrompt()).toBe("original loop prompt");
+		expect(setLoopPrompt).toHaveBeenCalledWith("direct body");
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
 		expect(showError).toHaveBeenCalledWith("attachment too large");
 	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -53,6 +53,7 @@ function createLoopContext(options: {
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 		updatePendingMessagesDisplay: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
+		handleBashCommand: vi.fn(),
 		queueCompactionMessage: vi.fn(),
 		onInputCallback: options.onInputCallback,
 		skillCommands: new Map(),
@@ -70,6 +71,7 @@ function createLoopContext(options: {
 		prompt,
 		getLoopPrompt: () => loopPrompt,
 		queueCompactionMessage: ctx.queueCompactionMessage as Spy,
+		handleBashCommand: ctx.handleBashCommand as Spy,
 	};
 }
 
@@ -130,5 +132,20 @@ describe("loop mode interjections", () => {
 		expect(setLoopPrompt).toHaveBeenCalledWith("compact loop body");
 		expect(getLoopPrompt()).toBe("compact loop body");
 		expect(queueCompactionMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not arm the loop when the inline body is a local command", async () => {
+		const { ctx, setLoopPrompt, getLoopPrompt, handleBashCommand } = createLoopContext({ isStreaming: false });
+		// Mirror handleLoopCommand: enabling loop mode hands the inline body
+		// back to the dispatcher, where the bash branch consumes it.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "!echo hi");
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 !echo hi");
+
+		expect(handleBashCommand).toHaveBeenCalledWith("echo hi", false);
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
 	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createLoopContext(options: { isStreaming: boolean; onInputCallback?: (...args: never[]) => void }) {
+	let loopPrompt: string | undefined = "original loop prompt";
+	const setLoopPrompt = vi.fn((prompt: string) => {
+		loopPrompt = prompt;
+	});
+	const prompt = vi.fn(async () => {});
+	const editor = {
+		pendingImages: [],
+		pendingImageLinks: [],
+		imageLinks: undefined,
+		addToHistory: vi.fn(),
+		setText: vi.fn(),
+		getText: () => "",
+		getExpandedText: () => "",
+		clearDraft: vi.fn(),
+		setCollapsedText: vi.fn(),
+	} as unknown as InteractiveModeContext["editor"];
+	const ctx = {
+		editor,
+		ui: { requestRender: vi.fn() },
+		session: {
+			isStreaming: options.isStreaming,
+			isCompacting: false,
+			isBashRunning: false,
+			isEvalRunning: false,
+			queuedMessageCount: 0,
+			extensionRunner: undefined,
+			customCommands: [],
+			promptTemplates: [],
+			prompt,
+			maybeStartTitleGeneration: vi.fn(),
+		},
+		sessionManager: { putBlob: vi.fn() },
+		loopModeEnabled: true,
+		get loopPrompt() {
+			return loopPrompt;
+		},
+		set loopPrompt(value: string | undefined) {
+			loopPrompt = value;
+		},
+		setLoopPrompt,
+		flushPendingBashComponents: vi.fn(),
+		startPendingSubmission: vi.fn((input: { text: string }) => ({ ...input, cancelled: false, started: false })),
+		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		updatePendingMessagesDisplay: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+		showError: vi.fn(),
+		onInputCallback: options.onInputCallback,
+		skillCommands: new Map(),
+		fileSlashCommands: new Set<string>(),
+		isBashMode: false,
+		isPythonMode: false,
+		focusedAgentId: undefined,
+		compactionQueuedMessages: [],
+		locallySubmittedUserSignatures: new Set<string>(),
+	} as unknown as InteractiveModeContext;
+	return { ctx, editor, setLoopPrompt, prompt, getLoopPrompt: () => loopPrompt };
+}
+
+describe("loop mode interjections", () => {
+	it("keeps the original loop prompt when steering mid-turn", async () => {
+		const { ctx, setLoopPrompt, prompt, getLoopPrompt } = createLoopContext({ isStreaming: true });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("one-off correction");
+
+		// One-off steer reaches the session but must not replace the loop body.
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
+	});
+
+	it("adopts an idle submission as the new loop prompt", async () => {
+		const onInputCallback = vi.fn();
+		const { ctx, setLoopPrompt } = createLoopContext({ isStreaming: false, onInputCallback });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("new loop body");
+
+		expect(setLoopPrompt).toHaveBeenCalledWith("new loop body");
+		expect(onInputCallback).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -66,6 +66,7 @@ function createLoopContext(options: {
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 		updatePendingMessagesDisplay: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
+		showError: vi.fn(),
 		handleBashCommand: vi.fn(),
 		queueCompactionMessage: vi.fn(),
 		onInputCallback: options.onInputCallback,
@@ -86,6 +87,7 @@ function createLoopContext(options: {
 		getLoopPrompt: () => loopPrompt,
 		queueCompactionMessage: ctx.queueCompactionMessage as Spy,
 		handleBashCommand: ctx.handleBashCommand as Spy,
+		showError: ctx.showError as Spy,
 	};
 }
 
@@ -182,7 +184,7 @@ describe("loop mode interjections", () => {
 		expect(getLoopPrompt()).toBe("original loop prompt");
 	});
 
-	it("parks the loop when a streamed body is consumed locally", async () => {
+	it("leaves the loop untouched when a streamed body is consumed locally", async () => {
 		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: true });
 		// Mirror handleLoopCommand: enabling loop mode hands the inline body
 		// back to the dispatcher for normal submission.
@@ -195,13 +197,14 @@ describe("loop mode interjections", () => {
 
 		await ctx.editor.onSubmit?.("/loop 3 /void-cmd");
 
-		expect(setLoopPrompt).toHaveBeenCalledWith("/void-cmd");
-		expect(pauseLoop).toHaveBeenCalledTimes(1);
-		expect(getLoopPrompt()).toBeUndefined();
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
 	});
 
-	it("parks the loop when a direct submission is consumed locally", async () => {
-		const { ctx, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: false });
+	it("leaves the loop untouched when a direct submission is consumed locally", async () => {
+		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: false });
 		prompt.mockResolvedValueOnce(false);
 		const controller = new InputController(ctx);
 		controller.setupEditorSubmitHandler();
@@ -209,7 +212,55 @@ describe("loop mode interjections", () => {
 		await ctx.editor.onSubmit?.("/void-cmd");
 
 		expect(prompt).toHaveBeenCalledTimes(1);
-		expect(pauseLoop).toHaveBeenCalledTimes(1);
-		expect(getLoopPrompt()).toBeUndefined();
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
+	});
+
+	it("arms a direct submission after dispatch succeeds", async () => {
+		const { ctx, setLoopPrompt, getLoopPrompt } = createLoopContext({ isStreaming: false });
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("direct body");
+
+		expect(setLoopPrompt).toHaveBeenCalledWith("direct body");
+		expect(getLoopPrompt()).toBe("direct body");
+	});
+
+	it("keeps the prior body when a streamed inline body is rejected", async () => {
+		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt, showError } = createLoopContext({
+			isStreaming: true,
+		});
+		// Mirror handleLoopCommand: enabling loop mode hands the inline body
+		// back to the dispatcher for normal submission.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "new body");
+		// Mirror attachment normalization failing inside prompt dispatch.
+		prompt.mockRejectedValueOnce(new Error("attachment too large"));
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 new body");
+
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
+		expect(showError).toHaveBeenCalledWith("attachment too large");
+	});
+
+	it("keeps the prior body when a direct submission is rejected", async () => {
+		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt, showError } = createLoopContext({
+			isStreaming: false,
+		});
+		prompt.mockRejectedValueOnce(new Error("attachment too large"));
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("direct body");
+
+		expect(setLoopPrompt).not.toHaveBeenCalled();
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(getLoopPrompt()).toBe("original loop prompt");
+		expect(showError).toHaveBeenCalledWith("attachment too large");
 	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -21,7 +21,10 @@ function createLoopContext(options: {
 	const setLoopPrompt = vi.fn((prompt: string) => {
 		loopPrompt = prompt;
 	});
-	const prompt = vi.fn(async () => {});
+	const prompt = vi.fn(async () => true);
+	const pauseLoop = vi.fn(() => {
+		loopPrompt = undefined;
+	});
 	const editor = {
 		pendingImages: [],
 		pendingImageLinks: [],
@@ -57,6 +60,7 @@ function createLoopContext(options: {
 			loopPrompt = value;
 		},
 		setLoopPrompt,
+		pauseLoop,
 		flushPendingBashComponents: vi.fn(),
 		startPendingSubmission: vi.fn((input: { text: string }) => ({ ...input, cancelled: false, started: false })),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
@@ -77,6 +81,7 @@ function createLoopContext(options: {
 		ctx,
 		editor,
 		setLoopPrompt,
+		pauseLoop,
 		prompt,
 		getLoopPrompt: () => loopPrompt,
 		queueCompactionMessage: ctx.queueCompactionMessage as Spy,
@@ -175,5 +180,36 @@ describe("loop mode interjections", () => {
 		expect(queueCompactionMessage).toHaveBeenCalledTimes(1);
 		expect(setLoopPrompt).not.toHaveBeenCalled();
 		expect(getLoopPrompt()).toBe("original loop prompt");
+	});
+
+	it("parks the loop when a streamed body is consumed locally", async () => {
+		const { ctx, setLoopPrompt, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: true });
+		// Mirror handleLoopCommand: enabling loop mode hands the inline body
+		// back to the dispatcher for normal submission.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "/void-cmd");
+		// Mirror AgentSession.prompt reporting local consumption (void custom
+		// command) instead of a started turn.
+		prompt.mockResolvedValueOnce(false);
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 /void-cmd");
+
+		expect(setLoopPrompt).toHaveBeenCalledWith("/void-cmd");
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
+	});
+
+	it("parks the loop when a direct submission is consumed locally", async () => {
+		const { ctx, pauseLoop, prompt, getLoopPrompt } = createLoopContext({ isStreaming: false });
+		prompt.mockResolvedValueOnce(false);
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/void-cmd");
+
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(getLoopPrompt()).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -86,4 +86,19 @@ describe("loop mode interjections", () => {
 		expect(setLoopPrompt).toHaveBeenCalledWith("new loop body");
 		expect(onInputCallback).toHaveBeenCalledTimes(1);
 	});
+
+	it("records an inline /loop prompt even while streaming", async () => {
+		const { ctx, setLoopPrompt, prompt, getLoopPrompt } = createLoopContext({ isStreaming: true });
+		// Mirror handleLoopCommand: enabling loop mode hands the inline prompt
+		// back to the dispatcher for normal submission.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "inline loop body");
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 inline loop body");
+
+		expect(setLoopPrompt).toHaveBeenCalledWith("inline loop body");
+		expect(getLoopPrompt()).toBe("inline loop body");
+		expect(prompt).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/input-controller-loop.test.ts
+++ b/packages/coding-agent/test/input-controller-loop.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from "bun:test";
+import { describe, expect, it, type Mock, vi } from "bun:test";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+type Spy = Mock<(...args: unknown[]) => unknown>;
 
-function createLoopContext(options: { isStreaming: boolean; onInputCallback?: (...args: never[]) => void }) {
+function createLoopContext(options: {
+	isStreaming: boolean;
+	isCompacting?: boolean;
+	onInputCallback?: (...args: never[]) => void;
+}) {
 	let loopPrompt: string | undefined = "original loop prompt";
 	const setLoopPrompt = vi.fn((prompt: string) => {
 		loopPrompt = prompt;
@@ -24,7 +29,7 @@ function createLoopContext(options: { isStreaming: boolean; onInputCallback?: (.
 		ui: { requestRender: vi.fn() },
 		session: {
 			isStreaming: options.isStreaming,
-			isCompacting: false,
+			isCompacting: options.isCompacting ?? false,
 			isBashRunning: false,
 			isEvalRunning: false,
 			queuedMessageCount: 0,
@@ -48,7 +53,7 @@ function createLoopContext(options: { isStreaming: boolean; onInputCallback?: (.
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 		updatePendingMessagesDisplay: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
-		showError: vi.fn(),
+		queueCompactionMessage: vi.fn(),
 		onInputCallback: options.onInputCallback,
 		skillCommands: new Map(),
 		fileSlashCommands: new Set<string>(),
@@ -58,7 +63,14 @@ function createLoopContext(options: { isStreaming: boolean; onInputCallback?: (.
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 	} as unknown as InteractiveModeContext;
-	return { ctx, editor, setLoopPrompt, prompt, getLoopPrompt: () => loopPrompt };
+	return {
+		ctx,
+		editor,
+		setLoopPrompt,
+		prompt,
+		getLoopPrompt: () => loopPrompt,
+		queueCompactionMessage: ctx.queueCompactionMessage as Spy,
+	};
 }
 
 describe("loop mode interjections", () => {
@@ -100,5 +112,23 @@ describe("loop mode interjections", () => {
 		expect(setLoopPrompt).toHaveBeenCalledWith("inline loop body");
 		expect(getLoopPrompt()).toBe("inline loop body");
 		expect(prompt).toHaveBeenCalledTimes(1);
+	});
+
+	it("records an inline /loop prompt queued during compaction", async () => {
+		const { ctx, setLoopPrompt, getLoopPrompt, queueCompactionMessage } = createLoopContext({
+			isStreaming: false,
+			isCompacting: true,
+		});
+		// Mirror handleLoopCommand: enabling loop mode hands the inline prompt
+		// back to the dispatcher for normal submission.
+		(ctx as unknown as Record<string, unknown>).handleLoopCommand = vi.fn(async () => "compact loop body");
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		await ctx.editor.onSubmit?.("/loop 3 compact loop body");
+
+		expect(setLoopPrompt).toHaveBeenCalledWith("compact loop body");
+		expect(getLoopPrompt()).toBe("compact loop body");
+		expect(queueCompactionMessage).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -240,4 +240,71 @@ describe("submitInteractiveInput", () => {
 		expect(mode.finishPendingSubmission).toHaveBeenCalledWith(input);
 		expect(mode.showError).not.toHaveBeenCalled();
 	});
+
+	it("parks the loop when dispatch consumes the armed body locally", async () => {
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+			loopPrompt: "/void-cmd",
+			pauseLoop: vi.fn(),
+		};
+		const session = {
+			prompt: vi.fn(async () => false),
+			promptCustomMessage: vi.fn(async () => true),
+			isStreaming: false,
+		};
+		const input = createInput({ text: "/void-cmd" });
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(session.prompt).toHaveBeenCalledWith("/void-cmd", { images: undefined, streamingBehavior: "followUp" });
+		expect(mode.pauseLoop).toHaveBeenCalledTimes(1);
+		expect(mode.showError).not.toHaveBeenCalled();
+	});
+
+	it("keeps the loop armed when dispatch starts a turn", async () => {
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+			loopPrompt: "repeat me",
+			pauseLoop: vi.fn(),
+		};
+		const session = {
+			prompt: vi.fn(async () => true),
+			promptCustomMessage: vi.fn(async () => true),
+			isStreaming: false,
+		};
+		const input = createInput({ text: "repeat me" });
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(mode.pauseLoop).not.toHaveBeenCalled();
+		expect(mode.showError).not.toHaveBeenCalled();
+	});
+
+	it("ignores local consumption when it is not the armed body", async () => {
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+			loopPrompt: "repeat me",
+			pauseLoop: vi.fn(),
+		};
+		const session = {
+			prompt: vi.fn(async () => false),
+			promptCustomMessage: vi.fn(async () => true),
+			isStreaming: false,
+		};
+		const input = createInput({ text: "/other-cmd" });
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(mode.pauseLoop).not.toHaveBeenCalled();
+		expect(mode.showError).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -307,4 +307,54 @@ describe("submitInteractiveInput", () => {
 		expect(mode.pauseLoop).not.toHaveBeenCalled();
 		expect(mode.showError).not.toHaveBeenCalled();
 	});
+
+	it("parks the loop when dispatch rejects the armed body", async () => {
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+			loopPrompt: "failing body",
+			pauseLoop: vi.fn(),
+		};
+		const session = {
+			prompt: vi.fn(async () => {
+				throw new Error("attachment too large");
+			}),
+			promptCustomMessage: vi.fn(async () => true),
+			isStreaming: false,
+		};
+		const input = createInput({ text: "failing body" });
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(mode.pauseLoop).toHaveBeenCalledTimes(1);
+		expect(mode.showError).toHaveBeenCalledWith("attachment too large");
+		expect(mode.finishPendingSubmission).toHaveBeenCalledWith(input);
+	});
+
+	it("ignores dispatch rejection when it is not the armed body", async () => {
+		const mode = {
+			markPendingSubmissionStarted: vi.fn(() => true),
+			finishPendingSubmission: vi.fn(),
+			showError: vi.fn(),
+			checkShutdownRequested: vi.fn(async () => {}),
+			loopPrompt: "repeat me",
+			pauseLoop: vi.fn(),
+		};
+		const session = {
+			prompt: vi.fn(async () => {
+				throw new Error("attachment too large");
+			}),
+			promptCustomMessage: vi.fn(async () => true),
+			isStreaming: false,
+		};
+		const input = createInput({ text: "/other-cmd" });
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(mode.pauseLoop).not.toHaveBeenCalled();
+		expect(mode.showError).toHaveBeenCalledWith("attachment too large");
+		expect(mode.finishPendingSubmission).toHaveBeenCalledWith(input);
+	});
 });


### PR DESCRIPTION
What

Mid-turn interjections (Enter while streaming → steer) no longer replace the /loop repeating prompt. setLoopPrompt moved past the compaction /
extension-command / streaming-steer early returns in input-controller.ts, so only an idle submission becomes the new loop body. Previously
every Enter submission overwrote loopPrompt, causing the interjection to re-run every iteration.

Why

Interjecting into a /loop run replaced the loop body with the interjection, which then auto-resubmitted forever (e.g. overnight quota burn on
repeated "Acknowledged." turns). Steers, /queue, Ctrl+Enter follow-ups, and compaction queues are one-off inputs and should never become the
loop body. No linked issue.

Testing

- New regression test test/input-controller-loop.test.ts: steer-while-streaming keeps "original loop prompt"; idle submit adopts the new
  prompt.
- bun test test/input-controller-loop.test.ts test/interactive-mode-loop.test.ts test/input-controller-escape.test.ts
  test/input-controller-orphan-submit.test.ts — 49 pass, 0 fail.
- bun check (oxlint + format + tsgo --noEmit) clean.


- bun check passes
- Tested locally
- CHANGELOG updated (if user-facing)
