### PR TITLE
feat(coding-agent): clarify subagent model badges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
+### Changed
+
+- When enabled (`task.showResolvedModelBadge`), subagent model badges show the thinking-level icon, model name, and attached-advisor eye before the agent name in task, eval, job, and HUD rows.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -27,7 +27,8 @@ import { getModelMatchPreferences, resolveModelRoleValue } from "../../config/mo
 import { getKnownRoleIds, getRoleInfo, MODEL_ROLE_IDS } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import type { ModelPerfStats } from "../../session/agent-storage";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../../thinking";
+import { type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../../thinking";
+import { thinkingLevelGlyph as sharedThinkingLevelGlyph } from "../../tools/render-utils";
 import { type ThemeColor, theme } from "../theme/theme";
 import {
 	matchesSelectCancel,
@@ -326,29 +327,9 @@ function modelSearchTier(query: string, item: ModelBrowserItem): number {
 	return 2;
 }
 
-/** Compact glyph for a configured thinking level; empty for `inherit` (nothing to show). */
+/** Compact glyph for a configured thinking level using the active theme. */
 export function thinkingLevelGlyph(level: ConfiguredThinkingLevel): string {
-	const glyphOf = (symbol: string) => symbol.split(" ")[0] ?? symbol;
-	switch (level) {
-		case AUTO_THINKING:
-			return glyphOf(theme.thinking.autoPending);
-		case ThinkingLevel.Off:
-			return theme.status.disabled;
-		case ThinkingLevel.Minimal:
-			return glyphOf(theme.thinking.minimal);
-		case ThinkingLevel.Low:
-			return glyphOf(theme.thinking.low);
-		case ThinkingLevel.Medium:
-			return glyphOf(theme.thinking.medium);
-		case ThinkingLevel.High:
-			return glyphOf(theme.thinking.high);
-		case ThinkingLevel.XHigh:
-			return glyphOf(theme.thinking.xhigh);
-		case ThinkingLevel.Max:
-			return glyphOf(theme.thinking.max);
-		case ThinkingLevel.Inherit:
-			return "";
-	}
+	return sharedThinkingLevelGlyph(level, theme);
 }
 
 /**

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -32,6 +32,7 @@ import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValu
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import { thinkingLevelGlyph } from "../../tools/render-utils";
 import { theme } from "../theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
@@ -41,7 +42,6 @@ import {
 	type RoleAssignments,
 	resolveRoleAssignments,
 	sortModelItems,
-	thinkingLevelGlyph,
 } from "./model-browser";
 import { bottomBorder, dividerSplit, row, splitBodyWidth, splitRow, topBorderSplit } from "./overlay-box";
 import { renderSegmentTrack } from "./segment-track";
@@ -955,7 +955,7 @@ export class ModelHubComponent implements Component {
 				: (this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit);
 		const chips: StripChip[] = options.map(level => {
 			const label = getConfiguredThinkingLevelMetadata(level).label;
-			const glyph = thinkingLevelGlyph(level);
+			const glyph = thinkingLevelGlyph(level, theme);
 			return {
 				label,
 				styled: glyph ? `${theme.fg("accent", glyph)} ${label}` : label,
@@ -1882,7 +1882,7 @@ export class ModelHubComponent implements Component {
 				dot = theme.fg(info.color ?? "muted", theme.status.enabled);
 				tagStyled = theme.fg(info.color ?? "muted", tag);
 				value = `${theme.fg("dim", `${assignment.model.provider}/`)}${selected ? theme.fg("accent", assignment.model.id) : assignment.model.id}`;
-				const glyph = thinkingLevelGlyph(assignment.thinkingLevel);
+				const glyph = thinkingLevelGlyph(assignment.thinkingLevel, theme);
 				const label = getConfiguredThinkingLevelMetadata(assignment.thinkingLevel).label;
 				if (assignment.thinkingLevel !== ThinkingLevel.Inherit) {
 					levelStyled = theme.fg("dim", glyph ? `${glyph} ${label}` : label);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -127,7 +127,16 @@ import { tinyTitleClient } from "../tiny/title-client";
 import { isMCPToolName } from "../tools/builtin-names";
 import type { LspStartupServerInfo } from "../tools";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
-import { formatMoreItems, replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
+import {
+	FEED_MODEL_BADGE_WIDTH,
+	formatFeedModelBadge,
+	formatMoreItems,
+	isFeedModelBadgeEnabled,
+	replaceTabs,
+	shortenPath,
+	TRUNCATE_LENGTHS,
+	truncateToWidth,
+} from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
 import {
 	formatPhaseDisplayName,
@@ -514,35 +523,55 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 	const dot = theme.styledSymbol("status.done", "accent");
 	const visible = running.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
 	const hiddenCount = running.length - visible.length;
+	const showModelBadge = isFeedModelBadgeEnabled();
+	const outerIndent = " ";
 	const rows = renderTreeList(
 		{
 			items: visible,
 			expanded: true,
-			renderItem: session => {
-				const displayId = formatTaskId(session.id);
+			renderItem: (session, context) => {
+				const rowWidth = Math.max(0, columns - visibleWidth(outerIndent) - (context.prefixWidth ?? 0));
 				const role = session.agent ?? session.progress?.agent;
-				const badge = agentTypeBadge(role, theme);
-				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
+				const displayId = truncateToWidth(
+					formatTaskId(session.id),
+					Math.max(0, rowWidth - visibleWidth(`${dot} `)),
+				);
+				const badge = truncateToWidth(
+					agentTypeBadge(role, theme),
+					Math.max(0, rowWidth - visibleWidth(`${dot} ${displayId}`)),
+				);
+				const titleBudget = Math.max(0, rowWidth - visibleWidth(`${dot} ${displayId}${badge}`));
+				const modelBadge = showModelBadge
+					? formatFeedModelBadge(
+							session.progress?.resolvedModelIdentity ?? session.progress?.resolvedModel,
+							session.progress?.resolvedThinkingLevel,
+							session.progress?.advisor,
+							theme,
+							Math.min(FEED_MODEL_BADGE_WIDTH, Math.max(0, titleBudget - 1)),
+						)
+					: "";
+				const modelLead = modelBadge ? `${modelBadge} ` : "";
+				let line = `${dot} ${modelLead}${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
 				const distinctDescription =
 					description && !labelEchoesHandle(session.id, description) ? description : undefined;
 				if (distinctDescription) {
-					const budget = Math.max(
-						TRUNCATE_LENGTHS.SHORT,
-						columns - visibleWidth(displayId) - visibleWidth(Bun.stripANSI(badge)) - 10,
-					);
+					const budget = Math.max(0, rowWidth - visibleWidth(line) - visibleWidth(": "));
 					const formatted = replaceTabs(distinctDescription).replace(/\s*[\r\n]+\s*/g, " ↵ ");
-					line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(formatted, budget))}`;
+					if (budget > 0) {
+						line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(formatted, budget))}`;
+					}
 				} else {
 					// No spawn description: fall back to a muted task preview, same as
 					// the inline task rows when a row has no label.
 					const taskPreview = session.progress?.task?.trim();
 					if (taskPreview && !labelEchoesHandle(session.id, taskPreview)) {
 						const formatted = replaceTabs(taskPreview).replace(/\s*[\r\n]+\s*/g, " ↵ ");
-						line += ` ${theme.fg("muted", truncateToWidth(formatted, TRUNCATE_LENGTHS.SHORT))}`;
+						const budget = Math.min(TRUNCATE_LENGTHS.SHORT, Math.max(0, rowWidth - visibleWidth(line) - 1));
+						if (budget > 0) line += ` ${theme.fg("muted", truncateToWidth(formatted, budget))}`;
 					}
 				}
-				return line;
+				return truncateToWidth(line, rowWidth, "");
 			},
 		},
 		theme,
@@ -550,7 +579,11 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 	if (hiddenCount > 0) {
 		rows.push(theme.fg("dim", `… ${hiddenCount} more running — open Agent Hub for full list`));
 	}
-	return ["", theme.bold(theme.fg("accent", "Subagents")), ...rows.map(line => ` ${line}`)];
+	return [
+		"",
+		truncateToWidth(theme.bold(theme.fg("accent", "Subagents")), columns),
+		...rows.map(line => truncateToWidth(`${outerIndent}${line}`, columns, "")),
+	];
 }
 
 const CTRL_L_APPEARANCE_RESPONSE_DEADLINE_MS = 2000;

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -61,6 +61,10 @@ export interface ActiveRetryFallbackState {
 export interface ServingModel {
 	/** Full selector including routing and thinking level. */
 	selector: string;
+	/** Provider/id including routing, with no added thinking suffix. */
+	modelIdentity?: string;
+	/** Concrete thinking level captured with the attributed model. */
+	thinkingLevel?: ThinkingLevel;
 	/** Whether fallback routing, rather than the configured primary, owns it. */
 	isFallback: boolean;
 }

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -367,6 +367,8 @@ export class TurnRecovery {
 		}
 		const value: ServingModel = {
 			selector: formatRetryFallbackSelector(model, level),
+			modelIdentity: formatModelStringWithRouting(model),
+			thinkingLevel: level,
 			isFallback: this.#fallbackRouted,
 		};
 		this.#bootstrapCache = { model, level, routed: this.#fallbackRouted, value };
@@ -420,9 +422,12 @@ export class TurnRecovery {
 		}
 		const model = this.#host.model();
 		if (model) {
+			const level = this.#host.thinkingLevel();
 			this.#lastServed = {
 				attribution: {
-					selector: formatRetryFallbackSelector(model, this.#host.thinkingLevel()),
+					selector: formatRetryFallbackSelector(model, level),
+					modelIdentity: formatModelStringWithRouting(model),
+					thinkingLevel: level,
 					isFallback: this.#fallbackRouted,
 				},
 				sessionId: this.#host.sessionManager.getSessionId(),

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1769,6 +1769,15 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		scheduleProgress(flushProgress);
 	};
 
+	const publishAdvisorState = (session: AgentSession | null): void => {
+		// A runtime can attach after startup when model discovery finishes.
+		// Retain this run's advised state through teardown for settled badges.
+		if (!progress.advisor && session?.isAdvisorActive() === true) {
+			progress.advisor = true;
+			scheduleProgress(true);
+		}
+	};
+
 	const attach = (session: AgentSession): (() => void) => {
 		// The session owns attribution: it knows which model produced its output
 		// and withholds an armed-but-unproven fallback. Re-deriving that here from
@@ -1781,16 +1790,21 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			const isFallback = serving.isFallback;
 			if (
 				serving.selector === progress.resolvedModel &&
+				serving.modelIdentity === progress.resolvedModelIdentity &&
+				serving.thinkingLevel === progress.resolvedThinkingLevel &&
 				(progress.resolvedModelIsFallback ?? false) === isFallback
 			) {
 				return;
 			}
 			progress.resolvedModel = serving.selector;
+			progress.resolvedModelIdentity = serving.modelIdentity;
+			progress.resolvedThinkingLevel = serving.thinkingLevel;
 			progress.resolvedModelIsFallback = isFallback;
 			scheduleProgress(true);
 		};
 		return session.subscribe(event => {
 			emitSubagentEvent(event);
+			publishAdvisorState(session);
 			publishServingModel();
 			if (event.type === "auto_retry_start") {
 				progress.retryState = {
@@ -1906,6 +1920,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		resolveAbortReasonText,
 		setActiveSession: session => {
 			activeSession = session;
+			publishAdvisorState(session);
 		},
 		takeActiveSession: () => {
 			const session = activeSession;
@@ -2414,7 +2429,10 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		modelOverride,
 		modelRole,
 		resolvedModel: progress.resolvedModel,
+		resolvedModelIdentity: progress.resolvedModelIdentity,
+		resolvedThinkingLevel: progress.resolvedThinkingLevel,
 		resolvedModelIsFallback: progress.resolvedModelIsFallback,
+		advisor: progress.advisor,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,
@@ -3220,10 +3238,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					: undefined;
 			if (model) {
 				const displayLevel = effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : undefined);
+				progress.resolvedModelIdentity = formatModelStringWithRouting(model);
+				progress.resolvedThinkingLevel = displayLevel;
 				progress.resolvedModel =
 					displayLevel !== undefined
-						? formatModelSelectorValue(formatModelStringWithRouting(model), displayLevel)
-						: formatModelStringWithRouting(model);
+						? formatModelSelectorValue(progress.resolvedModelIdentity, displayLevel)
+						: progress.resolvedModelIdentity;
 			}
 			// Precedence: caller `effort` > explicit `:level` suffix on the resolved
 			// model pattern > agent-definition default (e.g. task's `auto`) >

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1156,8 +1156,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							// status back to the subagent's initial "pending" snapshot.
 							progress.modelRole = nextProgress.modelRole ?? progress.modelRole;
 							progress.resolvedModel = nextProgress.resolvedModel;
-							progress.resolvedModelIsFallback =
-								nextProgress.resolvedModelIsFallback ?? progress.resolvedModelIsFallback;
+							progress.resolvedModelIdentity = nextProgress.resolvedModelIdentity;
+							progress.resolvedThinkingLevel = nextProgress.resolvedThinkingLevel;
+							progress.resolvedModelIsFallback = nextProgress.resolvedModel
+								? nextProgress.resolvedModelIsFallback
+								: undefined;
+							progress.advisor = nextProgress.advisor ?? progress.advisor;
 							progress.tokens = nextProgress.tokens;
 							progress.requests = nextProgress.requests;
 							progress.contextTokens = nextProgress.contextTokens;
@@ -1213,12 +1217,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					progress.retryFailure = singleResult?.retryFailure;
 					progress.retryState = undefined;
 					progress.modelRole = singleResult?.modelRole ?? progress.modelRole;
+					progress.advisor = singleResult?.advisor ?? progress.advisor;
 					if (singleResult?.resolvedModel) {
 						progress.resolvedModel = singleResult.resolvedModel;
-						progress.resolvedModelIsFallback =
-							singleResult.resolvedModelIsFallback ?? progress.resolvedModelIsFallback;
+						progress.resolvedModelIdentity = singleResult.resolvedModelIdentity;
+						progress.resolvedThinkingLevel = singleResult.resolvedThinkingLevel;
+						progress.resolvedModelIsFallback = singleResult.resolvedModelIsFallback;
 					} else {
 						delete progress.resolvedModel;
+						delete progress.resolvedModelIdentity;
+						delete progress.resolvedThinkingLevel;
 						delete progress.resolvedModelIsFallback;
 					}
 					onSettled?.(resultFailed);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -6,20 +6,22 @@
  */
 import path from "node:path";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Container, Markdown, Text } from "@oh-my-pi/pi-tui";
+import { Container, Markdown, Text, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
-import { settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
 import { stripGeneratedOutputNotice, stripRawOutputArtifactNotice } from "../tools/output-meta";
 import {
 	capPreviewLines,
+	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
 	formatDuration,
 	formatExpandHint,
+	formatFeedModelBadge,
 	formatMoreItems,
 	formatStatusIcon,
+	isFeedModelBadgeEnabled,
 	previewLine,
 	previewWindowRows,
 	replaceTabs,
@@ -34,7 +36,7 @@ import {
 	parseFindingDetails,
 	type SubmitReviewDetails,
 } from "../tools/review";
-import { framedBlock, renderStatusLine } from "../tui";
+import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../tui";
 import { repairDoubleEncodedJsonString } from "./repair-args";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import type { AgentProgress, SingleResult, TaskItem, TaskParams, TaskToolDetails, YieldItem } from "./types";
@@ -97,8 +99,6 @@ function appendAgentStats(
 		contextTokens?: number;
 		contextWindow?: number;
 		cost: number;
-		resolvedModel?: string;
-		showResolvedModelBadge?: boolean;
 	},
 	theme: Theme,
 ): string {
@@ -118,9 +118,6 @@ function appendAgentStats(
 	}
 	if (opts.cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${opts.cost.toFixed(2)}`)}`;
-	}
-	if (opts.resolvedModel && opts.showResolvedModelBadge) {
-		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(opts.resolvedModel), 30))}`;
 	}
 	return line;
 }
@@ -882,6 +879,17 @@ export function renderCall(args: TaskParams, options: TaskRenderOptions, theme: 
 	});
 }
 
+function truncateTaskRow(text: string, width: number, ellipsis?: ""): string {
+	return Number.isFinite(width) ? truncateToWidth(text, width, ellipsis) : text;
+}
+
+function renderDescriptionLines(description: string, prefix: string, width: number, theme: Theme): string[] {
+	if (!Number.isFinite(width)) return description.split("\n").map(line => `${prefix}${theme.fg("dim", line)}`);
+	const boundedPrefix = truncateToWidth(prefix, Math.max(0, width - 1), "");
+	const contentWidth = Math.max(1, width - visibleWidth(boundedPrefix));
+	return wrapTextWithAnsi(description, contentWidth).map(line => `${boundedPrefix}${theme.fg("dim", line)}`);
+}
+
 /**
  * Render streaming progress for a single agent.
  */
@@ -896,6 +904,7 @@ function renderAgentProgress(
 	seenNestedTasks?: WeakSet<object>,
 	nestedDepth = 0,
 	nowMs = Date.now(),
+	maxWidth = Number.POSITIVE_INFINITY,
 ): string[] {
 	const lines: string[] = [];
 
@@ -907,12 +916,50 @@ function renderAgentProgress(
 				? "error"
 				: "accent";
 
-	// Main status line: id: description [status] · stats · ⟨agent⟩
-	const trimmedDescription = progress.description?.trim();
-	const description = trimmedDescription ? previewLine(sanitizeText(trimmedDescription), 64) : undefined;
-	const displayId = formatTaskId(progress.id);
-	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
+	// Reserve the name and required badges before optional model metadata and details.
+	const fullDescription = progress.description ? sanitizeText(progress.description).trim() : undefined;
 	const indent = prefix ? `${prefix} ` : "";
+	let statusBadge = "";
+	// Provider retry state takes precedence over the generic failure marker.
+	if (progress.retryState && progress.status === "running") {
+		statusBadge = ` ${formatBadge("retrying", "warning", theme)}`;
+	} else if (progress.retryFailure && (progress.status === "failed" || progress.status === "aborted")) {
+		statusBadge = ` ${formatBadge("rate-limited", "error", theme)}`;
+	} else if (progress.status === "failed" || progress.status === "aborted") {
+		statusBadge = ` ${formatBadge(progress.status, iconColor, theme)}`;
+	}
+	const rowIcon =
+		progress.status === "running" || progress.status === "pending" || progress.status === "completed"
+			? theme.status.done
+			: icon;
+	const displayId = truncateTaskRow(
+		formatTaskId(progress.id),
+		Math.max(0, maxWidth - visibleWidth(`${indent}${rowIcon} ${statusBadge}`)),
+	);
+	const roleBadge = truncateTaskRow(
+		agentTypeBadge(progress.agent, theme),
+		Math.max(0, maxWidth - visibleWidth(`${indent}${rowIcon} ${displayId}${statusBadge}`)),
+	);
+	const badges = `${roleBadge}${statusBadge}`;
+	const modelBadge = isFeedModelBadgeEnabled()
+		? formatFeedModelBadge(
+				progress.resolvedModelIdentity ?? progress.resolvedModel,
+				progress.resolvedThinkingLevel,
+				progress.advisor,
+				theme,
+				Math.min(
+					FEED_MODEL_BADGE_WIDTH,
+					Math.max(0, maxWidth - visibleWidth(`${indent}${rowIcon} ${displayId}${badges}`) - 1),
+				),
+			)
+		: "";
+	const modelLead = modelBadge ? `${modelBadge} ` : "";
+	const description =
+		fullDescription &&
+		visibleWidth(`${indent}${rowIcon} ${modelLead}${displayId}: ${fullDescription}${badges}`) <= maxWidth
+			? fullDescription
+			: undefined;
+	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
 	let statusLine: string;
 	if (progress.status === "running" || progress.status === "pending") {
 		// Live (or queued) agents use the same dot finished rows keep: detached
@@ -922,44 +969,33 @@ function renderAgentProgress(
 		const dot = theme.styledSymbol("status.done", frozen ? "dim" : "accent");
 		const nameColor = frozen ? "dim" : "accent";
 		const name = theme.fg(nameColor, description ? theme.bold(displayId) : displayId);
-		statusLine = `${indent}${dot} ${name}`;
+		statusLine = `${indent}${dot} ${modelLead}${name}`;
 		if (description) {
 			statusLine += `${theme.fg(nameColor, ":")} ${theme.fg(nameColor, description)}`;
 		}
 	} else if (progress.status === "completed") {
 		// Finished rows keep the dot but settle from accent to the plain
 		// foreground: completion reads as a color change, not a new glyph.
-		statusLine = `${indent}${theme.styledSymbol("status.done", "text")} ${theme.fg("text", titlePart)}`;
+		statusLine = `${indent}${theme.styledSymbol("status.done", "text")} ${modelLead}${theme.fg("text", titlePart)}`;
 	} else {
-		statusLine = `${indent}${theme.fg(iconColor, icon)} ${theme.fg("accent", titlePart)}`;
+		statusLine = `${indent}${theme.fg(iconColor, icon)} ${modelLead}${theme.fg("accent", titlePart)}`;
 	}
-	statusLine += agentTypeBadge(progress.agent, theme);
+	statusLine += badges;
 
-	// Show retry-blocked badge so the parent immediately sees that a child
-	// is sleeping on a provider 429, not silently progressing. Wins over the
-	// generic running marker because "we're waiting on a quota window" is
-	// the operationally meaningful state.
-	if (progress.retryState && progress.status === "running") {
-		statusLine += ` ${formatBadge("retrying", "warning", theme)}`;
-	} else if (progress.retryFailure && (progress.status === "failed" || progress.status === "aborted")) {
-		statusLine += ` ${formatBadge("rate-limited", "error", theme)}`;
-	} else if (progress.status === "failed" || progress.status === "aborted") {
-		const statusLabel = progress.status === "failed" ? "failed" : "aborted";
-		statusLine += ` ${formatBadge(statusLabel, iconColor, theme)}`;
-	}
-
-	const showBadge = settings.get("task.showResolvedModelBadge");
 	if (progress.status === "running") {
-		if (!description) {
+		if (!fullDescription) {
 			const taskPreview = previewLine(sanitizeText(progress.assignment ?? progress.task), 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
-		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
+		statusLine = appendAgentStats(statusLine, progress, theme);
 	} else if (progress.status === "completed") {
-		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
+		statusLine = appendAgentStats(statusLine, progress, theme);
 	}
 
-	lines.push(statusLine);
+	lines.push(truncateTaskRow(statusLine, maxWidth, ""));
+	if (fullDescription && !description) {
+		lines.push(...renderDescriptionLines(fullDescription, continuePrefix, maxWidth, theme));
+	}
 
 	lines.push(...renderTaskSection(progress.assignment ?? progress.task, continuePrefix, expanded, theme));
 
@@ -1088,6 +1124,7 @@ function renderAgentProgress(
 			seenNestedTasks,
 			nestedDepth,
 			nowMs,
+			Math.max(0, maxWidth - visibleWidth(continuePrefix)),
 		);
 		for (const line of nestedLines) {
 			lines.push(`${continuePrefix}${line}`);
@@ -1218,6 +1255,7 @@ function renderAgentResult(
 	theme: Theme,
 	seenNestedTasks?: WeakSet<object>,
 	nestedDepth = 0,
+	maxWidth = Number.POSITIVE_INFINITY,
 ): string[] {
 	const lines: string[] = [];
 
@@ -1244,16 +1282,42 @@ function renderAgentResult(
 					? "merge failed"
 					: "failed";
 
-	// Main status line: id: description [status] · stats · ⟨agent⟩
-	const trimmedDescription = result.description ? sanitizeText(result.description).trim() : undefined;
-	const description = trimmedDescription ? previewLine(trimmedDescription, 64) : undefined;
-	const displayId = formatTaskId(result.id);
+	// Reserve the name and required badges before optional model metadata and details.
+	const fullDescription = result.description ? sanitizeText(result.description).trim() : undefined;
+	const indent = prefix ? `${prefix} ` : "";
+	const statusBadge = ` ${formatBadge(statusText, iconColor, theme)}`;
+	const displayId = truncateTaskRow(
+		formatTaskId(result.id),
+		Math.max(0, maxWidth - visibleWidth(`${indent}${icon} ${statusBadge}`)),
+	);
+	const roleBadge = truncateTaskRow(
+		agentTypeBadge(result.agent, theme),
+		Math.max(0, maxWidth - visibleWidth(`${indent}${icon} ${displayId}${statusBadge}`)),
+	);
+	const badges = `${roleBadge}${statusBadge}`;
+	const modelBadge = isFeedModelBadgeEnabled()
+		? formatFeedModelBadge(
+				result.resolvedModelIdentity ?? result.resolvedModel,
+				result.resolvedThinkingLevel,
+				result.advisor,
+				theme,
+				Math.min(
+					FEED_MODEL_BADGE_WIDTH,
+					Math.max(0, maxWidth - visibleWidth(`${indent}${icon} ${displayId}${badges}`) - 1),
+				),
+			)
+		: "";
+	const modelLead = modelBadge ? `${modelBadge} ` : "";
+	const description =
+		fullDescription &&
+		visibleWidth(`${indent}${icon} ${modelLead}${displayId}: ${fullDescription}${badges}`) <= maxWidth
+			? fullDescription
+			: undefined;
 	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
-	let statusLine = `${prefix ? `${prefix} ` : ""}${theme.fg(iconColor, icon)} ${theme.fg(
+	let statusLine = `${indent}${theme.fg(iconColor, icon)} ${modelLead}${theme.fg(
 		success && !needsWarning ? "text" : "accent",
 		titlePart,
-	)}${agentTypeBadge(result.agent, theme)} ${formatBadge(statusText, iconColor, theme)}`;
-	const showBadge = settings.get("task.showResolvedModelBadge");
+	)}${badges}`;
 	statusLine = appendAgentStats(
 		statusLine,
 		{
@@ -1262,8 +1326,6 @@ function renderAgentResult(
 			contextTokens: result.contextTokens,
 			contextWindow: result.contextWindow,
 			cost: result.usage?.cost.total ?? 0,
-			resolvedModel: result.resolvedModel,
-			showResolvedModelBadge: showBadge,
 		},
 		theme,
 	);
@@ -1273,7 +1335,10 @@ function renderAgentResult(
 		statusLine += ` ${theme.fg("warning", "[truncated]")}`;
 	}
 
-	lines.push(statusLine);
+	lines.push(truncateTaskRow(statusLine, maxWidth, ""));
+	if (fullDescription && !description) {
+		lines.push(...renderDescriptionLines(fullDescription, continuePrefix, maxWidth, theme));
+	}
 
 	lines.push(...renderTaskSection(result.assignment ?? result.task, continuePrefix, expanded, theme));
 
@@ -1336,6 +1401,7 @@ function renderAgentResult(
 					theme,
 					seenNestedTasks,
 					nestedDepth,
+					Math.max(0, maxWidth - visibleWidth(continuePrefix)),
 				)) {
 					deferredToolLines.push(`${continuePrefix}${line}`);
 				}
@@ -1571,6 +1637,7 @@ export function renderResult(
 		const frozen = options.renderContext?.frozen === true;
 		const nowMs = options.renderContext?.nowMs ?? Date.now();
 		const lines: string[] = [];
+		const contentWidth = outputBlockContentWidth(width);
 
 		// Result rows win once any exist; progress rows for spawns without a
 		// result (a mixed call's async subset) render as a supplement below.
@@ -1588,14 +1655,26 @@ export function renderResult(
 			}
 			for (const progress of visible) {
 				lines.push(
-					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
+					...renderAgentProgress(
+						progress,
+						"",
+						"  ",
+						expanded,
+						theme,
+						spinnerFrame,
+						frozen,
+						undefined,
+						0,
+						nowMs,
+						contentWidth,
+					),
 				);
 			}
 		} else if (details.results && details.results.length > 0) {
 			const ordered = orderResultsForDisplay(details.results);
 			const visible = expanded ? ordered : selectCollapsedResults(ordered);
 			for (const res of visible) {
-				lines.push(...renderAgentResult(res, "", "  ", expanded, theme));
+				lines.push(...renderAgentResult(res, "", "  ", expanded, theme, undefined, 0, contentWidth));
 			}
 			if (visible.length < ordered.length) {
 				const hint = formatExpandHint(theme, false, true);
@@ -1615,7 +1694,19 @@ export function renderResult(
 				: [];
 			for (const progress of supplementalProgress) {
 				lines.push(
-					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
+					...renderAgentProgress(
+						progress,
+						"",
+						"  ",
+						expanded,
+						theme,
+						spinnerFrame,
+						frozen,
+						undefined,
+						0,
+						nowMs,
+						contentWidth,
+					),
 				);
 			}
 
@@ -1711,6 +1802,7 @@ function renderNestedTaskResults(
 	theme: Theme,
 	seen: WeakSet<object> = new WeakSet<object>(),
 	depth = 0,
+	maxWidth = Number.POSITIVE_INFINITY,
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
@@ -1732,7 +1824,7 @@ function renderNestedTaskResults(
 		const hiddenCount = ordered.length - visible.length;
 		visible.forEach((result, index) => {
 			const { prefix, continuePrefix } = nestedMarkers(hiddenCount === 0 && index === visible.length - 1, theme);
-			lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1));
+			lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1, maxWidth));
 		});
 		if (hiddenCount > 0) {
 			const { prefix } = nestedMarkers(true, theme);
@@ -1757,6 +1849,7 @@ function renderNestedTaskTree(
 	seen: WeakSet<object> = new WeakSet<object>(),
 	depth = 0,
 	nowMs = Date.now(),
+	maxWidth = Number.POSITIVE_INFINITY,
 ): string[] {
 	const lines: string[] = [];
 	for (const details of detailsList) {
@@ -1776,7 +1869,9 @@ function renderNestedTaskTree(
 			const hiddenCount = ordered.length - visible.length;
 			visible.forEach((result, index) => {
 				const { prefix, continuePrefix } = nestedMarkers(hiddenCount === 0 && index === visible.length - 1, theme);
-				lines.push(...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1));
+				lines.push(
+					...renderAgentResult(result, prefix, continuePrefix, expanded, theme, seen, depth + 1, maxWidth),
+				);
 			});
 			if (hiddenCount > 0) {
 				const { prefix } = nestedMarkers(true, theme);
@@ -1804,6 +1899,7 @@ function renderNestedTaskTree(
 						seen,
 						depth + 1,
 						nowMs,
+						maxWidth,
 					),
 				);
 			});

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -451,8 +451,14 @@ export interface AgentProgress {
 	modelRole?: string;
 	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Undefined when the model could not be resolved. */
 	resolvedModel?: string;
+	/** Provider/id including routing, with no added thinking suffix. */
+	resolvedModelIdentity?: string;
+	/** Explicit thinking metadata; never inferred from the model identity. */
+	resolvedThinkingLevel?: ConfiguredThinkingLevel;
 	/** True when {@link resolvedModel} is the target of an active retry fallback (not the originally configured model). Lets observer-only UIs (collab guests, Agent Hub rows with no live session) flag the fallback and keep the provider. */
 	resolvedModelIsFallback?: boolean;
+	/** True when a live advisor was attached to this run's session, not merely enabled in settings. */
+	advisor?: boolean;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -522,8 +528,14 @@ export interface SingleResult {
 	modelRole?: string;
 	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Omitted from tool-result JSON when undefined to keep wire payloads small. */
 	resolvedModel?: string;
+	/** Retains the unambiguous identity from {@link AgentProgress.resolvedModelIdentity}. */
+	resolvedModelIdentity?: string;
+	/** Retains {@link AgentProgress.resolvedThinkingLevel} after settlement. */
+	resolvedThinkingLevel?: ConfiguredThinkingLevel;
 	/** True when {@link resolvedModel} is the target of an active retry fallback. Mirrors {@link AgentProgress.resolvedModelIsFallback} onto the settled result. */
 	resolvedModelIsFallback?: boolean;
+	/** Retains {@link AgentProgress.advisor} after the advised session is disposed. */
+	advisor?: boolean;
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -10,14 +10,14 @@
  * initialization`.
  */
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Markdown, Text } from "@oh-my-pi/pi-tui";
-import { formatNumber } from "@oh-my-pi/pi-utils";
-import { settings } from "../config/settings";
+import { Markdown, Text, visibleWidth } from "@oh-my-pi/pi-tui";
+import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import type { EvalCellResult, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
+import { parseConfiguredThinkingLevel } from "../thinking";
 import { markFramedBlockComponent, outputBlockContentWidth, renderCodeCell } from "../tui";
 import { formatEvalCodeForDisplay } from "./eval-format";
 import {
@@ -31,10 +31,13 @@ import {
 } from "./json-tree";
 import { formatStyledTruncationWarning, stripOutputNotice } from "./output-meta";
 import {
+	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
 	formatDuration,
+	formatFeedModelBadge,
 	formatStatusIcon,
 	formatTitle,
+	isFeedModelBadgeEnabled,
 	previewWindowRows,
 	replaceTabs,
 	shortenPath,
@@ -138,7 +141,7 @@ function agentEventStatus(value: unknown): AgentEventStatus {
 	}
 }
 
-/** Append the toolCount · context · cost · model stat run, mirroring the task tool. */
+/** Append the toolCount · context · cost stat run, mirroring the task tool. */
 function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	let line = "";
 	const toolCount = eventNumber(event.toolCount);
@@ -158,10 +161,6 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	if (cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${cost.toFixed(2)}`)}`;
 	}
-	const model = eventString(event.model);
-	if (model && settings.get("task.showResolvedModelBadge")) {
-		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(model), 30))}`;
-	}
 	return line;
 }
 
@@ -170,7 +169,12 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
  * subagent: a status line (icon · id · stats) plus, while running, the current
  * tool/intent. Drawn below the cell box so progress streams live.
  */
-function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spinnerFrame?: number): string[] {
+function renderAgentProgressEvents(
+	events: EvalStatusEvent[],
+	theme: Theme,
+	width: number,
+	spinnerFrame?: number,
+): string[] {
 	const lines: string[] = [];
 	for (let i = 0; i < events.length; i++) {
 		const event = events[i];
@@ -196,12 +200,30 @@ function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spin
 				? theme.styledSymbol("tool.eval", "accent")
 				: theme.fg(iconColor, formatStatusIcon(iconStatus, theme, status === "running" ? spinnerFrame : undefined));
 
-		const id = eventString(event.id) ?? "agent";
-		let line = `${prefix} ${icon} ${theme.fg("accent", theme.bold(id))}`;
-
-		if (status === "failed" || status === "aborted") {
-			line += ` ${formatBadge(status, iconColor, theme)}`;
-		}
+		const lead = `${prefix} ${icon} `;
+		const statusSuffix =
+			status === "failed" || status === "aborted" ? ` ${formatBadge(status, iconColor, theme)}` : "";
+		const id = truncateToWidth(
+			sanitizeText(eventString(event.id) ?? "agent").replace(/\s+/g, " "),
+			Math.max(0, width - visibleWidth(lead) - visibleWidth(statusSuffix)),
+		);
+		const model = eventString(event.resolvedModelIdentity ?? event.model ?? event.resolvedModel);
+		const thinkingLevel = parseConfiguredThinkingLevel(eventString(event.resolvedThinkingLevel));
+		const modelPrefix =
+			model && isFeedModelBadgeEnabled()
+				? formatFeedModelBadge(
+						model,
+						thinkingLevel,
+						event.advisor === true,
+						theme,
+						Math.min(
+							FEED_MODEL_BADGE_WIDTH,
+							width - visibleWidth(lead) - visibleWidth(id) - visibleWidth(statusSuffix) - 1,
+						),
+					)
+				: "";
+		const modelLead = modelPrefix ? `${modelPrefix} ` : "";
+		let line = `${lead}${modelLead}${theme.fg("accent", theme.bold(id))}${statusSuffix}`;
 
 		const currentTool = eventString(event.currentTool);
 		const lastIntent = eventString(event.lastIntent);
@@ -215,16 +237,22 @@ function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spin
 			const durationMs = eventNumber(event.durationMs);
 			if (durationMs > 0) line += `${theme.sep.dot}${theme.fg("dim", formatDuration(durationMs))}`;
 		}
-		lines.push(line);
+		// Do not let optional stats replace the end of the reserved failure status with an ellipsis.
+		lines.push(truncateToWidth(line, width, ""));
 
 		if (status === "running") {
 			if (currentTool) {
 				let toolLine = `${cont}${theme.tree.hook} ${theme.fg("muted", currentTool)}`;
 				const detail = lastIntent ?? eventString(event.currentToolArgs);
 				if (detail) toolLine += `: ${theme.fg("dim", truncateToWidth(replaceTabs(detail), 48))}`;
-				lines.push(toolLine);
+				lines.push(truncateToWidth(toolLine, width));
 			} else if (lastIntent) {
-				lines.push(`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`);
+				lines.push(
+					truncateToWidth(
+						`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`,
+						width,
+					),
+				);
 			}
 		}
 	}
@@ -663,7 +691,7 @@ export const evalToolRenderer = {
 						);
 						lines.push(...cellLines);
 						if (agentEvents.length > 0) {
-							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, options.spinnerFrame));
+							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, width, options.spinnerFrame));
 						}
 						if (i < cellResults.length - 1) {
 							lines.push("");

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -6,23 +6,26 @@
 
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Text } from "@oh-my-pi/pi-tui";
+import { Text, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { AsyncJob, AsyncJobManager, AsyncJobType } from "../../async";
-import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
 import { renderStructuredJson } from "../../session/async-job-delivery";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import type { StructuredSubagentOutput } from "../../task/types";
+import { parseConfiguredThinkingLevel } from "../../thinking";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import type { ToolSession } from "..";
 import {
+	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
 	formatDuration,
 	formatEmptyMessage,
+	formatFeedModelBadge,
 	formatStatusIcon,
 	getPreviewLines,
+	isFeedModelBadgeEnabled,
 	PREVIEW_LIMITS,
 	replaceTabs,
 	type ToolUIColor,
@@ -164,6 +167,9 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 		const latest = current ?? j;
 		const resultConsumed = session.asyncJobManager?.isJobResultConsumed(latest.id) === true;
 		let resolvedModel: string | undefined;
+		let resolvedModelIdentity: string | undefined;
+		let resolvedThinkingLevel: JobSnapshot["resolvedThinkingLevel"];
+		let advisor = false;
 		if (latest.type === "task") {
 			const progressValue = latest.latestDetails?.progress;
 			if (Array.isArray(progressValue)) {
@@ -182,6 +188,16 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 					const trimmed = modelValue.trim();
 					if (trimmed) resolvedModel = trimmed;
 				}
+				const identityValue = progressRecord?.resolvedModelIdentity;
+				if (typeof identityValue === "string") {
+					const trimmed = identityValue.trim();
+					if (trimmed) resolvedModelIdentity = trimmed;
+				}
+				const thinkingValue = progressRecord?.resolvedThinkingLevel;
+				if (typeof thinkingValue === "string") {
+					resolvedThinkingLevel = parseConfiguredThinkingLevel(thinkingValue);
+				}
+				advisor = progressRecord?.advisor === true;
 			}
 		}
 		return {
@@ -191,6 +207,9 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			label: latest.label,
 			durationMs: Math.max(0, now - latest.startTime),
 			...(resolvedModel ? { resolvedModel } : {}),
+			...(resolvedModelIdentity ? { resolvedModelIdentity } : {}),
+			...(resolvedThinkingLevel !== undefined ? { resolvedThinkingLevel } : {}),
+			...(advisor ? { advisor: true } : {}),
 			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
 			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
 			...(!resultConsumed && latest.structured
@@ -481,7 +500,6 @@ const PREVIEW_LINES_EXPANDED = 4;
 const LABEL_LINES_COLLAPSED = 1;
 const LABEL_LINES_EXPANDED = 3;
 const PREVIEW_LINE_WIDTH = 80;
-const MODEL_BADGE_MAX_WIDTH = 48;
 
 function statusToIcon(status: JobSnapshot["status"]): ToolUIStatus {
 	switch (status) {
@@ -643,7 +661,14 @@ export function jobsRenderResult(
 			// the animation state so a sealed block never hits stale shimmered
 			// bytes (spinnerFrame falls back to 0 on both sides of the seal).
 			const shimmerActive = counts.running > 0 && options.spinnerFrame !== undefined && shimmerEnabled();
-			const key = new Hasher().bool(expanded).u32(width).u32(spinnerFrame).bool(shimmerActive).digest();
+			const showModelBadge = isFeedModelBadgeEnabled();
+			const key = new Hasher()
+				.bool(expanded)
+				.u32(width)
+				.u32(spinnerFrame)
+				.bool(shimmerActive)
+				.bool(showModelBadge)
+				.digest();
 			if (!shimmerActive && cached?.key === key) return cached.lines;
 
 			const itemLines = renderTreeList<JobSnapshot>(
@@ -652,7 +677,8 @@ export function jobsRenderResult(
 					expanded,
 					maxCollapsed: COLLAPSED_LIST_LIMIT,
 					itemType: "job",
-					renderItem: job => {
+					renderItem: (job, context) => {
+						const rowWidth = Math.max(0, width - (context.prefixWidth ?? 0));
 						const lines: string[] = [];
 						const icon = formatStatusIcon(
 							statusToIcon(job.status),
@@ -660,9 +686,12 @@ export function jobsRenderResult(
 							job.status === "running" ? options.spinnerFrame : undefined,
 						);
 						const typeBadge = formatBadge(job.type, statusToColor(job.status), uiTheme);
-						// Task jobs label themselves with their agent id, which is also
-						// the job id — drop the id column instead of stuttering it twice.
-						const idPart = job.label.trim() === job.id ? "" : ` ${uiTheme.fg("muted", job.id)}`;
+						const durationSuffix = `${uiTheme.sep.dot}${uiTheme.fg("dim", formatDuration(job.durationMs))}`;
+						const displayId = truncateToWidth(
+							replaceTabs(job.id).replace(/\s+/g, " "),
+							Math.max(0, rowWidth - visibleWidth(`${icon} ${typeBadge} ${durationSuffix}`)),
+							Ellipsis.Unicode,
+						);
 						const rawLabelLines = (job.label || "(no label)").split(/\r?\n/);
 						const maxLabelLines = expanded ? LABEL_LINES_EXPANDED : LABEL_LINES_COLLAPSED;
 						const visibleLabelLines = rawLabelLines
@@ -672,37 +701,45 @@ export function jobsRenderResult(
 							const last = visibleLabelLines[visibleLabelLines.length - 1]!;
 							visibleLabelLines[visibleLabelLines.length - 1] = `${last} …`;
 						}
-						const durationText = uiTheme.fg("dim", formatDuration(job.durationMs));
-						const modelText =
-							job.type === "task" &&
-							typeof job.resolvedModel === "string" &&
-							job.resolvedModel.trim() &&
-							settings.get("task.showResolvedModelBadge")
-								? `${uiTheme.sep.dot}${uiTheme.fg(
-										"dim",
-										truncateToWidth(
-											replaceTabs(job.resolvedModel.trim()),
-											MODEL_BADGE_MAX_WIDTH,
-											Ellipsis.Unicode,
+						const rowPrefix = `${icon} ${typeBadge} `;
+						const modelIdentity = job.resolvedModelIdentity ?? job.resolvedModel;
+						const modelBadge =
+							job.type === "task" && showModelBadge && typeof modelIdentity === "string"
+								? formatFeedModelBadge(
+										modelIdentity,
+										job.resolvedThinkingLevel,
+										job.advisor === true,
+										uiTheme,
+										Math.min(
+											FEED_MODEL_BADGE_WIDTH,
+											Math.max(0, rowWidth - visibleWidth(`${rowPrefix}${displayId}${durationSuffix}`) - 1),
 										),
-									)}`
+									)
 								: "";
+						const modelLead = modelBadge ? `${modelBadge} ` : "";
+						const headRaw = displayId;
 						// Running rows in a live block shimmer their label; once the block
 						// stops animating (sealed, or a settled snapshot — spinnerFrame
 						// cleared) they render static so scrollback never keeps a mid-sweep
 						// shimmer band.
 						const live = job.status === "running" && options.spinnerFrame !== undefined;
-						const headRaw = visibleLabelLines[0] ?? "";
 						const headLabel = live
 							? shimmerEnabled()
 								? shimmerText(headRaw, uiTheme)
 								: uiTheme.fg("accent", headRaw)
 							: uiTheme.fg("toolOutput", headRaw);
-						lines.push(
-							`${icon}${idPart} ${typeBadge} ${headLabel}${modelText}${modelText ? uiTheme.sep.dot : " "}${durationText}`,
-						);
-						for (let i = 1; i < visibleLabelLines.length; i++) {
-							lines.push(`  ${uiTheme.fg("toolOutput", visibleLabelLines[i]!)}`);
+						let row = `${rowPrefix}${modelLead}${headLabel}`;
+						const distinctLabel = job.label.trim() !== job.id;
+						const label = visibleLabelLines[0] ?? "";
+						const inlineLabel = distinctLabel && visibleWidth(`${row} ${label}${durationSuffix}`) <= rowWidth;
+						if (inlineLabel) row += ` ${uiTheme.fg("toolOutput", label)}`;
+						row += durationSuffix;
+						lines.push(truncateToWidth(row, rowWidth, ""));
+						const continuationWidth = Math.max(0, rowWidth - visibleWidth("  "));
+						for (let i = distinctLabel && !inlineLabel ? 0 : 1; i < visibleLabelLines.length; i++) {
+							lines.push(
+								`  ${uiTheme.fg("toolOutput", truncateToWidth(visibleLabelLines[i]!, continuationWidth))}`,
+							);
 						}
 
 						const preview = flattenStructuredPreview(
@@ -710,7 +747,12 @@ export function jobsRenderResult(
 						);
 						if (preview) {
 							const maxLines = expanded ? PREVIEW_LINES_EXPANDED : PREVIEW_LINES_COLLAPSED;
-							const previewLines = getPreviewLines(preview, maxLines, PREVIEW_LINE_WIDTH, Ellipsis.Unicode);
+							const previewLines = getPreviewLines(
+								preview,
+								maxLines,
+								Math.min(PREVIEW_LINE_WIDTH, continuationWidth),
+								Ellipsis.Unicode,
+							);
 							const tone = job.errorText ? "error" : "dim";
 							for (const pl of previewLines) {
 								lines.push(`  ${uiTheme.fg(tone, pl)}`);
@@ -733,19 +775,31 @@ export function jobsRenderResult(
 								expanded,
 								maxCollapsed: COLLAPSED_LIST_LIMIT,
 								itemType: "agent",
-								renderItem: agent => {
+								renderItem: (agent, context) => {
+									const rowWidth = Math.max(0, width - (context.prefixWidth ?? 0));
 									const icon = agent.live
 										? formatStatusIcon("running", uiTheme, options.spinnerFrame)
 										: formatStatusIcon("warning", uiTheme);
 									const badge = agent.live
 										? formatBadge("agent", "accent", uiTheme)
 										: formatBadge("agent · no turn", "warning", uiTheme);
+									const id = truncateToWidth(
+										replaceTabs(agent.id).replace(/\s+/g, " "),
+										Math.max(0, rowWidth - visibleWidth(`${icon}  ${badge}`)),
+										Ellipsis.Unicode,
+									);
 									const gist = agent.activity
 										? ` ${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(agent.activity), LABEL_MAX_WIDTH, Ellipsis.Unicode))}`
 										: "";
 									const parent = agent.parentId ? uiTheme.fg("dim", ` ← ${agent.parentId}`) : "";
 									const age = uiTheme.fg("dim", formatDuration(agent.ageMs));
-									return [`${icon} ${uiTheme.fg("muted", agent.id)} ${badge}${gist} ${age}${parent}`];
+									return [
+										truncateToWidth(
+											`${icon} ${uiTheme.fg("muted", id)} ${badge}${gist} ${age}${parent}`,
+											rowWidth,
+											"",
+										),
+									];
 								},
 							},
 							uiTheme,

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -8,6 +8,7 @@ import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AsyncJobType } from "../../async";
 import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
 import type { StructuredSubagentOutput } from "../../task/types";
+import type { ConfiguredThinkingLevel } from "../../thinking";
 import type { LaunchParams, LaunchToolDetails } from "./launch";
 
 /**
@@ -65,6 +66,12 @@ export interface JobSnapshot {
 	durationMs: number;
 	/** Effective task model selector, including an explicit reasoning suffix when configured. */
 	resolvedModel?: string;
+	/** Provider/id including routing, with no added thinking suffix. */
+	resolvedModelIdentity?: string;
+	/** Explicit thinking metadata, independent of the model identity. */
+	resolvedThinkingLevel?: ConfiguredThinkingLevel;
+	/** True when the task progress reports an attached live advisor. */
+	advisor?: boolean;
 	resultText?: string;
 	errorText?: string;
 	structured?: StructuredSubagentOutput;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -7,15 +7,16 @@
 
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ToolCallContext } from "@oh-my-pi/pi-agent-core";
+import { ThinkingLevel, type ToolCallContext } from "@oh-my-pi/pi-agent-core";
 import type { Ellipsis } from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { getKeybindings, replaceTabs, truncateToWidth } from "@oh-my-pi/pi-tui";
-import { pluralize } from "@oh-my-pi/pi-utils";
+import { getKeybindings, replaceTabs, sliceByColumn, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import { pluralize, sanitizeText } from "@oh-my-pi/pi-utils";
 import { formatKeyHints, type KeyId } from "../config/keybindings";
 import { isSettingsInitialized, settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
 import type { Theme } from "../modes/theme/theme";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "../thinking";
 import { Hasher } from "../tui/utils";
 import { formatDimensionNote, type ResizedImage } from "../utils/image-resize";
 
@@ -72,6 +73,54 @@ export const PREVIEW_LIMITS = {
 /** Default number of terminal output rows shown before expansion. */
 export const DEFAULT_TERMINAL_PREVIEW_LINES = 10;
 
+export const FEED_MODEL_BADGE_WIDTH = 30;
+
+export function isFeedModelBadgeEnabled(): boolean {
+	return isSettingsInitialized() && settings.get("task.showResolvedModelBadge");
+}
+
+/** Compact glyph for a configured thinking level; empty for `inherit` (nothing to show). */
+export function thinkingLevelGlyph(level: ConfiguredThinkingLevel, uiTheme: Theme): string {
+	if (level === ThinkingLevel.Inherit) return "";
+	if (level === ThinkingLevel.Off) return uiTheme.status.disabled;
+	const symbol = uiTheme.thinking[level === AUTO_THINKING ? "autoPending" : level];
+	if (typeof symbol !== "string") return "";
+	const space = symbol.indexOf(" ");
+	return space < 0 ? symbol : symbol.slice(0, space);
+}
+
+/**
+ * Compact feed-row prefix: explicit thinking glyph, sanitized model identity,
+ * then advisor eye. Keep fitting icons if no model fits; preserve literal identity suffixes.
+ */
+export function formatFeedModelBadge(
+	modelIdentity: string | undefined,
+	thinkingLevel: ConfiguredThinkingLevel | undefined,
+	advisor: boolean | undefined,
+	uiTheme: Theme,
+	maxWidth = FEED_MODEL_BADGE_WIDTH,
+): string {
+	if (!modelIdentity) return "";
+	const width = Math.max(0, Math.floor(maxWidth));
+	const clean = sanitizeText(modelIdentity).replace(/\s+/g, " ").trim();
+	if (!clean || !(width > 0)) return "";
+	const glyph = thinkingLevel !== undefined ? thinkingLevelGlyph(thinkingLevel, uiTheme) : "";
+	const advisorIcon = advisor === true ? uiTheme.icon.advisor : "";
+	const prefix = glyph ? `${glyph} ` : "";
+	const suffix = advisorIcon ? ` ${advisorIcon}` : "";
+	const modelWidth = width - visibleWidth(prefix) - visibleWidth(suffix);
+	if (modelWidth < 1) {
+		const advisorWidth = visibleWidth(advisorIcon);
+		if (advisorIcon && advisorWidth <= width) {
+			const thinkingPrefix = glyph && visibleWidth(prefix) + advisorWidth <= width ? prefix : "";
+			return uiTheme.fg("accent", thinkingPrefix) + uiTheme.fg("dim", advisorIcon);
+		}
+		return glyph && visibleWidth(glyph) <= width ? uiTheme.fg("accent", glyph) : "";
+	}
+	const model = truncateMiddleToWidth(clean, modelWidth);
+	return uiTheme.fg("accent", prefix) + uiTheme.fg("dim", `${model}${suffix}`);
+}
+
 /** Truncation lengths for different content types */
 export const TRUNCATE_LENGTHS = {
 	/** Short titles, labels */
@@ -102,6 +151,15 @@ export function expandKeyHint(): string {
 // =============================================================================
 // Text Truncation Utilities
 // =============================================================================
+/** Keep both ends of a single-line label without splitting wide characters. */
+function truncateMiddleToWidth(text: string, maxWidth: number): string {
+	const width = visibleWidth(text);
+	if (width <= maxWidth) return text;
+	if (maxWidth <= 1) return maxWidth === 1 ? "…" : "";
+	const tailWidth = Math.ceil((maxWidth - 1) / 2);
+	const headWidth = maxWidth - 1 - tailWidth;
+	return `${sliceByColumn(text, 0, headWidth, true)}…${sliceByColumn(text, width - tailWidth, tailWidth, true)}`;
+}
 
 /**
  * Get first N lines of text as preview, with each line truncated.

--- a/packages/coding-agent/src/tui/tree-list.ts
+++ b/packages/coding-agent/src/tui/tree-list.ts
@@ -2,7 +2,7 @@
  * Hierarchical tree list rendering helper.
  */
 
-import { replaceTabs } from "@oh-my-pi/pi-tui";
+import { replaceTabs, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { Theme } from "../modes/theme/theme";
 import { formatMoreItems } from "../tools/render-utils";
 import type { TreeContext } from "./types";
@@ -42,6 +42,16 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 	} = options;
 	const maxItems = expanded ? items.length : Math.min(items.length, maxCollapsed);
 	const linesBudget = !expanded && maxCollapsedLines !== undefined ? maxCollapsedLines : Infinity;
+	const branchPrefix = `${theme.fg("dim", getTreeBranch(false, theme))} `;
+	const lastPrefix = `${theme.fg("dim", getTreeBranch(true, theme))} `;
+	const branchContinuePrefix = theme.fg("dim", getTreeContinuePrefix(false, theme));
+	const lastContinuePrefix = theme.fg("dim", getTreeContinuePrefix(true, theme));
+	const prefixWidth = Math.max(
+		visibleWidth(branchPrefix),
+		visibleWidth(lastPrefix),
+		visibleWidth(branchContinuePrefix),
+		visibleWidth(lastContinuePrefix),
+	);
 
 	// Caller-driven collapse: render exactly the provided items (the caller
 	// already picked/capped them) plus an optional trailing summary row. The
@@ -58,19 +68,20 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 				theme,
 				prefix: "",
 				continuePrefix: "",
+				prefixWidth,
 			});
 			const itemLines = Array.isArray(rendered) ? rendered : rendered ? [rendered] : [];
 			if (itemLines.length === 0) continue;
 			const isLast = summary === "" && i === items.length - 1;
-			const prefix = `${theme.fg("dim", getTreeBranch(isLast, theme))} `;
-			const continuePrefix = `${theme.fg("dim", getTreeContinuePrefix(isLast, theme))}`;
+			const prefix = isLast ? lastPrefix : branchPrefix;
+			const continuePrefix = isLast ? lastContinuePrefix : branchContinuePrefix;
 			lines.push(`${prefix}${replaceTabs(itemLines[0]!)}`);
 			for (let j = 1; j < itemLines.length; j++) {
 				lines.push(`${continuePrefix}${replaceTabs(itemLines[j]!)}`);
 			}
 		}
 		if (summary !== "") {
-			lines.push(`${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", summary)}`);
+			lines.push(`${lastPrefix}${theme.fg("muted", summary)}`);
 		}
 		return lines;
 	}
@@ -100,6 +111,7 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 			theme,
 			prefix: "",
 			continuePrefix: "",
+			prefixWidth,
 		});
 		preRendered.push(Array.isArray(rendered) ? rendered : rendered ? [rendered] : []);
 	}
@@ -147,15 +159,14 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 	const lines: string[] = [];
 
 	if (truncateFrom === "start" && hasSummary) {
-		lines.push(`${theme.fg("dim", theme.tree.branch)} ${theme.fg("muted", formatMoreItems(remaining, itemType))}`);
+		lines.push(`${branchPrefix}${theme.fg("muted", formatMoreItems(remaining, itemType))}`);
 	}
 
 	for (let i = displayedSlice.start; i < displayedSlice.end; i++) {
 		const isLast =
 			truncateFrom === "start" ? i === displayedSlice.end - 1 : !hasSummary && i === displayedSlice.end - 1;
-		const branch = getTreeBranch(isLast, theme);
-		const prefix = `${theme.fg("dim", branch)} `;
-		const continuePrefix = `${theme.fg("dim", getTreeContinuePrefix(isLast, theme))}`;
+		const prefix = isLast ? lastPrefix : branchPrefix;
+		const continuePrefix = isLast ? lastContinuePrefix : branchContinuePrefix;
 		const itemLines = preRendered[i]!;
 		if (itemLines.length === 0) continue;
 		lines.push(`${prefix}${replaceTabs(itemLines[0]!)}`);
@@ -165,7 +176,7 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 	}
 
 	if (truncateFrom === "end" && hasSummary) {
-		lines.push(`${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", formatMoreItems(remaining, itemType))}`);
+		lines.push(`${lastPrefix}${theme.fg("muted", formatMoreItems(remaining, itemType))}`);
 	}
 
 	return lines;

--- a/packages/coding-agent/src/tui/types.ts
+++ b/packages/coding-agent/src/tui/types.ts
@@ -12,4 +12,6 @@ export interface TreeContext {
 	theme: Theme;
 	prefix: string;
 	continuePrefix: string;
+	/** Maximum rendered branch/continuation prefix width reserved during pre-rendering. */
+	prefixWidth?: number;
 }

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1552,6 +1552,8 @@ describe("AgentSession retry fallback", () => {
 		// from the first request — there is no earlier model's work to misattribute.
 		expect(session.servingModel).toEqual({
 			selector: `${firstFallback.provider}/${firstFallback.id}`,
+			modelIdentity: `${firstFallback.provider}/${firstFallback.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 
@@ -1584,9 +1586,18 @@ describe("AgentSession retry fallback", () => {
 		// Nothing had served when the chain advanced, so there was no earlier work
 		// to miscredit and the candidate being attempted is the only answer — but
 		// it is still reported as fallback-routed.
-		expect(swapProbe).toEqual([{ selector: `${secondFallback.provider}/${secondFallback.id}`, isFallback: true }]);
+		expect(swapProbe).toEqual([
+			{
+				selector: `${secondFallback.provider}/${secondFallback.id}`,
+				modelIdentity: `${secondFallback.provider}/${secondFallback.id}`,
+				thinkingLevel: undefined,
+				isFallback: true,
+			},
+		]);
 		expect(session.servingModel).toEqual({
 			selector: `${secondFallback.provider}/${secondFallback.id}`,
+			modelIdentity: `${secondFallback.provider}/${secondFallback.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 	});
@@ -4483,6 +4494,8 @@ describe("AgentSession retry fallback", () => {
 		// The restored primary answered, so attribution moves back with it.
 		expect(session.servingModel).toEqual({
 			selector: `${primaryModel.provider}/${primaryModel.id}`,
+			modelIdentity: `${primaryModel.provider}/${primaryModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: false,
 		});
 	});
@@ -4536,6 +4549,8 @@ describe("AgentSession retry fallback", () => {
 		await session.waitForIdle();
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			modelIdentity: `${fallbackModel.provider}/${fallbackModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 
@@ -4597,13 +4612,23 @@ describe("AgentSession retry fallback", () => {
 		// The degrade swaps models without arming a retry-fallback chain, but it is
 		// still fallback routing — a bare model badge would hide that.
 		expect(requestedModels).toEqual([`${fastModel.provider}/${fastModel.id}`, `fireworks/${baseId}`]);
-		expect(session.servingModel).toEqual({ selector: `fireworks/${baseId}`, isFallback: true });
+		expect(session.servingModel).toEqual({
+			selector: `fireworks/${baseId}`,
+			modelIdentity: `fireworks/${baseId}`,
+			thinkingLevel: undefined,
+			isFallback: true,
+		});
 
 		// How the previous transcript was routed says nothing about a freshly
 		// loaded one: switching sessions in place must not describe the new
 		// session's model as fallback-routed.
 		vi.spyOn(session.sessionManager, "getSessionId").mockReturnValue("some-other-session");
-		expect(session.servingModel).toEqual({ selector: `fireworks/${baseId}`, isFallback: false });
+		expect(session.servingModel).toEqual({
+			selector: `fireworks/${baseId}`,
+			modelIdentity: `fireworks/${baseId}`,
+			thinkingLevel: undefined,
+			isFallback: false,
+		});
 	});
 
 	it("re-checks context before a cooldown-expiry revert onto a smaller-window model in the auto-continue path", async () => {
@@ -5856,6 +5881,8 @@ describe("AgentSession retry fallback", () => {
 		expect(session.servingModel?.isFallback).toBeFalsy();
 		expect(session.servingModel).toEqual({
 			selector: `${primaryModel.provider}/${primaryModel.id}`,
+			modelIdentity: `${primaryModel.provider}/${primaryModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: false,
 		});
 
@@ -5868,6 +5895,8 @@ describe("AgentSession retry fallback", () => {
 		expect(session.servingModel?.isFallback).toBeFalsy();
 		expect(session.servingModel).toEqual({
 			selector: `${primaryModel.provider}/${primaryModel.id}`,
+			modelIdentity: `${primaryModel.provider}/${primaryModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: false,
 		});
 		// Both attribution and how the model was routed belong to the session they
@@ -5878,6 +5907,8 @@ describe("AgentSession retry fallback", () => {
 		vi.spyOn(session.sessionManager, "getSessionId").mockReturnValue("some-other-session");
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			modelIdentity: `${fallbackModel.provider}/${fallbackModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: false,
 		});
 	});
@@ -5916,6 +5947,8 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.id).toBe(fallbackModel.id);
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			modelIdentity: `${fallbackModel.provider}/${fallbackModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 	});
@@ -5944,6 +5977,8 @@ describe("AgentSession retry fallback", () => {
 		await session.waitForIdle();
 		const served = {
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			modelIdentity: `${fallbackModel.provider}/${fallbackModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		};
 		expect(session.servingModel).toEqual(served);
@@ -6008,6 +6043,8 @@ describe("AgentSession retry fallback", () => {
 		await session.waitForIdle();
 		expect(session.servingModel).toEqual({
 			selector: `${firstFallback.provider}/${firstFallback.id}`,
+			modelIdentity: `${firstFallback.provider}/${firstFallback.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 
@@ -6026,6 +6063,8 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.id).toBe(secondFallback.id);
 		expect(session.servingModel).toEqual({
 			selector: `${firstFallback.provider}/${firstFallback.id}`,
+			modelIdentity: `${firstFallback.provider}/${firstFallback.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 		// Never the incoming candidate: mid-swap it has produced nothing.
@@ -6082,6 +6121,8 @@ describe("AgentSession retry fallback", () => {
 		expect(requestedModels).toEqual([`${fallbackModel.provider}/${fallbackModel.id}`]);
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			modelIdentity: `${fallbackModel.provider}/${fallbackModel.id}`,
+			thinkingLevel: undefined,
 			isFallback: true,
 		});
 	});

--- a/packages/coding-agent/test/helpers/session-defaults.ts
+++ b/packages/coding-agent/test/helpers/session-defaults.ts
@@ -1,0 +1,17 @@
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+/** Spread first in a session fake; keep state and behavior overrides on the fake itself. */
+export function createSessionDefaults() {
+	return {
+		setActiveToolsByName: async (_toolNames: string[]) => {},
+		waitForIdle: async () => {},
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async () => true,
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+		setIrcWakeTurnObserver: () => {},
+		isAdvisorActive: () => false,
+		subscribeRunState: () => () => {},
+	} satisfies Partial<AgentSession>;
+}

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { ServingModel } from "@oh-my-pi/pi-coding-agent/session/retry-fallback-chains";
+import { TurnRecovery, type TurnRecoveryHost } from "@oh-my-pi/pi-coding-agent/session/turn-recovery";
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
-import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, AgentProgress } from "@oh-my-pi/pi-coding-agent/task/types";
+import { createSessionDefaults } from "./helpers/session-defaults";
 
 function model(provider: string, id: string): Model<Api> {
 	return buildModel({
@@ -36,9 +39,13 @@ function model(provider: string, id: string): Model<Api> {
  * - `"served"` settles a real turn on it, which moves attribution.
  * - `"unproven"` errors on its first request, producing none of the run's work.
  */
-function createYieldingSession(fallback: "served" | "unproven" = "served"): AgentSession {
+function createYieldingSession(
+	fallback: "served" | "unproven" | "none" = "served",
+	beforeYield?: () => Promise<void>,
+): AgentSession {
 	const listeners: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
 	const session = {
+		...createSessionDefaults(),
 		agent: { state: { systemPrompt: ["test"] } },
 		state: { messages: [] },
 		model: model("primary", "bad-runtime-model"),
@@ -47,9 +54,6 @@ function createYieldingSession(fallback: "served" | "unproven" = "served"): Agen
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["yield"],
 		getEnabledToolNames: () => ["yield"],
-		setActiveToolsByName: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 		subscribe: (listener: (event: { type: string; [key: string]: unknown }) => void) => {
 			listeners.push(listener);
 			return () => {};
@@ -60,16 +64,19 @@ function createYieldingSession(fallback: "served" | "unproven" = "served"): Agen
 			const emit = (event: { type: string; [key: string]: unknown }): void => {
 				for (const listener of listeners) listener(event);
 			};
-			session.model = model("fallback", "working-model");
-			emit({
-				type: "retry_fallback_applied",
-				from: "primary/bad-runtime-model",
-				to: "fallback/working-model",
-				role: "subagent:issue-2750",
-			});
-			if (fallback === "served") {
-				session.servingModel = { selector: "fallback/working-model", isFallback: true };
-				emit({ type: "retry_fallback_succeeded", model: "fallback/working-model", role: "subagent:issue-2750" });
+			await beforeYield?.();
+			if (fallback !== "none") {
+				session.model = model("fallback", "working-model");
+				emit({
+					type: "retry_fallback_applied",
+					from: "primary/bad-runtime-model",
+					to: "fallback/working-model",
+					role: "subagent:issue-2750",
+				});
+				if (fallback === "served") {
+					session.servingModel = { selector: "fallback/working-model", isFallback: true };
+					emit({ type: "retry_fallback_succeeded", model: "fallback/working-model", role: "subagent:issue-2750" });
+				}
 			}
 			emit({
 				type: "tool_execution_end",
@@ -79,12 +86,6 @@ function createYieldingSession(fallback: "served" | "unproven" = "served"): Agen
 				isError: false,
 			});
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
 	};
 	return session as unknown as AgentSession;
 }
@@ -93,6 +94,74 @@ describe("subagent runtime model resolution", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
+
+	for (const { level, collide } of [
+		{ level: undefined, collide: false },
+		{ level: ThinkingLevel.High, collide: false },
+		{ level: undefined, collide: true },
+	]) {
+		it(`keeps literal suffix attribution distinct from thinking (${collide ? "colliding selector" : (level ?? "unset")})`, async () => {
+			const literal = model("custom", "coding-router:max");
+			const snapshots: AgentProgress[] = [];
+			vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+				if (!options?.model) throw new Error("Expected resolved model");
+				let activeModel = options.model;
+				let activeLevel: ThinkingLevel | undefined = level;
+				const recovery = new TurnRecovery({
+					model: () => activeModel,
+					thinkingLevel: () => activeLevel,
+					sessionManager: { getSessionId: () => "literal-model" },
+					settings: Settings.isolated({}),
+					modelRegistry: {},
+					configWarnings: [],
+				} as unknown as TurnRecoveryHost);
+				const session = createYieldingSession("none", async () => {
+					if (collide) {
+						// Same concatenated selector, different identity and reasoning.
+						activeModel = model("custom", "coding-router");
+						activeLevel = ThinkingLevel.Max;
+					}
+					await recovery.onAssistantSettledSuccessfully({
+						role: "assistant",
+						content: [{ type: "text", text: "literal model produced this answer" }],
+						stopReason: "stop",
+					} as AssistantMessage);
+					// A newly armed model must not steal the settled answer's identity.
+					activeModel = model("custom", "unserved-candidate");
+				});
+				Object.defineProperty(session, "servingModel", { get: () => recovery.servingModel });
+				expect(recovery.servingModel?.modelIdentity).toBe("custom/coding-router:max");
+				expect(recovery.servingModel?.thinkingLevel).toBe(level);
+				return { session, extensionsResult: {}, setToolUIContext: () => {} } as never;
+			});
+			const settings = Settings.isolated({});
+			settings.setModelRole("default", "custom/coding-router:max");
+			const result = await runSubprocess({
+				cwd: "/tmp",
+				agent: { name: "task", description: "test", systemPrompt: "test", source: "bundled" },
+				task: "work",
+				index: 0,
+				id: "literal-model",
+				modelOverride: level ? `custom/coding-router:max:${level}` : "custom/coding-router:max",
+				settings,
+				modelRegistry: {
+					refresh: async () => {},
+					getAvailable: () => [literal],
+					getApiKey: async () => "test-key",
+				} as never,
+				onProgress: progress => snapshots.push({ ...progress }),
+				enableLsp: false,
+			});
+			const expectedSelector = level ? `custom/coding-router:max:${level}` : "custom/coding-router:max";
+			const latest = snapshots.findLast(progress => progress.resolvedModel !== undefined);
+			expect(latest?.resolvedModelIdentity).toBe(collide ? "custom/coding-router" : "custom/coding-router:max");
+			expect(latest?.resolvedThinkingLevel).toBe(collide ? ThinkingLevel.Max : level);
+			expect(result.resolvedModel).toBe(expectedSelector);
+			expect(result.resolvedModelIdentity).toBe(collide ? "custom/coding-router" : "custom/coding-router:max");
+			expect(result.resolvedThinkingLevel).toBe(collide ? ThinkingLevel.Max : level);
+			expect(result.resolvedModelIsFallback).toBeFalsy();
+		});
+	}
 
 	it("passes ordered subagent candidates as a child retry fallback chain", async () => {
 		const primary = model("primary", "bad-runtime-model");

--- a/packages/coding-agent/test/job-model-badge-renderer.test.ts
+++ b/packages/coding-agent/test/job-model-badge-renderer.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 import { AsyncJobManager } from "../src/async/job-manager";
-import { Settings, settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings, settings } from "../src/config/settings";
 import { getThemeByName, setThemeInstance, type Theme } from "../src/modes/theme/theme";
 import type { ToolSession } from "../src/tools";
 import { jobsRenderResult, snapshotJobs } from "../src/tools/hub/jobs";
 import type { CoordinationDetails } from "../src/tools/hub/types";
+import { formatDuration, thinkingLevelGlyph } from "../src/tools/render-utils";
 
 const ansiPattern = /\x1b\[[0-9;]*m/g;
 const hyperlinkPattern = /\x1b\]8;[^\x1b\x07]*(?:\x07|\x1b\\)/g;
@@ -12,14 +15,14 @@ const hyperlinkPattern = /\x1b\]8;[^\x1b\x07]*(?:\x07|\x1b\\)/g;
 let uiTheme: Theme;
 let priorShowResolvedModelBadge = false;
 
-function renderJobText(details: Omit<CoordinationDetails, "op">, expanded = false): string {
+function renderJobText(details: Omit<CoordinationDetails, "op">, expanded = false, live = false, width = 160): string {
 	const component = jobsRenderResult(
 		{ content: [{ type: "text", text: "Listed background jobs" }], details: { op: "jobs", ...details } },
-		{ expanded, isPartial: false },
+		{ expanded, isPartial: live, spinnerFrame: live ? 0 : undefined },
 		uiTheme,
 		{ op: "jobs" },
 	);
-	let text = component.render(160).join("\n");
+	let text = component.render(width).join("\n");
 	text = text.replace(hyperlinkPattern, "");
 	text = text.replace(ansiPattern, "");
 	return text;
@@ -44,9 +47,9 @@ describe("hub jobs task model badges", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("renders a task job's resolved model selector with its explicit reasoning suffix exactly once when enabled", () => {
+	it("keeps a literal thinking suffix in a completed task's identity with a separate thinking glyph", () => {
 		settings.override("task.showResolvedModelBadge", true);
-		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const identity = "p/model:high";
 		const text = renderJobText({
 			jobs: [
 				{
@@ -56,18 +59,85 @@ describe("hub jobs task model badges", () => {
 					label: "Architect",
 					durationMs: 1_234,
 					resultText: "done",
-					resolvedModel: selector,
+					resolvedModel: `${identity}:high`,
+					resolvedModelIdentity: identity,
+					resolvedThinkingLevel: ThinkingLevel.High,
 				},
 			],
 		});
 
-		expect(text).toContain(selector);
-		expect(text.split(selector).length - 1).toBe(1);
+		expect(text).toContain(`${thinkingLevelGlyph(ThinkingLevel.High, uiTheme)} ${identity} Architect`);
+		expect(text.split(identity).length - 1).toBe(1);
+		expect(text).not.toContain(`${identity}:high`);
+		expect(text).not.toContain(uiTheme.icon.advisor);
 	});
 
-	it("renders the latest runtime selector from a running task job snapshot", async () => {
+	it("fits a long model badge around the agent name and duration at 60 columns", () => {
 		settings.override("task.showResolvedModelBadge", true);
-		const selector = "openai-codex/gpt-5.6-luna:max";
+		const text = renderJobText(
+			{
+				jobs: [
+					{
+						id: "Architect",
+						type: "task",
+						status: "running",
+						label: "Architect",
+						durationMs: 1_234,
+						resolvedModel: "provider/a-very-long-model-name-with-a-distinctive-tail:high",
+						resolvedModelIdentity: "provider/a-very-long-model-name-with-a-distinctive-tail",
+						resolvedThinkingLevel: ThinkingLevel.High,
+						advisor: true,
+					},
+				],
+			},
+			false,
+			true,
+			60,
+		);
+		const row = text.split("\n")[1]!;
+
+		expect(row).toContain(`${uiTheme.icon.advisor} Architect`);
+		expect(row).toContain(thinkingLevelGlyph(ThinkingLevel.High, uiTheme));
+		expect(row).toContain("…");
+		expect(row).toEndWith("1.2s");
+		for (const line of text.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(60);
+	});
+
+	it("keeps the ID and badge ahead of a long description and preserves expanded continuation", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const text = renderJobText(
+			{
+				jobs: [
+					{
+						id: "Architect",
+						type: "task",
+						status: "completed",
+						label: `Architect ${"設計".repeat(40)}\nFollow-up design details`,
+						durationMs: 1_234,
+						resolvedModel: "provider/a-very-long-model-name-with-a-distinctive-tail:high",
+						resolvedModelIdentity: "provider/a-very-long-model-name-with-a-distinctive-tail",
+						resolvedThinkingLevel: ThinkingLevel.High,
+						advisor: true,
+					},
+				],
+			},
+			true,
+			false,
+			60,
+		);
+		const row = text.split("\n")[1]!;
+
+		expect(row).toContain(`${uiTheme.icon.advisor} Architect`);
+		expect(row).toContain("task");
+		expect(row).toEndWith("1.2s");
+		expect(text.split("\n")[2]).toContain("Architect 設計");
+		expect(text.split("\n")[3]).toContain("Follow-up design details");
+		for (const line of text.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(60);
+	});
+
+	it("renders a running task snapshot's advisor badge and keeps it on the settled result", async () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const identity = "p/runtime:max";
 		const reported = Promise.withResolvers<void>();
 		const finish = Promise.withResolvers<string>();
 		const manager = new AsyncJobManager({ onJobComplete: () => {} });
@@ -76,7 +146,15 @@ describe("hub jobs task model badges", () => {
 			"Architect",
 			async ({ reportProgress }) => {
 				await reportProgress("running", {
-					progress: [{ id: "Architect", resolvedModel: selector }],
+					progress: [
+						{
+							id: "Architect",
+							resolvedModel: `${identity}:max`,
+							resolvedModelIdentity: identity,
+							resolvedThinkingLevel: ThinkingLevel.Max,
+							advisor: true,
+						},
+					],
 				});
 				reported.resolve();
 				return finish.promise;
@@ -86,18 +164,45 @@ describe("hub jobs task model badges", () => {
 		await reported.promise;
 
 		const session = { asyncJobManager: manager } as unknown as ToolSession;
-		const text = renderJobText({ jobs: snapshotJobs(session, manager.getAllJobs()) });
+		try {
+			const text = renderJobText({ jobs: snapshotJobs(session, manager.getAllJobs()) }, false, true);
+			const prefix = `${thinkingLevelGlyph(ThinkingLevel.Max, uiTheme)} ${identity} ${uiTheme.icon.advisor} Architect`;
+			expect(text).toContain(prefix);
+			expect(text.split(identity).length - 1).toBe(1);
+			expect(text).not.toContain(`${identity}:max`);
 
-		expect(text).toContain(selector);
-		expect(text.split(selector).length - 1).toBe(1);
+			finish.resolve("finished architecture review");
+			await manager.getJob(id)?.promise;
+			const settled = renderJobText({ jobs: snapshotJobs(session, manager.getAllJobs()) });
+			expect(settled).toContain(prefix);
+		} finally {
+			finish.resolve("done");
+			await manager.getJob(id)?.promise;
+		}
+	});
 
-		finish.resolve("done");
-		await manager.getJob(id)?.promise;
+	it("preserves a legacy selector without inferring a thinking glyph", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const text = renderJobText({
+			jobs: [
+				{
+					id: "Legacy",
+					type: "task",
+					status: "completed",
+					label: "Legacy",
+					durationMs: 0,
+					resolvedModel: "p/model:high",
+				},
+			],
+		});
+
+		expect(text).toContain("p/model:high Legacy");
+		expect(text).not.toContain(thinkingLevelGlyph(ThinkingLevel.High, uiTheme));
 	});
 
 	it("hides a task job's resolved model selector when the badge setting is disabled", () => {
 		settings.override("task.showResolvedModelBadge", false);
-		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const selector = "p/model:high";
 		const text = renderJobText({
 			jobs: [
 				{
@@ -108,17 +213,20 @@ describe("hub jobs task model badges", () => {
 					durationMs: 1_234,
 					resultText: "done",
 					resolvedModel: selector,
+					advisor: true,
 				},
 			],
 		});
 
 		expect(text).toContain("Architect");
-		expect(text).not.toContain(selector);
+		expect(text).not.toContain("p/model");
+		expect(text).not.toContain(thinkingLevelGlyph(ThinkingLevel.High, uiTheme));
+		expect(text).not.toContain(uiTheme.icon.advisor);
 	});
 
 	it("does not render resolved model metadata on bash job rows", () => {
 		settings.override("task.showResolvedModelBadge", true);
-		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const selector = "p/model:high";
 		const text = renderJobText({
 			jobs: [
 				{
@@ -129,13 +237,83 @@ describe("hub jobs task model badges", () => {
 					durationMs: 1_234,
 					resultText: "ok",
 					resolvedModel: selector,
+					advisor: true,
 				},
 			],
 		});
 
 		expect(text).toContain("shell-1");
 		expect(text).toContain("bash");
-		expect(text).not.toContain(selector);
+		expect(text).not.toContain("p/model");
+		expect(text).not.toContain(uiTheme.icon.advisor);
+	});
+
+	it("renders model-bearing task jobs before settings initialization", async () => {
+		resetSettingsForTest();
+		try {
+			const text = renderJobText({
+				jobs: [
+					{
+						id: "ColdStart",
+						type: "task",
+						status: "failed",
+						label: "ColdStart",
+						durationMs: 0,
+						resolvedModelIdentity: "provider/model",
+						advisor: true,
+					},
+				],
+			});
+			expect(text).toContain("ColdStart");
+			expect(text).toContain("task");
+			expect(text).not.toContain("provider/model");
+			expect(text).not.toContain(uiTheme.icon.advisor);
+		} finally {
+			await Settings.init({ inMemory: true });
+		}
+	});
+
+	it("reserves custom tree prefixes and task status for long IDs with badges on or off", () => {
+		const priorTree = Object.getOwnPropertyDescriptor(uiTheme, "tree");
+		try {
+			Object.defineProperty(uiTheme, "tree", {
+				configurable: true,
+				value: { ...uiTheme.tree, branch: "界├", last: "界界└", vertical: "界界│" },
+			});
+			for (const enabled of [true, false]) {
+				settings.override("task.showResolvedModelBadge", enabled);
+				for (const width of [40, 120]) {
+					const id = `LongWorker${"界".repeat(40)}`;
+					const text = renderJobText(
+						{
+							jobs: [
+								{
+									id,
+									type: "task",
+									status: "failed",
+									label: id,
+									durationMs: 1000,
+									resolvedModelIdentity: "provider/model",
+									advisor: true,
+								},
+							],
+						},
+						false,
+						false,
+						width,
+					);
+					const row = text.split("\n")[1]!;
+					expect(row).toStartWith("界界└ ");
+					expect(row).toEndWith(formatDuration(1000));
+					expect(row).toContain("LongWorker");
+					expect(row).toContain("task");
+					for (const line of text.split("\n")) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+				}
+			}
+		} finally {
+			if (priorTree) Object.defineProperty(uiTheme, "tree", priorTree);
+			else Reflect.deleteProperty(uiTheme, "tree");
+		}
 	});
 
 	it("renders task rows with missing or malformed resolved model metadata without leaking bogus badges", () => {

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode, renderSubagentHudLines } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
@@ -15,7 +15,7 @@ import {
 	type ObservableSession,
 	SessionObserverRegistry,
 } from "@oh-my-pi/pi-coding-agent/modes/session-observer-registry";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -95,6 +95,147 @@ function render(sessions: ObservableSession[], columns = 120): string {
 describe("subagent HUD lines", () => {
 	beforeAll(async () => {
 		await initTheme();
+	});
+
+	describe("model badges", () => {
+		beforeEach(async () => {
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, overrides: { "task.showResolvedModelBadge": true } });
+		});
+
+		afterEach(() => {
+			resetSettingsForTest();
+		});
+
+		it("places thinking, model and optional advisor before the detached agent name", () => {
+			const session = makeSession({
+				id: "BadgeWorker",
+				agent: "scout",
+				description: "Inspect rendering",
+				progress: makeProgress({
+					id: "BadgeWorker",
+					resolvedModel: "openai/gpt-5:high",
+					resolvedModelIdentity: "openai/gpt-5",
+					resolvedThinkingLevel: ThinkingLevel.High,
+					advisor: true,
+				}),
+			});
+			const out = render([session]);
+			expect(out).toContain(`${theme.thinking.high.split(" ")[0]} openai/gpt-5 ${theme.icon.advisor} BadgeWorker`);
+			expect(out).toContain(`BadgeWorker ${theme.format.bracketLeft}scout${theme.format.bracketRight}`);
+			expect(out).toContain(": Inspect rendering");
+
+			session.progress = makeProgress({
+				id: "BadgeWorker",
+				resolvedModel: "openai/gpt-5:high",
+				resolvedModelIdentity: "openai/gpt-5",
+				resolvedThinkingLevel: ThinkingLevel.High,
+				advisor: false,
+			});
+			const withoutAdvisor = render([session]);
+			expect(withoutAdvisor).toContain("openai/gpt-5 BadgeWorker");
+			expect(withoutAdvisor).not.toContain(theme.icon.advisor);
+		});
+
+		it("keeps metadata hidden when disabled or settings have not initialized", () => {
+			const sessions = [
+				makeSession({
+					id: "HiddenBadge",
+					description: "Inspect rendering",
+					progress: makeProgress({
+						id: "HiddenBadge",
+						resolvedModel: "openai/gpt-5:high",
+						resolvedModelIdentity: "openai/gpt-5",
+						resolvedThinkingLevel: ThinkingLevel.High,
+						advisor: true,
+					}),
+				}),
+			];
+			Settings.instance.override("task.showResolvedModelBadge", false);
+			const disabled = render(sessions);
+			expect(disabled).toContain(`${theme.status.done} HiddenBadge: Inspect rendering`);
+			expect(disabled).not.toContain("openai/gpt-5");
+			expect(disabled).not.toContain(theme.icon.advisor);
+
+			resetSettingsForTest();
+			expect(render(sessions)).toBe(disabled);
+		});
+
+		it("preserves model identity and the agent name while fitting descriptions and task previews", () => {
+			const metadata = {
+				resolvedModel: `provider/${"shared-prefix-".repeat(8)}variant-z:high`,
+				resolvedModelIdentity: `provider/${"shared-prefix-".repeat(8)}variant-z`,
+				resolvedThinkingLevel: ThinkingLevel.High,
+				advisor: true,
+			};
+			const sessions = [
+				makeSession({
+					id: "Description",
+					description: "Inspect rendering ".repeat(20),
+					progress: makeProgress({ id: "Description", ...metadata }),
+				}),
+				makeSession({
+					id: "TaskPreview",
+					progress: makeProgress({ id: "TaskPreview", task: "Inspect rendering ".repeat(20), ...metadata }),
+				}),
+			];
+			const lines = render(sessions, 60).split("\n");
+			for (const id of ["Description", "TaskPreview"]) {
+				const row = lines.find(line => line.includes(id))!;
+				expect(row).toContain(`variant-z ${theme.icon.advisor} ${id}`);
+				expect(row.indexOf("variant-z")).toBeLessThan(row.indexOf(id));
+				expect(row).not.toContain(":high");
+			}
+			for (const line of lines) {
+				expect(Bun.stringWidth(line)).toBeLessThanOrEqual(60);
+			}
+		});
+
+		it("reserves custom tree prefixes, outer indent and roles before optional details", () => {
+			const priorTree = Object.getOwnPropertyDescriptor(theme, "tree");
+			try {
+				Object.defineProperty(theme, "tree", {
+					configurable: true,
+					value: { ...theme.tree, branch: "界├", last: "界界└", vertical: "界界│" },
+				});
+				const sessions = [
+					makeSession({
+						id: `LongWorker${"界".repeat(30)}`,
+						agent: `custom-role-${"extended-".repeat(10)}`,
+						description: "Every available column ".repeat(10),
+						progress: makeProgress({ id: "LongWorker", resolvedModelIdentity: "provider/model", advisor: true }),
+					}),
+					makeSession({ id: "ShortWorker", agent: "scout", description: "Every available column ".repeat(10) }),
+				];
+				for (const enabled of [true, false]) {
+					Settings.instance.override("task.showResolvedModelBadge", enabled);
+					for (const width of [40, 120, 40]) {
+						const rows = render(sessions, width).split("\n");
+						expect(rows.find(row => row.includes("LongWorker"))).toStartWith(" 界├ ");
+						expect(rows.find(row => row.includes("ShortWorker"))).toStartWith(" 界界└ ");
+						for (const row of rows) expect(Bun.stringWidth(row)).toBeLessThanOrEqual(width);
+						expect(rows.find(row => row.includes("LongWorker"))).toContain("LongWorker");
+						expect(rows.find(row => row.includes("ShortWorker"))).toContain(
+							`${theme.format.bracketLeft}scout${theme.format.bracketRight}`,
+						);
+					}
+				}
+			} finally {
+				if (priorTree) Object.defineProperty(theme, "tree", priorTree);
+				else Reflect.deleteProperty(theme, "tree");
+			}
+		});
+
+		it("preserves a legacy selector without inventing a thinking glyph", () => {
+			const out = render([
+				makeSession({
+					id: "LegacyWorker",
+					progress: makeProgress({ id: "LegacyWorker", resolvedModel: "custom/model:high" }),
+				}),
+			]);
+			expect(out).toContain(`${theme.status.done} custom/model:high LegacyWorker`);
+			expect(out).not.toContain(theme.thinking.high.split(" ")[0]);
+		});
 	});
 
 	it("renders running subagents as Id: description under a Subagents header", () => {

--- a/packages/coding-agent/test/task/autoload-skills.test.ts
+++ b/packages/coding-agent/test/task/autoload-skills.test.ts
@@ -9,6 +9,7 @@ import { SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/mes
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -29,6 +30,7 @@ function createMockSession(
 	};
 
 	return {
+		...createSessionDefaults(),
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -38,7 +40,6 @@ function createMockSession(
 		},
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -51,14 +52,7 @@ function createMockSession(
 			onPrompt({ text, options, promptIndex, emit });
 		},
 		sendCustomMessage: vi.fn(async () => {}),
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
 		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	} as unknown as AgentSession;
 }
 

--- a/packages/coding-agent/test/task/executor-async-quiescence.test.ts
+++ b/packages/coding-agent/test/task/executor-async-quiescence.test.ts
@@ -16,6 +16,7 @@ import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const baseAgent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
 
@@ -129,6 +130,7 @@ function createAsyncSession(
 	};
 
 	const session = {
+		...createSessionDefaults(),
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -136,7 +138,6 @@ function createAsyncSession(
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -148,9 +149,6 @@ function createAsyncSession(
 			prompts.push(text);
 			onPrompt({ text, promptIndex: prompts.length, harness });
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
 		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
 		hasPendingAsyncWork: () => pendingAsync,
 		getAsyncJobSnapshot: () => ({ running: runningJobs, recent: [] }),
@@ -163,8 +161,6 @@ function createAsyncSession(
 			await options.abort?.();
 		},
 		dispose: options.dispose ?? (async () => {}),
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	harness.session = session as unknown as AgentSession;
 	return harness;

--- a/packages/coding-agent/test/task/executor-deferred-cleanup.test.ts
+++ b/packages/coding-agent/test/task/executor-deferred-cleanup.test.ts
@@ -21,6 +21,7 @@ import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const baseAgent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
 
@@ -61,6 +62,7 @@ function mockSession(opts: {
 		for (const l of [...listeners]) l(event);
 	};
 	return {
+		...createSessionDefaults(),
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -68,7 +70,6 @@ function mockSession(opts: {
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async () => {},
 		subscribe: (l: (event: AgentSessionEvent) => void) => {
 			listeners.push(l);
 			return () => {
@@ -82,17 +83,12 @@ function mockSession(opts: {
 			emit({ type: "message_end", message: msg } as AgentSessionEvent);
 			opts.onPrompt(emit);
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
 		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
 		hasPendingAsyncWork: () => false,
 		getAsyncJobSnapshot: () => ({ running: [], recent: [] }),
 		settleAsyncWork: async () => {},
 		abort: opts.abort ?? (async () => {}),
 		dispose: opts.dispose ?? (async () => {}),
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	} as unknown as AgentSession;
 }
 

--- a/packages/coding-agent/test/task/executor-launch-startup.test.ts
+++ b/packages/coding-agent/test/task/executor-launch-startup.test.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manage
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const authStorages: AuthStorage[] = [];
 const tempDirs: TempDir[] = [];
@@ -40,6 +41,7 @@ it("overlaps registry refresh with session-file opening and session setup", asyn
 	let sessionCreated = false;
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const session = {
+		...createSessionDefaults(),
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -47,7 +49,6 @@ it("overlaps registry refresh with session-file opening and session setup", asyn
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["yield"],
 		getEnabledToolNames: () => ["yield"],
-		setActiveToolsByName: async () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {};
@@ -63,14 +64,6 @@ it("overlaps registry refresh with session-file opening and session setup", asyn
 				} as AgentSessionEvent);
 			}
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	} as unknown as AgentSession;
 	vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
 		sessionCreationStarted.resolve();

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -21,6 +21,7 @@ import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/p
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
@@ -28,6 +29,7 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		for (const listener of listeners) listener(event);
 	};
 	const session = {
+		...createSessionDefaults(),
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -35,7 +37,6 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -46,14 +47,6 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			onPrompt({ emit });
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	return session as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/task/executor-prewalk.test.ts
+++ b/packages/coding-agent/test/task/executor-prewalk.test.ts
@@ -23,6 +23,7 @@ import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 function yieldEmittingSession(
 	initialTools: string[] = ["read", "yield"],
@@ -35,6 +36,7 @@ function yieldEmittingSession(
 	const serving = (model: Model | undefined): { selector: string; isFallback: boolean } | undefined =>
 		model ? { selector: `${model.provider}/${model.id}`, isFallback: false } : undefined;
 	const session = {
+		...createSessionDefaults(),
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },
 		model: modelSwitch?.from,
@@ -75,14 +77,6 @@ function yieldEmittingSession(
 				});
 			}
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	return session as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/task/executor-recent-output.test.ts
+++ b/packages/coding-agent/test/task/executor-recent-output.test.ts
@@ -24,6 +24,7 @@ import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition, AgentProgress } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const TAIL_BYTES = 8 * 1024;
 
@@ -167,6 +168,7 @@ function createScriptedSession(
 	const emittedGate = Promise.withResolvers<void>();
 	let aborted = false;
 	const session = {
+		...createSessionDefaults(),
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -174,7 +176,6 @@ function createScriptedSession(
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -186,17 +187,10 @@ function createScriptedSession(
 			await script(emit);
 			emittedGate.resolve();
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
 		abort: async () => {
 			aborted = true;
 		},
 		isAborted: () => aborted,
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	// AgentSession is a concrete class; the executor consumes only this
 	// structural subset. Deliberate documented test-double escape hatch,

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -18,6 +18,7 @@ import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 /**
  * Contracts under test — the soft request budget must degrade gracefully
@@ -68,6 +69,7 @@ function createMockSession(
 	};
 
 	const session: Partial<AgentSession> = {
+		...createSessionDefaults(),
 		state: { messages: [] } as never,
 		agent: { state: { systemPrompt: ["test"] } } as never,
 		model: { api: "anthropic-messages" } as never,
@@ -75,7 +77,6 @@ function createMockSession(
 		sessionManager: { appendSessionInit: () => {} } as never,
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -89,14 +90,12 @@ function createMockSession(
 			await onPrompt({ promptIndex, emit, pushMessage: message => messages.push(message) });
 			return true;
 		},
-		waitForIdle: async () => {},
 		getLastAssistantMessage: () => messages[messages.length - 1] as never,
 		sendUserMessage: async () => {},
 		setIrcWakeTurnObserver: observer => {
 			ircWakeTurnObserver = observer;
 		},
 		trackIrcReply: () => {},
-		subscribeRunState: () => () => {},
 		deliverIrcMessage: async msg => {
 			const record: CustomMessage = {
 				role: "custom",
@@ -299,31 +298,56 @@ describe("runSubprocess soft request budget", () => {
 		rpcRegistry.setSubscriptionLevel("progress");
 		const handle = createMockSession(({ promptIndex, emit, pushMessage }) => {
 			if (promptIndex !== 1) return;
+			// Configuration alone must not show an advisor to remote observers.
+			expect(
+				frames.some(frame => frame.type === "subagent_progress" && frame.payload.progress.advisor === true),
+			).toBe(false);
+			// Model discovery can attach the runtime after the monitor subscribes.
+			advisorActive.mockReturnValue(true);
 			// Never yields: budget 2 → stop at 3, grace exhausted at 3 + 5 = 8.
 			for (let i = 1; i <= 8; i++) {
 				const message = assistantText(`burning request ${i}`);
 				pushMessage(message);
 				emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+				if (i === 1) {
+					const advisedProgress = frames.find(
+						frame => frame.type === "subagent_progress" && frame.payload.progress.advisor === true,
+					);
+					expect(advisedProgress).toMatchObject({ payload: { progress: { requests: 0 } } });
+					// Losing the runtime later must not erase this run's advised history.
+					advisorActive.mockReturnValue(false);
+				}
 			}
 		});
+		const advisorActive = vi.spyOn(handle.session, "isAdvisorActive");
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);
 
-		const result = await runSubprocess(baseOptions(id, eventBus));
+		const result = await runSubprocess({
+			...baseOptions(id, eventBus),
+			agent: { ...baseAgent, advisor: true },
+		});
 
 		expect(result.aborted).toBe(true);
 		expect(result.abortReason).toMatch(/Soft request budget exceeded/);
+		expect(result.advisor).toBe(true);
 		// Resumable stop, not a terminal kill: the ref stays adopted and live.
 		expect(AgentRegistry.global().get(id)?.status).toBe("idle");
 		expect(AgentLifecycleManager.global().has(id)).toBe(true);
 		expect(handle.disposeCalls()).toBe(0);
 
-		const expectRpcTurn = (): void => {
+		const expectRpcTurn = (advised: boolean): void => {
 			expect(frames[0]).toMatchObject({
 				type: "subagent_lifecycle",
 				payload: { id, status: "started" },
 			});
-			expect(frames.some(frame => frame.type === "subagent_progress")).toBe(true);
+			const firstProgress = frames.find(frame => frame.type === "subagent_progress");
+			expect(firstProgress).toBeDefined();
+			expect(firstProgress?.payload.progress.advisor === true).toBe(advised);
+			if (advised) {
+				// The badge must appear before the awakened agent emits its first request.
+				expect(firstProgress?.payload.progress.requests).toBe(0);
+			}
 			expect(frames.at(-1)).toMatchObject({
 				type: "subagent_lifecycle",
 				payload: { id, status: "completed" },
@@ -331,20 +355,23 @@ describe("runSubprocess soft request budget", () => {
 		};
 
 		frames.length = 0;
+		advisorActive.mockReturnValue(true);
 		const idleTerminal = waitForFollowUpTerminal();
 		const idleReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume your inventory" });
 		expect(idleReceipt.outcome).toBe("woken");
 		await idleTerminal;
-		expectRpcTurn();
+		expectRpcTurn(true);
 
 		await AgentLifecycleManager.global().park(id);
 		expect(AgentRegistry.global().get(id)?.status).toBe("parked");
 		frames.length = 0;
+		// Parking can rebuild an unadvised session; don't retain the prior turn's marker.
+		advisorActive.mockReturnValue(false);
 		const revivedTerminal = waitForFollowUpTerminal();
 		const revivedReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume after parking" });
 		expect(revivedReceipt.outcome).toBe("revived");
 		await revivedTerminal;
-		expectRpcTurn();
+		expectRpcTurn(false);
 		rpcRegistry.dispose();
 	});
 

--- a/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
+++ b/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
@@ -18,6 +18,7 @@ import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/p
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
@@ -25,6 +26,7 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		for (const listener of listeners) listener(event);
 	};
 	const session = {
+		...createSessionDefaults(),
 		state: { messages: [] },
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -32,7 +34,6 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		sessionManager: { appendSessionInit: () => {} },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -43,14 +44,6 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			onPrompt({ emit });
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	return session as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -15,6 +15,7 @@ import {
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { logger } from "@oh-my-pi/pi-utils";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 function createAssistantStopMessage(text: string): AssistantMessage {
 	return {
@@ -54,6 +55,7 @@ function createMockSession(
 	};
 
 	const session = {
+		...createSessionDefaults(),
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -63,7 +65,6 @@ function createMockSession(
 		},
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -75,14 +76,7 @@ function createMockSession(
 			promptIndex += 1;
 			await onPrompt({ text, options, promptIndex, emit, state });
 		},
-		waitForIdle: async () => {},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
 		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 
 	return session as unknown as AgentSession;

--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -9,6 +9,7 @@ import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/p
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 /**
  * Contract: when `task.maxRuntimeMs` is set, a subagent whose inference call
@@ -31,8 +32,7 @@ function createHangingSession(): HangingSessionHandle {
 	let abortCount = 0;
 	const { promise: hang, resolve: releaseHang } = Promise.withResolvers<void>();
 	const session: Partial<AgentSession> = {
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
+		...createSessionDefaults(),
 		state: { messages: [] } as never,
 		agent: { state: { systemPrompt: ["test"] } } as never,
 		extensionRunner: undefined as never,
@@ -41,7 +41,6 @@ function createHangingSession(): HangingSessionHandle {
 		} as never,
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_names: string[]) => {},
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			await hang;
@@ -50,14 +49,10 @@ function createHangingSession(): HangingSessionHandle {
 		waitForIdle: async () => {
 			await hang;
 		},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
-		getLastAssistantMessage: () => undefined,
 		abort: async () => {
 			abortCount += 1;
 			releaseHang();
 		},
-		dispose: async () => {},
 	};
 	return {
 		session: session as AgentSession,
@@ -125,15 +120,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		// hang; we only need to assert that NO timeout fires when maxRuntimeMs=0.
 		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
 		const fastSession: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				// Fire a synthetic yield on the next tick to drive runSubprocess to
 				// completion without depending on the real agent loop.
@@ -152,12 +145,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				return () => {};
 			},
 			prompt: async () => true,
-			waitForIdle: async () => {},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
-			getLastAssistantMessage: () => undefined,
-			abort: async () => {},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(fastSession as AgentSession);
 
@@ -216,9 +203,8 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		const creationStarted = Promise.withResolvers<CreateAgentSessionOptions>();
 		const lateDisposed = Promise.withResolvers<void>();
 		const lateSession = {
+			...createSessionDefaults(),
 			dispose: async () => lateDisposed.resolve(),
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
 		} as unknown as AgentSession;
 		let lateInstall = registry.get("late-generation");
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async (options = {}) => {
@@ -255,11 +241,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		const cancelled = await run;
 		expect(cancelled.aborted).toBe(true);
 
-		const replacementSession = {
-			dispose: async () => {},
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
-		} as unknown as AgentSession;
+		const replacementSession = createSessionDefaults() as unknown as AgentSession;
 		const replacement = registry.register({
 			id: "late-generation",
 			displayName: "replacement B",
@@ -286,15 +268,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
 		let abortCount = 0;
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -306,9 +286,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 			waitForIdle: async () => {
 				await hang;
 			},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
-			getLastAssistantMessage: () => undefined,
 			abort: async () => {
 				abortCount += 1;
 				// Simulate a late yield arriving while the executor is tearing
@@ -325,7 +302,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				} as AgentSessionEvent);
 				releaseHang();
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 
@@ -368,15 +344,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let abortCount = 0;
 		let abortCountBeforeYieldExecutionEnd: number | undefined;
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -405,13 +379,10 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 					isError: false,
 				} as AgentSessionEvent);
 			},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
 			getLastAssistantMessage: () => yieldAssistantMessage as never,
 			abort: async () => {
 				abortCount += 1;
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 
@@ -472,15 +443,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let abortCountBeforeValidYieldExecutionEnd: number | undefined;
 		const promptCalls: Array<{ text: string; options?: PromptOptions }> = [];
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -534,13 +503,10 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 					} as AgentSessionEvent);
 				}
 			},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
 			getLastAssistantMessage: () => lastAssistantMessage as never,
 			abort: async () => {
 				abortCount += 1;
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 
@@ -606,15 +572,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let abortCountBeforeYieldExecutionEnd: number | undefined;
 		let abortCountAfterFollowingTurn: number | undefined;
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -655,13 +619,10 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				} as unknown as AgentSessionEvent);
 				abortCountAfterFollowingTurn = abortCount;
 			},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
 			getLastAssistantMessage: () => lastAssistantMessage as never,
 			abort: async () => {
 				abortCount += 1;
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 
@@ -693,15 +654,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		// executor must surface it on SingleResult.contextTokens.
 		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
 		const fastSession: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				queueMicrotask(() => {
 					listener({
@@ -726,12 +685,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				return () => {};
 			},
 			prompt: async () => true,
-			waitForIdle: async () => {},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
-			getLastAssistantMessage: () => undefined,
-			abort: async () => {},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(fastSession as AgentSession);
 
@@ -760,15 +713,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
 		let abortCount = 0;
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -787,9 +738,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 			waitForIdle: async () => {
 				await hang;
 			},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
-			getLastAssistantMessage: () => undefined,
 			abort: async () => {
 				abortCount += 1;
 				// Genuine delay: the defect is the real interleaving between the
@@ -799,7 +747,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				await Bun.sleep(1500);
 				releaseHang();
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 
@@ -819,15 +766,13 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		let listenerRef: ((event: AgentSessionEvent) => void) | undefined;
 		let abortCount = 0;
 		const session: Partial<AgentSession> = {
-			setIrcWakeTurnObserver: () => {},
-			subscribeRunState: () => () => {},
+			...createSessionDefaults(),
 			state: { messages: [] } as never,
 			agent: { state: { systemPrompt: ["test"] } } as never,
 			extensionRunner: undefined as never,
 			sessionManager: { appendSessionInit: () => {} } as never,
 			getActiveToolNames: () => ["read", "yield"],
 			getEnabledToolNames: () => ["read", "yield"],
-			setActiveToolsByName: async () => {},
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				listenerRef = listener;
 				return () => {};
@@ -846,10 +791,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				} as AgentSessionEvent);
 				return true;
 			},
-			waitForIdle: async () => {},
-			prepareForHeadlessAdvisorDrain: () => {},
-			waitForAdvisorCatchup: async () => true,
-			getLastAssistantMessage: () => undefined,
 			abort: async () => {
 				abortCount += 1;
 				// Genuine delay: post-yield teardown must outlast the real
@@ -857,7 +798,6 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				// committed. See the budget test above for why fake timers do not fit.
 				await Bun.sleep(1500);
 			},
-			dispose: async () => {},
 		};
 		mockCreateAgentSession(session as AgentSession);
 

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -17,6 +17,7 @@ import { createPersistedSubagentReviverFactory } from "@oh-my-pi/pi-coding-agent
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const tempDirs: TempDir[] = [];
 
@@ -56,6 +57,7 @@ function createRevivedSession(activeToolNames: string[][], extensionRunner?: unk
 	let lastAssistantText: string | undefined;
 	const trackedReplies: Promise<void>[] = [];
 	const session = {
+		...createSessionDefaults(),
 		getMountedXdevToolNames: () => [],
 		setActiveToolsByName: async (names: string[]) => {
 			activeToolNames.push(names);
@@ -67,7 +69,6 @@ function createRevivedSession(activeToolNames: string[][], extensionRunner?: unk
 		trackIrcReply: (pending: Promise<void>) => {
 			trackedReplies.push(pending);
 		},
-		subscribeRunState: () => () => {},
 		getLastAssistantMessage: () =>
 			lastAssistantText === undefined
 				? undefined

--- a/packages/coding-agent/test/task/subagent-lsp.test.ts
+++ b/packages/coding-agent/test/task/subagent-lsp.test.ts
@@ -19,6 +19,7 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/tools/yield";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 const TEST_TASK: TaskParams = { agent: "task", name: "CheckLsp", task: "Inspect LSP tools." };
 
@@ -51,6 +52,7 @@ function createYieldingSession(): AgentSession {
 	};
 
 	return {
+		...createSessionDefaults(),
 		state,
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
@@ -60,7 +62,6 @@ function createYieldingSession(): AgentSession {
 		},
 		getActiveToolNames: () => ["yield"],
 		getEnabledToolNames: () => ["yield"],
-		setActiveToolsByName: async () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
 			return () => {
@@ -81,12 +82,7 @@ function createYieldingSession(): AgentSession {
 				isError: false,
 			});
 		},
-		waitForIdle: async () => {},
 		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
-		abort: async () => {},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	} as unknown as AgentSession;
 }
 

--- a/packages/coding-agent/test/task/task-guards.test.ts
+++ b/packages/coding-agent/test/task/task-guards.test.ts
@@ -9,6 +9,7 @@ import { formatResultOutputFallback } from "@oh-my-pi/pi-coding-agent/task";
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { createSessionDefaults } from "../helpers/session-defaults";
 
 /**
  * Contract: runaway-subagent guards.
@@ -76,13 +77,13 @@ function createFakeSession(config: FakeSessionConfig = {}): FakeSessionHandle {
 	if (!config.hang) releaseHang();
 
 	const session: Partial<AgentSession> = {
+		...createSessionDefaults(),
 		state: { messages: [] } as never,
 		agent: { state: { systemPrompt: ["test"] } } as never,
 		extensionRunner: undefined as never,
 		sessionManager: { appendSessionInit: () => {} } as never,
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
-		setActiveToolsByName: async (_names: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			if (config.events?.length) {
 				const events = config.events;
@@ -99,8 +100,6 @@ function createFakeSession(config: FakeSessionConfig = {}): FakeSessionHandle {
 		waitForIdle: async () => {
 			await hang;
 		},
-		prepareForHeadlessAdvisorDrain: () => {},
-		waitForAdvisorCatchup: async () => true,
 		sendUserMessage: async (content, options) => {
 			steerCalls.push({ content: String(content), options });
 		},
@@ -109,9 +108,6 @@ function createFakeSession(config: FakeSessionConfig = {}): FakeSessionHandle {
 			abortCount += 1;
 			releaseHang();
 		},
-		dispose: async () => {},
-		setIrcWakeTurnObserver: () => {},
-		subscribeRunState: () => () => {},
 	};
 	return {
 		session: session as AgentSession,

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import type { RenderResultOptions } from "@oh-my-pi/pi-agent-core";
+import { type RenderResultOptions, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { SettingPath, SettingValue } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { taskToolRenderer } from "@oh-my-pi/pi-coding-agent/task/renderer";
+import { subprocessToolRegistry } from "@oh-my-pi/pi-coding-agent/task/subprocess-tool-registry";
 import type { AgentProgress, SingleResult, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
+import { FEED_MODEL_BADGE_WIDTH } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 
 function runningProgress(overrides: Partial<AgentProgress> = {}): AgentProgress {
 	return {
@@ -67,6 +70,264 @@ describe("task progress rendering", () => {
 		vi.restoreAllMocks();
 		resetSettingsForTest();
 	});
+
+	it("places the model and advisor before the live agent title without displacing stats", async () => {
+		Settings.instance.set("task.showResolvedModelBadge", true);
+		const theme = (await getThemeByName("dark"))!;
+		const progress = runningProgress({
+			id: "BadgeWorker",
+			agent: "scout",
+			description: "Inspect rendering",
+			resolvedModel: "openai/gpt-5:high",
+			resolvedModelIdentity: "openai/gpt-5",
+			resolvedThinkingLevel: ThinkingLevel.High,
+			advisor: true,
+			requests: 3,
+			cost: 0.25,
+		});
+		const row = Bun.stripANSI(
+			findRow(
+				taskToolRenderer.renderResult(
+					{ content: [], details: detailsFor(progress) },
+					{ expanded: false, isPartial: true },
+					theme,
+				),
+				"BadgeWorker",
+			),
+		);
+		expect(row).toContain(`openai/gpt-5 ${theme.icon.advisor} BadgeWorker: Inspect rendering`);
+		expect(row).not.toContain(":high");
+		expect(row).toContain(`${theme.thinking.high.split(" ")[0]} openai/gpt-5`);
+		expect(row.indexOf(theme.status.done)).toBeLessThan(row.indexOf("openai/gpt-5"));
+		expect(row).toContain(`${theme.format.bracketLeft}scout${theme.format.bracketRight}`);
+		expect(row.indexOf("3 req")).toBeGreaterThan(row.indexOf("BadgeWorker"));
+		expect(row).toContain("$0.25");
+	});
+
+	it("keeps the settled model before the name and only marks an enabled advisor", async () => {
+		Settings.instance.set("task.showResolvedModelBadge", true);
+		const theme = (await getThemeByName("dark"))!;
+		const renderRow = (advisor: boolean): string =>
+			Bun.stripANSI(
+				findRow(
+					taskToolRenderer.renderResult(
+						{
+							content: [],
+							details: {
+								projectAgentsDir: null,
+								totalDurationMs: 1000,
+								results: [
+									finishedResult({
+										id: "SettledWorker",
+										description: "Inspect rendering",
+										resolvedModel: "openai/gpt-5:high",
+										resolvedModelIdentity: "openai/gpt-5",
+										resolvedThinkingLevel: ThinkingLevel.High,
+										advisor,
+										durationMs: 1000,
+										requests: 3,
+									}),
+								],
+							},
+						},
+						{ expanded: false, isPartial: false },
+						theme,
+					),
+					"SettledWorker",
+				),
+			);
+		const withoutAdvisor = renderRow(false);
+		expect(withoutAdvisor).toContain("openai/gpt-5 SettledWorker: Inspect rendering");
+		expect(withoutAdvisor).not.toContain(theme.icon.advisor);
+		expect(withoutAdvisor).not.toContain(":high");
+		expect(withoutAdvisor.indexOf("3 req")).toBeGreaterThan(withoutAdvisor.indexOf("SettledWorker"));
+		expect(renderRow(true)).toContain(`openai/gpt-5 ${theme.icon.advisor} SettledWorker`);
+	});
+
+	it("keeps the name and status on the first row at 40 columns across resizes", async () => {
+		Settings.instance.set("task.showResolvedModelBadge", true);
+		const theme = (await getThemeByName("dark"))!;
+		const metadata = {
+			id: "ArchitectureScout",
+			agent: "scout",
+			description: "Inspect rendering boundaries",
+			resolvedModelIdentity: "openai/custom-architecture-model:high",
+			resolvedThinkingLevel: ThinkingLevel.High,
+			advisor: true,
+		};
+		const snapshots: { details: TaskToolDetails; status?: string }[] = [
+			{ details: detailsFor(runningProgress(metadata)) },
+			{ details: detailsFor(runningProgress({ ...metadata, status: "completed" })) },
+			{ details: detailsFor(runningProgress({ ...metadata, status: "failed" })), status: "failed" },
+			{
+				details: { projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult(metadata)] },
+				status: "done",
+			},
+			{
+				details: {
+					projectAgentsDir: null,
+					totalDurationMs: 0,
+					results: [finishedResult({ ...metadata, exitCode: 1 })],
+				},
+				status: "failed",
+			},
+		];
+		for (const { details, status } of snapshots) {
+			const component = taskToolRenderer.renderResult(
+				{ content: [], details },
+				{ expanded: false, isPartial: !!details.progress },
+				theme,
+			);
+			for (const width of [160, 40, 160]) {
+				const rows = component.render(width);
+				for (const row of rows) expect(visibleWidth(row)).toBeLessThanOrEqual(width);
+				const plainRows = rows.map(row => Bun.stripANSI(row));
+				const firstStatusRow = plainRows.find(row => row.startsWith(theme.boxRound.vertical));
+				expect(firstStatusRow).toBeDefined();
+				expect(firstStatusRow).toContain(metadata.id);
+				expect(firstStatusRow).toContain(`${theme.format.bracketLeft}scout${theme.format.bracketRight}`);
+				if (status) {
+					expect(firstStatusRow).toContain(`${theme.format.bracketLeft}${status}${theme.format.bracketRight}`);
+				}
+				expect(plainRows.join("\n")).toContain(metadata.description);
+				if (width === 160) {
+					const thinkingGlyph = theme.thinking.high.split(" ")[0];
+					expect(firstStatusRow).toContain("openai/");
+					expect(firstStatusRow).toContain(":high");
+					expect(firstStatusRow).toContain(thinkingGlyph);
+					const badge = firstStatusRow!
+						.slice(firstStatusRow!.indexOf(thinkingGlyph), firstStatusRow!.indexOf(metadata.id))
+						.trimEnd();
+					expect(visibleWidth(badge)).toBeLessThanOrEqual(FEED_MODEL_BADGE_WIDTH);
+					expect(firstStatusRow).toContain(theme.icon.advisor);
+				}
+			}
+		}
+	});
+
+	it("hides model and advisor metadata together on progress and settled rows", async () => {
+		Settings.instance.set("task.showResolvedModelBadge", false);
+		const theme = (await getThemeByName("dark"))!;
+		const metadata = {
+			id: "HiddenBadge",
+			resolvedModel: "openai/gpt-5:high",
+			resolvedModelIdentity: "openai/gpt-5",
+			resolvedThinkingLevel: ThinkingLevel.High,
+			advisor: true,
+		};
+		const snapshots: TaskToolDetails[] = [
+			detailsFor(runningProgress(metadata)),
+			{ projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult(metadata)] },
+		];
+		for (const details of snapshots) {
+			const row = Bun.stripANSI(
+				findRow(
+					taskToolRenderer.renderResult(
+						{ content: [], details },
+						{ expanded: false, isPartial: !!details.progress },
+						theme,
+					),
+					"HiddenBadge",
+				),
+			);
+			expect(row).toContain(`${theme.status.done} HiddenBadge`);
+			expect(row).not.toContain("openai/gpt-5");
+			expect(row).not.toContain(theme.icon.advisor);
+		}
+	});
+
+	it("preserves nested subprocess IDs and status when no width is known during row construction", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const details: TaskToolDetails = {
+			projectAgentsDir: null,
+			totalDurationMs: 0,
+			results: [finishedResult({ id: "UnknownWidthWorker", agent: "scout", exitCode: 1 })],
+		};
+		const component = subprocessToolRegistry.getHandler("task")!.renderFinal!([details], theme, false);
+		const text = Bun.stripANSI(component.render(120).join("\n"));
+		expect(text).toContain("UnknownWidthWorker");
+		expect(text).toContain(`${theme.format.bracketLeft}scout${theme.format.bracketRight}`);
+		expect(text).toContain(`${theme.format.bracketLeft}failed${theme.format.bracketRight}`);
+	});
+
+	it("renders model-bearing progress and results before settings initialization", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		resetSettingsForTest();
+		const metadata = { id: "ColdStart", resolvedModelIdentity: "provider/model", advisor: true };
+		for (const details of [
+			detailsFor(runningProgress(metadata)),
+			{ projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult(metadata)] },
+		]) {
+			const text = Bun.stripANSI(
+				taskToolRenderer
+					.renderResult({ content: [], details }, { expanded: false, isPartial: false }, theme)
+					.render(60)
+					.join("\n"),
+			);
+			expect(text).toContain("ColdStart");
+			expect(text).not.toContain("provider/model");
+			expect(text).not.toContain(theme.icon.advisor);
+		}
+	});
+
+	it("preserves long descriptions below bounded IDs and required status with badges on or off", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const description = "First distinctive description section followed by every remaining detail and final marker";
+		const metadata = {
+			id: `LongWorker${"界".repeat(30)}`,
+			agent: `custom-role-${"extended-".repeat(10)}`,
+			description,
+			resolvedModelIdentity: "provider/model",
+			advisor: true,
+		};
+		for (const enabled of [true, false]) {
+			Settings.instance.override("task.showResolvedModelBadge", enabled);
+			for (const details of [
+				detailsFor(runningProgress({ ...metadata, status: "failed" })),
+				{ projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult({ ...metadata, exitCode: 1 })] },
+			]) {
+				const component = taskToolRenderer.renderResult(
+					{ content: [], details },
+					{ expanded: false, isPartial: false },
+					theme,
+				);
+				for (const width of [40, 160, 40]) {
+					const rows = component.render(width).map(row => Bun.stripANSI(row));
+					for (const row of rows) expect(visibleWidth(row)).toBeLessThanOrEqual(width);
+					const statusRow = rows.find(row => row.includes("LongWorker"))!;
+					expect(statusRow).toContain("LongWorker");
+					expect(statusRow).toContain(`${theme.format.bracketLeft}failed${theme.format.bracketRight}`);
+					const text = rows.join("").replaceAll(theme.boxRound.vertical, "").replace(/\s+/g, "");
+					expect(text).toContain(description.replace(/\s+/g, ""));
+				}
+			}
+		}
+	});
+
+	it("preserves old snapshot selectors without inventing thinking glyphs", async () => {
+		Settings.instance.set("task.showResolvedModelBadge", true);
+		const theme = (await getThemeByName("dark"))!;
+		const metadata = { id: "LegacyWorker", resolvedModel: "custom/model:high" };
+		const snapshots: TaskToolDetails[] = [
+			detailsFor(runningProgress(metadata)),
+			{ projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult(metadata)] },
+		];
+		for (const details of snapshots) {
+			const row = Bun.stripANSI(
+				findRow(
+					taskToolRenderer.renderResult(
+						{ content: [], details },
+						{ expanded: false, isPartial: !!details.progress },
+						theme,
+					),
+					"LegacyWorker",
+				),
+			);
+			expect(row).toContain(`${theme.status.done} custom/model:high LegacyWorker`);
+			expect(row).not.toContain(theme.thinking.high.split(" ")[0]);
+		}
+	});
+
 	it("renders running task rows static with the agent dot", async () => {
 		const theme = (await getThemeByName("dark"))!;
 		expect(theme).toBeDefined();

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -13,6 +13,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type AsyncJob, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
@@ -20,8 +21,9 @@ import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
-import type { AgentDefinition, SingleResult, TaskParams } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, AgentProgress, SingleResult, TaskParams } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { snapshotJobs } from "@oh-my-pi/pi-coding-agent/tools/hub/jobs";
 
 const taskAgent: AgentDefinition = {
 	name: "task",
@@ -63,6 +65,11 @@ function makeResult(id: string, overrides: Partial<SingleResult> = {}): SingleRe
 		requests: 1,
 		...overrides,
 	};
+}
+
+function getJobProgress(job: AsyncJob): AgentProgress | undefined {
+	const progress = job.latestDetails?.progress;
+	return Array.isArray(progress) ? progress[0] : undefined;
 }
 
 interface Deferred {
@@ -148,6 +155,224 @@ describe("task spawn routing", () => {
 		expect(runSpy).toHaveBeenCalledTimes(1);
 		expect(runSpy.mock.calls[0]?.[0].modelOverride).toEqual(["openai/gpt-4.1-mini"]);
 	});
+
+	for (const { label, liveAdvisor, settledAdvisor, expectedAdvisor } of [
+		{
+			label: "retains an attached advisor through teardown",
+			liveAdvisor: true,
+			settledAdvisor: undefined,
+			expectedAdvisor: true,
+		},
+		{
+			label: "publishes an advisor attached at completion",
+			liveAdvisor: undefined,
+			settledAdvisor: true,
+			expectedAdvisor: true,
+		},
+		{
+			label: "omits an explicitly inactive advisor",
+			liveAdvisor: false,
+			settledAdvisor: false,
+			expectedAdvisor: undefined,
+		},
+	]) {
+		it(`${label} in detached job snapshots`, async () => {
+			vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+				// Configuration alone must not claim an attached runtime.
+				agents: [{ ...taskAgent, advisor: true }],
+				projectAgentsDir: null,
+			});
+			const gate = deferred();
+			let publishAdvisor: (() => void) | undefined;
+			vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+				const progress = {
+					index: 0,
+					id: options.id ?? "?",
+					agent: "task",
+					agentSource: "bundled" as const,
+					status: "pending" as const,
+					task: "Do the thing.",
+					recentTools: [],
+					recentOutput: [],
+					toolCount: 0,
+					requests: 1,
+					tokens: 1,
+					cost: 0,
+					durationMs: 1,
+					resolvedModel: "custom/coding-router:max:high",
+					resolvedModelIdentity: "custom/coding-router:max",
+					resolvedThinkingLevel: ThinkingLevel.High,
+				};
+				options.onProgress?.(progress);
+				publishAdvisor = () => options.onProgress?.({ ...progress, tokens: 2, advisor: liveAdvisor });
+				await gate.promise;
+				return makeResult(options.id ?? "?", {
+					resolvedModel: progress.resolvedModel,
+					resolvedModelIdentity: progress.resolvedModelIdentity,
+					resolvedThinkingLevel: progress.resolvedThinkingLevel,
+					advisor: settledAdvisor,
+				});
+			});
+
+			const manager = createManager();
+			const session = createSession({ manager });
+			const tool = await TaskTool.create(session);
+			const result = await tool.execute("tc-advisor", {
+				agent: "task",
+				name: "Advised",
+				task: "Do the thing.",
+			} as TaskParams);
+			const job = manager.getJob(result.details!.async!.jobId)!;
+			try {
+				await pollUntil(() => publishAdvisor !== undefined);
+				await pollUntil(() => snapshotJobs(session, [job])[0]?.resolvedModel === "custom/coding-router:max:high");
+				expect(snapshotJobs(session, [job])[0]).toMatchObject({
+					id: job.id,
+					status: "running",
+					resolvedModel: "custom/coding-router:max:high",
+					resolvedModelIdentity: "custom/coding-router:max",
+					resolvedThinkingLevel: ThinkingLevel.High,
+				});
+				expect(snapshotJobs(session, [job])[0]?.advisor).toBeUndefined();
+
+				publishAdvisor!();
+				await pollUntil(() => {
+					const progress = job.latestDetails?.progress;
+					return Array.isArray(progress) && progress[0]?.tokens === 2;
+				});
+				expect(snapshotJobs(session, [job])[0]?.advisor).toBe(liveAdvisor === true ? true : undefined);
+				expect(snapshotJobs(session, [job])[0]?.status).toBe("running");
+			} finally {
+				gate.resolve();
+				await job.promise;
+			}
+
+			expect(snapshotJobs(session, [job])[0]?.status).toBe("completed");
+			expect(snapshotJobs(session, [job])[0]).toMatchObject({
+				resolvedModelIdentity: "custom/coding-router:max",
+				resolvedThinkingLevel: ThinkingLevel.High,
+			});
+			expect(snapshotJobs(session, [job])[0]?.advisor).toBe(expectedAdvisor);
+		});
+	}
+
+	it("clears stale model metadata and fallback state from detached progress", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [taskAgent], projectAgentsDir: null });
+		const gate = deferred();
+		let publishProgress: ((metadata: Partial<AgentProgress>) => void) | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			const progress: AgentProgress = {
+				...makeResult(options.id ?? "?"),
+				status: "running",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 0,
+				cost: 0,
+				resolvedModel: "custom/coding-router:max:high",
+				resolvedModelIdentity: "custom/coding-router:max",
+				resolvedThinkingLevel: ThinkingLevel.High,
+				resolvedModelIsFallback: true,
+			};
+			options.onProgress?.(progress);
+			publishProgress = metadata => options.onProgress?.({ ...progress, ...metadata });
+			await gate.promise;
+			return makeResult(options.id ?? "?");
+		});
+		const manager = createManager();
+		const session = createSession({ manager });
+		const tool = await TaskTool.create(session);
+		const result = await tool.execute("tc-metadata", { agent: "task", name: "Metadata", task: "work" } as TaskParams);
+		const job = manager.getJob(result.details!.async!.jobId)!;
+		try {
+			await pollUntil(
+				() =>
+					publishProgress !== undefined &&
+					snapshotJobs(session, [job])[0]?.resolvedThinkingLevel === ThinkingLevel.High,
+			);
+			expect(getJobProgress(job)?.resolvedModelIsFallback).toBe(true);
+			publishProgress!({
+				resolvedModel: undefined,
+				resolvedModelIdentity: undefined,
+				resolvedThinkingLevel: undefined,
+				resolvedModelIsFallback: true,
+			});
+			await pollUntil(() => snapshotJobs(session, [job])[0]?.resolvedModel === undefined);
+			expect(getJobProgress(job)?.resolvedModelIsFallback).toBeUndefined();
+
+			publishProgress!({});
+			await pollUntil(() => getJobProgress(job)?.resolvedModelIsFallback === true);
+			publishProgress!({
+				resolvedModel: "custom/legacy:low",
+				resolvedModelIdentity: undefined,
+				resolvedThinkingLevel: undefined,
+				resolvedModelIsFallback: undefined,
+			});
+			await pollUntil(() => snapshotJobs(session, [job])[0]?.resolvedModel === "custom/legacy:low");
+			const legacy = snapshotJobs(session, [job])[0];
+			expect(legacy?.resolvedModelIdentity).toBeUndefined();
+			expect(legacy?.resolvedThinkingLevel).toBeUndefined();
+			expect(getJobProgress(job)?.resolvedModelIsFallback).toBeUndefined();
+
+			publishProgress!({ resolvedModelIsFallback: false });
+			await pollUntil(() => getJobProgress(job)?.resolvedModelIsFallback === false);
+			publishProgress!({});
+			await pollUntil(() => getJobProgress(job)?.resolvedModelIsFallback === true);
+		} finally {
+			gate.resolve();
+			await job.promise;
+		}
+		const settled = snapshotJobs(session, [job])[0];
+		expect(settled?.status).toBe("completed");
+		expect(settled?.resolvedModel).toBeUndefined();
+		expect(settled?.resolvedModelIdentity).toBeUndefined();
+		expect(settled?.resolvedThinkingLevel).toBeUndefined();
+		expect(getJobProgress(job)?.resolvedModelIsFallback).toBeUndefined();
+	});
+
+	it.each([undefined, false, true])(
+		"uses the settled model's authoritative fallback state (%s), not the previous model's",
+		async settledFallback => {
+			vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [taskAgent], projectAgentsDir: null });
+			const gate = deferred();
+			vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+				options.onProgress?.({
+					...makeResult(options.id ?? "?"),
+					status: "running",
+					recentTools: [],
+					recentOutput: [],
+					toolCount: 0,
+					cost: 0,
+					resolvedModel: "custom/previous",
+					resolvedModelIdentity: "custom/previous",
+					resolvedModelIsFallback: settledFallback !== true,
+				});
+				await gate.promise;
+				return makeResult(options.id ?? "?", {
+					resolvedModel: "custom/settled",
+					resolvedModelIdentity: "custom/settled",
+					resolvedModelIsFallback: settledFallback,
+				});
+			});
+			const manager = createManager();
+			const tool = await TaskTool.create(createSession({ manager }));
+			const result = await tool.execute("tc-fallback", {
+				agent: "task",
+				name: "Fallback",
+				task: "work",
+			} as TaskParams);
+			const job = manager.getJob(result.details!.async!.jobId)!;
+			try {
+				await pollUntil(() => getJobProgress(job)?.resolvedModel === "custom/previous");
+				expect(getJobProgress(job)?.resolvedModelIsFallback).toBe(settledFallback !== true);
+			} finally {
+				gate.resolve();
+				await job.promise;
+			}
+			expect(job.status).toBe("completed");
+			expect(getJobProgress(job)?.resolvedModel).toBe("custom/settled");
+			expect(getJobProgress(job)?.resolvedModelIsFallback).toBe(settledFallback);
+		},
+	);
 
 	it("retains the temporary artifacts directory for a completed async spawn (in-memory session)", async () => {
 		// Regression: with no session file (in-memory session), leaseArtifacts()

--- a/packages/coding-agent/test/tools/eval-agent-progress.test.ts
+++ b/packages/coding-agent/test/tools/eval-agent-progress.test.ts
@@ -1,8 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { EvalStatusEvent, EvalToolDetails } from "@oh-my-pi/pi-coding-agent/eval/types";
 import { getThemeByName, setThemeInstance, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { thinkingLevelGlyph } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 
 /**
  * Defends the contract that `agent()` calls inside an eval cell surface as a
@@ -23,6 +26,10 @@ describe("eval renderer: agent() progress below the cell box", () => {
 
 	afterAll(() => {
 		resetSettingsForTest();
+	});
+
+	afterEach(() => {
+		settings.clearOverride("task.showResolvedModelBadge");
 	});
 
 	function render(statusEvents: EvalStatusEvent[], status: "running" | "complete" = "running"): string[] {
@@ -50,11 +57,12 @@ describe("eval renderer: agent() progress below the cell box", () => {
 	}
 
 	/** Index of the box's closing border (bottom-right corner glyph). */
-	function boxBottomIndex(lines: string[]): number {
+	function boxBottomIndex(lines: readonly string[]): number {
 		return lines.findIndex(line => line.includes(theme.boxRound.bottomRight));
 	}
 
 	it("draws a running subagent below the box with its current tool and intent", () => {
+		settings.override("task.showResolvedModelBadge", true);
 		const event: EvalStatusEvent = {
 			op: "agent",
 			id: "0-Scout",
@@ -69,7 +77,10 @@ describe("eval renderer: agent() progress below the cell box", () => {
 			contextWindow: 200000,
 			cost: 0.03,
 			durationMs: 800,
-			model: "p/model",
+			resolvedModel: "p/model:high:high",
+			resolvedModelIdentity: "p/model:high",
+			resolvedThinkingLevel: ThinkingLevel.High,
+			advisor: true,
 		};
 
 		const lines = render([event]);
@@ -85,12 +96,18 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		expect(below).toContain("0-Scout");
 		expect(below).toContain("read");
 		expect(below).toContain("Reading config");
+		expect(below).toContain(
+			`${thinkingLevelGlyph(ThinkingLevel.High, theme)} p/model:high ${theme.icon.advisor} 0-Scout`,
+		);
+		expect(below.split("p/model:high").length - 1).toBe(1);
+		expect(below).not.toContain("p/model:high:high");
 		// Agent progress is NOT folded into the box's Status section.
 		expect(inside).not.toContain("0-Scout");
 		expect(inside).not.toContain("Reading config");
 	});
 
 	it("keeps full stats on a completed subagent below the box", () => {
+		settings.override("task.showResolvedModelBadge", true);
 		const event: EvalStatusEvent = {
 			op: "agent",
 			id: "0-Scout",
@@ -101,7 +118,10 @@ describe("eval renderer: agent() progress below the cell box", () => {
 			contextWindow: 200000,
 			cost: 0.06,
 			durationMs: 1500,
-			model: "p/model",
+			model: "p/model:low:high",
+			resolvedModelIdentity: "p/model:low",
+			resolvedThinkingLevel: ThinkingLevel.High,
+			advisor: false,
 		};
 
 		const lines = render([event], "complete");
@@ -112,6 +132,66 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		const below = lines.slice(bottom + 1).join("\n");
 		// Cost stat survives the completed snapshot.
 		expect(below).toContain("$0.06");
+		expect(below).toContain(`${thinkingLevelGlyph(ThinkingLevel.High, theme)} p/model:low 0-Scout`);
+		expect(below.split("p/model:low").length - 1).toBe(1);
+		expect(below).not.toContain("p/model:low:high");
+		expect(below).not.toContain(theme.icon.advisor);
+	});
+
+	it("preserves legacy model fields without inferring thinking levels from their suffixes", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const lines = render([
+			{
+				op: "agent",
+				id: "LegacyModel",
+				status: "running",
+				model: "p/model:high",
+				resolvedModel: "p/unused:max",
+			},
+			{
+				op: "agent",
+				id: "LegacyResolved",
+				status: "completed",
+				resolvedModel: "p/model:max",
+			},
+			{
+				op: "agent",
+				id: "LiteralAuto",
+				status: "completed",
+				resolvedModelIdentity: "p/model:auto",
+				resolvedThinkingLevel: "invalid",
+			},
+		]);
+		const below = lines.slice(boxBottomIndex(lines) + 1).join("\n");
+
+		expect(below).toContain("p/model:high LegacyModel");
+		expect(below).toContain("p/model:max LegacyResolved");
+		expect(below).toContain("p/model:auto LiteralAuto");
+		expect(below).not.toContain("p/unused");
+		expect(below).not.toContain(thinkingLevelGlyph(ThinkingLevel.High, theme));
+		expect(below).not.toContain(thinkingLevelGlyph(ThinkingLevel.Max, theme));
+	});
+
+	it("hides the entire agent badge when disabled without hiding live tool activity", () => {
+		settings.override("task.showResolvedModelBadge", false);
+		const lines = render([
+			{
+				op: "agent",
+				id: "0-Scout",
+				agent: "task",
+				status: "running",
+				model: "p/model:high",
+				advisor: true,
+				currentTool: "read",
+				lastIntent: "Reading config",
+			},
+		]);
+		const below = lines.slice(boxBottomIndex(lines) + 1).join("\n");
+		expect(below).toContain("0-Scout");
+		expect(below).toContain("Reading config");
+		expect(below).not.toContain("p/model");
+		expect(below).not.toContain(thinkingLevelGlyph(ThinkingLevel.High, theme));
+		expect(below).not.toContain(theme.icon.advisor);
 	});
 
 	it("renders one line per subagent for a parallel fan-out", () => {
@@ -126,6 +206,121 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		expect(below).toContain("0-Alpha");
 		expect(below).toContain("1-Beta");
 		expect(below).toContain("2-Gamma");
+	});
+
+	it("renders model-bearing events before settings initialization", async () => {
+		resetSettingsForTest();
+		try {
+			const lines = render([
+				{
+					op: "agent",
+					id: "ColdStart",
+					status: "failed",
+					resolvedModelIdentity: "provider/model",
+					advisor: true,
+				},
+			]);
+			const text = lines.slice(boxBottomIndex(lines) + 1).join("\n");
+			expect(text).toContain("ColdStart");
+			expect(text).toContain("failed");
+			expect(text).not.toContain("provider/model");
+			expect(text).not.toContain(theme.icon.advisor);
+		} finally {
+			await Settings.init({ inMemory: true });
+		}
+	});
+
+	it("reserves failure status for oversized IDs even when badges are disabled", () => {
+		settings.override("task.showResolvedModelBadge", false);
+		const lines = render([
+			{
+				op: "agent",
+				id: `LongWorker${"界".repeat(100)}`,
+				status: "failed",
+				resolvedModelIdentity: "provider/model",
+				advisor: true,
+			},
+		]);
+		const row = lines.slice(boxBottomIndex(lines) + 1).find(line => line.includes("LongWorker"))!;
+		expect(row).toContain("failed");
+		expect(row).not.toContain("provider/model");
+		expect(visibleWidth(row)).toBeLessThanOrEqual(120);
+	});
+
+	it("keeps agent identities and failure status within the viewport across resizes", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const model = "openai-codex/gpt-6-astra";
+		const intent = "Reading renderer and framework boundaries";
+		const statusEvents: EvalStatusEvent[] = [
+			{
+				op: "agent",
+				id: "ArchitectureScout",
+				status: "failed",
+				resolvedModelIdentity: model,
+				resolvedThinkingLevel: ThinkingLevel.High,
+				advisor: true,
+				toolCount: 7,
+				contextTokens: 8000,
+				contextWindow: 200000,
+				cost: 0.06,
+				durationMs: 1500,
+			},
+			{
+				op: "agent",
+				id: "ResearchScout",
+				status: "running",
+				resolvedModelIdentity: model,
+				currentTool: "read",
+				lastIntent: intent,
+			},
+			{
+				op: "agent",
+				id: "CancelledScout",
+				status: "aborted",
+				resolvedModelIdentity: `${model}/${"extended-identity-".repeat(8)}end`,
+				cost: 0.09,
+			},
+		];
+		const details: EvalToolDetails = {
+			language: "python",
+			languages: ["python"],
+			cells: [
+				{
+					index: 0,
+					code: "results = parallel([...])",
+					language: "python",
+					output: "",
+					status: "running",
+					statusEvents,
+				},
+			],
+		};
+		const component = evalToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme,
+		);
+
+		for (const width of [40, 120, 40]) {
+			const lines = component.render(width);
+			const bottom = boxBottomIndex(lines);
+			expect(bottom).toBeGreaterThanOrEqual(0);
+			const below = lines.slice(bottom + 1);
+			for (const line of below) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			const text = Bun.stripANSI(below.join("\n"));
+			expect(Bun.stripANSI(below[0])).toContain("ArchitectureScout");
+			expect(Bun.stripANSI(below[0])).toContain("failed");
+			expect(text).toContain("ResearchScout");
+			expect(text).toContain("CancelledScout");
+			expect(text).toContain("aborted");
+			expect(text).toContain("read");
+			if (width === 120) {
+				expect(text).toContain(model);
+				expect(text).toContain("$0.06");
+				expect(text).toContain("$0.09");
+				expect(text).toContain(intent);
+			}
+		}
 	});
 
 	it("still folds non-agent status events into the box Status section", () => {

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { KeybindingsManager, setKeyHintPlatform } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { getThemeByName, initTheme, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
@@ -11,11 +12,85 @@ import {
 	formatErrorMessage,
 	formatExpandHint,
 	formatParseErrors,
+	formatFeedModelBadge,
 	formatScreenshot,
 	shortenPath,
 	truncateDiffByHunk,
 } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
 import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
+
+describe("feed model badges", () => {
+	let uiTheme: Theme;
+
+	beforeAll(async () => {
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("Dark theme is unavailable");
+		uiTheme = loaded;
+	});
+
+	it("preserves literal effort-like model suffixes and uses only explicit thinking metadata", () => {
+		const glyph = uiTheme.thinking.high.split(" ")[0];
+		expect(Bun.stripANSI(formatFeedModelBadge("custom:model:max", undefined, false, uiTheme))).toBe(
+			"custom:model:max",
+		);
+		expect(Bun.stripANSI(formatFeedModelBadge("custom:model:max", ThinkingLevel.High, true, uiTheme))).toBe(
+			`${glyph} custom:model:max ${uiTheme.icon.advisor}`,
+		);
+		expect(formatFeedModelBadge("custom:model:max", ThinkingLevel.High, true, uiTheme)).toBe(
+			uiTheme.fg("accent", `${glyph} `) + uiTheme.fg("dim", `custom:model:max ${uiTheme.icon.advisor}`),
+		);
+		expect(uiTheme.fg("accent", glyph)).not.toBe(uiTheme.fg("dim", glyph));
+		expect(Bun.stripANSI(formatFeedModelBadge("custom:model:auto", ThinkingLevel.Inherit, false, uiTheme))).toBe(
+			"custom:model:auto",
+		);
+	});
+
+	it("ignores unknown runtime thinking levels without changing the model identity", () => {
+		for (const level of ["future-level", "toString"]) {
+			expect(Bun.stripANSI(formatFeedModelBadge("custom:model:max", level as ThinkingLevel, true, uiTheme))).toBe(
+				`custom:model:max ${uiTheme.icon.advisor}`,
+			);
+		}
+	});
+
+	it("removes terminal controls and collapses whitespace into a single model row", () => {
+		const badge = formatFeedModelBadge("\x1b[31mcustom\tmodel\nname\x1b[0m", undefined, false, uiTheme);
+		expect(badge).not.toContain("\x1b[31m");
+		expect(Bun.stripANSI(badge)).toBe("custom model name");
+		expect(formatFeedModelBadge("\t\n\x1b[31m", undefined, true, uiTheme)).toBe("");
+	});
+
+	it("preserves disambiguating model tails and reserves advisor space when truncating wide names", () => {
+		const badge = Bun.stripANSI(
+			formatFeedModelBadge(`provider/${"界".repeat(20)}-variant-b`, ThinkingLevel.High, true, uiTheme, 24),
+		);
+		expect(badge).toContain("…");
+		expect(badge.endsWith(`variant-b ${uiTheme.icon.advisor}`)).toBe(true);
+		expect(Bun.stringWidth(badge)).toBeLessThanOrEqual(24);
+	});
+
+	it("never overflows tiny budgets even when glyphs leave no room for a model", () => {
+		for (let width = 0; width <= 8; width++) {
+			const badge = formatFeedModelBadge("provider/界界界-version", ThinkingLevel.Off, true, uiTheme, width);
+			expect(Bun.stringWidth(badge)).toBeLessThanOrEqual(width);
+		}
+		const glyph = uiTheme.thinking.high.split(" ")[0];
+		const advisor = uiTheme.icon.advisor;
+		const advisorWidth = Bun.stringWidth(advisor);
+		const iconsWidth = Bun.stringWidth(`${glyph} ${advisor}`);
+		expect(Bun.stripANSI(formatFeedModelBadge("model", ThinkingLevel.High, true, uiTheme, advisorWidth))).toBe(
+			advisor,
+		);
+		expect(Bun.stripANSI(formatFeedModelBadge("model", ThinkingLevel.High, true, uiTheme, iconsWidth))).toBe(
+			`${glyph} ${advisor}`,
+		);
+		expect(
+			Bun.stripANSI(formatFeedModelBadge("model", ThinkingLevel.High, false, uiTheme, Bun.stringWidth(glyph))),
+		).toBe(glyph);
+		expect(formatFeedModelBadge("model", ThinkingLevel.High, true, uiTheme, 0)).toBe("");
+		expect(formatFeedModelBadge(undefined, ThinkingLevel.High, true, uiTheme)).toBe("");
+	});
+});
 
 describe("parse error formatting", () => {
 	it("deduplicates parse errors while preserving order", () => {

--- a/packages/coding-agent/test/tui-tree-list-collapsed-lines.test.ts
+++ b/packages/coding-agent/test/tui-tree-list-collapsed-lines.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { renderTreeList } from "@oh-my-pi/pi-coding-agent/tui/tree-list";
+import { truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 
 const stubTheme = {
 	fg: (_color: string, text: string) => text,
@@ -11,6 +12,31 @@ function expectWithinBudget(lines: string[], budget: number) {
 }
 
 describe("renderTreeList maxCollapsedLines", () => {
+	it("reserves custom branch and continuation widths in both rendering paths", () => {
+		const customTheme = {
+			...stubTheme,
+			tree: { ...stubTheme.tree, branch: "界├", last: "界界└", vertical: "界界│" },
+		} as typeof stubTheme;
+		for (const trailingSummary of [undefined, "", "summary"]) {
+			const lines = renderTreeList(
+				{
+					items: ["first item with long details", "second item with long details"],
+					trailingSummary,
+					renderItem: (item, context) => [
+						truncateToWidth(item, 18 - (context.prefixWidth ?? 0)),
+						truncateToWidth("continued details", 18 - (context.prefixWidth ?? 0)),
+					],
+				},
+				customTheme,
+			);
+			expect(lines[0]).toStartWith("界├ ");
+			expect(lines[2]).toStartWith(trailingSummary ? "界├ " : "界界└ ");
+			expect(lines[1]).toStartWith("界界│");
+			expect(lines[1]).toContain("continued");
+			for (const line of lines) expect(visibleWidth(line)).toBeLessThanOrEqual(18);
+		}
+	});
+
 	it("skips oversized first item instead of rendering broken fragments", () => {
 		const largeGroup = Array.from({ length: 15 }, (_, i) => `line-${i}`);
 		const smallGroup = ["a", "b"];


### PR DESCRIPTION
## What

Show subagent model badges before the agent name in task progress/results, the detached-agent HUD, eval progress, and hub job rows. A shared formatter preserves literal model identity, uses separate thinking metadata for its glyph, and shows an eye only when an advisor runtime was attached.

Keep the existing `task.showResolvedModelBadge` setting and its default unchanged. Preserve model-name tails within the badge width, sanitize terminal controls, and propagate advisor metadata through startup, late attachment, and resumed turns. Session test doubles share a lifecycle-default factory, and serving-model assertions cover the full object; no provider, catalog, council, or status-line changes are included.

All four feeds share one 30-column badge limit and initialization-safe visibility guard. Thinking glyphs use the accent color; unknown levels render no glyph; tiny budgets retain fitting advisor icons. Names and status take priority over badges and descriptions, and tree-list consumers use renderer-supplied prefix widths.

## Why

makes it easier to see what model subagents are using

## Testing

- `bun run check` in `packages/coding-agent`: lint, formatting, and type checks passed.
- 536 tests passed across 25 files: all changed test files plus `model-browser.test.ts` and `model-resolver.test.ts`. Coverage includes running/settled rows, advisor presence/absence, hidden badges, terminal sanitization, narrow widths, advisor attachment after startup and across wake-up transitions, actual detached TaskTool execution into hub snapshots, literal model IDs with optional thinking, same-selector identity collisions, and last-served attribution.
- Launched the source CLI from this upstream-based branch and ran a real read-only `BadgeSmoke` scout. Inspected its task row and settled hub row: thinking glyph and model appear before `BadgeSmoke`, without a textual effort suffix. That run did not display a child advisor eye.
- Interacted with the production task renderer on a real PTY using advised and unadvised snapshots: only the advised row showed the eye; toggling the setting hid/restored the whole badge; resizing from 100 to 60 columns preserved the badge and wrapped the remaining row within the box. The temporary renderer harness is not included in the PR.

- Review-fix smoke: the production hub renderer retained the thinking/model/eye, `Architect` label, and duration at 60 and 40 columns; toggling badges hid/restored the metadata. A runtime smoke exercised the existing one-argument `thinkingLevelGlyph` API through the direct module, components barrel, and package-root imports.

- Literal-ID smoke: at 100 and 60 columns, `nanogpt/coding-router:max` remained intact with no inferred icon; supplying explicit High added the High glyph while preserving `:max`. Legacy snapshots retained the full selector without an invented thinking level. Badge visibility toggling still worked. The feature changelog entry is under `Unreleased`.

- Task/eval width smoke: at 40 columns, task progress and settled rows retained `ArchitectureScout` on the first status row, with the settled `done` badge intact; eval agent rows stayed within 40 cells. Resizing 40→120→40 restored wide-row metadata/stats and reapplied narrow budgets; disabling badges preserved the compact layout. Regression tests also cover failed/aborted status, long descriptions, continuation rows, and same-component resizing.

- Maintainer-nit verification: exercised all four production feed renderers at 40 and 120 columns with badges enabled/disabled, including complete bounded task descriptions and eye-only tiny badges. Tests cover actual custom theme prefix overrides, raw glyph colors, invalid levels, pre-initialization guards, stale fallback clearing, and exact serving-model snapshots.

---

- [x] Coding-agent `bun run check` passes
- [x] Tested locally as described above
- [x] CHANGELOG updated
