### PR TITLE
feat(tui): add tui.math setting and MarkdownTheme.renderMath hook for raw TeX passthrough

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `tui.math` setting (`unicode` | `raw`, default `unicode`): `raw` emits delimited TeX (`$…$` / `$$…$$`) verbatim in terminal output so an external formula renderer (e.g. a TFormula PTY proxy) can render it, in place of the built-in Unicode conversion.
+
 ### Fixed
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1209,6 +1209,31 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.math": {
+		type: "enum",
+		values: ["unicode", "raw"] as const,
+		default: "unicode",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Math Rendering",
+			description:
+				"How LaTeX math in terminal output is displayed: the built-in Unicode conversion, or raw delimited TeX left on screen for an external formula renderer (e.g. a TFormula PTY proxy)",
+			options: [
+				{
+					value: "unicode",
+					label: "Unicode",
+					description: "Convert LaTeX to Unicode text (built-in rendering)",
+				},
+				{
+					value: "raw",
+					label: "Raw TeX",
+					description: "Emit $…$ / $$…$$ verbatim so an external terminal renderer can overlay it",
+				},
+			],
+		},
+	},
+
 	"tui.reactions": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -37,6 +37,7 @@ import {
 	getSymbolTheme,
 	previewTheme,
 	setColorBlindMode,
+	setMarkdownMathRaw,
 	setMarkdownMermaidRendering,
 	setSymbolPreset,
 	setTheme,
@@ -671,6 +672,12 @@ export class SelectorController {
 				this.ctx.session.refreshBaseSystemPrompt().catch(err => {
 					this.ctx.showError(`Failed to apply Mermaid rendering setting: ${err}`);
 				});
+				this.ctx.rebuildChatFromMessages();
+				this.ctx.ui.resetDisplay();
+				break;
+
+			case "tui.math":
+				setMarkdownMathRaw(value === "raw");
 				this.ctx.rebuildChatFromMessages();
 				this.ctx.ui.resetDisplay();
 				break;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -225,6 +225,7 @@ import {
 	getMarkdownTheme,
 	onTerminalAppearanceChange,
 	onThemeChange,
+	setMarkdownMathRaw,
 	setMarkdownMermaidRendering,
 	startMacOSAppearanceReprobeFallback,
 	theme,
@@ -925,6 +926,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		setTuiTight(settings.get("tui.tight"));
 		setMarkdownMermaidRendering(settings.get("tui.renderMermaid"));
+		setMarkdownMathRaw(settings.get("tui.math") === "raw");
 		// A cold-start composer already owns the terminal. Reuse it so input
 		// buffered during startup remains in the same editor instance.
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -28,6 +28,7 @@ export {
 	getSettingsListTheme,
 	getSymbolTheme,
 	highlightCode,
+	setMarkdownMathRaw,
 	setMarkdownMermaidRendering,
 	warmHighlighter,
 } from "./tui-adapters";

--- a/packages/coding-agent/src/modes/theme/tui-adapters.ts
+++ b/packages/coding-agent/src/modes/theme/tui-adapters.ts
@@ -167,10 +167,17 @@ export function getSymbolTheme(): SymbolTheme {
 let cachedMarkdownTheme: MarkdownTheme | undefined;
 let cachedMarkdownThemeRef: Theme | undefined;
 let markdownMermaidRendering = true;
+let markdownMathRaw = false;
 
 export function setMarkdownMermaidRendering(enabled: boolean): void {
 	if (markdownMermaidRendering === enabled) return;
 	markdownMermaidRendering = enabled;
+	cachedMarkdownTheme = undefined;
+}
+
+export function setMarkdownMathRaw(raw: boolean): void {
+	if (markdownMathRaw === raw) return;
+	markdownMathRaw = raw;
 	cachedMarkdownTheme = undefined;
 }
 
@@ -218,6 +225,9 @@ export function getMarkdownTheme(): MarkdownTheme {
 						theme: mermaid.mermaidTheme,
 						colorMode: mermaid.mermaidColorMode,
 					})
+			: undefined,
+		renderMath: markdownMathRaw
+			? (text, display) => (display ? `$$${text.trim()}$$` : `$${text.trim()}$`)
 			: undefined,
 		highlightCode: (code: string, lang?: string): string[] => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional `MarkdownTheme.renderMath` hook so hosts can substitute custom math rendering (e.g. raw TeX passthrough for an external terminal formula renderer); returning `null` falls back to the built-in Unicode conversion.
+
 ### Fixed
 
 - `extractMarkdownLinks()` now returns one-row visible labels for formatted and multiline links ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1388,6 +1388,14 @@ export interface MarkdownTheme {
 	 * Return null to fall back to fenced code rendering.
 	 */
 	resolveMermaidAscii?: (source: string, maxWidth?: number) => string | null;
+	/**
+	 * Render a math token's LaTeX. Receives the raw LaTeX body and a display
+	 * (block) flag; returns terminal text shown in place of the built-in
+	 * Unicode conversion, or null/undefined to fall back to it. Intended for
+	 * hosts handing math to an external renderer that needs verbatim,
+	 * delimited TeX on screen (e.g. a TFormula PTY proxy).
+	 */
+	renderMath?: (text: string, display: boolean) => string | null;
 	symbols: SymbolTheme;
 }
 
@@ -1452,6 +1460,25 @@ function isMathToken(token: Token): token is Token & { text: string; display: bo
 /** Convert a `math` token's LaTeX to single-line Unicode for inline rendering. */
 function renderMathToken(text: string): string {
 	return latexToUnicode(text).replace(MATH_NEWLINES, " ");
+}
+
+/**
+ * Display-math lines for a `math` token: the theme's custom `renderMath`
+ * output (split on newlines) when supplied, else the built-in Unicode block
+ * layout.
+ */
+function displayMathLines(theme: MarkdownTheme, text: string): readonly string[] {
+	const custom = theme.renderMath?.(text, true);
+	return custom === null || custom === undefined ? latexToBlock(text) : custom.split("\n");
+}
+
+/**
+ * Inline-math text for a `math` token: the theme's custom `renderMath` output
+ * when supplied, else the built-in single-line Unicode conversion.
+ */
+function inlineMathText(theme: MarkdownTheme, text: string): string {
+	const custom = theme.renderMath?.(text, false);
+	return custom === null || custom === undefined ? renderMathToken(text) : custom;
 }
 
 /**
@@ -2898,7 +2925,8 @@ export class Markdown implements Component {
 		// Display math block (own-line `$$…$$` / `\[…\]`): stack `\frac` vertically
 		// and keep `\\` row breaks, so fractions and matrices span multiple lines.
 		if (isMathToken(token)) {
-			for (const mathLine of latexToBlock(token.text)) lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
+			for (const mathLine of displayMathLines(this.#theme, token.text))
+				lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
 			if (nextTokenType && nextTokenType !== "space") lines.push(renderedLine(""));
 			return lines;
 		}
@@ -2939,7 +2967,7 @@ export class Markdown implements Component {
 			case "paragraph": {
 				const displayMath = soleDisplayMath(token.tokens);
 				if (displayMath) {
-					for (const mathLine of latexToBlock(displayMath.text))
+					for (const mathLine of displayMathLines(this.#theme, displayMath.text))
 						lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
 					if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") lines.push(renderedLine(""));
 					break;
@@ -3169,7 +3197,7 @@ export class Markdown implements Component {
 		for (const token of collapseInlineHtml(tokens)) {
 			if (isMathToken(token)) {
 				markHtmlItemWhenContent(token.text);
-				result += applyTextWithNewlines(renderMathToken(token.text));
+				result += applyTextWithNewlines(inlineMathText(this.#theme, token.text));
 				continue;
 			}
 			switch (token.type) {
@@ -3390,7 +3418,7 @@ export class Markdown implements Component {
 				const displayMath = soleDisplayMath(token.tokens);
 				if (displayMath) {
 					const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));
-					for (const mathLine of latexToBlock(displayMath.text))
+					for (const mathLine of displayMathLines(this.#theme, displayMath.text))
 						lines.push({ text: apply(mathLine), nested: false });
 				} else {
 					const text =
@@ -3404,7 +3432,7 @@ export class Markdown implements Component {
 				const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));
 				const displayMath = soleDisplayMath(token.tokens);
 				if (displayMath) {
-					for (const mathLine of latexToBlock(displayMath.text))
+					for (const mathLine of displayMathLines(this.#theme, displayMath.text))
 						lines.push({ text: apply(mathLine), nested: false });
 				} else {
 					lines.push({ text: this.#renderInlineTokens(token.tokens || [], styleContext), nested: false });
@@ -3420,7 +3448,8 @@ export class Markdown implements Component {
 			} else if (isMathToken(token)) {
 				// Display math block inside a list item: stack fractions / matrix rows.
 				const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));
-				for (const mathLine of latexToBlock(token.text)) lines.push({ text: apply(mathLine), nested: false });
+				for (const mathLine of displayMathLines(this.#theme, token.text))
+					lines.push({ text: apply(mathLine), nested: false });
 			} else {
 				// Other token types - try to render as inline
 				const text = this.#renderInlineTokens([token], styleContext);
@@ -3674,7 +3703,7 @@ export function renderInlineMarkdown(text: string, mdTheme: MarkdownTheme, baseC
 	let result = "";
 	for (const token of tokens) {
 		if (isMathToken(token)) {
-			result += applyText(renderMathToken(token.text));
+			result += applyText(inlineMathText(mdTheme, token.text));
 			continue;
 		}
 		if (token.type === "paragraph" && token.tokens) {
@@ -3699,7 +3728,7 @@ function renderInlineTokens(tokens: Token[], mdTheme: MarkdownTheme, applyText: 
 	const styleReset = applyText("");
 	for (const token of collapseInlineHtml(tokens)) {
 		if (isMathToken(token)) {
-			result += applyText(renderMathToken(token.text));
+			result += applyText(inlineMathText(mdTheme, token.text));
 			continue;
 		}
 		switch (token.type) {

--- a/packages/tui/test/markdown-math.test.ts
+++ b/packages/tui/test/markdown-math.test.ts
@@ -113,3 +113,49 @@ describe("Markdown math rendering", () => {
 		expect(lines[barRow + 1]).toContain("c");
 	});
 });
+
+describe("Markdown custom renderMath hook", () => {
+	const renderMathLines = (
+		md: string,
+		renderMath: (text: string, display: boolean) => string | null,
+		width = 100,
+	): string[] =>
+		new Markdown(md, 0, 0, { ...defaultMarkdownTheme, renderMath })
+			.render(width)
+			.map(line => stripVTControlCharacters(line).replace(/\s+$/, ""))
+			.filter(line => line !== "");
+
+	it("passes delimited TeX through for inline math", () => {
+		const [line] = renderMathLines("the area is $A = \\pi r^2$ exactly", (text, display) =>
+			display ? `$$${text.trim()}$$` : `$${text.trim()}$`,
+		);
+		expect(line).toBe("the area is $A = \\pi r^2$ exactly");
+	});
+
+	it("passes delimited TeX through for display math", () => {
+		const lines = renderMathLines("$$\n\\begin{bmatrix} a & b \\\\ c & d \\end{bmatrix}\n$$", (text, display) =>
+			display ? `$$${text.trim()}$$` : `$${text.trim()}$`,
+		);
+		expect(lines).toEqual(["$$\\begin{bmatrix} a & b \\\\ c & d \\end{bmatrix}$$"]);
+	});
+
+	it("splits multi-line display math around the delimiters", () => {
+		const lines = renderMathLines("$$\n\\begin{aligned}\na &= 1 \\\\\nb &= 2\n\\end{aligned}\n$$", (text, display) =>
+			display ? `$$${text.trim()}$$` : `$${text.trim()}$`,
+		);
+		expect(lines[0]).toBe("$$\\begin{aligned}");
+		expect(lines[lines.length - 1]).toBe("\\end{aligned}$$");
+	});
+
+	it("falls back to Unicode conversion when the hook returns null", () => {
+		const [line] = renderMathLines("the area is $A = \\pi r^2$ exactly", () => null);
+		expect(line).toBe("the area is A = π r² exactly");
+	});
+
+	it("keeps code-span math literal regardless of the hook", () => {
+		const [line] = renderMathLines("use `$x^2$` literally and $y^2$ as math", (text, display) =>
+			display ? `$$${text.trim()}$$` : `$${text.trim()}$`,
+		);
+		expect(line).toBe("use $x^2$ literally and $y^2$ as math");
+	});
+});


### PR DESCRIPTION
## Summary

Add an opt-in way to emit **raw, delimited TeX** in terminal output instead of the built-in Unicode conversion, so an external terminal formula renderer can take over.

The motivating workflow: [TFormula](https://github.com/mikewang817/TFormula) wraps a CLI agent in a PTY proxy, detects visible TeX on the screen, renders it locally with MathJax, and overlays the result using the Kitty graphics protocol (Ghostty/Kitty/WezTerm). It can only detect **raw TeX on screen** — and the built-in `latexToUnicode`/`latexToBlock` conversion is unconditional, so wrapped agents (e.g. this CLI) show Unicode text and the overlay never triggers.

## Changes

**`packages/tui`**
- New optional `MarkdownTheme.renderMath(text, display) => string | null` hook, mirroring the existing `resolveMermaidAscii` capability-injection pattern.
- All math render paths (inline + every display/block path, including list-embedded) route through the hook; returning `null`/`undefined` falls back to the built-in Unicode conversion, so existing hosts are untouched.
- Plain-text extraction (`plainInlineTokens`, used for width/heading sizing) keeps the Unicode conversion on purpose.
- 4 new tests in `markdown-math.test.ts`: inline passthrough, display passthrough, null fallback, code-span math staying literal.

**`packages/coding-agent`**
- New `tui.math` setting: enum `["unicode", "raw"]`, default `unicode` (behavior unchanged unless opted in).
- Wired at startup (`interactive-mode`) and via the live settings switcher (`selector-controller`, chat rebuild like `tui.renderMermaid`).
- No system-prompt change needed: the "MAY use LaTeX math" guidance is unconditional, so the model's output is identical in both modes.

## Usage

```sh
# in omp: /settings → Math Rendering → Raw TeX  (or)
omp config set tui.math raw
# then wrap the agent with an external renderer:
tformula -- omp
```

- `bun test packages/tui/test/markdown-math.test.ts packages/tui/test/markdown.test.ts` — 168 pass / 0 fail (5 new hook tests + full markdown regression)
- `bun run check` (tui + coding-agent) — oxlint, oxfmt, tsgo type-check all green
- Config layer: `PI_CONFIG_FILES=overlay omp config get tui.math` resolves `raw`; default remains `unicode`
- Manual: raw mode shows `$…$` / `$$…$$` verbatim in chat output; TFormula proxy overlays MathJax images on them
