### PR TITLE
fix(natives): highlight .astro files with a vendored Astro grammar

### DIFF
--- a/crates/pi-natives/src/highlight.rs
+++ b/crates/pi-natives/src/highlight.rs
@@ -43,6 +43,7 @@ const EXTRA_SYNTAXES: &[&str] = &[
 	include_str!("syntaxes/Mermaid.sublime-syntax"),
 	include_str!("syntaxes/TypeScript.sublime-syntax"),
 	include_str!("syntaxes/TypeScriptReact.sublime-syntax"),
+	include_str!("syntaxes/Astro.sublime-syntax"),
 ];
 
 fn get_syntax_set() -> &'static SyntaxSet {
@@ -222,7 +223,8 @@ const LANG_ALIASES: &[(&[&str], &str)] = &[
 	(&["php"], "PHP"),
 	(&["sh", "bash", "zsh", "shell"], "Bash"),
 	(&["ps1", "powershell"], "PowerShell"),
-	(&["html", "htm", "astro", "vue", "svelte"], "HTML"),
+	(&["html", "htm", "vue", "svelte"], "HTML"),
+	(&["astro"], "Astro"),
 	(&["css"], "CSS"),
 	(&["scss"], "SCSS"),
 	(&["sass"], "Sass"),
@@ -697,5 +699,40 @@ mod tests {
 		assert!(last.contains("<k>const"), "trailing code lost keyword highlighting: {last}");
 		assert!(last.contains("<n>1"), "trailing code lost number highlighting: {last}");
 		assert!(!last.contains("<s>const"), "string scope leaked past template literal: {last}");
+	}
+
+	/// Regression: `.astro` resolved to the HTML grammar, which treats the
+	/// `---` TypeScript frontmatter as plain text, so component scripts
+	/// rendered without any highlighting in the write/edit previews.
+	#[test]
+	fn highlights_astro_vendored_syntax() {
+		assert!(get_supported_languages().contains(&"Astro".to_string()));
+		assert!(supports_language_impl("astro"));
+
+		let code = "---\nimport { Menu } from '@lucide/astro';\nconst locale = \
+		            localeOf(path);\n---\n\n<a class=\"nav\">{locale === 'tr' ? 'EN' : 'TR'}</a>\n";
+		let out = highlight_code_impl(code, Some("astro"), &test_colors());
+		let lines: Vec<&str> = out.lines().collect();
+		assert!(
+			lines[1].contains("<k>import"),
+			"frontmatter lost keyword highlighting: {}",
+			lines[1]
+		);
+		assert!(
+			lines[1].contains("<s>@lucide/astro"),
+			"frontmatter lost string highlighting: {}",
+			lines[1]
+		);
+		assert!(
+			lines[2].contains("<f>localeOf"),
+			"frontmatter lost function highlighting: {}",
+			lines[2]
+		);
+		assert!(lines[5].contains("<v>a"), "template lost HTML tag highlighting: {}", lines[5]);
+		assert!(
+			lines[5].contains("<s>tr"),
+			"template expression lost TypeScript highlighting: {}",
+			lines[5]
+		);
 	}
 }

--- a/crates/pi-natives/src/syntaxes/Astro.sublime-syntax
+++ b/crates/pi-natives/src/syntaxes/Astro.sublime-syntax
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+# Astro component syntax for syntect.
+#
+# An Astro file is an optional `---` fenced TypeScript frontmatter followed by
+# an HTML-like template whose `{…}` holes are TypeScript expressions. Sublime
+# ships no Astro grammar, so this one composes the vendored TypeScript syntax
+# (`source.ts`) with syntect's bundled HTML (`text.html.basic`).
+name: Astro
+file_extensions:
+  - astro
+scope: source.astro
+contexts:
+  main:
+    # The frontmatter fence is only valid before any template content.
+    - match: '^(---)[ \t]*$'
+      captures:
+        1: punctuation.section.frontmatter.begin.astro
+      set: frontmatter
+    - match: '(?=\S)'
+      set: template
+
+  frontmatter:
+    - meta_content_scope: source.ts.embedded.astro
+    - match: '^(---)[ \t]*$'
+      captures:
+        1: punctuation.section.frontmatter.end.astro
+      set: template
+    - include: scope:source.ts
+
+  template:
+    - include: expression
+    - include: scope:text.html.basic
+
+  # `{expr}` holes in template text. Nested braces are balanced by the
+  # TypeScript grammar's own block/object contexts, so the first unmatched `}`
+  # closes the hole.
+  expression:
+    - match: '\{'
+      scope: punctuation.section.embedded.begin.astro
+      push:
+        - meta_content_scope: source.ts.embedded.astro
+        - match: '\}'
+          scope: punctuation.section.embedded.end.astro
+          pop: true
+        - include: scope:source.ts

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
 - Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body ([#11159](https://github.com/can1357/oh-my-pi/pull/11159) by [@H4vC](https://github.com/H4vC)).
+- Fixed `.astro` files rendering without syntax highlighting in write/edit previews and diffs: a vendored Astro grammar now highlights the `---` frontmatter and `{…}` template expressions as TypeScript and the template as HTML, instead of treating the whole file as HTML text.
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed Ask custom answers requiring another submission after paste or remaining on the same multi-select question; pending clipboard text is preserved before submission, and single-question multi-select answers still go through review ([#11099](https://github.com/can1357/oh-my-pi/pull/11099) by [@camjac251](https://github.com/camjac251)).
 - The startup update notice no longer counts standalone `* * *` and `- - -` separator lines as changes.
 - Fixed `/loop` replacing the repeating prompt with a mid-turn interjection; steering while the agent runs is now one-off, and only an idle submission becomes the new loop body ([#11159](https://github.com/can1357/oh-my-pi/pull/11159) by [@H4vC](https://github.com/H4vC)).
-- Fixed `.astro` files rendering without syntax highlighting in write/edit previews and diffs: a vendored Astro grammar now highlights the `---` frontmatter and `{…}` template expressions as TypeScript and the template as HTML, instead of treating the whole file as HTML text.
+- Fixed `.astro` files rendering without syntax highlighting in write/edit previews and diffs: a vendored Astro grammar now highlights the `---` frontmatter and `{…}` template expressions as TypeScript and the template as HTML, instead of treating the whole file as HTML text ([#11164](https://github.com/can1357/oh-my-pi/pull/11164) by [@byigitt](https://github.com/byigitt)).
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a vendored Astro grammar so `.astro` files highlight the `---` TypeScript frontmatter and `{…}` template expressions instead of falling back to plain HTML ([#11164](https://github.com/can1357/oh-my-pi/pull/11164) by [@byigitt](https://github.com/byigitt)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Added


### PR DESCRIPTION
## Problem

`.astro` files render with no syntax highlighting in write/edit previews and diffs.

`getLanguageFromPath` already maps `.astro` → `astro`, but `LANG_ALIASES` in `crates/pi-natives/src/highlight.rs` aliased `astro` to syntect's HTML grammar. HTML treats the `---` TypeScript frontmatter (and every `{…}` template expression) as plain text, so the part of the file that carries the logic comes out uncoloured. Example: a `Write` card for `Header.astro` where `import { … } from '@lucide/astro'`, `const path = Astro.url.pathname;` etc. are all default foreground.

## Fix

- Add `crates/pi-natives/src/syntaxes/Astro.sublime-syntax`, a ~45-line grammar that composes what is already in the syntax set:
  - `---` fence at the top of the file → frontmatter, highlighted with the vendored `source.ts` grammar until the closing `---`.
  - Template body → syntect's bundled `text.html.basic` (so `<script>`/`<style>` keep their JS/CSS embedding).
  - `{…}` holes in template text → `source.ts`; nested braces are balanced by the TypeScript grammar's own block/object contexts.
- Register it in `EXTRA_SYNTAXES` and point the `astro` alias at `Astro` instead of `HTML`. `vue`/`svelte` are untouched.
- Regression test `highlights_astro_vendored_syntax` asserts keyword/string/function colouring in the frontmatter, tag colouring in the template, and TypeScript colouring inside a `{…}` expression.
- CHANGELOG entry under `[Unreleased] / Fixed`.

No TypeScript-side changes: `lang-from-path.ts` already returns `astro`, and `highlightCode` resolves through `supportsLanguage` → `find_syntax`, which now hits the new grammar by token before the alias table is consulted.

## Verification

- `cargo nextest run -p pi-natives --lib highlight` — 6 passed (including the new test).
- `cargo clippy -p pi-natives --no-deps -- -D warnings` — clean.
- `cargo fmt -p pi-natives -- --check` — clean.
- Scope dump of a real `Header.astro` through `SyntaxSet::load_defaults_newlines()` + the vendored TS/Astro syntaxes: frontmatter yields `keyword.control.import.ts` / `string.quoted.single.ts` / `entity.name.function.ts`; template yields `entity.name.tag.*.html`; `{locale === 'tr' ? 'EN' : 'TR'}` yields `keyword.operator.comparison.ts` / `string.quoted.single.ts`; `<script>` and `<style>` bodies still land in `source.js` / `source.css`.

## Known limits

- `{expr}` used as an attribute value (`href={item.href}`) is inside HTML's tag context, so it is coloured as an unquoted attribute string rather than as TypeScript. Text-position expressions are fully highlighted.
- JSX-style markup inside a `{…}` expression is parsed by the TypeScript grammar (as it is in plain `.ts`), not as HTML.