### PR TITLE
feat(tui): continue Markdown lists in the prompt editor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [18.1.14] - 2026-09-07
 ### Added
 
 - New `tui.listContinuation` setting (Input group in `/settings`) toggles Markdown list continuation and preserves your choice across composer shape changes and editor replacement.
 
+## [18.1.14] - 2026-09-07
 ### Fixed
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [18.1.14] - 2026-09-07
+### Added
+
+- New `tui.listContinuation` setting (Input group in `/settings`) toggles Markdown list continuation and preserves your choice across composer shape changes and editor replacement.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2118,6 +2118,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.listContinuation": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Markdown List Continuation",
+			description:
+				"Continue Markdown lists when breaking a line: `1. first` starts the next line with `2. `, bullets re-emit themselves; an empty item ends the list",
+		},
+	},
+
 	"paste.largeMenuThreshold": {
 		type: "number",
 		default: 100,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1609,6 +1609,7 @@ export async function runRootCommand(
 			spellingTypoDetection: settingsInstance.get("spelling.typoDetection"),
 			spellingAutocomplete: settingsInstance.get("spelling.autocomplete"),
 			spellingAutocorrect: settingsInstance.get("spelling.autocorrect"),
+			listContinuation: settingsInstance.get("tui.listContinuation"),
 			theme: {
 				symbolPreset: settingsInstance.get("symbolPreset"),
 				colorBlindMode: settingsInstance.get("colorBlindMode"),

--- a/packages/coding-agent/src/modes/composer-cache.ts
+++ b/packages/coding-agent/src/modes/composer-cache.ts
@@ -207,7 +207,7 @@ function readUiState(file: string): { preferences: ComposerPreferences; theme: C
 		typeof spellingTypoDetection !== "boolean" ||
 		typeof spellingAutocomplete !== "boolean" ||
 		typeof spellingAutocorrect !== "boolean" ||
-		typeof listContinuation !== "boolean"
+		(listContinuation !== undefined && typeof listContinuation !== "boolean")
 	) {
 		return undefined;
 	}
@@ -241,7 +241,7 @@ function readUiState(file: string): { preferences: ComposerPreferences; theme: C
 			spellingTypoDetection,
 			spellingAutocomplete,
 			spellingAutocorrect,
-			listContinuation,
+			listContinuation: listContinuation ?? true,
 		},
 		theme: { symbolPreset, colorBlindMode, darkTheme, lightTheme },
 	};

--- a/packages/coding-agent/src/modes/composer-cache.ts
+++ b/packages/coding-agent/src/modes/composer-cache.ts
@@ -192,6 +192,7 @@ function readUiState(file: string): { preferences: ComposerPreferences; theme: C
 	const spellingTypoDetection = field(rawPreferences, "spellingTypoDetection");
 	const spellingAutocomplete = field(rawPreferences, "spellingAutocomplete");
 	const spellingAutocorrect = field(rawPreferences, "spellingAutocorrect");
+	const listContinuation = field(rawPreferences, "listContinuation");
 	if (
 		typeof quiet !== "boolean" ||
 		typeof composerShape !== "string" ||
@@ -205,7 +206,8 @@ function readUiState(file: string): { preferences: ComposerPreferences; theme: C
 		typeof autocompleteMaxVisible !== "number" ||
 		typeof spellingTypoDetection !== "boolean" ||
 		typeof spellingAutocomplete !== "boolean" ||
-		typeof spellingAutocorrect !== "boolean"
+		typeof spellingAutocorrect !== "boolean" ||
+		typeof listContinuation !== "boolean"
 	) {
 		return undefined;
 	}
@@ -239,6 +241,7 @@ function readUiState(file: string): { preferences: ComposerPreferences; theme: C
 			spellingTypoDetection,
 			spellingAutocomplete,
 			spellingAutocorrect,
+			listContinuation,
 		},
 		theme: { symbolPreset, colorBlindMode, darkTheme, lightTheme },
 	};

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -35,6 +35,7 @@ export interface ComposerPreferences {
 	readonly spellingTypoDetection: boolean;
 	readonly spellingAutocomplete: boolean;
 	readonly spellingAutocorrect: boolean;
+	readonly listContinuation: boolean;
 }
 
 /** Settings-schema-compatible defaults used when constructing a dependency-free composer. */
@@ -49,6 +50,7 @@ export const COMPOSER_DEFAULTS: ComposerPreferences = {
 	spellingTypoDetection: true,
 	spellingAutocomplete: true,
 	spellingAutocorrect: false,
+	listContinuation: true,
 };
 
 /** Welcome data that can be supplied initially or patched as startup resolves it. */
@@ -226,6 +228,7 @@ export class Composer implements TerminalFrameProvider {
 			autocomplete: this.#preferences.spellingAutocomplete,
 			autocorrect: this.#preferences.spellingAutocorrect,
 		});
+		this.editor.setListContinuation(this.#preferences.listContinuation);
 		try {
 			this.editor.setBorderStyle(this.#preferences.composerShape);
 		} catch {
@@ -559,6 +562,7 @@ export class Composer implements TerminalFrameProvider {
 			autocomplete: this.#preferences.spellingAutocomplete,
 			autocorrect: this.#preferences.spellingAutocorrect,
 		});
+		this.editor.setListContinuation(this.#preferences.listContinuation);
 		this.#applyStatusSnapshot();
 		if (this.#preferences.quiet) {
 			this.#welcome?.stopIntro();

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -526,6 +526,12 @@ export class Composer implements TerminalFrameProvider {
 	get started(): boolean {
 		return this.#started && !this.#stopped;
 	}
+	/** Current list-continuation preference; the source of truth replacement
+	 *  editors must inherit instead of re-reading a possibly-isolated settings
+	 *  instance the /settings selector cannot write through. */
+	get listContinuation(): boolean {
+		return this.#preferences.listContinuation;
+	}
 
 	/** Start terminal ownership and optionally begin the welcome intro. */
 	start(options: ComposerStartOptions = {}): void {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -572,6 +572,9 @@ export class SelectorController {
 				this.ctx.syncEditorSpelling();
 				this.ctx.ui.requestRender();
 				break;
+			case "tui.listContinuation":
+				this.ctx.syncEditorListContinuation();
+				break;
 
 			// Settings with UI side effects
 			case "display.hideToolActivity": {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -573,7 +573,7 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 				break;
 			case "tui.listContinuation":
-				this.ctx.syncEditorListContinuation();
+				this.ctx.applyEditorListContinuation(value === true);
 				break;
 
 			// Settings with UI side effects

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4956,7 +4956,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			autocomplete: this.settings.get("spelling.autocomplete"),
 			autocorrect: this.settings.get("spelling.autocorrect"),
 		});
-		nextEditor.setListContinuation(this.settings.get("tui.listContinuation"));
+		nextEditor.setListContinuation(this.composer.listContinuation);
 		nextEditor.viewportRowsProvider = () => this.ui.terminal.rows;
 		nextEditor.magicKeywordsEnabled = () => this.settings.get("magicKeywords.enabled");
 		nextEditor.imageReferenceHyperlink = imageReferenceHyperlink;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -870,6 +870,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			spellingTypoDetection: settings.get("spelling.typoDetection"),
 			spellingAutocomplete: settings.get("spelling.autocomplete"),
 			spellingAutocorrect: settings.get("spelling.autocorrect"),
+			listContinuation: settings.get("tui.listContinuation"),
 		};
 		const wasStarted = composer?.started ?? false;
 		this.composer =
@@ -2127,6 +2128,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			autocomplete: this.settings.get("spelling.autocomplete"),
 			autocorrect: this.settings.get("spelling.autocorrect"),
 		});
+	}
+
+	syncEditorListContinuation(): void {
+		this.composer.setPreferences({ listContinuation: settings.get("tui.listContinuation") });
 	}
 
 	#syncStatusLineSettings(): void {
@@ -4948,6 +4953,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			autocomplete: this.settings.get("spelling.autocomplete"),
 			autocorrect: this.settings.get("spelling.autocorrect"),
 		});
+		nextEditor.setListContinuation(this.settings.get("tui.listContinuation"));
 		nextEditor.viewportRowsProvider = () => this.ui.terminal.rows;
 		nextEditor.magicKeywordsEnabled = () => this.settings.get("magicKeywords.enabled");
 		nextEditor.imageReferenceHyperlink = imageReferenceHyperlink;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2131,7 +2131,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	syncEditorListContinuation(): void {
-		this.composer.setPreferences({ listContinuation: settings.get("tui.listContinuation") });
+		// Session-scoped on purpose: the settings selector persists toggles through
+		// ctx.settings, so this must read the same instance, not the module global.
+		this.composer.setPreferences({ listContinuation: this.settings.get("tui.listContinuation") });
 	}
 
 	#syncStatusLineSettings(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -870,7 +870,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			spellingTypoDetection: settings.get("spelling.typoDetection"),
 			spellingAutocomplete: settings.get("spelling.autocomplete"),
 			spellingAutocorrect: settings.get("spelling.autocorrect"),
-			listContinuation: settings.get("tui.listContinuation"),
+			listContinuation: this.settings.get("tui.listContinuation"),
 		};
 		const wasStarted = composer?.started ?? false;
 		this.composer =

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2130,10 +2130,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		});
 	}
 
-	syncEditorListContinuation(): void {
-		// Session-scoped on purpose: the settings selector persists toggles through
-		// ctx.settings, so this must read the same instance, not the module global.
-		this.composer.setPreferences({ listContinuation: this.settings.get("tui.listContinuation") });
+	applyEditorListContinuation(value: boolean): void {
+		// Apply the callback value directly: the /settings selector persists through
+		// the module-global settings instance, which an isolated session's this.settings
+		// cannot see — re-reading it here would drop the user's toggle.
+		this.composer.setPreferences({ listContinuation: value });
 	}
 
 	#syncStatusLineSettings(): void {

--- a/packages/coding-agent/src/modes/startup-composer.ts
+++ b/packages/coding-agent/src/modes/startup-composer.ts
@@ -143,6 +143,7 @@ export function applyStartupComposerPreferences(update: PrepaintComposerPreferen
 		spellingTypoDetection: update.spellingTypoDetection,
 		spellingAutocomplete: update.spellingAutocomplete,
 		spellingAutocorrect: update.spellingAutocorrect,
+		listContinuation: update.listContinuation,
 	};
 	pending.composer.setPreferences(preferences);
 	// Settings resolved means the module graph is loaded and the event loop is

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -134,7 +134,7 @@ export interface InteractiveModeContext {
 	statusLine: StatusLineComponent;
 	syncComposerShape(): void;
 	syncEditorSpelling(): void;
-	syncEditorListContinuation(): void;
+	applyEditorListContinuation(value: boolean): void;
 
 	// Session access
 	session: AgentSession;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -134,6 +134,7 @@ export interface InteractiveModeContext {
 	statusLine: StatusLineComponent;
 	syncComposerShape(): void;
 	syncEditorSpelling(): void;
+	syncEditorListContinuation(): void;
 
 	// Session access
 	session: AgentSession;

--- a/packages/coding-agent/test/composer-cache.test.ts
+++ b/packages/coding-agent/test/composer-cache.test.ts
@@ -95,6 +95,31 @@ describe("composer startup cache", () => {
 		}
 	});
 
+	it("treats pre-listContinuation ui caches as the new default", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-composer-cache-no-list-"));
+		const key = Bun.hash.wyhash(path.resolve(cwd)).toString(16).padStart(16, "0");
+		const cacheDir = path.join(getComposerCacheDir(), key);
+		try {
+			const legacyPreferences: Record<string, unknown> = { ...COMPOSER_DEFAULTS };
+			delete legacyPreferences.listContinuation;
+			await Bun.write(
+				path.join(cacheDir, "ui.json"),
+				JSON.stringify({
+					version: 1,
+					preferences: legacyPreferences,
+					theme: { symbolPreset: "ascii" },
+				}),
+			);
+
+			expect(readComposerStartupCache(cwd).preferences?.listContinuation).toBe(true);
+		} finally {
+			await Promise.all([
+				fs.rm(cwd, { recursive: true, force: true }),
+				fs.rm(cacheDir, { recursive: true, force: true }),
+			]);
+		}
+	});
+
 	it("loads XDG_CACHE_HOME from the home .env before the first cache access", async () => {
 		if (process.platform === "win32") return;
 

--- a/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
+++ b/packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts
@@ -54,6 +54,7 @@ describe("issue #9597 — cold-launch welcome duplication", () => {
 			spellingTypoDetection: settings.get("spelling.typoDetection"),
 			spellingAutocomplete: settings.get("spelling.autocomplete"),
 			spellingAutocorrect: settings.get("spelling.autocorrect"),
+			listContinuation: settings.get("tui.listContinuation"),
 		};
 	});
 

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { getDefault } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
-import { COMPOSER_DEFAULTS, Composer, type ComposerPreferences } from "@oh-my-pi/pi-coding-agent/modes/composer";
+import { Composer, type ComposerPreferences } from "@oh-my-pi/pi-coding-agent/modes/composer";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import {
 	applyStartupComposerPreferences,
@@ -73,6 +73,7 @@ describe("Composer prepaint", () => {
 			spellingTypoDetection: settings.get("spelling.typoDetection"),
 			spellingAutocomplete: settings.get("spelling.autocomplete"),
 			spellingAutocorrect: settings.get("spelling.autocorrect"),
+			listContinuation: settings.get("tui.listContinuation"),
 		};
 	});
 
@@ -394,21 +395,68 @@ describe("Composer prepaint", () => {
 		expect(exit).toHaveBeenCalledWith(0);
 		expect(terminal.stops).toBe(1);
 	});
+	it("keeps a user-toggled list continuation across shape updates and editor replacement", async () => {
+		const terminal = new CountingTerminal(80, 24);
+		const composer = new Composer({ preferences: config, terminal });
+		composer.start();
+		const lease = new ComposerLease(composer);
+		const testSession = await createTestSession({ inMemory: true });
+		const mode = new InteractiveMode(
+			testSession.session,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			lease.composer,
+		);
+		lease.adopt();
+		const selector = new SelectorController(mode);
 
-	it("first frame mirrors the canonical settings-schema defaults", () => {
-		expect(COMPOSER_DEFAULTS).toEqual({
-			quiet: getDefault("startup.quiet"),
-			composerShape: getDefault("composer.shape") ?? "box",
-			showHardwareCursor: getDefault("showHardwareCursor"),
-			maxInlineImages: getDefault("tui.maxInlineImages"),
-			resizeScrollback: getDefault("tui.resizeScrollback"),
-			imeSafeCursor: getDefault("tui.imeSafeCursor"),
-			autocompleteMaxVisible: getDefault("autocompleteMaxVisible"),
-			spellingTypoDetection: getDefault("spelling.typoDetection"),
-			spellingAutocomplete: getDefault("spelling.autocomplete"),
-			spellingAutocorrect: getDefault("spelling.autocorrect"),
-		});
+		try {
+			vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+			vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
+			await mode.init({ suppressWelcomeIntro: true });
+
+			// The settings selector persists the value before dispatching the side
+			// effect; drive the same save-then-notify sequence.
+			settings.set("tui.listContinuation", false);
+			selector.handleSettingChange("tui.listContinuation", false);
+			terminal.sendInput("- item");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n");
+
+			// An unrelated preference change replays composer preferences over the
+			// editor; the explicit false must survive it instead of the startup
+			// default resurrecting continuation.
+			settings.set("composer.shape", "box");
+			selector.handleSettingChange("composer.shape", "box");
+			terminal.sendInput("- second");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n");
+
+			// A replacement editor must inherit the stored preference, not the
+			// schema default.
+			mode.setEditorComponent(undefined);
+			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n");
+			terminal.sendInput("- third");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n- third\n");
+
+			settings.set("tui.listContinuation", true);
+			selector.handleSettingChange("tui.listContinuation", true);
+			terminal.sendInput("- next");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n- third\n- next\n- ");
+		} finally {
+			mode.stop();
+			lease.dispose();
+			await testSession.cleanup();
+			vi.restoreAllMocks();
+		}
 	});
+
 	it("renders the complete interactive welcome scene on the first frame", async () => {
 		const terminal = new CountingTerminal(80, 32);
 		const composer = new Composer({
@@ -559,6 +607,7 @@ describe("Composer prepaint", () => {
 			spellingTypoDetection: settings.get("spelling.typoDetection"),
 			spellingAutocomplete: settings.get("spelling.autocomplete"),
 			spellingAutocorrect: settings.get("spelling.autocorrect"),
+			listContinuation: settings.get("tui.listContinuation"),
 			theme: {},
 		});
 		await terminal.waitForRender();

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -419,9 +419,9 @@ describe("Composer prepaint", () => {
 			vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
 			await mode.init({ suppressWelcomeIntro: true });
 
-			// The settings selector persists the value before dispatching the side
-			// effect; drive the same save-then-notify sequence.
-			settings.set("tui.listContinuation", false);
+			// The settings selector persists toggles on the session-scoped settings
+			// instance before dispatching the side effect; drive the same source.
+			mode.settings.set("tui.listContinuation", false);
 			selector.handleSettingChange("tui.listContinuation", false);
 			terminal.sendInput("- item");
 			terminal.sendInput("\n");
@@ -444,7 +444,7 @@ describe("Composer prepaint", () => {
 			terminal.sendInput("\n");
 			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n- third\n");
 
-			settings.set("tui.listContinuation", true);
+			mode.settings.set("tui.listContinuation", true);
 			selector.handleSettingChange("tui.listContinuation", true);
 			terminal.sendInput("- next");
 			terminal.sendInput("\n");

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -457,6 +457,45 @@ describe("Composer prepaint", () => {
 		}
 	});
 
+	it("initializes list continuation from the session settings, not the global", async () => {
+		const terminal = new CountingTerminal(80, 24);
+		// Startup preferences are built from the global instance (default on); the
+		// session isolates the same setting off and must win at adoption.
+		const composer = new Composer({ preferences: { ...config, listContinuation: true }, terminal });
+		composer.start();
+		const lease = new ComposerLease(composer);
+		const testSession = await createTestSession({
+			inMemory: true,
+			settingsOverrides: { "tui.listContinuation": false },
+		});
+		const mode = new InteractiveMode(
+			testSession.session,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			lease.composer,
+		);
+		lease.adopt();
+
+		try {
+			vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+			vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
+			await mode.init({ suppressWelcomeIntro: true });
+
+			terminal.sendInput("- item");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n");
+		} finally {
+			mode.stop();
+			lease.dispose();
+			await testSession.cleanup();
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("renders the complete interactive welcome scene on the first frame", async () => {
 		const terminal = new CountingTerminal(80, 32);
 		const composer = new Composer({

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -498,6 +498,54 @@ describe("Composer prepaint", () => {
 		}
 	});
 
+	it("keeps a toggle that the isolated session instance cannot see across editor replacement", async () => {
+		const terminal = new CountingTerminal(80, 24);
+		// The session isolates the setting off; the /settings selector persists the
+		// toggle through the module-global instance. A replacement editor must
+		// inherit the composer's current preference — re-reading the isolated
+		// instance would silently re-disable continuation.
+		const composer = new Composer({ preferences: { ...config, listContinuation: false }, terminal });
+		composer.start();
+		const lease = new ComposerLease(composer);
+		const testSession = await createTestSession({
+			inMemory: true,
+			settingsOverrides: { "tui.listContinuation": false },
+		});
+		const mode = new InteractiveMode(
+			testSession.session,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			lease.composer,
+		);
+		lease.adopt();
+		const selector = new SelectorController(mode);
+
+		try {
+			vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+			vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
+			await mode.init({ suppressWelcomeIntro: true });
+
+			selector.handleSettingChange("tui.listContinuation", true);
+			terminal.sendInput("- item");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n- ");
+
+			mode.setEditorComponent(undefined);
+			terminal.sendInput("next");
+			terminal.sendInput("\n");
+			expect(mode.editor.getExpandedText()).toBe("- item\n- next\n- ");
+		} finally {
+			mode.stop();
+			lease.dispose();
+			await testSession.cleanup();
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("renders the complete interactive welcome scene on the first frame", async () => {
 		const terminal = new CountingTerminal(80, 32);
 		const composer = new Composer({

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -419,9 +419,10 @@ describe("Composer prepaint", () => {
 			vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
 			await mode.init({ suppressWelcomeIntro: true });
 
-			// The settings selector persists toggles on the session-scoped settings
-			// instance before dispatching the side effect; drive the same source.
-			mode.settings.set("tui.listContinuation", false);
+			// The /settings selector persists through the module-global settings
+			// instance and dispatches the side effect with the new value; the handler
+			// must apply that value directly, since an isolated this.settings cannot
+			// see the selector's write.
 			selector.handleSettingChange("tui.listContinuation", false);
 			terminal.sendInput("- item");
 			terminal.sendInput("\n");
@@ -444,7 +445,8 @@ describe("Composer prepaint", () => {
 			terminal.sendInput("\n");
 			expect(mode.editor.getExpandedText()).toBe("- item\n- second\n- third\n");
 
-			mode.settings.set("tui.listContinuation", true);
+			// Same dispatch contract on re-enable: the value must win even though the
+			// session-scoped instance still holds the startup default.
 			selector.handleSettingChange("tui.listContinuation", true);
 			terminal.sendInput("- next");
 			terminal.sendInput("\n");

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Markdown lists now continue on newline and end on empty items, preserving numbering, indentation, and blockquote prefixes while leaving fenced/indented code and horizontal rules unchanged. Prompt behavior follows the `tui.listContinuation` setting (default on); the `Editor` component itself defaults off and hosts opt in with `setListContinuation(true)`.
 
+### Fixed
+
+- Large Markdown messages made of consecutive headings (no blank lines) no longer freeze rendering: the bounded lexer now also cuts windows at column-0 headings instead of lexing such runs in one pass.
+
 ## [18.1.14] - 2026-09-07
 ### Fixed
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Markdown lists now continue on newline and end on empty items, preserving numbering and indentation while leaving fenced code and horizontal rules unchanged. Prompt behavior follows the `tui.listContinuation` setting (default on); the `Editor` component itself defaults off and hosts opt in with `setListContinuation(true)`.
+- Markdown lists now continue on newline and end on empty items, preserving numbering, indentation, and blockquote prefixes while leaving fenced/indented code and horizontal rules unchanged. Prompt behavior follows the `tui.listContinuation` setting (default on); the `Editor` component itself defaults off and hosts opt in with `setListContinuation(true)`.
 
 ## [18.1.14] - 2026-09-07
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [18.1.14] - 2026-09-07
+### Added
+
+- Markdown lists now continue on newline and end on empty items, preserving numbering and indentation while leaving fenced code and horizontal rules unchanged. Disable with `Editor.setListContinuation(false)`.
 
 ### Fixed
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [18.1.14] - 2026-09-07
 ### Added
 
 - Markdown lists now continue on newline and end on empty items, preserving numbering and indentation while leaving fenced code and horizontal rules unchanged. Disable with `Editor.setListContinuation(false)`.
 
+## [18.1.14] - 2026-09-07
 ### Fixed
 
 - `extractMarkdownLinks()` now returns one-row visible labels for formatted and multiline links ([#11086](https://github.com/can1357/oh-my-pi/pull/11086) by [@mustafaabidali](https://github.com/mustafaabidali)).

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Markdown lists now continue on newline and end on empty items, preserving numbering and indentation while leaving fenced code and horizontal rules unchanged. Disable with `Editor.setListContinuation(false)`.
+- Markdown lists now continue on newline and end on empty items, preserving numbering and indentation while leaving fenced code and horizontal rules unchanged. Prompt behavior follows the `tui.listContinuation` setting (default on); the `Editor` component itself defaults off and hosts opt in with `setListContinuation(true)`.
 
 ## [18.1.14] - 2026-09-07
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -68,6 +68,11 @@ function sanitizeLoadedText(text: string): string {
  *  a paragraph, not a list. */
 const LIST_MARKER_RE = /^([\t ]*)(?:(\d{1,9})([.)])|([-*+]))([\t ]*)/;
 
+/** A GFM task checkbox that is the item's whole content: `[ ]`, `[x]`, `[X]`,
+ *  followed only by whitespace. One trailing space belongs to the checkbox
+ *  (marked requires it), so `- [ ] ` is an empty task and `- [x]` is literal. */
+const EMPTY_TASK_CHECKBOX_RE = /^\[[ xX]\][ \t]+$/;
+
 interface ListContinuation {
 	/** Replacement for the text before the cursor on the broken line. */
 	before: string;
@@ -81,9 +86,10 @@ interface ListContinuation {
 /**
  * Continuation for a Markdown list item split by a newline: `1. a` → `2. `,
  * `- a` → `- `, `> - a` → `> - `, preserving the container prefix, indentation, and
- * delimiter. A completed empty item (`1. `, `> - `, nothing else on the line)
- * terminates the list instead — the marker is stripped and the emptied item vanishes
- * (or collapses onto its quote prefix) rather than spawning a permanent empty item.
+ * delimiter. A completed empty item (`1. `, `> - `, `- [x] ` — marker plus at most
+ * a task checkbox) terminates the list instead — the marker is stripped and the
+ * emptied item vanishes (or collapses onto its quote prefix) rather than spawning
+ * a permanent empty item.
  *
  * Returns null when the text before the cursor does not open a list item.
  */
@@ -96,10 +102,14 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	// A marker without trailing whitespace is not a list (`1.a`, `>-a`); only a bare
 	// marker ending exactly at the cursor (`1.` as the whole input) continues.
 	if (ws === "" && (after !== "" || markerEnd !== before.length)) return null;
-	// A completed empty item (`- `, `> - `) terminates the list. The emptied line
-	// collapses: an indented item vanishes entirely; a quoted line keeps exactly
-	// its quote prefix (`> - ` → `> `) with the cursor after it.
-	if (ws !== "" && after === "" && markerEnd === before.length) {
+	// A completed empty item (`- `, `> - `, `- [x] `) terminates the list. The
+	// emptied line collapses: an indented item vanishes entirely; a quoted line
+	// keeps exactly its quote prefix (`> - ` → `> `) with the cursor after it.
+	if (
+		ws !== "" &&
+		after === "" &&
+		(markerEnd === before.length || EMPTY_TASK_CHECKBOX_RE.test(before.slice(markerEnd)))
+	) {
 		const quote = before.slice(0, markerStart);
 		return { before: quote.includes(">") ? quote : "", prefix: "", terminate: true };
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -103,9 +103,10 @@ function listContinuation(before: string, after: string): ListContinuation | nul
  *  or tildes; the capture after the fence is the (possibly empty) info string. */
 const FENCE_LINE_RE = /^([\t ]*)(?:([-*+]|\d{1,9}[.)])([\t ]*))?(`{3,}|~{3,})(.*)$/;
 
-/** A thematic break: up to 3 spaces of indent, then 3+ of one marker character
- *  (`-`, `*` or `_`), each optionally separated by spaces or tabs. */
-const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
+/** A thematic break at any indentation: 3+ of one marker character (`-`, `*` or `_`),
+ *  each optionally separated by spaces or tabs. Indentation beyond the top-level bound is
+ *  either the containing list's indent or indented code — neither continues a list. */
+const THEMATIC_BREAK_RE = /^[\t ]*([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
@@ -113,10 +114,10 @@ const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
  * indentation that stays inside. A fence opened after a list marker floors at its list
  * content indent, an indented fence token floors at the top-level code bound (four), and
  * a top-level fence floors at zero (nothing ends it but its closer). A line closes the
- * fence only when it is a bare fence — no list marker — using the same character, at
- * least as long, with no info string, and within three columns of the floor; a fence
- * nested under a list item closes within its list context, and a shallower fence-shaped
- * line stays literal.
+ * only when it is a bare fence — no list marker — using the same character, at least as
+ * long, with no info string, indented at or above the floor, and within three columns of
+ * it; a fence nested under a list item closes within its list context, and a shallower
+ * fence-shaped line stays literal (or opens a fresh top-level fence on an outdent).
  *
  * A non-blank line above the floor ends list-content and indented-code fence state, and
  * the cursor line's own outdent counts too — so an indented fence token does not swallow
@@ -154,7 +155,8 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 				fence[0] === open &&
 				fence.length >= openLength &&
 				info.trim() === "" &&
-				Math.abs(indent - openFloor) <= 3
+				indent >= openFloor &&
+				indent - openFloor <= 3
 			) {
 				open = undefined;
 			} else if (openFloor > 0 && indent < openFloor) {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -98,10 +98,11 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	return { before, prefix: `${container}${bullet}${ws || " "}`, terminate: false };
 }
 
-/** A fenced code block delimiter line: any indent (fences nest inside list items), an
- *  optional list marker the fence may open directly after (`- ``` `), then 3+ backticks
- *  or tildes; the capture after the fence is the (possibly empty) info string. */
-const FENCE_LINE_RE = /^([\t ]*)(?:([-*+]|\d{1,9}[.)])([\t ]*))?(`{3,}|~{3,})(.*)$/;
+/** A fenced code block delimiter line: a container prefix — blockquote (`> `) and/or
+ *  indent, or a list marker the fence may open directly after, which requires separating
+ *  whitespace between marker and fence — then 3+ backticks or tildes; the capture after
+ *  the fence is the (possibly empty) info string. */
+const FENCE_LINE_RE = /^([\t ]*)((?:>[ \t]*)+[\t ]*)?(?:([-*+]|\d{1,9}[.)])([\t ]+))?(`{3,}|~{3,})(.*)$/;
 
 /** A thematic break at any container prefix (indent, blockquote, or both): 3+ of one
  *  marker character (`-`, `*` or `_`), each optionally separated by spaces or tabs.
@@ -111,24 +112,25 @@ const THEMATIC_BREAK_RE = /^(?:(?:[\t ]*>?[ \t]*)*)([-*_])[ \t]*(?:\1[ \t]*){2,}
 
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
- * above it, tracking the open fence's marker character, length, and floor — the minimum
- * indentation that stays inside. A fence opened after a list marker floors at its list
- * content indent, an indented fence token floors at the top-level code bound (four), and
- * a top-level fence floors at zero (nothing ends it but its closer). A line closes the
- * only when it is a bare fence — no list marker — using the same character, at least as
- * long, with no info string, indented at or above the floor, and within three columns of
- * it; a fence nested under a list item closes within its list context, and a shallower
- * fence-shaped line stays literal (or opens a fresh top-level fence on an outdent).
+ * above it, tracking the open fence's marker character, length, floor, and container —
+ * the floor is the minimum container-indent that stays inside (list content indent for
+ * marker-opened fences, the top-level code bound of four for indented fence tokens, the
+ * quoted fence's own column, or zero for a top-level fence, which only its closer ends).
+ * Container indent counts both leading whitespace and blockquote prefixes, so a quoted
+ * line stays inside its quoted fence. A line closes the fence only when it is bare — no
+ * list marker — uses the same character and container, is at least as long, has no info
+ * string, and sits at or above the floor within three columns; a shallower fence-shaped
+ * line stays literal.
  *
- * A non-blank line above the floor ends list-content and indented-code fence state, and
- * the cursor line's own outdent counts too — so an indented fence token does not swallow
- * a following outdented list. A fence-shaped line on such an outdent opens a fresh
- * top-level fence instead.
+ * A non-blank line below the floor ends list-content, quoted, and indented-code fence
+ * state, and the cursor line's own outdent counts too — so an indented or quoted fence
+ * token does not swallow a following outdented list. A fence-shaped line on such an
+ * outdent opens a fresh top-level fence instead.
  *
- * Fence-shape at any indent is treated as code state: a backtick line indented past the
- * top-level fence bound is either a fence nested under a list item or an indented code
- * block, and both should keep list continuation out of their literal content. Indented
- * prose is not tracked separately — list indentation and indented code are
+ * Fence-shape at any container is treated as code state: a backtick line indented past
+ * the top-level fence bound is either a fence nested under a list item or an indented
+ * code block, and both should keep list continuation out of their literal content.
+ * Indented prose is not tracked separately — list indentation and indented code are
  * indistinguishable without full list-context parsing, and misclassifying nested-list
  * indentation would break list continuation.
  */
@@ -136,23 +138,27 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 	let open: string | undefined; // marker character of the currently open fence
 	let openLength = 0;
 	let openFloor = 0;
+	let openQuote: string | undefined; // blockquote prefix of the opener, when quoted
 	for (let index = 0; index < lineIndex; index++) {
 		const line = lines[index] ?? "";
 		const match = FENCE_LINE_RE.exec(line);
 		if (match) {
-			const fence = match[4]!;
-			const markered = match[2] !== undefined;
-			const indent = match[1]!.length + (markered ? match[2]!.length + match[3]!.length : 0);
-			const info = match[5]!;
+			const fence = match[5]!;
+			const quote = match[2];
+			const markered = match[3] !== undefined;
+			const indent = match[1]!.length + (quote?.length ?? 0) + (markered ? match[3]!.length + match[4]!.length : 0);
+			const info = match[6]!;
 			const opensFence = !(fence[0] === "`" && info.includes("`"));
 			if (open === undefined) {
 				if (opensFence) {
 					open = fence[0];
 					openLength = fence.length;
-					openFloor = markered ? indent : indent > 3 ? 4 : 0;
+					openFloor = quote !== undefined || markered ? indent : indent > 3 ? 4 : 0;
+					openQuote = quote;
 				}
 			} else if (
 				!markered &&
+				quote === openQuote &&
 				fence[0] === open &&
 				fence.length >= openLength &&
 				info.trim() === "" &&
@@ -167,19 +173,24 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 					open = fence[0];
 					openLength = fence.length;
 					openFloor = 0;
+					openQuote = undefined;
 				} else {
 					open = undefined;
 				}
 			}
 			continue;
 		}
-		const lineIndent = /^[\t ]*/.exec(line)![0].length;
+		const lineIndent = /^(?:[\t ]*>?[ \t]*)*/.exec(line)![0].length;
 		if (open !== undefined && line.trim() !== "" && lineIndent < openFloor) open = undefined;
 	}
 	if (open !== undefined) {
 		// The cursor line can be the outdent that ends the context.
 		const current = lines[lineIndex] ?? "";
-		if (!FENCE_LINE_RE.exec(current) && current.trim() !== "" && /^[\t ]*/.exec(current)![0].length < openFloor) {
+		if (
+			!FENCE_LINE_RE.exec(current) &&
+			current.trim() !== "" &&
+			/^(?:[\t ]*>?[ \t]*)*/.exec(current)![0].length < openFloor
+		) {
 			return false;
 		}
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -109,12 +109,19 @@ const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
- * above it, tracking the open fence's marker character, length, and indentation (a fence
- * opening after a list marker sits at the list content indent). A line closes the fence
- * only when it is a bare fence — no list marker — using the same character, at least as
- * long, with no info string, and within three columns of the opener's indent; a fence
+ * above it, tracking the open fence's marker character, length, and floor — the minimum
+ * indentation that stays inside. A fence opened after a list marker floors at its list
+ * content indent, an indented fence token floors at the top-level code bound (four), and
+ * a top-level fence floors at zero (nothing ends it but its closer). A line closes the
+ * fence only when it is a bare fence — no list marker — using the same character, at
+ * least as long, with no info string, and within three columns of the floor; a fence
  * nested under a list item closes within its list context, and a shallower fence-shaped
  * line stays literal.
+ *
+ * A non-blank line above the floor ends list-content and indented-code fence state, and
+ * the cursor line's own outdent counts too — so an indented fence token does not swallow
+ * a following outdented list. A fence-shaped line on such an outdent opens a fresh
+ * top-level fence instead.
  *
  * Fence-shape at any indent is treated as code state: a backtick line indented past the
  * top-level fence bound is either a fence nested under a list item or an indented code
@@ -126,25 +133,51 @@ const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 function insideFencedCode(lines: readonly string[], lineIndex: number): boolean {
 	let open: string | undefined; // marker character of the currently open fence
 	let openLength = 0;
-	let openIndent = 0;
+	let openFloor = 0;
 	for (let index = 0; index < lineIndex; index++) {
-		const match = FENCE_LINE_RE.exec(lines[index] ?? "");
-		if (!match) continue;
-		const fence = match[4]!;
-		const indent = match[1]!.length + (match[2] !== undefined ? match[2]!.length + match[3]!.length : 0);
-		if (open === undefined) {
-			if (fence[0] === "`" && match[5]!.includes("`")) continue;
-			open = fence[0];
-			openLength = fence.length;
-			openIndent = indent;
-		} else if (
-			match[2] === undefined &&
-			fence[0] === open &&
-			fence.length >= openLength &&
-			match[5]!.trim() === "" &&
-			Math.abs(indent - openIndent) <= 3
-		) {
-			open = undefined;
+		const line = lines[index] ?? "";
+		const match = FENCE_LINE_RE.exec(line);
+		if (match) {
+			const fence = match[4]!;
+			const markered = match[2] !== undefined;
+			const indent = match[1]!.length + (markered ? match[2]!.length + match[3]!.length : 0);
+			const info = match[5]!;
+			const opensFence = !(fence[0] === "`" && info.includes("`"));
+			if (open === undefined) {
+				if (opensFence) {
+					open = fence[0];
+					openLength = fence.length;
+					openFloor = markered ? indent : indent > 3 ? 4 : 0;
+				}
+			} else if (
+				!markered &&
+				fence[0] === open &&
+				fence.length >= openLength &&
+				info.trim() === "" &&
+				Math.abs(indent - openFloor) <= 3
+			) {
+				open = undefined;
+			} else if (openFloor > 0 && indent < openFloor) {
+				// Outdent below the fence's floor ends that context; a fence-shaped
+				// line here opens a fresh top-level fence.
+				if (opensFence) {
+					open = fence[0];
+					openLength = fence.length;
+					openFloor = 0;
+				} else {
+					open = undefined;
+				}
+			}
+			continue;
+		}
+		const lineIndent = /^[\t ]*/.exec(line)![0].length;
+		if (open !== undefined && line.trim() !== "" && lineIndent < openFloor) open = undefined;
+	}
+	if (open !== undefined) {
+		// The cursor line can be the outdent that ends the context.
+		const current = lines[lineIndex] ?? "";
+		if (!FENCE_LINE_RE.exec(current) && current.trim() !== "" && /^[\t ]*/.exec(current)![0].length < openFloor) {
+			return false;
 		}
 	}
 	return open !== undefined;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -109,23 +109,21 @@ const FENCE_LINE_RE = /^([\t ]*)((?:>[ \t]*)+[\t ]*)?(?:([-*+]|\d{1,9}[.)])([\t 
  *  Indentation beyond the top-level bound is either the containing list's indent or
  *  indented code — neither continues a list. */
 const THEMATIC_BREAK_RE = /^(?:(?:[\t ]*>?[ \t]*)*)([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
-
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
  * above it, tracking the open fence's marker character, length, floor, and container —
  * the floor is the minimum container-indent that stays inside (list content indent for
- * marker-opened fences, the top-level code bound of four for indented fence tokens, the
- * quoted fence's own column, or zero for a top-level fence, which only its closer ends).
- * Container indent counts both leading whitespace and blockquote prefixes, so a quoted
- * line stays inside its quoted fence. A line closes the fence only when it is bare — no
- * list marker — uses the same character and container, is at least as long, has no info
- * string, and sits at or above the floor within three columns; a shallower fence-shaped
- * line stays literal.
+ * marker-opened fences and for bare fences inside a preceding list item's content, the
+ * top-level code bound of four for indented fence tokens, the quoted fence's own column,
+ * or zero for a top-level fence, which only its closer ends). A line closes the fence
+ * only when it is bare — no list marker — uses the same character and container, is at
+ * least as long, has no info string, and sits at or above the floor within three columns;
+ * a shallower fence-shaped line stays literal.
  *
  * A non-blank line below the floor ends list-content, quoted, and indented-code fence
- * state, and the cursor line's own outdent counts too — so an indented or quoted fence
- * token does not swallow a following outdented list. A fence-shaped line on such an
- * outdent opens a fresh top-level fence instead.
+ * state, and the cursor line's own outdent counts too — so an indented, quoted, or
+ * list-nested fence token does not swallow a following outdented list. A fence-shaped
+ * line on such an outdent opens a fresh top-level fence instead.
  *
  * Fence-shape at any container is treated as code state: a backtick line indented past
  * the top-level fence bound is either a fence nested under a list item or an indented
@@ -134,6 +132,26 @@ const THEMATIC_BREAK_RE = /^(?:(?:[\t ]*>?[ \t]*)*)([-*_])[ \t]*(?:\1[ \t]*){2,}
  * indistinguishable without full list-context parsing, and misclassifying nested-list
  * indentation would break list continuation.
  */
+
+/**
+ * Content indent of the enclosing list item for a bare fence opener at `fenceIndex`:
+ * walk back over the directly preceding list-item chain (blanks skipped, any other
+ * non-blank line stops it) and take the deepest item whose content indent the fence
+ * reaches. Null when no list context applies.
+ */
+function enclosingListFloor(lines: readonly string[], fenceIndex: number, fenceIndent: number): number | null {
+	let floor: number | null = null;
+	for (let index = fenceIndex - 1; index >= 0; index--) {
+		const line = lines[index] ?? "";
+		if (line.trim() === "") continue;
+		const match = LIST_MARKER_RE.exec(line);
+		if (!match) break;
+		const contentIndent = match[0].length;
+		if (contentIndent <= fenceIndent) floor = contentIndent;
+	}
+	return floor;
+}
+
 function insideFencedCode(lines: readonly string[], lineIndex: number): boolean {
 	let open: string | undefined; // marker character of the currently open fence
 	let openLength = 0;
@@ -154,7 +172,12 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 				if (opensFence) {
 					open = fence[0];
 					openLength = fence.length;
-					openFloor = quote !== undefined || markered ? indent : indent > 3 ? 4 : 0;
+					openFloor =
+						quote !== undefined || markered
+							? indent
+							: indent > 3
+								? 4
+								: (enclosingListFloor(lines, index, indent) ?? 0);
 					openQuoteDepth = quoteDepth;
 				}
 			} else if (

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -98,26 +98,49 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	return { before, prefix: `${indent}${bullet}${ws || " "}`, terminate: false };
 }
 
-/** Top-level code fences allow up to three spaces before their marker. */
-const FENCE_LINE_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+/** A fenced code block delimiter line: any indent (fences nest inside list items), then
+ *  3+ backticks or tildes; the capture after the marker is the (possibly empty) info string. */
+const FENCE_LINE_RE = /^([\t ]*)(`{3,}|~{3,})(.*)$/;
 
 /** A thematic break: up to 3 spaces of indent, then 3+ of one marker character
  *  (`-`, `*` or `_`), each optionally separated by spaces or tabs. */
 const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 
-/** Scan preceding lines for an unmatched fence. Nested-list indentation remains unrestricted. */
+/**
+ * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
+ * above it, tracking the open fence's marker character, length, and indentation. A line
+ * closes the fence only when it uses the same character, is at least as long, carries no
+ * info string, and sits within three columns of the opener's indent — a fence nested
+ * under a list item closes within its list context, and a shallower fence-shaped line
+ * stays literal.
+ *
+ * Fence-shape at any indent is treated as code state: a backtick line indented past the
+ * top-level fence bound is either a fence nested under a list item or an indented code
+ * block, and both should keep list continuation out of their literal content. Indented
+ * prose is not tracked separately — list indentation and indented code are
+ * indistinguishable without full list-context parsing, and misclassifying nested-list
+ * indentation would break list continuation.
+ */
 function insideFencedCode(lines: readonly string[], lineIndex: number): boolean {
 	let open: string | undefined; // marker character of the currently open fence
 	let openLength = 0;
+	let openIndent = 0;
 	for (let index = 0; index < lineIndex; index++) {
 		const match = FENCE_LINE_RE.exec(lines[index] ?? "");
 		if (!match) continue;
-		const marker = match[1]!;
+		const marker = match[2]!;
+		const indent = match[1]!.length;
 		if (open === undefined) {
-			if (marker[0] === "`" && match[2]!.includes("`")) continue;
+			if (marker[0] === "`" && match[3]!.includes("`")) continue;
 			open = marker[0];
 			openLength = marker.length;
-		} else if (marker[0] === open && marker.length >= openLength && match[2]!.trim() === "") {
+			openIndent = indent;
+		} else if (
+			marker[0] === open &&
+			marker.length >= openLength &&
+			match[3]!.trim() === "" &&
+			Math.abs(indent - openIndent) <= 3
+		) {
 			open = undefined;
 		}
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -98,9 +98,10 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	return { before, prefix: `${indent}${bullet}${ws || " "}`, terminate: false };
 }
 
-/** A fenced code block delimiter line: any indent (fences nest inside list items), then
- *  3+ backticks or tildes; the capture after the marker is the (possibly empty) info string. */
-const FENCE_LINE_RE = /^([\t ]*)(`{3,}|~{3,})(.*)$/;
+/** A fenced code block delimiter line: any indent (fences nest inside list items), an
+ *  optional list marker the fence may open directly after (`- ``` `), then 3+ backticks
+ *  or tildes; the capture after the fence is the (possibly empty) info string. */
+const FENCE_LINE_RE = /^([\t ]*)(?:([-*+]|\d{1,9}[.)])([\t ]*))?(`{3,}|~{3,})(.*)$/;
 
 /** A thematic break: up to 3 spaces of indent, then 3+ of one marker character
  *  (`-`, `*` or `_`), each optionally separated by spaces or tabs. */
@@ -108,11 +109,12 @@ const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
- * above it, tracking the open fence's marker character, length, and indentation. A line
- * closes the fence only when it uses the same character, is at least as long, carries no
- * info string, and sits within three columns of the opener's indent — a fence nested
- * under a list item closes within its list context, and a shallower fence-shaped line
- * stays literal.
+ * above it, tracking the open fence's marker character, length, and indentation (a fence
+ * opening after a list marker sits at the list content indent). A line closes the fence
+ * only when it is a bare fence — no list marker — using the same character, at least as
+ * long, with no info string, and within three columns of the opener's indent; a fence
+ * nested under a list item closes within its list context, and a shallower fence-shaped
+ * line stays literal.
  *
  * Fence-shape at any indent is treated as code state: a backtick line indented past the
  * top-level fence bound is either a fence nested under a list item or an indented code
@@ -128,17 +130,18 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 	for (let index = 0; index < lineIndex; index++) {
 		const match = FENCE_LINE_RE.exec(lines[index] ?? "");
 		if (!match) continue;
-		const marker = match[2]!;
-		const indent = match[1]!.length;
+		const fence = match[4]!;
+		const indent = match[1]!.length + (match[2] !== undefined ? match[2]!.length + match[3]!.length : 0);
 		if (open === undefined) {
-			if (marker[0] === "`" && match[3]!.includes("`")) continue;
-			open = marker[0];
-			openLength = marker.length;
+			if (fence[0] === "`" && match[5]!.includes("`")) continue;
+			open = fence[0];
+			openLength = fence.length;
 			openIndent = indent;
 		} else if (
-			marker[0] === open &&
-			marker.length >= openLength &&
-			match[3]!.trim() === "" &&
+			match[2] === undefined &&
+			fence[0] === open &&
+			fence.length >= openLength &&
+			match[5]!.trim() === "" &&
 			Math.abs(indent - openIndent) <= 3
 		) {
 			open = undefined;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -848,9 +848,11 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
-	/** Continue Markdown list items across a newline (`1. a⏎` → `2. `); default on. */
-	#listContinuation = true;
+	/** Host-applied Markdown list continuation flag; see {@link setListContinuation}. */
+	#listContinuation = false;
 
+	/** Continue Markdown list items across a newline (`1. a⏎` → `2. `). Off by default;
+	 *  hosts opt in (omp: the `tui.listContinuation` setting, default on). */
 	setListContinuation(enabled: boolean): void {
 		this.#listContinuation = enabled;
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,6 +1,6 @@
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
-import { Lexer, type Token, type Tokens } from "@oh-my-pi/pi-utils/marked";
-import { markdownParser } from "./markdown";
+import { type Token, type Tokens } from "@oh-my-pi/pi-utils/marked";
+import { lexDocument } from "./markdown";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
@@ -137,7 +137,7 @@ function listContentOffset(line: string): number {
  */
 function continuesList(lines: readonly string[], lineIndex: number): boolean {
 	const source = lines.join("\n");
-	const tokens = new Lexer(markdownParser.defaults).blockTokens(source, []);
+	const tokens = lexDocument(source);
 	return listMarkerAt(tokens, source, 0, lineIndex);
 }
 
@@ -179,6 +179,9 @@ function listMarkerAt(children: readonly Token[], parentText: string, baseLine: 
 	const starts = lineStarts(parentText);
 	let from = 0;
 	for (const child of children) {
+		// Synthetic task-list checkboxes carry raw text the parser already
+		// removed from the item text; they own no source span to map.
+		if (child.type === "checkbox") continue;
 		const pos = child.raw === "" ? from : Math.max(from, parentText.indexOf(child.raw, from));
 		from = pos + child.raw.length;
 		const start = baseLine + lineIndexOf(starts, pos);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -90,22 +90,30 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	const markerStart = listContentOffset(before);
 	const match = LIST_MARKER_RE.exec(before.slice(markerStart));
 	if (!match) return null;
-	const container = `${before.slice(0, markerStart)}${match[1]}`;
 	const [, , num, delim, bullet, ws] = match;
 	const markerEnd = markerStart + match[0].length;
 	// A marker without trailing whitespace is not a list (`1.a`, `>-a`); only a bare
 	// marker ending exactly at the cursor (`1.` as the whole input) continues.
 	if (ws === "" && (after !== "" || markerEnd !== before.length)) return null;
+	// A completed empty item (`- `, `> - `) terminates the list. The emptied line
+	// collapses: an indented item vanishes entirely; a quoted line keeps exactly
+	// its quote prefix (`> - ` → `> `) with the cursor after it.
 	if (ws !== "" && after === "" && markerEnd === before.length) {
-		return { before: container, prefix: "", terminate: true };
+		const quote = before.slice(0, markerStart);
+		return { before: quote.includes(">") ? quote : "", prefix: "", terminate: true };
 	}
+	const container = `${before.slice(0, markerStart)}${match[1]}`;
 	if (num !== undefined) {
 		return { before, prefix: `${container}${Number(num) + 1}${delim}${ws || " "}`, terminate: false };
 	}
 	return { before, prefix: `${container}${bullet}${ws || " "}`, terminate: false };
 }
 
-/** Skip quote markers without ambiguous, nested-whitespace regex backtracking. */
+/**
+ * Content offset after any blockquote container prefix (`> `, `> > `): each `>`
+ * consumes exactly one optional following space, so extra spacing is preserved
+ * rather than treated as quote syntax.
+ */
 function listContentOffset(line: string): number {
 	let offset = 0;
 	for (;;) {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -59,9 +59,9 @@ function sanitizeLoadedText(text: string): string {
 	return replaceTabs(text.replace(/\r\n?/g, "\n")).replace(/[\x00-\x09\x0b-\x1f]/g, "");
 }
 
-/** A Markdown list marker opening a line: optional indent, then `1.`/`1)` or `-`/`*`/`+`,
- *  then optional whitespace. */
-const LIST_MARKER_RE = /^([ \t]*)(?:(\d{1,9})([.)])|([-*+]))([ \t]*)/;
+/** A Markdown list marker opening a line: an optional blockquote container prefix
+ *  (`> `, `> > `) and/or indent, then `1.`/`1)` or `-`/`*`/`+`, then optional whitespace. */
+const LIST_MARKER_RE = /^((?:[\t ]*>?[ \t]*)*)(?:(\d{1,9})([.)])|([-*+]))([\t ]*)/;
 
 interface ListContinuation {
 	/** Replacement for the text before the cursor on the broken line. */
@@ -69,33 +69,33 @@ interface ListContinuation {
 	/** Prefix for the new line. */
 	prefix: string;
 	/** True when a completed empty item is being terminated: the marker is stripped
-	 *  and the emptied line collapses so the list simply ends. */
+	 *  and the emptied line collapses (a quoted line keeps its container prefix). */
 	terminate: boolean;
 }
 
 /**
  * Continuation for a Markdown list item split by a newline: `1. a` → `2. `,
- * `- a` → `- `, preserving indentation and the delimiter. A completed empty
- * item (`1. `, nothing else on the line) terminates the list instead — the
- * marker is stripped and the emptied item vanishes rather than spawning a
- * permanent empty item.
+ * `- a` → `- `, `> - a` → `> - `, preserving the container prefix, indentation, and
+ * delimiter. A completed empty item (`1. `, `> - `, nothing else on the line)
+ * terminates the list instead — the marker is stripped and the emptied item vanishes
+ * (or collapses onto its quote prefix) rather than spawning a permanent empty item.
  *
  * Returns null when the text before the cursor does not open a list item.
  */
 function listContinuation(before: string, after: string): ListContinuation | null {
 	const match = LIST_MARKER_RE.exec(before);
 	if (!match) return null;
-	const [, indent, num, delim, bullet, ws] = match;
-	// A marker without trailing whitespace is not a list (`1.a`); only a bare
+	const [, container, num, delim, bullet, ws] = match;
+	// A marker without trailing whitespace is not a list (`1.a`, `>-a`); only a bare
 	// marker ending exactly at the cursor (`1.` as the whole input) continues.
 	if (ws === "" && (after !== "" || match[0].length !== before.length)) return null;
 	if (ws !== "" && after === "" && match[0].length === before.length) {
-		return { before: "", prefix: "", terminate: true };
+		return { before: container, prefix: "", terminate: true };
 	}
 	if (num !== undefined) {
-		return { before, prefix: `${indent}${Number(num) + 1}${delim}${ws || " "}`, terminate: false };
+		return { before, prefix: `${container}${Number(num) + 1}${delim}${ws || " "}`, terminate: false };
 	}
-	return { before, prefix: `${indent}${bullet}${ws || " "}`, terminate: false };
+	return { before, prefix: `${container}${bullet}${ws || " "}`, terminate: false };
 }
 
 /** A fenced code block delimiter line: any indent (fences nest inside list items), an
@@ -103,10 +103,11 @@ function listContinuation(before: string, after: string): ListContinuation | nul
  *  or tildes; the capture after the fence is the (possibly empty) info string. */
 const FENCE_LINE_RE = /^([\t ]*)(?:([-*+]|\d{1,9}[.)])([\t ]*))?(`{3,}|~{3,})(.*)$/;
 
-/** A thematic break at any indentation: 3+ of one marker character (`-`, `*` or `_`),
- *  each optionally separated by spaces or tabs. Indentation beyond the top-level bound is
- *  either the containing list's indent or indented code — neither continues a list. */
-const THEMATIC_BREAK_RE = /^[\t ]*([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
+/** A thematic break at any container prefix (indent, blockquote, or both): 3+ of one
+ *  marker character (`-`, `*` or `_`), each optionally separated by spaces or tabs.
+ *  Indentation beyond the top-level bound is either the containing list's indent or
+ *  indented code — neither continues a list. */
+const THEMATIC_BREAK_RE = /^(?:(?:[\t ]*>?[ \t]*)*)([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
 
 /**
  * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
@@ -2577,12 +2578,19 @@ export class Editor implements Component, Focusable {
 		this.#state.lines.splice(this.#state.cursorLine + 1, 0, prefix + after);
 
 		if (continuation?.terminate) {
-			// The item line is now empty; drop it so the fresh line moves up into its place.
-			this.#state.lines.splice(this.#state.cursorLine, 1);
+			// The marker-stripped item line collapses: fully when only the marker was
+			// removed, otherwise (a quoted line) keeping its container prefix with the
+			// cursor resting after it.
+			if (before === "") {
+				this.#state.lines.splice(this.#state.cursorLine, 1);
+				this.#setCursorCol(0);
+			} else {
+				this.#setCursorCol(before.length);
+			}
 		} else {
 			this.#state.cursorLine++;
+			this.#setCursorCol(prefix.length);
 		}
-		this.#setCursorCol(prefix.length);
 
 		if (this.onChange) {
 			this.onChange(this.getText());

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -138,13 +138,14 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 	let open: string | undefined; // marker character of the currently open fence
 	let openLength = 0;
 	let openFloor = 0;
-	let openQuote: string | undefined; // blockquote prefix of the opener, when quoted
+	let openQuoteDepth = 0; // blockquote depth of the opener's container prefix
 	for (let index = 0; index < lineIndex; index++) {
 		const line = lines[index] ?? "";
 		const match = FENCE_LINE_RE.exec(line);
 		if (match) {
 			const fence = match[5]!;
 			const quote = match[2];
+			const quoteDepth = (quote?.match(/>/g) ?? []).length;
 			const markered = match[3] !== undefined;
 			const indent = match[1]!.length + (quote?.length ?? 0) + (markered ? match[3]!.length + match[4]!.length : 0);
 			const info = match[6]!;
@@ -154,11 +155,11 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 					open = fence[0];
 					openLength = fence.length;
 					openFloor = quote !== undefined || markered ? indent : indent > 3 ? 4 : 0;
-					openQuote = quote;
+					openQuoteDepth = quoteDepth;
 				}
 			} else if (
 				!markered &&
-				quote === openQuote &&
+				quoteDepth === openQuoteDepth &&
 				fence[0] === open &&
 				fence.length >= openLength &&
 				info.trim() === "" &&
@@ -173,25 +174,32 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 					open = fence[0];
 					openLength = fence.length;
 					openFloor = 0;
-					openQuote = undefined;
+					openQuoteDepth = 0;
 				} else {
 					open = undefined;
 				}
 			}
 			continue;
 		}
-		const lineIndent = /^(?:[\t ]*>?[ \t]*)*/.exec(line)![0].length;
-		if (open !== undefined && line.trim() !== "" && lineIndent < openFloor) open = undefined;
+		// A line inside a quoted fence stays while its blockquote depth holds; an
+		// unquoted fence keeps every line whose container prefix reaches the floor.
+		const containerPrefix = /^(?:[\t ]*>?[ \t]*)*/.exec(line)![0];
+		const stays =
+			openQuoteDepth > 0
+				? (containerPrefix.match(/>/g) ?? []).length >= openQuoteDepth
+				: containerPrefix.length >= openFloor;
+		if (open !== undefined && line.trim() !== "" && !stays) open = undefined;
 	}
 	if (open !== undefined) {
 		// The cursor line can be the outdent that ends the context.
 		const current = lines[lineIndex] ?? "";
-		if (
-			!FENCE_LINE_RE.exec(current) &&
-			current.trim() !== "" &&
-			/^(?:[\t ]*>?[ \t]*)*/.exec(current)![0].length < openFloor
-		) {
-			return false;
+		if (!FENCE_LINE_RE.exec(current) && current.trim() !== "") {
+			const containerPrefix = /^(?:[\t ]*>?[ \t]*)*/.exec(current)![0];
+			const stays =
+				openQuoteDepth > 0
+					? (containerPrefix.match(/>/g) ?? []).length >= openQuoteDepth
+					: containerPrefix.length >= openFloor;
+			if (!stays) return false;
 		}
 	}
 	return open !== undefined;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,4 +1,5 @@
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import { Lexer, type Token, type Tokens } from "@oh-my-pi/pi-utils/marked";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
@@ -59,9 +60,12 @@ function sanitizeLoadedText(text: string): string {
 	return replaceTabs(text.replace(/\r\n?/g, "\n")).replace(/[\x00-\x09\x0b-\x1f]/g, "");
 }
 
-/** A Markdown list marker opening a line: an optional blockquote container prefix
- *  (`> `, `> > `) and/or indent, then `1.`/`1)` or `-`/`*`/`+`, then optional whitespace. */
-const LIST_MARKER_RE = /^((?:[\t ]*>?[ \t]*)*)(?:(\d{1,9})([.)])|([-*+]))([\t ]*)/;
+/** A Markdown list marker at the start of a quote-stripped line: optional indent,
+ *  then `1.`/`1)` or `-`/`*`/`+`, then the separating whitespace. Every quantifier
+ *  is single-star and anchored, so matching is linear — no nested-whitespace
+ *  backtracking. An empty `ws` means the marker is glued to its text (`1.a`, `-x`):
+ *  a paragraph, not a list. */
+const LIST_MARKER_RE = /^([\t ]*)(?:(\d{1,9})([.)])|([-*+]))([\t ]*)/;
 
 interface ListContinuation {
 	/** Replacement for the text before the cursor on the broken line. */
@@ -83,13 +87,16 @@ interface ListContinuation {
  * Returns null when the text before the cursor does not open a list item.
  */
 function listContinuation(before: string, after: string): ListContinuation | null {
-	const match = LIST_MARKER_RE.exec(before);
+	const markerStart = listContentOffset(before);
+	const match = LIST_MARKER_RE.exec(before.slice(markerStart));
 	if (!match) return null;
-	const [, container, num, delim, bullet, ws] = match;
+	const container = `${before.slice(0, markerStart)}${match[1]}`;
+	const [, , num, delim, bullet, ws] = match;
+	const markerEnd = markerStart + match[0].length;
 	// A marker without trailing whitespace is not a list (`1.a`, `>-a`); only a bare
 	// marker ending exactly at the cursor (`1.` as the whole input) continues.
-	if (ws === "" && (after !== "" || match[0].length !== before.length)) return null;
-	if (ws !== "" && after === "" && match[0].length === before.length) {
+	if (ws === "" && (after !== "" || markerEnd !== before.length)) return null;
+	if (ws !== "" && after === "" && markerEnd === before.length) {
 		return { before: container, prefix: "", terminate: true };
 	}
 	if (num !== undefined) {
@@ -98,138 +105,41 @@ function listContinuation(before: string, after: string): ListContinuation | nul
 	return { before, prefix: `${container}${bullet}${ws || " "}`, terminate: false };
 }
 
-/** A fenced code block delimiter line: a container prefix — blockquote (`> `) and/or
- *  indent, or a list marker the fence may open directly after, which requires separating
- *  whitespace between marker and fence — then 3+ backticks or tildes; the capture after
- *  the fence is the (possibly empty) info string. */
-const FENCE_LINE_RE = /^([\t ]*)((?:>[ \t]*)+[\t ]*)?(?:([-*+]|\d{1,9}[.)])([\t ]+))?(`{3,}|~{3,})(.*)$/;
-
-/** A thematic break at any container prefix (indent, blockquote, or both): 3+ of one
- *  marker character (`-`, `*` or `_`), each optionally separated by spaces or tabs.
- *  Indentation beyond the top-level bound is either the containing list's indent or
- *  indented code — neither continues a list. */
-const THEMATIC_BREAK_RE = /^(?:(?:[\t ]*>?[ \t]*)*)([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
-/**
- * Whether the line at `lineIndex` sits inside an open fenced code block: walk the lines
- * above it, tracking the open fence's marker character, length, floor, and container —
- * the floor is the minimum container-indent that stays inside (list content indent for
- * marker-opened fences and for bare fences inside a preceding list item's content, the
- * top-level code bound of four for indented fence tokens, the quoted fence's own column,
- * or zero for a top-level fence, which only its closer ends). A line closes the fence
- * only when it is bare — no list marker — uses the same character and container, is at
- * least as long, has no info string, and sits at or above the floor within three columns;
- * a shallower fence-shaped line stays literal.
- *
- * A non-blank line below the floor ends list-content, quoted, and indented-code fence
- * state, and the cursor line's own outdent counts too — so an indented, quoted, or
- * list-nested fence token does not swallow a following outdented list. A fence-shaped
- * line on such an outdent opens a fresh top-level fence instead.
- *
- * Fence-shape at any container is treated as code state: a backtick line indented past
- * the top-level fence bound is either a fence nested under a list item or an indented
- * code block, and both should keep list continuation out of their literal content.
- * Indented prose is not tracked separately — list indentation and indented code are
- * indistinguishable without full list-context parsing, and misclassifying nested-list
- * indentation would break list continuation.
- */
-
-/**
- * Content indent of the enclosing list item for a bare fence opener at `fenceIndex`:
- * walk back over the directly preceding list-item chain (blanks skipped, any other
- * non-blank line stops it) and take the deepest item whose content indent the fence
- * reaches. Null when no list context applies.
- */
-function enclosingListFloor(lines: readonly string[], fenceIndex: number, fenceIndent: number): number | null {
-	let floor: number | null = null;
-	for (let index = fenceIndex - 1; index >= 0; index--) {
-		const line = lines[index] ?? "";
-		if (line.trim() === "") continue;
-		const match = LIST_MARKER_RE.exec(line);
-		if (!match) break;
-		const contentIndent = match[0].length;
-		if (contentIndent <= fenceIndent) floor = Math.max(floor ?? 0, contentIndent);
+/** Skip quote markers without ambiguous, nested-whitespace regex backtracking. */
+function listContentOffset(line: string): number {
+	let offset = 0;
+	for (;;) {
+		let next = offset;
+		while (line[next] === " " || line[next] === "\t") next++;
+		if (line[next] !== ">") return offset;
+		offset = next + 1;
+		if (line[offset] === " " || line[offset] === "\t") offset++;
 	}
-	return floor;
 }
 
-function insideFencedCode(lines: readonly string[], lineIndex: number): boolean {
-	let open: string | undefined; // marker character of the currently open fence
-	let openLength = 0;
-	let openFloor = 0;
-	let openQuoteDepth = 0; // blockquote depth of the opener's container prefix
-	for (let index = 0; index < lineIndex; index++) {
-		const line = lines[index] ?? "";
-		const match = FENCE_LINE_RE.exec(line);
-		if (match) {
-			const fence = match[5]!;
-			const quote = match[2];
-			const quoteDepth = (quote?.match(/>/g) ?? []).length;
-			const quoteWidth = quote?.length ?? 0;
-			const markered = match[3] !== undefined;
-			const indent = match[1]!.length + quoteWidth + (markered ? match[3]!.length + match[4]!.length : 0);
-			// Column after the container prefix: quote-spacing style must not affect
-			// closer matching, so quoted fences compare relative columns.
-			const relative = indent - quoteWidth;
-			const info = match[6]!;
-			const opensFence = !(fence[0] === "`" && info.includes("`"));
-			if (open === undefined) {
-				if (opensFence) {
-					open = fence[0];
-					openLength = fence.length;
-					openFloor =
-						quote !== undefined || markered
-							? relative
-							: indent > 3
-								? 4
-								: (enclosingListFloor(lines, index, indent) ?? 0);
-					openQuoteDepth = quoteDepth;
-				}
-			} else if (
-				!markered &&
-				quoteDepth === openQuoteDepth &&
-				fence[0] === open &&
-				fence.length >= openLength &&
-				info.trim() === "" &&
-				relative >= openFloor &&
-				relative - openFloor <= 3
-			) {
-				open = undefined;
-			} else if (openQuoteDepth > 0 ? quoteDepth < openQuoteDepth : openFloor > 0 && indent < openFloor) {
-				// Outdent below the fence's floor (or its blockquote depth) ends that
-				// context; a fence-shaped line here opens a fresh top-level fence.
-				if (opensFence) {
-					open = fence[0];
-					openLength = fence.length;
-					openFloor = 0;
-					openQuoteDepth = 0;
-				} else {
-					open = undefined;
-				}
-			}
+/**
+ * The cursor line must start a real list item, not merely resemble one inside
+ * code, a rule, or paragraph content. Use the shared block grammar so container
+ * exits and indentation agree with Markdown rendering; inline tokens are only
+ * queued by blockTokens, not parsed.
+ */
+function continuesList(lines: readonly string[], lineIndex: number): boolean {
+	const source = (lineIndex === lines.length - 1 ? lines : lines.slice(0, lineIndex + 1)).join("\n");
+	let tokens: Token[] = new Lexer().blockTokens(source);
+	for (;;) {
+		const last = tokens.at(-1);
+		if (last?.type === "blockquote") {
+			tokens = (last as Tokens.Blockquote).tokens;
 			continue;
 		}
-		// A line inside a quoted fence stays while its blockquote depth holds; an
-		// unquoted fence keeps every line whose container prefix reaches the floor.
-		const containerPrefix = /^(?:[\t ]*>?[ \t]*)*/.exec(line)![0];
-		const stays =
-			openQuoteDepth > 0
-				? (containerPrefix.match(/>/g) ?? []).length >= openQuoteDepth
-				: containerPrefix.length >= openFloor;
-		if (open !== undefined && line.trim() !== "" && !stays) open = undefined;
+		if (last?.type !== "list") return false;
+		const item = (last as Tokens.List).items.at(-1);
+		if (!item) return false;
+		// With no later line in this item, the cursor is on its opening marker.
+		// Otherwise only a nested list/quote can establish another list marker.
+		if (!item.raw.includes("\n")) return true;
+		tokens = item.tokens;
 	}
-	if (open !== undefined) {
-		// The cursor line can be the outdent that ends the context.
-		const current = lines[lineIndex] ?? "";
-		if (!FENCE_LINE_RE.exec(current) && current.trim() !== "") {
-			const containerPrefix = /^(?:[\t ]*>?[ \t]*)*/.exec(current)![0];
-			const stays =
-				openQuoteDepth > 0
-					? (containerPrefix.match(/>/g) ?? []).length >= openQuoteDepth
-					: containerPrefix.length >= openFloor;
-			if (!stays) return false;
-		}
-	}
-	return open !== undefined;
 }
 
 const segmenter = getSegmenter();
@@ -2606,11 +2516,9 @@ export class Editor implements Component, Focusable {
 		let continuation = this.#listContinuation ? listContinuation(before, after) : null;
 		// Not every marker-shaped line continues a list: a thematic break (`- - -`,
 		// `* * *`) is a rule rather than an item — inspect the whole line, the cursor
-		// may split it — and a marker inside a fenced code block is literal text.
-		if (
-			continuation &&
-			(THEMATIC_BREAK_RE.test(currentLine) || insideFencedCode(this.#state.lines, this.#state.cursorLine))
-		) {
+		// may split it — and a marker inside a fenced or indented code block is
+		// literal text.
+		if (continuation !== null && !continuesList(this.#state.lines, this.#state.cursorLine)) {
 			continuation = null;
 		}
 		let prefix = "";

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -59,6 +59,71 @@ function sanitizeLoadedText(text: string): string {
 	return replaceTabs(text.replace(/\r\n?/g, "\n")).replace(/[\x00-\x09\x0b-\x1f]/g, "");
 }
 
+/** A Markdown list marker opening a line: optional indent, then `1.`/`1)` or `-`/`*`/`+`,
+ *  then optional whitespace. */
+const LIST_MARKER_RE = /^([ \t]*)(?:(\d{1,9})([.)])|([-*+]))([ \t]*)/;
+
+interface ListContinuation {
+	/** Replacement for the text before the cursor on the broken line. */
+	before: string;
+	/** Prefix for the new line. */
+	prefix: string;
+	/** True when a completed empty item is being terminated: the marker is stripped
+	 *  and the emptied line collapses so the list simply ends. */
+	terminate: boolean;
+}
+
+/**
+ * Continuation for a Markdown list item split by a newline: `1. a` → `2. `,
+ * `- a` → `- `, preserving indentation and the delimiter. A completed empty
+ * item (`1. `, nothing else on the line) terminates the list instead — the
+ * marker is stripped and the emptied item vanishes rather than spawning a
+ * permanent empty item.
+ *
+ * Returns null when the text before the cursor does not open a list item.
+ */
+function listContinuation(before: string, after: string): ListContinuation | null {
+	const match = LIST_MARKER_RE.exec(before);
+	if (!match) return null;
+	const [, indent, num, delim, bullet, ws] = match;
+	// A marker without trailing whitespace is not a list (`1.a`); only a bare
+	// marker ending exactly at the cursor (`1.` as the whole input) continues.
+	if (ws === "" && (after !== "" || match[0].length !== before.length)) return null;
+	if (ws !== "" && after === "" && match[0].length === before.length) {
+		return { before: "", prefix: "", terminate: true };
+	}
+	if (num !== undefined) {
+		return { before, prefix: `${indent}${Number(num) + 1}${delim}${ws || " "}`, terminate: false };
+	}
+	return { before, prefix: `${indent}${bullet}${ws || " "}`, terminate: false };
+}
+
+/** Top-level code fences allow up to three spaces before their marker. */
+const FENCE_LINE_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+
+/** A thematic break: up to 3 spaces of indent, then 3+ of one marker character
+ *  (`-`, `*` or `_`), each optionally separated by spaces or tabs. */
+const THEMATIC_BREAK_RE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
+
+/** Scan preceding lines for an unmatched fence. Nested-list indentation remains unrestricted. */
+function insideFencedCode(lines: readonly string[], lineIndex: number): boolean {
+	let open: string | undefined; // marker character of the currently open fence
+	let openLength = 0;
+	for (let index = 0; index < lineIndex; index++) {
+		const match = FENCE_LINE_RE.exec(lines[index] ?? "");
+		if (!match) continue;
+		const marker = match[1]!;
+		if (open === undefined) {
+			if (marker[0] === "`" && match[2]!.includes("`")) continue;
+			open = marker[0];
+			openLength = marker.length;
+		} else if (marker[0] === open && marker.length >= openLength && match[2]!.trim() === "") {
+			open = undefined;
+		}
+	}
+	return open !== undefined;
+}
+
 const segmenter = getSegmenter();
 
 /**
@@ -758,6 +823,13 @@ export class Editor implements Component, Focusable {
 				this.#autocompleteList?.setMaxVisible(newMaxVisible);
 			}
 		}
+	}
+
+	/** Continue Markdown list items across a newline (`1. a⏎` → `2. `); default on. */
+	#listContinuation = true;
+
+	setListContinuation(enabled: boolean): void {
+		this.#listContinuation = enabled;
 	}
 
 	/** Loads persistent prompts for navigation and enables future persistence. */
@@ -2415,17 +2487,39 @@ export class Editor implements Component, Focusable {
 		this.#recordUndoState();
 
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
-
-		const before = currentLine.slice(0, this.#state.cursorCol);
+		let before = currentLine.slice(0, this.#state.cursorCol);
 		const after = currentLine.slice(this.#state.cursorCol);
+
+		// Continue a Markdown list across the break (`1. a⏎` → `2. `, `- a⏎` → `- `);
+		// breaking a completed empty item ends the list: its marker is stripped and
+		// the emptied item line collapses so no permanent empty item is left behind.
+		let continuation = this.#listContinuation ? listContinuation(before, after) : null;
+		// Not every marker-shaped line continues a list: a thematic break (`- - -`,
+		// `* * *`) is a rule rather than an item — inspect the whole line, the cursor
+		// may split it — and a marker inside a fenced code block is literal text.
+		if (
+			continuation &&
+			(THEMATIC_BREAK_RE.test(currentLine) || insideFencedCode(this.#state.lines, this.#state.cursorLine))
+		) {
+			continuation = null;
+		}
+		let prefix = "";
+		if (continuation) {
+			before = continuation.before;
+			prefix = continuation.prefix;
+		}
 
 		// Split current line
 		this.#state.lines[this.#state.cursorLine] = before;
-		this.#state.lines.splice(this.#state.cursorLine + 1, 0, after);
+		this.#state.lines.splice(this.#state.cursorLine + 1, 0, prefix + after);
 
-		// Move cursor to start of new line
-		this.#state.cursorLine++;
-		this.#setCursorCol(0);
+		if (continuation?.terminate) {
+			// The item line is now empty; drop it so the fresh line moves up into its place.
+			this.#state.lines.splice(this.#state.cursorLine, 1);
+		} else {
+			this.#state.cursorLine++;
+		}
+		this.#setCursorCol(prefix.length);
 
 		if (this.onChange) {
 			this.onChange(this.getText());

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -147,7 +147,7 @@ function enclosingListFloor(lines: readonly string[], fenceIndex: number, fenceI
 		const match = LIST_MARKER_RE.exec(line);
 		if (!match) break;
 		const contentIndent = match[0].length;
-		if (contentIndent <= fenceIndent) floor = contentIndent;
+		if (contentIndent <= fenceIndent) floor = Math.max(floor ?? 0, contentIndent);
 	}
 	return floor;
 }
@@ -164,8 +164,12 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 			const fence = match[5]!;
 			const quote = match[2];
 			const quoteDepth = (quote?.match(/>/g) ?? []).length;
+			const quoteWidth = quote?.length ?? 0;
 			const markered = match[3] !== undefined;
-			const indent = match[1]!.length + (quote?.length ?? 0) + (markered ? match[3]!.length + match[4]!.length : 0);
+			const indent = match[1]!.length + quoteWidth + (markered ? match[3]!.length + match[4]!.length : 0);
+			// Column after the container prefix: quote-spacing style must not affect
+			// closer matching, so quoted fences compare relative columns.
+			const relative = indent - quoteWidth;
 			const info = match[6]!;
 			const opensFence = !(fence[0] === "`" && info.includes("`"));
 			if (open === undefined) {
@@ -174,7 +178,7 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 					openLength = fence.length;
 					openFloor =
 						quote !== undefined || markered
-							? indent
+							? relative
 							: indent > 3
 								? 4
 								: (enclosingListFloor(lines, index, indent) ?? 0);
@@ -186,13 +190,13 @@ function insideFencedCode(lines: readonly string[], lineIndex: number): boolean 
 				fence[0] === open &&
 				fence.length >= openLength &&
 				info.trim() === "" &&
-				indent >= openFloor &&
-				indent - openFloor <= 3
+				relative >= openFloor &&
+				relative - openFloor <= 3
 			) {
 				open = undefined;
-			} else if (openFloor > 0 && indent < openFloor) {
-				// Outdent below the fence's floor ends that context; a fence-shaped
-				// line here opens a fresh top-level fence.
+			} else if (openQuoteDepth > 0 ? quoteDepth < openQuoteDepth : openFloor > 0 && indent < openFloor) {
+				// Outdent below the fence's floor (or its blockquote depth) ends that
+				// context; a fence-shaped line here opens a fresh top-level fence.
 				if (opensFence) {
 					open = fence[0];
 					openLength = fence.length;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,6 @@
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import { Lexer, type Token, type Tokens } from "@oh-my-pi/pi-utils/marked";
+import { markdownParser } from "./markdown";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
@@ -124,30 +125,91 @@ function listContentOffset(line: string): number {
 		if (line[offset] === " " || line[offset] === "\t") offset++;
 	}
 }
-
 /**
- * The cursor line must start a real list item, not merely resemble one inside
- * code, a rule, or paragraph content. Use the shared block grammar so container
- * exits and indentation agree with Markdown rendering; inline tokens are only
- * queued by blockTokens, not parsed.
+ * Whether the line at `lineIndex` sits on a list item's opening marker in the
+ * renderer's block grammar. The full document is lexed once with the same
+ * configured grammar the message renderer uses (display math, custom rules),
+ * and the walk descends through blockquote/list/item containers — their child
+ * text strips container prefixes per line without merging lines, so child
+ * token spans map one-to-one onto source lines. A cursor inside anything that
+ * is not a list marker line — fenced or display-math code, a rule, item body
+ * text — is literal, matching what the renderer will paint.
  */
 function continuesList(lines: readonly string[], lineIndex: number): boolean {
-	const source = (lineIndex === lines.length - 1 ? lines : lines.slice(0, lineIndex + 1)).join("\n");
-	let tokens: Token[] = new Lexer().blockTokens(source);
-	for (;;) {
-		const last = tokens.at(-1);
-		if (last?.type === "blockquote") {
-			tokens = (last as Tokens.Blockquote).tokens;
-			continue;
-		}
-		if (last?.type !== "list") return false;
-		const item = (last as Tokens.List).items.at(-1);
-		if (!item) return false;
-		// With no later line in this item, the cursor is on its opening marker.
-		// Otherwise only a nested list/quote can establish another list marker.
-		if (!item.raw.includes("\n")) return true;
-		tokens = item.tokens;
+	const source = lines.join("\n");
+	const tokens = new Lexer(markdownParser.defaults).blockTokens(source, []);
+	return listMarkerAt(tokens, source, 0, lineIndex);
+}
+
+/** Zero-based index of the source line containing character `offset`. */
+function lineIndexOf(starts: readonly number[], offset: number): number {
+	let low = 0;
+	let high = starts.length - 1;
+	while (low < high) {
+		const mid = (low + high + 1) >> 1;
+		if (starts[mid]! <= offset) low = mid;
+		else high = mid - 1;
 	}
+	return low;
+}
+
+/** Character offset that starts each line of `text`. */
+function lineStarts(text: string): number[] {
+	const starts = [0];
+	for (let at = text.indexOf("\n"); at !== -1; at = text.indexOf("\n", at + 1)) starts.push(at + 1);
+	return starts;
+}
+
+/** Number of source lines a token's raw slice occupies. */
+function rawLines(raw: string): number {
+	if (raw === "") return 0;
+	let lines = 1;
+	for (let at = raw.indexOf("\n"); at !== -1; at = raw.indexOf("\n", at + 1)) {
+		if (at !== raw.length - 1) lines++;
+	}
+	return lines;
+}
+
+/**
+ * Walks sibling tokens (contiguous raw slices of `parentText`) to the one
+ * containing `cursorLine`; blockquotes recurse into their stripped text, and
+ * anything else that is not a list is literal content.
+ */
+function listMarkerAt(children: readonly Token[], parentText: string, baseLine: number, cursorLine: number): boolean {
+	const starts = lineStarts(parentText);
+	let from = 0;
+	for (const child of children) {
+		const pos = child.raw === "" ? from : Math.max(from, parentText.indexOf(child.raw, from));
+		from = pos + child.raw.length;
+		const start = baseLine + lineIndexOf(starts, pos);
+		if (cursorLine < start) return false;
+		if (cursorLine >= start + rawLines(child.raw)) continue;
+		if (child.type === "blockquote") {
+			const quote = child as Tokens.Blockquote;
+			return listMarkerAt(quote.tokens, quote.text, start, cursorLine);
+		}
+		if (child.type === "list") return itemMarkerAt(child as Tokens.List, start, cursorLine);
+		return false;
+	}
+	return false;
+}
+
+/** Locates the list item containing the cursor: its opening line continues
+ *  the list; anything deeper descends into the item's own tokens. */
+function itemMarkerAt(list: Tokens.List, baseLine: number, cursorLine: number): boolean {
+	const raw = list.raw;
+	const starts = lineStarts(raw);
+	let from = 0;
+	for (const item of list.items) {
+		const pos = item.raw === "" ? from : Math.max(from, raw.indexOf(item.raw, from));
+		from = pos + item.raw.length;
+		const start = baseLine + lineIndexOf(starts, pos);
+		if (cursorLine < start) return false;
+		if (cursorLine === start) return true;
+		if (cursorLine >= start + rawLines(item.raw)) continue;
+		return listMarkerAt(item.tokens, item.text, start, cursorLine);
+	}
+	return false;
 }
 
 const segmenter = getSegmenter();

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -520,7 +520,7 @@ class StrictStrikethroughTokenizer extends Tokenizer {
 	}
 }
 
-const markdownParser = new Marked();
+export const markdownParser = new Marked();
 markdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),
 });

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1185,6 +1185,32 @@ function stableBlockBoundary(
 	return { end, count };
 }
 
+/**
+ * Offset just past the last token that ends a line immediately before a
+ * column-0 ATX heading, together with the token count up to and including it.
+ * A heading can never be a lazy continuation and can never nest inside the
+ * column-0 blocks around it, so splitting right before it is invisible to the
+ * lexer; code and html tokens are skipped because an unclosed fence or block
+ * would swallow the heading, making a cut split it.
+ */
+function headingBlockBoundary(text: string, base: number, tokens: readonly Token[]): { count: number; end: number } {
+	let pos = base;
+	let end = 0;
+	let count = 0;
+	for (let i = 0; i < tokens.length; i++) {
+		const raw = tokens[i]!.raw;
+		const tokenEnd = pos + raw.length;
+		if (tokenEnd < text.length && raw.endsWith("\n") && tokens[i]!.type !== "code" && tokens[i]!.type !== "html") {
+			if (/^#{1,6}(?:[ \t]|\n|$)/.test(text.slice(tokenEnd, tokenEnd + 8))) {
+				end = tokenEnd;
+				count = i + 1;
+			}
+		}
+		pos = tokenEnd;
+	}
+	return count === 0 ? NO_BLOCK_BOUNDARY : { count, end };
+}
+
 // Bun's regex engine skips the start-anchor optimization for several of marked's
 // block rules — `hr`, `lheading`, `table` and `html` are `^`-anchored
 // alternations of quantified branches — so each failing `exec` rescans the whole
@@ -1216,16 +1242,31 @@ const WINDOWED_LEX_MIN_BYTES = 16 * 1024;
  * window that contains no blank line cannot cut: each round starts at the next
  * `"\n\n"` (skipping straight to the end when there is none — e.g. a tail
  * that is one long tight list) instead of probing sizes that cannot succeed.
+ * A tail with no blank line at all is bounded by column-0 headings instead:
+ * every heading line is its own block, so those windows stay small and the
+ * quadratic scan never sees a multi-window stretch.
  */
 function lexWindowed(text: string): Token[] {
 	const lexer = new Lexer(markdownParser.defaults);
 	let offset = 0;
 	while (offset < text.length) {
 		let segment = "";
-		const nextBlank = text.indexOf("\n\n", offset);
-		if (nextBlank === -1) {
-			segment = text.slice(offset);
+		if (text.indexOf("\n\n", offset) === -1) {
+			// No blank line ahead: the blank-line boundary can never fire, but a
+			// column-0 heading still bounds a window — probe for one instead of
+			// lexing the whole remaining document in one quadratic pass.
+			for (let size = LEX_WINDOW_BYTES; segment.length === 0; size *= 2) {
+				if (offset + size >= text.length) {
+					segment = text.slice(offset);
+					break;
+				}
+				const probe = new Lexer(markdownParser.defaults);
+				probe.blockTokens(text.slice(offset, offset + size), probe.tokens);
+				const boundary = headingBlockBoundary(text, offset, probe.tokens);
+				if (boundary.count > 0) segment = text.slice(offset, boundary.end);
+			}
 		} else {
+			const nextBlank = text.indexOf("\n\n", offset);
 			const minSize = Math.max(LEX_WINDOW_BYTES, nextBlank + 2 - offset);
 			for (let size = minSize; segment.length === 0; size *= 2) {
 				if (offset + size >= text.length) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1246,8 +1246,7 @@ function lexWindowed(text: string): Token[] {
 	return lexer.tokens;
 }
 
-/** Lex a whole document, windowing anything large enough for the quadratic scan to bite. */
-function lexDocument(text: string): Token[] {
+export function lexDocument(text: string): Token[] {
 	// A CR shifts every `raw` span (marked normalizes CRLF before tokenizing), so
 	// window offsets would address the wrong characters — lex those in one pass.
 	if (text.length < WINDOWED_LEX_MIN_BYTES || text.includes("\r")) return markdownParser.lexer(text);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -572,6 +572,41 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("- parent\n  ```\n> - item\n> - ");
 		});
+
+		it("keeps a list-shaped equation line literal inside a display-math block", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("$$\n- x\n$$");
+			for (let i = 0; i < 3; i++) editor.handleInput("\x1b[D"); // Left — end of the "- x" equation line
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("$$\n- x\n\n$$");
+		});
+
+		it("continues a list after a display-math block closes", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("$$\n- x\n$$\n- item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("$$\n- x\n$$\n- item\n- ");
+		});
+
+		it("keeps a list-shaped line literal inside display math nested in a list item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- $$\n  - x\n  $$");
+			for (let i = 0; i < 5; i++) editor.handleInput("\x1b[D"); // Left — end of the "  - x" equation line
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- $$\n  - x\n\n  $$");
+		});
+
+		it("keeps a quoted equation line literal inside a display-math block", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> $$\n> - x\n> $$");
+			for (let i = 0; i < 5; i++) editor.handleInput("\x1b[D"); // Left — end of the "> - x" equation line
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> $$\n> - x\n\n> $$");
+		});
 	});
 
 	describe("Prompt history navigation", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -201,6 +201,27 @@ describe("Editor component", () => {
 			expect(editor.debugState().cursorCol).toBe(2);
 		});
 
+		it("keeps bullets literal inside a fence nested under a list item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. item\n    ```\n    - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n");
+		});
+
+		it("resumes continuation after a nested list fence closes", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. item\n    ```\n    - literal\n    ```\n    - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n    ```\n    - item\n    - ");
+		});
+
+		it("stays literal when a shallower fence-shaped line appears inside a nested fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. item\n    ```\n    - literal\n```\n    - still literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n```\n    - still literal\n");
+		});
+
 		it("continues a list after backticks that cannot open a code fence", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setText("```not `an info string`\n- item");

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -97,6 +97,7 @@ describe("Editor component", () => {
 	describe("Markdown list continuation", () => {
 		it("continues a numbered list with the next number on Shift+Enter", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. first item");
 			editor.handleInput("\x1b[13;2~"); // Shift+Enter (legacy CSI)
 			expect(editor.getText()).toBe("1. first item\n2. ");
@@ -105,6 +106,7 @@ describe("Editor component", () => {
 
 		it("continues numbering from the typed start", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("16. item");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("16. item\n17. ");
@@ -112,6 +114,7 @@ describe("Editor component", () => {
 
 		it("keeps the ordered-list delimiter and indentation", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("  1) nested");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("  1) nested\n  2) ");
@@ -119,6 +122,7 @@ describe("Editor component", () => {
 
 		it("continues bullet lists with the same bullet and indentation", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("  - nested");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("  - nested\n  - ");
@@ -126,6 +130,7 @@ describe("Editor component", () => {
 
 		it("splits mid-item content after the marker", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. ab");
 			editor.handleInput("\x1b[D"); // Left arrow — cursor between a and b
 			editor.handleInput("\x1b[13;2~");
@@ -135,6 +140,7 @@ describe("Editor component", () => {
 
 		it("ends the list when breaking a completed empty item", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. first\n2. ");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1. first\n");
@@ -144,6 +150,7 @@ describe("Editor component", () => {
 
 		it("treats a bare marker ending at the cursor as the next item", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1.");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1.\n2. ");
@@ -151,6 +158,7 @@ describe("Editor component", () => {
 
 		it("leaves non-list lines alone", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("hello\n*em* world");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("hello\n*em* world\n");
@@ -158,14 +166,14 @@ describe("Editor component", () => {
 
 		it("does not continue a marker glued to its text", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1.a");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1.a\n");
 		});
 
-		it("inserts a plain newline when continuation is disabled", () => {
+		it("stays off until the host opts in", () => {
 			const editor = new Editor(defaultEditorTheme);
-			editor.setListContinuation(false);
 			editor.setText("1. first");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1. first\n");
@@ -173,6 +181,7 @@ describe("Editor component", () => {
 
 		it("keeps a bullet literal inside a fenced code block", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```diff\n- removed");
 			editor.handleInput("\x1b[13;2~"); // Shift+Enter
 			expect(editor.getText()).toBe("```diff\n- removed\n");
@@ -180,6 +189,7 @@ describe("Editor component", () => {
 
 		it("splits inside a fenced code block without adding a marker prefix", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```\n- removed");
 			for (let i = 0; i < 3; i++) editor.handleInput("\x1b[D"); // Left — before "ved"
 			editor.handleInput("\x1b[13;2~");
@@ -188,6 +198,7 @@ describe("Editor component", () => {
 
 		it("preserves a completed empty item inside a fenced code block", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```\n- ");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("```\n- \n");
@@ -195,6 +206,7 @@ describe("Editor component", () => {
 
 		it("resumes list continuation after a valid closing fence", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```diff\n- removed\n```\n- item");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("```diff\n- removed\n```\n- item\n- ");
@@ -203,6 +215,7 @@ describe("Editor component", () => {
 
 		it("keeps bullets literal inside a fence nested under a list item", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. item\n    ```\n    - literal");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n");
@@ -210,6 +223,7 @@ describe("Editor component", () => {
 
 		it("resumes continuation after a nested list fence closes", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. item\n    ```\n    - literal\n    ```\n    - item");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n    ```\n    - item\n    - ");
@@ -217,6 +231,7 @@ describe("Editor component", () => {
 
 		it("stays literal when a shallower fence-shaped line appears inside a nested fence", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("1. item\n    ```\n    - literal\n```\n    - still literal");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n```\n    - still literal\n");
@@ -224,6 +239,7 @@ describe("Editor component", () => {
 
 		it("continues a list after backticks that cannot open a code fence", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```not `an info string`\n- item");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("```not `an info string`\n- item\n- ");
@@ -231,6 +247,7 @@ describe("Editor component", () => {
 
 		it("stays inside a fence whose closing marker is shorter than the opener", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("````\ncode\n```\n- literal");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("````\ncode\n```\n- literal\n");
@@ -238,6 +255,7 @@ describe("Editor component", () => {
 
 		it("stays inside a fence whose closing line carries an info string", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("```\ncode\n```text\n- literal");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("```\ncode\n```text\n- literal\n");
@@ -245,6 +263,7 @@ describe("Editor component", () => {
 
 		it("keeps a backtick line literal inside a tilde fence", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("~~~\n```\n- literal");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("~~~\n```\n- literal\n");
@@ -252,6 +271,7 @@ describe("Editor component", () => {
 
 		it("appends a plain newline after a '* * *' thematic break", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("* * *");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("* * *\n");
@@ -259,6 +279,7 @@ describe("Editor component", () => {
 
 		it("splits a thematic break plainly when the cursor divides it", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("- - -");
 			editor.handleInput("\x1b[D"); // Left
 			editor.handleInput("\x1b[D"); // Left — cursor before " -"
@@ -268,6 +289,7 @@ describe("Editor component", () => {
 
 		it("still continues a bullet whose content opens with the same marker", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("- - item");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("- - item\n- ");
@@ -275,6 +297,7 @@ describe("Editor component", () => {
 
 		it("still continues a list indented past the fence-indent bound", () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
 			editor.setText("- parent\n    - deep");
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("- parent\n    - deep\n    - ");

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -335,6 +335,38 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("> > 1. item\n> > 2. ");
 		});
 
+		it("keeps bullets literal inside a blockquoted fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> ```\n> - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> ```\n> - literal\n");
+		});
+
+		it("resumes continuation after a blockquoted fence closes", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> ```\n> - literal\n> ```\n> - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> ```\n> - literal\n> ```\n> - item\n> - ");
+		});
+
+		it("treats an unquoted fence line inside a quoted fence as a new top-level fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> ```\n```\n> - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> ```\n```\n> - literal\n");
+		});
+
+		it("does not treat a marker-glued fence as opening code state", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("-```js\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("-```js\n- literal\n- ");
+		});
+
 		it("stays inside a fence whose closing marker is shorter than the opener", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -343,6 +343,22 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("> ```\n> - literal\n");
 		});
 
+		it("keeps bullets literal after a no-space blockquote content line", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> ```\n>code\n> - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> ```\n>code\n> - literal\n");
+		});
+
+		it("keeps wider-spaced quoted lines inside a quoted fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> ```\n>  - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> ```\n>  - literal\n");
+		});
+
 		it("resumes continuation after a blockquoted fence closes", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -94,6 +94,172 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Markdown list continuation", () => {
+		it("continues a numbered list with the next number on Shift+Enter", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. first item");
+			editor.handleInput("\x1b[13;2~"); // Shift+Enter (legacy CSI)
+			expect(editor.getText()).toBe("1. first item\n2. ");
+			expect(editor.debugState().cursorCol).toBe(3);
+		});
+
+		it("continues numbering from the typed start", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("16. item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("16. item\n17. ");
+		});
+
+		it("keeps the ordered-list delimiter and indentation", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("  1) nested");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("  1) nested\n  2) ");
+		});
+
+		it("continues bullet lists with the same bullet and indentation", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("  - nested");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("  - nested\n  - ");
+		});
+
+		it("splits mid-item content after the marker", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. ab");
+			editor.handleInput("\x1b[D"); // Left arrow — cursor between a and b
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. a\n2. b");
+			expect(editor.debugState().cursorCol).toBe(3);
+		});
+
+		it("ends the list when breaking a completed empty item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1. first\n2. ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. first\n");
+			expect(editor.debugState().cursorLine).toBe(1);
+			expect(editor.debugState().cursorCol).toBe(0);
+		});
+
+		it("treats a bare marker ending at the cursor as the next item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1.");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1.\n2. ");
+		});
+
+		it("leaves non-list lines alone", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("hello\n*em* world");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("hello\n*em* world\n");
+		});
+
+		it("does not continue a marker glued to its text", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("1.a");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1.a\n");
+		});
+
+		it("inserts a plain newline when continuation is disabled", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(false);
+			editor.setText("1. first");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("1. first\n");
+		});
+
+		it("keeps a bullet literal inside a fenced code block", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```diff\n- removed");
+			editor.handleInput("\x1b[13;2~"); // Shift+Enter
+			expect(editor.getText()).toBe("```diff\n- removed\n");
+		});
+
+		it("splits inside a fenced code block without adding a marker prefix", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```\n- removed");
+			for (let i = 0; i < 3; i++) editor.handleInput("\x1b[D"); // Left — before "ved"
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```\n- remo\nved");
+		});
+
+		it("preserves a completed empty item inside a fenced code block", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```\n- ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```\n- \n");
+		});
+
+		it("resumes list continuation after a valid closing fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```diff\n- removed\n```\n- item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```diff\n- removed\n```\n- item\n- ");
+			expect(editor.debugState().cursorCol).toBe(2);
+		});
+
+		it("continues a list after backticks that cannot open a code fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```not `an info string`\n- item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```not `an info string`\n- item\n- ");
+		});
+
+		it("stays inside a fence whose closing marker is shorter than the opener", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("````\ncode\n```\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("````\ncode\n```\n- literal\n");
+		});
+
+		it("stays inside a fence whose closing line carries an info string", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("```\ncode\n```text\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```\ncode\n```text\n- literal\n");
+		});
+
+		it("keeps a backtick line literal inside a tilde fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("~~~\n```\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("~~~\n```\n- literal\n");
+		});
+
+		it("appends a plain newline after a '* * *' thematic break", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("* * *");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("* * *\n");
+		});
+
+		it("splits a thematic break plainly when the cursor divides it", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("- - -");
+			editor.handleInput("\x1b[D"); // Left
+			editor.handleInput("\x1b[D"); // Left — cursor before " -"
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- -\n -");
+		});
+
+		it("still continues a bullet whose content opens with the same marker", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("- - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- - item\n- ");
+		});
+
+		it("still continues a list indented past the fence-indent bound", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("- parent\n    - deep");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n    - deep\n    - ");
+		});
+	});
+
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -632,6 +632,45 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText().endsWith("\n- item\n- ")).toBe(true);
 		});
+
+		it("terminates an empty task-list item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- [x] a\n- [ ] ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- [x] a\n");
+		});
+
+		it("collapses an empty quoted task-list item onto its quote prefix", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - [ ] ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> \n");
+			expect(editor.debugState().cursorCol).toBe(2);
+		});
+
+		it("continues a task-list item whose checkbox is literal text", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			// No trailing space: the checkbox is item content, not a task marker.
+			editor.setText("- [x]");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- [x]\n- ");
+		});
+
+		it("continues lists in large drafts without blank-line boundaries", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			// Headings only: no "\n\n" cut exists, so the windowed lexer must
+			// bound the run with heading boundaries instead of one quadratic pass.
+			const headings = Array.from({ length: 1300 }, (_, i) => `### heading ${i} with padding text`).join("\n");
+			editor.setText(`${headings}\n- item`);
+			expect(editor.getText().length).toBeGreaterThan(16 * 1024);
+			expect(editor.getText().includes("\n\n")).toBe(false);
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText().endsWith("\n- item\n- ")).toBe(true);
+		});
 	});
 
 	describe("Prompt history navigation", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -464,6 +464,114 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("- parent\n    - deep\n    - ");
 		});
+		it("appends a plain newline after a top-level indented-code bullet literal", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("    - literal"); // 4 spaces: indented code block, not a list item
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("    - literal\n");
+		});
+
+		it("appends a plain newline after a top-level indented-code empty item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("    - ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("    - \n");
+		});
+
+		it("appends a plain newline after a blockquoted indented-code bullet literal", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText(">     - literal"); // 4 spaces past the quote marker: indented code
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe(">     - literal\n");
+		});
+
+		it("continues a deep nested list inside a blockquote", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - parent\n>   - deep");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> - parent\n>   - deep\n>   - ");
+			expect(editor.debugState().cursorCol).toBe(6);
+		});
+
+		it("exits a quoted fence opened on a marker line when a sibling item appears", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - ```\n>   code\n> - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> - ```\n>   code\n> - next\n> - ");
+			expect(editor.debugState().cursorCol).toBe(4);
+		});
+
+		it("exits a quoted fence opened on a separate line when a sibling item appears", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - parent\n>   ```\n>   code\n> - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> - parent\n>   ```\n>   code\n> - next\n> - ");
+			expect(editor.debugState().cursorCol).toBe(4);
+		});
+
+		it("preserves the nested list floor across intervening prose", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- outer\n  - inner\n\n    prose\n  - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- outer\n  - inner\n\n    prose\n  - next\n  - ");
+			expect(editor.debugState().cursorCol).toBe(4);
+		});
+
+		it("preserves the nested list floor across a blank line", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- outer\n  - inner\n\n  - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- outer\n  - inner\n\n  - next\n  - ");
+			expect(editor.debugState().cursorCol).toBe(4);
+		});
+
+		it("keeps deeply indented paragraph continuation literal", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- parent\n      - deep");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n      - deep\n");
+		});
+
+		it("keeps a blank line from ending a list-contained code fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- parent\n  ```\n\n  - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n  ```\n\n  - literal\n");
+		});
+
+		it("does not open a fence from indented code inside a quote", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText(">     ```\n> - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe(">     ```\n> - item\n> - ");
+		});
+
+		it("continues a deeply nested sibling after it exits a code fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- outer\n  - inner\n    - deepest\n      ```\n    - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- outer\n  - inner\n    - deepest\n      ```\n    - next\n    - ");
+		});
+
+		it("does not count a quote marker as indentation within a list fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- parent\n  ```\n> - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n  ```\n> - item\n> - ");
+		});
 	});
 
 	describe("Prompt history navigation", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -277,6 +277,22 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("    ```\n```js\n- item\n");
 		});
 
+		it("treats an outdented fence line as a new top-level fence, not a closer", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- ```\n```\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- ```\n```\n- literal\n");
+		});
+
+		it("appends a plain newline after a thematic break nested under a list item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- parent\n    * * *");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n    * * *\n");
+		});
+
 		it("continues a list after backticks that cannot open a code fence", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -607,6 +607,31 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[13;2~");
 			expect(editor.getText()).toBe("> $$\n> - x\n\n> $$");
 		});
+
+		it("continues a nested child under a completed task-list item", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			// The parser prepends a synthetic checkbox token whose raw text is
+			// removed from the item text; line mapping must skip it.
+			editor.setText("- [x] a\n  - child");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- [x] a\n  - child\n  - ");
+		});
+
+		it("continues lists in drafts large enough for the bounded window lexer", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			// Above the 16 KB crossover the renderer lexes in bounded windows;
+			// continuation must classify through the same path, not a bare lex.
+			const filler = Array.from(
+				{ length: 450 },
+				(_, i) => `paragraph ${i} with enough padding text to matter.`,
+			).join("\n\n");
+			editor.setText(`${filler}\n\n- item`);
+			expect(editor.getText().length).toBeGreaterThan(16 * 1024);
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText().endsWith("\n- item\n- ")).toBe(true);
+		});
 	});
 
 	describe("Prompt history navigation", () => {
@@ -617,7 +642,6 @@ describe("Editor component", () => {
 
 			expect(editor.getText()).toBe("");
 		});
-
 		it("shows most recent history entry on Up arrow when editor is empty", () => {
 			const editor = new Editor(defaultEditorTheme);
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -261,6 +261,22 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("```\n- ```\n- literal\n");
 		});
 
+		it("does not carry an indented fence token across an outdent", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("    ```\n- item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("    ```\n- item\n- ");
+		});
+
+		it("keeps a list literal under a top-level fence opened on an outdent", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("    ```\n```js\n- item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("    ```\n```js\n- item\n");
+		});
+
 		it("continues a list after backticks that cannot open a code fence", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -237,6 +237,30 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("1. item\n    ```\n    - literal\n```\n    - still literal\n");
 		});
 
+		it("keeps bullets literal inside a fence opened directly after a list marker", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- ```\n  - literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- ```\n  - literal\n");
+		});
+
+		it("resumes continuation after a marker-opened fence closes", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- ```\n  - literal\n  ```\n  - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- ```\n  - literal\n  ```\n  - item\n  - ");
+		});
+
+		it("stays literal when a marker-prefixed fence-shaped line appears inside a fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("```\n- ```\n- literal");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("```\n- ```\n- literal\n");
+		});
+
 		it("continues a list after backticks that cannot open a code fence", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -367,6 +367,22 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("- parent\n  ```\n- next\n- ");
 		});
 
+		it("retains the deepest enclosing list floor across a nested chain", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- outer\n  - inner\n    ~~~\n  - next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- outer\n  - inner\n    ~~~\n  - next\n  - ");
+		});
+
+		it("closes a wide-spaced quoted fence with a tighter quoted closer", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText(">   ~~~\n> ~~~\n> - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe(">   ~~~\n> ~~~\n> - item\n> - ");
+		});
+
 		it("resumes continuation after a blockquoted fence closes", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -301,6 +301,40 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("```not `an info string`\n- item\n- ");
 		});
 
+		it("continues a blockquoted bullet with the container prefix", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> - item\n> - ");
+		});
+
+		it("increments a blockquoted ordered list after its container prefix", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> 1. item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> 1. item\n> 2. ");
+		});
+
+		it("collapses an empty blockquoted item onto its container prefix", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> - ");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> \n");
+			expect(editor.debugState().cursorLine).toBe(0);
+			expect(editor.debugState().cursorCol).toBe(2);
+		});
+
+		it("continues a list nested inside two blockquote levels", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("> > 1. item");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("> > 1. item\n> > 2. ");
+		});
+
 		it("stays inside a fence whose closing marker is shorter than the opener", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -359,6 +359,14 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("> ```\n>  - literal\n");
 		});
 
+		it("does not keep an outdented sibling inside a list-context fence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setListContinuation(true);
+			editor.setText("- parent\n  ```\n- next");
+			editor.handleInput("\x1b[13;2~");
+			expect(editor.getText()).toBe("- parent\n  ```\n- next\n- ");
+		});
+
 		it("resumes continuation after a blockquoted fence closes", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setListContinuation(true);

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Markdown no longer treats backtick fences with backticks in their info strings as code blocks.
+- Large Markdown documents tokenize faster when no block extensions need the remaining source.
+
 ## [18.1.13] - 2026-09-07
 
 ### Fixed

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -706,7 +706,8 @@ function splitTableRow(line: string): string[] {
 }
 
 function isFence(line: string): RegExpExecArray | null {
-	return /^ {0,3}(`{3,}|~{3,})(.*?)(?:\n|$)$/.exec(line);
+	const match = /^ {0,3}(`{3,}|~{3,})(.*?)(?:\n|$)$/.exec(line);
+	return match?.[1]?.[0] === "`" && match[2]!.includes("`") ? null : match;
 }
 function isHeading(line: string): boolean {
 	return /^ {0,3}#{1,6}(?:\s|$)/.test(line);
@@ -903,7 +904,7 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 	const lines = lineArray(src);
 	let i = 0;
 	while (i < lines.length) {
-		const remaining = lines.slice(i).join("");
+		const remaining = lexer.extensions.block.length > 0 ? lines.slice(i).join("") : "";
 		let custom: Tokens.Generic | undefined;
 		for (const extension of lexer.extensions.block) {
 			custom = extension.tokenizer.call({ lexer }, remaining, output);
@@ -1060,7 +1061,7 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 		if (i + 1 < lines.length && /^ {0,3}(=+|-+)[ \t]*(?:\n|$)$/.test(lines[i + 1]!)) {
 			let fallback: Tokens.Heading | undefined | false;
 			const override = lexer.tokenizerOverrides.lheading;
-			if (override) fallback = override.call(lexer.tokenizer, remaining);
+			if (override) fallback = override.call(lexer.tokenizer, remaining || lines.slice(i).join(""));
 			if (!override || fallback === false) {
 				const raw = line + lines[i + 1]!;
 				const text = stripFinalNewline(line);


### PR DESCRIPTION
<!-- Proposed title: feat(tui): continue Markdown lists in the prompt editor -->
<!-- Review draft only: replace every YOUR INPUT block before submission. No push or PR creation until your review is complete. -->

## What

- Continue ordered Markdown lists (`1.`, `2.`, `3.`...) and `-`/`*`/`+` bullet lists when inserting a newline, preserving indentation and ordered-list delimiters. Splitting a completed empty item ends the list.
- Add the default-on `tui.listContinuation` setting under Interaction → Input in `/settings`, plus `Editor.setListContinuation(boolean)` for TUI consumers.

## Why

When writing prompts with lists, it's boring to manually format it with dashes to separate lines, or numbers for an ordered list to be later referenced. This is a QOL feature that makes that experience more frictionless

This is especially useful when .e.g. using Matt Pocock's /grill-me skill, which asks for answers to a numbered list. Continuing the numbered list makes it really quick to answer each of those questions


## Testing

### Automated verification performed by the coding assistant

- `bun check` passed when run from both `packages/tui` and `packages/coding-agent` (lint, formatting, and TypeScript checks).
- Repository-root `bun check` passed (workspace lint, formatting, TypeScript checks, and Rust checks). Rust emitted a future-incompatibility warning for the existing `nix v0.28.0` dependency.
- `bun test packages/tui/test/editor.test.ts packages/coding-agent/test/startup-composer.test.ts packages/coding-agent/test/issue-9597-cold-launch-double-clear.test.ts` — **212 passed, 0 failed**.
- Regression coverage exercises real editor input/output for list continuation, empty-item termination, fenced-code boundaries, horizontal rules, and disabled continuation. The settings regression drives the real settings side-effect handler through shape changes, editor replacement, and re-enabling continuation.

### Live CLI verification performed by the coding assistant

Launched the source CLI in a PTY with isolated settings; no model request was submitted. Exercised input and inspected the painted terminal frame and editor state:

- `1. first` + Shift+Enter produced a new `2. ` item.
- Inside a fenced `diff` block, `- removed` + Shift+Enter inserted a plain newline.
- `* * *` + Shift+Enter inserted a plain newline, with no bullet prefix.
- Disabled Markdown List Continuation in `/settings`, changed Composer Shape to Rounded Box, then entered `1. first` + Shift+Enter: continuation remained disabled.

I manually tested list continuation using the ordered list formats: `1.`, `1)` and also the unordered list formats `- item` and `* item`

I also tested manually disabling the setting and verified that list continuation does not happen in that case.

I briefly reviewed the code and understand its working. It's a narrow modification which shouldn't have any side effects

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
