### PR TITLE
feat(plan): timed auto-accept for plan approval and plan-mode ask prompts

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -719,7 +719,10 @@ For a custom status line, set `statusLine.preset: custom` and configure `statusL
 | `autoResume`           | boolean | `false`         | Auto-resume the most recent session in the cwd.                                                         |
 | `plan.enabled`         | boolean | `true`          | Enable plan mode.                                                                                       |
 | `plan.defaultOnStartup` | boolean | `false`         | Start each fresh interactive session in plan mode when plan mode is enabled. Print/JSON (`--print`) mode ignores this and prints a note; use `--plan-yolo` for a headless plan flow. |
+| `plan.approvalTimeout` | number  | `0`             | Seconds before the plan-approval overlay auto-selects `plan.approvalDefault`; `0` = wait indefinitely. The countdown restarts on any keypress. |
+| `plan.approvalDefault` | enum    | `execute`       | `execute`, `compact`, `keep-context`. Option chosen when `plan.approvalTimeout` expires. Falls back to `execute` when keep-context is disabled by context pressure. |
 | `ask.timeout`          | number  | `0`             | Seconds before an `ask` prompt times out; `0` = no timeout. (Legacy ms values are migrated to seconds.) |
+| `ask.timeoutInPlanMode` | boolean | `false`        | Apply `ask.timeout` during plan mode. Off by default, so plan-mode asks wait indefinitely. |
 | `ask.notify`           | enum    | `on`            | `on`, `off`.                                                                                            |
 
 ### Providers and services

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Added
 
-- Timed auto-accept for plan approval: `plan.approvalTimeout` counts down on the plan-review overlay and auto-selects `plan.approvalDefault` (`execute`/`compact`/`keep-context`) when nobody is at the keyboard, so plan → implement can run unattended. Any keypress restarts the window, a disabled keep-context option falls back to execute, and the transcript records that the approval was automatic. Defaults to off.
-- `ask.timeoutInPlanMode` applies `ask.timeout` during plan mode, which previously always waited indefinitely. Defaults to off.
+- Timed auto-accept for plan approval: `plan.approvalTimeout` counts down on the plan-review overlay and auto-selects `plan.approvalDefault` (`execute`/`compact`/`keep-context`) when nobody is at the keyboard, so plan → implement can run unattended. Any keypress restarts the window, an open external editor suspends it, a disabled keep-context option falls back to execute, and the approved-plan prompt records that the approval was automatic. Defaults to off ([#11166](https://github.com/can1357/oh-my-pi/pull/11166) by [@billpku](https://github.com/billpku)).
+- `ask.timeoutInPlanMode` applies `ask.timeout` during plan mode, which previously always waited indefinitely. Defaults to off ([#11166](https://github.com/can1357/oh-my-pi/pull/11166) by [@billpku](https://github.com/billpku)).
+
+### Fixed
+
+- Fixed dialog countdowns longer than ~24.8 days (`ask.timeout`, `plan.approvalTimeout`) firing almost immediately: `CountdownTimer` now re-arms across bounded chunks instead of handing an overflowing delay to `setTimeout`, which the runtime clamps to 1ms ([#11166](https://github.com/can1357/oh-my-pi/pull/11166) by [@billpku](https://github.com/billpku)).
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Timed auto-accept for plan approval: `plan.approvalTimeout` counts down on the plan-review overlay and auto-selects `plan.approvalDefault` (`execute`/`compact`/`keep-context`) when nobody is at the keyboard, so plan → implement can run unattended. Any keypress restarts the window, a disabled keep-context option falls back to execute, and the transcript records that the approval was automatic. Defaults to off.
+- `ask.timeoutInPlanMode` applies `ask.timeout` during plan mode, which previously always waited indefinitely. Defaults to off.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2330,6 +2330,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"ask.timeoutInPlanMode": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Notifications",
+			label: "Ask Timeout In Plan Mode",
+			description: "Apply the ask timeout during plan mode instead of waiting indefinitely",
+		},
+	},
+
 	"ask.notify": {
 		type: "enum",
 		values: ["on", "off"] as const,
@@ -4800,6 +4811,38 @@ export const SETTINGS_SCHEMA = {
 			group: "Modes",
 			label: "Start in Plan Mode",
 			description: "Automatically enter plan mode at the start of every new session",
+			condition: "planModeEnabled",
+		},
+	},
+
+	"plan.approvalTimeout": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Plan Approval Timeout",
+			description: "Auto-select the default plan-approval option after this many seconds (0 disables)",
+			condition: "planModeEnabled",
+			options: [
+				{ value: "0", label: "Disabled" },
+				{ value: "60", label: "1 minute" },
+				{ value: "300", label: "5 minutes" },
+				{ value: "600", label: "10 minutes" },
+				{ value: "1800", label: "30 minutes" },
+			],
+		},
+	},
+
+	"plan.approvalDefault": {
+		type: "enum",
+		values: ["execute", "compact", "keep-context"] as const,
+		default: "execute",
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Plan Approval Default",
+			description: "Option chosen when the plan-approval timeout expires",
 			condition: "planModeEnabled",
 		},
 	},

--- a/packages/coding-agent/src/modes/components/countdown-timer.ts
+++ b/packages/coding-agent/src/modes/components/countdown-timer.ts
@@ -3,6 +3,9 @@
  */
 import type { TUI } from "@oh-my-pi/pi-tui";
 
+/** Largest delay a 32-bit signed timer accepts; longer values are clamped to 1ms. */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 export class CountdownTimer {
 	#intervalId: NodeJS.Timeout | undefined;
 	#expireTimeoutId: NodeJS.Timeout | undefined;
@@ -32,13 +35,24 @@ export class CountdownTimer {
 		this.#remainingSeconds = this.#calculateRemainingSeconds(now);
 		this.onTick(this.#remainingSeconds);
 		this.tui?.requestRender();
+		this.#scheduleExpiry();
+		this.#startInterval();
+	}
 
+	/** Arm the expiry timer, re-arming across `MAX_TIMEOUT_MS` chunks when the
+	 *  deadline is further out than a 32-bit timer can express. A raw
+	 *  `setTimeout(ms)` above that limit is clamped to 1ms by the runtime, which
+	 *  would fire a deliberately long window almost immediately. */
+	#scheduleExpiry(): void {
+		const remainingMs = Math.max(0, this.#deadlineMs - Date.now());
+		if (remainingMs > MAX_TIMEOUT_MS) {
+			this.#expireTimeoutId = setTimeout(() => this.#scheduleExpiry(), MAX_TIMEOUT_MS);
+			return;
+		}
 		this.#expireTimeoutId = setTimeout(() => {
 			this.dispose();
 			this.onExpire();
-		}, this.#initialMs);
-
-		this.#startInterval();
+		}, remainingMs);
 	}
 
 	#startInterval(): void {

--- a/packages/coding-agent/src/modes/components/plan-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/plan-review-overlay.ts
@@ -223,6 +223,10 @@ export class PlanReviewOverlay implements Component {
 	#countdown: CountdownTimer | undefined;
 	/** Seconds left on `#countdown`, rendered next to the prompt title. */
 	#countdownSeconds: number | undefined;
+	/** Retained so the timer can be re-armed after a suspend. */
+	#countdownConfig: { timeoutMs: number; tui: TUI; label: string } | undefined;
+	/** True between `suspendCountdown` and `resumeCountdown`. */
+	#countdownSuspended = false;
 
 	constructor(
 		planContent: string,
@@ -270,10 +274,17 @@ export class PlanReviewOverlay implements Component {
 		if (timeoutMs <= 0 || !options.tui) return;
 		const target = options.timeoutIndex ?? 0;
 		if (target < 0 || target >= this.#options.length || this.#disabled.has(target)) return;
-		const label = this.#options[target]!;
+		this.#countdownConfig = { timeoutMs, tui: options.tui, label: this.#options[target]! };
+		this.#armCountdown();
+	}
+
+	/** (Re)start the timer from a full window using the stored config. */
+	#armCountdown(): void {
+		const config = this.#countdownConfig;
+		if (!config || this.#committed) return;
 		this.#countdown = new CountdownTimer(
-			timeoutMs,
-			options.tui,
+			config.timeoutMs,
+			config.tui,
 			seconds => {
 				this.#countdownSeconds = seconds;
 			},
@@ -284,18 +295,42 @@ export class PlanReviewOverlay implements Component {
 				// Latch before dispatching so a keypress racing the expiry cannot
 				// double-fire: `handleInput` returns early once `#committed` is set.
 				this.#committed = true;
-				this.#committedLabel = label;
-				this.callbacks.onTimeoutSelect?.(label);
-				this.callbacks.onPick(label);
+				this.#committedLabel = config.label;
+				this.callbacks.onTimeoutSelect?.(config.label);
+				this.callbacks.onPick(config.label);
 			},
 		);
 	}
 
-	/** Stop the auto-select countdown. Idempotent; safe after expiry. */
+	/** Pause the countdown while a modal, out-of-band interaction owns the
+	 *  terminal — notably an external editor, which stops the TUI and awaits a
+	 *  child process, so no `handleInput` can arrive to reset the timer. Without
+	 *  this the window expires mid-edit and approves the pre-edit plan.
+	 *  Idempotent; safe when no countdown is configured. */
+	suspendCountdown(): void {
+		if (!this.#countdownConfig) return;
+		this.#countdown?.dispose();
+		this.#countdown = undefined;
+		this.#countdownSeconds = undefined;
+		this.#countdownSuspended = true;
+	}
+
+	/** Resume after `suspendCountdown`, restarting a full window: the operator
+	 *  was demonstrably present, so they get the whole budget back. No-op unless
+	 *  actually suspended, and never revives a committed overlay. */
+	resumeCountdown(): void {
+		if (!this.#countdownSuspended) return;
+		this.#countdownSuspended = false;
+		this.#armCountdown();
+	}
+
+	/** Stop the auto-select countdown for good. Idempotent; safe after expiry. */
 	dispose(): void {
 		this.#countdown?.dispose();
 		this.#countdown = undefined;
 		this.#countdownSeconds = undefined;
+		this.#countdownSuspended = false;
+		this.#countdownConfig = undefined;
 	}
 
 	invalidate(): void {

--- a/packages/coding-agent/src/modes/components/plan-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/plan-review-overlay.ts
@@ -27,6 +27,7 @@ import {
 	routeSgrMouseInput,
 	ScrollView,
 	truncateToWidth,
+	type TUI,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
@@ -38,6 +39,7 @@ import {
 	matchesSelectDown,
 	matchesSelectUp,
 } from "../utils/keybinding-matchers";
+import { CountdownTimer } from "./countdown-timer";
 import type { HookSelectorSlider } from "./hook-selector";
 import {
 	bottomBorder,
@@ -120,6 +122,8 @@ interface UndoEntry {
 export interface PlanReviewOverlayCallbacks {
 	/** Invoked with the chosen option label (never a disabled one). */
 	onPick: (label: string) => void;
+	/** Invoked just before `onPick` when the countdown expired instead of a keypress. */
+	onTimeoutSelect?: (label: string) => void;
 	/** Invoked on Esc / cancel. */
 	onCancel: () => void;
 	/** Invoked with the current full plan text when the copy hotkey is pressed. */
@@ -152,6 +156,12 @@ export interface PlanReviewOverlayOptions {
 	externalEditorLabel?: string;
 	/** Serializable annotations restored into this overlay instance. */
 	annotationState?: PlanReviewAnnotationState;
+	/** Auto-select `timeoutIndex` after this many milliseconds; omitted/0 disables. */
+	timeoutMs?: number;
+	/** Option index auto-selected when the countdown expires. */
+	timeoutIndex?: number;
+	/** TUI handle used to schedule repaints while the countdown ticks. */
+	tui?: TUI;
 }
 
 /** Default trailing footer hint when the caller supplies none. */
@@ -209,6 +219,10 @@ export class PlanReviewOverlay implements Component {
 	#annotating = false;
 	#input: Input;
 	#annotationTarget: BodyRowAnchor | { sectionIndex: number; row: null; context: null } | undefined;
+	/** Live auto-select countdown, present only while a timeout is configured. */
+	#countdown: CountdownTimer | undefined;
+	/** Seconds left on `#countdown`, rendered next to the prompt title. */
+	#countdownSeconds: number | undefined;
 
 	constructor(
 		planContent: string,
@@ -245,6 +259,43 @@ export class PlanReviewOverlay implements Component {
 		if (Array.isArray(options.annotationState?.annotations) && options.annotationState.annotations.length > 0) {
 			this.#recomputeFeedback();
 		}
+		this.#startCountdown(options);
+	}
+
+	/** Arm the auto-select countdown, mirroring `HookSelector`'s timeout wiring.
+	 *  A disabled or out-of-range target leaves the overlay blocking forever —
+	 *  auto-picking a dimmed row would drive an approval path the caller refuses. */
+	#startCountdown(options: PlanReviewOverlayOptions): void {
+		const timeoutMs = options.timeoutMs ?? 0;
+		if (timeoutMs <= 0 || !options.tui) return;
+		const target = options.timeoutIndex ?? 0;
+		if (target < 0 || target >= this.#options.length || this.#disabled.has(target)) return;
+		const label = this.#options[target]!;
+		this.#countdown = new CountdownTimer(
+			timeoutMs,
+			options.tui,
+			seconds => {
+				this.#countdownSeconds = seconds;
+			},
+			() => {
+				this.#countdown = undefined;
+				this.#countdownSeconds = undefined;
+				if (this.#committed) return;
+				// Latch before dispatching so a keypress racing the expiry cannot
+				// double-fire: `handleInput` returns early once `#committed` is set.
+				this.#committed = true;
+				this.#committedLabel = label;
+				this.callbacks.onTimeoutSelect?.(label);
+				this.callbacks.onPick(label);
+			},
+		);
+	}
+
+	/** Stop the auto-select countdown. Idempotent; safe after expiry. */
+	dispose(): void {
+		this.#countdown?.dispose();
+		this.#countdown = undefined;
+		this.#countdownSeconds = undefined;
 	}
 
 	invalidate(): void {
@@ -481,6 +532,7 @@ export class PlanReviewOverlay implements Component {
 	#confirmSelection(): void {
 		const index = this.#selectedIndex;
 		if (index >= 0 && index < this.#options.length && !this.#disabled.has(index)) {
+			this.dispose();
 			this.#committed = true;
 			this.#committedLabel = this.#options[index]!;
 			this.callbacks.onPick(this.#options[index]!);
@@ -489,6 +541,9 @@ export class PlanReviewOverlay implements Component {
 
 	handleInput(keyData: string): void {
 		if (this.#committed) return;
+		// Any keystroke — including inside the annotation sub-mode — proves an
+		// operator is present, so the full auto-select window restarts.
+		this.#countdown?.reset();
 		if (keyData.startsWith("\x1b[<") && this.#handleMouse(keyData)) return;
 		if (this.#annotating) {
 			if (this.callbacks.onAnnotationExternalEditor && matchesAppExternalEditor(keyData)) {
@@ -501,6 +556,7 @@ export class PlanReviewOverlay implements Component {
 			return;
 		}
 		if (matchesSelectCancel(keyData)) {
+			this.dispose();
 			this.#committed = true;
 			this.callbacks.onCancel();
 			return;
@@ -1170,7 +1226,11 @@ export class PlanReviewOverlay implements Component {
 		const sliderLines = committed ? [] : this.#renderSliderLines();
 		const submittingLabel = this.#committedLabel ? `${this.#committedLabel} — submitting…` : "Submitting…";
 		const optionLines = committed ? [theme.bold(theme.fg("accent", submittingLabel))] : this.#renderOptionLines();
-		const promptLines = this.#promptTitle ? [theme.bold(theme.fg("accent", this.#promptTitle))] : [];
+		const promptTitle =
+			this.#promptTitle !== undefined && this.#countdownSeconds !== undefined
+				? `${this.#promptTitle} (${this.#countdownSeconds}s)`
+				: this.#promptTitle;
+		const promptLines = promptTitle ? [theme.bold(theme.fg("accent", promptTitle))] : [];
 		const footerLines = committed
 			? [theme.fg("dim", "Applying your selection — this can take a moment while context is prepared.")]
 			: this.#renderFooterLines(innerWidth);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3718,7 +3718,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #openPlanInExternalEditor(planFilePath: string): Promise<void> {
+	async #openPlanInExternalEditor(planFilePath: string, onEditorResult?: (content: string) => void): Promise<void> {
 		const editorCmd = getEditorCommand();
 		if (!editorCmd) {
 			this.showWarning("No editor configured. Set $VISUAL or $EDITOR environment variable.");
@@ -3752,6 +3752,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (result !== null) {
 				await Bun.write(resolvedPath, result);
 				this.#planReviewOverlay?.setPlanContent(result);
+				// The editor is now the newest authority on the plan. Without this the
+				// caller's `editedContent` keeps a pre-editor in-overlay snapshot and
+				// the approval branch would write that stale text back over the file.
+				onEditorResult?.(result);
 				this.showStatus("Plan updated in external editor.");
 			}
 		} catch (error) {
@@ -4624,7 +4628,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			],
 			{
 				helpText,
-				onExternalEditor: () => void this.#openPlanInExternalEditor(planFilePath),
+				onExternalEditor: () =>
+					void this.#openPlanInExternalEditor(planFilePath, content => {
+						editedContent = content;
+					}),
 				onPlanEdited: content => {
 					editedContent = content;
 					void Bun.write(this.#resolvePlanFilePath(planFilePath), content);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3738,6 +3738,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		// The editor stops the TUI and awaits a child process, so no keypress can
+		// reach `handleInput` to reset the approval countdown. Left running it
+		// would expire mid-edit and approve the pre-edit plan, and the editor's
+		// write would then land on an already-executing session.
+		this.#planReviewOverlay?.suspendCountdown();
 		try {
 			this.ui.stop();
 			const result = await openInEditor(editorCmd, currentText, {
@@ -3753,6 +3758,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);
 		} finally {
 			this.ui.start();
+			this.#planReviewOverlay?.resumeCountdown();
 			this.ui.requestRender(true);
 		}
 	}
@@ -3764,6 +3770,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		// Same suspend as the plan editor: the annotation editor also stops the TUI
+		// and blocks on a child process, so the countdown must not run meanwhile.
+		this.#planReviewOverlay?.suspendCountdown();
 		try {
 			this.ui.stop();
 			const result = await openInEditor(editorCmd, draft, { extension: ".md" });
@@ -3774,6 +3783,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);
 		} finally {
 			this.ui.start();
+			this.#planReviewOverlay?.resumeCountdown();
 			this.ui.requestRender(true);
 		}
 	}
@@ -3807,6 +3817,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			preserveContext?: boolean;
 			compactBeforeExecute?: boolean;
 			executionModel?: ResolvedRoleModel;
+			/** Seconds of the expired approval timeout, when nobody picked this. */
+			autoApprovedAfterSeconds?: number;
 		},
 	): Promise<boolean> {
 		const previousPresentation = this.#planModePreviousToolPresentation ?? {
@@ -3931,6 +3943,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		const planModePrompt = prompt.render(planModeApprovedPrompt, {
 			planFilePath: options.planFilePath,
 			contextPreserved: options.preserveContext === true,
+			// Durable disclosure: `showWarning` is a UI component that the
+			// `preserveContext: false` clear wipes, so the record of "nobody
+			// reviewed this" has to ride the synthetic prompt into the new session.
+			autoApproved: options.autoApprovedAfterSeconds !== undefined,
+			autoApprovalSeconds: options.autoApprovedAfterSeconds,
 		});
 		// Close the review overlay only now — after the async title write and plan
 		// prompt are prepared, immediately before the execution turn is queued. The
@@ -4650,11 +4667,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (choice === "Approve and execute" || choice === "Approve and compact context" || choice === keepContextLabel) {
-			// Disclose that nobody picked this — the transcript must not read as a
-			// deliberate operator choice. Mirrors ask's "auto-selected after timeout".
-			if (autoSelected) {
-				this.showWarning(`Plan auto-approved after ${approvalTimeoutSeconds}s with "${choice}".`);
-			}
+			// The durable disclosure rides the synthetic approved-plan prompt (see
+			// `#approvePlan`); an on-screen notice is emitted *after* dispatch so it
+			// survives the `preserveContext: false` clear, which resets the transcript.
 			try {
 				// Prefer in-overlay edits (already in memory) over a disk re-read. The
 				// overlay mirrors edits as they happen, and approval awaits one final
@@ -4702,7 +4717,11 @@ export class InteractiveMode implements InteractiveModeContext {
 					preserveContext: choice !== "Approve and execute",
 					compactBeforeExecute: choice === "Approve and compact context",
 					executionModel,
+					autoApprovedAfterSeconds: autoSelected ? approvalTimeoutSeconds : undefined,
 				});
+				if (autoSelected) {
+					this.showWarning(`Plan auto-approved after ${approvalTimeoutSeconds}s with "${choice}".`);
+				}
 				if (executionDispatched) this.#planReviewAnnotationState.delete(annotationStateKey);
 			} catch (error) {
 				this.showError(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3536,6 +3536,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			annotationState?: PlanReviewAnnotationState;
 			onAnnotationStateChange?: (state: PlanReviewAnnotationState) => void;
 			initialIndex?: number;
+			timeoutMs?: number;
+			timeoutIndex?: number;
+			onTimeoutSelect?: (label: string) => void;
 		},
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
@@ -3559,9 +3562,13 @@ export class InteractiveMode implements InteractiveModeContext {
 				slider: extra?.slider,
 				externalEditorLabel: this.keybindings.getDisplayString("app.editor.external") || undefined,
 				annotationState: dialogOptions?.annotationState,
+				timeoutMs: dialogOptions?.timeoutMs,
+				timeoutIndex: dialogOptions?.timeoutIndex,
+				tui: this.ui,
 			},
 			{
 				onPick: choice => finish(choice),
+				onTimeoutSelect: dialogOptions?.onTimeoutSelect,
 				onCancel: () => finish(undefined),
 				onCopyPlan: content => void this.#copyPlanToClipboard(content),
 				onExternalEditor: dialogOptions?.onExternalEditor,
@@ -3585,6 +3592,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#hidePlanReview(): void {
+		// Dispose before dropping the handle: Esc, #dismissPlanReview, and the
+		// post-approval closePlanReview() all route through here, and a live
+		// countdown interval would keep ticking against a hidden overlay.
+		this.#planReviewOverlay?.dispose();
 		this.#planReviewCancel = undefined;
 		this.#planReviewOverlayHandle?.hide();
 		this.#planReviewOverlayHandle = undefined;
@@ -4567,6 +4578,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		let feedback = "";
 		const annotationStateKey = this.#resolvePlanFilePath(planFilePath);
 
+		// Timed auto-accept: when `plan.approvalTimeout` is set, an unattended
+		// overlay commits `plan.approvalDefault` instead of blocking forever.
+		// "Refine plan" and "Save and quit" are never auto-select targets —
+		// expiry means no operator is present, so looping the model or quitting
+		// the session would both be wrong. Keep-context falls back to index 0
+		// when the context is too full for that option: a fresh-context execute
+		// is always available, and skipping the auto-select would reintroduce
+		// the indefinite wait the timeout exists to remove.
+		const approvalTimeoutSeconds = this.session.settings.get("plan.approvalTimeout");
+		const approvalDefault = this.session.settings.get("plan.approvalDefault");
+		const preferredIndex =
+			approvalDefault === "compact" ? 1 : approvalDefault === "keep-context" ? PLAN_KEEP_CONTEXT_OPTION_INDEX : 0;
+		const timeoutIndex =
+			keepContextDisabled && preferredIndex === PLAN_KEEP_CONTEXT_OPTION_INDEX ? 0 : preferredIndex;
+		const timeoutMs = approvalTimeoutSeconds > 0 ? approvalTimeoutSeconds * 1000 : undefined;
+		let autoSelected = false;
+
 		const choice = await this.showPlanReview(
 			planContent,
 			"Plan mode - next step",
@@ -4593,6 +4621,11 @@ export class InteractiveMode implements InteractiveModeContext {
 					else this.#planReviewAnnotationState.delete(annotationStateKey);
 				},
 				disabledIndices: keepContextDisabled ? [PLAN_KEEP_CONTEXT_OPTION_INDEX] : undefined,
+				timeoutMs,
+				timeoutIndex,
+				onTimeoutSelect: () => {
+					autoSelected = true;
+				},
 			},
 			{ slider },
 		);
@@ -4617,6 +4650,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (choice === "Approve and execute" || choice === "Approve and compact context" || choice === keepContextLabel) {
+			// Disclose that nobody picked this — the transcript must not read as a
+			// deliberate operator choice. Mirrors ask's "auto-selected after timeout".
+			if (autoSelected) {
+				this.showWarning(`Plan auto-approved after ${approvalTimeoutSeconds}s with "${choice}".`);
+			}
 			try {
 				// Prefer in-overlay edits (already in memory) over a disk re-read. The
 				// overlay mirrors edits as they happen, and approval awaits one final

--- a/packages/coding-agent/src/prompts/system/plan-mode-approved.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-approved.md
@@ -1,4 +1,7 @@
 Plan approved.
+{{#if autoApproved}}
+- Auto-approved: the {{autoApprovalSeconds}}s approval timeout expired with no operator input; nobody reviewed this plan.
+{{/if}}
 {{#if contextPreserved}}
 - History usable; the plan below authoritative if it conflicts with earlier exploration.
 {{/if}}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -873,7 +873,11 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		// Settings.get("ask.timeout") returns seconds (0 = disabled), convert to ms
 		const timeoutSeconds = this.session.settings.get("ask.timeout");
 		const settingsTimeout = timeoutSeconds === 0 ? null : timeoutSeconds * 1000;
-		const timeout = planModeEnabled ? null : settingsTimeout;
+		// Plan mode blocks the timeout by default so an unattended planning session
+		// never auto-answers; `ask.timeoutInPlanMode` opts into the same countdown
+		// that already runs outside plan mode.
+		const allowTimeoutInPlanMode = this.session.settings.get("ask.timeoutInPlanMode");
+		const timeout = planModeEnabled && !allowTimeoutInPlanMode ? null : settingsTimeout;
 
 		// Send notification if waiting and not suppressed
 		this.#sendAskNotification();

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -19,19 +19,58 @@ async function drainMicrotasks(): Promise<void> {
 	await Promise.resolve();
 }
 
-function createAskTool(): AskTool {
+function createAskTool(overrides: { planMode?: boolean; timeoutInPlanMode?: boolean } = {}): AskTool {
 	return new AskTool({
 		hasUI: true,
 		settings: {
 			get(key: string): unknown {
 				if (key === "ask.timeout") return 0.01;
+				if (key === "ask.timeoutInPlanMode") return overrides.timeoutInPlanMode ?? false;
 				if (key === "ask.notify") return "off";
 				if (key === "speech.enabled") return false;
 				return undefined;
 			},
 		},
-		getPlanModeState: () => ({ enabled: false }),
+		getPlanModeState: () => ({ enabled: overrides.planMode ?? false }),
 	} as unknown as ToolSession);
+}
+
+/** Runs one single-question ask against a selector that never settles, so the
+ *  only thing that can resolve it is the fallback timeout. */
+async function runNeverSettlingAsk(tool: AskTool): Promise<AskExecutionResult | undefined> {
+	const select = vi.fn<AskSelect>(() => Promise.withResolvers<string | undefined>().promise);
+	const context = {
+		hasUI: true,
+		ui: { select, editor: vi.fn() },
+		abort: vi.fn(),
+	} as unknown as AgentToolContext;
+	let result: AskExecutionResult | undefined;
+
+	void tool
+		.execute(
+			"ask-plan-mode",
+			{
+				questions: [
+					{
+						id: "db",
+						question: "Which database?",
+						options: [{ label: "SQLite" }, { label: "Postgres" }],
+						recommended: 1,
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		)
+		.then(value => {
+			result = value;
+		});
+
+	await drainMicrotasks();
+	vi.advanceTimersByTime(10);
+	await drainMicrotasks();
+	return result;
 }
 
 describe("AskTool timeout", () => {
@@ -311,5 +350,18 @@ describe("AskTool timeout", () => {
 		expect(onTimeoutStart).toHaveBeenCalledTimes(1);
 		expect(onTimeoutReset).toHaveBeenCalledTimes(1);
 		selector.dispose();
+	});
+
+	it("blocks the timeout in plan mode unless ask.timeoutInPlanMode is set", async () => {
+		vi.useFakeTimers();
+		expect(await runNeverSettlingAsk(createAskTool({ planMode: true }))).toBeUndefined();
+	});
+
+	it("applies the timeout in plan mode when ask.timeoutInPlanMode is set", async () => {
+		vi.useFakeTimers();
+		const result = await runNeverSettlingAsk(createAskTool({ planMode: true, timeoutInPlanMode: true }));
+
+		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
+		expect(result?.details?.timedOut).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/countdown-timer.test.ts
+++ b/packages/coding-agent/test/countdown-timer.test.ts
@@ -35,4 +35,21 @@ describe("CountdownTimer", () => {
 		vi.advanceTimersByTime(1);
 		expect(onExpire).toHaveBeenCalledTimes(1);
 	});
+
+	it("does not fire early for windows past the 32-bit timer limit", () => {
+		// A raw setTimeout above 2^31-1 ms is clamped to 1ms by the runtime, which
+		// would fire a deliberately long window almost immediately.
+		const onExpire = vi.fn();
+		const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000; // ~2.59e9 > 2_147_483_647
+		new CountdownTimer(thirtyDaysMs, undefined, () => {}, onExpire);
+
+		vi.advanceTimersByTime(2_147_483_647);
+		expect(onExpire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(thirtyDaysMs - 2_147_483_647 - 1);
+		expect(onExpire).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(onExpire).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -2122,6 +2122,112 @@ describe("InteractiveMode plan review rendering", () => {
 			expect(mode.planModeEnabled).toBe(false);
 			expect(prompt.mock.calls.some(isPlanApprovedCall)).toBe(true);
 			expect(overlayHandle.hide).toHaveBeenCalled();
+
+			// The disclosure must survive `handleClearCommand`, which resets the
+			// transcript on this default `execute` path — so it rides the synthetic
+			// approved-plan prompt rather than living only in a UI warning.
+			const dispatched = prompt.mock.calls.find(isPlanApprovedCall)?.[0] as string;
+			expect(dispatched).toContain("Auto-approved");
+			expect(dispatched).toContain("no operator input");
+		});
+
+		it("omits the auto-approval line from the approved-plan prompt on a manual pick", async () => {
+			session.settings.set("plan.approvalTimeout", 600);
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+			vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
+
+			await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+			const dispatched = prompt.mock.calls.find(isPlanApprovedCall)?.[0] as string;
+			expect(dispatched).toContain("Plan approved.");
+			expect(dispatched).not.toContain("Auto-approved");
+		});
+
+		it("does not auto-approve while a real external editor outlives the window", async () => {
+			// Regression (PR #11166 review): the editor stops the TUI and awaits a
+			// child process, so no keypress can reach handleInput to reset the timer.
+			// Left running, the countdown expired mid-edit, approved the pre-edit
+			// plan, and the editor's write landed on an already-executing session.
+			const editorPath = path.join(tempDir.path(), "slow-editor.sh");
+			await Bun.write(editorPath, "#!/bin/sh\nsleep 1\nprintf '# Plan\\n\\nedited in editor\\n' > \"$1\"\n");
+			await fs.chmod(editorPath, 0o755);
+			const previousEditor = Bun.env.EDITOR;
+			const previousVisual = Bun.env.VISUAL;
+			const keybindings = KeybindingsManager.inMemory({ "app.editor.external": "ctrl+e" });
+			mode.keybindings = keybindings;
+			setKeybindings(keybindings);
+
+			// 0.3s window against a ~1s editor: without the suspend this expires
+			// while the child process is still running.
+			session.settings.set("plan.approvalTimeout", 0.3);
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\noriginal body");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(session, "getContextUsage").mockReturnValue(undefined);
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+			let capturedOverlay: PlanReviewOverlay | undefined;
+			vi.spyOn(mode.ui, "showOverlay").mockImplementation(component => {
+				capturedOverlay = component as PlanReviewOverlay;
+				// Enter the external editor as soon as the overlay mounts.
+				queueMicrotask(() => capturedOverlay?.handleInput("\x05"));
+				return { hide: vi.fn() } as never;
+			});
+			// Resolve on the editor's real commit signal rather than a guessed sleep;
+			// setPlanContent is what #openPlanInExternalEditor calls after the child
+			// process returns, i.e. the exact moment the suspend window closes.
+			const { promise: editorReturned, resolve: markEditorReturned } = Promise.withResolvers<void>();
+			const setPlanContent = PlanReviewOverlay.prototype.setPlanContent;
+			vi.spyOn(PlanReviewOverlay.prototype, "setPlanContent").mockImplementation(function (
+				this: PlanReviewOverlay,
+				content: string,
+			) {
+				setPlanContent.call(this, content);
+				markEditorReturned();
+			});
+
+			try {
+				Bun.env.EDITOR = editorPath;
+				delete Bun.env.VISUAL;
+				const approval = mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+				// The editor ran ~1s against a 0.3s window. If the countdown had kept
+				// ticking it would already have approved the pre-edit plan by now.
+				await editorReturned;
+				expect(prompt.mock.calls.some(isPlanApprovedCall)).toBe(false);
+				expect(mode.planModeEnabled).toBe(true);
+
+				// The editor's write reached the plan file rather than a session that
+				// had already started executing the pre-edit plan.
+				expect(await Bun.file(resolvedPlanPath).text()).toContain("edited in editor");
+
+				// Resume re-arms a full window, so the approval still lands — and it
+				// lands after the editor's write, so execution reads the edited plan.
+				await approval;
+				expect(prompt.mock.calls.some(isPlanApprovedCall)).toBe(true);
+				expect(await Bun.file(resolvedPlanPath).text()).toContain("edited in editor");
+			} finally {
+				if (previousEditor === undefined) delete Bun.env.EDITOR;
+				else Bun.env.EDITOR = previousEditor;
+				if (previousVisual === undefined) delete Bun.env.VISUAL;
+				else Bun.env.VISUAL = previousVisual;
+				capturedOverlay?.dispose();
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { Agent, AgentBusyError, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
@@ -1970,6 +1971,158 @@ describe("InteractiveMode plan review rendering", () => {
 
 		expect(selector).toHaveBeenCalledTimes(2);
 		expect(showError).not.toHaveBeenCalled();
+	});
+
+	describe("timed auto-accept (plan.approvalTimeout / plan.approvalDefault)", () => {
+		/** Runs one approval, resolving the overlay through the auto-select target
+		 *  the caller plumbed rather than a keypress, and reports what was passed. */
+		const driveTimedApproval = async (): Promise<{
+			timeoutMs: number | undefined;
+			timeoutIndex: number | undefined;
+			disabledIndices: number[] | undefined;
+			choice: string | undefined;
+		}> => {
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			vi.spyOn(mode, "handleCompactCommand").mockResolvedValue("ok");
+			vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+			let timeoutMs: number | undefined;
+			let timeoutIndex: number | undefined;
+			let disabledIndices: number[] | undefined;
+			let choice: string | undefined;
+			vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options, dialogOptions) => {
+				timeoutMs = dialogOptions?.timeoutMs;
+				timeoutIndex = dialogOptions?.timeoutIndex;
+				disabledIndices = dialogOptions?.disabledIndices;
+				if (dialogOptions?.timeoutMs === undefined) return undefined;
+				choice = options[dialogOptions.timeoutIndex ?? 0]!;
+				dialogOptions.onTimeoutSelect?.(choice);
+				return choice;
+			});
+
+			await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+			return { timeoutMs, timeoutIndex, disabledIndices, choice };
+		};
+
+		it("plumbs no timeout by default so the overlay keeps blocking", async () => {
+			const result = await driveTimedApproval();
+			expect(result.timeoutMs).toBeUndefined();
+			expect(result.choice).toBeUndefined();
+		});
+
+		it("converts plan.approvalTimeout to ms and auto-approves on the execute option", async () => {
+			session.settings.set("plan.approvalTimeout", 600);
+			const warn = vi.spyOn(mode, "showWarning");
+
+			const result = await driveTimedApproval();
+
+			expect(result.timeoutMs).toBe(600_000);
+			expect(result.timeoutIndex).toBe(0);
+			expect(result.choice).toBe("Approve and execute");
+			expect(mode.planModeEnabled).toBe(false);
+			// The transcript must not read as a deliberate operator choice.
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("Plan auto-approved after 600s"));
+		});
+
+		it("targets the compact option when plan.approvalDefault is compact", async () => {
+			session.settings.set("plan.approvalTimeout", 30);
+			session.settings.set("plan.approvalDefault", "compact");
+
+			const result = await driveTimedApproval();
+
+			expect(result.timeoutIndex).toBe(1);
+			expect(result.choice).toBe("Approve and compact context");
+		});
+
+		it("targets the keep-context option when it is selectable", async () => {
+			session.settings.set("plan.approvalTimeout", 45);
+			session.settings.set("plan.approvalDefault", "keep-context");
+			vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 4000, contextWindow: 10000, percent: 40 });
+
+			const result = await driveTimedApproval();
+
+			expect(result.disabledIndices).toBeUndefined();
+			expect(result.timeoutIndex).toBe(2);
+			expect(result.choice).toMatch(/^Approve and keep context/);
+		});
+
+		it("falls back to execute rather than auto-selecting a disabled keep-context option", async () => {
+			session.settings.set("plan.approvalTimeout", 45);
+			session.settings.set("plan.approvalDefault", "keep-context");
+			vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 9700, contextWindow: 10000, percent: 97 });
+
+			const result = await driveTimedApproval();
+
+			expect(result.disabledIndices).toEqual([2]);
+			expect(result.timeoutIndex).toBe(0);
+			expect(result.choice).toBe("Approve and execute");
+		});
+
+		it("stays silent about auto-approval when the operator picks manually", async () => {
+			session.settings.set("plan.approvalTimeout", 600);
+			const warn = vi.spyOn(mode, "showWarning");
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+			// No onTimeoutSelect call: a real keypress resolved the overlay.
+			vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
+
+			await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+			expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("auto-approved"));
+		});
+
+		it("drives the real overlay from countdown expiry through execution dispatch", async () => {
+			// End-to-end: no showPlanReview mock. The real PlanReviewOverlay mounts,
+			// its countdown expires, and the approval resolves into the execution
+			// turn — the unattended plan → implement path this setting exists for.
+			session.settings.set("plan.approvalTimeout", 0.15);
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\nAdd hello() to notes.ts.");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(session, "getContextUsage").mockReturnValue(undefined);
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			const warn = vi.spyOn(mode, "showWarning");
+			const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+			let renderedPrompt = "";
+			const overlayHandle = { hide: vi.fn() };
+			vi.spyOn(mode.ui, "showOverlay").mockImplementation(component => {
+				const overlay = component as PlanReviewOverlay;
+				renderedPrompt = stripVTControlCharacters(overlay.render(80).join("\n"));
+				return overlayHandle as never;
+			});
+
+			await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+			// The operator saw a live countdown, nobody pressed a key, and the
+			// session left plan mode and dispatched the execution turn.
+			expect(renderedPrompt).toContain("Plan mode - next step (1s)");
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("Plan auto-approved"));
+			expect(mode.planModeEnabled).toBe(false);
+			expect(prompt.mock.calls.some(isPlanApprovedCall)).toBe(true);
+			expect(overlayHandle.hide).toHaveBeenCalled();
+		});
 	});
 
 	describe("openPlanReview (manual /plan-review)", () => {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -2229,6 +2229,87 @@ describe("InteractiveMode plan review rendering", () => {
 				capturedOverlay?.dispose();
 			}
 		});
+
+		it("executes the external-editor text, not a stale in-overlay snapshot", async () => {
+			// Regression (PR #11166 review): an in-overlay section delete sets
+			// `editedContent`, but `setPlanContent` deliberately does not re-emit
+			// `onPlanEdited`, so a later external-editor save left that pre-editor
+			// snapshot in place. On approval the branch preferred the stale snapshot
+			// and wrote it back over the file, discarding the editor's work.
+			const editorPath = path.join(tempDir.path(), "replacing-editor.sh");
+			await Bun.write(editorPath, "#!/bin/sh\nprintf '# Plan\\n\\nfrom external editor\\n' > \"$1\"\n");
+			await fs.chmod(editorPath, 0o755);
+			const previousEditor = Bun.env.EDITOR;
+			const previousVisual = Bun.env.VISUAL;
+			const keybindings = KeybindingsManager.inMemory({ "app.editor.external": "ctrl+e" });
+			mode.keybindings = keybindings;
+			setKeybindings(keybindings);
+
+			// Short window: the resumed countdown is what approves the plan, so the
+			// assertion covers the unattended path rather than a synthetic keypress.
+			session.settings.set("plan.approvalTimeout", 0.3);
+
+			const planFilePath = "local://PLAN.md";
+			const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+			await Bun.write(resolvedPlanPath, "# Plan\n\nintro\n\n## Doomed\n\ndelete me\n\n## Keep\n\nkeep me\n");
+			mode.planModeEnabled = true;
+			mode.planModePlanFilePath = planFilePath;
+			vi.spyOn(session, "getContextUsage").mockReturnValue(undefined);
+			vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+			vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+			const { promise: editorReturned, resolve: markEditorReturned } = Promise.withResolvers<void>();
+			const setPlanContent = PlanReviewOverlay.prototype.setPlanContent;
+			vi.spyOn(PlanReviewOverlay.prototype, "setPlanContent").mockImplementation(function (
+				this: PlanReviewOverlay,
+				content: string,
+			) {
+				setPlanContent.call(this, content);
+				markEditorReturned();
+			});
+
+			let capturedOverlay: PlanReviewOverlay | undefined;
+			const { promise: overlayMounted, resolve: markOverlayMounted } = Promise.withResolvers<void>();
+			vi.spyOn(mode.ui, "showOverlay").mockImplementation(component => {
+				capturedOverlay = component as PlanReviewOverlay;
+				markOverlayMounted();
+				return { hide: vi.fn() } as never;
+			});
+
+			try {
+				Bun.env.EDITOR = editorPath;
+				delete Bun.env.VISUAL;
+				const approval = mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+				// `handlePlanApproval` awaits file I/O before mounting; wait for the
+				// real mount signal rather than guessing a microtask depth.
+				await overlayMounted;
+
+				const overlay = capturedOverlay!;
+				overlay.render(80);
+				// Delete a section in the overlay -> populates `editedContent`.
+				overlay.handleInput("\t"); // focus the ToC
+				overlay.handleInput("\x1b[B"); // move onto "Doomed"
+				overlay.handleInput("d");
+				// Then round-trip through the external editor, which replaces the file.
+				overlay.handleInput("\x05"); // ctrl+e
+				await editorReturned;
+
+				// The resumed countdown approves it — the unattended path where a
+				// stale snapshot would silently overwrite the operator's editor work.
+				await approval;
+
+				expect(await Bun.file(resolvedPlanPath).text()).toBe("# Plan\n\nfrom external editor\n");
+			} finally {
+				if (previousEditor === undefined) delete Bun.env.EDITOR;
+				else Bun.env.EDITOR = previousEditor;
+				if (previousVisual === undefined) delete Bun.env.VISUAL;
+				else Bun.env.VISUAL = previousVisual;
+				capturedOverlay?.dispose();
+			}
+		});
 	});
 
 	describe("openPlanReview (manual /plan-review)", () => {

--- a/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
@@ -936,4 +936,134 @@ describe("PlanReviewOverlay", () => {
 		expect(hoverRow(overlay, "Approve and keep context")).toBe(true);
 		expect(optionLineRaw(overlay, "Approve and keep context")).not.toContain(selectedBg);
 	});
+
+	describe("auto-select countdown", () => {
+		const TUI_STUB = { requestRender: () => {} } as never;
+		const promptLine = (overlay: PlanReviewOverlay): string =>
+			render(overlay)
+				.split("\n")
+				.find(line => line.includes("Plan mode - next step")) ?? "";
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("counts down on the prompt line and auto-picks the timeout target", () => {
+			const onPick = vi.fn();
+			const onTimeoutSelect = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{
+					promptTitle: "Plan mode - next step",
+					options: APPROVAL_OPTIONS,
+					timeoutMs: 20_000,
+					timeoutIndex: 0,
+					tui: TUI_STUB,
+				},
+				{ onPick, onCancel: vi.fn(), onTimeoutSelect },
+			);
+
+			expect(promptLine(overlay)).toContain("Plan mode - next step (20s)");
+			vi.advanceTimersByTime(15_000);
+			expect(promptLine(overlay)).toContain("Plan mode - next step (5s)");
+			expect(onPick).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(5_000);
+			expect(onTimeoutSelect).toHaveBeenCalledWith("Approve and execute");
+			expect(onPick.mock.calls).toEqual([["Approve and execute"]]);
+		});
+
+		it("restarts the full window on any keypress", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{
+					promptTitle: "Plan mode - next step",
+					options: APPROVAL_OPTIONS,
+					timeoutMs: 20_000,
+					timeoutIndex: 0,
+					tui: TUI_STUB,
+				},
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			vi.advanceTimersByTime(15_000);
+			overlay.handleInput(DOWN);
+			expect(promptLine(overlay)).toContain("Plan mode - next step (20s)");
+
+			// Past the original deadline, still inside the restarted window.
+			vi.advanceTimersByTime(15_000);
+			expect(onPick).not.toHaveBeenCalled();
+
+			// The target is pinned to `timeoutIndex` at construction; unlike
+			// HookSelector it does not follow the cursor, so navigating away does
+			// not change which option an absent operator ends up approving.
+			vi.advanceTimersByTime(5_000);
+			expect(onPick.mock.calls).toEqual([["Approve and execute"]]);
+		});
+
+		it("never auto-picks a disabled option and shows no countdown for one", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{
+					promptTitle: "Plan mode - next step",
+					options: APPROVAL_OPTIONS,
+					disabledIndices: [2],
+					timeoutMs: 20_000,
+					timeoutIndex: 2,
+					tui: TUI_STUB,
+				},
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			expect(promptLine(overlay)).not.toMatch(/\(\d+s\)/);
+			vi.advanceTimersByTime(60_000);
+			expect(onPick).not.toHaveBeenCalled();
+		});
+
+		it("stops the timer on dispose, cancel, and manual confirmation", () => {
+			const timed = {
+				promptTitle: "Plan mode - next step",
+				options: APPROVAL_OPTIONS,
+				timeoutMs: 20_000,
+				timeoutIndex: 0,
+				tui: TUI_STUB,
+			};
+
+			const onPickDisposed = vi.fn();
+			new PlanReviewOverlay("plan body", timed, { onPick: onPickDisposed, onCancel: vi.fn() }).dispose();
+			vi.advanceTimersByTime(60_000);
+			expect(onPickDisposed).not.toHaveBeenCalled();
+
+			const onPickCancelled = vi.fn();
+			const onCancel = vi.fn();
+			new PlanReviewOverlay("plan body", timed, { onPick: onPickCancelled, onCancel }).handleInput(CANCEL);
+			vi.advanceTimersByTime(60_000);
+			expect(onCancel).toHaveBeenCalledTimes(1);
+			expect(onPickCancelled).not.toHaveBeenCalled();
+
+			const onPickManual = vi.fn();
+			new PlanReviewOverlay("plan body", timed, { onPick: onPickManual, onCancel: vi.fn() }).handleInput(ENTER);
+			vi.advanceTimersByTime(60_000);
+			expect(onPickManual.mock.calls).toEqual([["Approve and execute"]]);
+		});
+
+		it("waits indefinitely when no timeout is configured", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{ promptTitle: "Plan mode - next step", options: APPROVAL_OPTIONS },
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			expect(promptLine(overlay)).not.toMatch(/\(\d+s\)/);
+			vi.advanceTimersByTime(600_000);
+			expect(onPick).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
@@ -1065,5 +1065,74 @@ describe("PlanReviewOverlay", () => {
 			vi.advanceTimersByTime(600_000);
 			expect(onPick).not.toHaveBeenCalled();
 		});
+
+		it("does not expire while suspended for an external editor", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{
+					promptTitle: "Plan mode - next step",
+					options: APPROVAL_OPTIONS,
+					timeoutMs: 20_000,
+					timeoutIndex: 0,
+					tui: TUI_STUB,
+				},
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			overlay.suspendCountdown();
+			// An editor session far longer than the window: the TUI is stopped, so no
+			// keypress can reach handleInput to reset the timer.
+			vi.advanceTimersByTime(10 * 60_000);
+			expect(onPick).not.toHaveBeenCalled();
+			expect(promptLine(overlay)).not.toMatch(/\(\d+s\)/);
+
+			overlay.resumeCountdown();
+			expect(promptLine(overlay)).toContain("Plan mode - next step (20s)");
+			vi.advanceTimersByTime(19_000);
+			expect(onPick).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(1_000);
+			expect(onPick.mock.calls).toEqual([["Approve and execute"]]);
+		});
+
+		it("keeps suspend/resume inert when no timeout is configured", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{ promptTitle: "Plan mode - next step", options: APPROVAL_OPTIONS },
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			overlay.suspendCountdown();
+			overlay.resumeCountdown();
+
+			expect(promptLine(overlay)).not.toMatch(/\(\d+s\)/);
+			vi.advanceTimersByTime(600_000);
+			expect(onPick).not.toHaveBeenCalled();
+		});
+
+		it("does not revive the countdown when resumed after disposal", () => {
+			const onPick = vi.fn();
+			const overlay = new PlanReviewOverlay(
+				"plan body",
+				{
+					promptTitle: "Plan mode - next step",
+					options: APPROVAL_OPTIONS,
+					timeoutMs: 20_000,
+					timeoutIndex: 0,
+					tui: TUI_STUB,
+				},
+				{ onPick, onCancel: vi.fn() },
+			);
+
+			// Editor open when the overlay is torn down (Esc, session switch).
+			overlay.suspendCountdown();
+			overlay.dispose();
+			overlay.resumeCountdown();
+
+			vi.advanceTimersByTime(600_000);
+			expect(onPick).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
## Problem

The plan-approval overlay and plan-mode `ask` prompts both block indefinitely. If you step away after the model writes a plan, the session sits on the approval gate forever instead of implementing the plan it just produced.

The ask-side countdown machinery already exists and works — it is explicitly force-disabled in plan mode:

```ts
// src/tools/ask.ts
const timeout = planModeEnabled ? null : settingsTimeout;
```

The plan-approval overlay has no countdown at all.

## Change

Three settings, all defaulting to today's behavior:

| Setting | Type | Default | Effect |
| --- | --- | --- | --- |
| `plan.approvalTimeout` | number (seconds) | `0` | Arms a countdown on the plan-review overlay; `0` waits indefinitely. |
| `plan.approvalDefault` | `execute` \| `compact` \| `keep-context` | `execute` | Option the expiry commits. |
| `ask.timeoutInPlanMode` | boolean | `false` | Applies `ask.timeout` during plan mode. |

`PlanReviewOverlay` gains an optional countdown built on the existing `CountdownTimer`, wired with the same semantics `HookSelector` already uses for `ask.timeout`:

- Remaining seconds render on the prompt line (`Plan mode - next step (20s)`).
- Any keystroke — including inside the annotation sub-mode — restarts the full window, so an operator who is present is never rushed.
- The commit latch is set before dispatching, so a keypress racing the expiry cannot double-fire.
- `dispose()` stops the timer; `#hidePlanReview` calls it, so `Esc`, `#dismissPlanReview`, and the post-approval close all tear the interval down rather than leaving it ticking against a hidden overlay.

`handlePlanApproval` maps the setting to an option index, with two deliberate constraints:

- **`Refine plan` / `Save and quit` are never auto-select targets.** Expiry means no operator is present; refining would loop the model against nobody and quitting would discard the session.
- **`keep-context` falls back to `execute` when that row is disabled** by context pressure (`PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT`). Auto-picking a dimmed row would drive an approval path the interactive branch refuses; skipping the auto-select would reintroduce the hang the setting exists to remove.

Auto-approval is disclosed in the transcript (`Plan auto-approved after 600s with "Approve and execute".`) so it never reads as a deliberate operator choice, mirroring `ask`'s `auto-selected after timeout`.

The dispatch branch itself is unchanged — auto-select resolves the promise with a real option label, so `preserveContext` / `compactBeforeExecute` derive exactly as for a manual pick. That is what lets plan → implement run end-to-end.

## Relationship to `--plan-yolo`

Complementary, not duplicated. `--plan-yolo` is startup-only, one-shot, unconditional, auto-approves on the model's *first* `xd://propose` with no review window, bypasses the overlay entirely, and force-switches the execution model. This adds a timed default to the interactive overlay, which stays fully interactive until the window expires.

## Tests

- `test/modes/components/plan-review-overlay.test.ts` — countdown rendering, auto-pick, keypress restart, disabled-target refusal, dispose/cancel/manual-pick teardown, and no-timeout inertness.
- `test/interactive-mode-plan-review.test.ts` — settings→index mapping for all three defaults, the disabled keep-context fallback, the auto-approval disclosure (and its absence on a manual pick), and one end-to-end case that mounts the **real** overlay, lets the countdown expire, and asserts the session leaves plan mode and dispatches the execution turn.
- `test/ask-timeout.test.ts` — plan mode still blocks by default; `ask.timeoutInPlanMode` restores the countdown.

`bun run check` passes. The touched suites are green (120 tests across the four affected files). The wider `bun test test/` run has 175 pre-existing failures on this machine (`SQLITE_IOERR_VNODE` in test tempdirs plus network-dependent Exa/Jina cases); they reproduce identically on the pristine parent commit, and none are in the files this PR touches.

## Defaults

`0` / `false` / `execute` preserve current behavior for every existing user. Happy to flip the defaults to opt-out if you would rather this be on by default.
