### PR TITLE
refactor: stop importing nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,40 +58,55 @@
         "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
-      nixpkgsFor = system: if system == "x86_64-darwin" then nixpkgs-darwin-x64 else nixpkgs;
-      bun2nixFor = system: if system == "x86_64-darwin" then bun2nix-darwin-x64 else bun2nix;
       pkgsFor =
         system:
-        import (nixpkgsFor system) {
-          inherit system;
-          overlays = [
-            rust-overlay.overlays.default
-            (bun2nixFor system).overlays.default
-            (final: _previous: {
-              # Instantiate the pinned upstream binary against this package
-              # set so Intel macOS does not re-enter nix-bun's unstable input.
-              bun = final.callPackage (nix-bun.outPath + "/package.nix") {
-                sourcesFile = nix-bun.outPath + "/versions/1.4.0.json";
-              };
-            })
-          ];
+        (if system == "x86_64-darwin" then nixpkgs-darwin-x64 else nixpkgs).legacyPackages.${system};
+
+      bun2nixFor =
+        system:
+        (if system == "x86_64-darwin" then bun2nix-darwin-x64 else bun2nix).packages.${system}.bun2nix;
+
+      rustToolchainFor =
+        system:
+        (rust-overlay.lib.mkRustBin { } (pkgsFor system)).fromRustupToolchainFile ./rust-toolchain.toml;
+
+      localPackagesFor =
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          bun = pkgs.callPackage (nix-bun.outPath + "/package.nix") {
+            sourcesFile = nix-bun.outPath + "/versions/1.4.0.json";
+          };
+          bun2nix = bun2nixFor system;
+          rustToolchain = rustToolchainFor system;
         };
+
       packageFor =
         system:
         let
           pkgs = pkgsFor system;
-          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          localPkgs = localPackagesFor system;
         in
-        pkgs.callPackage ./nix/package.nix {
-          inherit rustToolchain;
-          source = self.outPath;
-        };
+        pkgs.callPackage ./nix/package.nix (
+          {
+            source = self.outPath;
+          }
+          // localPkgs
+        );
     in
     {
-      packages = forAllSystems (system: {
-        default = packageFor system;
-        omp = packageFor system;
-      });
+      packages = forAllSystems (
+        system:
+        let
+          omp = packageFor system;
+        in
+        {
+          inherit omp;
+          default = omp;
+        }
+      );
 
       apps = forAllSystems (system: {
         default = {
@@ -106,10 +121,10 @@
         system:
         let
           pkgs = pkgsFor system;
-          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          localPackages = localPackagesFor system;
         in
         {
-          default = import ./nix/dev-shell.nix { inherit pkgs rustToolchain; };
+          default = import ./nix/dev-shell.nix ({ inherit pkgs; } // localPackages);
         }
       );
 
@@ -117,6 +132,7 @@
         system:
         let
           pkgs = pkgsFor system;
+          bun2nix = bun2nixFor system;
           homeManagerEvaluation = pkgs.lib.evalModules {
             specialArgs = { inherit pkgs; };
             modules = [
@@ -158,7 +174,7 @@
             pkgs.runCommand "omp-module-evaluation" { } "touch $out";
         in
         {
-          bun-lock = pkgs.runCommand "omp-bun-lock" { nativeBuildInputs = [ pkgs.bun2nix ]; } ''
+          bun-lock = pkgs.runCommand "omp-bun-lock" { nativeBuildInputs = [ bun2nix ]; } ''
             cp -R ${self.outPath} source
             chmod -R u+w source
             cd source

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,5 +1,7 @@
 {
   pkgs,
+  bun,
+  bun2nix,
   rustToolchain,
 }:
 let
@@ -16,10 +18,8 @@ pkgs.mkShell (
     name = "omp-dev";
 
     packages =
-      (with pkgs; [
-        bun
-        bun2nix
-        rustToolchain
+      [ bun bun2nix rustToolchain ]
+      ++ (with pkgs; [
         cargo-nextest
         rustPlatform.bindgenHook
         nixfmt


### PR DESCRIPTION
## What

Refactor nix flake to stop using `import nixpkgs` and stop using overlays. Instead, just pass the required packages directly into `callPackage` where needed. 

## Why

Eval of my system config with the omp input added would literally freeze my PC. Not build. Eval. After this change, I see nothing weird happening.
Speed up evaluation of the input when consumed in other flakes.
Refer to https://zimbatm.com/notes/1000-instances-of-nixpkgs/


## Testing

`nix flake check --all-systems --no-build --show-trace`
`nix build --no-link .#checks.x86_64-linux.bun-lock --show-trace`
`nix run .#omp`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
