### PR TITLE
fix(computer): fetch fresh capabilities for the direct helper

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `computer.capabilities()` returning `undefined` when called before any `computer.run`; the direct helper now fetches fresh backend and permission state from the desktop worker instead of a run-populated cache ([#11169](https://github.com/can1357/oh-my-pi/issues/11169)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -171,7 +171,9 @@ async function invokeComputer(
 			if (lifetime.isClosed()) throw new ToolError("Computer session is closed");
 			return await runComputer(session, controller, params, context.signal);
 		case "capabilities": {
-			const capabilities = lifetime.isClosed() ? undefined : await controller.capabilities();
+			const capabilities = lifetime.isClosed()
+				? undefined
+				: await controller.capabilities(buildComputerSnapshot(session, true), context.signal);
 			throwIfAborted(context.signal);
 			return {
 				content: [
@@ -208,20 +210,12 @@ function resolveComputerRunCode(params: ComputerRunParams | ComputerCallParams):
 	throw new ToolError("Action 'run' requires exactly one of 'code' or 'fn'.");
 }
 
-async function runComputer(
-	session: ToolSession,
-	controller: ComputerController,
-	params: ComputerRunParams | ComputerCallParams,
-	signal?: AbortSignal,
-): Promise<AgentToolResult<unknown>> {
-	const code = resolveComputerRunCode(params);
-	// Direct inspection calls run read-only so the desktop guard backs the read approval tier.
-	const readOnly = params.action === "call" ? isReadOnlyComputerCall(params.chain) : (params.read_only ?? false);
-	const timeoutSeconds = clampTimeout("computer", params.timeout, session.settings.get("tools.maxTimeout"));
+/** Freezes the current session settings into the snapshot every worker command carries. */
+function buildComputerSnapshot(session: ToolSession, readOnly: boolean): ComputerSessionSnapshot {
 	const coordinateSafe = usesCoordinateSafeImageSizing(session.getActiveModel?.());
 	const configuredMaxWidth = session.settings.get("computer.maxWidth");
 	const configuredMaxHeight = session.settings.get("computer.maxHeight");
-	const snapshot: ComputerSessionSnapshot = {
+	return {
 		cwd: session.cwd,
 		sessionId: session.getEvalSessionId?.() ?? session.getSessionId?.() ?? "computer",
 		captureMaxWidth: coordinateSafe
@@ -233,6 +227,19 @@ async function runComputer(
 		display: session.settings.get("computer.display") ?? "all",
 		readOnly,
 	};
+}
+
+async function runComputer(
+	session: ToolSession,
+	controller: ComputerController,
+	params: ComputerRunParams | ComputerCallParams,
+	signal?: AbortSignal,
+): Promise<AgentToolResult<unknown>> {
+	const code = resolveComputerRunCode(params);
+	// Direct inspection calls run read-only so the desktop guard backs the read approval tier.
+	const readOnly = params.action === "call" ? isReadOnlyComputerCall(params.chain) : (params.read_only ?? false);
+	const timeoutSeconds = clampTimeout("computer", params.timeout, session.settings.get("tools.maxTimeout"));
+	const snapshot = buildComputerSnapshot(session, readOnly);
 	const run = await controller.run(code, timeoutSeconds * 1000, snapshot, signal);
 	throwIfAborted(signal);
 

--- a/packages/coding-agent/src/tools/computer/protocol.ts
+++ b/packages/coding-agent/src/tools/computer/protocol.ts
@@ -21,6 +21,7 @@ export type ToolReply = { ok: true; value: unknown } | { ok: false; error: RunEr
 export type ComputerWorkerInbound =
 	| { type: "ping"; id: string }
 	| { type: "run"; id: string; code: string; timeoutMs: number; session: ComputerSessionSnapshot }
+	| { type: "capabilities"; id: string; session: ComputerSessionSnapshot }
 	| { type: "abort"; id: string }
 	| { type: "tool-reply"; id: string; reply: ToolReply }
 	| { type: "close" };
@@ -58,6 +59,8 @@ export type ComputerWorkerOutbound =
 	| { type: "pong"; id: string }
 	| { type: "result"; id: string; ok: true; payload: ComputerRunOk }
 	| { type: "result"; id: string; ok: false; error: RunErrorPayload }
+	| { type: "capabilities"; id: string; ok: true; capabilities: DesktopCapabilities }
+	| { type: "capabilities"; id: string; ok: false; error: RunErrorPayload }
 	| { type: "tool-call"; id: string; runId: string; name: string; args: unknown }
 	| { type: "closed" };
 

--- a/packages/coding-agent/src/tools/computer/supervisor.ts
+++ b/packages/coding-agent/src/tools/computer/supervisor.ts
@@ -18,6 +18,9 @@ const START_TIMEOUT_MS = 10_000;
 const CLOSE_TIMEOUT_MS = 1_500;
 const GRACE_MS = 750;
 const SMOKE_TIMEOUT_MS = 5_000;
+// A capabilities request only ensures the native session and reads a getter, but
+// the first ensure may load the desktop addon, so it shares the start budget.
+const CAPABILITIES_TIMEOUT_MS = 10_000;
 const RESTART_MESSAGE = "computer worker restarted; captures and ax refs were reset";
 
 /** Runs desktop scripts and owns their persistent worker session. */
@@ -28,7 +31,7 @@ export interface ComputerController {
 		snapshot: ComputerSessionSnapshot,
 		signal?: AbortSignal,
 	): Promise<ComputerRunOk>;
-	capabilities(): Promise<DesktopCapabilities | undefined>;
+	capabilities(snapshot: ComputerSessionSnapshot, signal?: AbortSignal): Promise<DesktopCapabilities | undefined>;
 	close(): Promise<void>;
 }
 
@@ -66,6 +69,11 @@ interface PendingRun {
 	reject(error: unknown): void;
 	signal?: AbortSignal;
 	toolCalls: Map<string, AbortController>;
+}
+
+interface PendingCapabilities {
+	resolve(value: DesktopCapabilities | undefined): void;
+	reject(error: unknown): void;
 }
 
 function wrapWorker(worker: Worker): ComputerWorkerHandle {
@@ -142,7 +150,7 @@ export class ComputerSupervisor implements ComputerController {
 	#startPromise?: Promise<void>;
 	#startReject?: (error: unknown) => void;
 	#startResolve?: () => void;
-	#latestCapabilities?: DesktopCapabilities;
+	#pendingCapabilities = new Map<string, PendingCapabilities>();
 	#pending = new Map<string, PendingRun>();
 	#nextId = 0;
 	#closed = false;
@@ -163,8 +171,28 @@ export class ComputerSupervisor implements ComputerController {
 		this.#callSessionTool = callSessionTool;
 	}
 
-	async capabilities(): Promise<DesktopCapabilities | undefined> {
-		return this.#latestCapabilities;
+	async capabilities(
+		snapshot: ComputerSessionSnapshot,
+		signal?: AbortSignal,
+	): Promise<DesktopCapabilities | undefined> {
+		if (this.#closed) throw new ToolError("Computer session is closed");
+		if (signal?.aborted) throw new ToolAbortError();
+		await this.#start();
+		if (signal?.aborted) throw new ToolAbortError();
+
+		const id = `computer-cap-${++this.#nextId}`;
+		const { promise, resolve, reject } = Promise.withResolvers<DesktopCapabilities | undefined>();
+		this.#pendingCapabilities.set(id, { resolve, reject });
+		const abort = (): void => reject(signal?.reason instanceof Error ? signal.reason : new ToolAbortError());
+		if (signal?.aborted) abort();
+		else signal?.addEventListener("abort", abort, { once: true });
+		try {
+			this.#safeSend({ type: "capabilities", id, session: snapshot });
+			return await withTimeout(promise, CAPABILITIES_TIMEOUT_MS, "Timed out fetching computer capabilities");
+		} finally {
+			signal?.removeEventListener("abort", abort);
+			this.#pendingCapabilities.delete(id);
+		}
 	}
 
 	async run(
@@ -236,12 +264,16 @@ export class ComputerSupervisor implements ComputerController {
 			const pending = this.#pending.get(message.id);
 			if (!pending) return;
 			this.#pending.delete(message.id);
-			if (message.ok) {
-				this.#latestCapabilities = message.payload.capabilities;
-				pending.resolve(message.payload);
-			} else {
-				pending.reject(errorFromPayload(message.error));
-			}
+			if (message.ok) pending.resolve(message.payload);
+			else pending.reject(errorFromPayload(message.error));
+			return;
+		}
+		if (message.type === "capabilities") {
+			const pending = this.#pendingCapabilities.get(message.id);
+			if (!pending) return;
+			this.#pendingCapabilities.delete(message.id);
+			if (message.ok) pending.resolve(message.capabilities);
+			else pending.reject(errorFromPayload(message.error));
 			return;
 		}
 		if (message.type === "tool-call") {
@@ -328,6 +360,8 @@ export class ComputerSupervisor implements ComputerController {
 			pending.reject(reason);
 		}
 		this.#pending.clear();
+		for (const pending of this.#pendingCapabilities.values()) pending.reject(reason);
+		this.#pendingCapabilities.clear();
 		await worker?.terminate().catch(() => undefined);
 	}
 

--- a/packages/coding-agent/src/tools/computer/worker.ts
+++ b/packages/coding-agent/src/tools/computer/worker.ts
@@ -444,6 +444,9 @@ export class ComputerWorkerCore {
 			case "run":
 				void this.#run(message);
 				return;
+			case "capabilities":
+				void this.#capabilities(message);
+				return;
 			case "abort":
 				if (this.#active?.id === message.id) this.#active.ac.abort(new ToolAbortError());
 				return;
@@ -595,6 +598,34 @@ export class ComputerWorkerCore {
 				id: message.id,
 				ok: true,
 				payload: { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots, capabilities },
+			});
+		}
+	}
+
+	/**
+	 * Answers a direct capabilities request without executing a script. Unlike a
+	 * run, this never touches `#active`, so it resolves even while a run is in
+	 * flight and always reports the session's current permission/backend state.
+	 */
+	async #capabilities(message: Extract<ComputerWorkerInbound, { type: "capabilities" }>): Promise<void> {
+		if (this.#closed) {
+			this.#transport.send({
+				type: "capabilities",
+				id: message.id,
+				ok: false,
+				error: errorPayload(new ToolError("Computer worker is closed")),
+			});
+			return;
+		}
+		try {
+			const session = await this.#ensureSession(message.session);
+			this.#transport.send({ type: "capabilities", id: message.id, ok: true, capabilities: session.capabilities });
+		} catch (error) {
+			this.#transport.send({
+				type: "capabilities",
+				id: message.id,
+				ok: false,
+				error: errorPayload(error instanceof ToolAbortError ? error : nativeError(error)),
 			});
 		}
 	}

--- a/packages/coding-agent/src/tools/computer/worker.ts
+++ b/packages/coding-agent/src/tools/computer/worker.ts
@@ -73,7 +73,9 @@ export interface NativeDesktopSession {
 }
 
 /** Creates the native session co-located with the computer worker runtime. */
-export type NativeDesktopSessionFactory = (options: DesktopSessionOptions) => NativeDesktopSession;
+export type NativeDesktopSessionFactory = (
+	options: DesktopSessionOptions,
+) => NativeDesktopSession | Promise<NativeDesktopSession>;
 
 type WindowFilter = { app?: string; title?: string };
 type DeliveryOptions = { delivery?: string };
@@ -418,6 +420,8 @@ export class ComputerWorkerCore {
 	readonly #createSession?: NativeDesktopSessionFactory;
 	readonly #unsubscribe: () => void;
 	#session?: NativeDesktopSession;
+	/** In-flight lazy session creation, shared so concurrent run/capabilities requests never double-create. */
+	#sessionInit?: Promise<NativeDesktopSession>;
 	#runtime?: JsRuntime;
 	#active: ActiveRun | null = null;
 	/**
@@ -460,15 +464,27 @@ export class ComputerWorkerCore {
 
 	async #ensureSession(snapshot: ComputerSessionSnapshot): Promise<NativeDesktopSession> {
 		if (this.#session) return this.#session;
+		// Single-flight: share one creation promise so a run and a capabilities
+		// request racing on a cold worker cannot each build (and leak) a session.
+		this.#sessionInit ??= (async () => {
+			try {
+				// The worker must answer its readiness handshake without loading the native
+				// addon; normal CLI startup and selector pings never execute desktop code.
+				const createSession =
+					this.#createSession ?? (await import("@oh-my-pi/pi-natives/desktop")).createDesktopSession;
+				const session = await createSession({ display: snapshot.display });
+				this.#session = session;
+				return session;
+			} catch (error) {
+				throw nativeError(error);
+			}
+		})();
 		try {
-			// The worker must answer its readiness handshake without loading the native
-			// addon; normal CLI startup and selector pings never execute desktop code.
-			const createSession =
-				this.#createSession ?? (await import("@oh-my-pi/pi-natives/desktop")).createDesktopSession;
-			this.#session = createSession({ display: snapshot.display });
-			return this.#session;
+			return await this.#sessionInit;
 		} catch (error) {
-			throw nativeError(error);
+			// A failed attempt must not pin the rejection; let the next request retry.
+			this.#sessionInit = undefined;
+			throw error;
 		}
 	}
 
@@ -780,6 +796,7 @@ export class ComputerWorkerCore {
 			// Closing is best-effort; the worker is exiting and has no request to report this against.
 		} finally {
 			this.#session = undefined;
+			this.#sessionInit = undefined;
 			this.#unsubscribe();
 			this.#transport.send({ type: "closed" });
 			this.#transport.close();

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -1007,6 +1007,16 @@ describe("computer worker round trips", () => {
 		expect(second.ok).toBe(true);
 		if (second.ok) expect(second.payload.returnValue).toEqual({ x: 7, y: 8, width: 9, height: 10 });
 	});
+
+	it("answers a direct capabilities request without a prior run", async () => {
+		const transport = new MemoryTransport();
+		new ComputerWorkerCore(transport, () => new FakeNativeSession());
+		transport.inbound({ type: "capabilities", id: "caps", session: snapshot(true) });
+		const reply = await transport.waitFor(message => message.type === "capabilities" && message.id === "caps");
+		expect(reply.type).toBe("capabilities");
+		if (reply.type !== "capabilities" || !reply.ok) throw new Error("expected a successful capabilities reply");
+		expect(reply.capabilities).toEqual(capabilities);
+	});
 });
 
 class SupervisorWorker implements ComputerWorkerHandle {
@@ -1027,6 +1037,8 @@ class SupervisorWorker implements ComputerWorkerHandle {
 					payload: { displays: [], returnValue: "fresh", screenshots: [], capabilities },
 				}),
 			);
+		} else if (message.type === "capabilities" && this.#respond) {
+			queueMicrotask(() => this.#emit({ type: "capabilities", id: message.id, ok: true, capabilities }));
 		} else if (message.type === "close") {
 			queueMicrotask(() => this.#emit({ type: "closed" }));
 		}
@@ -1064,6 +1076,18 @@ describe("computer supervisor recovery", () => {
 		const result = await supervisor.run("41 + 1", 1_000, snapshot());
 		expect(result.returnValue).toBe("fresh");
 		expect(workers).toBe(2);
+		await supervisor.close();
+	});
+
+	it("resolves direct capabilities before any run instead of a stale cache", async () => {
+		const supervisor = new ComputerSupervisor(toolSession(), () => new SupervisorWorker(true), {
+			startMs: 200,
+			closeMs: 200,
+		});
+		// Regression (#11169): capabilities() used to return the run-populated
+		// cache, so a fresh session yielded undefined until a run happened.
+		const direct = await supervisor.capabilities(snapshot(true));
+		expect(direct).toEqual(capabilities);
 		await supervisor.close();
 	});
 });

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -1017,6 +1017,32 @@ describe("computer worker round trips", () => {
 		if (reply.type !== "capabilities" || !reply.ok) throw new Error("expected a successful capabilities reply");
 		expect(reply.capabilities).toEqual(capabilities);
 	});
+
+	it("creates the native session once when a run and capabilities race a cold worker", async () => {
+		const transport = new MemoryTransport();
+		const native = new FakeNativeSession();
+		let creations = 0;
+		const release = Promise.withResolvers<void>();
+		// Async factory reproduces the real `import(...)` suspension so both
+		// handlers reach session creation before it resolves.
+		new ComputerWorkerCore(transport, async () => {
+			creations += 1;
+			await release.promise;
+			return native;
+		});
+
+		transport.inbound({ type: "run", id: "race-run", code: "42", timeoutMs: 2_000, session: snapshot(true) });
+		transport.inbound({ type: "capabilities", id: "race-caps", session: snapshot(true) });
+		release.resolve();
+
+		const runReply = await transport.waitFor(message => message.type === "result" && message.id === "race-run");
+		const capsReply = await transport.waitFor(
+			message => message.type === "capabilities" && message.id === "race-caps",
+		);
+		expect(runReply.type === "result" && runReply.ok).toBe(true);
+		expect(capsReply.type === "capabilities" && capsReply.ok).toBe(true);
+		expect(creations).toBe(1);
+	});
 });
 
 class SupervisorWorker implements ComputerWorkerHandle {


### PR DESCRIPTION
## Repro
`computer.capabilities()` resolves to `undefined` when called before any `computer.run` in a session, while `computer.run(({desktop}) => desktop.capabilities())` returns the full capability object. Driving the reporter's exact order against a real `ComputerSupervisor` backed by a fake worker that (like the native worker) only surfaces capabilities on completed run results reproduces it: `bun test test/tools/computer.test.ts` — the pre-fix path yields `direct: undefined` / `run backend: x11`.

## Cause
`ComputerSupervisor.capabilities()` in `packages/coding-agent/src/tools/computer/supervisor.ts` returned the private `#latestCapabilities` field. That field is written only in `#handleMessage` on a successful run result (`this.#latestCapabilities = message.payload.capabilities`), because `ComputerWorkerCore.#run` is the only path that emits capabilities. On a fresh session no run has completed, so the `capabilities` action (`invokeComputer` in `packages/coding-agent/src/tools/computer.ts`) received `undefined`, returned `details: undefined`, and the prelude helper (`prelude.js`) yielded `undefined`.

## Fix
- `protocol.ts`: add a `capabilities` request/response pair to `ComputerWorkerInbound`/`ComputerWorkerOutbound`.
- `worker.ts`: route the new command to `#capabilities`, which ensures the native session and returns `session.capabilities` without executing a script or touching the active run.
- `supervisor.ts`: replace the `#latestCapabilities` cache with a request-reply that round-trips to the worker (bounded by a 10s timeout, abortable, cleaned up on `#terminate`); `capabilities()` now takes the session snapshot like `run()`.
- `computer.ts`: extract `buildComputerSnapshot` (shared by `runComputer`) and pass a read-only snapshot into `controller.capabilities(...)`.
- Tests: worker round-trip answering a capabilities request with no prior run, and a supervisor regression asserting `capabilities()` resolves the object before any run.

## Verification
`bun test test/tools/computer.test.ts` → 21 pass. `bun run check:types` clean. The pre-existing failure in `test/sdk-computer-prelude-toggle.test.ts` (browser prelude after a model switch, line 83) reproduces identically with my changes stashed and is unrelated to this fix.

Fixes #11169