### PR TITLE
feat(coding-agent): allow selecting model in `/prewalk`

### DIFF
--- a/docs/prewalk.md
+++ b/docs/prewalk.md
@@ -47,18 +47,25 @@ The switch is one-shot: after the handoff, prewalk disarms itself. The target mo
 
 ## Arm from an active session
 
-Run either slash command without restarting OMP:
+Run one of these commands without restarting OMP:
 
 ```text
-/prewalk
+/prewalk [model-or-role]
 /prewalk restart
 ```
 
-`/prewalk` arms a one-shot handoff from the active model to the current `@smol` assignment.
+Without an argument, `/prewalk` targets the `@smol` role. An explicit selector follows the normal [model-resolution rules](./models.md#runtime-model-resolution): it can be a provider-qualified id, bare or fuzzy model id, role alias, or a selector with a thinking-level suffix.
 
-After a handoff, `/prewalk restart` immediately returns the session to the current `@default` assignment and re-arms the handoff to `@smol`. Both roles are resolved when the command runs, so the cycle is independent of concrete model names and does not alter either role's persisted configuration.
+```text
+/prewalk
+/prewalk @smol
+/prewalk openai/gpt-5.6-luna
+/prewalk claude-sonnet-4-6:high
+```
 
-If prewalk is already armed, the command leaves the existing target in place. To choose a different target at startup, use `--prewalk-into`.
+If the selector cannot resolve or its model has no configured credentials, the command does not create or replace a prewalk arm. While a prewalk is already armed, `/prewalk`—with or without a different selector—keeps its existing target in place. After a handoff is consumed, switch to another model and run `/prewalk [model-or-role]` again to arm another one-shot handoff.
+
+`/prewalk restart` immediately returns the session to the current `@default` assignment and re-arms the handoff to the current `@smol` assignment. Both roles are resolved when the command runs, so the cycle is independent of concrete model names and does not alter either role's persisted configuration.
 
 ## Subagent prewalk
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - The `remote` compaction method now covers Claude: Anthropic server-side compaction (`compact-2026-01-12` beta) runs behind the existing `compaction.methodOrder` / `compaction.remoteEnabled` gates for first-party Anthropic models, persists its plain-text summary with a native replay payload that later Anthropic turns send back as a `compaction` block, and falls through to the next configured method on failure like OpenAI server compaction.
+- `/prewalk` now accepts a model selector and offers model autocomplete, defaulting to `@smol` when omitted.
 
 ### Fixed
 

--- a/packages/coding-agent/src/slash-commands/builtin-completions.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-completions.ts
@@ -192,23 +192,26 @@ export function buildStaticInlineHint(hint: string): (argumentText: string) => s
 }
 
 /**
- * Build getArgumentCompletions for `/switch <model>`: configured `@role`
- * aliases first, then the session's cycle scope (or every authenticated
- * model) as `provider/id`, substring-filtered on the typed prefix. Any
- * `:level` suffix already typed is kept out of the match and re-appended.
+ * Build getArgumentCompletions for model selectors: configured `@role` aliases
+ * first, then the session's cycle scope (or every authenticated model) as
+ * `provider/id`, substring-filtered on the typed prefix. Any `:level` suffix
+ * already typed is kept out of the match and re-appended. Optional subcommands
+ * remain in the same completion list, so they do not prevent model selection.
  * Returning matches also keeps `@smol` from falling through to `@`-file
  * mention completion.
  */
 export function buildModelSelectorCompletions(
 	runtime: TuiSlashCommandRuntime,
+	subcommands?: SubcommandDef[],
 ): (argumentPrefix: string) => AutocompleteItem[] | null {
+	const subcommandCompletions = subcommands ? buildArgumentCompletions(subcommands) : undefined;
 	return (argumentPrefix: string) => {
 		if (argumentPrefix.includes(" ")) return null;
 		const suffixIndex = argumentPrefix.indexOf(":");
 		const suffix = suffixIndex === -1 ? "" : argumentPrefix.slice(suffixIndex);
 		const query = (suffixIndex === -1 ? argumentPrefix : argumentPrefix.slice(0, suffixIndex)).toLowerCase();
 		const { session, settings } = runtime.ctx;
-		const matches: AutocompleteItem[] = [];
+		const matches = subcommandCompletions?.(argumentPrefix) ?? [];
 		for (const role of getKnownRoleIds(settings)) {
 			const configured = settings.getModelRole(role);
 			if (!configured) continue;

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import {
+	DEFAULT_PREWALK_TARGET,
 	formatModelString,
 	getModelMatchPreferences,
 	resolveCliModel,
@@ -618,19 +619,21 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		description: "Arm or restart a one-shot model handoff",
 		allowArgs: true,
 		acpDescription: "Arm or restart prewalk",
-		acpInputHint: "[restart]",
+		acpInputHint: "[model|restart]",
+		inlineHint: "[model|restart]",
 		subcommands: [{ name: "restart", description: "Return to @default and re-arm the handoff to @smol" }],
 		handle: async (command, runtime) => {
-			const arg = command.args.trim().toLowerCase();
-			if (arg && arg !== "restart") return usage("Usage: /prewalk [restart]", runtime);
-			const target = resolveSessionModelSelector("@smol", runtime.session, runtime.settings);
+			const arg = command.args.trim();
+			const isRestart = arg.toLowerCase() === "restart";
+			const selector = isRestart || !arg ? DEFAULT_PREWALK_TARGET : arg;
+			const target = resolveSessionModelSelector(selector, runtime.session, runtime.settings);
 			if (target.error || !target.model) {
-				return usage(target.error ?? 'Model "@smol" not found', runtime);
+				return usage(target.error ?? `Model "${selector}" not found`, runtime);
 			}
 			if (!runtime.session.modelRegistry.hasConfiguredAuth(target.model)) {
 				return usage(`No API key for ${target.model.provider}/${target.model.id}`, runtime);
 			}
-			if (arg === "restart") {
+			if (isRestart) {
 				const source = resolveSessionModelSelector("@default", runtime.session, runtime.settings);
 				if (source.error || !source.model) {
 					return usage(source.error ?? 'Model "@default" not found', runtime);
@@ -648,8 +651,8 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				const restartSource = `${source.model.provider}/${source.model.id}`;
 				await runtime.output(
 					result === "armed"
-						? `Prewalk restarted: using @default (${restartSource}) for planning, then switching to @smol (${target.model.provider}/${target.model.id}) at the next edit/write (todo-gated).`
-						: `Prewalk reset: using @default (${restartSource}); @smol resolves to the same model and thinking level, so no handoff was armed.`,
+						? `Prewalk restarted: using @default (${restartSource}) for planning, then switching to ${selector} (${target.model.provider}/${target.model.id}) at the next edit/write (todo-gated).`
+						: `Prewalk reset: using @default (${restartSource}); ${selector} resolves to the same model and thinking level, so no handoff was armed.`,
 				);
 				return commandConsumed();
 			}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -74,11 +74,16 @@ function materializeTuiBuiltinSlashCommand(
 ): TuiBuiltinSlashCommand {
 	const materialized: TuiBuiltinSlashCommand = { ...cmd };
 	if (cmd.subcommands) {
-		materialized.getArgumentCompletions =
-			cmd.name === "mcp" && runtime
-				? buildMcpArgumentCompletions(cmd.subcommands, runtime)
-				: buildArgumentCompletions(cmd.subcommands);
-		materialized.getInlineHint = buildSubcommandInlineHint(cmd.subcommands);
+		if (cmd.name === "prewalk" && runtime) {
+			materialized.getArgumentCompletions = buildModelSelectorCompletions(runtime, cmd.subcommands);
+			if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);
+		} else {
+			materialized.getArgumentCompletions =
+				cmd.name === "mcp" && runtime
+					? buildMcpArgumentCompletions(cmd.subcommands, runtime)
+					: buildArgumentCompletions(cmd.subcommands);
+			materialized.getInlineHint = buildSubcommandInlineHint(cmd.subcommands);
+		}
 	} else if (cmd.name === "move") {
 		materialized.getArgumentCompletions = buildDirectoryArgumentCompletions();
 		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -12,7 +12,10 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import {
+	buildTuiBuiltinSlashCommands,
+	executeBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -870,6 +873,88 @@ describe("AgentSession prewalk", () => {
 		expect(session.getPrewalkState()).toBeUndefined();
 		expect(showStatus).toHaveBeenCalledTimes(2);
 		expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Prewalk reset"));
+	});
+	it("/prewalk prefers an explicit bare model selector over @smol", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: Effort.Medium,
+		});
+		const ctx = {
+			session,
+			sessionManager,
+			settings,
+			collabGuest: false,
+			showStatus: vi.fn(),
+			editor: { setText: vi.fn() },
+			refreshSlashCommandState: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const runtime = { ctx } satisfies TuiSlashCommandRuntime;
+
+		settings.setModelRole("smol", `${primary.provider}/${primary.id}`);
+		expect(await executeBuiltinSlashCommand("/prewalk claude-sonnet-4-6", runtime)).toBe(true);
+		expect(session.getPrewalkState()?.target.id).toBe(target.id);
+	});
+
+	it("/prewalk autocompletes model selectors and restart", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: Effort.Medium,
+		});
+		const ctx = {
+			session,
+			sessionManager,
+			settings,
+			collabGuest: false,
+			showStatus: vi.fn(),
+			editor: { setText: vi.fn() },
+			refreshSlashCommandState: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const runtime = { ctx } satisfies TuiSlashCommandRuntime;
+		const prewalk = buildTuiBuiltinSlashCommands(runtime).find(command => command.name === "prewalk");
+		if (!prewalk?.getArgumentCompletions) throw new Error("expected /prewalk model completions");
+
+		const modelMatches = await prewalk.getArgumentCompletions("claude-sonnet-4-6");
+		expect(modelMatches?.some(match => match.value === "anthropic/claude-sonnet-4-6 ")).toBe(true);
+
+		const restartMatches = await prewalk.getArgumentCompletions("r");
+		expect(restartMatches?.some(match => match.value === "restart ")).toBe(true);
 	});
 
 	it("requires a fresh todo before a later explicit prewalk can hand off", async () => {


### PR DESCRIPTION
## What

- Add `/prewalk [model-or-role]` for selecting a prewalk target from an active session; it defaults to `@smol` when omitted.
- Same UX as `/switch`

## Why

I use `/prewalk` for one-shotting tasks after loading enough context, and deciding on a plan. I also switch providers/models frequently. It would make my workflow simpler if i could arm prewalk with a specific model. Currently, I have to remember to change the `@smol` role before arming, or exit and resume with `--pre-walk-into $model`.

## Testing

- [x] `bun check` passes
- [x] Tested locally -- 4aa6fa5 was made using `gpt-5.6-terra` and `/prewalk deepseek/deepseek-v4-flash`
- [x] CHANGELOG updated (if user-facing)