### PR TITLE
fix(plugins): remove linked artifacts during uninstall

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Uninstalling a locally linked plugin now removes its `node_modules` symlink, so a later registry install cannot continue running the linked checkout ([#11172](https://github.com/can1357/oh-my-pi/issues/11172)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -674,6 +674,10 @@ export class PluginManager {
 			throw new Error(`npm uninstall failed for ${name}`);
 		}
 
+		// Linked plugins have no package.json dependency, so Bun has no entry to
+		// remove. Clean the runtime path explicitly after Bun updates its lockfile.
+		await fs.promises.rm(path.join(getPluginsNodeModules(), name), { recursive: true, force: true });
+
 		// Remove from runtime config
 		const config = await this.#ensureConfigLoaded();
 		delete config.plugins[name];

--- a/packages/coding-agent/test/plugin-install-local.test.ts
+++ b/packages/coding-agent/test/plugin-install-local.test.ts
@@ -32,13 +32,13 @@ const FAKE_INSTALLED: InstalledPlugin = {
 	enabled: true,
 };
 
-async function createLocalPlugin(root: string): Promise<string> {
-	const localPlugin = path.join(root, "kimi-datasource");
+async function createLocalPlugin(root: string, name = "kimi-datasource"): Promise<string> {
+	const localPlugin = path.join(root, name);
 	await fs.mkdir(localPlugin, { recursive: true });
 	await Bun.write(
 		path.join(localPlugin, "package.json"),
 		JSON.stringify({
-			name: "kimi-datasource",
+			name,
 			version: "1.0.0",
 			omp: { extensions: ["./src/extension.ts"] },
 		}),
@@ -142,6 +142,18 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 			enabled: true,
 		});
 	});
+	test("uninstall removes a linked scoped plugin from node_modules", async () => {
+		const pluginName = "@getpipher/omp-statusline";
+		const localPlugin = await createLocalPlugin(tmpRoot, pluginName);
+		const manager = new PluginManager(tmpRoot);
+		const linkPath = path.join(tmpRoot, "plugins", "node_modules", pluginName);
+
+		await manager.link(localPlugin);
+		await manager.uninstall(pluginName);
+
+		await expect(fs.lstat(linkPath)).rejects.toHaveProperty("code", "ENOENT");
+	});
+
 	test("list --json includes linked local plugin without package dependencies", async () => {
 		const localPlugin = await createLocalPlugin(tmpRoot);
 		const output: string[] = [];


### PR DESCRIPTION
## Repro
A locally linked scoped plugin survives its first uninstall because its `node_modules` symlink is not dependency-managed. Before the fix, `bun test packages/coding-agent/test/plugin-install-local.test.ts` failed the regression assertion that `fs.lstat(linkPath)` rejects with `ENOENT`.

## Cause
`PluginManager.link()` in `packages/coding-agent/src/extensibility/plugins/manager.ts` creates the runtime symlink and lock entry without a `package.json` dependency. `PluginManager.uninstall()` delegated artifact cleanup entirely to `bun uninstall`, so Bun updated dependency state but had no dependency edge authorizing removal of the linked path; omp then deleted its runtime bookkeeping and left the symlink resolvable.

## Fix
- Remove the plugin's canonical `node_modules` path after `bun uninstall` succeeds.
- Cover a scoped link → uninstall sequence with a filesystem-level regression test.
- Document the corrected uninstall behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/plugin-install-local.test.ts` passes: 7 tests, 0 failures. The publish gate also completed `bun run fix` and `bun check`.

Fixes #11172