### PR TITLE
fix(edit): execute revised streamed arguments

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-execution extensions that rewrite a streamed edit now execute the rewritten edit instead of the original input.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -340,6 +340,7 @@ export class EditTool implements AgentTool<TInput> {
 	readonly #editMode?: EditMode;
 	readonly #deferredDiagnostics: DeferredDiagnostics;
 	readonly #sessions = new Map<string, EditSession>();
+	readonly #streamedArgs = new Map<string, string>();
 
 	constructor(
 		private readonly session: ToolSession,
@@ -433,6 +434,7 @@ export class EditTool implements AgentTool<TInput> {
 	openArgStream(init: AgentToolArgStreamInit): AgentToolArgStream {
 		const existing = this.#sessions.get(init.toolCallId);
 		if (existing) existing.close();
+		this.#streamedArgs.delete(init.toolCallId);
 		// A call that arrived through the custom-tool wire streams the payload
 		// verbatim; JSON function calls stream JSON text.
 		const rawInput = init.customWireName !== undefined;
@@ -450,13 +452,18 @@ export class EditTool implements AgentTool<TInput> {
 			if (oldestId === undefined) break;
 			this.#sessions.get(oldestId)?.close();
 			this.#sessions.delete(oldestId);
+			this.#streamedArgs.delete(oldestId);
 		}
 		return {
 			push: delta => editSession.push(delta),
-			end: () => editSession.finish(),
+			end: args => {
+				editSession.finish();
+				this.#streamedArgs.set(init.toolCallId, JSON.stringify(args));
+			},
 			cancel: () => {
 				editSession.close();
 				if (this.#sessions.get(init.toolCallId) === editSession) this.#sessions.delete(init.toolCallId);
+				this.#streamedArgs.delete(init.toolCallId);
 			},
 		};
 	}
@@ -469,11 +476,19 @@ export class EditTool implements AgentTool<TInput> {
 		context?: AgentToolContext,
 	): Promise<AgentToolResult<EditToolDetails, TInput>> {
 		let editSession = this.#sessions.get(toolCallId);
+		const argsJson = JSON.stringify(params);
+		if (editSession && this.#streamedArgs.get(toolCallId) !== argsJson) {
+			editSession.close();
+			this.#sessions.delete(toolCallId);
+			editSession = undefined;
+		}
+		this.#streamedArgs.delete(toolCallId);
 		if (!editSession) {
 			// No deltas were streamed (non-streaming provider, inline recovery,
-			// Cursor batch frames): the parsed args are the whole payload.
+			// Cursor batch frames), or a pre-execution hook revised the arguments:
+			// the parsed args are the whole effective payload.
 			editSession = new EditSession(getEditStore(this.session), this.#policy(false));
-			editSession.setArgsJson(JSON.stringify(params));
+			editSession.setArgsJson(argsJson);
 			editSession.finish();
 		}
 		const batch = getLspBatchRequest(context?.toolCall);
@@ -492,6 +507,7 @@ export class EditTool implements AgentTool<TInput> {
 		} finally {
 			editSession.close();
 			if (this.#sessions.get(toolCallId) === editSession) this.#sessions.delete(toolCallId);
+			this.#streamedArgs.delete(toolCallId);
 		}
 
 		if (outcome.isError) {

--- a/packages/coding-agent/test/streaming-edit-abort.test.ts
+++ b/packages/coding-agent/test/streaming-edit-abort.test.ts
@@ -4,8 +4,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Agent, AgentEvent } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
+import { EditTool, getEditStore } from "@oh-my-pi/pi-coding-agent/edit";
 import { StreamingEditGuard } from "@oh-my-pi/pi-coding-agent/session/stream-guards";
+import { formatHashlineHeader } from "@oh-my-pi/pi-coding-agent/tools/hashline-format";
 import type { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -48,6 +49,51 @@ function previewEvent(
 		update: { generation: 1, streaming, files },
 	};
 }
+
+describe("streamed edit revisions", () => {
+	test("executes revised arguments instead of the cached streamed edit", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "stream-revision-"));
+		try {
+			const filePath = path.join(cwd, "sample.jl");
+			const initial = "value = original\n";
+			await Bun.write(filePath, initial);
+			const settings = Settings.isolated({ "edit.mode": "hashline" });
+			const toolSession = {
+				cwd,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				enableLsp: false,
+				settings,
+				getArtifactsDir: () => null,
+				getSessionId: () => null,
+				getPlanModeState: () => undefined,
+			} as unknown as ToolSession;
+			const tool = new EditTool(toolSession, "hashline");
+			const tag = getEditStore(toolSession).recordSnapshot(filePath, initial);
+			const header = formatHashlineHeader("sample.jl", tag);
+			const original = { input: `${header}\nPUT 1-1:\n+value = condition ? left : right` };
+			const revised = {
+				input: `${header}\nPUT 1-1:\n+value = if condition\n+    left\n+else\n+    right\n+end`,
+			};
+			const stream = tool.openArgStream({
+				toolCallId: "revised-edit",
+				toolName: "edit",
+				emit() {},
+			});
+			const encoded = JSON.stringify(original);
+			for (let offset = 0; offset < encoded.length; offset += 7) stream.push(encoded.slice(offset, offset + 7));
+			stream.end(original);
+
+			const result = await tool.execute("revised-edit", revised);
+
+			expect(result.isError).not.toBe(true);
+			expect(await Bun.file(filePath).text()).toBe("value = if condition\n    left\nelse\n    right\nend\n");
+		} finally {
+			await removeWithRetries(cwd);
+		}
+	});
+});
 
 describe("streaming edit abort", () => {
 	test("aborts from a final preview emitted by EditTool.openArgStream", async () => {


### PR DESCRIPTION
## Summary

- remember the finalized arguments behind streamed Edit previews
- discard and reparse the cached native edit session when a pre-execution extension revises those arguments
- cover the regression with a hashline edit that streams a ternary but executes its rewritten `if` form

## Testing

- `bun test packages/coding-agent/test/streaming-edit-abort.test.ts`
- `bun --cwd=packages/coding-agent run check`
