### PR TITLE
fix(import): use Claude transcript cwd for session listing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `memory://` now resolves against the session that issued it: a caller's own memory backend answers `memory://<id>`, so co-located sessions no longer read each other's memory rows, and a caller whose session is no longer live fails closed instead of being answered by a peer. Prompt completion binds to the same caller, so `memory://<memory-id>` stays on offer while a subagent shares the working directory. Advisors retain their owning session's memory access even without a session file.
 - Fullscreen `/copy` now opens on the recent tail of the branch instead of replaying the whole session, so it appears immediately and steps without lag on long sessions (`a` loads the earlier turns). Both it and the esc-esc rewind selector also cache each transcript row set instead of re-stripping it every frame.
 - Fixed the fullscreen `/copy` and esc-esc rewind selectors repainting the whole frame for a wheel notch that cannot move the viewport; because both open scrolled to the newest turn, wheeling down there made the frame twitch.
+- Claude Code sessions without history metadata use the working directory recorded by their transcript before falling back to the encoded project folder name.
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/src/session/claude-session-store.ts
+++ b/packages/coding-agent/src/session/claude-session-store.ts
@@ -121,6 +121,19 @@ function projectCwd(encoded: string, registered: readonly string[]): string {
 	return encoded.replaceAll("-", path.sep);
 }
 
+/**
+ * The working directory Claude recorded for a session, taken from the
+ * transcript itself. Stops at the first record that carries one, so a listing
+ * reads a short prefix rather than the body.
+ */
+async function recordedCwd(file: string): Promise<string | undefined> {
+	for await (const { value } of readForeignJsonRecords(file)) {
+		const cwd = stringField(value, "cwd");
+		if (cwd) return cwd;
+	}
+	return undefined;
+}
+
 async function projectFiles(root: string): Promise<Array<{ file: string; cwd: string }>> {
 	const registered = await readRegisteredProjects(root);
 	const found: Array<{ file: string; cwd: string }> = [];
@@ -329,7 +342,7 @@ export class ClaudeSessionStore implements ForeignSessionStore {
 					source: this.source,
 					id,
 					path: item.file,
-					cwd: indexed?.cwd ?? item.cwd,
+					cwd: indexed?.cwd ?? (await recordedCwd(item.file)) ?? item.cwd,
 					created: new Date(createdMs),
 					modified: new Date(modifiedMs),
 					firstMessage: indexed?.firstMessage,

--- a/packages/coding-agent/src/session/claude-session-store.ts
+++ b/packages/coding-agent/src/session/claude-session-store.ts
@@ -11,7 +11,7 @@ import type {
 	Usage,
 	UserMessage,
 } from "@oh-my-pi/pi-ai";
-import { isRecord } from "@oh-my-pi/pi-utils";
+import { isRecord, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { resolveClaudePaths } from "../config/claude-paths";
 import { collectForeignJsonRecords, type ForeignJsonRecord, readForeignJsonRecords } from "./foreign-session-jsonl";
 import type { ForeignSessionInfo, ForeignSessionStore } from "./foreign-session-store";
@@ -121,13 +121,18 @@ function projectCwd(encoded: string, registered: readonly string[]): string {
 	return encoded.replaceAll("-", path.sep);
 }
 
+const CLAUDE_CWD_PREFIX_BYTES = 64 * 1024;
+
 /**
  * The working directory Claude recorded for a session, taken from the
- * transcript itself. Stops at the first record that carries one, so a listing
- * reads a short prefix rather than the body.
+ * transcript itself. Claude writes it on the first user record, so listing only
+ * reads a bounded prefix and falls back to the encoded project directory when
+ * that prefix has no cwd.
  */
 async function recordedCwd(file: string): Promise<string | undefined> {
-	for await (const { value } of readForeignJsonRecords(file)) {
+	const prefix = await Bun.file(file).slice(0, CLAUDE_CWD_PREFIX_BYTES).text();
+	for (const value of parseJsonlLenient<unknown>(prefix)) {
+		if (!isRecord(value)) continue;
 		const cwd = stringField(value, "cwd");
 		if (cwd) return cwd;
 	}

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -89,6 +89,49 @@ async function createClaudeFixture(): Promise<{ info: ForeignSessionInfo; store:
 }
 
 describe("ClaudeSessionStore", () => {
+	it("lists an unindexed session at the cwd its transcript recorded", async () => {
+		const root = path.join(tempRoot, ".claude");
+		const cwd = path.join(tempRoot, "my-project.dir");
+		const id = "33333333-3333-4333-8333-333333333333";
+		// No history entry, and a directory name whose "-" separators are ambiguous.
+		await writeJsonl(path.join(root, "projects", cwd.replace(/[/\\._]/g, "-"), `${id}.jsonl`), [
+			{ type: "file-history-snapshot", timestamp: "2026-01-01T00:00:00.000Z" },
+			{
+				type: "user",
+				uuid: "u",
+				parentUuid: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				cwd,
+				message: { content: "." },
+			},
+		]);
+
+		const info = (await new ClaudeSessionStore(root).list()).find(item => item.id === id);
+		expect(info?.cwd).toBe(cwd);
+	});
+
+	it("prefers the history index cwd over the transcript's", async () => {
+		const root = path.join(tempRoot, ".claude");
+		const indexedCwd = path.join(tempRoot, "indexed-project");
+		const id = "44444444-4444-4444-8444-444444444444";
+		await writeJsonl(path.join(root, "history.jsonl"), [
+			{ sessionId: id, timestamp: 1_767_225_600_000, display: ".", project: indexedCwd },
+		]);
+		await writeJsonl(path.join(root, "projects", indexedCwd.replaceAll(path.sep, "-"), `${id}.jsonl`), [
+			{
+				type: "user",
+				uuid: "u",
+				parentUuid: null,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: path.join(tempRoot, "somewhere-else"),
+				message: { content: "." },
+			},
+		]);
+
+		const info = (await new ClaudeSessionStore(root).list()).find(item => item.id === id);
+		expect(info?.cwd).toBe(indexedCwd);
+	});
+
 	it("uses current history metadata and converts linked messages in memory", async () => {
 		const { info, store } = await createClaudeFixture();
 

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -110,6 +110,20 @@ describe("ClaudeSessionStore", () => {
 		expect(info?.cwd).toBe(cwd);
 	});
 
+	it("bounds cwd discovery to the transcript prefix before using the encoded fallback", async () => {
+		const root = path.join(tempRoot, ".claude");
+		const cwd = path.join(tempRoot, "late-project.dir");
+		const encoded = cwd.replace(/[/\\._]/g, "-");
+		const id = "55555555-5555-4555-8555-555555555555";
+		await writeJsonl(path.join(root, "projects", encoded, `${id}.jsonl`), [
+			{ type: "file-history-snapshot", snapshot: "x".repeat(128 * 1024) },
+			{ type: "user", cwd, message: { content: "." } },
+		]);
+
+		const info = (await new ClaudeSessionStore(root).list()).find(item => item.id === id);
+		expect(info?.cwd).toBe(encoded.replaceAll("-", path.sep));
+	});
+
 	it("prefers the history index cwd over the transcript's", async () => {
 		const root = path.join(tempRoot, ".claude");
 		const indexedCwd = path.join(tempRoot, "indexed-project");


### PR DESCRIPTION
## What

Use the working directory recorded in a Claude session transcript when the history index has no entry. Preserve history-index precedence and the encoded project-directory fallback.

## Why

Claude flattens path separators, periods, underscores, and hyphens into ambiguous project directory names. Decoding those names can split real hyphens and list an imported session under the wrong working directory, while the transcript contains the exact cwd.

## Testing

- bun test packages/coding-agent/test/foreign-session-stores.test.ts
- bun check

---

- [x] bun check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)