### PR TITLE
fix(compaction): shake after prompt cache expiry

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -435,7 +435,7 @@ From `settings-schema.ts`:
 - `compaction.remoteStreamingV2Enabled` = `true`
 - `compaction.v2RetainedMessageBudget` = `64000`
 - `compaction.thresholdPercent` = `-1` and `compaction.thresholdTokens` = `-1`; a positive fixed token limit takes precedence over percentage, and otherwise the reserve-based threshold is used.
-- `compaction.idleEnabled` = `false`
+- `compaction.idleEnabled` = `false`. When enabled, oversized context compacts while idle; smaller cached context is shaken only after its provider cache expires, immediately before the next user turn. ChatGPT expiry uses persisted assistant timestamps, so it also applies to the first turn after reopening a session.
 - `compaction.idleThresholdTokens` = `200000`
 - `compaction.idleTimeoutSeconds` = `300`
 - `compaction.supersedeReads` = `true`

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -435,7 +435,7 @@ From `settings-schema.ts`:
 - `compaction.remoteStreamingV2Enabled` = `true`
 - `compaction.v2RetainedMessageBudget` = `64000`
 - `compaction.thresholdPercent` = `-1` and `compaction.thresholdTokens` = `-1`; a positive fixed token limit takes precedence over percentage, and otherwise the reserve-based threshold is used.
-- `compaction.idleEnabled` = `false`. When enabled, oversized context compacts while idle; smaller cached context is shaken only after its provider cache expires, immediately before the next user turn. ChatGPT expiry uses persisted assistant timestamps, so it also applies to the first turn after reopening a session.
+- `compaction.idleEnabled` = `false`. When enabled, oversized context compacts while idle; smaller cached context is shaken only after its provider cache expires, immediately before the next user turn. Expiry uses the active model's cache policy and persisted assistant timestamps, so it also applies to the first turn after reopening a session.
 - `compaction.idleThresholdTokens` = `200000`
 - `compaction.idleTimeoutSeconds` = `300`
 - `compaction.supersedeReads` = `true`

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Queued-message hooks that rewrite history now update the active provider context before the queued turn runs.
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1068,6 +1068,9 @@ async function runLoopBody(
 		// Skip when the run is already externally aborted — dequeuing would strand
 		// the messages in a run that is about to die.
 		try {
+			if (!signal?.aborted) {
+				await config.beforeQueuedMessageDequeue?.(currentContext.messages, "steering", signal);
+			}
 			pendingMessages = signal?.aborted ? [] : (await config.getSteeringMessages?.(signal)) || [];
 		} catch (error) {
 			stream.push({ type: "turn_start" });
@@ -1510,6 +1513,9 @@ async function runLoopBody(
 				// instantly aborts — message lands in history, agent never responds. The
 				// mid-batch interrupt poll only peeks (hasSteeringMessages), so the queue
 				// still owns every message until this dequeue.
+				if (!signal?.aborted) {
+					await config.beforeQueuedMessageDequeue?.(currentContext.messages, "steering", signal);
+				}
 				const steering = signal?.aborted ? [] : (await config.getSteeringMessages?.(signal)) || [];
 				if (hasMoreToolCalls) {
 					// Mid-work: fold any non-interrupting asides into the next turn alongside steering.
@@ -1539,8 +1545,14 @@ async function runLoopBody(
 			// Re-poll steering too: a steer can land between the stop-boundary dequeue
 			// above and this yield point (e.g. queued while onBeforeYield ran). Without
 			// this poll it would strand in the queue until the next manual prompt.
+			if (!signal?.aborted) {
+				await config.beforeQueuedMessageDequeue?.(currentContext.messages, "steering", signal);
+			}
 			const lateSteering = signal?.aborted ? [] : (await config.getSteeringMessages?.(signal)) || [];
 			const asideMessages = signal?.aborted ? [] : resolveAsides(await config.getAsideMessages?.());
+			if (!signal?.aborted) {
+				await config.beforeQueuedMessageDequeue?.(currentContext.messages, "followUp", signal);
+			}
 			const followUpMessages = signal?.aborted ? [] : (await config.getFollowUpMessages?.(signal)) || [];
 			if (lateSteering.length > 0 || asideMessages.length > 0 || followUpMessages.length > 0) {
 				// Set as pending so the inner loop processes them before stopping.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -428,7 +428,9 @@ export class Agent {
 	#asideMessageProvider?: () => AsideMessage[] | Promise<AsideMessage[]>;
 	#telemetry?: AgentLoopConfig["telemetry"];
 	#appendOnlyContext?: AppendOnlyContextManager;
-	#beforeQueuedMessageDequeueHooks = new Set<(signal?: AbortSignal) => Promise<void> | void>();
+	#beforeQueuedMessageDequeueHooks = new Set<
+		(signal: AbortSignal | undefined, queue: "steering" | "followUp") => Promise<void> | void
+	>();
 	#beforeModelCallHooks = new Set<(signal?: AbortSignal) => Promise<void> | void>();
 
 	/** Buffered Cursor tool results with text length at time of call (for correct ordering) */
@@ -808,8 +810,10 @@ export class Agent {
 	}
 
 	/** Register an independently removable hook that runs before queued messages are consumed. */
-	addBeforeQueuedMessageDequeueHook(hook: (signal?: AbortSignal) => Promise<void> | void): () => void {
-		const registration = (signal?: AbortSignal) => hook(signal);
+	addBeforeQueuedMessageDequeueHook(
+		hook: (signal: AbortSignal | undefined, queue: "steering" | "followUp") => Promise<void> | void,
+	): () => void {
+		const registration = (signal: AbortSignal | undefined, queue: "steering" | "followUp") => hook(signal, queue);
 		this.#beforeQueuedMessageDequeueHooks.add(registration);
 		return () => this.#beforeQueuedMessageDequeueHooks.delete(registration);
 	}
@@ -825,19 +829,19 @@ export class Agent {
 		for (const hook of this.#beforeModelCallHooks) await hook(signal);
 	}
 
-	async #runBeforeQueuedMessageDequeueHooks(signal?: AbortSignal): Promise<void> {
-		for (const hook of this.#beforeQueuedMessageDequeueHooks) await hook(signal);
+	async #runBeforeQueuedMessageDequeueHooks(queue: "steering" | "followUp", signal?: AbortSignal): Promise<void> {
+		for (const hook of this.#beforeQueuedMessageDequeueHooks) await hook(signal, queue);
 	}
 
 	async #dequeueSteeringMessagesAfterHooks(signal?: AbortSignal): Promise<AgentMessage[]> {
 		if (signal?.aborted || this.#steeringQueue.length === 0) return [];
-		await this.#runBeforeQueuedMessageDequeueHooks(signal);
+		await this.#runBeforeQueuedMessageDequeueHooks("steering", signal);
 		return signal?.aborted ? [] : this.#dequeueSteeringMessages();
 	}
 
 	async #dequeueFollowUpMessagesAfterHooks(signal?: AbortSignal): Promise<AgentMessage[]> {
 		if (signal?.aborted || this.#followUpQueue.length === 0) return [];
-		await this.#runBeforeQueuedMessageDequeueHooks(signal);
+		await this.#runBeforeQueuedMessageDequeueHooks("followUp", signal);
 		return signal?.aborted ? [] : this.#dequeueFollowUpMessages();
 	}
 
@@ -1484,12 +1488,20 @@ export class Agent {
 			getReasoning: () => this.#state.thinkingLevel,
 			getDisableReasoning: () => this.#state.disableReasoning,
 			getServiceTier: this.#serviceTierResolver,
+			beforeQueuedMessageDequeue: async (contextMessages, queue, signal) => {
+				if (queue === "steering" && skipInitialSteeringPoll) return;
+				const hasQueuedMessages =
+					queue === "steering" ? this.#steeringQueue.length > 0 : this.#followUpQueue.length > 0;
+				if (!hasQueuedMessages) return;
+				await this.#runBeforeQueuedMessageDequeueHooks(queue, signal);
+				contextMessages.splice(0, contextMessages.length, ...this.#state.messages);
+			},
 			getSteeringMessages: async signal => {
 				if (skipInitialSteeringPoll) {
 					skipInitialSteeringPoll = false;
 					return [];
 				}
-				return this.#dequeueSteeringMessagesAfterHooks(signal);
+				return signal?.aborted ? [] : this.#dequeueSteeringMessages();
 			},
 			hasSteeringMessages: () => {
 				if (this.#steeringQueue.length === 0) {
@@ -1514,7 +1526,7 @@ export class Agent {
 			},
 			waitForSteeringMessages: signal => this.#waitForSteeringMessages(signal),
 			hasIrcInterrupts: this.hasIrcInterrupts,
-			getFollowUpMessages: signal => this.#dequeueFollowUpMessagesAfterHooks(signal),
+			getFollowUpMessages: async signal => (signal?.aborted ? [] : this.#dequeueFollowUpMessages()),
 			getAsideMessages: async () => (await this.#asideMessageProvider?.()) ?? [],
 			onBeforeYield: () => this.#onBeforeYield?.(),
 			telemetry: this.#telemetry,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -242,6 +242,13 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 */
 	getSteeringMessages?: (signal?: AbortSignal) => Promise<AgentMessage[]>;
 
+	/** Lets a host rewrite the active context immediately before a queued batch is consumed. */
+	beforeQueuedMessageDequeue?: (
+		contextMessages: AgentMessage[],
+		queue: "steering" | "followUp",
+		signal?: AbortSignal,
+	) => Promise<void> | void;
+
 	/**
 	 * Peeks whether steering messages are queued, without consuming them.
 	 *

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -318,6 +318,30 @@ describe("Agent", () => {
 		expect(calls).toBe(1);
 	});
 
+	it("uses history rewritten by a dequeue hook for an active-loop follow-up", async () => {
+		const mock = createMockModel({ responses: [{ content: ["first"] }, { content: ["second"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+		agent.replaceMessages([
+			{ role: "user", content: "stale cached prefix", timestamp: Date.now() - 2 },
+			createAssistantMessage([{ type: "text", text: "stale response" }]),
+		]);
+		agent.addBeforeQueuedMessageDequeueHook((_signal, queue) => {
+			if (queue !== "followUp") return;
+			agent.replaceMessages(agent.state.messages.slice(2));
+		});
+		agent.followUp({ role: "user", content: "queued follow-up", timestamp: Date.now() });
+
+		await agent.prompt("active turn");
+
+		expect(mock.calls).toHaveLength(2);
+		expect(mock.calls[1]?.context.messages).not.toContainEqual(
+			expect.objectContaining({ role: "user", content: "stale cached prefix" }),
+		);
+		expect(mock.calls[1]?.context.messages).toContainEqual(
+			expect.objectContaining({ role: "user", content: "queued follow-up" }),
+		);
+	});
+
 	it("continue() leaves queued messages owned when its signal is already aborted", async () => {
 		const agent = new Agent();
 		agent.replaceMessages([createAssistantMessage([{ type: "text", text: "ready" }])]);

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added provider-aware prompt-cache expiry reporting for cache-cold session maintenance.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -64,6 +64,7 @@ import type {
 	Api,
 	AssistantMessage,
 	AssistantMessageEvent,
+	CacheRetention,
 	Context,
 	FetchImpl,
 	Model,
@@ -1158,6 +1159,10 @@ const ANTHROPIC_CACHE_TTL_MS = 5 * 60_000;
 const ANTHROPIC_CACHE_REFRESH_LEAD_MS = 15_000;
 const ANTHROPIC_CACHE_REFRESH_LIMIT = 3;
 const ANTHROPIC_CACHE_REFRESH_STATE_KEY = "anthropic-cache-refresh";
+const THIRTY_MINUTE_CACHE_TTL_MS = 30 * 60_000;
+const ONE_HOUR_CACHE_TTL_MS = 60 * 60_000;
+const OPENAI_LONG_CACHE_TTL_MS = 24 * ONE_HOUR_CACHE_TTL_MS;
+const GENERIC_CACHE_TTL_MS = 5 * 60_000;
 
 interface AnthropicCacheRefreshPlan {
 	refresh(controller: AbortController): Promise<number | undefined>;
@@ -1169,6 +1174,13 @@ class AnthropicCacheRefreshState implements ProviderSessionState {
 	#plan: AnthropicCacheRefreshPlan | undefined;
 	#refreshesRemaining = 0;
 	#timer: NodeJS.Timeout | undefined;
+	#cacheTouchedAtMs: number | undefined;
+
+	/** Expiry of the most recent successful cache write or keep-alive refresh. */
+	get coldAtMs(): number | undefined {
+		if (this.#cacheTouchedAtMs === undefined) return undefined;
+		return this.#cacheTouchedAtMs + ANTHROPIC_CACHE_TTL_MS;
+	}
 
 	cancel(): void {
 		this.#generation++;
@@ -1180,12 +1192,14 @@ class AnthropicCacheRefreshState implements ProviderSessionState {
 		this.#controller = undefined;
 		this.#plan = undefined;
 		this.#refreshesRemaining = 0;
+		this.#cacheTouchedAtMs = undefined;
 	}
 
 	arm(plan: AnthropicCacheRefreshPlan, cacheTouchedAtMs: number): void {
 		this.cancel();
 		this.#plan = plan;
 		this.#refreshesRemaining = ANTHROPIC_CACHE_REFRESH_LIMIT;
+		this.#cacheTouchedAtMs = cacheTouchedAtMs;
 		this.#schedule(cacheTouchedAtMs, this.#generation);
 	}
 
@@ -1194,6 +1208,7 @@ class AnthropicCacheRefreshState implements ProviderSessionState {
 	}
 
 	#schedule(cacheTouchedAtMs: number, generation: number): void {
+		this.#cacheTouchedAtMs = cacheTouchedAtMs;
 		const refreshAtMs = cacheTouchedAtMs + ANTHROPIC_CACHE_TTL_MS - ANTHROPIC_CACHE_REFRESH_LEAD_MS;
 		this.#timer = setTimeout(
 			() => {
@@ -1228,6 +1243,7 @@ class AnthropicCacheRefreshState implements ProviderSessionState {
 			return;
 		}
 
+		this.#cacheTouchedAtMs = cacheTouchedAtMs;
 		this.#refreshesRemaining--;
 		if (this.#refreshesRemaining <= 0) {
 			this.#plan = undefined;
@@ -1235,6 +1251,80 @@ class AnthropicCacheRefreshState implements ProviderSessionState {
 		}
 		this.#schedule(cacheTouchedAtMs, generation);
 	}
+}
+
+/**
+ * Epoch ms at which the most recently confirmed prompt-cache write or refresh
+ * goes cold. Undefined when nothing is kept warm.
+ */
+export function getPromptCacheColdAtMs(
+	providerSessionState: Map<string, ProviderSessionState> | undefined,
+): number | undefined {
+	const state = providerSessionState?.get(ANTHROPIC_CACHE_REFRESH_STATE_KEY);
+	if (!(state instanceof AnthropicCacheRefreshState)) return undefined;
+	return state.coldAtMs;
+}
+
+export interface PromptCacheExpiryOptions<TApi extends Api = Api> {
+	model: Model<TApi>;
+	/** Last successful provider request/cache touch persisted by the caller. */
+	cacheTouchedAtMs: number;
+	cacheRetention?: CacheRetention;
+	providerSessionState?: Map<string, ProviderSessionState>;
+}
+
+function supportsLongCacheRetention(model: Model): boolean {
+	const compat = model.compat;
+	return (
+		compat !== undefined &&
+		(("supportsLongCacheRetention" in compat && compat.supportsLongCacheRetention === true) ||
+			("supportsLongPromptCacheRetention" in compat && compat.supportsLongPromptCacheRetention === true))
+	);
+}
+
+function getPromptCacheMinimumTtlMs(model: Model): number | undefined {
+	const compat = model.compat;
+	if (compat === undefined || !("promptCacheBreakpointTtl" in compat)) return undefined;
+	return compat.promptCacheBreakpointTtl === "30m" ? THIRTY_MINUTE_CACHE_TTL_MS : undefined;
+}
+
+/**
+ * Epoch at which callers should treat a model's reusable prompt cache as
+ * expired. Provider-owned live state wins, followed by advertised minimum
+ * lifetimes and explicit retention policies, with a 5m generic fallback.
+ */
+export function getPromptCacheExpiryMs<TApi extends Api>(options: PromptCacheExpiryOptions<TApi>): number {
+	const { model, cacheTouchedAtMs } = options;
+	const retention = resolveCacheRetention(options.cacheRetention);
+	if (retention === "none") return cacheTouchedAtMs;
+
+	if (model.api === "openai-codex-responses") return cacheTouchedAtMs + ONE_HOUR_CACHE_TTL_MS;
+
+	if (model.api === "anthropic-messages" || model.api === "bedrock-converse-stream") {
+		if (model.api === "anthropic-messages" && model.provider === "anthropic") {
+			const liveColdAtMs = getPromptCacheColdAtMs(options.providerSessionState);
+			if (liveColdAtMs !== undefined) return liveColdAtMs;
+		}
+		if (retention === "long" && supportsLongCacheRetention(model)) {
+			return cacheTouchedAtMs + ONE_HOUR_CACHE_TTL_MS;
+		}
+		return cacheTouchedAtMs + ANTHROPIC_CACHE_TTL_MS;
+	}
+
+	if (
+		model.api === "openai-responses" ||
+		model.api === "azure-openai-responses" ||
+		model.api === "openai-completions"
+	) {
+		const minimumTtlMs = getPromptCacheMinimumTtlMs(model);
+		if (minimumTtlMs !== undefined) return cacheTouchedAtMs + minimumTtlMs;
+		if (retention === "long" && supportsLongCacheRetention(model)) {
+			return cacheTouchedAtMs + OPENAI_LONG_CACHE_TTL_MS;
+		}
+		return cacheTouchedAtMs + GENERIC_CACHE_TTL_MS;
+	}
+
+	return cacheTouchedAtMs + GENERIC_CACHE_TTL_MS;
 }
 
 function supportsAnthropicCacheRefresh<TApi extends Api>(model: Model<TApi>): boolean {

--- a/packages/ai/test/anthropic-cache-refresh.test.ts
+++ b/packages/ai/test/anthropic-cache-refresh.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { streamSimple } from "@oh-my-pi/pi-ai";
+import { getPromptCacheColdAtMs, getPromptCacheExpiryMs, streamSimple } from "@oh-my-pi/pi-ai";
 import type { CacheControlEphemeral, MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { CacheRetention, Context, FetchImpl, Model, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -235,6 +235,33 @@ describe("Anthropic prompt-cache refresh", () => {
 		}
 	});
 
+	it("advances cache expiry only after each keep-alive refresh succeeds", async () => {
+		vi.useFakeTimers();
+		const capture: FetchCapture = { bodies: [], thinkingRefreshAborted: false };
+		const fetch = createFetch(["ordinary-write", "refresh-read", "refresh-read", "refresh-read"], capture);
+		const states = createProviderSessionState();
+
+		await finishRequest(fetch, states);
+		let expiry = getPromptCacheColdAtMs(states);
+		if (expiry === undefined) throw new Error("Expected an armed cache refresh window");
+		expect(expiry).toBe(Date.now() + 5 * 60_000);
+		expect(
+			getPromptCacheExpiryMs({
+				model,
+				cacheTouchedAtMs: Date.now(),
+				cacheRetention: "short",
+				providerSessionState: states,
+			}),
+		).toBe(expiry);
+
+		// A scheduled refresh does not extend the lifetime speculatively. Each
+		// successful refresh moves expiry forward by the actual refresh interval.
+		for (let requestCount = 2; requestCount <= 4; requestCount++) {
+			await advanceToRefresh(capture, requestCount);
+			expiry += CACHE_REFRESH_DELAY_MS;
+			expect(getPromptCacheColdAtMs(states)).toBe(expiry);
+		}
+	});
 	it("resets the idle gap when another normal request starts", async () => {
 		vi.useFakeTimers();
 		const capture: FetchCapture = { bodies: [], thinkingRefreshAborted: false };

--- a/packages/ai/test/prompt-cache-expiry.test.ts
+++ b/packages/ai/test/prompt-cache-expiry.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import { getPromptCacheExpiryMs } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const TOUCHED_AT_MS = 1_000;
+const FIVE_MINUTES_MS = 5 * 60_000;
+const THIRTY_MINUTES_MS = 30 * 60_000;
+const ONE_HOUR_MS = 60 * 60_000;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+describe("getPromptCacheExpiryMs", () => {
+	it("uses the short cache lifetime for models without a provider-specific policy", () => {
+		const model = createMockModel();
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "short" })).toBe(
+			TOUCHED_AT_MS + FIVE_MINUTES_MS,
+		);
+	});
+
+	it("reports an explicitly disabled cache as cold at its last provider request", () => {
+		const model = createMockModel();
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "none" })).toBe(
+			TOUCHED_AT_MS,
+		);
+	});
+
+	it("uses ChatGPT's one-hour cache lifetime", () => {
+		const model = buildModel({
+			id: "gpt-test",
+			name: "GPT Test",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api/codex",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		});
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "short" })).toBe(
+			TOUCHED_AT_MS + ONE_HOUR_MS,
+		);
+	});
+
+	it("uses the advertised 30-minute minimum lifetime for current GPT caches", () => {
+		const model = buildModel({
+			id: "gpt-5.6-sol",
+			name: "GPT 5.6 Sol",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 },
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		});
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "short" })).toBe(
+			TOUCHED_AT_MS + THIRTY_MINUTES_MS,
+		);
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "long" })).toBe(
+			TOUCHED_AT_MS + THIRTY_MINUTES_MS,
+		);
+	});
+
+	it("uses legacy OpenAI in-memory and extended retention lifetimes", () => {
+		const model = buildModel({
+			id: "gpt-4.1",
+			name: "GPT 4.1",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 },
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		});
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "short" })).toBe(
+			TOUCHED_AT_MS + FIVE_MINUTES_MS,
+		);
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "long" })).toBe(
+			TOUCHED_AT_MS + ONE_DAY_MS,
+		);
+	});
+
+	it("distinguishes Anthropic short and long cache retention", () => {
+		const model = buildModel({
+			id: "claude-test",
+			name: "Claude Test",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 1, cacheRead: 0.1, cacheWrite: 1.25 },
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		});
+
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "short" })).toBe(
+			TOUCHED_AT_MS + FIVE_MINUTES_MS,
+		);
+		expect(getPromptCacheExpiryMs({ model, cacheTouchedAtMs: TOUCHED_AT_MS, cacheRetention: "long" })).toBe(
+			TOUCHED_AT_MS + ONE_HOUR_MS,
+		);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ChatGPT auto-shake now waits until the prompt cache has expired and runs before the next user message, including after reopening a session.
+- Pre-execution extensions that rewrite a streamed edit now execute the rewritten edit instead of the original input.
+- Claude Code sessions without history metadata use the working directory recorded by their transcript before falling back to the encoded project folder name.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Fixed
 
-- ChatGPT auto-shake now waits until the prompt cache has expired and runs before the next user message, including after reopening a session.
-- Pre-execution extensions that rewrite a streamed edit now execute the rewritten edit instead of the original input.
-- Claude Code sessions without history metadata use the working directory recorded by their transcript before falling back to the encoded project folder name.
+- Auto-shake now runs before the first user message after the active model's prompt cache expires, including after reopening a session.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2667,7 +2667,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "context",
 			group: "Compaction",
 			label: "Idle Compaction",
-			description: "Compact context while idle when token count exceeds threshold",
+			description: "Compact oversized context while idle and shake expired cached context before the next user turn",
 		},
 	},
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -316,7 +316,7 @@ import {
 	type InterruptedThinkingDetails,
 	isEmptyErrorTurn,
 	isUserInterruptAbort,
-	isUserInvokedSkillPrompt,
+	isUserTurnInitiator,
 	logProviderTurnError,
 	normalizeCustomMessagePayload,
 	type PythonExecutionMessage,
@@ -707,6 +707,7 @@ export class AgentSession {
 	#modeExitDrainSuppressionDepth = 0;
 	#usagePreflightReadyForNextModelCall = false;
 	#usagePreflightReadyModel: Model | undefined;
+	#detachCacheExpiryBeforeQueueDequeue: (() => void) | undefined;
 	#detachUsageBeforeQueueDequeue: (() => void) | undefined;
 	#detachUsageBeforeModelCall: (() => void) | undefined;
 
@@ -1311,6 +1312,18 @@ export class AgentSession {
 			withBashBranchTransition: operation => this.#bash.withBranchTransition(operation),
 		};
 		this.#recovery = new TurnRecovery(recoveryHost, { initialRetryFallback: config.initialRetryFallback });
+		this.#detachCacheExpiryBeforeQueueDequeue = this.agent.addBeforeQueuedMessageDequeueHook(
+			async (signal, queue) => {
+				const queuedMessages =
+					queue === "steering" ? this.agent.peekSteeringQueue() : this.agent.peekFollowUpQueue();
+				const hasUserTurn = queuedMessages.some(
+					message => message.role === "user" || (message.role === "custom" && isUserTurnInitiator(message)),
+				);
+				if (!hasUserTurn) return;
+				await this.#maintenance.runCacheExpiredPrePromptShakeIfNeeded();
+				signal?.throwIfAborted();
+			},
+		);
 		this.#detachUsageBeforeQueueDequeue = this.agent.addBeforeQueuedMessageDequeueHook(async signal => {
 			if (
 				!this.settings.get("retry.usageAwareFallback") ||
@@ -4373,6 +4386,8 @@ export class AgentSession {
 		this.#modelDiscoveryAbortController.abort();
 		this.#queuedMessageDrainBlocked = false;
 		this.#usagePreflightReadyForNextModelCall = false;
+		this.#detachCacheExpiryBeforeQueueDequeue?.();
+		this.#detachCacheExpiryBeforeQueueDequeue = undefined;
 		this.#detachUsageBeforeQueueDequeue?.();
 		this.#detachUsageBeforeQueueDequeue = undefined;
 		this.#detachUsageBeforeModelCall?.();
@@ -6246,6 +6261,11 @@ export class AgentSession {
 			) {
 				await this.#maintenance.checkCompaction(lastAssistant, false, false, false);
 			}
+			const isUserTurn = message.role === "user" || (message.role === "custom" && isUserTurnInitiator(message));
+			if (isUserTurn && !options?.skipCompactionCheck) {
+				await this.#maintenance.runCacheExpiredPrePromptShakeIfNeeded();
+				if (this.#promptGeneration !== generation) return false;
+			}
 
 			await this.#prewalk.armPlanYoloIfNeeded();
 
@@ -6370,7 +6390,6 @@ export class AgentSession {
 			// (developer roles), agent-originated or autoloaded skill injections, and
 			// non-auto sessions are skipped. Never blocks the turn — failures fall
 			// back to a concrete level inside the helper.
-			const isUserTurn = message.role === "user" || (message.role === "custom" && isUserInvokedSkillPrompt(message));
 			if (this.isAutoThinking && isUserTurn) {
 				await this.#models.applyAutoThinkingLevel(expandedText, generation);
 				if (this.#promptGeneration !== generation) {

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -52,7 +52,7 @@ import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/to
 import {
 	type AssistantMessage,
 	type CodexCompactionContext,
-	getPromptCacheColdAtMs,
+	getPromptCacheExpiryMs,
 	type Message,
 	type Model,
 	type ProviderSessionState,
@@ -97,6 +97,7 @@ import { getLatestCompactionEntry, getOpenAiRemoteCompactionPayload } from "./se
 import type { CompactionEntry, SessionEntry } from "./session-entries";
 import type { SessionManager } from "./session-manager";
 import type { ShakeMode, ShakeResult } from "./shake-types";
+import { resolveConfiguredCacheRetention } from "./settings-stream-fn";
 import { resolveSpeculationLeadTokens, SPECULATION_LEAD_MIN_TOKENS } from "./speculation-lead";
 
 export type CompactionCheckResult = Readonly<{
@@ -205,9 +206,6 @@ const PRUNE_CACHE_WARM_SUFFIX_TOKENS = 8_000;
  * still-warm prefix is busted by the flush. 90 min leaves margin over the 1h TTL.
  */
 const PRUNE_IDLE_FLUSH_MS = 90 * 60_000;
-
-/** ChatGPT's session prompt cache remains reusable for one hour after the last model turn. */
-const CHATGPT_PROMPT_CACHE_TTL_MS = 60 * 60_000;
 
 /**
  * Hysteresis band for the post-maintenance "did we actually create headroom?"
@@ -1231,11 +1229,12 @@ export class SessionMaintenance {
 			return lastAssistant.timestamp;
 		}
 
-		if (model.api === "openai-codex-responses") {
-			return lastAssistant.timestamp + CHATGPT_PROMPT_CACHE_TTL_MS;
-		}
-		if (model.api !== "anthropic-messages" || model.provider !== "anthropic") return undefined;
-		return getPromptCacheColdAtMs(this.#host.providerSessionState);
+		return getPromptCacheExpiryMs({
+			model,
+			cacheTouchedAtMs: lastAssistant.timestamp,
+			cacheRetention: resolveConfiguredCacheRetention(this.#host.settings),
+			providerSessionState: this.#host.providerSessionState,
+		});
 	}
 
 	/** Shake a cold reusable prefix immediately before its next user-authored turn. */

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -49,7 +49,14 @@ import {
 	readToolSupersedeKey,
 } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
-import type { AssistantMessage, CodexCompactionContext, Message, Model, ProviderSessionState } from "@oh-my-pi/pi-ai";
+import {
+	type AssistantMessage,
+	type CodexCompactionContext,
+	getPromptCacheColdAtMs,
+	type Message,
+	type Model,
+	type ProviderSessionState,
+} from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
@@ -198,6 +205,9 @@ const PRUNE_CACHE_WARM_SUFFIX_TOKENS = 8_000;
  * still-warm prefix is busted by the flush. 90 min leaves margin over the 1h TTL.
  */
 const PRUNE_IDLE_FLUSH_MS = 90 * 60_000;
+
+/** ChatGPT's session prompt cache remains reusable for one hour after the last model turn. */
+const CHATGPT_PROMPT_CACHE_TTL_MS = 60 * 60_000;
 
 /**
  * Hysteresis band for the post-maintenance "did we actually create headroom?"
@@ -377,6 +387,7 @@ export class SessionMaintenance {
 	/** In-flight or armed background speculative compaction, if any. */
 	#speculation: SpeculationRun | undefined;
 	#skipPostTurnMaintenanceAssistantTimestamp: number | undefined;
+	#lastCacheExpiryShakeKey: string | undefined;
 	/**
 	 * Consecutive no-progress `response.incomplete` (length-stop) recoveries in
 	 * the current continuation loop. Bounded by {@link INCOMPLETE_RECOVERY_MAX_RETRIES};
@@ -1201,6 +1212,44 @@ export class SessionMaintenance {
 	async runIdleCompaction(): Promise<void> {
 		if (this.#host.isStreaming() || this.isCompacting) return;
 		await this.runAutoCompaction("idle", false, true);
+	}
+
+	/**
+	 * Epoch at which the active model's reusable prompt cache goes cold. Live
+	 * provider state wins while this process remains open; otherwise the last
+	 * durable assistant timestamp makes the decision survive session resume.
+	 */
+	promptCacheColdAtMs(): number | undefined {
+		const lastAssistant = this.#host.findLastAssistantMessage();
+		const model = this.#model;
+		if (!lastAssistant || !model || !Number.isFinite(lastAssistant.timestamp)) return undefined;
+		if (
+			lastAssistant.api !== model.api ||
+			lastAssistant.provider !== model.provider ||
+			lastAssistant.model !== model.id
+		) {
+			return lastAssistant.timestamp;
+		}
+
+		if (model.api === "openai-codex-responses") {
+			return lastAssistant.timestamp + CHATGPT_PROMPT_CACHE_TTL_MS;
+		}
+		if (model.api !== "anthropic-messages" || model.provider !== "anthropic") return undefined;
+		return getPromptCacheColdAtMs(this.#host.providerSessionState);
+	}
+
+	/** Shake a cold reusable prefix immediately before its next user-authored turn. */
+	async runCacheExpiredPrePromptShakeIfNeeded(): Promise<void> {
+		if (!this.#host.settings.get("compaction.idleEnabled")) return;
+		const lastAssistant = this.#host.findLastAssistantMessage();
+		const model = this.#model;
+		if (!lastAssistant || !model) return;
+		const shakeKey = `${lastAssistant.timestamp}:${model.api}:${model.provider}:${model.id}`;
+		if (this.#lastCacheExpiryShakeKey === shakeKey) return;
+		const coldAtMs = this.promptCacheColdAtMs();
+		if (coldAtMs === undefined || Date.now() < coldAtMs) return;
+		this.#lastCacheExpiryShakeKey = shakeKey;
+		await this.#runAutoShake("idle", false, this.#host.promptGeneration(), false, false, undefined, true);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -11,7 +11,7 @@
  * and OpenRouter response-cache hits across advisor calls.
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
-import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { type CacheRetention, type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
 import { classifyModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
 
@@ -19,6 +19,12 @@ function timeoutSecondsToMs(value: number): number | undefined {
 	if (!Number.isFinite(value) || value < 0) return undefined;
 	if (value === 0) return 0;
 	return Math.max(1, Math.trunc(value * 1000));
+}
+
+/** Effective cache-retention option the settings wrapper sends to the provider. */
+export function resolveConfiguredCacheRetention(settings: Settings): CacheRetention | undefined {
+	const configured = settings.get("providers.cacheRetention");
+	return configured === "auto" ? undefined : configured;
 }
 
 /**
@@ -45,8 +51,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		// PI_CACHE_RETENTION env override keep working; anything else is an
 		// explicit per-request retention (long restores 1h Anthropic TTLs and
 		// implicitly disables the short-entry keep-alive refresh loop).
-		const cacheRetentionSetting = settings.get("providers.cacheRetention");
-		const cacheRetention = cacheRetentionSetting === "auto" ? undefined : cacheRetentionSetting;
+		const cacheRetention = resolveConfiguredCacheRetention(settings);
 		const streamFirstEventTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamFirstEventTimeoutSeconds"));
 		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
 		// Server-side fallback (opt-in): when the user enables it AND the

--- a/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
@@ -115,6 +115,7 @@ describe("EventController idle compaction teardown", () => {
 
 		expect(runIdleCompaction).not.toHaveBeenCalled();
 	});
+
 	it("emits an LLM-generated recap after the default four-minute delay", async () => {
 		resetSettingsForTest();
 		await Settings.init({

--- a/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
@@ -115,7 +115,6 @@ describe("EventController idle compaction teardown", () => {
 
 		expect(runIdleCompaction).not.toHaveBeenCalled();
 	});
-
 	it("emits an LLM-generated recap after the default four-minute delay", async () => {
 		resetSettingsForTest();
 		await Settings.init({

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -4,9 +4,11 @@ import { scheduler } from "node:timers/promises";
 import { Agent, type AgentMessage, RESCUE_SHAKE_CONFIG, Tokenizer } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, ImageContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { COLLAB_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-wire";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -42,7 +44,10 @@ describe("AgentSession shake", () => {
 		if (!model) throw new Error("Expected built-in anthropic model to exist");
 		apiInfo = { api: model.api, provider: model.provider, model: model.id };
 
-		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } });
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+		});
 		session = new AgentSession({
 			agent,
 			sessionManager,
@@ -476,6 +481,123 @@ describe("AgentSession shake", () => {
 			const texts = branchToolResults().map(m => (m.content[0] as { text: string }).text);
 			expect(texts.some(t => t.startsWith("B"))).toBe(false);
 			expect(texts.some(t => t.startsWith("R"))).toBe(true);
+		});
+	});
+
+	describe("cache-expired pre-prompt shake", () => {
+		async function seedCodexConversation(ageMs: number): Promise<ToolResultMessage> {
+			authStorage.setRuntimeApiKey("openai-codex", "test-key");
+			const model = getBundledModel("openai-codex", "gpt-5.6-sol");
+			if (!model) throw new Error("Expected built-in ChatGPT model to exist");
+			apiInfo = { api: model.api, provider: model.provider, model: model.id };
+
+			const completedAt = Date.now() - ageMs;
+			const toolCallId = "call_cold_cache";
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "inspect the large output" }],
+				timestamp: completedAt - 3,
+			});
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "build" } }],
+				...apiInfo,
+				stopReason: "toolUse",
+				usage,
+				timestamp: completedAt - 2,
+			});
+			const result: ToolResultMessage = {
+				role: "toolResult",
+				toolCallId,
+				toolName: "bash",
+				content: [{ type: "text", text: "cold output ".repeat(12_000) }],
+				isError: false,
+				timestamp: completedAt - 1,
+			};
+			sessionManager.appendMessage(result);
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: `finished\n${"tail ".repeat(20_000)}` }],
+				...apiInfo,
+				stopReason: "stop",
+				usage,
+				timestamp: completedAt,
+			});
+			await sessionManager.rewriteEntries();
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) throw new Error("Expected a persisted ChatGPT session");
+			await session.dispose();
+			sessionManager = await SessionManager.open(sessionFile, tempDir.path());
+			const resumedAgent = new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: createMockModel({ responses: [{ content: ["Done"] }, { content: ["Done again"] }] }).stream,
+			});
+			session = new AgentSession({
+				agent: resumedAgent,
+				sessionManager,
+				settings: Settings.isolated({
+					"compaction.enabled": false,
+					"compaction.idleEnabled": true,
+				}),
+				modelRegistry,
+			});
+			session.subscribe(event => events.push(event));
+			session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+			const resumedResult = session.messages.find(
+				message => message.role === "toolResult" && message.toolCallId === result.toolCallId,
+			);
+			if (resumedResult?.role !== "toolResult") throw new Error("Expected resumed tool result");
+			return resumedResult;
+		}
+
+		it("preserves a warm ChatGPT prefix when the user returns after five minutes", async () => {
+			const result = await seedCodexConversation(5 * 60_000);
+			const shakeSpy = vi.spyOn(session, "shake");
+
+			await session.prompt("continue");
+
+			expect(shakeSpy).not.toHaveBeenCalled();
+			expect(result.prunedAt).toBeUndefined();
+		});
+
+		it("shakes an expired ChatGPT prefix before the first resumed user turn", async () => {
+			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const shakeSpy = vi.spyOn(session, "shake");
+
+			await session.prompt("continue after reopening");
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide", expect.objectContaining({ config: expect.anything() }));
+			expect(result.prunedAt).toBeGreaterThan(0);
+			const text = result.content.map(block => (block.type === "text" ? block.text : "")).join("");
+			expect(text).toContain("shaken");
+		});
+
+		it("shakes before an expired queued user follow-up resumes", async () => {
+			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const shakeSpy = vi.spyOn(session, "shake");
+
+			await session.followUp("queued after the cache expired");
+			await Bun.sleep(0);
+			await session.waitForIdle();
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide", expect.objectContaining({ config: expect.anything() }));
+			expect(result.prunedAt).toBeGreaterThan(0);
+		});
+
+		it("treats a writable collaboration prompt as a user turn", async () => {
+			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const shakeSpy = vi.spyOn(session, "shake");
+
+			await session.promptCustomMessage({
+				customType: COLLAB_PROMPT_MESSAGE_TYPE,
+				content: "continue from a collaborator",
+				display: true,
+				details: { from: "reviewer" },
+				attribution: "user",
+			});
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide", expect.objectContaining({ config: expect.anything() }));
+			expect(result.prunedAt).toBeGreaterThan(0);
 		});
 	});
 

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentMessage, RESCUE_SHAKE_CONFIG, Tokenizer } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
-import type { AssistantMessage, ImageContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent, Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -485,10 +485,10 @@ describe("AgentSession shake", () => {
 	});
 
 	describe("cache-expired pre-prompt shake", () => {
-		async function seedCodexConversation(ageMs: number): Promise<ToolResultMessage> {
-			authStorage.setRuntimeApiKey("openai-codex", "test-key");
-			const model = getBundledModel("openai-codex", "gpt-5.6-sol");
-			if (!model) throw new Error("Expected built-in ChatGPT model to exist");
+		async function seedConversation(ageMs: number, selectedModel?: Model): Promise<ToolResultMessage> {
+			const model = selectedModel ?? getBundledModel("openai-codex", "gpt-5.6-sol");
+			if (!model) throw new Error("Expected test model to exist");
+			authStorage.setRuntimeApiKey(model.provider, "test-key");
 			apiInfo = { api: model.api, provider: model.provider, model: model.id };
 
 			const completedAt = Date.now() - ageMs;
@@ -525,7 +525,7 @@ describe("AgentSession shake", () => {
 			});
 			await sessionManager.rewriteEntries();
 			const sessionFile = sessionManager.getSessionFile();
-			if (!sessionFile) throw new Error("Expected a persisted ChatGPT session");
+			if (!sessionFile) throw new Error("Expected a persisted session");
 			await session.dispose();
 			sessionManager = await SessionManager.open(sessionFile, tempDir.path());
 			const resumedAgent = new Agent({
@@ -551,7 +551,7 @@ describe("AgentSession shake", () => {
 		}
 
 		it("preserves a warm ChatGPT prefix when the user returns after five minutes", async () => {
-			const result = await seedCodexConversation(5 * 60_000);
+			const result = await seedConversation(5 * 60_000);
 			const shakeSpy = vi.spyOn(session, "shake");
 
 			await session.prompt("continue");
@@ -561,7 +561,7 @@ describe("AgentSession shake", () => {
 		});
 
 		it("shakes an expired ChatGPT prefix before the first resumed user turn", async () => {
-			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const result = await seedConversation(60 * 60_000 + 1);
 			const shakeSpy = vi.spyOn(session, "shake");
 
 			await session.prompt("continue after reopening");
@@ -572,8 +572,18 @@ describe("AgentSession shake", () => {
 			expect(text).toContain("shaken");
 		});
 
+		it("shakes an expired prefix for a model without a provider-specific cache policy", async () => {
+			const result = await seedConversation(5 * 60_000 + 1, createMockModel());
+			const shakeSpy = vi.spyOn(session, "shake");
+
+			await session.prompt("continue on a generic model");
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide", expect.objectContaining({ config: expect.anything() }));
+			expect(result.prunedAt).toBeGreaterThan(0);
+		});
+
 		it("shakes before an expired queued user follow-up resumes", async () => {
-			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const result = await seedConversation(60 * 60_000 + 1);
 			const shakeSpy = vi.spyOn(session, "shake");
 
 			await session.followUp("queued after the cache expired");
@@ -585,7 +595,7 @@ describe("AgentSession shake", () => {
 		});
 
 		it("treats a writable collaboration prompt as a user turn", async () => {
-			const result = await seedCodexConversation(60 * 60_000 + 1);
+			const result = await seedConversation(60 * 60_000 + 1);
 			const shakeSpy = vi.spyOn(session, "shake");
 
 			await session.promptCustomMessage({


### PR DESCRIPTION
## Summary

- Run auto-shake immediately before the first user-authored turn after the active model prompt cache expires, instead of coupling it to a fixed idle interval.
- Determine expiry through a provider-aware helper, including ChatGPT/Codex at one hour, GPT-5.6+ API caches at the documented 30-minute minimum, and Anthropic retention plus confirmed refresh state.
- Cover direct prompts, queued steering and follow-up turns, and resumed sessions while preserving the existing idle compaction feature.
 
## Testing
- Focused test suite: 97 passed, 0 failed
- bun run --cwd packages/ai check
- bun run --cwd packages/agent check
- bun run --cwd packages/coding-agent check