### PR TITLE
fix(session): match retry fallback keys by exact effort, not base

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed effort-specific retry fallback chains selecting the wrong chain by object/YAML order: a `model:low` selector no longer matches a configured `model:max` key (or vice versa), so a 429 retry stays on the same effort instead of escalating to an unrelated chain ([#11192](https://github.com/can1357/oh-my-pi/issues/11192)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -252,9 +252,11 @@ type SelectorMatchKind = "exact" | "base" | "none";
 
 /**
  * Classify how a chain key's primary selector matches the current selector.
+ * Comparisons are on parsed model + thinking-level values, so effort aliases
+ * (`hi`/`med`/`min`) match their canonical forms (`high`/`medium`/`minimal`).
  *
- * - `exact` — same model *and* effort (raw selector equality, checked against
- *   both the routed selector and its plain, unrouted variant).
+ * - `exact` — same provider/model *and* effort, against either the routed
+ *   current selector or its plain, unrouted variant.
  * - `base` — a suffixless key (no explicit effort) naming the same
  *   provider/model, so it applies to that model at any effort.
  * - `none` — no match. A key carrying a *different* explicit effort lands here:
@@ -262,20 +264,29 @@ type SelectorMatchKind = "exact" | "base" | "none";
  */
 function selectorMatchKind(
 	primary: RetryFallbackSelector | undefined,
-	currentSelector: string,
-	currentBaseSelector: string,
-	currentPlainSelector: string | undefined,
-	currentPlainBaseSelector: string | undefined,
+	current: RetryFallbackSelector,
+	currentPlain: RetryFallbackSelector | undefined,
 ): SelectorMatchKind {
 	if (!primary) return "none";
-	if (primary.raw === currentSelector || (currentPlainSelector && primary.raw === currentPlainSelector)) {
+	const provider = primary.provider;
+	const id = primary.id;
+	const level = primary.thinkingLevel;
+	if (
+		(provider === current.provider && id === current.id && level === current.thinkingLevel) ||
+		(currentPlain !== undefined &&
+			provider === currentPlain.provider &&
+			id === currentPlain.id &&
+			level === currentPlain.thinkingLevel)
+	) {
 		return "exact";
 	}
 	// An explicit-effort key only matches that effort (handled above); only a
 	// suffixless key falls back to matching the model at any effort.
-	if (primary.thinkingLevel !== undefined) return "none";
-	const base = formatRetryFallbackBaseSelector(primary);
-	if (base === currentBaseSelector || (!!currentPlainBaseSelector && base === currentPlainBaseSelector)) {
+	if (level !== undefined) return "none";
+	if (
+		(provider === current.provider && id === current.id) ||
+		(currentPlain !== undefined && provider === currentPlain.provider && id === currentPlain.id)
+	) {
 		return "base";
 	}
 	return "none";
@@ -303,10 +314,9 @@ export function resolveRetryFallbackChainKey(
 		if (roleHint && Array.isArray(context.chains[roleHint])) return roleHint;
 		return undefined;
 	}
-	const currentBaseSelector = formatRetryFallbackBaseSelector(parsedCurrent);
-	const currentPlainBaseSelector =
+	const parsedPlainCurrent =
 		currentPlainSelector && currentPlainSelector !== currentSelector
-			? formatRetryFallbackBaseSelector(parseRetryFallbackSelector(currentPlainSelector) ?? parsedCurrent)
+			? (parseRetryFallbackSelector(currentPlainSelector, context.modelLookup) ?? parsedCurrent)
 			: undefined;
 
 	// 1. Exact model-selector keys — most specific. An exact model+effort match
@@ -315,13 +325,7 @@ export function resolveRetryFallbackChainKey(
 	let baseModelKey: string | undefined;
 	for (const key in context.chains) {
 		if (!isRetryFallbackModelKey(key) || isRetryFallbackWildcardKey(key)) continue;
-		const kind = selectorMatchKind(
-			getRetryFallbackPrimarySelector(context, key),
-			currentSelector,
-			currentBaseSelector,
-			currentPlainSelector,
-			currentPlainBaseSelector,
-		);
+		const kind = selectorMatchKind(getRetryFallbackPrimarySelector(context, key), parsedCurrent, parsedPlainCurrent);
 		if (kind === "exact") return key;
 		if (kind === "base") baseModelKey ??= key;
 	}
@@ -355,13 +359,7 @@ export function resolveRetryFallbackChainKey(
 	for (const key in context.chains) {
 		if (isRetryFallbackModelKey(key)) continue;
 		if (
-			selectorMatchKind(
-				getRetryFallbackPrimarySelector(context, key),
-				currentSelector,
-				currentBaseSelector,
-				currentPlainSelector,
-				currentPlainBaseSelector,
-			) !== "none"
+			selectorMatchKind(getRetryFallbackPrimarySelector(context, key), parsedCurrent, parsedPlainCurrent) !== "none"
 		) {
 			if (key === "default") return "default";
 			matchedRole ??= key;

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -8,7 +8,7 @@ import {
 	parseModelString,
 } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
-import { type ConfiguredThinkingLevel, concreteThinkingLevel } from "../thinking";
+import { type ConfiguredThinkingLevel, concreteThinkingLevel, resolveThinkingLevelForModel } from "../thinking";
 
 /** Configured fallback chains keyed by role or model selector. */
 export type RetryFallbackChains = Record<string, string[]>;
@@ -248,46 +248,47 @@ function getRetryFallbackPrimarySelector(
 }
 
 /** How a chain key's primary selector matches the current selector. */
-type SelectorMatchKind = "exact" | "base" | "none";
+type SelectorMatchKind = "exact" | "normalized" | "base" | "none";
 
 /**
  * Classify how a chain key's primary selector matches the current selector.
- * Comparisons are on parsed model + thinking-level values, so effort aliases
+ * Comparisons use parsed model + thinking-level values, so effort aliases
  * (`hi`/`med`/`min`) match their canonical forms (`high`/`medium`/`minimal`).
  *
- * - `exact` — same provider/model *and* effort, against either the routed
- *   current selector or its plain, unrouted variant.
- * - `base` — a suffixless key (no explicit effort) naming the same
- *   provider/model, so it applies to that model at any effort.
- * - `none` — no match. A key carrying a *different* explicit effort lands here:
- *   it must never masquerade as an exact match for another effort.
+ * - `exact` — same provider/model and parsed effort.
+ * - `normalized` — same provider/model and both efforts clamp to the same
+ *   level supported by the active model (`max` and `high` on a high-capped
+ *   model).
+ * - `base` — a suffixless key naming the same provider/model, so it applies
+ *   to that model at any effort.
+ * - `none` — no match. Explicit efforts that remain distinct after model
+ *   normalization must never masquerade as exact matches.
  */
 function selectorMatchKind(
 	primary: RetryFallbackSelector | undefined,
 	current: RetryFallbackSelector,
 	currentPlain: RetryFallbackSelector | undefined,
+	currentModel: Model | null | undefined,
 ): SelectorMatchKind {
 	if (!primary) return "none";
 	const provider = primary.provider;
 	const id = primary.id;
 	const level = primary.thinkingLevel;
-	if (
-		(provider === current.provider && id === current.id && level === current.thinkingLevel) ||
-		(currentPlain !== undefined &&
-			provider === currentPlain.provider &&
-			id === currentPlain.id &&
-			level === currentPlain.thinkingLevel)
-	) {
-		return "exact";
+	let matchedCurrent: RetryFallbackSelector | undefined;
+	if (provider === current.provider && id === current.id) {
+		matchedCurrent = current;
+	} else if (currentPlain !== undefined && provider === currentPlain.provider && id === currentPlain.id) {
+		matchedCurrent = currentPlain;
 	}
-	// An explicit-effort key only matches that effort (handled above); only a
-	// suffixless key falls back to matching the model at any effort.
-	if (level !== undefined) return "none";
+	if (!matchedCurrent) return "none";
+	if (level === matchedCurrent.thinkingLevel) return "exact";
+	if (level === undefined) return "base";
 	if (
-		(provider === current.provider && id === current.id) ||
-		(currentPlain !== undefined && provider === currentPlain.provider && id === currentPlain.id)
+		currentModel &&
+		resolveThinkingLevelForModel(currentModel, level) ===
+			resolveThinkingLevelForModel(currentModel, matchedCurrent.thinkingLevel)
 	) {
-		return "base";
+		return "normalized";
 	}
 	return "none";
 }
@@ -319,16 +320,25 @@ export function resolveRetryFallbackChainKey(
 			? (parseRetryFallbackSelector(currentPlainSelector, context.modelLookup) ?? parsedCurrent)
 			: undefined;
 
-	// 1. Exact model-selector keys — most specific. An exact model+effort match
-	//    wins over a suffixless (any-effort) key regardless of object/YAML
-	//    order; a key naming a different explicit effort never matches here.
+	// 1. Model-selector keys — most specific. Parsed exact effort beats
+	//    model-normalized effort, which beats a suffixless (any-effort) key,
+	//    regardless of object/YAML order. Efforts that remain distinct after
+	//    normalization never match.
+	let normalizedModelKey: string | undefined;
 	let baseModelKey: string | undefined;
 	for (const key in context.chains) {
 		if (!isRetryFallbackModelKey(key) || isRetryFallbackWildcardKey(key)) continue;
-		const kind = selectorMatchKind(getRetryFallbackPrimarySelector(context, key), parsedCurrent, parsedPlainCurrent);
+		const kind = selectorMatchKind(
+			getRetryFallbackPrimarySelector(context, key),
+			parsedCurrent,
+			parsedPlainCurrent,
+			currentModel,
+		);
 		if (kind === "exact") return key;
+		if (kind === "normalized") normalizedModelKey ??= key;
 		if (kind === "base") baseModelKey ??= key;
 	}
+	if (normalizedModelKey) return normalizedModelKey;
 	if (baseModelKey) return baseModelKey;
 
 	// 2. Provider wildcards — an id-prefixed key (`openrouter/google/*`)
@@ -359,7 +369,12 @@ export function resolveRetryFallbackChainKey(
 	for (const key in context.chains) {
 		if (isRetryFallbackModelKey(key)) continue;
 		if (
-			selectorMatchKind(getRetryFallbackPrimarySelector(context, key), parsedCurrent, parsedPlainCurrent) !== "none"
+			selectorMatchKind(
+				getRetryFallbackPrimarySelector(context, key),
+				parsedCurrent,
+				parsedPlainCurrent,
+				currentModel,
+			) !== "none"
 		) {
 			if (key === "default") return "default";
 			matchedRole ??= key;

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -247,17 +247,38 @@ function getRetryFallbackPrimarySelector(
 	return configuredSelector ? parseRetryFallbackSelector(configuredSelector, context.modelLookup) : undefined;
 }
 
-function selectorMatchesCurrent(
+/** How a chain key's primary selector matches the current selector. */
+type SelectorMatchKind = "exact" | "base" | "none";
+
+/**
+ * Classify how a chain key's primary selector matches the current selector.
+ *
+ * - `exact` — same model *and* effort (raw selector equality, checked against
+ *   both the routed selector and its plain, unrouted variant).
+ * - `base` — a suffixless key (no explicit effort) naming the same
+ *   provider/model, so it applies to that model at any effort.
+ * - `none` — no match. A key carrying a *different* explicit effort lands here:
+ *   it must never masquerade as an exact match for another effort.
+ */
+function selectorMatchKind(
 	primary: RetryFallbackSelector | undefined,
 	currentSelector: string,
 	currentBaseSelector: string,
 	currentPlainSelector: string | undefined,
 	currentPlainBaseSelector: string | undefined,
-): boolean {
-	if (!primary) return false;
-	if (primary.raw === currentSelector || (currentPlainSelector && primary.raw === currentPlainSelector)) return true;
+): SelectorMatchKind {
+	if (!primary) return "none";
+	if (primary.raw === currentSelector || (currentPlainSelector && primary.raw === currentPlainSelector)) {
+		return "exact";
+	}
+	// An explicit-effort key only matches that effort (handled above); only a
+	// suffixless key falls back to matching the model at any effort.
+	if (primary.thinkingLevel !== undefined) return "none";
 	const base = formatRetryFallbackBaseSelector(primary);
-	return base === currentBaseSelector || (!!currentPlainBaseSelector && base === currentPlainBaseSelector);
+	if (base === currentBaseSelector || (!!currentPlainBaseSelector && base === currentPlainBaseSelector)) {
+		return "base";
+	}
+	return "none";
 }
 
 /**
@@ -288,22 +309,23 @@ export function resolveRetryFallbackChainKey(
 			? formatRetryFallbackBaseSelector(parseRetryFallbackSelector(currentPlainSelector) ?? parsedCurrent)
 			: undefined;
 
-	// 1. Exact model-selector keys — most specific.
+	// 1. Exact model-selector keys — most specific. An exact model+effort match
+	//    wins over a suffixless (any-effort) key regardless of object/YAML
+	//    order; a key naming a different explicit effort never matches here.
+	let baseModelKey: string | undefined;
 	for (const key in context.chains) {
-		if (isRetryFallbackModelKey(key) && !isRetryFallbackWildcardKey(key)) {
-			if (
-				selectorMatchesCurrent(
-					getRetryFallbackPrimarySelector(context, key),
-					currentSelector,
-					currentBaseSelector,
-					currentPlainSelector,
-					currentPlainBaseSelector,
-				)
-			) {
-				return key;
-			}
-		}
+		if (!isRetryFallbackModelKey(key) || isRetryFallbackWildcardKey(key)) continue;
+		const kind = selectorMatchKind(
+			getRetryFallbackPrimarySelector(context, key),
+			currentSelector,
+			currentBaseSelector,
+			currentPlainSelector,
+			currentPlainBaseSelector,
+		);
+		if (kind === "exact") return key;
+		if (kind === "base") baseModelKey ??= key;
 	}
+	if (baseModelKey) return baseModelKey;
 
 	// 2. Provider wildcards — an id-prefixed key (`openrouter/google/*`)
 	//    beats the plain `provider/*` key for ids under its prefix.
@@ -333,13 +355,13 @@ export function resolveRetryFallbackChainKey(
 	for (const key in context.chains) {
 		if (isRetryFallbackModelKey(key)) continue;
 		if (
-			selectorMatchesCurrent(
+			selectorMatchKind(
 				getRetryFallbackPrimarySelector(context, key),
 				currentSelector,
 				currentBaseSelector,
 				currentPlainSelector,
 				currentPlainBaseSelector,
-			)
+			) !== "none"
 		) {
 			if (key === "default") return "default";
 			matchedRole ??= key;

--- a/packages/coding-agent/test/retry-fallback.test.ts
+++ b/packages/coding-agent/test/retry-fallback.test.ts
@@ -172,4 +172,16 @@ describe("retry fallback selector resolution", () => {
 		const maxWithHint = createContext({ [max]: ["openai/gpt-4o-mini:max"], smol: ["openai/gpt-4o-mini:medium"] });
 		expect(resolveRetryFallbackChainKey(maxWithHint, low, model, "smol")).toBe("smol");
 	});
+
+	it("treats effort aliases as equivalent to their canonical form when matching keys", () => {
+		const model = getBundledModel("google", "gemini-2.5-flash");
+		const canonicalHigh = "google/gemini-2.5-flash:high";
+		const aliasKey = "google/gemini-2.5-flash:hi";
+
+		const context = createContext({ [aliasKey]: ["openai/gpt-4o-mini:high"] });
+		expect(resolveRetryFallbackChainKey(context, canonicalHigh, model)).toBe(aliasKey);
+		expect(
+			findRetryFallbackCandidates(context, aliasKey, canonicalHigh, model).map(candidate => candidate.raw),
+		).toEqual(["openai/gpt-4o-mini:high"]);
+	});
 });

--- a/packages/coding-agent/test/retry-fallback.test.ts
+++ b/packages/coding-agent/test/retry-fallback.test.ts
@@ -127,4 +127,49 @@ describe("retry fallback selector resolution", () => {
 		expect(expanded.task).toBe(defaultChain);
 		expect(expanded.slow).toEqual(["google/gemini-2.5-flash"]);
 	});
+
+	it("prefers an exact model+effort key over a different-effort key regardless of object order", () => {
+		const model = getBundledModel("google", "gemini-2.5-flash");
+		const low = "google/gemini-2.5-flash:low";
+		const max = "google/gemini-2.5-flash:max";
+
+		const maxFirst = createContext({ [max]: ["openai/gpt-4o-mini:max"], [low]: ["openai/gpt-4o-mini:low"] });
+		expect(resolveRetryFallbackChainKey(maxFirst, low, model)).toBe(low);
+		expect(findRetryFallbackCandidates(maxFirst, low, low, model).map(candidate => candidate.raw)).toEqual([
+			"openai/gpt-4o-mini:low",
+		]);
+
+		const lowFirst = createContext({ [low]: ["openai/gpt-4o-mini:low"], [max]: ["openai/gpt-4o-mini:max"] });
+		expect(resolveRetryFallbackChainKey(lowFirst, low, model)).toBe(low);
+	});
+
+	it("lets a suffixless key match any effort but an exact effort key still wins", () => {
+		const model = getBundledModel("google", "gemini-2.5-flash");
+		const low = "google/gemini-2.5-flash:low";
+		const suffixless = "google/gemini-2.5-flash";
+
+		const baseOnly = createContext({ [suffixless]: ["openai/gpt-4o-mini"] });
+		expect(resolveRetryFallbackChainKey(baseOnly, low, model)).toBe(suffixless);
+
+		const suffixlessFirst = createContext({
+			[suffixless]: ["openai/gpt-4o-mini"],
+			[low]: ["openai/gpt-4o-mini:low"],
+		});
+		expect(resolveRetryFallbackChainKey(suffixlessFirst, low, model)).toBe(low);
+	});
+
+	it("never escalates to a different-effort chain when no matching effort is configured", () => {
+		const model = getBundledModel("google", "gemini-2.5-flash");
+		const low = "google/gemini-2.5-flash:low";
+		const max = "google/gemini-2.5-flash:max";
+
+		const maxOnly = createContext({ [max]: ["openai/gpt-4o-mini:max"] });
+		expect(resolveRetryFallbackChainKey(maxOnly, low, model)).toBeUndefined();
+
+		const maxWithDefault = createContext({ [max]: ["openai/gpt-4o-mini:max"], default: ["openai/gpt-4o-mini"] });
+		expect(resolveRetryFallbackChainKey(maxWithDefault, low, model)).toBe("default");
+
+		const maxWithHint = createContext({ [max]: ["openai/gpt-4o-mini:max"], smol: ["openai/gpt-4o-mini:medium"] });
+		expect(resolveRetryFallbackChainKey(maxWithHint, low, model, "smol")).toBe("smol");
+	});
 });

--- a/packages/coding-agent/test/retry-fallback.test.ts
+++ b/packages/coding-agent/test/retry-fallback.test.ts
@@ -184,4 +184,22 @@ describe("retry fallback selector resolution", () => {
 			findRetryFallbackCandidates(context, aliasKey, canonicalHigh, model).map(candidate => candidate.raw),
 		).toEqual(["openai/gpt-4o-mini:high"]);
 	});
+
+	it("matches a requested effort key to the active model's clamped effort", () => {
+		const model = getBundledModel("google", "gemini-2.5-flash");
+		const high = "google/gemini-2.5-flash:high";
+		const max = "google/gemini-2.5-flash:max";
+
+		const maxOnly = createContext({ [max]: ["openai/gpt-4o-mini:max"] });
+		expect(resolveRetryFallbackChainKey(maxOnly, high, model)).toBe(max);
+		expect(findRetryFallbackCandidates(maxOnly, max, high, model).map(candidate => candidate.raw)).toEqual([
+			"openai/gpt-4o-mini:max",
+		]);
+
+		const exactHigh = createContext({
+			[max]: ["openai/gpt-4o-mini:max"],
+			[high]: ["openai/gpt-4o-mini:high"],
+		});
+		expect(resolveRetryFallbackChainKey(exactHigh, high, model)).toBe(high);
+	});
 });


### PR DESCRIPTION
## Repro
With an effort-specific `retry.fallbackChains` config carrying both a `model:low` and a `model:max` exact key, a child running at `low` that hits a 429 resolves to the `max` chain and escalates to that chain's max candidate — but only when the `:max` key is object/YAML-ordered before `:low`. Reversing the two keys yields the correct `:low` chain. Reproduced against the native resolvers:

```
maxFirst => key: google/gemini-2.5-flash:max  candidates: [ openai/gpt-4o-mini:max ]
lowFirst => key: google/gemini-2.5-flash:low  candidates: [ openai/gpt-4o-mini:low ]
```

## Cause
`resolveRetryFallbackChainKey`'s step-1 exact-model loop (`packages/coding-agent/src/session/retry-fallback-chains.ts`) tested each key with `selectorMatchesCurrent`, which accepted a provider/model **base** match even when the configured key named a *different* explicit effort suffix. The base match exists only to let a suffixless key apply to any effort, but it ignored `thinkingLevel` entirely. Because the loop returned the first base-match in object insertion order, a `model:max` key preceding `model:low` masqueraded as an exact match for a current `model:low` selector.

## Fix
- Replace `selectorMatchesCurrent` with `selectorMatchKind`, returning `exact` only on raw model+effort equality (checked against the routed selector and its plain variant) and `base` only when the key is suffixless (`thinkingLevel === undefined`); a key naming a different explicit effort now returns `none`.
- Step 1 collects at most one suffixless `base` candidate but returns immediately on an `exact` match, so an exact model+effort key wins regardless of object order.
- The role-matching loop (step 3) uses the same classifier, so shared-assignment roles no longer match across differing explicit efforts.
- Add regression tests covering both key orders, suffixless-precedes-exact, suffixless-only base match, and the no-matching-effort case (falls through to default / honors the role hint instead of escalating to `max`).

## Verification
`bun test test/retry-fallback.test.ts` — 9 pass, 0 fail. `bun run check:ts` clean. Manual native-resolver repro now returns `:low` for both key orders. Fixes #11192