### PR TITLE
docs(context-files): describe RULES.md system-prefix placement accurately

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -9,7 +9,7 @@ You never have to ask the agent to go read `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
 Four similarly named things behave differently. Keep them straight:
 
 - **Context files** are read as plain Markdown and shown to the agent in generated project instructions (inside `<repo-rules>` with the default prompt template). They are session-opening instructions and background for repository work.
-- **Sticky rules** come from a top-level native `RULES.md`. They are converted into an always-apply rule whose full body is re-emitted in the system prompt on every request, so it stays in context and keeps its hold even after the visible conversation grows. See "Sticky rules vs normal context" below.
+- **Sticky rules** come from a top-level native `RULES.md`. They are converted into an always-apply rule whose full body is carried on every request, so it stays in context and keeps its hold even after the visible conversation grows. See "Sticky rules vs normal context" below.
 - **Discovery providers** are the config-source adapters that know where each tool keeps its files. The full registry is `native`, `omp-plugins`, `claude`, `agent-plugins`, `codex`, `agents`, `claude-plugins`, `gemini`, `opencode`, `cursor`, `windsurf`, `cline`, `github`, `vscode`, `agents-md`, `mcp-json`, `ssh-json`, and `builtin-defaults`. Only some contribute context files (`native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md`); the rest contribute other capabilities such as rules, MCP servers, skills, commands, hooks, tools, or SSH hosts. The same provider that contributes context files may also contribute MCP servers, slash commands, skills, hooks, tools, prompts, and settings.
 - **Model providers** are inference backends such as `anthropic`, `openai`, `google`, `groq`, `ollama`, and `openrouter`. They have nothing to do with context files except that both kinds of id share the one `disabledProviders` list — see "Disabling discovery providers" below and [Providers](./providers.md).
 
@@ -182,7 +182,7 @@ Do not edit generated files.
 `RULES.md` is special:
 
 - It is read **only** at native locations: the active user agent directory and the nearest non-empty project `.omp/` directory selected by the cwd-to-repository-root walk. If that project directory has no `RULES.md`, OMP does not fall back to a farther `.omp/RULES.md`.
-- It is loaded as an **always-apply rule**, not as a context file, so its full body is re-emitted in the system prompt on every request — never demoted to an on-demand rulebook entry — and keeps its hold across long sessions.
+- It is loaded as an **always-apply rule**, not as a context file, so its full body is carried on every request — never demoted to an on-demand rulebook entry — and keeps its hold across long sessions. By default it rides in the system prompt; on vision models with `snapcompact.systemPrompt` imaging enabled the system prompt (this rule included) may instead ship as attached image frames, but the body travels with the request either way.
 - It is **always sticky**: frontmatter cannot make it non-sticky. If you want conditional or opt-in behavior, write a normal rule file instead (see [Skills](./skills.md)).
 - Both top-level candidates are synthesized with the rule name `RULES`, and rule deduplication is name-based. In the usual case, a user `RULES.md` shadows the project `RULES.md`; they are not concatenated. Avoid naming a regular file under `.omp/rules/` or the user `rules/` directory `RULES.md`, because native regular rules load earlier and can shadow both sticky candidates.
 

--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -9,7 +9,7 @@ You never have to ask the agent to go read `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
 Four similarly named things behave differently. Keep them straight:
 
 - **Context files** are read as plain Markdown and shown to the agent in generated project instructions (inside `<repo-rules>` with the default prompt template). They are session-opening instructions and background for repository work.
-- **Sticky rules** come from a top-level native `RULES.md`. They are converted into an always-apply rule that is re-attached near the current turn, so they keep their hold even after the visible conversation grows. See "Sticky rules vs normal context" below.
+- **Sticky rules** come from a top-level native `RULES.md`. They are converted into an always-apply rule whose full body is re-emitted in the system prompt on every request, so it stays in context and keeps its hold even after the visible conversation grows. See "Sticky rules vs normal context" below.
 - **Discovery providers** are the config-source adapters that know where each tool keeps its files. The full registry is `native`, `omp-plugins`, `claude`, `agent-plugins`, `codex`, `agents`, `claude-plugins`, `gemini`, `opencode`, `cursor`, `windsurf`, `cline`, `github`, `vscode`, `agents-md`, `mcp-json`, `ssh-json`, and `builtin-defaults`. Only some contribute context files (`native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md`); the rest contribute other capabilities such as rules, MCP servers, skills, commands, hooks, tools, or SSH hosts. The same provider that contributes context files may also contribute MCP servers, slash commands, skills, hooks, tools, prompts, and settings.
 - **Model providers** are inference backends such as `anthropic`, `openai`, `google`, `groq`, `ollama`, and `openrouter`. They have nothing to do with context files except that both kinds of id share the one `disabledProviders` list — see "Disabling discovery providers" below and [Providers](./providers.md).
 
@@ -182,7 +182,7 @@ Do not edit generated files.
 `RULES.md` is special:
 
 - It is read **only** at native locations: the active user agent directory and the nearest non-empty project `.omp/` directory selected by the cwd-to-repository-root walk. If that project directory has no `RULES.md`, OMP does not fall back to a farther `.omp/RULES.md`.
-- It is loaded as an **always-apply rule**, not as a context file, so it is re-attached near the current turn and keeps its hold across long sessions.
+- It is loaded as an **always-apply rule**, not as a context file, so its full body is re-emitted in the system prompt on every request — never demoted to an on-demand rulebook entry — and keeps its hold across long sessions.
 - It is **always sticky**: frontmatter cannot make it non-sticky. If you want conditional or opt-in behavior, write a normal rule file instead (see [Skills](./skills.md)).
 - Both top-level candidates are synthesized with the rule name `RULES`, and rule deduplication is name-based. In the usual case, a user `RULES.md` shadows the project `RULES.md`; they are not concatenated. Avoid naming a regular file under `.omp/rules/` or the user `rules/` directory `RULES.md`, because native regular rules load earlier and can shadow both sticky candidates.
 

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -385,8 +385,9 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 	}
 
 	// Top-level RULES.md is a sticky always-apply rule. Documented in
-	// https://omp.sh/docs/context-files: its full body is re-emitted in the
-	// system prompt on every request so it keeps its hold across long sessions.
+	// https://omp.sh/docs/context-files: its full body is carried on every
+	// request (system-prompt text, or image frames under snapcompact
+	// system-prompt imaging) so it keeps its hold across long sessions.
 	// User scope:    ~/.omp/agent/RULES.md
 	// Project scope: nearest .omp/RULES.md walking up from cwd to repoRoot
 	const userRulesFile = path.join(getAgentDir(), "RULES.md");
@@ -415,7 +416,8 @@ async function loadStickyRulesFile(filePath: string, level: "user" | "project"):
 	const rule = discoverRuleFromMarkdown("RULES.md", content, filePath, source, { ruleName });
 	if (!rule) return null;
 	// Force alwaysApply regardless of frontmatter — the whole point of RULES.md
-	// is that its body stays in the system prompt on every request.
+	// is that its body is carried on every request instead of degrading to an
+	// on-demand rulebook entry.
 	return { ...rule, alwaysApply: true };
 }
 

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -385,8 +385,8 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 	}
 
 	// Top-level RULES.md is a sticky always-apply rule. Documented in
-	// https://omp.sh/docs/context-files as the file that gets "re-injected near
-	// the current turn so they keep hold across long conversations".
+	// https://omp.sh/docs/context-files: its full body is re-emitted in the
+	// system prompt on every request so it keeps its hold across long sessions.
 	// User scope:    ~/.omp/agent/RULES.md
 	// Project scope: nearest .omp/RULES.md walking up from cwd to repoRoot
 	const userRulesFile = path.join(getAgentDir(), "RULES.md");
@@ -415,7 +415,7 @@ async function loadStickyRulesFile(filePath: string, level: "user" | "project"):
 	const rule = discoverRuleFromMarkdown("RULES.md", content, filePath, source, { ruleName });
 	if (!rule) return null;
 	// Force alwaysApply regardless of frontmatter — the whole point of RULES.md
-	// is to be reattached every turn.
+	// is that its body stays in the system prompt on every request.
 	return { ...rule, alwaysApply: true };
 }
 


### PR DESCRIPTION
## Repro

The [context-files docs](https://omp.sh/docs/context-files#sticky-rules-vs-normal-context) and the source comments in `builtin.ts` state that a top-level `RULES.md` is "re-attached near the current turn." Inspecting the request path (and the reporter's agent-core probe in #11195) shows the opposite: the always-apply rule's body is rendered into `<generic-rules>` in the system prefix and stays there on every request, never placed near the end of the growing message list. No built-in path performs a near-current-turn reattachment, so the wording describes a mechanism that does not exist.

## Cause

`loadStickyRulesFile` (`packages/coding-agent/src/discovery/builtin.ts`) forces `alwaysApply: true`, `bucketRules` routes the rule into `alwaysApplyRules` (`capability/rule-buckets.ts`), and `buildSystemPromptInternal` renders those bodies into `<generic-rules>` in the system prompt (`system-prompt.ts` -> `prompts/system/system-prompt.md`). The per-request transforms in `sdk.ts` deliberately keep stable content in the system prefix for prompt-cache stability (only the volatile date/cwd reminder rides a user turn, `sdk.ts:3461-3463`), and pi-agent-core 14.7.0 removed the old per-call project-context injection (`projectPrompt`/`setProjectPrompt`). The behavior is intentional; the docs and comments were the defect.

## Fix

- `docs/context-files.md`: replaced the two "re-attached near the current turn" claims with an accurate description — the rule's full body is re-emitted in the system prompt on every request (never demoted to an on-demand rulebook entry), so it keeps its hold across long sessions.
- `packages/coding-agent/src/discovery/builtin.ts`: updated the two matching source comments to the same accurate wording.

## Verification

Docs/comment-only change; no runtime behavior altered. Re-read the diff for accuracy against the traced request path (`builtin.ts` -> `rule-buckets.ts` -> `system-prompt.ts`/`system-prompt.md`, with `sdk.ts` transforms confirming system-prefix delivery). Fixes #11195