### PR TITLE
fix(settings): refresh project cache before reload

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 - Codex turns interrupted before terminal completion now auto-continue after resolved tool calls instead of stopping ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
 - `/handoff` no longer leaves the TUI in a running state when completion races with delayed session events ([#11263](https://github.com/can1357/oh-my-pi/issues/11263)).
+- Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 
 ## [18.1.15] - 2026-09-08
 
@@ -40,9 +41,6 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
-### Fixed
-
-- Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,9 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
+### Fixed
+
+- Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -23,6 +23,7 @@ import {
 	getAgentDir,
 	getLastChangelogVersionPath,
 	getProjectDir,
+	getProjectAgentDir,
 	isEnoent,
 	logger,
 	MAIN_CONFIG_FILENAMES,
@@ -1809,6 +1810,10 @@ export class Settings {
 	}
 
 	async #readProjectSettings(quarantineInvalid: boolean): Promise<ProjectSettingsReadResult> {
+		const projectConfigDir = getProjectAgentDir(this.#cwd);
+		const projectConfigPath = path.join(projectConfigDir, "config.yml");
+		invalidateCapabilityFsCache(projectConfigPath);
+		invalidateCapabilityFsCache(path.join(projectConfigDir, "settings.json"));
 		let shellPathSource: string | undefined;
 		let merged: RawSettings = {};
 		try {
@@ -1824,7 +1829,6 @@ export class Settings {
 			// Capability discovery is best-effort; the native project config below
 			// remains authoritative for its model-role layer and must not be hidden.
 		}
-		const projectConfigPath = path.join(this.#cwd, ".omp", "config.yml");
 		const nativeProject = quarantineInvalid
 			? await this.#loadYaml(projectConfigPath)
 			: (this.#unwrapYamlLoadResult(projectConfigPath, await this.#loadYamlIfPresent(projectConfigPath, false)) ??
@@ -2904,7 +2908,7 @@ export class Settings {
 	async #saveProjectNow(): Promise<void> {
 		if (this.#savesCancelled || !this.#persist || this.#modifiedProjectModelRoles.size === 0) return;
 
-		const projectConfigPath = path.join(this.#cwd, ".omp", "config.yml");
+		const projectConfigPath = path.join(getProjectAgentDir(this.#cwd), "config.yml");
 		const modifiedModelRoles = [...this.#modifiedProjectModelRoles];
 		this.#modifiedProjectModelRoles.clear();
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -965,6 +965,87 @@ describe("Settings", () => {
 			expect(settings.getModelRole("global_role")).toBe("openai/global");
 			expect(settings.getModelRole("project_role")).toBe("openai/project");
 		});
+		it("refreshes native project settings without changing overlay or runtime precedence", async () => {
+			await writeSettings({
+				task: { enableEffort: true, maxConcurrency: 2 },
+				retry: { modelFallback: true },
+			});
+			const overlayPath = tempDir.join("reload-overlay.yml");
+			await Bun.write(overlayPath, YAML.stringify({ task: { enableEffort: false } }, null, 2));
+			const reloadProjectDir = tempDir.join("reload-project");
+			await fsp.mkdir(reloadProjectDir, { recursive: true });
+			const projectConfigPath = path.join(getProjectAgentDir(reloadProjectDir), "config.yml");
+			const settings = await Settings.loadIsolated({
+				cwd: reloadProjectDir,
+				agentDir,
+				configFiles: [overlayPath],
+				overrides: { "task.maxConcurrency": 7 },
+			});
+
+			expect(await Bun.file(projectConfigPath).exists()).toBe(false);
+			await Bun.write(
+				projectConfigPath,
+				YAML.stringify(
+					{
+						task: {
+							agentModelOverrides: { task: "xai-oauth/grok-4.6:medium" },
+							enableEffort: true,
+							maxConcurrency: 3,
+						},
+						retry: { modelFallback: false },
+					},
+					null,
+					2,
+				),
+			);
+			await settings.reloadFromDisk();
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				task: "xai-oauth/grok-4.6:medium",
+			});
+			expect(settings.get("retry.modelFallback")).toBe(false);
+			expect(settings.get("task.enableEffort")).toBe(false);
+			expect(settings.get("task.maxConcurrency")).toBe(7);
+
+			await Bun.write(
+				projectConfigPath,
+				YAML.stringify(
+					{
+						task: {
+							agentModelOverrides: { task: "openai/gpt-4o" },
+							enableEffort: true,
+							maxConcurrency: 4,
+						},
+						retry: { modelFallback: true },
+					},
+					null,
+					2,
+				),
+			);
+			await settings.reloadFromDisk();
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({ task: "openai/gpt-4o" });
+			expect(settings.get("retry.modelFallback")).toBe(true);
+			expect(settings.get("task.enableEffort")).toBe(false);
+			expect(settings.get("task.maxConcurrency")).toBe(7);
+
+			await Bun.write(
+				projectConfigPath,
+				YAML.stringify({ task: { enableEffort: true, maxConcurrency: 4 } }, null, 2),
+			);
+			await settings.reloadFromDisk();
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+			expect(settings.get("retry.modelFallback")).toBe(true);
+
+			await fsp.rm(projectConfigPath);
+			await settings.reloadFromDisk();
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+			expect(settings.get("retry.modelFallback")).toBe(true);
+			expect(settings.get("task.enableEffort")).toBe(false);
+			expect(settings.get("task.maxConcurrency")).toBe(7);
+		});
 		it("retries when a persisted setting changes while files are being read", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -182,11 +182,15 @@ describe("structured subagent primitive", () => {
 		);
 		expect(discover).not.toHaveBeenCalled();
 	});
-	it("reloads model roles before resolving an agent added during the session", async () => {
+	it("reloads project task and retry policy before resolving an agent added during the session", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-task-hot-reload-"));
 		const projectDir = path.join(root, "project");
 		const agentDir = path.join(root, "agent");
 		await fs.mkdir(projectDir, { recursive: true });
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			"task:\n  enableEffort: true\nretry:\n  modelFallback: true\n",
+		);
 		const liveSettings = await Settings.loadIsolated({ cwd: projectDir, agentDir });
 		const liveSession = {
 			...session(),
@@ -195,16 +199,20 @@ describe("structured subagent primitive", () => {
 		} as ToolSession;
 
 		try {
-			await Bun.write(path.join(projectDir, ".omp", "config.yml"), "modelRoles:\n  hot_worker: kimi-code/k3:max\n");
+			await Bun.write(
+				path.join(projectDir, ".omp", "config.yml"),
+				"task:\n  agentModelOverrides:\n    hot-worker: xai-oauth/grok-4.6:medium\n  enableEffort: false\nretry:\n  modelFallback: false\n",
+			);
 			await Bun.write(
 				path.join(projectDir, ".omp", "agents", "hot-worker.md"),
-				'---\nname: hot-worker\ndescription: Newly added worker.\nmodel: "@hot_worker"\n---\n\nInspect the assignment.\n',
+				"---\nname: hot-worker\ndescription: Newly added worker.\nmodel: openai/gpt-4o\n---\n\nInspect the assignment.\n",
 			);
 
 			const policy = await resolveEffectiveSubagentPolicy(request({ session: liveSession, agent: "hot-worker" }));
 
-			expect(policy.modelRole).toBe("hot_worker");
-			expect(policy.modelOverride).toEqual(["kimi-code/k3:max"]);
+			expect(policy.modelOverride).toEqual(["xai-oauth/grok-4.6:medium"]);
+			expect(liveSettings.get("task.enableEffort")).toBe(false);
+			expect(liveSettings.get("retry.modelFallback")).toBe(false);
 		} finally {
 			liveSettings.cancelPendingSaves();
 			await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Repro
Load a persisted `Settings` instance before the project has `.omp/`, then write `.omp/config.yml` with a task model pin and `retry.modelFallback: false` and call `reloadFromDisk()`. Before this fix, `bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/task/structured-subagent.test.ts` fails the new reload/preflight cases because the live instance retains `{ agentModelOverrides: {}, modelFallback: true }`.

## Cause
`Settings.#readProjectSettings()` loaded project leaves through `loadCapability()`, while `capability/fs.ts` retained cached missing directory entries and cached file contents indefinitely. Its direct YAML read only replaced `modelRoles`, so task and retry leaves stayed stale during `resolveEffectiveSubagentPolicy()` preflight.

## Fix
- Invalidate only the native project `config.yml` and `settings.json` capability cache entries before reading project settings.
- Use the shared `getProjectAgentDir()` path helper for project settings reads and writes.
- Cover absent directories, file changes, leaf removal, file deletion, explicit overlay/runtime precedence, and no-LLM task preflight.
- Document the user-visible reload correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/task/structured-subagent.test.ts` — 147 passed, 0 failed. The original source-import repro now returns the new model pin with `enableEffort: false` and `modelFallback: false`.

Fixes #11191