### PR TITLE
fix(compaction): bound stalled requests and preserve fallback transport

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Codex V2 compaction omitting its feature-gate header on the provider transport and exhausting the request deadline before a stalled WebSocket could replay over SSE.
+- Fixed V2 deadline exhaustion restarting the full timeout twice before advancing to fallback; transient failures within the deadline remain retryable.
+- Bounded local compaction summary requests to three minutes, including retries, so stalled providers release maintenance and cannot commit partial summaries after cancellation. SDK callers can override the per-request deadline with `SummaryOptions.timeoutMs`; zero disables it.
+- Fixed automatic soft compaction multiplying the caller's retry budget by dropping `oneshotRetry: false`.
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -291,19 +291,24 @@ export async function requestCompactionV2Streaming(
 				})
 			: undefined;
 	let lastError: Error | undefined;
+	const timeoutMs = options?.timeoutMs ?? V2_COMPACTION_TIMEOUT_MS;
 
 	for (let attempt = 0; attempt <= V2_COMPACTION_MAX_RETRIES; attempt++) {
-		const timeoutSignal = withRequestTimeout(signal, options?.timeoutMs ?? V2_COMPACTION_TIMEOUT_MS);
+		const timeoutSignal = withRequestTimeout(signal, timeoutMs);
 		try {
 			return await attemptCompactionV2Streaming(endpoint, apiKey, model, request, fetchImpl, timeoutSignal, {
 				codexMetadata,
 				providerSessionState: options?.providerSessionState,
 				codexCompaction: options?.codexCompaction,
 				preferWebsockets: options?.preferWebsockets,
+				websocketTimeoutMs: timeoutMs > 0 ? Math.max(1, Math.floor(timeoutMs / 3)) : undefined,
 			});
 		} catch (err) {
 			const error = err instanceof Error ? err : new Error(String(err));
 			if (signal?.aborted) throw error;
+			// A full request budget already includes WebSocket-to-SSE recovery.
+			// Replaying it on timeout only postpones the next compaction method.
+			timeoutSignal?.throwIfAborted();
 
 			if (isRetryableCompactionError(error) && attempt < V2_COMPACTION_MAX_RETRIES) {
 				lastError = error;
@@ -336,6 +341,7 @@ async function attemptCompactionV2Streaming(
 		providerSessionState?: Map<string, ProviderSessionState>;
 		codexCompaction?: CodexCompactionContext;
 		preferWebsockets?: boolean;
+		websocketTimeoutMs?: number;
 	},
 ): Promise<CompactionV2Response> {
 	// Faithful to Codex: append the compaction trigger as the final input item
@@ -359,6 +365,8 @@ async function attemptCompactionV2Streaming(
 			sessionId: request.sessionId,
 			providerSessionState: options.providerSessionState,
 			preferWebsockets: options.preferWebsockets,
+			websocketTimeoutMs: options.websocketTimeoutMs,
+			headers: { [OPENAI_HEADERS.CODEX_BETA_FEATURES]: OPENAI_HEADER_VALUES.REMOTE_COMPACTION_V2 },
 			responsesLite: model.useResponsesLite,
 			codexCompaction: createOpenAICodexCompactionRequestContext({
 				context: options.codexCompaction,

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -36,9 +36,9 @@ import { buildResponsesInput, resolveOpenAICompatPolicy } from "@oh-my-pi/pi-ai/
 import { stripOpenAIResponsesOutputOnlyStatusesForReplay } from "@oh-my-pi/pi-ai/utils";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
-import { isRecord, logger, prompt } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
-import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
+import { type AgentTelemetry, type InstrumentedChatSpanOptions, instrumentedCompleteSimple } from "../telemetry";
 import { ThinkingLevel } from "../thinking";
 import { Tokenizer } from "../tokenizer";
 import type { AgentMessage } from "../types";
@@ -58,6 +58,7 @@ import {
 	buildOpenAiNativeHistory,
 	getPreservedOpenAiRemoteCompactionData,
 	requestOpenAiRemoteCompaction,
+	REMOTE_COMPACTION_TIMEOUT_MS,
 	requestRemoteCompaction,
 	shouldUseOpenAiRemoteCompaction,
 	trimRemoteCompactionInputToContextWindow,
@@ -701,6 +702,8 @@ export interface SummaryOptions {
 	tools?: Tool[];
 	/** Optional fetch implementation threaded into remote compaction calls. */
 	fetch?: FetchImpl;
+	/** Deadline per local summarization request, including retries; defaults to 3 minutes. Zero disables it. */
+	timeoutMs?: number;
 	/**
 	 * Optional completion transport override for host-level request wrappers
 	 * (e.g. the coding-agent provider-concurrency limiter). When provided,
@@ -739,6 +742,34 @@ function summaryOneshotRetry(options: SummaryOptions | undefined): OneshotRetryO
 	const configured = options?.oneshotRetry;
 	if (configured === false) return undefined;
 	return configured ?? {};
+}
+
+/** Bound all local summary phases, including providers that fail to settle on abort. */
+async function completeSummary(
+	model: Model,
+	context: Context,
+	requestOptions: SimpleStreamOptions,
+	span: InstrumentedChatSpanOptions,
+	options: SummaryOptions | undefined,
+): Promise<AssistantMessage> {
+	const timeoutMs = options?.timeoutMs ?? REMOTE_COMPACTION_TIMEOUT_MS;
+	const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+	const signal =
+		requestOptions.signal && timeoutSignal
+			? AbortSignal.any([requestOptions.signal, timeoutSignal])
+			: (requestOptions.signal ?? timeoutSignal);
+	try {
+		const response = await untilAborted(signal, () =>
+			instrumentedCompleteSimple(model, context, { ...requestOptions, signal }, span),
+		);
+		signal?.throwIfAborted();
+		return response;
+	} catch (error) {
+		// Keep TimeoutError distinct from operator cancellation so the caller can
+		// advance to another model rather than accepting a partial summary.
+		signal?.throwIfAborted();
+		throw error;
+	}
 }
 
 function localCodexCompaction(options: SummaryOptions | undefined) {
@@ -986,7 +1017,7 @@ async function summarizeConversationWindow(
 		return remote.summary;
 	}
 
-	const response = await instrumentedCompleteSimple(
+	const response = await completeSummary(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
 		{
@@ -1008,6 +1039,7 @@ async function summarizeConversationWindow(
 			completeImpl: options?.completeImpl,
 			retry: summaryOneshotRetry(options),
 		},
+		options,
 	);
 
 	if (response.stopReason === "error") {
@@ -1197,7 +1229,7 @@ async function generateShortSummary(
 		return remote.summary;
 	}
 
-	const response = await instrumentedCompleteSimple(
+	const response = await completeSummary(
 		model,
 		{
 			systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT],
@@ -1222,6 +1254,7 @@ async function generateShortSummary(
 			completeImpl: options?.completeImpl,
 			retry: summaryOneshotRetry(options),
 		},
+		options,
 	);
 
 	if (response.stopReason === "error") {
@@ -1585,6 +1618,8 @@ export async function compact(
 		tools: options?.tools,
 		fetch: options?.fetch,
 		completeImpl: options?.completeImpl,
+		oneshotRetry: options?.oneshotRetry,
+		timeoutMs: options?.timeoutMs,
 	};
 
 	const previousSnapcompactArchive = snapcompact.getPreservedArchive(previousPreserveData);
@@ -1897,7 +1932,7 @@ async function generateTurnPrefixSummary(
 		},
 	];
 
-	const response = await instrumentedCompleteSimple(
+	const response = await completeSummary(
 		model,
 		{ systemPrompt: [SUMMARIZATION_SYSTEM_PROMPT], messages: summarizationMessages },
 		{
@@ -1919,6 +1954,7 @@ async function generateTurnPrefixSummary(
 			completeImpl: options?.completeImpl,
 			retry: summaryOneshotRetry(options),
 		},
+		options,
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/agent/test/compaction-deadline.test.ts
+++ b/packages/agent/test/compaction-deadline.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+	compact,
+	type CompactionPreparation,
+	createFileOps,
+	DEFAULT_COMPACTION_SETTINGS,
+} from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+
+const model = {
+	id: "summary-model",
+	provider: "test",
+	api: "openai-completions",
+	contextWindow: 200_000,
+	maxTokens: 8192,
+} as Model;
+
+function preparation(): CompactionPreparation {
+	return {
+		firstKeptEntryId: "kept",
+		messagesToSummarize: [{ role: "user", content: "Keep the deployment on hold", timestamp: 1 }],
+		turnPrefixMessages: [],
+		recentMessages: [],
+		isSplitTurn: false,
+		tokensBefore: 100_000,
+		fileOps: createFileOps(),
+		settings: { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+	};
+}
+
+function response(stopReason: "stop" | "aborted"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "deployment remains on hold" }],
+		provider: model.provider,
+		model: model.id,
+		api: model.api,
+		stopReason,
+		timestamp: 1,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+describe("soft compaction deadlines", () => {
+	test("a silent completion releases maintenance instead of hanging indefinitely", async () => {
+		let requestSignal: AbortSignal | undefined;
+		await expect(
+			compact(preparation(), model, "fixture-key", undefined, undefined, {
+				timeoutMs: 20,
+				oneshotRetry: false,
+				completeImpl: async (_model, _context, options) => {
+					requestSignal = options.signal;
+					return Promise.withResolvers<AssistantMessage>().promise;
+				},
+			}),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+		expect(requestSignal?.aborted).toBe(true);
+	});
+
+	test("a stalled short summary cannot hold a completed history summary forever", async () => {
+		let calls = 0;
+		await expect(
+			compact(preparation(), model, "fixture-key", undefined, undefined, {
+				timeoutMs: 20,
+				oneshotRetry: false,
+				completeImpl: async () => {
+					if (++calls === 1) return response("stop");
+					return Promise.withResolvers<AssistantMessage>().promise;
+				},
+			}),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+		expect(calls).toBe(2);
+	});
+
+	test("operator cancellation never commits a partially returned summary", async () => {
+		const controller = new AbortController();
+		const reason = new Error("operator cancelled maintenance");
+		await expect(
+			compact(preparation(), model, "fixture-key", undefined, controller.signal, {
+				timeoutMs: 0,
+				completeImpl: async () => {
+					controller.abort(reason);
+					return response("aborted");
+				},
+			}),
+		).rejects.toBe(reason);
+	});
+});

--- a/packages/agent/test/compaction-oneshot-retry.test.ts
+++ b/packages/agent/test/compaction-oneshot-retry.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { generateSummary } from "@oh-my-pi/pi-agent-core/compaction";
+import {
+	compact,
+	type CompactionPreparation,
+	createFileOps,
+	DEFAULT_COMPACTION_SETTINGS,
+	generateSummary,
+} from "@oh-my-pi/pi-agent-core/compaction";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core/types";
 import type { AssistantMessage, Model, Usage } from "@oh-my-pi/pi-ai/types";
 
@@ -97,6 +103,30 @@ describe("SummaryOptions.oneshotRetry", () => {
 
 		// The failure must surface for the outer loop to classify and retry.
 		await expect(attempt).rejects.toThrow();
+		expect(calls).toBe(1);
+	});
+
+	it("preserves the outer retry budget through a complete soft-compaction attempt", async () => {
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "kept",
+			messagesToSummarize: messages,
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100_000,
+			fileOps: createFileOps(),
+			settings: { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+		};
+		let calls = 0;
+		await expect(
+			compact(preparation, model, apiKey, undefined, undefined, {
+				oneshotRetry: false,
+				completeImpl: async () => {
+					calls++;
+					return overloaded();
+				},
+			}),
+		).rejects.toThrow();
 		expect(calls).toBe(1);
 	});
 });

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -1002,6 +1002,35 @@ describe("requestCompactionV2Streaming", () => {
 		expect(attempts).toBe(2);
 	});
 
+	test("an exhausted V2 deadline advances fallback instead of restarting the full timeout", async () => {
+		const model = makeOpenAiModel({
+			remoteCompaction: {
+				enabled: true,
+				v2StreamingEnabled: true,
+				v2Endpoint: "https://compact.example/v1/responses",
+			},
+		});
+		const request = buildCompactionV2Request(
+			model,
+			[{ type: "message", role: "user", content: [{ type: "input_text", text: "preserve the hold" }] }],
+			"instructions",
+		);
+		let attempts = 0;
+		await expect(
+			requestCompactionV2Streaming(model, "test-key", request, undefined, {
+				timeoutMs: 20,
+				retryWait: async () => {},
+				fetch: async (_input, init) => {
+					attempts++;
+					const { promise, reject } = Promise.withResolvers<Response>();
+					init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+					return promise;
+				},
+			}),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+		expect(attempts).toBe(1);
+	});
+
 	test("does not retry and preserves auth_unavailable from V2 HTTP failures", async () => {
 		const model = makeOpenAiModel({
 			remoteCompaction: {
@@ -1353,6 +1382,69 @@ describe("Responses Lite remote compaction", () => {
 		} finally {
 			for (const state of providerSessionState.values()) state.close();
 			providerSessionState.clear();
+			webSocket.restore();
+		}
+	});
+
+	test("V2 provider transport sends the compaction feature gate over SSE", async () => {
+		const model = makeCodexLiteModel({ preferWebsockets: false });
+		const request = buildCompactionV2Request(
+			model,
+			[{ type: "message", role: "user", content: [{ type: "input_text", text: "remember the deployment hold" }] }],
+			"Keep deployment holds",
+		);
+		const result = await requestCompactionV2Streaming(model, "test-key", request, undefined, {
+			preferWebsockets: false,
+			fetch: async (_input, init) => {
+				if (new Headers(init?.headers).get("x-codex-beta-features") !== "remote_compaction_v2") {
+					return new Response("Compaction feature not enabled", { status: 400 });
+				}
+				return sseResponse(compactionV2Events("enc-feature-enabled"));
+			},
+		});
+		expect(result.compactionItem.encrypted_content).toBe("enc-feature-enabled");
+	});
+
+	test("V2 replays a stalled partial WebSocket over SSE before the request deadline", async () => {
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const webSocket = installCodexCompactionWebSocket({
+			respond: socket => {
+				socket.emit({
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "compaction", encrypted_content: "incomplete" },
+				});
+			},
+		});
+		try {
+			const model = makeCodexLiteModel({ preferWebsockets: true });
+			const request = buildCompactionV2Request(
+				model,
+				[
+					{
+						type: "message",
+						role: "user",
+						content: [{ type: "input_text", text: "remember the deployment hold" }],
+					},
+				],
+				"Keep deployment holds",
+				{ sessionId: "stalled-compaction-budget" },
+			);
+			const fetchMock = vi.fn(async () => sseResponse(compactionV2Events("enc-recovered")));
+			const result = await requestCompactionV2Streaming(model, "test-key", request, undefined, {
+				timeoutMs: 90,
+				retryWait: async () => {
+					throw new Error("The WebSocket exhausted the outer request deadline");
+				},
+				preferWebsockets: true,
+				providerSessionState,
+				fetch: fetchMock,
+			});
+			expect(webSocket.sockets[0]?.sent).toHaveLength(1);
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(result.compactionItem.encrypted_content).toBe("enc-recovered");
+		} finally {
+			for (const state of providerSessionState.values()) state.close();
 			webSocket.restore();
 		}
 	});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 - GitHub Copilot sign-in uses the minimal-grant OpenCode OAuth app again (`read:user` only): GitHub renders each app's existing per-user grant on the consent page, so Enterprise organizations that block the Copilot CLI app's broad historic grant can log in as on 18.1.4. API request identity still mimics the Copilot CLI, and tokens minted by either app keep working ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - GitHub Copilot plan/model-policy 403s no longer count as credential failures for credential-lifetime decisions: the token is valid, so stored credentials are preserved instead of wiped ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - Fixed custom `google-generative-ai` providers failing mid-turn model fallback when Gemini 3 tool calls are replayed without their original thought signature ([#11270](https://github.com/can1357/oh-my-pi/issues/11270)).
+### Fixed
+
+- Added an independent WebSocket attempt deadline for native Codex compaction so transport stalls can replay over SSE without reviving cancelled requests.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -181,6 +181,8 @@ export interface OpenAICodexCompactionBody extends CodexLiteShapedBody {
 /** Transport controls for a provider-native Codex V2 compaction stream. */
 export interface OpenAICodexCompactionStreamOptions extends OpenAICodexResponsesOptions {
 	apiKey: string;
+	/** Bound the WebSocket attempt without consuming the SSE fallback deadline. */
+	websocketTimeoutMs?: number;
 }
 
 /** Inputs for synthesizing Codex request identity outside the normal stream path. */
@@ -1619,6 +1621,7 @@ async function openInitialCodexEventStream(
 	options: OpenAICodexResponsesOptions | undefined,
 	requestSetup: CodexRequestSetup,
 	requestContext: CodexRequestContext,
+	websocketRequestSetup = requestSetup,
 ): Promise<{
 	eventStream: AsyncGenerator<Record<string, unknown>>;
 	requestBodyForState: RequestBody;
@@ -1634,13 +1637,17 @@ async function openInitialCodexEventStream(
 					model,
 					options,
 					requestContext,
-					requestSetup,
+					websocketRequestSetup,
 					websocketState,
 					websocketRetries,
 					options ? event => options.onSseEvent?.(event, model) : undefined,
 				);
 			} catch (error) {
-				if (!(error instanceof CodexWebSocketTransportError)) throw error;
+				if (requestSetup.requestSignal.aborted || !(error instanceof CodexWebSocketTransportError)) throw error;
+				if (websocketRequestSetup.requestSignal.aborted) {
+					recordCodexWebSocketFailure(websocketState, true);
+					break;
+				}
 				const fatalWebSocketMessage = error.message.toLowerCase();
 				const isFatal = CODEX_WEBSOCKET_FATAL_PATTERNS.some(pattern =>
 					fatalWebSocketMessage.includes(pattern.toLowerCase()),
@@ -1697,7 +1704,21 @@ export async function openCodexCompactionEventStream(
 		requestContext = createCodexRequestContext(model, toCodexRequestBody(body), options, {
 			isolateCompactionTransport: false,
 		});
-		initial = await openInitialCodexEventStream(model, options, requestSetup, requestContext);
+		// The regular WebSocket watchdog can exceed the entire compaction deadline.
+		// Keep its attempt signal separate so SSE can replay without reviving cancellation.
+		const websocketRequestSetup =
+			options.websocketTimeoutMs !== undefined &&
+			options.websocketTimeoutMs > 0 &&
+			shouldUseCodexWebSocket(model, requestContext.websocketState, options.preferWebsockets)
+				? {
+						...requestSetup,
+						requestSignal: AbortSignal.any([
+							requestSetup.requestSignal,
+							AbortSignal.timeout(options.websocketTimeoutMs),
+						]),
+					}
+				: requestSetup;
+		initial = await openInitialCodexEventStream(model, options, requestSetup, requestContext, websocketRequestSetup);
 	} catch (error) {
 		requestSetup.requestAbortController.abort();
 		throw error;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
+- Fixed automatic soft compaction bypassing the session's configured side-request transport and provider concurrency controls.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -4075,6 +4075,14 @@ export class SessionMaintenance {
 									providerSessionState: this.#host.providerSessionState,
 									preferWebsockets: this.#host.preferWebsockets,
 									codexCompaction,
+									completeImpl: async (requestModel, requestContext, requestOptions) => {
+										const stream = await this.#host.sideStreamFn(
+											requestModel,
+											requestContext,
+											requestOptions,
+										);
+										return stream.result();
+									},
 									// This loop already retries the whole compaction attempt on
 									// transient errors, so the summarization oneshots must not
 									// retry too — the budgets would multiply and each outer

--- a/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
@@ -3,6 +3,9 @@ import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import * as ai from "@oh-my-pi/pi-ai";
+import type { StreamFn } from "@oh-my-pi/pi-agent-core";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -88,6 +91,7 @@ describe("issue #986 compaction auth fallback", () => {
 	async function createAutoNativeFallbackSession(options?: {
 		sameProviderNativeEnabled?: boolean;
 		includeSoftFallback?: boolean;
+		sideStreamFn?: StreamFn;
 	}) {
 		const currentModel = getBundledModel("openai", "gpt-5");
 		const sameProviderBase = getBundledModel("openai", "gpt-5-mini");
@@ -121,6 +125,7 @@ describe("issue #986 compaction auth fallback", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry,
+			sideStreamFn: options?.sideStreamFn,
 		});
 		session.subscribe(() => {});
 		for (const [userText, assistantText] of [
@@ -384,6 +389,32 @@ describe("issue #986 compaction auth fallback", () => {
 			`${sameProviderModel.provider}/${sameProviderModel.id}`,
 			`${crossProviderModel.provider}/${crossProviderModel.id}`,
 		]);
+	});
+
+	it("recovers native failure through the configured side transport during automatic soft fallback", async () => {
+		const originalCompact = compactionModule.compact;
+		vi.spyOn(ai, "completeSimple").mockRejectedValue(new Error("Direct transport is unavailable"));
+		const { triggerAutoCompaction } = await createAutoNativeFallbackSession({
+			includeSoftFallback: true,
+			sideStreamFn: async () => {
+				const stream = new AssistantMessageEventStream();
+				const message = assistantMsg("Deployment remains on hold pending approval.");
+				stream.push({ type: "done", reason: "stop", message });
+				stream.end(message);
+				return stream;
+			},
+		});
+		vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, ...args) => {
+			if (preparation.settings.remoteEnabled) {
+				throw new compactionModule.NativeCompactionError(new Error("native transport timeout"));
+			}
+			return originalCompact(preparation, ...args);
+		});
+		await triggerAutoCompaction();
+		const compacted = session.sessionManager.getBranch().findLast(entry => entry.type === "compaction");
+		expect(compacted?.type === "compaction" ? compacted.summary : undefined).toContain(
+			"Deployment remains on hold pending approval.",
+		);
 	});
 
 	it("tries same-provider native candidates during manual compaction before crossing providers", async () => {


### PR DESCRIPTION
## Summary
Fix stalled compaction requests and preserve the configured fallback behavior.

## Root causes and changes
- Codex V2 compaction omitted `x-codex-beta-features: remote_compaction_v2` on the provider WebSocket/SSE path, unlike the direct HTTP path. Send the feature header consistently.
- The regular WebSocket watchdog can exceed the entire V2 deadline. Reserve one third of the V2 request budget for WebSocket attempts, leaving time for SSE replay; cancellation and partial-output isolation remain intact.
- V2 deadline exhaustion restarted the full timeout twice. Surface the exhausted deadline instead of issuing three full-duration attempts; transient failures before deadline exhaustion remain retryable.
- Local summary phases lacked an overall deadline. Bound each request, including retries, to three minutes by default; expose `SummaryOptions.timeoutMs` with zero disabling it. Abort the underlying request and reject partial results after cancellation.
- `compact()` dropped `oneshotRetry: false`, multiplying caller-owned retries. Preserve the option through all summary phases.
- Automatic soft compaction bypassed the configured side-request transport. Use the session transport, as manual compaction already does.

## Verification
- 738 tests passed across 45 affected core, Codex transport, and compaction lifecycle test files.
- Lint, formatting, and type checks passed for agent, ai, and coding-agent packages.
- Regression tests reproduce missing feature-gate headers, exhausted WebSocket replay budgets, repeated V2 deadlines, multiplied summary retries, silent completions, cancellation, and automatic side-transport bypass.
- Local HTTP smoke completed native compaction and replayed its replacement history in a second request.
- Backported these changes onto an installed 18.1.14 runtime and exercised real Codex V2 compaction in the TUI, followed by exact recall of three synthetic history markers.
- Controlled native failure selected snapcompact before soft, preserved all three markers in a non-truncated archive, and the saved session reopened with exact recall.

## Scope and limitations
The upstream default method order is unchanged; it already puts snapcompact immediately after remote compaction. The live acceptance profile explicitly used `remote -> snapcompact -> soft`.

The provider-internal cause of the original timeout is not established; the protocol mismatch, deadline, retry, and fallback defects are independently reproduced. Existing snapcompact frame-budget truncation for oversized histories is unchanged. No credentials or private conversation contents are included.
