### PR TITLE
fix(cli, usage): declare worker host entry before worker selector dispatch and surface activity error

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
+- Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -457,6 +457,18 @@ export async function runCli(argv: string[]): Promise<void> {
 		return;
 	}
 
+	// Declare this module as the worker-host entry now that the active profile
+	// is resolved. The worker-host module is side-effect-free; importing
+	// `@oh-my-pi/pi-utils/env` here would snapshot the wrong agent `.env`.
+	// Gated on `isProcessEntry`: only the real CLI process entry is a valid
+	// worker host. Worker-thread re-entry has `!Bun.isMainThread` (isProcessEntry === false),
+	// and importers (`runCli` in profile-CLI tests, SDK embedding) have `import.meta.main === false`
+	// — declaring there would poison `workerHostEntry()` for the whole test process, forcing eval/stats/
+	// browser workers onto the same-realm inline fallback.
+	// This must run before worker selector dispatch so that worker subprocesses
+	// (e.g. stats activity) are registered as hosts and can themselves spawn worker threads.
+	if (isProcessEntry) declareWorkerHostEntry();
+
 	// Worker-thread entry dispatch must run before the first `await`: the
 	// stats sync worker's buffering onmessage handler is installed in the
 	// synchronous prefix of `runWorkerEntrypoint`, and Bun flushes the
@@ -470,17 +482,6 @@ export async function runCli(argv: string[]): Promise<void> {
 		}
 		return;
 	}
-
-	// Declare this module as the worker-host entry now that the active profile
-	// is resolved. The worker-host module is side-effect-free; importing
-	// `@oh-my-pi/pi-utils/env` here would snapshot the wrong agent `.env`.
-	// Gated on `isProcessEntry`: only the real CLI process entry is a valid
-	// worker host. Worker-thread re-entry already returned above at the
-	// `__omp_worker_` dispatch, and importers (`runCli` in profile-CLI tests,
-	// SDK embedding) have `import.meta.main === false` — declaring there would
-	// poison `workerHostEntry()` for the whole test process, forcing eval/stats/
-	// browser workers onto the same-realm inline fallback.
-	if (isProcessEntry) declareWorkerHostEntry();
 
 	// `PI_PROXY` must reach the bare global `fetch` before any provider call:
 	// OAuth refresh/login and usage probes never pass through

--- a/packages/coding-agent/src/modes/components/usage-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/usage-dashboard.ts
@@ -315,7 +315,7 @@ export class UsageDashboardComponent implements Component {
 	#view: "overview" | "detail" = "overview";
 	#scroll = 0;
 	#activity: DailyActivityPoint[] | null = null;
-	#activityError = false;
+	#activityError: string | null = null;
 	#syncing = true;
 	#detailCache: { width: number; lines: string[] } | null = null;
 	#lastViewportRows = 10;
@@ -336,8 +336,8 @@ export class UsageDashboardComponent implements Component {
 				this.#activity = points;
 				this.#options.requestRender();
 			}, this.#closeController.signal);
-		} catch {
-			this.#activityError = true;
+		} catch (error) {
+			this.#activityError = error instanceof Error ? error.message : String(error);
 		} finally {
 			this.#syncing = false;
 			if (!this.#closed) this.#options.requestRender();
@@ -483,7 +483,8 @@ export class UsageDashboardComponent implements Component {
 	#renderHeatmap(innerWidth: number): string[] {
 		const summary: string[] = [];
 		if (this.#activityError) {
-			return [theme.fg("dim", "Usage history unavailable (stats database could not be read).")];
+			const detail = this.#activityError.trim().replace(/\.+$/, "");
+			return [theme.fg("dim", detail ? `Usage history unavailable (${detail}).` : "Usage history unavailable.")];
 		}
 		const points = this.#activity;
 		if (!points) return [theme.fg("dim", "Loading usage history…")];

--- a/packages/coding-agent/src/modes/components/usage-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/usage-dashboard.ts
@@ -5,10 +5,18 @@
  * above a GitHub-style daily activity heatmap fed by the local stats DB.
  * Enter flips into the classic full per-account report, scrollable in place.
  */
+import * as os from "node:os";
 import { resolveUsedFraction, type UsageLimit, type UsageReport } from "@oh-my-pi/pi-ai";
 import type { DailyActivityPoint } from "@oh-my-pi/omp-stats/shared-types";
-import { type Component, matchesKey, routeSgrMouseInput, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
-import { colorLuma, formatDuration, hexToRgb, rgbToHex } from "@oh-my-pi/pi-utils";
+import {
+	type Component,
+	matchesKey,
+	replaceTabs,
+	routeSgrMouseInput,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
+import { colorLuma, formatDuration, hexToRgb, rgbToHex, sanitizeText } from "@oh-my-pi/pi-utils";
 import { formatProviderName } from "../../slash-commands/helpers/format";
 import { colorToAnsi } from "../theme/color";
 import { theme } from "../theme/theme";
@@ -304,6 +312,21 @@ export interface UsageDashboardOptions {
 	onClose: () => void;
 }
 
+/**
+ * Sanitize activity loading error text for safe single-line display in the TUI overlay.
+ * Strips ANSI/control sequences, expands tabs, collapses whitespace runs/newlines,
+ * shortens home directory paths to ~, and removes trailing dots.
+ */
+export function formatActivityErrorDetail(error: string, homeDir = os.homedir()): string {
+	let text = replaceTabs(sanitizeText(error)).replace(/\s+/g, " ").trim();
+	if (homeDir) {
+		const escaped = homeDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const forward = homeDir.replaceAll("\\", "/").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		text = text.replace(new RegExp(`${escaped}|${forward}`, "gi"), "~");
+	}
+	return text.replace(/\.+$/, "");
+}
+
 const CARD_MIN_WIDTH = 32;
 const CARD_GUTTER = 3;
 const CARD_MAX_WINDOWS = 4;
@@ -483,7 +506,7 @@ export class UsageDashboardComponent implements Component {
 	#renderHeatmap(innerWidth: number): string[] {
 		const summary: string[] = [];
 		if (this.#activityError) {
-			const detail = this.#activityError.trim().replace(/\.+$/, "");
+			const detail = formatActivityErrorDetail(this.#activityError);
 			return [theme.fg("dim", detail ? `Usage history unavailable (${detail}).` : "Usage history unavailable.")];
 		}
 		const points = this.#activity;

--- a/packages/coding-agent/test/usage-dashboard.test.ts
+++ b/packages/coding-agent/test/usage-dashboard.test.ts
@@ -1,9 +1,11 @@
+import * as os from "node:os";
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { DailyActivityPoint } from "@oh-my-pi/omp-stats/shared-types";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
 import {
 	buildHeatmapLayout,
 	buildProviderCards,
+	formatActivityErrorDetail,
 	UsageDashboardComponent,
 } from "@oh-my-pi/pi-coding-agent/modes/components/usage-dashboard";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -131,5 +133,43 @@ describe("UsageDashboardComponent", () => {
 		const lines = component.render(80).join("\n");
 		expect(lines).toContain("Usage history unavailable (worker spawn failed).");
 		expect(lines).not.toContain("stats database could not be read");
+	});
+	it("sanitizes control sequences, collapses multiline errors, and shortens paths", async () => {
+		const home = os.homedir();
+		const rawError = `subprocess crashed at ${home}/.omp/stats.db:\n\tfailed to open\x1b[2J\r\nline 2\x1b[31m...`;
+		const { promise: rendered, resolve: markRendered } = Promise.withResolvers<void>();
+		const component = new UsageDashboardComponent({
+			reports: [],
+			renderDetail: () => "",
+			loadActivity: () => Promise.reject(new Error(rawError)),
+			requestRender: () => markRendered(),
+			onClose: () => {},
+		});
+
+		await rendered;
+		const renderedLines = component.render(140);
+		const contentLine = renderedLines.find(l => l.includes("Usage history unavailable"));
+		expect(contentLine).toBeDefined();
+		expect(contentLine).not.toContain("\x1b[2J");
+		expect(contentLine).not.toContain("\n");
+		expect(contentLine).not.toContain("\t");
+		expect(contentLine).not.toContain(home);
+		expect(contentLine).toContain("~/.omp/stats.db");
+		expect(contentLine).toContain(
+			"Usage history unavailable (subprocess crashed at ~/.omp/stats.db: failed to open line 2).",
+		);
+	});
+});
+
+describe("formatActivityErrorDetail", () => {
+	it("strips ANSI control sequences and collapses multiline error text to single line", () => {
+		const input = "worker spawn failed\ntrace\x1b[2J\r\n\tsecond line";
+		expect(formatActivityErrorDetail(input)).toBe("worker spawn failed trace second line");
+	});
+
+	it("shortens home directory paths to tilde and removes trailing dots", () => {
+		const home = "/Users/testuser";
+		const input = `Error: failed to open ${home}/.omp/stats.db...`;
+		expect(formatActivityErrorDetail(input, home)).toBe("Error: failed to open ~/.omp/stats.db");
 	});
 });

--- a/packages/coding-agent/test/usage-dashboard.test.ts
+++ b/packages/coding-agent/test/usage-dashboard.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import type { DailyActivityPoint } from "@oh-my-pi/omp-stats/shared-types";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
-import { buildHeatmapLayout, buildProviderCards } from "@oh-my-pi/pi-coding-agent/modes/components/usage-dashboard";
+import {
+	buildHeatmapLayout,
+	buildProviderCards,
+	UsageDashboardComponent,
+} from "@oh-my-pi/pi-coding-agent/modes/components/usage-dashboard";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 function day(day: string, cost: number, requests = 1): DailyActivityPoint {
 	return { day, cost, requests, totalTokens: 0 };
@@ -106,5 +111,25 @@ describe("buildProviderCards", () => {
 		expect(idle.sort()).toEqual(["cursor", "ollama-cloud"]);
 		const unlimited = cards.find(card => card.provider === "ollama-cloud");
 		expect(unlimited?.unlimited).toBe(true);
+	});
+});
+describe("UsageDashboardComponent", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+	it("renders specific error reason when activity loading fails instead of generic DB read error", async () => {
+		const { promise: rendered, resolve: markRendered } = Promise.withResolvers<void>();
+		const component = new UsageDashboardComponent({
+			reports: [],
+			renderDetail: () => "",
+			loadActivity: () => Promise.reject(new Error("worker spawn failed")),
+			requestRender: () => markRendered(),
+			onClose: () => {},
+		});
+
+		await rendered;
+		const lines = component.render(80).join("\n");
+		expect(lines).toContain("Usage history unavailable (worker spawn failed).");
+		expect(lines).not.toContain("stats database could not be read");
 	});
 });

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -26,6 +26,29 @@ describe("worker selector dispatch", () => {
 		expect(process.exitCode).toBe(1);
 		expect(stderr).toHaveBeenCalledWith("Error: unknown worker selector: __omp_worker_does_not_exist\n");
 	});
+	it("declares workerHostEntry in process entry before dispatching worker selector", async () => {
+		const repoRoot = path.resolve(__dirname, "../../..");
+		const proc = Bun.spawn({
+			cmd: [
+				process.execPath,
+				"-e",
+				`
+				import { workerHostEntry } from "./packages/utils/src/worker-host.ts";
+				await import("./packages/coding-agent/src/cli.ts");
+				process.stdout.write("ENTRY=" + (workerHostEntry() ?? "null"));
+				process.exit(0);
+				`,
+				"__omp_worker_does_not_exist",
+			],
+			cwd: repoRoot,
+			env: { ...process.env, PI_COMPILED: "true" },
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const stdout = await new Response(proc.stdout).text();
+		expect(stdout).toContain("ENTRY=");
+		expect(stdout).not.toBe("ENTRY=null");
+	});
 
 	it("leaves normal root flags untouched", async () => {
 		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);


### PR DESCRIPTION
### Problem

1. **Worker Host Declaration Order in `cli.ts`:**
   In `runCli()`, `declareWorkerHostEntry()` was previously called *after* the `isWorkerHostSelector(resolvedArgv[0])` check. When OMP spawns a background worker subprocess (such as `__omp_worker_stats_activity`), `resolvedArgv[0]` matches `isWorkerHostSelector`, executing `await runWorkerEntrypoint()` and returning immediately before `declareWorkerHostEntry()` is ever called. Consequently, inside that worker subprocess, `workerHostEntry()` remained `null`.
   When that activity subprocess subsequently attempted to sync sessions on multi-core systems (`hardwareConcurrency >= 2`), it invoked `syncAllSessions()`, which attempts to spawn thread workers via `new Worker(workerHostEntry(), { argv: ["__omp_worker_stats_sync"] })`. Because `workerHostEntry()` was `null`, it fell back to loading `./sync-worker.ts` via URL, which fails inside compiled standalone binaries and crashed the worker.

2. **Error Masking in `UsageDashboardComponent`:**
   When `#loadActivity()` threw or rejected, `UsageDashboardComponent` caught the error into a boolean flag (`#activityError = true`) and rendered a hardcoded message:
   `Usage history unavailable (stats database could not be read).`
   This masked the real root cause, falsely reporting a database read failure even when the stats database was completely healthy and the real failure was a worker spawn error or module crash.

### Solution

- In `packages/coding-agent/src/cli.ts`: moved `if (isProcessEntry) declareWorkerHostEntry();` to precede `if (isWorkerHostSelector(resolvedArgv[0]))`. This guarantees that process entries (including worker subprocesses) register the executable path as a worker host before dispatching the worker entrypoint, allowing them to spawn thread workers. Worker threads (`!Bun.isMainThread`) and test/SDK embedding importers still bypass the declaration.
- In `packages/coding-agent/src/modes/components/usage-dashboard.ts`: updated `#activityError` to store `string | null` capturing `error.message`. When activity loading fails, the UI surfaces the actual reason (e.g. `Usage history unavailable (<reason>).`) rather than a misleading static DB read claim.
- Added test coverage in:
  - `packages/coding-agent/test/worker-selector.test.ts`: verifies that `workerHostEntry()` is declared in process entries before worker selector dispatch.
  - `packages/coding-agent/test/usage-dashboard.test.ts`: verifies that `UsageDashboardComponent` renders the specific activity failure reason.

### Verification

- `bun test packages/coding-agent/test/worker-selector.test.ts` passes (8/8).
- `bun test packages/coding-agent/test/usage-dashboard.test.ts` passes (7/7).
- `bun run check:tools` passes clean with zero lint or format errors.