### PR TITLE
fix(anthropic): advertise tool-changes beta only when tools change [premise falsified, see body]

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -203,13 +203,53 @@ const serverSideFallbackBeta = "server-side-fallback-2026-06-01";
 function resolveAnthropicControlBetas(
 	model: Model<"anthropic-messages">,
 	prefixMismatchBehavior: "drop_block" | "error" | undefined,
+	toolsChangedThisTurn: boolean,
 ): string[] {
 	const betas: string[] = [];
 	if (prefixMismatchBehavior) betas.push(THINKING_BINDING_CONTROLS_BETA);
 	if (model.compat.supportsTurnScopedSystem) betas.push(midConversationSystemClearAtBeta);
-	if (model.compat.supportsMidConversationToolChanges) betas.push(midConversationToolChangesBeta);
+	// Advertised only on turns whose tool set differs from the previous turn on
+	// this (baseUrl, modelId) session. The beta declares that tools[] may change
+	// mid-conversation, and the server honors that declaration by treating the
+	// tools block as non-cacheable: it is excluded from the prompt-cache prefix
+	// for the whole request. A session that declares it on every turn therefore
+	// re-uploads its entire tool schema each turn at the cache-write rate rather
+	// than reading it back at the cache-read rate -- an order-of-magnitude
+	// per-token price difference applied to the largest stable region of the
+	// prefix. Gating on real change keeps the capability available on the turns
+	// that need it while leaving the tools block cacheable on the turns that do
+	// not, which for an agent session with a fixed toolset is nearly all of them.
+	// A caller that keeps no session state cannot be diffed against a previous
+	// turn, so it always advertises the beta and keeps full mid-conversation
+	// freedom.
+	if (model.compat.supportsMidConversationToolChanges && toolsChangedThisTurn) {
+		betas.push(midConversationToolChangesBeta);
+	}
 	if (model.compat.supportsPerMessageEffort) betas.push(midConversationOutputConfigBeta);
 	return betas;
+}
+
+/**
+ * Stable JSON signature of the caller-supplied tools[] for comparison across
+ * turns. Captures the identity fields (name + description + parameters) the
+ * wire serializer eventually emits, so semantically-equal tool sets across
+ * turns produce byte-identical signatures. Any tool that isn't JSON-safe
+ * falls back to a per-call unique marker, which reads as a changed tool set and
+ * keeps the beta advertised for that turn.
+ */
+function computeAnthropicToolsSignature(tools: Context["tools"] | undefined): string {
+	if (!tools || tools.length === 0) return "";
+	try {
+		return JSON.stringify(
+			tools.map(t => ({
+				name: t.name,
+				description: t.description ?? "",
+				parameters: t.parameters,
+			})),
+		);
+	} catch {
+		return `__anthropic_toolsig_fallback_${Math.random()}`;
+	}
 }
 
 function buildClaudeCodeBetas({
@@ -444,6 +484,15 @@ type AnthropicProviderSessionState = ProviderSessionState & {
 	prefixDroppedThinkingBlocks: Set<string>;
 	/** Conversation-scoped control baselines, isolated from side requests and advisors. */
 	controlStates: Map<string, AnthropicControlState>;
+	/**
+	 * Signature of the `tools[]` schema block observed on the most recent turn
+	 * of this session (JSON-stringified). Used to gate the
+	 * `mid-conversation-tool-changes-*` beta so it is advertised only on turns
+	 * where tools actually differ from the prior turn, preserving Anthropic's
+	 * server-side prompt-cache reuse of the tools block on the common case
+	 * where a coding-agent session's tool set never changes.
+	 */
+	priorToolsSignature: string | undefined;
 };
 
 function createAnthropicControlState(): AnthropicControlState {
@@ -466,12 +515,14 @@ function createAnthropicProviderSessionState(): AnthropicProviderSessionState {
 		replayUnsignedThinkingDisabled: false,
 		prefixDroppedThinkingBlocks: new Set(),
 		controlStates: new Map(),
+		priorToolsSignature: undefined,
 		close: () => {
 			state.strictToolsDisabled = false;
 			state.fastModeDisabled = false;
 			state.replayUnsignedThinkingDisabled = false;
 			state.prefixDroppedThinkingBlocks.clear();
 			state.controlStates.clear();
+			state.priorToolsSignature = undefined;
 		},
 	};
 	return state;
@@ -2049,7 +2100,19 @@ const streamAnthropicOnce = (
 				model.thinking?.prefixBinding && model.compat.supportsThinkingBindingControls
 					? (options?.anthropicPrefixMismatchBehavior ?? "drop_block")
 					: undefined;
-			const controlBetas = resolveAnthropicControlBetas(model, prefixMismatchBehavior);
+			// Diff the caller's tool set against the previous turn on this
+			// (baseUrl, modelId) session. Recorded before the betas resolve, and
+			// consumed both here and on the Vertex rawPredict path in buildParams.
+			// resolveAnthropicControlBetas explains what the result gates.
+			const currentToolsSignature = computeAnthropicToolsSignature(context.tools);
+			const toolsChangedThisTurn =
+				!providerSessionState ||
+				providerSessionState.priorToolsSignature === undefined ||
+				providerSessionState.priorToolsSignature !== currentToolsSignature;
+			if (providerSessionState) {
+				providerSessionState.priorToolsSignature = currentToolsSignature;
+			}
+			const controlBetas = resolveAnthropicControlBetas(model, prefixMismatchBehavior, toolsChangedThisTurn);
 			const mergedCallerHeaders = mergeHeaders(model.headers, options?.headers);
 			const umansGatewayWebSearchHeader = getUmansWebSearchHeader(model, mergedCallerHeaders);
 			// Keep fallback payloads aligned with the top-level Vertex effort gate:
@@ -2195,6 +2258,7 @@ const streamAnthropicOnce = (
 					dropAllThinking,
 					droppedThinkingBlocks: providerSessionState?.prefixDroppedThinkingBlocks,
 					providerSessionState,
+					toolsChangedThisTurn,
 					fallbacks,
 				});
 				if (disableStrictTools) {
@@ -3879,6 +3943,15 @@ type AnthropicParamBuildOptions = {
 	dropAllThinking: boolean;
 	droppedThinkingBlocks?: ReadonlySet<string>;
 	providerSessionState?: AnthropicProviderSessionState;
+	/**
+	 * Whether the caller's tool set differs from the prior turn on this
+	 * (baseUrl, modelId) session. Gates the
+	 * `mid-conversation-tool-changes-*` beta on the Vertex rawPredict path,
+	 * which places the beta in the request body's `anthropic_beta` field
+	 * instead of the `anthropic-beta` HTTP header.
+	 * Computed once per turn at the upstream call site and threaded here.
+	 */
+	toolsChangedThisTurn: boolean;
 	/** Sanitized server-side fallback entries; defaults to `options?.fallbacks` when omitted. */
 	fallbacks?: AnthropicOptions["fallbacks"];
 };
@@ -3899,6 +3972,7 @@ function buildParams(
 		dropAllThinking,
 		droppedThinkingBlocks,
 		providerSessionState,
+		toolsChangedThisTurn,
 		fallbacks = options?.fallbacks,
 	} = buildOptions;
 	// A session-scoped auto-demote (learned from a live signing 400) clones the
@@ -4059,7 +4133,7 @@ function buildParams(
 	const maxOutputTokens = isOAuthToken ? Math.min(CLAUDE_CODE_MAX_OUTPUT_TOKENS, modelMaxTokens) : modelMaxTokens;
 
 	const vertexControlBetas = isVertexRawPredictUrl(model.baseUrl)
-		? resolveAnthropicControlBetas(model, prefixMismatchBehavior)
+		? resolveAnthropicControlBetas(model, prefixMismatchBehavior, toolsChangedThisTurn)
 		: [];
 
 	// Build params in the canonical field order: model → messages → system → tools →

--- a/packages/ai/test/anthropic-fable-request-shaping.test.ts
+++ b/packages/ai/test/anthropic-fable-request-shaping.test.ts
@@ -440,3 +440,128 @@ describe("MiniMax Anthropic adaptive thinking", () => {
 		expect(payload.output_config?.effort).toBeUndefined();
 	});
 });
+
+/**
+ * The Vertex rawPredict endpoint carries betas in the request body
+ * (`anthropic_beta`) rather than the `anthropic-beta` HTTP header, so it is
+ * the one transport where `capturePayload` can observe the beta list directly.
+ */
+function makeVertexRawPredictModel(id: string): Model<"anthropic-messages"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "google-vertex",
+		baseUrl: `https://aiplatform.googleapis.com/v1/projects/p/locations/global/publishers/anthropic/models/${id}:streamRawPredict`,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	});
+}
+
+const MID_CONVERSATION_TOOL_CHANGES_BETA = "mid-conversation-tool-changes-2026-07-01";
+
+describe("mid-conversation tool-changes beta gating", () => {
+	const readTool = { name: "read", description: "Read a file.", parameters: { type: "object", properties: {} } };
+	const grepTool = { name: "grep", description: "Search files.", parameters: { type: "object", properties: {} } };
+
+	function turn(text: string, timestamp: number): Context["messages"] {
+		return [{ role: "user", content: text, timestamp }];
+	}
+
+	it("advertises the beta on the first turn of a session", async () => {
+		const model = makeVertexRawPredictModel("claude-opus-5");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const payload = await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("start", 1), tools: [readTool] },
+		);
+
+		expect(payload.anthropic_beta).toContain(MID_CONVERSATION_TOOL_CHANGES_BETA);
+	});
+
+	it("drops the beta on a later turn whose tool set is unchanged", async () => {
+		const model = makeVertexRawPredictModel("claude-opus-5");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("start", 1), tools: [readTool] },
+		);
+		const payload = await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("continue", 2), tools: [readTool] },
+		);
+
+		expect(payload.anthropic_beta ?? []).not.toContain(MID_CONVERSATION_TOOL_CHANGES_BETA);
+	});
+
+	it("re-advertises the beta on the turn the tool set actually changes", async () => {
+		const model = makeVertexRawPredictModel("claude-opus-5");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("start", 1), tools: [readTool] },
+		);
+		const payload = await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("continue", 2), tools: [readTool, grepTool] },
+		);
+
+		expect(payload.anthropic_beta).toContain(MID_CONVERSATION_TOOL_CHANGES_BETA);
+	});
+
+	it("keeps every other control beta on an unchanged-tools turn", async () => {
+		const model = makeVertexRawPredictModel("claude-opus-5");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const first = await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("start", 1), tools: [readTool] },
+		);
+		const second = await capturePayload(
+			model,
+			{ thinkingEnabled: true, providerSessionState },
+			{ ...CONTEXT, messages: turn("continue", 2), tools: [readTool] },
+		);
+
+		const dropped = (first.anthropic_beta ?? []).filter(beta => !(second.anthropic_beta ?? []).includes(beta));
+		expect(dropped).toEqual([MID_CONVERSATION_TOOL_CHANGES_BETA]);
+	});
+
+	it("advertises the beta on every turn when the caller keeps no session state", async () => {
+		const model = makeVertexRawPredictModel("claude-opus-5");
+
+		const first = await capturePayload(
+			model,
+			{ thinkingEnabled: true },
+			{
+				...CONTEXT,
+				messages: turn("start", 1),
+				tools: [readTool],
+			},
+		);
+		const second = await capturePayload(
+			model,
+			{ thinkingEnabled: true },
+			{
+				...CONTEXT,
+				messages: turn("continue", 2),
+				tools: [readTool],
+			},
+		);
+
+		expect(first.anthropic_beta).toContain(MID_CONVERSATION_TOOL_CHANGES_BETA);
+		expect(second.anthropic_beta).toContain(MID_CONVERSATION_TOOL_CHANGES_BETA);
+	});
+});


### PR DESCRIPTION
> **Status: the premise behind this change is falsified. Do not merge it as written.**
> The diff produces the request shape it claims, but the cost benefit it was written to deliver does not exist. Measurement below. Kept open because the measurement located a different and much larger defect, described at the end.

## What this change does

`resolveAnthropicControlBetas` pushed `mid-conversation-tool-changes-2026-07-01` onto every request whose model sets `supportsMidConversationToolChanges`, never consulting whether the tool set actually changed:

```ts
if (model.compat.supportsMidConversationToolChanges) betas.push(midConversationToolChangesBeta);
```

The diff records a signature of `tools[]` on the provider session state and advertises the beta only when that signature differs from the previous turn. That part works, and is verified by five tests plus a negative control.

## Why it should not be merged

The change was written on the theory that the beta tells the server the tools block may change, so the server excludes it from the cacheable prefix, so a session with a fixed tool set re-uploads its whole tool schema every turn at cache-write rates. That theory is wrong, and a live session disproves it directly.

Instrumenting the provider to print the resolved beta list alongside the per-turn usage, over a three-turn session against Vertex `claude-opus-5`:

| turn | tool-changes beta | `cacheRead` | `cacheWrite` |
|---|---|---:|---:|
| 1 | advertised | 27,671 | 55,193 |
| 2 | **dropped by this change** | **27,671** | 55,887 |

`cacheRead` is identical on both turns. The tools block was **already** being cached on turn 1, while the beta was being advertised. Removing the beta changed the request shape and changed nothing else. The benefit this PR claims is not measurable because it does not occur.

For completeness, the same gating applied to `mid-conversation-system-clear-at-2026-08-21` — the analogous unconditional push on line 210 — also produced no change: write share stayed at 67% across both variants.

## What the measurement actually found

The head of the request is byte-identical between turns. Hashing the serialized blocks directly:

```
turn 1  toolsHash=98dd5ac316cc335d  s0:15cc2c54.../63547  s1:45669b2e.../1055  s2:c340302e.../84887*
turn 2  toolsHash=98dd5ac316cc335d  s0:15cc2c54.../63547  s1:45669b2e.../1055  s2:c340302e.../84887*
```

Same tools, same three system blocks, and `*` marks a correctly-placed `cache_control` breakpoint on the last system block. Breakpoint counts confirm it: `toolsBP=1 sysBP=1`.

At the observed 2.6 chars/token for this payload, the regions divide cleanly and the split is unambiguous:

| region | chars | ≈ tokens | observed |
|---|---:|---:|---|
| `tools[]` | 66,069 | ~27.7k | matches `cacheRead=27,671` — **cached every turn** |
| `system` s0+s1+s2 | 149,489 | ~55.4k | matches `cacheWrite≈55k` — **never cached, any turn** |

So the tools block caches correctly, and the **system block never caches at all** despite being byte-stable and carrying a breakpoint. `applyHeadCaching` anchors the last system block precisely as its docblock describes, and the canonical `tools → system → messages` order should make that breakpoint cache the entire head. It does not.

That is the defect worth fixing, and it is roughly twice the size of the one this PR targets: ~55k tokens re-written at cache-write rates on every single turn of every session. I have not identified its root cause, so I am not proposing a fix for it here.

## Disposition

Happy to close this. It is posted rather than deleted because the negative result and the region-level measurement seemed more useful to a maintainer than silence, and because the system-block finding may be worth its own issue. If a maintainer would prefer that as an issue instead, say so and I will move it there rather than leaving a PR open on a premise I have disproven.
