### PR TITLE
fix(tui): restore shortcuts while ask dialog holds focus

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Editor shortcuts for thinking visibility, history search, external editing, and tool activity now work while the Ask dialog has focus ([#11213](https://github.com/can1357/oh-my-pi/issues/11213)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -39,10 +39,6 @@ type ConfigurableEditorAction = Extract<
 	| "app.model.cycleBackward"
 	| "app.model.select"
 	| "app.model.selectTemporary"
-	| "app.tools.toggleVisibility"
-	| "app.thinking.toggle"
-	| "app.editor.external"
-	| "app.history.search"
 	| "app.message.dequeue"
 	| "app.retry"
 	| "app.clipboard.pasteImage"
@@ -61,10 +57,6 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.model.cycleBackward": ["shift+ctrl+p"],
 	"app.model.select": ["alt+m"],
 	"app.model.selectTemporary": ["alt+p"],
-	"app.tools.toggleVisibility": ["ctrl+shift+o"],
-	"app.thinking.toggle": ["ctrl+t"],
-	"app.editor.external": ["ctrl+g"],
-	"app.history.search": ["ctrl+r"],
 	"app.message.dequeue": ["alt+up", "shift+up"],
 	"app.retry": ["f5", "alt+r"],
 	"app.clipboard.pasteImage": ["ctrl+v"],
@@ -704,10 +696,6 @@ export class CustomEditor extends Editor {
 	onCycleModelForward?: () => void;
 	onCycleModelBackward?: () => void;
 	onSelectModel?: () => void;
-	onToggleToolActivity?: () => void;
-	onToggleThinking?: () => void;
-	onExternalEditor?: () => void;
-	onHistorySearch?: () => void;
 	onSuspend?: () => void;
 	onSelectModelTemporary?: () => void;
 	/** Called when the configured copy-prompt shortcut is pressed. */
@@ -1028,12 +1016,6 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured external editor shortcut
-			if (this.#matchesAction(canonical, "app.editor.external") && this.onExternalEditor) {
-				this.onExternalEditor();
-				return;
-			}
-
 			// Intercept configured temporary model selector shortcut
 			if (this.#matchesAction(canonical, "app.model.selectTemporary") && this.onSelectModelTemporary) {
 				this.onSelectModelTemporary();
@@ -1052,27 +1034,9 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured thinking block visibility toggle
-			if (this.#matchesAction(canonical, "app.thinking.toggle") && this.onToggleThinking) {
-				this.onToggleThinking();
-				return;
-			}
-
 			// Intercept configured model selector shortcut
 			if (this.#matchesAction(canonical, "app.model.select") && this.onSelectModel) {
 				this.onSelectModel();
-				return;
-			}
-
-			// Intercept configured history search shortcut
-			if (this.#matchesAction(canonical, "app.history.search") && this.onHistorySearch) {
-				this.onHistorySearch();
-				return;
-			}
-
-			// Intercept configured tool activity visibility toggle
-			if (this.#matchesAction(canonical, "app.tools.toggleVisibility") && this.onToggleToolActivity) {
-				this.onToggleToolActivity();
 				return;
 			}
 
@@ -1166,13 +1130,12 @@ export class CustomEditor extends Editor {
 
 	/**
 	 * Route a keystroke through the base text-editor pipeline only, skipping the
-	 * app-level shortcut interception in {@link handleInput} (Agent Hub, model
-	 * selector, history search, external editor, …). Used when the editor is
-	 * mounted for draft editing beneath another focused surface — e.g. an Ask
-	 * dialog opened over a non-empty prompt — so finishing or submitting the
-	 * draft can never fire an editor-slot shortcut that clears `editorContainer`
-	 * and orphans the overlay. Only text editing, cursor movement, submission,
-	 * and the clear action reach the buffer.
+	 * editor-scoped shortcut interception in {@link handleInput}. Used when the
+	 * editor is mounted for draft editing beneath another focused surface — e.g.
+	 * an Ask dialog opened over a non-empty prompt — so finishing or submitting
+	 * the draft cannot fire an editor-slot shortcut that clears
+	 * `editorContainer` and orphans the overlay. Only text editing, cursor
+	 * movement, submission, and the clear action reach the buffer.
 	 */
 	handleDraftEdit(data: string): void {
 		// The base editor reserves Ctrl+C for parent handling and returns without

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -8,6 +8,7 @@ import { resolveLocalRoot } from "../../internal-urls";
 import { AskDialogComponent } from "../../modes/components/ask-dialog";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { extractImagePathFromText } from "../../modes/components/custom-editor";
+import { HistorySearchComponent } from "../../modes/components/history-search";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
 import { renderSegmentTrack } from "../../modes/components/segment-track";
 import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-title-download-progress";
@@ -196,6 +197,7 @@ export class InputController {
 	#focusedPasteListenerInstalled = false;
 	#btwBranchListenerInstalled = false;
 	#btwCopyListenerInstalled = false;
+	#globalEditorActionsListenerInstalled = false;
 	#expandToolsListenerInstalled = false;
 
 	/** Return the last full editor snapshot delivered by its change contract. */
@@ -306,6 +308,51 @@ export class InputController {
 				if (!this.ctx.keybindings.matches(data, "app.clipboard.pasteImage")) return undefined;
 				void this.handleImagePaste();
 				return { consume: true };
+			});
+		}
+		if (!this.#globalEditorActionsListenerInstalled) {
+			this.#globalEditorActionsListenerInstalled = true;
+			// These actions target the main transcript/editor rather than the
+			// focused prompt. Keep focused components' own bindings authoritative.
+			this.ctx.ui.addInputListener(data => {
+				if (this.ctx.keybindings.matches(data, "app.thinking.toggle")) {
+					if (this.ctx.ui.hasOverlay()) return undefined;
+					this.ctx.toggleThinkingBlockVisibility();
+					return { consume: true };
+				}
+				if (this.ctx.keybindings.matches(data, "app.history.search")) {
+					if (this.ctx.ui.hasOverlay() || this.ctx.ui.getFocused() instanceof HistorySearchComponent) {
+						return undefined;
+					}
+					this.ctx.showHistorySearch();
+					return { consume: true };
+				}
+				if (this.ctx.keybindings.matches(data, "app.editor.external")) {
+					if (this.ctx.ui.hasOverlay()) return undefined;
+					const focused = this.ctx.ui.getFocused();
+					if (
+						focused === this.ctx.hookSelector ||
+						focused === this.ctx.hookInput ||
+						focused === this.ctx.hookEditor
+					) {
+						return undefined;
+					}
+					void this.openExternalEditor();
+					return { consume: true };
+				}
+				if (this.ctx.keybindings.matches(data, "app.tools.toggleVisibility")) {
+					if (this.ctx.ui.hasOverlay()) return undefined;
+					const focused = this.ctx.ui.getFocused();
+					if (
+						focused instanceof TreeSelectorComponent &&
+						(matchesKey(data, "shift+ctrl+o") || matchesKey(data, "ctrl+shift+o"))
+					) {
+						return undefined;
+					}
+					this.toggleToolActivityVisibility();
+					return { consume: true };
+				}
+				return undefined;
 			});
 		}
 		if (!this.#expandToolsListenerInstalled) {
@@ -509,12 +556,6 @@ export class InputController {
 		this.ctx.ui.onDebug = () => this.ctx.showDebugSelector();
 		this.ctx.editor.setActionKeys("app.model.select", this.ctx.keybindings.getKeys("app.model.select"));
 		this.ctx.editor.onSelectModel = () => this.ctx.showModelSelector();
-		this.ctx.editor.setActionKeys("app.history.search", this.ctx.keybindings.getKeys("app.history.search"));
-		this.ctx.editor.onHistorySearch = () => this.ctx.showHistorySearch();
-		this.ctx.editor.setActionKeys("app.thinking.toggle", this.ctx.keybindings.getKeys("app.thinking.toggle"));
-		this.ctx.editor.onToggleThinking = () => this.ctx.toggleThinkingBlockVisibility();
-		this.ctx.editor.setActionKeys("app.editor.external", this.ctx.keybindings.getKeys("app.editor.external"));
-		this.ctx.editor.onExternalEditor = () => void this.openExternalEditor();
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.pasteImage",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteImage"),
@@ -532,11 +573,6 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
 		);
 		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
-		this.ctx.editor.setActionKeys(
-			"app.tools.toggleVisibility",
-			this.ctx.keybindings.getKeys("app.tools.toggleVisibility"),
-		);
-		this.ctx.editor.onToggleToolActivity = () => this.toggleToolActivityVisibility();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.retry", this.ctx.keybindings.getKeys("app.retry"));

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -9,6 +9,7 @@ import { AskDialogComponent } from "../../modes/components/ask-dialog";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { extractImagePathFromText } from "../../modes/components/custom-editor";
 import { HistorySearchComponent } from "../../modes/components/history-search";
+import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
 import { renderSegmentTrack } from "../../modes/components/segment-track";
 import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-title-download-progress";
@@ -331,9 +332,9 @@ export class InputController {
 					if (this.ctx.ui.hasOverlay()) return undefined;
 					const focused = this.ctx.ui.getFocused();
 					if (
+						focused instanceof HookEditorComponent ||
 						focused === this.ctx.hookSelector ||
-						focused === this.ctx.hookInput ||
-						focused === this.ctx.hookEditor
+						focused === this.ctx.hookInput
 					) {
 						return undefined;
 					}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -172,14 +172,20 @@ export class SelectorController {
 	}
 
 	/**
-	 * Shows a selector component in place of the editor.
-	 * @param create Factory that receives a `done` callback and returns the component and focus target
+	 * Temporarily replaces the editor slot with a selector, restoring the prior
+	 * slot contents and focus when the selector finishes.
 	 */
 	showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {
+		const previousChildren = [...this.ctx.editorContainer.children];
+		const previousFocus = this.ctx.ui.getFocused();
 		const done = () => {
 			this.ctx.editorContainer.clear();
-			this.ctx.editorContainer.addChild(this.ctx.editor);
-			this.ctx.ui.setFocus(this.ctx.editor);
+			for (const child of previousChildren) this.ctx.editorContainer.addChild(child);
+			const focus =
+				previousFocus && previousChildren.includes(previousFocus)
+					? previousFocus
+					: (previousChildren[0] ?? this.ctx.editor);
+			this.ctx.ui.setFocus(focus);
 		};
 		const { component, focus } = create(done);
 		this.ctx.editorContainer.clear();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -19,17 +19,6 @@ describe("CustomEditor keybindings", () => {
 		expect(onRetry).toHaveBeenCalledTimes(1);
 	});
 
-	it("routes the configured tool activity visibility chord through handleInput", () => {
-		const editor = new CustomEditor(getEditorTheme());
-		const onToggleToolActivity = vi.fn();
-
-		editor.setActionKeys("app.tools.toggleVisibility", ["alt+h"]);
-		editor.onToggleToolActivity = onToggleToolActivity;
-		editor.handleInput("\x1bh");
-
-		expect(onToggleToolActivity).toHaveBeenCalledTimes(1);
-	});
-
 	it("lets custom handlers keep precedence over the default retry chord", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onRetry = vi.fn();

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -21,12 +21,8 @@ type FakeEditor = {
 	onSelectModelTemporary?: () => void;
 	onSelectModel?: () => void;
 	onLeftAtStart?: () => void;
-	onHistorySearch?: () => void;
 	onPasteImage?: () => void;
 	onCopyPrompt?: () => void;
-	onExpandTools?: () => void;
-	onToggleThinking?: () => void;
-	onExternalEditor?: () => void;
 	onDequeue?: () => void;
 	onChange?: (text: string) => void;
 	setText(text: string): void;

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -719,7 +719,7 @@ describe("InputController global editor actions", () => {
 		expect(context.ctx.toggleThinkingBlockVisibility).not.toHaveBeenCalled();
 	});
 
-	it("defers external editing to a focused hook editor", async () => {
+	it("defers external editing to a focused ask-dialog prompt editor untracked by ctx.hookEditor", async () => {
 		const context = await createContext();
 		const controller = new context.InputController(context.ctx);
 		const openExternalEditor = vi.spyOn(controller, "openExternalEditor").mockResolvedValue();
@@ -731,7 +731,8 @@ describe("InputController global editor actions", () => {
 			() => {},
 			() => {},
 		);
-		context.ctx.hookEditor = hookEditor;
+		// The ask dialog's "Other" prompt focuses a HookEditorComponent without
+		// assigning ctx.hookEditor; the defer must recognize it structurally.
 		context.setFocused(hookEditor);
 		const listeners = registeredInputListeners(context.spies.addInputListener);
 

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { AskDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
+import { HookEditorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/hook-editor";
 import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -20,13 +21,8 @@ type FakeEditor = {
 	onCycleModelBackward?: () => void;
 	onSelectModelTemporary?: () => void;
 	onSelectModel?: () => void;
-	onHistorySearch?: () => void;
 	onPasteImage?: () => Promise<boolean>;
 	onCopyPrompt?: () => void;
-	onExpandTools?: () => void;
-	onToggleToolActivity?: () => void;
-	onToggleThinking?: () => void;
-	onExternalEditor?: () => void;
 	onRetry?: () => void;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => Promise<void>;
@@ -65,6 +61,9 @@ async function createContext() {
 	let editorText = "";
 	const keyMap: Record<string, KeyId[]> = {
 		"app.display.reset": ["ctrl+l"],
+		"app.thinking.toggle": ["ctrl+t"],
+		"app.history.search": ["ctrl+r"],
+		"app.editor.external": ["ctrl+g"],
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["alt+m"],
 		"app.retry": ["alt+r"],
@@ -297,24 +296,6 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplayAfterAppearanceRefresh).toHaveBeenCalledTimes(1);
-	});
-
-	it("registers the tool activity visibility action", async () => {
-		const { InputController, ctx, editor, spies } = await createContext();
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-
-		expect(spies.setActionKeys).toHaveBeenCalledWith("app.tools.toggleVisibility", ["ctrl+shift+o"]);
-		expect(editor.onToggleToolActivity).toBeDefined();
-
-		editor.onToggleToolActivity?.();
-
-		expect(ctx.hideToolActivity).toBe(true);
-		expect(ctx.settings.set).toHaveBeenCalledWith("display.hideToolActivity", true);
-		expect(spies.clearInlineImages).toHaveBeenCalledTimes(1);
-		expect(spies.requestRender).toHaveBeenCalledWith(true);
-		expect(ctx.chatContainer.setToolActivityVisible).toHaveBeenCalledWith(false);
 	});
 
 	it("does not mark pasted shell prompts as Python mode while editing", async () => {
@@ -681,6 +662,106 @@ describe("InputController keybinding setup", () => {
 				userInitiated: true,
 			});
 		}
+	});
+});
+
+describe("InputController global editor actions", () => {
+	const CTRL_T = "\x14";
+	const CTRL_R = "\x12";
+	const CTRL_G = "\x07";
+	const CTRL_SHIFT_O = "\x1b[111;6u";
+
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	it("routes shortcuts while an ask dialog holds focus", async () => {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		const openExternalEditor = vi.spyOn(controller, "openExternalEditor").mockResolvedValue();
+		controller.setupKeyHandlers();
+		const listeners = registeredInputListeners(context.spies.addInputListener);
+		const dialog = new AskDialogComponent([{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }] }], {
+			onSubmit: () => {},
+			onCancel: () => {},
+			onPrompt: async () => undefined,
+		});
+		context.setFocused(dialog);
+
+		expect(dispatchInput(listeners, CTRL_T)).toEqual({ consume: true });
+		expect(context.ctx.toggleThinkingBlockVisibility).toHaveBeenCalledTimes(1);
+		expect(dispatchInput(listeners, CTRL_R)).toEqual({ consume: true });
+		expect(context.ctx.showHistorySearch).toHaveBeenCalledTimes(1);
+		expect(dispatchInput(listeners, CTRL_G)).toEqual({ consume: true });
+		expect(openExternalEditor).toHaveBeenCalledTimes(1);
+		expect(dispatchInput(listeners, CTRL_SHIFT_O)).toEqual({ consume: true });
+		expect(context.ctx.hideToolActivity).toBe(true);
+	});
+
+	it("still routes transcript actions when the main editor holds focus", async () => {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		controller.setupKeyHandlers();
+		const listeners = registeredInputListeners(context.spies.addInputListener);
+
+		expect(dispatchInput(listeners, CTRL_T)).toEqual({ consume: true });
+		expect(context.ctx.toggleThinkingBlockVisibility).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers while an overlay owns the active surface", async () => {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		controller.setupKeyHandlers();
+		context.setOverlayVisible(true);
+		const listeners = registeredInputListeners(context.spies.addInputListener);
+
+		expect(dispatchInput(listeners, CTRL_T)).toBeUndefined();
+		expect(context.ctx.toggleThinkingBlockVisibility).not.toHaveBeenCalled();
+	});
+
+	it("defers external editing to a focused hook editor", async () => {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		const openExternalEditor = vi.spyOn(controller, "openExternalEditor").mockResolvedValue();
+		controller.setupKeyHandlers();
+		const hookEditor = new HookEditorComponent(
+			context.ctx.ui,
+			"Edit",
+			undefined,
+			() => {},
+			() => {},
+		);
+		context.ctx.hookEditor = hookEditor;
+		context.setFocused(hookEditor);
+		const listeners = registeredInputListeners(context.spies.addInputListener);
+
+		expect(dispatchInput(listeners, CTRL_G)).toBeUndefined();
+		expect(openExternalEditor).not.toHaveBeenCalled();
+	});
+
+	it("defers the tree selector's Ctrl+Shift+O filter binding", async () => {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		controller.setupKeyHandlers();
+		const tree = [
+			{
+				entry: { id: "root", type: "message", parentId: null, message: { role: "user", content: "hi" } },
+				children: [],
+			},
+		] as unknown as SessionTreeNode[];
+		context.setFocused(
+			new TreeSelectorComponent(
+				tree,
+				"root",
+				20,
+				() => {},
+				() => {},
+			),
+		);
+		const listeners = registeredInputListeners(context.spies.addInputListener);
+
+		expect(dispatchInput(listeners, CTRL_SHIFT_O)).toBeUndefined();
+		expect(context.ctx.hideToolActivity).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
@@ -5,6 +5,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Text } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	await initTheme();
@@ -32,12 +33,13 @@ function createEditorSlot(...initial: unknown[]): EditorSlot {
 	};
 }
 
-function createCtx(slot: EditorSlot, editor: unknown) {
+function createCtx(slot: EditorSlot, editor: unknown, focused: unknown = editor) {
 	const setFocus = vi.fn();
 	const ctx = {
 		editor,
 		editorContainer: slot,
 		ui: {
+			getFocused: vi.fn(() => focused),
 			setFocus,
 			requestRender: vi.fn(),
 		},
@@ -88,6 +90,29 @@ describe("SelectorController.focusActiveEditorArea", () => {
 
 		expect(setFocus).toHaveBeenCalledTimes(1);
 		expect(setFocus).toHaveBeenCalledWith(editor);
+	});
+});
+
+describe("SelectorController.showSelector", () => {
+	it("restores an ask dialog and its draft editor after history search closes", () => {
+		const editor = new Text("editor", 0, 0);
+		const askDialog = new Text("ask", 0, 0);
+		const historySearch = new Text("history", 0, 0);
+		const slot = createEditorSlot(askDialog, editor);
+		const { ctx, setFocus } = createCtx(slot, editor, askDialog);
+		let finish: (() => void) | undefined;
+
+		new SelectorController(ctx).showSelector(done => {
+			finish = done;
+			return { component: historySearch, focus: historySearch };
+		});
+
+		expect(slot.children).toEqual([historySearch]);
+		expect(setFocus).toHaveBeenLastCalledWith(historySearch);
+		if (!finish) throw new Error("selector did not provide its completion callback");
+		finish();
+		expect(slot.children).toEqual([askDialog, editor]);
+		expect(setFocus).toHaveBeenLastCalledWith(askDialog);
 	});
 });
 


### PR DESCRIPTION
## Repro
With an `AskDialogComponent` focused, `bun test packages/coding-agent/test/input-controller-keybindings.test.ts` reproduced Ctrl+T returning `undefined` from global input dispatch instead of `{ consume: true }`; Ctrl+R, Ctrl+G, and Ctrl+Shift+O shared the same editor-only path.

## Cause
`InputController.setupKeyHandlers()` in `packages/coding-agent/src/modes/controllers/input-controller.ts` wired these actions only through `CustomEditor.handleInput()`, while TUI focus dispatch sent ask-dialog input exclusively to `AskDialogComponent`; no listener could route the actions to their application handlers.

## Fix
- Promote thinking visibility, history search, external editing, and tool activity visibility to global TUI listeners, while deferring to overlays and focused components that own the same keys.
- Remove the obsolete `CustomEditor` action handlers and key tables.
- Restore the prior editor-slot contents and focus after nested history search, keeping the active ask dialog answerable.
- Add ask-focus, editor-focus, overlay, hook-editor, tree-selector, and selector-restoration regression coverage.

## Verification
`bun test packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/input-controller-escape.test.ts` passes: 84 tests, 260 assertions. `bun check` passes in `packages/coding-agent`. The source TUI smoke was blocked by an unrelated pre-existing `editDescription is not a function` startup crash. Skipped the root pre-publish gate because `bun check` fails identically on a clean `origin/main` archive: `audiopus_sys` cannot execute the unavailable `cmake` binary.

Fixes #11213