### PR TITLE
fix(eval): expose preludes to Python shortcuts

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3749,6 +3749,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			slashCommands,
 			extensionRunner,
 			getEvalPreludes,
+			evalToolSession: toolSession,
 			customCommands: customCommandsResult.commands,
 			skills,
 			skillWarnings,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -37,6 +37,7 @@ import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { ConfiguredThinkingLevel } from "../thinking";
+import type { ToolSession } from "../tools";
 import type { XdevState } from "../tools/xdev";
 import type { CodexAutoRedeemCoordinator } from "./codex-auto-reset";
 import type { SessionManager } from "./session-manager";
@@ -178,6 +179,8 @@ export interface AgentSessionConfig {
 	extensionRunner?: ExtensionRunner;
 	/** Returns the current enabled eval prelude definitions. */
 	getEvalPreludes?: () => readonly EvalPreludeDefinition[];
+	/** Tool bridge context used by user-initiated Python cells to project enabled eval preludes. */
+	evalToolSession?: ToolSession;
 	/** Loaded skills already discovered by the SDK. */
 	skills?: Skill[];
 	/** Skill loading warnings already captured by the SDK. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1177,6 +1177,7 @@ export class AgentSession {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
 			settings: this.settings,
+			evalToolSession: config.evalToolSession,
 			extensionRunner: () => this.#extensionRunner,
 			isStreaming: () => this.isStreaming,
 			appendSessionMessage: message => {

--- a/packages/coding-agent/src/session/eval-runner.ts
+++ b/packages/coding-agent/src/session/eval-runner.ts
@@ -10,6 +10,7 @@ import {
 } from "../eval/py/executor";
 import { defaultEvalSessionId } from "../eval/session-id";
 import type { ExtensionRunner } from "../extensibility/extensions";
+import type { ToolSession } from "../tools";
 import { outputMeta } from "../tools/output-meta";
 import type { PythonExecutionMessage } from "./messages";
 import type { SessionManager } from "./session-manager";
@@ -20,6 +21,7 @@ export interface EvalRunnerHost {
 	sessionManager: SessionManager;
 	settings: Settings;
 	extensionRunner(): ExtensionRunner | undefined;
+	evalToolSession?: ToolSession;
 	isStreaming(): boolean;
 	appendSessionMessage(message: PythonExecutionMessage): void;
 }
@@ -79,6 +81,7 @@ export class EvalRunner {
 				interpreter: this.#host.settings.get("python.interpreter")?.trim() || undefined,
 				onChunk,
 				signal: abortController.signal,
+				toolSession: this.#host.evalToolSession,
 			});
 			this.recordPythonResult(code, result, options);
 			return result;

--- a/packages/coding-agent/src/tools/computer/prelude.py
+++ b/packages/coding-agent/src/tools/computer/prelude.py
@@ -41,6 +41,8 @@ def _make_computer():
                 "action": action,
             },
         )
+        if isinstance(response, str):
+            return {}
         if not isinstance(response, dict):
             raise RuntimeError("computer returned an invalid response")
         text = response.get("text")

--- a/packages/coding-agent/test/sdk-computer-prelude-toggle.test.ts
+++ b/packages/coding-agent/test/sdk-computer-prelude-toggle.test.ts
@@ -83,6 +83,34 @@ describe("AgentSession eval preludes", () => {
 		expect(session.getEvalPreludes().map(definition => definition.name)).toEqual(["browser"]);
 	});
 
+	it("exposes enabled host preludes to user-initiated Python cells", async () => {
+		const settings = Settings.isolated({
+			"browser.enabled": false,
+			"computer.enabled": true,
+		});
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		sessions.push(session);
+
+		const result = await session.executePython("print(computer is not None)");
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("True");
+	});
+
 	it("reconciles browser MCP filtering on live browser toggles", async () => {
 		const manager = new MCPManager(registryDir, null, async () => ({
 			configs: {},

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -698,6 +698,44 @@ describe("computer prelude", () => {
 		]);
 	});
 
+	it("treats text-only Python host responses as unavailable capabilities", async () => {
+		const calls: unknown[] = [];
+		let definitions: readonly EvalPreludeDefinition[] = [];
+		const session: ToolSession = {
+			...toolSession(),
+			getEvalPreludes: () => definitions,
+		};
+		const shipped = createComputerPrelude(session, () => ({
+			async run() {
+				return { displays: [], returnValue: undefined, screenshots: [] };
+			},
+			async capabilities() {
+				return undefined;
+			},
+			async close() {},
+		}));
+		definitions = [
+			{
+				...shipped,
+				async invoke(parameters) {
+					calls.push(parameters);
+					return { content: [{ type: "text", text: "Computer capabilities unavailable" }] };
+				},
+			},
+		];
+
+		const result = await executePython("print(await computer.capabilities())", {
+			cwd: process.cwd(),
+			sessionId: `computer-unavailable-py-${crypto.randomUUID()}`,
+			toolSession: session,
+			kernelMode: "per-call",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("None");
+		expect(calls).toEqual([{ action: "capabilities" }]);
+	});
+
 	it("reflects the live enabled setting", () => {
 		const session = toolSession();
 		const prelude = createComputerPrelude(session, () => ({


### PR DESCRIPTION
## Problem

Enabled eval preludes are available through the model-facing `eval` tool, but user-initiated `$` Python cells bypass the SDK `ToolSession`. As a result, `/computer status` reports an active prelude while `computer` raises `NameError` in the Python shortcut.

A second edge appears once the prelude is projected: text-only host responses (for example unavailable capabilities with no `details`) are valid bridge results, but the Python computer facade rejects them instead of treating capabilities as unavailable like the JavaScript facade.

## Change

- pass the SDK `ToolSession` through `AgentSession`'s user Python runner
- synchronize enabled eval preludes before `$` Python cells
- accept text-only computer bridge responses as empty details
- add SDK-boundary and Python-facade regression coverage

## Verification

- `bun test packages/coding-agent/test/sdk-computer-prelude-toggle.test.ts packages/coding-agent/test/agent-session-user-shortcut-hooks.test.ts packages/coding-agent/test/eval/prelude-runtime.test.ts packages/coding-agent/test/tools/computer.test.ts`
- `bun run --cwd packages/coding-agent check:types`
- targeted `oxlint` and `oxfmt --check`
- source CLI smoke: `/computer status` reports active, `$ print(computer is not None)` prints `True`, and `$ print(await computer.capabilities())` returns `None` instead of raising when capabilities are unavailable