### PR TITLE
feat(browser): freeze idle headless tabs at turn settle with idle-clo…

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.
+- Headless browser tabs now freeze when a turn settles so idle animated/WebGL pages stop burning CPU/GPU, resuming automatically on next use; tabs idle past `browser.idleCloseSec` (default 30 minutes) are closed. `persist: true` on `browser.open` opts a tab out of both ([#8246](https://github.com/can1357/oh-my-pi/issues/8246) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4588,6 +4588,34 @@ export const SETTINGS_SCHEMA = {
 				"Use cmux WKWebView surfaces for browser automation when a cmux socket is available. Set PI_BROWSER_CMUX=0 or PI_BROWSER_CMUX=1 to override.",
 		},
 	},
+	"browser.freezeOnTurnEnd": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			group: "Grep & Browser",
+			label: "Freeze Browser Tabs On Turn End",
+			description:
+				"Freeze OMP-owned headless browser tabs when a turn settles so animated pages stop burning CPU/GPU while idle. Tabs unfreeze automatically on next use; pass persist:true on open to opt a tab out.",
+		},
+	},
+	"browser.idleCloseSec": {
+		type: "number",
+		default: 1800,
+		ui: {
+			tab: "tools",
+			group: "Grep & Browser",
+			label: "Browser Idle Close Timeout",
+			description:
+				"Close OMP-owned headless browser tabs idle longer than this many seconds (0 = never; session dispose still reaps). Applies only to OMP-launched headless tabs, never relay/CDP/spawned browsers or other sessions' tabs.",
+			options: [
+				{ value: "0", label: "Never" },
+				{ value: "900", label: "15 minutes" },
+				{ value: "1800", label: "30 minutes" },
+				{ value: "3600", label: "1 hour" },
+			],
+		},
+	},
 	"browser.screenshotDir": {
 		type: "string",
 		default: undefined,

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -4,7 +4,7 @@ Drive real Chromium tabs from JavaScript or Python Eval with the global `browser
 - Static content? Use `read`. Use `browser` for JavaScript execution, authenticated sessions, and interactive actions.
 - JavaScript: `await browser.open(options)` returns a `BrowserTab`; `browser.tab(name)` returns an existing handle; `await browser.close(options)` releases tabs.
 - Python: `await browser.open(name=…, url=…)`, synchronous `browser.tab(name)`, and `await browser.close(name=…)`. Python methods accept keyword arguments.
-- `open` options: `name`, `url`, `app`, `viewport`, `wait_until`, `dialogs`, `timeout`.
+- `open` options: `name`, `url`, `app`, `viewport`, `wait_until`, `dialogs`, `timeout`, `persist`.
 - `close` options: `name`, `all`, `kill`, `timeout`.
 - Direct tab helpers:
   - Navigation: `url`, `title`, `goto`.
@@ -28,6 +28,7 @@ Application modes:
 - `app.relay: true`: drive the user's Chrome through the omp relay. `app.target` selects a tab by URL/title substring; without it, the visible tab is adopted. Opening with `url` navigates that adopted tab.
 - Relay sessions are the user's real logged-in browser. Sites attribute actions to the user. Name a target or create a dedicated tab; NEVER navigate the visible tab without authorization.
 - Closing releases the managed tab. It never closes relay/CDP-attached pages. Spawned browsers remain open unless `kill: true`.
+- Idle tabs auto-freeze at turn settle (animated pages stop burning CPU/GPU) and unfreeze on next use; tabs idle past the idle-close timeout are closed. Pass `persist: true` on `open` to keep a tab live across turns (e.g. multi-step login); `browser.close` still releases explicitly.
 </instruction>
 
 <examples>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -202,7 +202,7 @@ import { shutdownTinyTitleClient } from "../tiny/title-client";
 import type { ImageAttachmentEntry } from "../tools";
 import { resolveApproval } from "../tools/approval";
 import { type AskToolDetails, type AskToolInput, recoverAskQuestions } from "../tools/ask";
-import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
+import { freezeTabsForOwner, releaseIdleTabsForOwner, releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import type { CheckpointState, CompletedRewindState } from "../tools/checkpoint";
 import { releaseComputerSessionsForOwner } from "../tools/computer/supervisor";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
@@ -2976,6 +2976,13 @@ export class AgentSession {
 				this.#toolChoiceQueue.resolve();
 			}
 		}
+		// Settle owned headless browser tabs: freeze live pages so animated
+		// content stops burning CPU/GPU while idle (issue #8246), then close
+		// tabs idle past the timeout. Detached — tool results for this turn
+		// are already paired, and teardown must never block the event flow.
+		if (event.type === "turn_end") {
+			void this.#settleOwnedBrowserTabs();
+		}
 		if (event.type === "tool_execution_end") {
 			if (event.toolName === "goal") {
 				await this.#goalRuntime.onGoalToolCompleted();
@@ -4446,6 +4453,45 @@ export class AgentSession {
 			}
 		} catch (error) {
 			logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+		}
+	}
+
+	/**
+	 * Turn-settle checkpoint for owned headless browser tabs (issue #8246).
+	 * Freeze first so idle animated pages stop burning CPU/GPU while keeping
+	 * their state for millisecond resume, then close tabs idle past
+	 * `browser.idleCloseSec` as the memory backstop. Scoped to OMP-owned
+	 * headless tabs of this session only — relay/CDP/spawned tabs, other
+	 * sessions' tabs, and `persist` tabs are never touched. Best-effort:
+	 * never throws, so teardown cannot break the event flow.
+	 */
+	async #settleOwnedBrowserTabs(): Promise<void> {
+		const ownerId = this.sessionManager.getSessionId();
+		if (!ownerId) return;
+		try {
+			const idleSec = this.settings.get("browser.idleCloseSec");
+			if (idleSec > 0) {
+				const closed = await withTimeout(
+					releaseIdleTabsForOwner(ownerId, { idleMs: idleSec * 1000 }),
+					3_000,
+					"Timed out closing idle browser tabs at turn settle",
+				);
+				if (closed > 0) {
+					logger.debug("Closed idle owned browser tabs at turn settle", { ownerId, closed });
+				}
+			}
+			if (this.settings.get("browser.freezeOnTurnEnd")) {
+				const frozen = await withTimeout(
+					freezeTabsForOwner(ownerId),
+					3_000,
+					"Timed out freezing owned browser tabs at turn settle",
+				);
+				if (frozen > 0) {
+					logger.debug("Froze owned browser tabs at turn settle", { ownerId, frozen });
+				}
+			}
+		} catch (error) {
+			logger.warn("Failed to settle owned browser tabs at turn end", { error: String(error) });
 		}
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -203,6 +203,7 @@ import type { ImageAttachmentEntry } from "../tools";
 import { resolveApproval } from "../tools/approval";
 import { type AskToolDetails, type AskToolInput, recoverAskQuestions } from "../tools/ask";
 import {
+	armIdleCloseForOwner,
 	cancelIdleCloseForOwner,
 	freezeTabsForOwner,
 	releaseIdleTabsForOwner,
@@ -1843,11 +1844,16 @@ export class AgentSession {
 			});
 		});
 		this.#unsubscribeIdleCloseSetting = this.settings.onEffectiveChange((path, value) => {
-			// Dropping the idle-close timeout to "never" at runtime must
-			// invalidate a deadline armed under the previous value; the
-			// turn/open checkpoints below only cancel when they run.
-			if (path !== "browser.idleCloseSec" || value) return;
-			cancelIdleCloseForOwner(this.sessionManager.getSessionId() ?? "");
+			if (path !== "browser.idleCloseSec") return;
+			const ownerId = this.sessionManager.getSessionId() ?? "";
+			// Any change invalidates the armed deadline: cancel first (its
+			// sequence bump stops an in-flight sweep re-arming the old
+			// value), then re-arm under the new one. A non-positive value
+			// arms nothing, which is the disable path.
+			cancelIdleCloseForOwner(ownerId);
+			if (typeof value === "number" && value > 0) {
+				armIdleCloseForOwner(ownerId, value * 1000);
+			}
 		});
 		this.#unsubscribeCodeMode = onCodeModeChanged(() => {
 			void this.#tools.reconcileCodeMode().catch(error => {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -202,7 +202,12 @@ import { shutdownTinyTitleClient } from "../tiny/title-client";
 import type { ImageAttachmentEntry } from "../tools";
 import { resolveApproval } from "../tools/approval";
 import { type AskToolDetails, type AskToolInput, recoverAskQuestions } from "../tools/ask";
-import { freezeTabsForOwner, releaseIdleTabsForOwner, releaseTabsForOwner } from "../tools/browser/tab-supervisor";
+import {
+	cancelIdleCloseForOwner,
+	freezeTabsForOwner,
+	releaseIdleTabsForOwner,
+	releaseTabsForOwner,
+} from "../tools/browser/tab-supervisor";
 import type { CheckpointState, CompletedRewindState } from "../tools/checkpoint";
 import { releaseComputerSessionsForOwner } from "../tools/computer/supervisor";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
@@ -4479,6 +4484,10 @@ export class AgentSession {
 				if (closed > 0) {
 					logger.debug("Closed idle owned browser tabs at turn settle", { ownerId, closed });
 				}
+			} else {
+				// Idle close disabled at runtime: drop any deadline armed
+				// under a previous positive value so it cannot fire stale.
+				cancelIdleCloseForOwner(ownerId);
 			}
 			if (this.settings.get("browser.freezeOnTurnEnd")) {
 				const frozen = await withTimeout(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -584,6 +584,7 @@ export class AgentSession {
 	#unsubscribeExtendedContext?: () => void;
 	#unsubscribeCodeMode?: () => void;
 	#unsubscribeEvalPreludeSettings?: () => void;
+	#unsubscribeIdleCloseSetting?: () => void;
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
@@ -1841,6 +1842,13 @@ export class AgentSession {
 				});
 			});
 		});
+		this.#unsubscribeIdleCloseSetting = this.settings.onEffectiveChange((path, value) => {
+			// Dropping the idle-close timeout to "never" at runtime must
+			// invalidate a deadline armed under the previous value; the
+			// turn/open checkpoints below only cancel when they run.
+			if (path !== "browser.idleCloseSec" || value) return;
+			cancelIdleCloseForOwner(this.sessionManager.getSessionId() ?? "");
+		});
 		this.#unsubscribeCodeMode = onCodeModeChanged(() => {
 			void this.#tools.reconcileCodeMode().catch(error => {
 				logger.warn("Code Mode reconcile after setting change failed", { error: String(error) });
@@ -2981,10 +2989,11 @@ export class AgentSession {
 				this.#toolChoiceQueue.resolve();
 			}
 		}
-		// Settle owned headless browser tabs: freeze live pages so animated
-		// content stops burning CPU/GPU while idle (issue #8246), then close
-		// tabs idle past the timeout. Detached — tool results for this turn
-		// are already paired, and teardown must never block the event flow.
+		// Settle owned headless browser tabs: close tabs idle past the
+		// timeout, then freeze the survivors so animated content stops
+		// burning CPU/GPU while idle (issue #8246). Detached — tool results
+		// for this turn are already paired, and teardown must never block
+		// the event flow.
 		if (event.type === "turn_end") {
 			void this.#settleOwnedBrowserTabs();
 		}
@@ -4463,9 +4472,9 @@ export class AgentSession {
 
 	/**
 	 * Turn-settle checkpoint for owned headless browser tabs (issue #8246).
-	 * Freeze first so idle animated pages stop burning CPU/GPU while keeping
-	 * their state for millisecond resume, then close tabs idle past
-	 * `browser.idleCloseSec` as the memory backstop. Scoped to OMP-owned
+	 * Close tabs idle past `browser.idleCloseSec` as the memory backstop,
+	 * then freeze the survivors so idle animated pages stop burning CPU/GPU
+	 * while keeping their state for millisecond resume. Scoped to OMP-owned
 	 * headless tabs of this session only — relay/CDP/spawned tabs, other
 	 * sessions' tabs, and `persist` tabs are never touched. Best-effort:
 	 * never throws, so teardown cannot break the event flow.
@@ -4631,6 +4640,10 @@ export class AgentSession {
 		if (this.#unsubscribeEvalPreludeSettings) {
 			this.#unsubscribeEvalPreludeSettings();
 			this.#unsubscribeEvalPreludeSettings = undefined;
+		}
+		if (this.#unsubscribeIdleCloseSetting) {
+			this.#unsubscribeIdleCloseSetting();
+			this.#unsubscribeIdleCloseSetting = undefined;
 		}
 		this.#eventListeners = [];
 		this.#runStateListeners.clear();

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -1,6 +1,6 @@
 import { type } from "@oh-my-pi/omptype";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
 import type { EvalPreludeContext, EvalPreludeDefinition } from "../eval/preludes";
 import browserDescription from "../prompts/tools/browser.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
@@ -28,6 +28,7 @@ import {
 	dropHeadlessTabs,
 	getTab,
 	releaseAllTabs,
+	releaseIdleTabsForOwner,
 	releaseTab,
 	runInTab,
 } from "./browser/tab-supervisor";
@@ -82,6 +83,7 @@ const browserSchema = type({
 	"timeout?": type("number").describe("timeout in seconds"),
 	"all?": type("boolean").describe("release every managed tab"),
 	"kill?": type("boolean").describe("also kill spawned-app browsers"),
+	"persist?": type("boolean").describe("keep tab live across turn settle and idle close"),
 });
 
 type BrowserParams = typeof browserSchema.infer;
@@ -156,6 +158,23 @@ export function createBrowserPrelude(session: ToolSession): EvalPreludeDefinitio
 /** Drop headless tabs so a browser mode change applies to the next open. */
 export async function restartBrowserForModeChange(): Promise<void> {
 	await dropHeadlessTabs();
+}
+
+/**
+ * Best-effort idle-close sweep for the calling session's owned headless
+ * tabs. Never throws — callers detach it (`void`) so a slow reap cannot
+ * delay the open it follows.
+ */
+function sweepIdleOwnedTabs(session: ToolSession): Promise<number> {
+	const ownerId = session.getSessionId?.() ?? undefined;
+	const idleSec = session.settings.get("browser.idleCloseSec");
+	if (!ownerId || !(idleSec > 0)) return Promise.resolve(0);
+	return releaseIdleTabsForOwner(ownerId, { idleMs: idleSec * 1000 }).catch((error: unknown) => {
+		logger.debug("Browser idle-close sweep failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return 0;
+	});
 }
 
 async function invokeBrowser(
@@ -267,6 +286,9 @@ async function openBrowser(
 					dialogs: params.dialogs,
 					signal: openSignal,
 					ownerSessionId: session.getSessionId?.() ?? undefined,
+					// Recorded on the tab at creation only; later reuse
+					// cannot extend another session's tab lifetime.
+					persist: params.persist ?? false,
 				}),
 			);
 		} catch (error) {
@@ -276,6 +298,13 @@ async function openBrowser(
 			throw error;
 		}
 		await releaseBrowser(browser, { kill: false });
+		// Opportunistic idle-close sweep for long turns that rarely settle:
+		// close owned tabs idle past the timeout. Detached by design (same
+		// as the orphan-target sweep on attach) — failures only log. Freeze
+		// is deliberately NOT done here: freezing a sibling with an
+		// in-flight run would stall it mid-execution, while turn_end is
+		// race-free by construction (all tool results are paired).
+		void sweepIdleOwnedTabs(session);
 
 		const tab = result.tab;
 		const url = tab.info.url;

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -291,9 +291,9 @@ async function openBrowser(
 					dialogs: params.dialogs,
 					signal: openSignal,
 					ownerSessionId: session.getSessionId?.() ?? undefined,
-					// Recorded on the tab at creation only; later reuse
-					// cannot extend another session's tab lifetime.
-					persist: params.persist ?? false,
+					// Omitted stays undefined: creation defaults it to false
+					// while reuse by the owner leaves a set value alone.
+					persist: params.persist,
 				}),
 			);
 		} catch (error) {

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -25,6 +25,7 @@ import type { OutputMeta } from "./output-meta";
 import {
 	type AcquireTabResult,
 	acquireTab,
+	cancelIdleCloseForOwner,
 	dropHeadlessTabs,
 	getTab,
 	releaseAllTabs,
@@ -167,8 +168,12 @@ export async function restartBrowserForModeChange(): Promise<void> {
  */
 function sweepIdleOwnedTabs(session: ToolSession): Promise<number> {
 	const ownerId = session.getSessionId?.() ?? undefined;
+	if (!ownerId) return Promise.resolve(0);
 	const idleSec = session.settings.get("browser.idleCloseSec");
-	if (!ownerId || !(idleSec > 0)) return Promise.resolve(0);
+	if (!(idleSec > 0)) {
+		cancelIdleCloseForOwner(ownerId);
+		return Promise.resolve(0);
+	}
 	return releaseIdleTabsForOwner(ownerId, { idleMs: idleSec * 1000 }).catch((error: unknown) => {
 		logger.debug("Browser idle-close sweep failed", {
 			error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/src/tools/browser/declarations.d.ts
+++ b/packages/coding-agent/src/tools/browser/declarations.d.ts
@@ -39,6 +39,8 @@ interface BrowserOpenOptions {
 	wait_until?: BrowserWaitUntil;
 	/** Automatic JavaScript-dialog policy. */
 	dialogs?: "accept" | "dismiss";
+	/** Keep the tab live across turn settle and idle close (default false). */
+	persist?: boolean;
 	/** Whole-operation timeout in seconds. */
 	timeout?: number;
 }

--- a/packages/coding-agent/src/tools/browser/prelude.py
+++ b/packages/coding-agent/src/tools/browser/prelude.py
@@ -246,6 +246,7 @@ def _make_browser():
             viewport=None,
             wait_until=None,
             dialogs=None,
+            timeout=None,
             persist=None,
         ):
             """Open or attach to a browser tab and return its handle."""
@@ -260,6 +261,7 @@ def _make_browser():
                     "viewport": viewport,
                     "wait_until": wait_until,
                     "dialogs": dialogs,
+                    "timeout": timeout,
                     "persist": persist,
                 },
             )

--- a/packages/coding-agent/src/tools/browser/prelude.py
+++ b/packages/coding-agent/src/tools/browser/prelude.py
@@ -246,7 +246,7 @@ def _make_browser():
             viewport=None,
             wait_until=None,
             dialogs=None,
-            timeout=None,
+            persist=None,
         ):
             """Open or attach to a browser tab and return its handle."""
             if name is not None:
@@ -260,7 +260,7 @@ def _make_browser():
                     "viewport": viewport,
                     "wait_until": wait_until,
                     "dialogs": dialogs,
-                    "timeout": timeout,
+                    "persist": persist,
                 },
             )
             opened_name = details.get("name")

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -550,6 +550,10 @@ async function runInTabWithSnapshot(
 		);
 	}
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
+	// An already-aborted call never runs: without this early exit the worker
+	// branch below would send `abort` before `run`, which the worker ignores
+	// for a not-yet-active run and then execute anyway.
+	if (opts.signal?.aborted) throw new ToolAbortError();
 	// A run is use: refresh the idle clock for idle-close.
 	tab.lastActivityAt = Date.now();
 	const id = Snowflake.next();
@@ -585,6 +589,11 @@ async function runInTabWithSnapshot(
 	// subagent is reusing between our unfreeze check and this registration,
 	// stalling timer/rAF-dependent code to timeout.
 	tab.pending.set(id, pending);
+	// Observe the run promise from registration on: every exit below this
+	// point (resume failure, teardown race) throws before the backends
+	// attach their consumers, and an unobserved `pending.reject` would fire
+	// `unhandledRejection` and tear the whole session down (issue #4499).
+	promise.catch(() => undefined);
 	// Resume a settle-frozen page before driving it — frozen rAF/timers would
 	// otherwise hang the execution below. A refused resume fails the run
 	// here with an actionable error instead of stalling to timeout.
@@ -592,14 +601,19 @@ async function runInTabWithSnapshot(
 		tab.pending.delete(id);
 		throw new ToolError(`Tab ${JSON.stringify(name)} is frozen and could not be resumed. Close and reopen it.`);
 	}
+	// An abort that landed during the resume roundtrip must not dispatch:
+	// the worker ignores `abort` for a run that was never started.
+	if (opts.signal?.aborted) {
+		tab.pending.delete(id);
+		throw new ToolAbortError();
+	}
 	const current = tabs.get(name);
 	if (current !== tab || current.state === "dead") {
 		// A teardown won the race with our unfreeze roundtrip. Prefer its
 		// close error when one was recorded (`releaseTab` rejects `pending`
 		// synchronously, so it is already settled here); otherwise surface
 		// the closure. `race` — not a bare `await promise` — so a teardown
-		// that never settled the run cannot hang us, and `race` observes
-		// every rejection (issue #4499).
+		// that never settled the run cannot hang us.
 		tab.pending.delete(id);
 		const notAlive = new ToolError(`Tab ${JSON.stringify(name)} is not alive. Open it first with action:"open".`);
 		return await Promise.race([promise, Promise.reject(notAlive)]);
@@ -1000,17 +1014,31 @@ export async function releaseIdleTabsForOwner(
 		.filter(tab => isIdleCloseCandidate(tab, ownerId, now, opts.idleMs))
 		.map(tab => tab.name);
 	let count = 0;
-	for (const name of names) {
-		// Revalidate immediately before closing: an earlier close in this
-		// loop awaits worker cleanup, during which a later candidate may
-		// have been reused or started a run.
-		const current = tabs.get(name);
-		if (!current || !isIdleCloseCandidate(current, ownerId, Date.now(), opts.idleMs)) continue;
-		if (await releaseTab(name, opts)) count++;
+	try {
+		for (const name of names) {
+			// Revalidate immediately before closing: an earlier close in this
+			// loop awaits worker cleanup, during which a later candidate may
+			// have been reused or started a run.
+			const current = tabs.get(name);
+			if (!current || !isIdleCloseCandidate(current, ownerId, Date.now(), opts.idleMs)) continue;
+			try {
+				if (await releaseTab(name, opts)) count++;
+			} catch (error) {
+				// One tab's wedged cleanup must not abandon the remaining
+				// candidates; the tab is already removed from the map, so
+				// the next sweep (or close path) retries it.
+				logger.debug("Failed to close idle browser tab; continuing sweep", {
+					name,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	} finally {
+		// Leave the next deadline armed even when a close threw: sweeps only
+		// fire on turns, opens, and timer callbacks, so without this the
+		// survivors would never close.
+		armIdleCloseForOwner(ownerId, opts.idleMs);
 	}
-	// Leave the next deadline armed: sweeps only fire on turns, opens, and
-	// timer callbacks, so without this an abandoned tab would never close.
-	armIdleCloseForOwner(ownerId, opts.idleMs);
 	return count;
 }
 

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -300,6 +300,12 @@ async function acquireTabImpl(
 				// error a run would raise, instead of reporting a reuse
 				// that can never execute.
 				existing.lastActivityAt = Date.now();
+				// The creator may opt out later: an explicit `persist` on
+				// reuse by the owning session updates the tab (omitted
+				// leaves it). Reuse by any other session never changes it.
+				if (opts.persist !== undefined && existing.ownerSessionId === opts.ownerSessionId) {
+					existing.persist = opts.persist;
+				}
 				if (!(await unfreezeTabSession(existing))) {
 					throw new ToolError(
 						`Tab ${JSON.stringify(name)} is frozen and could not be resumed. Close and reopen it.`,
@@ -708,7 +714,7 @@ async function runInTabWithSnapshot(
  * (and the shared browser hold would release twice). Joiners share the
  * first release's outcome.
  */
-const releaseInflight = new WeakMap<TabSession, Promise<boolean>>();
+const releaseInflight = new WeakMap<TabSession, { promise: Promise<boolean>; opts: ReleaseTabOptions }>();
 
 export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Promise<boolean> {
 	const tab = tabs.get(name);
@@ -717,11 +723,19 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		return false;
 	}
 	const ongoing = releaseInflight.get(tab);
-	if (ongoing) return await ongoing;
-	const run = releaseTabInner(tab, name, opts);
-	releaseInflight.set(tab, run);
+	if (ongoing) {
+		// Coalesce cleanup strength: a joining disposal must not lose its
+		// kill request to an earlier non-killing close — `releaseBrowser`
+		// reads `opts.kill` at teardown time, so the upgrade lands as long
+		// as the first release has not finished. (Not directly testable
+		// in-process: observing it needs a real spawned application.)
+		ongoing.opts.kill = ongoing.opts.kill || opts.kill;
+		return await ongoing.promise;
+	}
+	const entry = { promise: releaseTabInner(tab, name, opts), opts };
+	releaseInflight.set(tab, entry);
 	try {
-		return await run;
+		return await entry.promise;
 	} finally {
 		releaseInflight.delete(tab);
 	}

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -619,6 +619,9 @@ async function runInTabWithSnapshot(
 			return await promise;
 		} finally {
 			tab.pending.delete(id);
+			// Completion is use too: a run outlasting the idle timeout must
+			// not look stale to the sweep right after it finishes.
+			tab.lastActivityAt = Date.now();
 		}
 	}
 	const abort = (): void => {
@@ -668,6 +671,9 @@ async function runInTabWithSnapshot(
 	} finally {
 		opts.signal?.removeEventListener("abort", abort);
 		tab.pending.delete(id);
+		// Completion is use too: a run outlasting the idle timeout must
+		// not look stale to the sweep right after it finishes.
+		tab.lastActivityAt = Date.now();
 	}
 }
 
@@ -870,7 +876,19 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 		if (frozen) {
 			if (tab.frozen) return false;
 			if (tab.pending.size > 0) {
-				await session.send("Page.setWebLifecycleState", { state: "active" }).catch(() => undefined);
+				const undone = await session.send("Page.setWebLifecycleState", { state: "active" }).then(
+					() => true,
+					() => false,
+				);
+				if (!undone) {
+					// The frozen frame very likely landed while its undo did
+					// not. Record frozen so the owning run and later runs
+					// resume via unfreeze instead of executing against a
+					// paused page; a redundant `active` on an already-active
+					// page is harmless, and idle-close still bounds a tab
+					// that never runs again.
+					tab.frozen = true;
+				}
 				return false;
 			}
 			tab.frozen = true;
@@ -961,6 +979,11 @@ export async function releaseIdleTabsForOwner(
 		.map(tab => tab.name);
 	let count = 0;
 	for (const name of names) {
+		// Revalidate immediately before closing: an earlier close in this
+		// loop awaits worker cleanup, during which a later candidate may
+		// have been reused or started a run.
+		const current = tabs.get(name);
+		if (!current || !isIdleCloseCandidate(current, ownerId, Date.now(), opts.idleMs)) continue;
 		if (await releaseTab(name, opts)) count++;
 	}
 	return count;

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -300,16 +300,21 @@ async function acquireTabImpl(
 				// error a run would raise, instead of reporting a reuse
 				// that can never execute.
 				existing.lastActivityAt = Date.now();
-				// The creator may opt out later: an explicit `persist` on
-				// reuse by the owning session updates the tab (omitted
-				// leaves it). Reuse by any other session never changes it.
-				if (opts.persist !== undefined && existing.ownerSessionId === opts.ownerSessionId) {
-					existing.persist = opts.persist;
-				}
+				// Resume BEFORE applying `persist` below: flipping the flag
+				// first would make `isSettleManaged` reject this very
+				// resume, so reopening a frozen tab with `persist: true`
+				// would always fail.
 				if (!(await unfreezeTabSession(existing))) {
 					throw new ToolError(
 						`Tab ${JSON.stringify(name)} is frozen and could not be resumed. Close and reopen it.`,
 					);
+				}
+				// The creator may opt out later: an explicit `persist` on
+				// reuse by the owning session updates the tab (omitted
+				// leaves it). Reuse by any other session never changes it.
+				// Applied after the resume above for the reason stated there.
+				if (opts.persist !== undefined && existing.ownerSessionId === opts.ownerSessionId) {
+					existing.persist = opts.persist;
 				}
 				const reuseSteps: string[] = [];
 				if (opts.viewport && browser.kind.kind !== "cmux") {

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -1015,7 +1015,10 @@ export async function releaseIdleTabsForOwner(
 }
 
 /** Per-owner one-shot timers arming the idle-close backstop. Always unref'd. */
-const idleCloseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const idleCloseTimers = new Map<string, NodeJS.Timeout>();
+
+/** Recheck cadence when a firing sweep skips due-but-busy tabs. Overridable in tests. */
+const IDLE_DUE_RETRY_MS = 30_000;
 
 /**
  * Milliseconds until the owner's next managed tab goes idle, `0` when one
@@ -1035,6 +1038,14 @@ export function earliestIdleCloseInMs(ownerId: string, idleMs: number, nowMs: nu
 	return earliest;
 }
 
+/** Drop a pending idle-close deadline, e.g. when the timeout is disabled at runtime. */
+export function cancelIdleCloseForOwner(ownerId: string): void {
+	const existing = idleCloseTimers.get(ownerId);
+	if (existing === undefined) return;
+	idleCloseTimers.delete(ownerId);
+	clearTimeout(existing);
+}
+
 /**
  * (Re)arm the owner-scoped one-shot that closes idle tabs when the timeout
  * elapses without further activity. Without this, a tab used in the final
@@ -1043,25 +1054,21 @@ export function earliestIdleCloseInMs(ownerId: string, idleMs: number, nowMs: nu
  * holds the process open (print/RPC exits are unaffected), firing
  * re-enters through `releaseIdleTabsForOwner` — which re-arms while
  * survivors remain — and disposal needs no cleanup since a fired sweep
- * over released tabs is a no-op.
+ * over released tabs is a no-op. Due-but-busy survivors re-arm on a short
+ * retry cadence instead of losing their deadline until the next sweep.
  */
-export function armIdleCloseForOwner(ownerId: string, idleMs: number): void {
-	const existing = idleCloseTimers.get(ownerId);
-	if (existing !== undefined) {
-		idleCloseTimers.delete(ownerId);
-		clearTimeout(existing);
-	}
+export function armIdleCloseForOwner(ownerId: string, idleMs: number, retryMs: number = IDLE_DUE_RETRY_MS): void {
+	cancelIdleCloseForOwner(ownerId);
+	if (!ownerId || !(idleMs > 0)) return;
 	const delay = earliestIdleCloseInMs(ownerId, idleMs);
-	if (delay === undefined || delay <= 0) return;
-	const timer = setTimeout(
-		() => {
-			idleCloseTimers.delete(ownerId);
-			void releaseIdleTabsForOwner(ownerId, { idleMs })
-				.then(() => armIdleCloseForOwner(ownerId, idleMs))
-				.catch(() => undefined);
-		},
-		Math.min(delay, 2_147_483_647),
-	);
+	if (delay === undefined) return;
+	const wait = delay <= 0 ? retryMs : Math.min(delay, 2_147_483_647);
+	const timer = setTimeout(() => {
+		idleCloseTimers.delete(ownerId);
+		void releaseIdleTabsForOwner(ownerId, { idleMs })
+			.then(() => armIdleCloseForOwner(ownerId, idleMs, retryMs))
+			.catch(() => undefined);
+	}, wait);
 	timer.unref();
 	idleCloseTimers.set(ownerId, timer);
 }

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -7,7 +7,7 @@ import {
 	withTimeout,
 	workerHostEntry,
 } from "@oh-my-pi/pi-utils";
-import type { Page, Target } from "puppeteer-core";
+import type { CDPSession, Page, Target } from "puppeteer-core";
 import { callSessionTool } from "../../eval/js/tool-bridge";
 import { webpExclusionForModel } from "../../utils/image-loading";
 import type { ToolSession } from "../index";
@@ -586,9 +586,12 @@ async function runInTabWithSnapshot(
 	// stalling timer/rAF-dependent code to timeout.
 	tab.pending.set(id, pending);
 	// Resume a settle-frozen page before driving it — frozen rAF/timers would
-	// otherwise hang the execution below. Never throws: on failure the run
-	// proceeds and surfaces the underlying page error itself.
-	await unfreezeTabSession(tab);
+	// otherwise hang the execution below. A refused resume fails the run
+	// here with an actionable error instead of stalling to timeout.
+	if (!(await unfreezeTabSession(tab))) {
+		tab.pending.delete(id);
+		throw new ToolError(`Tab ${JSON.stringify(name)} is frozen and could not be resumed. Close and reopen it.`);
+	}
 	const current = tabs.get(name);
 	if (current !== tab || current.state === "dead") {
 		// A teardown won the race with our unfreeze roundtrip. Prefer its
@@ -876,19 +879,13 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 		if (frozen) {
 			if (tab.frozen) return false;
 			if (tab.pending.size > 0) {
-				const undone = await session.send("Page.setWebLifecycleState", { state: "active" }).then(
-					() => true,
-					() => false,
-				);
-				if (!undone) {
-					// The frozen frame very likely landed while its undo did
-					// not. Record frozen so the owning run and later runs
-					// resume via unfreeze instead of executing against a
-					// paused page; a redundant `active` on an already-active
-					// page is harmless, and idle-close still bounds a tab
-					// that never runs again.
-					tab.frozen = true;
-				}
+				if (await sendLifecycleState(session, "active")) return false;
+				// One retry for the in-flight run's sake: a brief frozen
+				// blip is harmless (rAF just skips frames), but an
+				// indefinite freeze stalls it to timeout.
+				await Bun.sleep(100);
+				if (await sendLifecycleState(session, "active")) return false;
+				tab.frozen = true;
 				return false;
 			}
 			tab.frozen = true;
@@ -905,6 +902,16 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 		return false;
 	} finally {
 		await session.detach().catch(() => undefined);
+	}
+}
+
+/** Best-effort lifecycle write on an owned CDP session; false when the call fails. */
+async function sendLifecycleState(session: CDPSession, state: "frozen" | "active"): Promise<boolean> {
+	try {
+		await session.send("Page.setWebLifecycleState", { state });
+		return true;
+	} catch {
+		return false;
 	}
 }
 
@@ -928,13 +935,28 @@ export async function unfreezeTab(name: string): Promise<boolean> {
 }
 
 /**
- * Resume a tab before driving it. Never throws: a failed unfreeze leaves
- * `frozen` set so the next checkpoint retries, and the caller's run proceeds
- * to surface the underlying page error itself.
+ * Resume a tab before driving it. Returns false only when the page target
+ * exists but refuses the `active` transition even after one retry — the
+ * page is most likely still paused, so the caller must not dispatch onto
+ * it. A vanished target returns true: the run proceeds and surfaces the
+ * real page error immediately instead of hanging to timeout.
  */
-async function unfreezeTabSession(tab: TabSession): Promise<void> {
-	if (!tab.frozen) return;
-	await setTabFrozen(tab, false).catch(() => false);
+async function unfreezeTabSession(tab: TabSession): Promise<boolean> {
+	if (!tab.frozen) return true;
+	if (tab.backend === "worker") {
+		const target = await findTargetForTab(tab).catch(() => undefined);
+		// Page target gone: let the run proceed and surface the real page
+		// error immediately instead of hanging to timeout.
+		if (!target) return true;
+	}
+	if (await setTabFrozen(tab, false).catch(() => false)) return true;
+	await Bun.sleep(100);
+	return await setTabFrozen(tab, false).catch(() => false);
+}
+
+/** Test hook for the pre-run resume without a tabs-map entry. */
+export function unfreezeTabSessionForTest(tab: TabSession): Promise<boolean> {
+	return unfreezeTabSession(tab);
 }
 
 /**
@@ -986,7 +1008,62 @@ export async function releaseIdleTabsForOwner(
 		if (!current || !isIdleCloseCandidate(current, ownerId, Date.now(), opts.idleMs)) continue;
 		if (await releaseTab(name, opts)) count++;
 	}
+	// Leave the next deadline armed: sweeps only fire on turns, opens, and
+	// timer callbacks, so without this an abandoned tab would never close.
+	armIdleCloseForOwner(ownerId, opts.idleMs);
 	return count;
+}
+
+/** Per-owner one-shot timers arming the idle-close backstop. Always unref'd. */
+const idleCloseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * Milliseconds until the owner's next managed tab goes idle, `0` when one
+ * already is, or undefined when no managed tab is tracked. The sweep
+ * checkpoints (turn settle, open) handle the due case synchronously; the
+ * timer covers abandonment with no further activity.
+ */
+export function earliestIdleCloseInMs(ownerId: string, idleMs: number, nowMs: number = Date.now()): number | undefined {
+	if (!ownerId || !(idleMs > 0)) return undefined;
+	let earliest: number | undefined;
+	for (const tab of tabs.values()) {
+		if (tab.ownerSessionId !== ownerId || !isSettleManaged(tab)) continue;
+		const remaining = idleMs - (nowMs - tab.lastActivityAt);
+		if (remaining <= 0) return 0;
+		earliest = earliest === undefined ? remaining : Math.min(earliest, remaining);
+	}
+	return earliest;
+}
+
+/**
+ * (Re)arm the owner-scoped one-shot that closes idle tabs when the timeout
+ * elapses without further activity. Without this, a tab used in the final
+ * turn before an idle session would sit until the next turn, open, or
+ * dispose despite the advertised timeout. The timer is unref'd so it never
+ * holds the process open (print/RPC exits are unaffected), firing
+ * re-enters through `releaseIdleTabsForOwner` — which re-arms while
+ * survivors remain — and disposal needs no cleanup since a fired sweep
+ * over released tabs is a no-op.
+ */
+export function armIdleCloseForOwner(ownerId: string, idleMs: number): void {
+	const existing = idleCloseTimers.get(ownerId);
+	if (existing !== undefined) {
+		idleCloseTimers.delete(ownerId);
+		clearTimeout(existing);
+	}
+	const delay = earliestIdleCloseInMs(ownerId, idleMs);
+	if (delay === undefined || delay <= 0) return;
+	const timer = setTimeout(
+		() => {
+			idleCloseTimers.delete(ownerId);
+			void releaseIdleTabsForOwner(ownerId, { idleMs })
+				.then(() => armIdleCloseForOwner(ownerId, idleMs))
+				.catch(() => undefined);
+		},
+		Math.min(delay, 2_147_483_647),
+	);
+	timer.unref();
+	idleCloseTimers.set(ownerId, timer);
 }
 
 /** Test-only accessor for the module-global tabs map. */

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -13,7 +13,7 @@ import { webpExclusionForModel } from "../../utils/image-loading";
 import type { ToolSession } from "../index";
 import { expandPath } from "../path-utils";
 import { ToolAbortError, ToolError } from "../tool-errors";
-import { pickElectronTarget, shouldPreserveConnectedBrowserFocus } from "./attach";
+import { gracefulKillTreeOnce, pickElectronTarget, shouldPreserveConnectedBrowserFocus } from "./attach";
 import { CmuxTab, runCmuxCode } from "./cmux/cmux-tab";
 import { mapWaitUntil } from "./cmux/rpc";
 import { DEFAULT_VIEWPORT } from "./launch";
@@ -735,7 +735,12 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		// as the first release has not finished. (Not directly testable
 		// in-process: observing it needs a real spawned application.)
 		ongoing.opts.kill = ongoing.opts.kill || opts.kill;
-		return await ongoing.promise;
+		const joined = await ongoing.promise;
+		// The upgrade above lands too late when the first release already
+		// passed `releaseBrowser`: verify a still-running spawned app is
+		// terminated rather than trusting the joined outcome.
+		if (opts.kill) await ensureSpawnedKilled(tab.browser);
+		return joined;
 	}
 	const entry = { promise: releaseTabInner(tab, name, opts), opts };
 	releaseInflight.set(tab, entry);
@@ -744,6 +749,23 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 	} finally {
 		releaseInflight.delete(tab);
 	}
+}
+
+/**
+ * Best-effort termination of a spawned app that outlived a joined teardown.
+ * Fires only behind a live subprocess handle (kernel-tracked, so no
+ * pid-reuse hazard): anything else already died or was never ours to kill.
+ */
+async function ensureSpawnedKilled(browser: BrowserHandle): Promise<void> {
+	if (browser.kind.kind !== "spawned" || !("subprocess" in browser)) return;
+	const { pid, subprocess } = browser;
+	if (pid === undefined || !subprocess || subprocess.exitCode !== null) return;
+	await gracefulKillTreeOnce(pid).catch(() => undefined);
+}
+
+/** Test hook for the kill guards without a live application. */
+export function ensureSpawnedKilledForTest(browser: BrowserHandle): Promise<void> {
+	return ensureSpawnedKilled(browser);
 }
 
 async function releaseTabInner(tab: TabSession, name: string, opts: ReleaseTabOptions): Promise<boolean> {
@@ -939,7 +961,13 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 		if (tab.state !== "alive") return false;
 		if (frozen) {
 			if (tab.frozen) return false;
-			if (tab.pending.size > 0) {
+			if (tab.pending.size > 0 || tab.persist) {
+				// A run registered, or the owner opted out with `persist`,
+				// while our CDP roundtrip was in flight. Either way the
+				// frozen frame may already have landed, so re-assert
+				// `active` instead of recording frozen — a persist tab left
+				// frozen could never resume (unfreeze is rejected by the
+				// same persist eligibility gate).
 				if (await sendLifecycleState(session, "active")) return false;
 				// One retry for the in-flight run's sake: a brief frozen
 				// blip is harmless (rAF just skips frames), but an

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -295,10 +295,16 @@ async function acquireTabImpl(
 				await releaseTab(name, { kill: false });
 			} else {
 				// Reuse counts as use: refresh the idle clock and resume a
-				// settle-frozen page before driving it again. Unfreeze is a
-				// flag-check no-op unless a previous settle froze the tab.
+				// settle-frozen page before driving it again. A refused
+				// resume fails the open here with the same actionable
+				// error a run would raise, instead of reporting a reuse
+				// that can never execute.
 				existing.lastActivityAt = Date.now();
-				await unfreezeTabSession(existing);
+				if (!(await unfreezeTabSession(existing))) {
+					throw new ToolError(
+						`Tab ${JSON.stringify(name)} is frozen and could not be resumed. Close and reopen it.`,
+					);
+				}
 				const reuseSteps: string[] = [];
 				if (opts.viewport && browser.kind.kind !== "cmux") {
 					const dsf = opts.viewport.deviceScaleFactor;
@@ -694,12 +700,34 @@ async function runInTabWithSnapshot(
 	}
 }
 
+/**
+ * In-flight releases by tab object. A second `releaseTab` for a tab already
+ * being torn down joins the first instead of redoubling teardown: without
+ * this, a same-name acquire racing a sweep's release would publish a
+ * replacement that the first release's unconditional delete then removes
+ * (and the shared browser hold would release twice). Joiners share the
+ * first release's outcome.
+ */
+const releaseInflight = new WeakMap<TabSession, Promise<boolean>>();
+
 export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Promise<boolean> {
 	const tab = tabs.get(name);
 	if (!tab) {
 		logger.debug("releaseTab: unknown tab", { name });
 		return false;
 	}
+	const ongoing = releaseInflight.get(tab);
+	if (ongoing) return await ongoing;
+	const run = releaseTabInner(tab, name, opts);
+	releaseInflight.set(tab, run);
+	try {
+		return await run;
+	} finally {
+		releaseInflight.delete(tab);
+	}
+}
+
+async function releaseTabInner(tab: TabSession, name: string, opts: ReleaseTabOptions): Promise<boolean> {
 	const wasAlive = tab.state === "alive";
 	tab.state = "dead";
 	const closeError = postmortem.markExpectedCleanupError(new ToolError(`Tab ${JSON.stringify(name)} was closed`));

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -85,6 +85,21 @@ interface TabSessionBase<TBrowser extends BrowserHandle = BrowserHandle> {
 	 * Undefined when the acquirer did not identify itself.
 	 */
 	ownerSessionId?: string;
+	/**
+	 * Opt out of settle-freeze and idle-close reaping. Recorded on the tab
+	 * when created (never on reuse), mirroring `ownerSessionId`: keeping a
+	 * tab live across turns is the creator's explicit decision.
+	 */
+	persist?: boolean;
+	/** Wall-clock (`Date.now()`) last use: create, reuse, or run start. Drives idle-close. */
+	lastActivityAt: number;
+	/**
+	 * True after a successful settle-freeze (`Page.setWebLifecycleState`
+	 * frozen). Cleared on unfreeze/create. Freeze pauses rAF/timers so an
+	 * idle animated page stops burning CPU/GPU; the renderer, worker, and
+	 * DOM state stay alive for millisecond resume.
+	 */
+	frozen: boolean;
 }
 
 export interface WorkerTabSession extends TabSessionBase<PuppeteerBrowserHandle> {
@@ -126,6 +141,12 @@ export interface AcquireTabOptions {
 	 * dispose. Optional — omitting it opts the tab out of session-scoped reap.
 	 */
 	ownerSessionId?: string;
+	/**
+	 * Keep the tab live across turn settle and idle close. Recorded on the
+	 * tab when created (never on reuse) so a later caller cannot silently
+	 * extend another session's tab lifetime.
+	 */
+	persist?: boolean;
 }
 
 export interface AcquireTabResult {
@@ -273,6 +294,11 @@ async function acquireTabImpl(
 				tempHold = true;
 				await releaseTab(name, { kill: false });
 			} else {
+				// Reuse counts as use: refresh the idle clock and resume a
+				// settle-frozen page before driving it again. Unfreeze is a
+				// flag-check no-op unless a previous settle froze the tab.
+				existing.lastActivityAt = Date.now();
+				await unfreezeTabSession(existing);
 				const reuseSteps: string[] = [];
 				if (opts.viewport && browser.kind.kind !== "cmux") {
 					const dsf = opts.viewport.deviceScaleFactor;
@@ -405,6 +431,9 @@ async function acquireTabImpl(
 		kindTag: browser.kind.kind,
 		activateForScreenshot: initPayload.mode === "headless" || initPayload.activateForScreenshot !== false,
 		ownerSessionId: opts.ownerSessionId,
+		persist: opts.persist ?? false,
+		lastActivityAt: Date.now(),
+		frozen: false,
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
 	tabs.set(name, tab);
@@ -480,6 +509,9 @@ async function acquireCmuxTab(
 			kindTag: browser.kind.kind,
 			cmuxAttachedSurface: attachedSurface,
 			ownerSessionId: opts.ownerSessionId,
+			persist: opts.persist ?? false,
+			lastActivityAt: Date.now(),
+			frozen: false,
 		};
 		tabs.set(name, tab);
 		return { tab, created: true };
@@ -518,6 +550,11 @@ async function runInTabWithSnapshot(
 		);
 	}
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
+	// A run is use: refresh the idle clock and resume a settle-frozen page
+	// first so frozen rAF/timers cannot hang the execution below. Unfreeze
+	// never throws — on failure the run proceeds and surfaces the page error.
+	tab.lastActivityAt = Date.now();
+	await unfreezeTabSession(tab);
 	const id = Snowflake.next();
 	const { promise, resolve, reject } = Promise.withResolvers<RunResultOk>();
 	// `releaseTab` calls `pending.reject(closeError)` when the tab dies
@@ -749,6 +786,131 @@ export async function dropHeadlessTabs(): Promise<void> {
 export async function releaseTabsForOwner(ownerId: string, opts: ReleaseTabOptions = {}): Promise<number> {
 	if (!ownerId) return 0;
 	const names = [...tabs.values()].filter(tab => tab.ownerSessionId === ownerId).map(tab => tab.name);
+	let count = 0;
+	for (const name of names) {
+		if (await releaseTab(name, opts)) count++;
+	}
+	return count;
+}
+
+/**
+ * Tabs this settle machinery may ever touch: OMP-launched headless puppeteer
+ * tabs (`kindTag === "headless"` covers hidden and visible shared-daemon
+ * tabs) that are alive and not opted out with `persist`. Connected, relay,
+ * and spawned tabs drive the user's own pages/apps, and cmux surfaces are a
+ * different backend with no CDP lifecycle — all are never frozen or reaped
+ * here. Ownership follows the `releaseTabsForOwner` contract: recorded on
+ * creation, never transferred by reuse.
+ */
+function isSettleManaged(tab: TabSession): boolean {
+	return tab.backend === "worker" && tab.kindTag === "headless" && tab.state === "alive" && !tab.persist;
+}
+
+/**
+ * Find the live puppeteer target backing a tab. Mirrors the tab worker's
+ * attach scan: fast `_targetId` path first, CDP comparison across targets
+ * otherwise. Returns undefined when the target is already gone.
+ */
+async function findTargetForTab(tab: WorkerTabSession): Promise<Target | undefined> {
+	for (const target of tab.browser.browser.targets()) {
+		if ((await targetIdForTarget(target).catch(() => "")) !== tab.targetId) continue;
+		return target;
+	}
+	return undefined;
+}
+
+/**
+ * Set a tab's web lifecycle state through a supervisor-owned CDP session —
+ * no worker-protocol change needed; CDP allows multiple sessions per target.
+ * `frozen` pauses rAF/timers (the SwiftShader burn in #8246); `active`
+ * resumes. Best-effort in the safe direction: false when the tab is gone or
+ * the protocol call fails, leaving `frozen` untouched so the next checkpoint
+ * retries and close paths still apply.
+ */
+async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> {
+	if (!isSettleManaged(tab) || tab.backend !== "worker") return false;
+	if (tab.pending.size > 0) return false;
+	if (tab.frozen === frozen) return false;
+	const target = await findTargetForTab(tab).catch(() => undefined);
+	if (!target) return false;
+	const session = await target.createCDPSession().catch(() => null);
+	if (!session) return false;
+	try {
+		await session.send("Page.enable").catch(() => undefined);
+		await session.send("Page.setWebLifecycleState", { state: frozen ? "frozen" : "active" });
+	} catch (error) {
+		logger.debug("Browser tab lifecycle transition failed; leaving tab unfrozen", {
+			name: tab.name,
+			frozen,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return false;
+	} finally {
+		await session.detach().catch(() => undefined);
+	}
+	tab.frozen = frozen;
+	return true;
+}
+
+/** Test hook for the lifecycle transition without a tabs-map entry. */
+export function setTabFrozenForTest(tab: TabSession, frozen: boolean): Promise<boolean> {
+	return setTabFrozen(tab, frozen);
+}
+
+/** Freeze one managed tab by name. No-op (false) unless a transition happened. */
+export async function freezeTab(name: string): Promise<boolean> {
+	const tab = tabs.get(name);
+	if (!tab) return false;
+	return await setTabFrozen(tab, true);
+}
+
+/** Resume one frozen tab by name. No-op (false) unless a transition happened. */
+export async function unfreezeTab(name: string): Promise<boolean> {
+	const tab = tabs.get(name);
+	if (!tab) return false;
+	return await setTabFrozen(tab, false);
+}
+
+/**
+ * Resume a tab before driving it. Never throws: a failed unfreeze leaves
+ * `frozen` set so the next checkpoint retries, and the caller's run proceeds
+ * to surface the underlying page error itself.
+ */
+async function unfreezeTabSession(tab: TabSession): Promise<void> {
+	if (!tab.frozen) return;
+	await setTabFrozen(tab, false).catch(() => false);
+}
+
+/**
+ * Freeze every managed tab owned by `ownerId` (issue #8246). Turn-settle
+ * checkpoint: an idle animated page stops burning CPU/GPU while keeping its
+ * renderer, worker, and DOM state for millisecond resume on next use. Tabs
+ * with in-flight runs are skipped and picked up at the next settle.
+ */
+export async function freezeTabsForOwner(ownerId: string): Promise<number> {
+	if (!ownerId) return 0;
+	let count = 0;
+	for (const tab of tabs.values()) {
+		if (tab.ownerSessionId !== ownerId) continue;
+		if (await setTabFrozen(tab, true).catch(() => false)) count++;
+	}
+	return count;
+}
+
+/**
+ * Close managed tabs owned by `ownerId` idle longer than `idleMs` — the
+ * memory backstop under settle-freeze (frozen tabs still hold their renderer
+ * and worker). Frozen or not, `persist` tabs are never touched.
+ */
+export async function releaseIdleTabsForOwner(
+	ownerId: string,
+	opts: { idleMs: number } & ReleaseTabOptions = { idleMs: 0 },
+): Promise<number> {
+	if (!ownerId) return 0;
+	const now = Date.now();
+	const names = [...tabs.values()]
+		.filter(tab => tab.ownerSessionId === ownerId && isSettleManaged(tab) && now - tab.lastActivityAt >= opts.idleMs)
+		.map(tab => tab.name);
 	let count = 0;
 	for (const name of names) {
 		if (await releaseTab(name, opts)) count++;

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -934,20 +934,6 @@ export function setTabFrozenForTest(tab: TabSession, frozen: boolean): Promise<b
 	return setTabFrozen(tab, frozen);
 }
 
-/** Freeze one managed tab by name. No-op (false) unless a transition happened. */
-export async function freezeTab(name: string): Promise<boolean> {
-	const tab = tabs.get(name);
-	if (!tab) return false;
-	return await setTabFrozen(tab, true);
-}
-
-/** Resume one frozen tab by name. No-op (false) unless a transition happened. */
-export async function unfreezeTab(name: string): Promise<boolean> {
-	const tab = tabs.get(name);
-	if (!tab) return false;
-	return await setTabFrozen(tab, false);
-}
-
 /**
  * Resume a tab before driving it. Returns false only when the page target
  * exists but refuses the `active` transition even after one retry — the
@@ -1014,6 +1000,9 @@ export async function releaseIdleTabsForOwner(
 		.filter(tab => isIdleCloseCandidate(tab, ownerId, now, opts.idleMs))
 		.map(tab => tab.name);
 	let count = 0;
+	// Program-order token: a cancel landing after this increment suppresses
+	// the re-arm below, so disabling mid-sweep cannot resurrect the deadline.
+	const sweepSeq = ++idleCloseSeq;
 	try {
 		for (const name of names) {
 			// Revalidate immediately before closing: an earlier close in this
@@ -1034,16 +1023,27 @@ export async function releaseIdleTabsForOwner(
 			}
 		}
 	} finally {
-		// Leave the next deadline armed even when a close threw: sweeps only
-		// fire on turns, opens, and timer callbacks, so without this the
-		// survivors would never close.
-		armIdleCloseForOwner(ownerId, opts.idleMs);
+		// Leave the next deadline armed even when a close threw — unless
+		// cancelled mid-sweep. Sweeps only fire on turns, opens, and timer
+		// callbacks, so without re-arming the survivors would never close.
+		if ((idleCloseCancelSeq.get(ownerId) ?? 0) <= sweepSeq) {
+			armIdleCloseForOwner(ownerId, opts.idleMs);
+		}
 	}
 	return count;
 }
 
 /** Per-owner one-shot timers arming the idle-close backstop. Always unref'd. */
 const idleCloseTimers = new Map<string, NodeJS.Timeout>();
+
+/**
+ * Monotonic clock ordering sweeps against cancels: each sweep entry and
+ * each cancel takes the next value, so a sweep can tell whether a cancel
+ * landed mid-flight.
+ */
+let idleCloseSeq = 0;
+/** Last cancel sequence per owner; sweeps re-arm only when uncancelled. */
+const idleCloseCancelSeq = new Map<string, number>();
 
 /** Recheck cadence when a firing sweep skips due-but-busy tabs. Overridable in tests. */
 const IDLE_DUE_RETRY_MS = 30_000;
@@ -1066,8 +1066,19 @@ export function earliestIdleCloseInMs(ownerId: string, idleMs: number, nowMs: nu
 	return earliest;
 }
 
-/** Drop a pending idle-close deadline, e.g. when the timeout is disabled at runtime. */
+/** Drop a pending idle-close deadline and invalidate a sweep in flight. */
 export function cancelIdleCloseForOwner(ownerId: string): void {
+	if (!ownerId) return;
+	clearIdleCloseTimer(ownerId);
+	idleCloseCancelSeq.set(ownerId, ++idleCloseSeq);
+}
+
+/** Test probe: whether the owner currently has an armed deadline. */
+export function hasIdleCloseTimerForTest(ownerId: string): boolean {
+	return idleCloseTimers.has(ownerId);
+}
+
+function clearIdleCloseTimer(ownerId: string): void {
 	const existing = idleCloseTimers.get(ownerId);
 	if (existing === undefined) return;
 	idleCloseTimers.delete(ownerId);
@@ -1084,10 +1095,10 @@ export function cancelIdleCloseForOwner(ownerId: string): void {
  * survivors remain — and disposal needs no cleanup since a fired sweep
  * over released tabs is a no-op. Due-but-busy survivors re-arm on a short
  * retry cadence instead of losing their deadline until the next sweep.
+ * @param retryMs recheck cadence for due-but-busy survivors; keep well above zero.
  */
 export function armIdleCloseForOwner(ownerId: string, idleMs: number, retryMs: number = IDLE_DUE_RETRY_MS): void {
-	cancelIdleCloseForOwner(ownerId);
-	if (!ownerId || !(idleMs > 0)) return;
+	clearIdleCloseTimer(ownerId);
 	const delay = earliestIdleCloseInMs(ownerId, idleMs);
 	if (delay === undefined) return;
 	const wait = delay <= 0 ? retryMs : Math.min(delay, 2_147_483_647);

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -990,6 +990,12 @@ export function isIdleCloseCandidate(tab: TabSession, ownerId: string, nowMs: nu
 		nowMs - tab.lastActivityAt >= idleMs
 	);
 }
+/**
+ * Close managed tabs owned by `ownerId` idle longer than `idleMs` — the
+ * memory backstop under settle-freeze (frozen tabs still hold their renderer
+ * and worker). Never throws: a wedged tab counts as unclosed and the sweep
+ * continues, returning the partial count — reapers must not fail callers.
+ */
 export async function releaseIdleTabsForOwner(
 	ownerId: string,
 	opts: { idleMs: number } & ReleaseTabOptions = { idleMs: 0 },

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -550,11 +550,8 @@ async function runInTabWithSnapshot(
 		);
 	}
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
-	// A run is use: refresh the idle clock and resume a settle-frozen page
-	// first so frozen rAF/timers cannot hang the execution below. Unfreeze
-	// never throws — on failure the run proceeds and surfaces the page error.
+	// A run is use: refresh the idle clock for idle-close.
 	tab.lastActivityAt = Date.now();
-	await unfreezeTabSession(tab);
 	const id = Snowflake.next();
 	const { promise, resolve, reject } = Promise.withResolvers<RunResultOk>();
 	// `releaseTab` calls `pending.reject(closeError)` when the tab dies
@@ -581,7 +578,29 @@ async function runInTabWithSnapshot(
 		toolCalls: new Map(),
 		closeAc,
 	};
+	// Register BEFORE the unfreeze await below. Settle-freeze guards on
+	// `pending` (and undoes a transition already in flight when it observes
+	// one at completion), so a turn-end freeze can neither start nor land
+	// mid-run. Without this ordering a parent's settle could freeze a tab a
+	// subagent is reusing between our unfreeze check and this registration,
+	// stalling timer/rAF-dependent code to timeout.
 	tab.pending.set(id, pending);
+	// Resume a settle-frozen page before driving it — frozen rAF/timers would
+	// otherwise hang the execution below. Never throws: on failure the run
+	// proceeds and surfaces the underlying page error itself.
+	await unfreezeTabSession(tab);
+	const current = tabs.get(name);
+	if (current !== tab || current.state === "dead") {
+		// A teardown won the race with our unfreeze roundtrip. Prefer its
+		// close error when one was recorded (`releaseTab` rejects `pending`
+		// synchronously, so it is already settled here); otherwise surface
+		// the closure. `race` — not a bare `await promise` — so a teardown
+		// that never settled the run cannot hang us, and `race` observes
+		// every rejection (issue #4499).
+		tab.pending.delete(id);
+		const notAlive = new ToolError(`Tab ${JSON.stringify(name)} is not alive. Open it first with action:"open".`);
+		return await Promise.race([promise, Promise.reject(notAlive)]);
+	}
 	if (tab.backend === "cmux") {
 		const runSignal = opts.signal ? AbortSignal.any([opts.signal, closeAc.signal]) : closeAc.signal;
 		try {
@@ -826,11 +845,20 @@ async function findTargetForTab(tab: WorkerTabSession): Promise<Target | undefin
  * resumes. Best-effort in the safe direction: false when the tab is gone or
  * the protocol call fails, leaving `frozen` untouched so the next checkpoint
  * retries and close paths still apply.
+ *
+ * Race protocol (all flag reads/writes below run atomically between awaits):
+ * runs register `pending` before driving the page, so a freeze that starts
+ * after a run began stands down at the guard. A freeze already past the
+ * guard when a run registers rechecks `pending` after its CDP roundtrip and
+ * re-asserts `active` on the same session — a frozen frame already sent
+ * cannot be unsent, so the undo guarantees the run never executes on a
+ * frozen page. Unfreezing always proceeds: resuming is safe under any
+ * pending state.
  */
 async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> {
 	if (!isSettleManaged(tab) || tab.backend !== "worker") return false;
-	if (tab.pending.size > 0) return false;
 	if (tab.frozen === frozen) return false;
+	if (frozen && tab.pending.size > 0) return false;
 	const target = await findTargetForTab(tab).catch(() => undefined);
 	if (!target) return false;
 	const session = await target.createCDPSession().catch(() => null);
@@ -838,8 +866,20 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 	try {
 		await session.send("Page.enable").catch(() => undefined);
 		await session.send("Page.setWebLifecycleState", { state: frozen ? "frozen" : "active" });
+		if (tab.state !== "alive") return false;
+		if (frozen) {
+			if (tab.frozen) return false;
+			if (tab.pending.size > 0) {
+				await session.send("Page.setWebLifecycleState", { state: "active" }).catch(() => undefined);
+				return false;
+			}
+			tab.frozen = true;
+			return true;
+		}
+		tab.frozen = false;
+		return true;
 	} catch (error) {
-		logger.debug("Browser tab lifecycle transition failed; leaving tab unfrozen", {
+		logger.debug("Browser tab lifecycle transition failed; leaving tab lifecycle state unchanged", {
 			name: tab.name,
 			frozen,
 			error: error instanceof Error ? error.message : String(error),
@@ -848,8 +888,6 @@ async function setTabFrozen(tab: TabSession, frozen: boolean): Promise<boolean> 
 	} finally {
 		await session.detach().catch(() => undefined);
 	}
-	tab.frozen = frozen;
-	return true;
 }
 
 /** Test hook for the lifecycle transition without a tabs-map entry. */
@@ -885,7 +923,9 @@ async function unfreezeTabSession(tab: TabSession): Promise<void> {
  * Freeze every managed tab owned by `ownerId` (issue #8246). Turn-settle
  * checkpoint: an idle animated page stops burning CPU/GPU while keeping its
  * renderer, worker, and DOM state for millisecond resume on next use. Tabs
- * with in-flight runs are skipped and picked up at the next settle.
+ * with in-flight runs are skipped at the guard; a freeze already past the
+ * guard when a run registers undoes itself at completion (see
+ * `setTabFrozen`), so neither path can stall a run mid-execution.
  */
 export async function freezeTabsForOwner(ownerId: string): Promise<number> {
 	if (!ownerId) return 0;
@@ -896,12 +936,20 @@ export async function freezeTabsForOwner(ownerId: string): Promise<number> {
 	}
 	return count;
 }
-
 /**
- * Close managed tabs owned by `ownerId` idle longer than `idleMs` — the
- * memory backstop under settle-freeze (frozen tabs still hold their renderer
- * and worker). Frozen or not, `persist` tabs are never touched.
+ * Idle-close eligibility: owned, settle-managed, no in-flight run, and idle
+ * past the deadline. An executing tab is not idle even when its run outlasts
+ * the timeout. Exported so the never-touch contract is unit-testable;
+ * `releaseIdleTabsForOwner` walks the map with exactly this predicate.
  */
+export function isIdleCloseCandidate(tab: TabSession, ownerId: string, nowMs: number, idleMs: number): boolean {
+	return (
+		tab.ownerSessionId === ownerId &&
+		isSettleManaged(tab) &&
+		tab.pending.size === 0 &&
+		nowMs - tab.lastActivityAt >= idleMs
+	);
+}
 export async function releaseIdleTabsForOwner(
 	ownerId: string,
 	opts: { idleMs: number } & ReleaseTabOptions = { idleMs: 0 },
@@ -909,7 +957,7 @@ export async function releaseIdleTabsForOwner(
 	if (!ownerId) return 0;
 	const now = Date.now();
 	const names = [...tabs.values()]
-		.filter(tab => tab.ownerSessionId === ownerId && isSettleManaged(tab) && now - tab.lastActivityAt >= opts.idleMs)
+		.filter(tab => isIdleCloseCandidate(tab, ownerId, now, opts.idleMs))
 		.map(tab => tab.name);
 	let count = 0;
 	for (const name of names) {

--- a/packages/coding-agent/test/eval/browser-prelude-facade.test.ts
+++ b/packages/coding-agent/test/eval/browser-prelude-facade.test.ts
@@ -280,6 +280,29 @@ describe("browser facade in real Eval runtimes", () => {
 		});
 		expect(calls).toContainEqual({ action: "run", name: "real-py", code: "return 42;", timeout: 2 });
 	});
+
+	it("forwards Python open timeout and persist side by side (issue #8246 review)", async () => {
+		const calls: unknown[] = [];
+		let definitions: readonly EvalPreludeDefinition[] = [];
+		const session = makeSession(() => definitions);
+		definitions = [recorderDefinition(session, calls)];
+		const result = await executePython(
+			[
+				'tab = await browser.open(name="py-opts", timeout=7, persist=True)',
+				'plain = await browser.open(name="py-plain")',
+			].join("\n"),
+			{
+				cwd: process.cwd(),
+				sessionId: `browser-facade-py-open-${crypto.randomUUID()}`,
+				toolSession: session,
+				kernelMode: "per-call",
+			},
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(calls).toContainEqual({ action: "open", name: "py-opts", timeout: 7, persist: true });
+		expect(calls).toContainEqual({ action: "open", name: "py-plain" });
+	});
 });
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -23,6 +23,7 @@ import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry
 import {
 	acquireTab,
 	armIdleCloseForOwner,
+	cancelIdleCloseForOwner,
 	earliestIdleCloseInMs,
 	freezeTabsForOwner,
 	getTabsMapForTest,
@@ -580,6 +581,39 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			armIdleCloseForOwner("session-retimer", 3_600_000);
 			// Real clock required (see above): past the first deadline with
 			// the replacement armed, the tab must still be tracked.
+			await Bun.sleep(600);
+			expect(getTabsMapForTest().has(name)).toBe(true);
+		}, 120_000);
+
+		it("re-arms when the timer fires into an in-flight run", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-retry-${process.pid}`;
+			const session = makeSession(process.cwd());
+			await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-retry" });
+
+			const run = runInTab(name, { code: "await wait(2000); return 1;", timeoutMs: 30_000, session });
+			void run.catch(() => undefined);
+			armIdleCloseForOwner("session-retry", 300, 150);
+			// The 300ms deadline fires mid-run: skipped, not closed.
+			// Real clock required (see above).
+			await Bun.sleep(1000);
+			expect(getTabsMapForTest().has(name)).toBe(true);
+			expect((await run).returnValue).toBe(1);
+			// After completion the chain re-arms from the fresh timestamp
+			// and the tab closes without any further settle or open.
+			for (let i = 0; i < 120 && getTabsMapForTest().has(name); i++) await Bun.sleep(50);
+			expect(getTabsMapForTest().has(name)).toBe(false);
+		}, 120_000);
+
+		it("cancelling drops the armed deadline", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-cancel-${process.pid}`;
+			await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-cancel" });
+
+			armIdleCloseForOwner("session-cancel", 200);
+			cancelIdleCloseForOwner("session-cancel");
+			// Real clock required (see above): past the deadline with the
+			// timer cancelled, the tab must still be tracked.
 			await Bun.sleep(600);
 			expect(getTabsMapForTest().has(name)).toBe(true);
 		}, 120_000);

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -22,6 +22,8 @@ import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/s
 import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import {
 	acquireTab,
+	armIdleCloseForOwner,
+	earliestIdleCloseInMs,
 	freezeTabsForOwner,
 	getTabsMapForTest,
 	isIdleCloseCandidate,
@@ -29,6 +31,7 @@ import {
 	releaseTab,
 	runInTab,
 	setTabFrozenForTest,
+	unfreezeTabSessionForTest,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { PendingRun, TabSession } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
@@ -251,14 +254,109 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			releaseFrozenSend.resolve();
 
 			// No transition happened, but the frozen frame very likely landed
-			// while its undo did not: later runs must resume via unfreeze.
+			// while its undo did not (initial attempt plus one retry): later
+			// runs must resume via unfreeze.
 			expect(await freeze).toBe(false);
 			expect(tab.frozen).toBe(true);
 			expect(calls.map(call => call.method)).toEqual([
 				"Page.enable",
 				"Page.setWebLifecycleState",
 				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
 			]);
+		});
+
+		it("recovers the in-flight run when the race undo succeeds on retry", async () => {
+			const calls: CdpCall[] = [];
+			const frozenStarted = Promise.withResolvers<void>();
+			const releaseFrozenSend = Promise.withResolvers<void>();
+			let lifecycleSends = 0;
+			const session = {
+				send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+					calls.push({ method, params });
+					if (method === "Page.setWebLifecycleState") {
+						lifecycleSends++;
+						if (lifecycleSends === 1) {
+							frozenStarted.resolve();
+							await releaseFrozenSend.promise;
+						} else if (lifecycleSends === 2) {
+							throw new Error("undo blip");
+						}
+					}
+					return {};
+				},
+				detach: async (): Promise<void> => undefined,
+			};
+			const { tab } = makeStubTab({
+				browser: {
+					browser: { targets: () => [{ _targetId: "stub-target-1", createCDPSession: async () => session }] },
+				},
+			});
+
+			const freeze = setTabFrozenForTest(tab, true);
+			await frozenStarted.promise;
+			tab.pending.set("run-1", {} as unknown as PendingRun);
+			releaseFrozenSend.resolve();
+
+			expect(await freeze).toBe(false);
+			expect(tab.frozen).toBe(false);
+			expect(calls.map(call => call.method)).toEqual([
+				"Page.enable",
+				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
+			]);
+			expect(calls.at(-1)?.params).toEqual({ state: "active" });
+		});
+	});
+
+	describe("browser settle — pre-run resume", () => {
+		it("reports resumable tabs without touching CDP", async () => {
+			const { tab, calls } = makeStubTab();
+			expect(await unfreezeTabSessionForTest(tab)).toBe(true);
+			expect(calls.length).toBe(0);
+		});
+
+		it("resumes a frozen tab and clears the flag", async () => {
+			const { tab, calls } = makeStubTab({ frozen: true });
+			expect(await unfreezeTabSessionForTest(tab)).toBe(true);
+			expect(tab.frozen).toBe(false);
+			expect(calls.map(call => call.method)).toEqual(["Page.enable", "Page.setWebLifecycleState"]);
+			expect(calls.at(-1)?.params).toEqual({ state: "active" });
+		});
+
+		it("fails a refused resume so the run errors instead of stalling", async () => {
+			const { tab, calls } = makeStubTab({
+				frozen: true,
+				browser: {
+					browser: {
+						targets: () => [
+							{
+								_targetId: "stub-target-1",
+								createCDPSession: async () => ({
+									send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+										calls.push({ method, params });
+										if (method === "Page.setWebLifecycleState") throw new Error("refused");
+										return {};
+									},
+									detach: async (): Promise<void> => undefined,
+								}),
+							},
+						],
+					},
+				},
+			});
+			expect(await unfreezeTabSessionForTest(tab)).toBe(false);
+			expect(tab.frozen).toBe(true);
+		});
+
+		it("lets a run proceed when the frozen target is already gone", async () => {
+			const { tab, calls } = makeStubTab({
+				frozen: true,
+				browser: { browser: { targets: () => [] } },
+			});
+			expect(await unfreezeTabSessionForTest(tab)).toBe(true);
+			expect(calls.length).toBe(0);
 		});
 	});
 
@@ -376,11 +474,33 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(tab.lastActivityAt).toBeGreaterThan(Date.now() - 5_000);
 		});
 
+		it("fails the run instead of dispatching onto an unresumable page", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-unresumable"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-stuck", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			tab.frozen = true;
+
+			await expect(
+				runInTab("settle-stuck", { code: "return 1;", timeoutMs: 5_000, session: makeSession("/tmp") }),
+			).rejects.toThrow(/could not be resumed/);
+			expect(tab.pending.size).toBe(0);
+			expect(getTabsMapForTest().has("settle-stuck")).toBe(true);
+		});
+
 		it("settle is a no-op for unknown owners", async () => {
 			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
 			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);
 			expect(await freezeTabsForOwner("")).toBe(0);
 			expect(await releaseIdleTabsForOwner("", { idleMs: 0 })).toBe(0);
+		});
+	});
+
+	describe("browser settle — idle deadline arithmetic", () => {
+		it("returns undefined without an owner, a timeout, or tracked tabs", () => {
+			expect(earliestIdleCloseInMs("session-nobody", 60_000)).toBeUndefined();
+			expect(earliestIdleCloseInMs("", 60_000)).toBeUndefined();
+			expect(earliestIdleCloseInMs("session-nobody", 0)).toBeUndefined();
+			expect(earliestIdleCloseInMs("session-nobody", -5)).toBeUndefined();
 		});
 	});
 
@@ -433,6 +553,35 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(await closing).toBe(1);
 			expect(getTabsMapForTest().has(`${base}-a`)).toBe(false);
 			expect(getTabsMapForTest().has(`${base}-b`)).toBe(true);
+		}, 120_000);
+
+		it("closes idle tabs when the timeout elapses without further activity", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-timer-${process.pid}`;
+			await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-timer" });
+			const due = earliestIdleCloseInMs("session-timer", 60_000);
+			expect(due).toBeGreaterThan(0);
+			expect(due).toBeLessThanOrEqual(60_000);
+
+			armIdleCloseForOwner("session-timer", 200);
+			// Real clock required: the deadline, worker teardown, and CDP
+			// roundtrips all run on platform time; fake timers cannot advance
+			// real subprocess IPC, so poll the exercised condition instead.
+			for (let i = 0; i < 100 && getTabsMapForTest().has(name); i++) await Bun.sleep(50);
+			expect(getTabsMapForTest().has(name)).toBe(false);
+		}, 120_000);
+
+		it("re-arming replaces the pending deadline", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-retimer-${process.pid}`;
+			await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-retimer" });
+
+			armIdleCloseForOwner("session-retimer", 200);
+			armIdleCloseForOwner("session-retimer", 3_600_000);
+			// Real clock required (see above): past the first deadline with
+			// the replacement armed, the tab must still be tracked.
+			await Bun.sleep(600);
+			expect(getTabsMapForTest().has(name)).toBe(true);
 		}, 120_000);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -27,9 +27,11 @@ import {
 	earliestIdleCloseInMs,
 	freezeTabsForOwner,
 	getTabsMapForTest,
+	hasIdleCloseTimerForTest,
 	isIdleCloseCandidate,
 	releaseIdleTabsForOwner,
 	releaseTab,
+	releaseTabsForOwner,
 	runInTab,
 	setTabFrozenForTest,
 	unfreezeTabSessionForTest,
@@ -53,13 +55,17 @@ function makeSession(cwd: string): ToolSession {
 	} as unknown as ToolSession;
 }
 
+let mockSurfaceSeq = 0;
+
 function mockCmuxSocket(): void {
 	spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
 	spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
 	spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
 		async (method: string): Promise<Record<string, unknown>> => {
-			if (method === "browser.open_split")
-				return { surface_id: `surface-${method}-${Date.now()}`, url: "about:blank" };
+			if (method === "browser.open_split") {
+				mockSurfaceSeq++;
+				return { surface_id: `surface-mock-${mockSurfaceSeq}`, url: "about:blank" };
+			}
 			if (method === "browser.url.get") return { url: "about:blank" };
 			if (method === "browser.snapshot") return { page: { html: "" } };
 			if (method === "browser.geometry") return {};
@@ -502,6 +508,16 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-cancelled")).toBe(true);
 		});
 
+		it("double release is idempotent for concurrent sweep losers", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-idempotent"), { cwd: "/tmp" });
+			await acquireTab("settle-twice", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+
+			expect(await releaseTab("settle-twice", { kill: false })).toBe(true);
+			expect(await releaseTab("settle-twice", { kill: false })).toBe(false);
+			expect(getTabsMapForTest().has("settle-twice")).toBe(false);
+		});
+
 		it("settle is a no-op for unknown owners", async () => {
 			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
 			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);
@@ -550,6 +566,39 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(await releaseIdleTabsForOwner("session-settle-real", { idleMs: 60_000 })).toBe(1);
 			expect(getTabsMapForTest().has(name)).toBe(false);
 		}, 120_000);
+
+		it("closes a frozen tab directly", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-frozclose-${process.pid}`;
+			await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-frozclose" });
+			expect(await freezeTabsForOwner("session-frozclose")).toBe(1);
+			expect(await releaseTab(name, { kill: false })).toBe(true);
+			expect(getTabsMapForTest().has(name)).toBe(false);
+		}, 120_000);
+
+		it("recreates a tab reused after eviction instead of resurrecting state", async () => {
+			// Worker-tab release→recreate cannot run in this environment
+			// (Bun worker re-spawn fails even on the clean tree); the
+			// eviction→recreate shape is backend-independent — a missing
+			// name always takes the create path — so pin it on cmux while
+			// the worker half is covered by removal assertions above.
+			mockCmuxSocket();
+			// No pre-attached surface: each open mints an owned split, so
+			// the two generations land on distinct targets.
+			const browser = await acquireBrowser(
+				{ kind: "cmux", socketPath: "/tmp/omp-test-settle-recreate.sock" },
+				{ cwd: "/tmp" },
+			);
+			const first = await acquireTab("settle-gone", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			expect(await releaseTabsForOwner("session-A", { kill: false })).toBe(1);
+			expect(getTabsMapForTest().has("settle-gone")).toBe(false);
+
+			const second = await acquireTab("settle-gone", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			expect(second.created).toBe(true);
+			expect(second.tab.targetId).not.toBe(first.tab.targetId);
+			expect(second.tab.frozen).toBe(false);
+			expect(second.tab.ownerSessionId).toBe("session-A");
+		});
 
 		it("revalidates candidates mid-drain: reuse during an earlier close is honored", async () => {
 			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
@@ -632,6 +681,27 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			// timer cancelled, the tab must still be tracked.
 			await Bun.sleep(600);
 			expect(getTabsMapForTest().has(name)).toBe(true);
+		}, 120_000);
+
+		it("does not re-arm when cancelled mid-sweep", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const base = `settle-cancelsweep-${process.pid}`;
+			const due = await acquireTab(`${base}-due`, browser, {
+				timeoutMs: 30_000,
+				ownerSessionId: "session-cancelsweep",
+			});
+			await acquireTab(`${base}-fresh`, browser, { timeoutMs: 30_000, ownerSessionId: "session-cancelsweep" });
+			due.tab.lastActivityAt = Date.now() - 3_600_000;
+
+			// Cancel strictly after the sweep entry takes its sequence
+			// token, while the first close is still awaiting worker
+			// teardown: the sweep completes, but no deadline may survive.
+			const closing = releaseIdleTabsForOwner("session-cancelsweep", { idleMs: 60_000 });
+			cancelIdleCloseForOwner("session-cancelsweep");
+			expect(await closing).toBe(1);
+			expect(getTabsMapForTest().has(`${base}-due`)).toBe(false);
+			expect(getTabsMapForTest().has(`${base}-fresh`)).toBe(true);
+			expect(hasIdleCloseTimerForTest("session-cancelsweep")).toBe(false);
 		}, 120_000);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -20,11 +20,13 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import type { CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
 import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
 import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import type { BrowserHandle } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import {
 	acquireTab,
 	armIdleCloseForOwner,
 	cancelIdleCloseForOwner,
 	earliestIdleCloseInMs,
+	ensureSpawnedKilledForTest,
 	freezeTabsForOwner,
 	getTabsMapForTest,
 	hasIdleCloseTimerForTest,
@@ -229,6 +231,48 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(calls.at(-1)?.params).toEqual({ state: "active" });
 		});
 
+		it("backs out when the tab opts out mid-transition", async () => {
+			const calls: CdpCall[] = [];
+			const frozenStarted = Promise.withResolvers<void>();
+			const releaseFrozenSend = Promise.withResolvers<void>();
+			let lifecycleSends = 0;
+			const session = {
+				send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+					calls.push({ method, params });
+					if (method === "Page.setWebLifecycleState") {
+						lifecycleSends++;
+						if (lifecycleSends === 1) {
+							frozenStarted.resolve();
+							await releaseFrozenSend.promise;
+						}
+					}
+					return {};
+				},
+				detach: async (): Promise<void> => undefined,
+			};
+			const { tab } = makeStubTab({
+				browser: {
+					browser: { targets: () => [{ _targetId: "stub-target-1", createCDPSession: async () => session }] },
+				},
+			});
+
+			const freeze = setTabFrozenForTest(tab, true);
+			await frozenStarted.promise;
+			// Owner promotes to persist with no run involved: the freeze
+			// must still undo instead of recording a frozen persist tab.
+			tab.persist = true;
+			releaseFrozenSend.resolve();
+
+			expect(await freeze).toBe(false);
+			expect(tab.frozen).toBe(false);
+			expect(calls.map(call => call.method)).toEqual([
+				"Page.enable",
+				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
+			]);
+			expect(calls.at(-1)?.params).toEqual({ state: "active" });
+		});
+
 		it("records frozen when the race undo itself fails", async () => {
 			const calls: CdpCall[] = [];
 			const frozenStarted = Promise.withResolvers<void>();
@@ -365,6 +409,33 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			});
 			expect(await unfreezeTabSessionForTest(tab)).toBe(true);
 			expect(calls.length).toBe(0);
+		});
+	});
+
+	describe("browser settle — spawned kill guards", () => {
+		function stubBrowser(overrides: Record<string, unknown> = {}): BrowserHandle {
+			return { kind: { kind: "headless" }, ...overrides } as unknown as BrowserHandle;
+		}
+
+		it("never touches non-spawned browsers", async () => {
+			await expect(ensureSpawnedKilledForTest(stubBrowser())).resolves.toBeUndefined();
+			await expect(
+				ensureSpawnedKilledForTest(stubBrowser({ kind: { kind: "connected", cdpUrl: "http://x" } })),
+			).resolves.toBeUndefined();
+		});
+
+		it("skips exited or untracked spawned apps", async () => {
+			await expect(
+				ensureSpawnedKilledForTest(
+					stubBrowser({ kind: { kind: "spawned", path: "/x" }, pid: 1, subprocess: { exitCode: 0 } }),
+				),
+			).resolves.toBeUndefined();
+			await expect(
+				ensureSpawnedKilledForTest(stubBrowser({ kind: { kind: "spawned", path: "/x" }, pid: 1 })),
+			).resolves.toBeUndefined();
+			await expect(
+				ensureSpawnedKilledForTest(stubBrowser({ kind: { kind: "spawned", path: "/x" } })),
+			).resolves.toBeUndefined();
 		});
 	});
 

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -518,6 +518,60 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-twice")).toBe(false);
 		});
 
+		it("rejects reuse when the frozen tab cannot resume", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-reuse-frozen"), { cwd: "/tmp" });
+			await acquireTab("settle-frozreuse", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			const tab = getTabsMapForTest().get("settle-frozreuse");
+			expect(tab).toBeDefined();
+			if (tab) tab.frozen = true;
+
+			await expect(
+				acquireTab("settle-frozreuse", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" }),
+			).rejects.toThrow(/could not be resumed/);
+		});
+
+		it("tears down once when two releases race the same tab", async () => {
+			let clientCloses = 0;
+			const closedSurfaces: string[] = [];
+			spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+			spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => {
+				clientCloses++;
+			});
+			spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+				async (method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> => {
+					if (method === "browser.open_split") {
+						return { surface_id: `surface-join-${++mockSurfaceSeq}`, url: "about:blank" };
+					}
+					if (method === "surface.close") {
+						closedSurfaces.push(String(params.surface_id ?? ""));
+						return {};
+					}
+					return {};
+				},
+			);
+			// No pre-attached surface: the tab owns its split, so the race
+			// below contends over one real teardown.
+			const browser = await acquireBrowser(
+				{ kind: "cmux", socketPath: "/tmp/omp-test-settle-join.sock" },
+				{ cwd: "/tmp" },
+			);
+			await acquireTab("settle-join", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+
+			// Both expressions run their synchronous prefixes in order: the
+			// second lookup provably observes the first release in flight,
+			// so it must join instead of redoubling teardown.
+			const [first, second] = await Promise.all([
+				releaseTab("settle-join", { kill: false }),
+				releaseTab("settle-join", { kill: false }),
+			]);
+			expect(first).toBe(true);
+			expect(second).toBe(true);
+			expect(closedSurfaces.length).toBe(1);
+			expect(clientCloses).toBe(1);
+			expect(getTabsMapForTest().has("settle-join")).toBe(false);
+		});
+
 		it("settle is a no-op for unknown owners", async () => {
 			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
 			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -24,12 +24,13 @@ import {
 	acquireTab,
 	freezeTabsForOwner,
 	getTabsMapForTest,
+	isIdleCloseCandidate,
 	releaseIdleTabsForOwner,
 	releaseTab,
 	runInTab,
 	setTabFrozenForTest,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import type { TabSession } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import type { PendingRun, TabSession } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
 import { chromiumAvailable } from "./chromium-probe";
 
@@ -175,6 +176,85 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 		expect(await setTabFrozenForTest(tab, true)).toBe(false);
 		expect(tab.frozen).toBe(false);
 		expect(calls.length).toBe(0);
+	});
+	describe("browser settle — freeze vs run race", () => {
+		it("a run that registers mid-transition forces the freeze to undo itself", async () => {
+			const calls: CdpCall[] = [];
+			const frozenStarted = Promise.withResolvers<void>();
+			const releaseFrozenSend = Promise.withResolvers<void>();
+			let lifecycleSends = 0;
+			const session = {
+				send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+					calls.push({ method, params });
+					if (method === "Page.setWebLifecycleState" && lifecycleSends++ === 0) {
+						frozenStarted.resolve();
+						await releaseFrozenSend.promise;
+					}
+					return {};
+				},
+				detach: async (): Promise<void> => undefined,
+			};
+			const { tab } = makeStubTab({
+				browser: {
+					browser: { targets: () => [{ _targetId: "stub-target-1", createCDPSession: async () => session }] },
+				},
+			});
+
+			const freeze = setTabFrozenForTest(tab, true);
+			await frozenStarted.promise;
+			// The run path registers `pending` before driving the page; the
+			// freeze observes it at completion and must back out.
+			const inFlight = {} as unknown as PendingRun;
+			tab.pending.set("run-1", inFlight);
+			releaseFrozenSend.resolve();
+
+			expect(await freeze).toBe(false);
+			expect(tab.frozen).toBe(false);
+			expect(calls.map(call => call.method)).toEqual([
+				"Page.enable",
+				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
+			]);
+			expect(calls.at(-1)?.params).toEqual({ state: "active" });
+		});
+	});
+
+	describe("browser settle — idle-close eligibility", () => {
+		const NOW = 1_000_000;
+		function candidate(overrides: Record<string, unknown> = {}): TabSession {
+			return makeStubTab({ lastActivityAt: NOW - 120_000, ...overrides }).tab;
+		}
+
+		it("selects owned managed tabs idle past the deadline, including the boundary", () => {
+			expect(isIdleCloseCandidate(candidate(), "session-stub", NOW, 60_000)).toBe(true);
+			expect(isIdleCloseCandidate(candidate({ lastActivityAt: NOW - 60_000 }), "session-stub", NOW, 60_000)).toBe(
+				true,
+			);
+		});
+
+		it("holds back fresh tabs", () => {
+			expect(isIdleCloseCandidate(candidate({ lastActivityAt: NOW - 1_000 }), "session-stub", NOW, 60_000)).toBe(
+				false,
+			);
+		});
+
+		it("never selects other owners, opt-outs, foreign kinds, dead, or executing tabs", () => {
+			const cases: Array<[string, Record<string, unknown>]> = [
+				["other owner", { ownerSessionId: "session-other" }],
+				["persist opt-out", { persist: true }],
+				["relay", { kindTag: "relay" }],
+				["connected", { kindTag: "connected" }],
+				["spawned", { kindTag: "spawned" }],
+				["cmux backend", { backend: "cmux", kindTag: "cmux" }],
+				["dead tab", { state: "dead" }],
+			];
+			for (const [label, overrides] of cases) {
+				expect(isIdleCloseCandidate(candidate(overrides), "session-stub", NOW, 60_000), label).toBe(false);
+			}
+			const executing = candidate();
+			executing.pending.set("run-1", {} as unknown as PendingRun);
+			expect(isIdleCloseCandidate(executing, "session-stub", NOW, 60_000)).toBe(false);
+		});
 	});
 
 	describe("browser settle — ownership and bookkeeping", () => {

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -658,6 +658,27 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has(name)).toBe(false);
 		}, 120_000);
 
+		it("reopens a frozen tab with persist without failing the resume", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-frozpersist-${process.pid}`;
+			const first = await acquireTab(name, browser, { timeoutMs: 30_000, ownerSessionId: "session-frozpersist" });
+			expect(first.tab.persist).toBe(false);
+			expect(await freezeTabsForOwner("session-frozpersist")).toBe(1);
+			expect(first.tab.frozen).toBe(true);
+
+			// The resume must run while the tab is still managed; applying
+			// `persist` first would gate the resume off and always throw.
+			const second = await acquireTab(name, browser, {
+				timeoutMs: 30_000,
+				ownerSessionId: "session-frozpersist",
+				persist: true,
+			});
+			expect(second.created).toBe(false);
+			expect(second.tab).toBe(first.tab);
+			expect(second.tab.frozen).toBe(false);
+			expect(second.tab.persist).toBe(true);
+		}, 120_000);
+
 		it("recreates a tab reused after eviction instead of resurrecting state", async () => {
 			// Worker-tab release→recreate cannot run in this environment
 			// (Bun worker re-spawn fails even on the clean tree); the

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -34,6 +34,7 @@ import {
 	setTabFrozenForTest,
 	unfreezeTabSessionForTest,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import type { PendingRun, TabSession } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
 import { chromiumAvailable } from "./chromium-probe";
@@ -433,13 +434,6 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(second.tab.lastActivityAt).toBeGreaterThan(stale);
 		});
 
-		it("tabs without persist default to reaping", async () => {
-			mockCmuxSocket();
-			const browser = await acquireBrowser(makeKind("settle-default"), { cwd: "/tmp" });
-			const { tab } = await acquireTab("settle-plain", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
-			expect(tab.persist).toBe(false);
-		});
-
 		it("freezeTabsForOwner skips non-headless tabs", async () => {
 			mockCmuxSocket();
 			const browser = await acquireBrowser(makeKind("settle-freeze-skip"), { cwd: "/tmp" });
@@ -488,6 +482,26 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-stuck")).toBe(true);
 		});
 
+		it("rejects an already-aborted run before dispatching", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-abort"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-cancelled", browser, {
+				timeoutMs: 1_000,
+				ownerSessionId: "session-A",
+			});
+
+			await expect(
+				runInTab("settle-cancelled", {
+					code: "return 1;",
+					timeoutMs: 5_000,
+					session: makeSession("/tmp"),
+					signal: AbortSignal.abort(),
+				}),
+			).rejects.toThrow(ToolAbortError);
+			expect(tab.pending.size).toBe(0);
+			expect(getTabsMapForTest().has("settle-cancelled")).toBe(true);
+		});
+
 		it("settle is a no-op for unknown owners", async () => {
 			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
 			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);
@@ -529,7 +543,9 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(tab.frozen).toBe(false);
 			expect(result.returnValue).toBe(42);
 
-			// Backdated past the timeout, the owned tab closes.
+			// Backdated past the timeout, the owned tab closes. Tabs default
+			// to reaping: no `persist` was passed at creation.
+			expect(tab.persist).toBe(false);
 			tab.lastActivityAt = Date.now() - 3_600_000;
 			expect(await releaseIdleTabsForOwner("session-settle-real", { idleMs: 60_000 })).toBe(1);
 			expect(getTabsMapForTest().has(name)).toBe(false);

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -217,6 +217,49 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			]);
 			expect(calls.at(-1)?.params).toEqual({ state: "active" });
 		});
+
+		it("records frozen when the race undo itself fails", async () => {
+			const calls: CdpCall[] = [];
+			const frozenStarted = Promise.withResolvers<void>();
+			const releaseFrozenSend = Promise.withResolvers<void>();
+			let lifecycleSends = 0;
+			const session = {
+				send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+					calls.push({ method, params });
+					if (method === "Page.setWebLifecycleState") {
+						lifecycleSends++;
+						if (lifecycleSends === 1) {
+							frozenStarted.resolve();
+							await releaseFrozenSend.promise;
+						} else {
+							throw new Error("undo lost");
+						}
+					}
+					return {};
+				},
+				detach: async (): Promise<void> => undefined,
+			};
+			const { tab } = makeStubTab({
+				browser: {
+					browser: { targets: () => [{ _targetId: "stub-target-1", createCDPSession: async () => session }] },
+				},
+			});
+
+			const freeze = setTabFrozenForTest(tab, true);
+			await frozenStarted.promise;
+			tab.pending.set("run-1", {} as unknown as PendingRun);
+			releaseFrozenSend.resolve();
+
+			// No transition happened, but the frozen frame very likely landed
+			// while its undo did not: later runs must resume via unfreeze.
+			expect(await freeze).toBe(false);
+			expect(tab.frozen).toBe(true);
+			expect(calls.map(call => call.method)).toEqual([
+				"Page.enable",
+				"Page.setWebLifecycleState",
+				"Page.setWebLifecycleState",
+			]);
+		});
 	});
 
 	describe("browser settle — idle-close eligibility", () => {
@@ -318,6 +361,21 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-old")).toBe(true);
 		});
 
+		it("refreshes activity when a run completes", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-complete"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-done", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			tab.lastActivityAt = Date.now() - 3_600_000;
+
+			const result = await runInTab("settle-done", {
+				code: "return 42;",
+				timeoutMs: 5_000,
+				session: makeSession("/tmp"),
+			});
+			expect(result.returnValue).toBe(42);
+			expect(tab.lastActivityAt).toBeGreaterThan(Date.now() - 5_000);
+		});
+
 		it("settle is a no-op for unknown owners", async () => {
 			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
 			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);
@@ -354,6 +412,27 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			tab.lastActivityAt = Date.now() - 3_600_000;
 			expect(await releaseIdleTabsForOwner("session-settle-real", { idleMs: 60_000 })).toBe(1);
 			expect(getTabsMapForTest().has(name)).toBe(false);
+		}, 120_000);
+
+		it("revalidates candidates mid-drain: reuse during an earlier close is honored", async () => {
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const base = `settle-reval-${process.pid}`;
+			const a = await acquireTab(`${base}-a`, browser, { timeoutMs: 30_000, ownerSessionId: "session-reval" });
+			const b = await acquireTab(`${base}-b`, browser, { timeoutMs: 30_000, ownerSessionId: "session-reval" });
+			const ancient = Date.now() - 3_600_000;
+			a.tab.lastActivityAt = ancient;
+			b.tab.lastActivityAt = ancient;
+
+			const closing = releaseIdleTabsForOwner("session-reval", { idleMs: 60_000 });
+			void closing.catch(() => undefined);
+			// Refresh b synchronously in this same task: the touch provably
+			// precedes the loop's second-iteration recheck, which runs only
+			// after a's full worker teardown. Without the recheck, b would
+			// close from the stale snapshot and this would return 2.
+			await acquireTab(`${base}-b`, browser, { timeoutMs: 30_000, ownerSessionId: "session-reval" });
+			expect(await closing).toBe(1);
+			expect(getTabsMapForTest().has(`${base}-a`)).toBe(false);
+			expect(getTabsMapForTest().has(`${base}-b`)).toBe(true);
 		}, 120_000);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -518,6 +518,34 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-twice")).toBe(false);
 		});
 
+		it("honors persist only on reuse by the owning session", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-reuse-persist"), { cwd: "/tmp" });
+			const first = await acquireTab("settle-rp", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			expect(first.tab.persist).toBe(false);
+
+			const second = await acquireTab("settle-rp", browser, {
+				timeoutMs: 1_000,
+				ownerSessionId: "session-A",
+				persist: true,
+			});
+			expect(second.tab).toBe(first.tab);
+			expect(second.tab.persist).toBe(true);
+
+			const third = await acquireTab("settle-rp", browser, {
+				timeoutMs: 1_000,
+				ownerSessionId: "session-B",
+				persist: false,
+			});
+			expect(third.tab).toBe(first.tab);
+			expect(third.tab.ownerSessionId).toBe("session-A");
+			expect(third.tab.persist).toBe(true);
+
+			// Omitted on reuse leaves a previously set value alone.
+			const fourth = await acquireTab("settle-rp", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			expect(fourth.tab).toBe(first.tab);
+			expect(fourth.tab.persist).toBe(true);
+		});
 		it("rejects reuse when the frozen tab cannot resume", async () => {
 			mockCmuxSocket();
 			const browser = await acquireBrowser(makeKind("settle-reuse-frozen"), { cwd: "/tmp" });

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression tests for issue #8246: session-owned headless tabs outlive their
+ * purpose and burn CPU/GPU (unthrottled rAF + SwiftShader) until session
+ * dispose. The settle machinery under test:
+ *
+ * - `freezeTabsForOwner` pauses rAF/timers via `Page.setWebLifecycleState`
+ *   while keeping renderer/worker/DOM state for millisecond resume;
+ * - `releaseIdleTabsForOwner` closes tabs idle past the timeout as the
+ *   memory backstop;
+ * - reuse/run refresh `lastActivityAt` and resume frozen tabs.
+ *
+ * Scope contract (the thing that must never regress): settle touches ONLY
+ * OMP-launched headless worker tabs of the owning session that did not opt
+ * out with `persist`. Relay/connected/spawned tabs drive the user's own
+ * pages, cmux is a different backend with no CDP lifecycle, and other
+ * sessions' tabs belong to their owners.
+ */
+
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { CmuxKind } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/rpc";
+import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
+import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import {
+	acquireTab,
+	freezeTabsForOwner,
+	getTabsMapForTest,
+	releaseIdleTabsForOwner,
+	releaseTab,
+	runInTab,
+	setTabFrozenForTest,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import type { TabSession } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
+import { chromiumAvailable } from "./chromium-probe";
+
+const CHROMIUM_AVAILABLE = await chromiumAvailable();
+function makeKind(socketSuffix: string): CmuxKind {
+	return { kind: "cmux", socketPath: `/tmp/omp-test-${socketSuffix}.sock`, surface: `surface-${socketSuffix}` };
+}
+
+function makeSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		settings: { get: () => undefined },
+		getSessionFile: () => null,
+	} as unknown as ToolSession;
+}
+
+function mockCmuxSocket(): void {
+	spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+	spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+	spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+		async (method: string): Promise<Record<string, unknown>> => {
+			if (method === "browser.open_split")
+				return { surface_id: `surface-${method}-${Date.now()}`, url: "about:blank" };
+			if (method === "browser.url.get") return { url: "about:blank" };
+			if (method === "browser.snapshot") return { page: { html: "" } };
+			if (method === "browser.geometry") return {};
+			if (method === "browser.eval") return { value: "" };
+			return {};
+		},
+	);
+}
+
+async function drainAllTabs(): Promise<void> {
+	// oxlint-disable-next-line unicorn/no-useless-spread -- releasing tabs mutates the map
+	for (const name of [...getTabsMapForTest().keys()]) {
+		await releaseTab(name, { kill: false }).catch(() => undefined);
+	}
+}
+
+interface CdpCall {
+	method: string;
+	params?: unknown;
+}
+
+/** Minimal worker-tab double: `_targetId` hits the fast path in target lookup. */
+function makeStubTab(overrides: Record<string, unknown> = {}): { tab: TabSession; calls: CdpCall[] } {
+	const calls: CdpCall[] = [];
+	const session = {
+		send: async (method: string, params?: unknown): Promise<Record<string, unknown>> => {
+			calls.push({ method, params });
+			return {};
+		},
+		detach: async (): Promise<void> => undefined,
+	};
+	const target = {
+		_targetId: "stub-target-1",
+		createCDPSession: async () => session,
+	};
+	const tab = {
+		name: "stub-tab",
+		browser: { browser: { targets: () => [target] } },
+		targetId: "stub-target-1",
+		backend: "worker",
+		state: "alive",
+		info: {},
+		pending: new Map(),
+		kindTag: "headless",
+		ownerSessionId: "session-stub",
+		persist: false,
+		lastActivityAt: Date.now(),
+		frozen: false,
+		...overrides,
+	} as unknown as TabSession;
+	return { tab, calls };
+}
+
+describe("browser settle — lifecycle freeze via CDP", () => {
+	it("freezes a managed headless tab and resumes it", async () => {
+		const { tab, calls } = makeStubTab();
+
+		expect(await setTabFrozenForTest(tab, true)).toBe(true);
+		expect(tab.frozen).toBe(true);
+		expect(calls.map(call => call.method)).toEqual(["Page.enable", "Page.setWebLifecycleState"]);
+		expect(calls[1]?.params).toEqual({ state: "frozen" });
+
+		expect(await setTabFrozenForTest(tab, false)).toBe(true);
+		expect(tab.frozen).toBe(false);
+		expect(calls.at(-1)).toEqual({ method: "Page.setWebLifecycleState", params: { state: "active" } });
+	});
+
+	it("a repeated transition without state change issues no CDP call", async () => {
+		const { tab, calls } = makeStubTab();
+		expect(await setTabFrozenForTest(tab, true)).toBe(true);
+		const sendCount = calls.length;
+
+		expect(await setTabFrozenForTest(tab, true)).toBe(false);
+		expect(calls.length).toBe(sendCount);
+	});
+
+	it("never touches tabs outside the settle scope", async () => {
+		const cases: Array<{ label: string; overrides: Record<string, unknown> }> = [
+			{ label: "relay", overrides: { kindTag: "relay" } },
+			{ label: "connected", overrides: { kindTag: "connected" } },
+			{ label: "spawned", overrides: { kindTag: "spawned" } },
+			{ label: "cmux backend", overrides: { backend: "cmux", kindTag: "cmux" } },
+			{ label: "persist opt-out", overrides: { persist: true } },
+			{ label: "dead tab", overrides: { state: "dead" } },
+			{ label: "in-flight run", overrides: { pending: new Map([["run-1", {}]]) } },
+		];
+		for (const { label, overrides } of cases) {
+			const { tab, calls } = makeStubTab(overrides);
+			expect(await setTabFrozenForTest(tab, true), label).toBe(false);
+			expect(tab.frozen, label).toBe(false);
+			expect(calls.length, label).toBe(0);
+		}
+	});
+
+	it("leaves the tab unfrozen when its target is gone", async () => {
+		const { tab, calls } = makeStubTab({
+			browser: { browser: { targets: () => [] } },
+		});
+		expect(await setTabFrozenForTest(tab, true)).toBe(false);
+		expect(tab.frozen).toBe(false);
+		expect(calls.length).toBe(0);
+	});
+
+	it("leaves the tab unfrozen when the protocol call fails", async () => {
+		const { tab, calls } = makeStubTab({
+			browser: {
+				browser: {
+					targets: () => [
+						{
+							_targetId: "stub-target-1",
+							createCDPSession: async () => {
+								throw new Error("target crashed");
+							},
+						},
+					],
+				},
+			},
+		});
+		expect(await setTabFrozenForTest(tab, true)).toBe(false);
+		expect(tab.frozen).toBe(false);
+		expect(calls.length).toBe(0);
+	});
+
+	describe("browser settle — ownership and bookkeeping", () => {
+		afterEach(async () => {
+			try {
+				await drainAllTabs();
+			} finally {
+				vi.restoreAllMocks();
+			}
+		});
+
+		it("acquireTab records persist and activity; reuse preserves persist and refreshes activity", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-bookkeeping"), { cwd: "/tmp" });
+
+			const before = Date.now();
+			const first = await acquireTab("settle-book", browser, {
+				timeoutMs: 1_000,
+				ownerSessionId: "session-A",
+				persist: true,
+			});
+			expect(first.tab.persist).toBe(true);
+			expect(first.tab.frozen).toBe(false);
+			expect(first.tab.lastActivityAt).toBeGreaterThanOrEqual(before);
+			// Backdate, then reuse under a different session without persist: the
+			// creator's opt-out and ownership survive, the clock refreshes.
+			first.tab.lastActivityAt -= 60_000;
+			const stale = first.tab.lastActivityAt;
+			const second = await acquireTab("settle-book", browser, { timeoutMs: 1_000, ownerSessionId: "session-B" });
+			expect(second.tab).toBe(first.tab);
+			expect(second.created).toBe(false);
+			expect(second.tab.ownerSessionId).toBe("session-A");
+			expect(second.tab.persist).toBe(true);
+			expect(second.tab.lastActivityAt).toBeGreaterThan(stale);
+		});
+
+		it("tabs without persist default to reaping", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-default"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-plain", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			expect(tab.persist).toBe(false);
+		});
+
+		it("freezeTabsForOwner skips non-headless tabs", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-freeze-skip"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-cmux", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+
+			expect(await freezeTabsForOwner("session-A")).toBe(0);
+			expect(tab.frozen).toBe(false);
+			expect(tab.state).toBe("alive");
+		});
+
+		it("releaseIdleTabsForOwner skips non-headless tabs even when ancient", async () => {
+			mockCmuxSocket();
+			const browser = await acquireBrowser(makeKind("settle-idle-skip"), { cwd: "/tmp" });
+			const { tab } = await acquireTab("settle-old", browser, { timeoutMs: 1_000, ownerSessionId: "session-A" });
+			tab.lastActivityAt = Date.now() - 3_600_000;
+
+			expect(await releaseIdleTabsForOwner("session-A", { idleMs: 60_000 })).toBe(0);
+			expect(getTabsMapForTest().has("settle-old")).toBe(true);
+		});
+
+		it("settle is a no-op for unknown owners", async () => {
+			expect(await freezeTabsForOwner("session-nobody")).toBe(0);
+			expect(await releaseIdleTabsForOwner("session-nobody", { idleMs: 0 })).toBe(0);
+			expect(await freezeTabsForOwner("")).toBe(0);
+			expect(await releaseIdleTabsForOwner("", { idleMs: 0 })).toBe(0);
+		});
+	});
+
+	describe.skipIf(!CHROMIUM_AVAILABLE)("browser settle — real headless Chromium", () => {
+		afterEach(async () => {
+			await drainAllTabs();
+		});
+
+		it("freezes at settle, resumes transparently on run, and idle-closes", async () => {
+			const session = makeSession(process.cwd());
+			const browser = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+			const name = `settle-real-${process.pid}`;
+			const { tab } = await acquireTab(name, browser, {
+				url: "about:blank",
+				timeoutMs: 30_000,
+				ownerSessionId: "session-settle-real",
+			});
+			expect(tab.frozen).toBe(false);
+
+			expect(await freezeTabsForOwner("session-settle-real")).toBe(1);
+			expect(tab.frozen).toBe(true);
+
+			// A run resumes the page without the caller knowing it was frozen.
+			const result = await runInTab(name, { code: "return 40 + 2;", timeoutMs: 30_000, session });
+			expect(tab.frozen).toBe(false);
+			expect(result.returnValue).toBe(42);
+
+			// Backdated past the timeout, the owned tab closes.
+			tab.lastActivityAt = Date.now() - 3_600_000;
+			expect(await releaseIdleTabsForOwner("session-settle-real", { idleMs: 60_000 })).toBe(1);
+			expect(getTabsMapForTest().has(name)).toBe(false);
+		}, 120_000);
+	});
+});


### PR DESCRIPTION
What

Freeze-first lifecycle for session-owned headless browser tabs: freezeTabsForOwner pauses rAF/timers via
Page.setWebLifecycleState at turn settle (millisecond resume on next run/open), and releaseIdleTabsForOwner closes tabs
idle past browser.idleCloseSec (default 30 min) as the memory backstop. Adds persist: true on browser.open to opt a tab
out of both. Scoped strictly to OMP-launched headless worker tabs of the owning session — relay/CDP/spawned/cmux and
other sessions' tabs are never touched. New settings: browser.freezeOnTurnEnd (default true), browser.idleCloseSec
(default 1800, 0 disables).

Why

Fixes #8246. Idle animated/WebGL tabs run requestAnimationFrame at unlimited FPS through SwiftShader software rendering
— one abandoned tab pinned a GPU process at ~540% CPU for 1.5h. Tabs previously survived until session dispose with no
idle checkpoint. Freeze answers the CPU/GPU burn while preserving reuse state; close answers accumulated memory.
Open-path sweep does close-only (freezing a sibling mid-run could stall it; turn_end is race-free since all tool results
are paired).

Testing

- New test/tools/browser-freeze-settle.test.ts (11 pass): CDP freeze/resume/no-op semantics on stub targets, never-touch
  matrix (relay/connected/spawned/cmux/persist/dead/in-flight), persist+ownership preserved across reuse with activity
  refresh, cmux exclusion even when ancient.
- Live-Chromium integration case ran (not skipped): real headless tab froze at settle, runInTab returned 42 with
  transparent auto-resume, backdated tab idle-closed.
- Neighbors green (20/20: lifecycle-leak, schema, tab-call, open-lease, prelude-facade); full test/tools/browser 203/204
  — the single browser-relay-daemon lease failure reproduces on the clean tree, pre-existing and unrelated.

- bun check passes
- Tested locally
- CHANGELOG updated (if user-facing)