### PR TITLE
fix(tui): guard optimistic skill row reconcile against duplicate card

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
+- Fixed a user-invoked `/skill:` submission rendering two identical skill cards when the optimistic row retired into scrollback before the canonical message arrived during a slow preflight ([#11217](https://github.com/can1357/oh-my-pi/issues/11217)).
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -10,6 +10,12 @@ export class SkillMessageComponent extends Container {
 	#box: Box;
 	#contentComponent?: Component;
 	#expanded = false;
+	// Canonical and replayed skill cards finalize immediately so they retire to
+	// native scrollback like any settled block. An optimistically-painted
+	// `/skill:` row (issue #11217) is instead held live until its canonical
+	// `message_start` reconciles it, so it stays removable and never leaves a
+	// duplicate behind in scrollback if reconcile swaps it out.
+	#transcriptBlockFinalized = true;
 
 	constructor(private readonly message: CustomMessage<SkillPromptDetails>) {
 		super();
@@ -24,6 +30,26 @@ export class SkillMessageComponent extends Container {
 			this.#expanded = expanded;
 			this.#rebuild();
 		}
+	}
+
+	/**
+	 * Transcript finalization contract (see `FinalizableBlock`): an optimistic
+	 * `/skill:` row reports `false` so the container keeps it live and removable
+	 * until reconcile; every other skill card is finalized on creation.
+	 */
+	isTranscriptBlockFinalized(): boolean {
+		return this.#transcriptBlockFinalized;
+	}
+
+	/** Hold this card live as an unreconciled optimistic `/skill:` row (#11217). */
+	markTranscriptBlockPending(): void {
+		this.#transcriptBlockFinalized = false;
+	}
+
+	/** Finalize an optimistic row adopted in place after it already retired to
+	 *  scrollback before its canonical `message_start` arrived (#11217). */
+	markTranscriptBlockFinalized(): void {
+		this.#transcriptBlockFinalized = true;
 	}
 
 	override invalidate(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -176,6 +176,7 @@ import type { HookSelectorComponent, HookSelectorSlider } from "./components/hoo
 import { type PlanReviewAnnotationState, PlanReviewOverlay } from "./components/plan-review-overlay";
 import { PlanSaveOverlay, type PlanSaveOverlayResult } from "./components/plan-save-overlay";
 import { SessionInfoOverlay } from "./components/session-info-overlay";
+import { SkillMessageComponent } from "./components/skill-message";
 import { StatusLineComponent } from "./components/status-line";
 import { stopSharedSpinnerTicker, type ToolExecutionHandle } from "./components/tool-execution";
 import { TranscriptContainer } from "./components/transcript-container";
@@ -1944,19 +1945,39 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#optimisticSkillMessageComponents = this.#captureAddedChatComponents(() => {
 			this.addMessageToChat(message, options);
 		});
+		// Hold the row live (unfinalized) so it stays removable until reconcile,
+		// instead of settling and retiring into immutable scrollback mid-preflight
+		// where reconcile could no longer swap it out (issue #11217).
+		for (const component of this.#optimisticSkillMessageComponents) {
+			if (component instanceof SkillMessageComponent) component.markTranscriptBlockPending();
+		}
 		this.ensureLoadingAnimation();
 		this.ui.requestRender();
 	}
 
-	/** Replace the optimistic `/skill:` row with the canonical message emitted by
-	 *  the session, mirroring {@link replaceOptimisticUserMessage} for skills. */
+	/**
+	 * Reconcile the optimistic `/skill:` row against the canonical message emitted
+	 * by the session (mirrors {@link replaceOptimisticUserMessage} for skills).
+	 *
+	 * While the row is still live it is removed and the canonical message appended
+	 * in its place. If it already retired into native scrollback before the
+	 * canonical `message_start` arrived, {@link TranscriptContainer.removeChild}
+	 * refuses silently — appending the canonical then would leave two identical
+	 * cards (issue #11217). In that case the existing row is adopted in place
+	 * (finalized so it can retire normally) and the append is skipped.
+	 */
 	reconcileOptimisticSkillMessage(message: AgentMessage): void {
 		this.optimisticSkillMessagePending = false;
-		for (const component of this.#optimisticSkillMessageComponents) {
-			this.chatContainer.removeChild(component);
-		}
+		const components = this.#optimisticSkillMessageComponents;
 		this.#optimisticSkillMessageComponents = [];
-		this.addMessageToChat(message);
+		if (components.every(component => this.chatContainer.canRemoveBlock(component))) {
+			for (const component of components) this.chatContainer.removeChild(component);
+			this.addMessageToChat(message);
+			return;
+		}
+		for (const component of components) {
+			if (component instanceof SkillMessageComponent) component.markTranscriptBlockFinalized();
+		}
 	}
 
 	/** Drop the optimistic `/skill:` row when dispatch fails or bails before the

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1959,25 +1959,28 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * Reconcile the optimistic `/skill:` row against the canonical message emitted
 	 * by the session (mirrors {@link replaceOptimisticUserMessage} for skills).
 	 *
-	 * While the row is still live it is removed and the canonical message appended
-	 * in its place. If it already retired into native scrollback before the
-	 * canonical `message_start` arrived, {@link TranscriptContainer.removeChild}
-	 * refuses silently — appending the canonical then would leave two identical
-	 * cards (issue #11217). In that case the existing row is adopted in place
-	 * (finalized so it can retire normally) and the append is skipped.
+	 * The row is adopted in place — finalized, with the append skipped — only when
+	 * it is still on screen but no longer removable: it retired into native
+	 * scrollback before the canonical `message_start` arrived, so appending would
+	 * trail it with a second identical card (issue #11217). Otherwise the canonical
+	 * message is appended after clearing the tracked row, covering both a still-live
+	 * row (clean replace) and a row a transcript rebuild already detached from the
+	 * container (e.g. a display-setting toggle calling {@link rebuildChatFromMessages}),
+	 * whose card would otherwise vanish.
 	 */
 	reconcileOptimisticSkillMessage(message: AgentMessage): void {
 		this.optimisticSkillMessagePending = false;
 		const components = this.#optimisticSkillMessageComponents;
 		this.#optimisticSkillMessageComponents = [];
-		if (components.every(component => this.chatContainer.canRemoveBlock(component))) {
-			for (const component of components) this.chatContainer.removeChild(component);
-			this.addMessageToChat(message);
+		const present = components.filter(component => this.chatContainer.children.includes(component));
+		if (present.length > 0 && present.every(component => !this.chatContainer.canRemoveBlock(component))) {
+			for (const component of present) {
+				if (component instanceof SkillMessageComponent) component.markTranscriptBlockFinalized();
+			}
 			return;
 		}
-		for (const component of components) {
-			if (component instanceof SkillMessageComponent) component.markTranscriptBlockFinalized();
-		}
+		for (const component of components) this.chatContainer.removeChild(component);
+		this.addMessageToChat(message);
 	}
 
 	/** Drop the optimistic `/skill:` row when dispatch fails or bails before the

--- a/packages/coding-agent/test/interactive-mode-optimistic-skill-reconcile.test.ts
+++ b/packages/coding-agent/test/interactive-mode-optimistic-skill-reconcile.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Reconciliation contract for the optimistic `/skill:` row (issue #11217).
+ *
+ * A user-invoked `/skill:` submission paints an optimistic transcript row before
+ * its awaited preflight (issue #8895). When the canonical `message_start`
+ * arrives the row must be swapped in place — never left behind alongside an
+ * appended copy — even when the optimistic row already retired into native
+ * scrollback during a slow preflight.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SkillMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/skill-message";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const WIDTH = 80;
+
+function skillMessage(timestamp: number): AgentMessage {
+	return {
+		role: "custom",
+		customType: SKILL_PROMPT_MESSAGE_TYPE,
+		content: "run the skill",
+		display: true,
+		attribution: "user",
+		details: { name: "test-skill", path: "/skills/test-skill/SKILL.md", lineCount: 12 } satisfies SkillPromptDetails,
+		timestamp,
+	} as AgentMessage;
+}
+
+function skillCards(mode: InteractiveMode): SkillMessageComponent[] {
+	return mode.chatContainer.children.filter((child): child is SkillMessageComponent => {
+		return child instanceof SkillMessageComponent;
+	});
+}
+
+/** Force every settled block to commit into immutable scrollback. */
+function retireToScrollback(mode: InteractiveMode): void {
+	const batch = mode.chatContainer.peekFlushBatch(WIDTH);
+	if (batch) mode.chatContainer.acknowledgeFinalizedBatch(batch.id);
+}
+
+describe("InteractiveMode optimistic skill reconcile (#11217)", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(async () => {
+		initTheme();
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-optimistic-skill-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+		// The test drives reconcile directly and never starts the mode; keep the
+		// git branch watcher off so it does not leak an fs.watch into sibling files.
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+	});
+
+	beforeEach(() => {
+		mode.chatContainer.clear();
+		vi.spyOn(mode, "ensureLoadingAnimation").mockImplementation(() => {});
+	});
+
+	afterAll(async () => {
+		// No mode.stop(): the mode was never started, and stop() persists the
+		// composer status through the native VCS status line — unrelated to the
+		// reconcile contract under test.
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("keeps the optimistic row live so a retirement pass cannot commit it before reconcile", () => {
+		mode.renderOptimisticSkillMessage(skillMessage(1));
+		const [card] = skillCards(mode);
+		expect(card).toBeInstanceOf(SkillMessageComponent);
+		// Unfinalized while pending: the transcript keeps it removable.
+		expect(card!.isTranscriptBlockFinalized()).toBe(false);
+
+		// A retirement pass at submit time offers nothing (nothing settled), so
+		// the row stays removable and reconcile can swap it out cleanly.
+		retireToScrollback(mode);
+		expect(mode.chatContainer.canRemoveBlock(card!)).toBe(true);
+
+		mode.reconcileOptimisticSkillMessage(skillMessage(2));
+		expect(skillCards(mode)).toHaveLength(1);
+	});
+
+	it("adopts the optimistic row in place instead of duplicating it when it already retired", () => {
+		mode.renderOptimisticSkillMessage(skillMessage(1));
+		const [card] = skillCards(mode);
+		expect(card).toBeInstanceOf(SkillMessageComponent);
+
+		// Residual race: the row finalized and retired into immutable scrollback
+		// before the canonical message_start arrived.
+		card!.markTranscriptBlockFinalized();
+		retireToScrollback(mode);
+		expect(mode.chatContainer.canRemoveBlock(card!)).toBe(false);
+
+		mode.reconcileOptimisticSkillMessage(skillMessage(2));
+
+		const cards = skillCards(mode);
+		expect(cards).toHaveLength(1);
+		expect(cards[0]).toBe(card);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-optimistic-skill-reconcile.test.ts
+++ b/packages/coding-agent/test/interactive-mode-optimistic-skill-reconcile.test.ts
@@ -123,4 +123,18 @@ describe("InteractiveMode optimistic skill reconcile (#11217)", () => {
 		expect(cards).toHaveLength(1);
 		expect(cards[0]).toBe(card);
 	});
+
+	it("appends the canonical card when a transcript rebuild detached the optimistic row", () => {
+		mode.renderOptimisticSkillMessage(skillMessage(1));
+		expect(skillCards(mode)).toHaveLength(1);
+
+		// A mid-preflight transcript rebuild (e.g. a display-setting toggle) clears
+		// the container; the UI-only optimistic row is not replayed, so it is
+		// detached while still tracked for reconcile. canRemoveBlock reports false
+		// for the absent component, but the canonical card must still be appended.
+		mode.chatContainer.clear();
+
+		mode.reconcileOptimisticSkillMessage(skillMessage(2));
+		expect(skillCards(mode)).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Repro
A user-invoked `/skill:<name>` submission intermittently rendered two identical skill cards. It requires the optimistic `/skill:` row (added for #8895) to retire into native scrollback before the canonical `message_start` arrives — the ~32.5s preflight window measured in #8895 (MCP servers connecting, `before_agent_start` hooks, auto-thinking, pre-prompt compaction). Driving the real `TranscriptContainer` + `SkillMessageComponent` from pre-fix `pi-coding-agent@18.1.14` — paint the optimistic row, retire it via a flush/commit pass, then run the reconcile sequence — reproduces it deterministically: `canRemoveBlock(optimistic): false` then `skill cards rendered: 2`.

## Cause
`SkillMessageComponent` (`packages/coding-agent/src/modes/components/skill-message.ts`) declared no `isTranscriptBlockFinalized`, so `TranscriptContainer`'s `isFinalized` helper defaulted it to `true`; the optimistic row settled and could be committed to scrollback mid-preflight. `InteractiveMode.reconcileOptimisticSkillMessage` (`interactive-mode.ts`) then called `chatContainer.removeChild(...)` — which silently no-ops for a committed block (`transcript-container.ts` `removeChild`/`canRemoveBlock`) — but appended the canonical message via `addMessageToChat` unconditionally, leaving two identical cards. Every other `removeChild` site in the codebase guards with `canRemoveBlock`; this reconcile path was the exception.

## Fix
- `SkillMessageComponent` gains the `FinalizableBlock` finalization contract: `isTranscriptBlockFinalized()` plus `markTranscriptBlockPending()`/`markTranscriptBlockFinalized()`. Canonical and replayed cards finalize on creation (unchanged behavior); an optimistic row is held live so it stays removable until reconcile.
- `renderOptimisticSkillMessage` marks the painted row pending.
- `reconcileOptimisticSkillMessage` now branches: when the row is still removable it removes and appends the canonical message as before; when the row already retired to scrollback it adopts the existing card in place (finalizing it) and skips the append.

## Verification
`bun test test/interactive-mode-optimistic-skill-reconcile.test.ts` — 2 pass, covering both the finalizer-keeps-it-removable path and the already-committed adopt-in-place path. `bun test test/input-controller-skill-queue.test.ts test/modes/components/transcript-container.test.ts` — all pass. `bun check` clean. Full pre-fix repro against `pi-coding-agent@18.1.14` showed 2 cards; the fixed tree renders 1. Fixes #11217