### PR TITLE
fix(eval): avoid replaying cells after kernel failure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
 - Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
+### Fixed
+
+- Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -522,7 +522,9 @@ export async function executeWithKernelBase<
 			const timedOut = result.timedOut || abortShield.timedOut;
 			const annotation = timedOut
 				? formatKernelTimeoutAnnotation(executionTimeoutMs ?? options?.idleTimeoutMs, result.kernelKilled ?? false)
-				: undefined;
+				: result.kernelKilled && !abortShield.abortRequested
+					? "Kernel died during execution; completion is uncertain. The cell was not replayed; check for partial side effects before retrying."
+					: undefined;
 			const dumped = await sink.dump(annotation);
 			return {
 				exitCode: undefined,

--- a/packages/coding-agent/src/eval/kernel-session-registry.ts
+++ b/packages/coding-agent/src/eval/kernel-session-registry.ts
@@ -404,24 +404,6 @@ export function createKernelSessionRegistry<
 		}
 	}
 
-	async function acquireRetryKernel(
-		session: TSession,
-		kernel: TKernel,
-		cwd: string,
-		options: TOptions,
-	): Promise<TKernel> {
-		if (descriptor.acquireLiveSessionKernel) {
-			const retryKernel = await acquireLiveSessionKernel(session, cwd, options);
-			if (!isCurrent(session, retryKernel)) throw new descriptor.cancelledErrorClass(false);
-			return retryKernel;
-		}
-		const retryKernel = await acquireDefaultReplacementKernel(session, kernel, cwd, options);
-		if (!isCurrent(session) || session.kernel !== retryKernel) {
-			throw new descriptor.cancelledErrorClass(false);
-		}
-		return retryKernel;
-	}
-
 	function peekLiveKernel(cwd: string, options: TOptions): TKernel | undefined {
 		const sessionId = options.sessionId ?? `session:${cwd}`;
 		const sessionKey = resolveOwnerScopedSessionKey({
@@ -483,33 +465,12 @@ export function createKernelSessionRegistry<
 			)
 				throw err;
 			if (kernel.isAlive()) throw err;
-			const retryKernel = await acquireRetryKernel(session, kernel, cwd, options);
-			throwIfCallerCancelled(options);
-			return await descriptor.executeWithKernel(retryKernel, code, runOptions);
+			throw new Error(
+				`${descriptor.languageLabel} kernel died during execution; completion is uncertain and the cell was not replayed. The next call will start a fresh kernel.`,
+				{ cause: err },
+			);
 		}
-		if (
-			!result.cancelled ||
-			options.signal?.aborted ||
-			(options.deadlineMs !== undefined && options.deadlineMs <= Date.now()) ||
-			kernel.isAlive()
-		) {
-			return result;
-		}
-		let retryKernel: TKernel;
-		try {
-			retryKernel = await acquireRetryKernel(session, kernel, cwd, options);
-		} catch (err) {
-			const deadlineExpired = options.deadlineMs !== undefined && options.deadlineMs <= Date.now();
-			const cancelled = descriptor.isCancellation?.(err) || isCancellationError(err, descriptor.cancelledErrorClass);
-			if (deadlineExpired && cancelled) return result;
-			throw err;
-		}
-		throwIfCallerCancelled(options);
-		const retryResult = await descriptor.executeWithKernel(retryKernel, code, runOptions);
-		if (retryResult.cancelled && options.deadlineMs !== undefined && options.deadlineMs <= Date.now()) {
-			return result;
-		}
-		return retryResult;
+		return result;
 	}
 
 	return { disposeAll, disposeByOwner, executeOnSession, peekLiveKernel };

--- a/packages/coding-agent/test/core/python-executor-lifecycle.test.ts
+++ b/packages/coding-agent/test/core/python-executor-lifecycle.test.ts
@@ -100,7 +100,7 @@ describe("executePython lifecycle", () => {
 		expect(kernelNext.execute).toHaveBeenCalledTimes(1);
 	});
 
-	it("restarts after an execution failure when kernel is dead", async () => {
+	it("reports uncertain completion after a kernel crash and restarts for the next cell", async () => {
 		const kernel = new FakeKernel(OK_RESULT);
 		kernel.execute.mockImplementation(async () => {
 			kernel.alive = false;
@@ -113,7 +113,12 @@ describe("executePython lifecycle", () => {
 			.mockResolvedValueOnce(kernel as unknown as pythonKernel.PythonKernel)
 			.mockResolvedValueOnce(kernelNext as unknown as pythonKernel.PythonKernel);
 
-		await executePython("1 + 1", { kernelMode: "session", sessionId: "crash-session", cwd: getProjectDir() });
+		const options = { kernelMode: "session" as const, sessionId: "crash-session", cwd: getProjectDir() };
+		await expect(executePython("1 + 1", options)).rejects.toThrow("completion is uncertain");
+		expect(startSpy).toHaveBeenCalledTimes(1);
+		expect(kernelNext.execute).not.toHaveBeenCalled();
+		const next = await executePython("2 + 2", options);
+		expect(next.exitCode).toBe(0);
 
 		expect(startSpy).toHaveBeenCalledTimes(2);
 		expect(kernel.execute).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/core/python-runner.integration.test.ts
+++ b/packages/coding-agent/test/core/python-runner.integration.test.ts
@@ -7,7 +7,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { disposeAllKernelSessions, executePythonWithKernel } from "@oh-my-pi/pi-coding-agent/eval/py/executor";
+import {
+	disposeAllKernelSessions,
+	executePython,
+	executePythonWithKernel,
+} from "@oh-my-pi/pi-coding-agent/eval/py/executor";
 import { PythonKernel } from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
 import { filterEnv, resolvePythonRuntime } from "@oh-my-pi/pi-coding-agent/eval/py/runtime";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -42,6 +46,35 @@ describe.skipIf(!SHOULD_RUN)("python runner subprocess", () => {
 	afterEach(async () => {
 		await disposeAllKernelSessions();
 	});
+
+	it("does not replay a crashed cell's file write and accepts the next cell in a fresh kernel", async () => {
+		using tempDir = TempDir.createSync("@python-runner-crash-");
+		const options = {
+			cwd: tempDir.path(),
+			sessionId: "crash-recovery",
+			kernelMode: "session" as const,
+			timeoutMs: 10_000,
+		};
+		const result = await executePython(
+			[
+				"import os",
+				"with open('effects.txt', 'a') as effects:",
+				"    effects.write('once\\n')",
+				"print('before crash', flush=True)",
+				"os._exit(17)",
+			].join("\n"),
+			options,
+		);
+		expect(await Bun.file(path.join(tempDir.path(), "effects.txt")).text()).toBe("once\n");
+		expect(result.cancelled).toBe(true);
+		expect(result.output).toContain("before crash");
+		expect(result.output).toContain("completion is uncertain");
+
+		const next = await executePython("print(21 * 2)", options);
+		expect(next.exitCode).toBe(0);
+		expect(next.output.trim()).toBe("42");
+		expect(await Bun.file(path.join(tempDir.path(), "effects.txt")).text()).toBe("once\n");
+	}, 30_000);
 
 	it("streams stdout chunks as they are produced", async () => {
 		using tempDir = TempDir.createSync("@python-runner-stream-");

--- a/packages/coding-agent/test/eval/kernel-session-registry.test.ts
+++ b/packages/coding-agent/test/eval/kernel-session-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { createKernelSessionRegistry, type KernelSession } from "../../src/eval/kernel-session-registry";
 
 interface TestOptions {
@@ -62,131 +62,94 @@ function createFakeRegistry(executeWithKernel: ExecuteFakeKernel, onStartKernel?
 }
 
 describe("kernel session recovery", () => {
-	it("replaces a kernel that dies while returning a cancelled result and retries once", async () => {
-		const executions: number[] = [];
-		const { kernels, registry } = createFakeRegistry(async kernel => {
-			executions.push(kernel.index);
+	it("preserves partial output without replaying side effects and recovers on the next call", async () => {
+		const effects: string[] = [];
+		const { kernels, registry } = createFakeRegistry(async (kernel, code) => {
+			effects.push(code);
 			if (kernel.index === 0) {
 				kernel.alive = false;
-				return { cancelled: true, value: "kernel died" };
+				return { cancelled: true, value: "partial output before death" };
 			}
-			return { cancelled: false, value: "recovered" };
+			return { cancelled: false, value: "new cell completed" };
 		});
-
 		try {
-			const result = await registry.executeOnSession("code", "/tmp", { sessionId: "recovery" });
-
-			expect(result).toEqual({ cancelled: false, value: "recovered" });
-			expect(executions).toEqual([0, 1]);
-			expect(kernels).toHaveLength(2);
+			expect(await registry.executeOnSession("first effect", "/tmp", { sessionId: "recovery" })).toEqual({
+				cancelled: true,
+				value: "partial output before death",
+			});
+			expect(effects).toEqual(["first effect"]);
+			expect(kernels).toHaveLength(1);
+			expect(await registry.executeOnSession("next effect", "/tmp", { sessionId: "recovery" })).toEqual({
+				cancelled: false,
+				value: "new cell completed",
+			});
+			expect(effects).toEqual(["first effect", "next effect"]);
 			expect(kernels[0]?.shutdowns).toBe(1);
 		} finally {
 			await registry.disposeAll();
 		}
 	});
 
-	it("coalesces concurrent recovery from the same dead kernel", async () => {
-		const bothDeadExecutionsStarted = Promise.withResolvers<void>();
-		const releaseDeadResults = Promise.withResolvers<void>();
+	it("coalesces concurrent recovery before dispatch to a dead kernel", async () => {
 		const replacementStarted = Promise.withResolvers<void>();
 		const releaseReplacement = Promise.withResolvers<void>();
-		const executions: Array<{ code: string; kernel: number }> = [];
-		let deadExecutions = 0;
+		const executions: string[] = [];
 		const { kernels, registry } = createFakeRegistry(
-			async (kernel, code) => {
-				executions.push({ code, kernel: kernel.index });
-				if (kernel.index === 0) {
-					deadExecutions += 1;
-					if (deadExecutions === 2) bothDeadExecutionsStarted.resolve();
-					await releaseDeadResults.promise;
-					kernel.alive = false;
-					return { cancelled: true, value: "kernel died" };
-				}
-				return { cancelled: false, value: `recovered ${code}` };
+			async (_kernel, code) => {
+				executions.push(code);
+				return { cancelled: false, value: code };
 			},
 			async kernel => {
+				if (kernel.index === 0) kernel.alive = false;
 				if (kernel.index !== 1) return;
 				replacementStarted.resolve();
 				await releaseReplacement.promise;
 			},
 		);
-
 		try {
-			const first = registry.executeOnSession("first", "/tmp", { sessionId: "concurrent-recovery" });
-			const second = registry.executeOnSession("second", "/tmp", { sessionId: "concurrent-recovery" });
-			await bothDeadExecutionsStarted.promise;
-			releaseDeadResults.resolve();
+			const first = registry.executeOnSession("first", "/tmp", { sessionId: "concurrent" });
 			await replacementStarted.promise;
-
-			expect(kernels).toHaveLength(2);
+			const second = registry.executeOnSession("second", "/tmp", { sessionId: "concurrent" });
 			releaseReplacement.resolve();
-			const results = await Promise.all([first, second]);
-
-			expect(results).toEqual([
-				{ cancelled: false, value: "recovered first" },
-				{ cancelled: false, value: "recovered second" },
+			expect(await Promise.all([first, second])).toEqual([
+				{ cancelled: false, value: "first" },
+				{ cancelled: false, value: "second" },
 			]);
-			expect(
-				executions
-					.filter(execution => execution.kernel === 0)
-					.map(execution => execution.code)
-					.sort(),
-			).toEqual(["first", "second"]);
-			expect(
-				executions
-					.filter(execution => execution.kernel === 1)
-					.map(execution => execution.code)
-					.sort(),
-			).toEqual(["first", "second"]);
+			expect(executions.sort()).toEqual(["first", "second"]);
+			expect(kernels).toHaveLength(2);
 			expect(kernels[0]?.shutdowns).toBe(1);
 		} finally {
-			releaseDeadResults.resolve();
 			releaseReplacement.resolve();
 			await registry.disposeAll();
 		}
 	});
 
-	it("recovers a newer dead kernel for a stale caller that has not retried", async () => {
-		const bothOldExecutionsStarted = Promise.withResolvers<void>();
-		const releaseSecondOldResult = Promise.withResolvers<void>();
-		const executions: Array<{ code: string; kernel: number }> = [];
-		let oldExecutions = 0;
-		const { kernels, registry } = createFakeRegistry(async (kernel, code) => {
-			executions.push({ code, kernel: kernel.index });
-			if (kernel.index === 0) {
-				oldExecutions += 1;
-				if (oldExecutions === 2) bothOldExecutionsStarted.resolve();
-				await bothOldExecutionsStarted.promise;
-				if (code === "second") await releaseSecondOldResult.promise;
+	it("does not replay a stale execution after a newer call replaces its dead kernel", async () => {
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const effects: string[] = [];
+		const { registry } = createFakeRegistry(async (kernel, code) => {
+			effects.push(code);
+			if (code === "old") {
 				kernel.alive = false;
-				return { cancelled: true, value: "old kernel died" };
+				started.resolve();
+				await release.promise;
+				return { cancelled: true, value: "old partial output" };
 			}
-			if (kernel.index === 1) {
-				kernel.alive = false;
-				return { cancelled: true, value: "first replacement died" };
-			}
-			return { cancelled: false, value: `recovered ${code}` };
+			return { cancelled: false, value: "new result" };
 		});
-
 		try {
-			const first = registry.executeOnSession("first", "/tmp", { sessionId: "stale-caller" });
-			const second = registry.executeOnSession("second", "/tmp", { sessionId: "stale-caller" });
-			await bothOldExecutionsStarted.promise;
-
-			expect(await first).toEqual({ cancelled: true, value: "first replacement died" });
-			releaseSecondOldResult.resolve();
-			expect(await second).toEqual({ cancelled: false, value: "recovered second" });
-			expect(executions).toEqual([
-				{ code: "first", kernel: 0 },
-				{ code: "second", kernel: 0 },
-				{ code: "first", kernel: 1 },
-				{ code: "second", kernel: 2 },
-			]);
-			expect(kernels).toHaveLength(3);
-			expect(kernels[0]?.shutdowns).toBe(1);
-			expect(kernels[1]?.shutdowns).toBe(1);
+			const old = registry.executeOnSession("old", "/tmp", { sessionId: "stale" });
+			await started.promise;
+			expect(await registry.executeOnSession("new", "/tmp", { sessionId: "stale" })).toEqual({
+				cancelled: false,
+				value: "new result",
+			});
+			release.resolve();
+			expect(await old).toEqual({ cancelled: true, value: "old partial output" });
+			expect(effects).toEqual(["old", "new"]);
 		} finally {
-			releaseSecondOldResult.resolve();
+			release.resolve();
 			await registry.disposeAll();
 		}
 	});
@@ -207,6 +170,7 @@ describe("kernel session recovery", () => {
 				return { cancelled: false, value: `recovered ${code}` };
 			},
 			async (kernel, options) => {
+				if (kernel.index === 0) kernel.alive = false;
 				if (kernel.index !== 1) return;
 				replacementOptions = options;
 				replacementStarted.resolve();
@@ -238,10 +202,7 @@ describe("kernel session recovery", () => {
 
 			releaseReplacement.resolve();
 			expect(await second).toEqual({ cancelled: false, value: "recovered second" });
-			expect(executions).toEqual([
-				{ code: "first", kernel: 0 },
-				{ code: "second", kernel: 1 },
-			]);
+			expect(executions).toEqual([{ code: "second", kernel: 1 }]);
 			expect(kernels).toHaveLength(2);
 			expect(kernels[0]?.shutdowns).toBe(1);
 		} finally {
@@ -250,7 +211,7 @@ describe("kernel session recovery", () => {
 		}
 	});
 
-	it("does not execute a retry when the caller aborts during replacement", async () => {
+	it("does not dispatch a cell when the caller aborts during replacement", async () => {
 		const replacementStarted = Promise.withResolvers<void>();
 		const releaseReplacement = Promise.withResolvers<void>();
 		const controller = new AbortController();
@@ -262,6 +223,7 @@ describe("kernel session recovery", () => {
 				return { cancelled: true, value: "cancelled" };
 			},
 			async kernel => {
+				if (kernel.index === 0) kernel.alive = false;
 				if (kernel.index !== 1) return;
 				replacementStarted.resolve();
 				await releaseReplacement.promise;
@@ -285,29 +247,10 @@ describe("kernel session recovery", () => {
 			}
 			expect(rejection).toBeInstanceOf(TestCancelledError);
 			expect((rejection as TestCancelledError).timedOut).toBe(false);
-			expect(executions).toEqual([0]);
+			expect(executions).toEqual([]);
 			expect(kernels).toHaveLength(2);
 		} finally {
 			releaseReplacement.resolve();
-			await registry.disposeAll();
-		}
-	});
-
-	it("returns a cancelled replacement result without retrying again", async () => {
-		const executions: number[] = [];
-		const { kernels, registry } = createFakeRegistry(async kernel => {
-			executions.push(kernel.index);
-			if (kernel.index === 0) kernel.alive = false;
-			return { cancelled: true, value: kernel.index === 0 ? "kernel died" : "replacement cancelled" };
-		});
-
-		try {
-			const result = await registry.executeOnSession("code", "/tmp", { sessionId: "cancelled-retry" });
-
-			expect(result).toEqual({ cancelled: true, value: "replacement cancelled" });
-			expect(executions).toEqual([0, 1]);
-			expect(kernels).toHaveLength(2);
-		} finally {
 			await registry.disposeAll();
 		}
 	});
@@ -358,97 +301,64 @@ describe("kernel session recovery", () => {
 		}
 	});
 
-	it("preserves a dead-kernel result when its deadline expires during replacement", async () => {
-		vi.useFakeTimers();
+	it("times out while acquiring a replacement without dispatching the cell", async () => {
 		const replacementStarted = Promise.withResolvers<void>();
 		const releaseReplacement = Promise.withResolvers<void>();
-		const executions: number[] = [];
-		const { kernels, registry } = createFakeRegistry(
-			async kernel => {
-				executions.push(kernel.index);
-				kernel.alive = false;
-				return { cancelled: true, value: "partial output before replacement timeout" };
+		const executions: string[] = [];
+		const { registry } = createFakeRegistry(
+			async (_kernel, code) => {
+				executions.push(code);
+				return { cancelled: false, value: code };
 			},
 			async kernel => {
+				if (kernel.index === 0) kernel.alive = false;
 				if (kernel.index !== 1) return;
 				replacementStarted.resolve();
 				await releaseReplacement.promise;
 			},
 		);
-
 		try {
-			const execution = registry.executeOnSession("code", "/tmp", {
-				sessionId: "deadline-during-replacement",
-				deadlineMs: Date.now() + 60_000,
+			const execution = registry.executeOnSession("expired", "/tmp", {
+				sessionId: "deadline",
+				deadlineMs: Date.now() + 200,
 			});
 			await replacementStarted.promise;
-			vi.advanceTimersByTime(60_000);
-
-			expect(await execution).toEqual({
-				cancelled: true,
-				value: "partial output before replacement timeout",
+			await expect(execution).rejects.toMatchObject({ timedOut: true });
+			expect(executions).toEqual([]);
+			releaseReplacement.resolve();
+			expect(await registry.executeOnSession("next", "/tmp", { sessionId: "deadline" })).toEqual({
+				cancelled: false,
+				value: "next",
 			});
-			expect(executions).toEqual([0]);
-			expect(kernels).toHaveLength(2);
+			expect(executions).toEqual(["next"]);
 		} finally {
 			releaseReplacement.resolve();
-			vi.useRealTimers();
 			await registry.disposeAll();
 		}
 	});
 
-	it("preserves a dead-kernel result when the retry reaches its deadline", async () => {
-		vi.useFakeTimers();
-		const retryStarted = Promise.withResolvers<void>();
-		const releaseRetry = Promise.withResolvers<void>();
-		const executions: number[] = [];
-		const { kernels, registry } = createFakeRegistry(async kernel => {
-			executions.push(kernel.index);
+	it("surfaces uncertain completion after an exception without replaying effects", async () => {
+		const effects: string[] = [];
+		const failure = new Error("transport closed");
+		const { registry } = createFakeRegistry(async (kernel, code) => {
+			effects.push(code);
 			if (kernel.index === 0) {
 				kernel.alive = false;
-				return { cancelled: true, value: "original partial output" };
-			}
-			retryStarted.resolve();
-			await releaseRetry.promise;
-			return { cancelled: true, value: "replacement timeout without original output" };
-		});
-
-		try {
-			const execution = registry.executeOnSession("code", "/tmp", {
-				sessionId: "deadline-during-retry",
-				deadlineMs: Date.now() + 60_000,
-			});
-			await retryStarted.promise;
-			vi.advanceTimersByTime(60_000);
-			releaseRetry.resolve();
-
-			expect(await execution).toEqual({ cancelled: true, value: "original partial output" });
-			expect(executions).toEqual([0, 1]);
-			expect(kernels).toHaveLength(2);
-		} finally {
-			releaseRetry.resolve();
-			vi.useRealTimers();
-			await registry.disposeAll();
-		}
-	});
-
-	it("preserves retry for an exception thrown by a dead kernel", async () => {
-		const executions: number[] = [];
-		const { kernels, registry } = createFakeRegistry(async kernel => {
-			executions.push(kernel.index);
-			if (kernel.index === 0) {
-				kernel.alive = false;
-				throw new Error("transport closed");
+				throw failure;
 			}
 			return { cancelled: false, value: "recovered" };
 		});
-
 		try {
-			const result = await registry.executeOnSession("code", "/tmp", { sessionId: "throw" });
-
-			expect(result).toEqual({ cancelled: false, value: "recovered" });
-			expect(executions).toEqual([0, 1]);
-			expect(kernels).toHaveLength(2);
+			await expect(registry.executeOnSession("first", "/tmp", { sessionId: "throw" })).rejects.toMatchObject({
+				cause: failure,
+				message: expect.stringContaining("completion is uncertain"),
+			});
+			expect(effects).toEqual(["first"]);
+			expect(await registry.executeOnSession("next", "/tmp", { sessionId: "throw" })).toEqual({
+				cancelled: false,
+				value: "recovered",
+			});
+			expect(effects).toEqual(["first", "next"]);
 		} finally {
 			await registry.disposeAll();
 		}
@@ -459,11 +369,11 @@ describe("kernel session recovery", () => {
 		const releaseReplacement = Promise.withResolvers<void>();
 		const controller = new AbortController();
 		const { kernels, registry } = createFakeRegistry(
-			async kernel => {
-				if (kernel.index === 0) kernel.alive = false;
+			async () => {
 				return { cancelled: true, value: "kernel died" };
 			},
 			async kernel => {
+				if (kernel.index === 0) kernel.alive = false;
 				if (kernel.index !== 1) return;
 				replacementStarted.resolve();
 				await releaseReplacement.promise;
@@ -510,11 +420,11 @@ describe("kernel session recovery", () => {
 		const targetController = new AbortController();
 		const unrelatedController = new AbortController();
 		const { kernels, registry } = createFakeRegistry(
-			async kernel => {
-				if (kernel.index === 0 || kernel.index === 2) kernel.alive = false;
+			async () => {
 				return { cancelled: true, value: "kernel died" };
 			},
 			async kernel => {
+				if (kernel.index === 0 || kernel.index === 2) kernel.alive = false;
 				if (kernel.index === 1) {
 					targetReplacementStarted.resolve();
 					await releaseTargetReplacement.promise;


### PR DESCRIPTION
## What

Dispatched cells now report uncertain completion after kernel failure instead of running again automatically. Partial output is preserved, and the next call can recover the kernel. This prevents duplicate side effects while retaining cancellation and pre-dispatch recovery.

## Why

A kernel can die after a cell has already performed side effects; automatic replay can perform them twice.

## Testing

- [x] 44 focused tests, including a real Python write/crash/recovery regression; original code writes twice.
- [x] Coding-agent `bun check` and independent review.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
