### PR TITLE
fix(collab): keep hosts connected after malformed guest frames

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Shared sessions stay connected when a guest sends a corrupted frame or uses the wrong room key.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -3,7 +3,8 @@
  *
  * Connects to a relay room, seals/opens AES-GCM frames, and reconnects with
  * exponential backoff on transient drops. Fatal relay close codes (room gone,
- * host conflict, room full) and decryption failures never reconnect.
+ * host conflict, room full) and guest decryption failures never reconnect.
+ * Hosts discard undecryptable guest frames without closing the room.
  */
 import { logger } from "@oh-my-pi/pi-utils";
 import { open, seal } from "./crypto";
@@ -218,7 +219,12 @@ export class CollabSocket {
 				try {
 					frame = await open(this.#opts.key, envelope.payload);
 				} catch {
-					this.#failFatal("bad key or corrupted frame");
+					if (this.#ws !== ws) return;
+					if (this.#opts.role === "host") {
+						logger.debug("collab: ignoring undecryptable guest frame", { peer: envelope.peerId });
+					} else {
+						this.#failFatal("bad key or corrupted frame");
+					}
 					return;
 				}
 				if (this.#ws !== ws) return;

--- a/packages/coding-agent/test/collab/relay-client-isolation.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-isolation.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { type LocalRelay, startLocalRelay } from "../../../collab-web/scripts/local-relay";
+import { generateRoomKey, importRoomKey, seal } from "../../src/collab/crypto";
+import { type CollabFrame, packEnvelope } from "../../src/collab/protocol";
+import { CollabSocket } from "../../src/collab/relay-client";
+
+let relay: LocalRelay | undefined;
+const sockets: Array<CollabSocket | WebSocket> = [];
+
+afterEach(() => {
+	for (const socket of sockets.splice(0)) socket.close();
+	relay?.stop();
+	relay = undefined;
+});
+
+async function connect(role: "host" | "guest", key: CryptoKey): Promise<CollabSocket> {
+	const socket = new CollabSocket({ wsUrl: `${relay!.url}/r/IsolationRoom_123`, role, key });
+	sockets.push(socket);
+	const opened = Promise.withResolvers<void>();
+	socket.onOpen = () => opened.resolve();
+	socket.connect();
+	await opened.promise;
+	return socket;
+}
+
+describe("collab peer isolation", () => {
+	for (const corruption of ["truncated", "wrong-key"] as const) {
+		it(`keeps the room usable after a guest sends a ${corruption} frame`, async () => {
+			relay = startLocalRelay();
+			const key = await importRoomKey(generateRoomKey());
+			const host = await connect("host", key);
+			const guest = await connect("guest", key);
+			const closed: string[] = [];
+			const afterCorruption = Promise.withResolvers<string>();
+			host.onClose = reason => {
+				closed.push(`host: ${reason}`);
+				afterCorruption.resolve(reason);
+			};
+			guest.onClose = reason => closed.push(`guest: ${reason}`);
+			const received = Promise.withResolvers<CollabFrame>();
+			guest.onFrame = frame => received.resolve(frame);
+			host.onFrame = frame => {
+				if (frame.t === "prompt" && frame.text === "after corruption") afterCorruption.resolve("delivered");
+				if (frame.t === "prompt" && frame.text === "healthy guest") {
+					host.send({ t: "error", message: "healthy reply" });
+				}
+			};
+			const sender = new WebSocket(`${relay.url}/r/IsolationRoom_123?role=guest`);
+			sockets.push(sender);
+			const opened = Promise.withResolvers<void>();
+			sender.onopen = () => opened.resolve();
+			await opened.promise;
+			const payload =
+				corruption === "truncated"
+					? new Uint8Array(1)
+					: await seal(await importRoomKey(generateRoomKey()), { t: "abort" });
+			sender.send(packEnvelope(0, payload));
+			sender.send(packEnvelope(0, await seal(key, { t: "prompt", text: "after corruption" })));
+			expect(await afterCorruption.promise).toBe("delivered");
+			guest.send({ t: "prompt", text: "healthy guest" });
+			expect(await received.promise).toEqual({ t: "error", message: "healthy reply" });
+			expect(closed).toEqual([]);
+			expect(host.isOpen).toBe(true);
+			expect(guest.isOpen).toBe(true);
+		});
+	}
+
+	it("closes a guest with the wrong room key without retrying", async () => {
+		relay = startLocalRelay();
+		const host = await connect("host", await importRoomKey(generateRoomKey()));
+		const guest = await connect("guest", await importRoomKey(generateRoomKey()));
+		const closed = Promise.withResolvers<{ reason: string; retry: boolean }>();
+		guest.onClose = (reason, retry) => closed.resolve({ reason, retry });
+		host.send({ t: "error", message: "encrypted host traffic" });
+		expect(await closed.promise).toEqual({ reason: "bad key or corrupted frame", retry: false });
+		expect(guest.isOpen).toBe(false);
+		expect(host.isOpen).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Hosts discard guest frames that fail decryption, so one malformed frame cannot close the shared session. Guests still stop on a wrong room key. A stale socket failure cannot close a replacement connection.

## Why

Guest decryption failures currently close the host's shared connection.

## Testing

- [x] 82 collab tests and coding-agent `bun check`.
- [x] Independent local-relay attack sends 100 malformed frames followed by a valid prompt; the host stays connected and delivers it.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
