### PR TITLE
fix(ai): support nonextensible tool schemas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool schema normalization and cycle detection for frozen, sealed, and nonextensible schemas.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1877,9 +1877,9 @@ function inferStrictPrimitiveTypeFromEnumOrConst(node: Record<string, unknown>):
 }
 
 /**
- * Per-schema-object memoization slot. The result of `tryEnforceStrictSchema`
- * is stamped directly onto the input via `stamp(target, kStrictSchema, …)`
- * so repeated calls (different providers, retries, batching) reuse the same
+ * Per-schema-object memoization key. The result of `tryEnforceStrictSchema`
+ * is memoized against the input via `stamp(target, kStrictSchema, …)` so
+ * repeated calls (different providers, retries, batching) reuse the same
  * computed pair without re-walking the tree.
  */
 const kStrictSchema = Symbol("pi.schema.strict");

--- a/packages/ai/src/utils/schema/stamps.ts
+++ b/packages/ai/src/utils/schema/stamps.ts
@@ -1,59 +1,39 @@
 /**
- * Symbol-keyed lazy memoization stamped directly onto the host object.
+ * Lazy memoization keyed by host object identity, held in a module-level
+ * weak side table.
  *
- * Faster than a module-level `WeakMap` in V8/JSC because the symbol slot is
- * resolved through the object's hidden class instead of a side-table hash
- * lookup. The slot is defined as a non-enumerable property so the stamp
- * does not leak through `{...spread}`, `Object.keys`, `JSON.stringify`, or
- * `toEqual`-style deep equality.
+ * The bookkeeping deliberately lives outside the host rather than in a
+ * non-enumerable symbol property: schema objects are caller-owned and may be
+ * sealed, frozen, or deep-frozen after their first traversal. A recursive
+ * freeze that enumerates with `Reflect.ownKeys` reaches symbol slots, so an
+ * on-host slot would be frozen along with the schema and every later write
+ * would throw. A side table is also invisible to `{...spread}`,
+ * `Object.keys`, `JSON.stringify`, and `toEqual`-style deep equality.
  *
- * Caveats: the stamp lives as long as the host object, even after callers
+ * Caveats: an entry lives as long as the host object, even after callers
  * release their references to the cached value — only use this for caches
- * whose lifetime should match the host. Nonextensible hosts use a weak
- * side table. Mutable cells keep traversal state writable when a host is
- * frozen after its first traversal.
+ * whose lifetime should match the host.
  */
-interface Cell<V> {
-	value: V | undefined;
-}
-
-const fallback = new WeakMap<object, Map<symbol, Cell<unknown>>>();
-
-function cell<V>(target: object, key: symbol): Cell<V> {
-	const existing = Object.hasOwn(target, key) ? (target as Record<symbol, Cell<V>>)[key] : undefined;
-	if (existing) return existing;
-	if (Object.isExtensible(target)) {
-		const created: Cell<V> = { value: undefined };
-		Object.defineProperty(target, key, { value: created });
-		return created;
-	}
-	let slots = fallback.get(target);
-	if (!slots) {
-		slots = new Map();
-		fallback.set(target, slots);
-	}
-	let stored = slots.get(key);
-	if (!stored) {
-		stored = { value: undefined };
-		slots.set(key, stored);
-	}
-	return stored as Cell<V>;
-}
+const memos = new WeakMap<object, Map<symbol, unknown>>();
 
 export function stamp<T extends object, V>(target: T, key: symbol, compute: (target: T) => V): V {
-	const slot = cell<V>(target, key);
-	const existing = slot.value;
+	let slots = memos.get(target);
+	if (!slots) {
+		slots = new Map();
+		memos.set(target, slots);
+	}
+	const existing = slots.get(key) as V | undefined;
 	if (existing !== undefined) return existing;
 	const value = compute(target);
-	slot.value = value;
+	slots.set(key, value);
 	return value;
 }
 
 /**
- * Epoch-keyed cycle guard. Cheaper than `WeakSet` for recursive traversal
- * because the marker is a single property slot on the host object, written
- * once and overwritten in place on every subsequent traversal — the hidden
- * class transitions once per object lifetime, not per traversal.
+ * Epoch-keyed cycle guard. Cheaper than a per-call `WeakSet` for recursive
+ * traversal because the marker is a single side-table entry per host object,
+ * written once and overwritten in place on every subsequent traversal — no
+ * per-walk allocation.
  *
  * Usage:
  *   function walk(node, epoch = epochNext()) {
@@ -61,7 +41,7 @@ export function stamp<T extends object, V>(target: T, key: symbol, compute: (tar
  *     for (const child of node.children) walk(child, epoch);
  *   }
  */
-const kEpoch = Symbol("pi.schema.epoch");
+const epochs = new WeakMap<object, number>();
 let __epoch = 0;
 
 export function epochNext(): number {
@@ -74,10 +54,9 @@ export function epochNext(): number {
  * subsequent call within the same epoch.
  */
 export function once<T extends object>(target: T, epoch: number): boolean {
-	const slot = cell<number>(target, kEpoch);
-	const cur = slot.value;
+	const cur = epochs.get(target);
 	if (cur !== undefined && cur >= epoch) return false;
-	slot.value = epoch;
+	epochs.set(target, epoch);
 	return true;
 }
 
@@ -85,12 +64,8 @@ export function once<T extends object>(target: T, epoch: number): boolean {
  * Counter-based path tracker. Use when a traversal needs to distinguish
  * "currently on the recursion path" from "previously visited" — i.e. cycle
  * detection that throws while still allowing DAG sharing. Increment on
- * entry, decrement on exit; the slot returns to 0 after a balanced walk so
+ * entry, decrement on exit; the counter returns to 0 after a balanced walk so
  * subsequent top-level calls see a fresh state without any reset.
- *
- * Unlike a `WeakSet` with `seen.delete(...)`, the property is never deleted
- * — only incremented and decremented — so the host object's hidden class
- * is never invalidated.
  *
  * Usage:
  *   function walk(node) {
@@ -99,7 +74,7 @@ export function once<T extends object>(target: T, epoch: number): boolean {
  *     finally { exit(node); }
  *   }
  */
-const kDepth = Symbol("pi.schema.depth");
+const depths = new WeakMap<object, number>();
 
 /**
  * Returns `true` on first entry, `false` if `target` is already on the
@@ -109,16 +84,14 @@ const kDepth = Symbol("pi.schema.depth");
  * make every later top-level walk of the same object misreport a cycle.
  */
 export function enter<T extends object>(target: T): boolean {
-	const slot = cell<number>(target, kDepth);
-	const cur = slot.value;
+	const cur = depths.get(target);
 	if (cur !== undefined && cur !== 0) return false;
-	slot.value = 1;
+	depths.set(target, 1);
 	return true;
 }
 
 export function exit<T extends object>(target: T): void {
-	const slot = cell<number>(target, kDepth);
-	const cur = slot.value;
+	const cur = depths.get(target);
 	if (cur === undefined) return;
-	slot.value = cur - 1;
+	depths.set(target, cur - 1);
 }

--- a/packages/ai/src/utils/schema/stamps.ts
+++ b/packages/ai/src/utils/schema/stamps.ts
@@ -9,22 +9,43 @@
  *
  * Caveats: the stamp lives as long as the host object, even after callers
  * release their references to the cached value — only use this for caches
- * whose lifetime should match the host. Frozen hosts cannot be stamped;
- * `define` silently skips them, so memoization/visit-tracking degrades to
- * best-effort (recompute on every call, no cycle protection) instead of
- * throwing.
+ * whose lifetime should match the host. Nonextensible hosts use a weak
+ * side table. Mutable cells keep traversal state writable when a host is
+ * frozen after its first traversal.
  */
-function define<T extends object>(target: T, key: symbol, value: unknown): void {
-	if (Object.isFrozen(target)) return;
-	Object.defineProperty(target, key, { value, writable: true, configurable: true });
+interface Cell<V> {
+	value: V | undefined;
+}
+
+const fallback = new WeakMap<object, Map<symbol, Cell<unknown>>>();
+
+function cell<V>(target: object, key: symbol): Cell<V> {
+	const existing = Object.hasOwn(target, key) ? (target as Record<symbol, Cell<V>>)[key] : undefined;
+	if (existing) return existing;
+	if (Object.isExtensible(target)) {
+		const created: Cell<V> = { value: undefined };
+		Object.defineProperty(target, key, { value: created });
+		return created;
+	}
+	let slots = fallback.get(target);
+	if (!slots) {
+		slots = new Map();
+		fallback.set(target, slots);
+	}
+	let stored = slots.get(key);
+	if (!stored) {
+		stored = { value: undefined };
+		slots.set(key, stored);
+	}
+	return stored as Cell<V>;
 }
 
 export function stamp<T extends object, V>(target: T, key: symbol, compute: (target: T) => V): V {
-	const slot = target as Record<symbol, V | undefined>;
-	const existing = slot[key];
+	const slot = cell<V>(target, key);
+	const existing = slot.value;
 	if (existing !== undefined) return existing;
 	const value = compute(target);
-	define(target, key, value);
+	slot.value = value;
 	return value;
 }
 
@@ -53,11 +74,10 @@ export function epochNext(): number {
  * subsequent call within the same epoch.
  */
 export function once<T extends object>(target: T, epoch: number): boolean {
-	const slot = target as Record<symbol, number | undefined>;
-	const cur = slot[kEpoch];
+	const slot = cell<number>(target, kEpoch);
+	const cur = slot.value;
 	if (cur !== undefined && cur >= epoch) return false;
-	if (cur === undefined) define(target, kEpoch, epoch);
-	else slot[kEpoch] = epoch;
+	slot.value = epoch;
 	return true;
 }
 
@@ -89,21 +109,16 @@ const kDepth = Symbol("pi.schema.depth");
  * make every later top-level walk of the same object misreport a cycle.
  */
 export function enter<T extends object>(target: T): boolean {
-	const slot = target as Record<symbol, number | undefined>;
-	const cur = slot[kDepth];
-	if (cur === undefined) {
-		define(target, kDepth, 1);
-		return true;
-	}
-	if (cur !== 0) return false;
-	slot[kDepth] = 1;
+	const slot = cell<number>(target, kDepth);
+	const cur = slot.value;
+	if (cur !== undefined && cur !== 0) return false;
+	slot.value = 1;
 	return true;
 }
 
 export function exit<T extends object>(target: T): void {
-	const slot = target as Record<symbol, number | undefined>;
-	const cur = slot[kDepth];
-	// Frozen targets never received the kDepth stamp in `enter` — nothing to unwind.
+	const slot = cell<number>(target, kDepth);
+	const cur = slot.value;
 	if (cur === undefined) return;
-	slot[kDepth] = cur - 1;
+	slot.value = cur - 1;
 }

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Type } from "@oh-my-pi/omptype";
+import { structuredCloneJSON } from "@oh-my-pi/pi-utils";
 import type { Tool, TSchema } from "../../types";
 import { upgradeJsonSchemaTo202012 } from "./draft";
 import { stamp } from "./stamps";
@@ -107,7 +108,7 @@ function arkJsonAstToWire(value: unknown): unknown {
 	return {};
 }
 
-/** Symbol-stamped caches keyed by schema object identity. */
+/** `stamp` cache keys; the entries themselves live in a weak side table keyed by schema identity. */
 const kJsonWireSchema = Symbol("pi.schema.json.wire");
 const kArkWireSchema = Symbol("pi.schema.ark.wire");
 const kStrippedSchema = Symbol("pi.schema.descriptions.stripped");
@@ -602,7 +603,9 @@ export function toolWireSchema(tool: Tool): Record<string, unknown> {
 	const params: TSchema = tool.parameters;
 	if (isArkSchema(params)) return arkToWireSchema(params);
 	return stamp(params as Record<string, unknown>, kJsonWireSchema, p => {
-		const raw = isArkJsonAst(p) ? arkJsonAstToWire(p) : structuredClone(p);
+		// Legacy schemas may carry non-cloneable metadata (helper functions); the JSON
+		// fallback drops it the same way the wire serializer always has.
+		const raw = isArkJsonAst(p) ? arkJsonAstToWire(p) : structuredCloneJSON(p);
 		const upgraded = upgradeJsonSchemaTo202012(raw) as Record<string, unknown>;
 		return postProcessJsonSchema(upgraded);
 	});
@@ -663,10 +666,9 @@ function stripSchemaDescriptionsInPlace(node: unknown): void {
 
 /**
  * Return a deep clone of `schema` with every `description` annotation removed.
- * The result is memoized on the input via a non-enumerable symbol (`stamp`) so
- * repeated provider requests reuse the same stripped object; the input is never
- * mutated, so the stamped `toolWireSchema` cache stays intact for
- * system-prompt/UI rendering.
+ * The result is memoized against the input (`stamp`) so repeated provider
+ * requests reuse the same stripped object; the input is never mutated, so the
+ * memoized `toolWireSchema` result stays intact for system-prompt/UI rendering.
  */
 export function stripSchemaDescriptions(schema: Record<string, unknown>): Record<string, unknown> {
 	return stamp(schema, kStrippedSchema, source => {
@@ -682,7 +684,7 @@ export function stripSchemaDescriptions(schema: Record<string, unknown>): Record
  * Used when the full tool catalog is rendered into the system prompt instead, so
  * the descriptions ride the wire once (in the prompt) rather than duplicated on
  * every tool definition. Parameters are resolved to wire JSON Schema and cloned,
- * leaving the original tool objects and the stamped schema cache untouched.
+ * leaving the original tool objects and the memoized schema cache untouched.
  */
 export function stripToolDescriptions(tools: readonly Tool[]): Tool[] {
 	return tools.map(tool => ({

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -602,7 +602,7 @@ export function toolWireSchema(tool: Tool): Record<string, unknown> {
 	const params: TSchema = tool.parameters;
 	if (isArkSchema(params)) return arkToWireSchema(params);
 	return stamp(params as Record<string, unknown>, kJsonWireSchema, p => {
-		const raw = isArkJsonAst(p) ? arkJsonAstToWire(p) : p;
+		const raw = isArkJsonAst(p) ? arkJsonAstToWire(p) : structuredClone(p);
 		const upgraded = upgradeJsonSchemaTo202012(raw) as Record<string, unknown>;
 		return postProcessJsonSchema(upgraded);
 	});

--- a/packages/ai/test/apply-patch-freeform.test.ts
+++ b/packages/ai/test/apply-patch-freeform.test.ts
@@ -212,7 +212,20 @@ describe("convertTools: freeform emission", () => {
 		// distinguish it from an omitted flag when generating optional-arg values.
 		expect(out.strict).toBe(false);
 		expect(items.oneOf).toBeUndefined();
-		expect(items.anyOf).toEqual(unionBranches);
+		// Normalization adds the `enum`-implied `type`; the input fixture is no longer
+		// mutated in place, so the wire shape is asserted explicitly.
+		expect(items.anyOf).toEqual([
+			{
+				type: "object",
+				properties: { type: { enum: ["insert"], type: "string" }, text: { type: "string" } },
+				required: ["type", "text"],
+			},
+			{
+				type: "object",
+				properties: { type: { enum: ["delete"], type: "string" }, start: { type: "integer" } },
+				required: ["type", "start"],
+			},
+		]);
 	});
 
 	test("rewrites oneOf to anyOf before strict schema enforcement", () => {

--- a/packages/ai/test/schema-immutability.test.ts
+++ b/packages/ai/test/schema-immutability.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test";
+import {
+	enforceStrictSchema,
+	schemaNeedsDraft202012Upgrade,
+	stripSchemaDescriptions,
+	toolWireSchema,
+} from "@oh-my-pi/pi-ai/utils/schema";
+
+it("normalizes frozen tool parameters without modifying caller-owned required fields", () => {
+	const parameters = Object.freeze({
+		type: "object",
+		properties: Object.freeze({ extra: Object.freeze({}) }),
+		required: Object.freeze(["extra"]),
+	});
+	expect(toolWireSchema({ name: "t", description: "", parameters })).toEqual({
+		type: "object",
+		properties: { extra: true },
+		required: ["extra"],
+	});
+	expect(parameters.properties.extra).toEqual({});
+});
+
+it("strips annotations from sealed and nonextensible shared schema nodes", () => {
+	const leaf = Object.preventExtensions({ type: "string", description: "value" });
+	const schema = Object.seal({ type: "object", description: "root", properties: { a: leaf, b: leaf } });
+	expect(stripSchemaDescriptions(schema)).toEqual({
+		type: "object",
+		properties: { a: { type: "string" }, b: { type: "string" } },
+	});
+});
+
+it("revisits schemas frozen after their first draft check", () => {
+	const schema = { type: "object", properties: {} as Record<string, unknown> };
+	expect(schemaNeedsDraft202012Upgrade(schema)).toBe(false);
+	Object.freeze(schema);
+	schema.properties.legacy = { type: "string", nullable: true };
+	expect(schemaNeedsDraft202012Upgrade(schema)).toBe(true);
+});
+
+it("enforces shared frozen schemas repeatedly after traversal stamps were installed", () => {
+	const leaf = { type: "string" };
+	const schema = { type: "object", properties: { a: leaf, b: leaf }, required: ["a", "b"] };
+	const expected = {
+		...schema,
+		additionalProperties: false,
+	};
+	expect(enforceStrictSchema(schema)).toEqual(expected);
+	Object.freeze(schema);
+	Object.freeze(leaf);
+	expect(enforceStrictSchema(schema)).toEqual(expected);
+});
+
+it("rejects frozen cycles consistently without confusing subsequent shared nodes with cycles", () => {
+	const schema: Record<string, unknown> = { type: "object" };
+	const properties = { self: schema };
+	schema.properties = properties;
+	schema.required = ["self"];
+	Object.freeze(schema);
+	expect(() => enforceStrictSchema(schema)).toThrow("circular object graph");
+	expect(() => enforceStrictSchema(schema)).toThrow("circular object graph");
+	expect(schemaNeedsDraft202012Upgrade(schema)).toBe(false);
+	properties.self = Object.freeze({ type: "string" });
+	expect(enforceStrictSchema(schema)).toEqual({
+		type: "object",
+		properties: { self: { type: "string" } },
+		required: ["self"],
+		additionalProperties: false,
+	});
+	const leaf = Object.seal({ type: "string" });
+	expect(enforceStrictSchema({ type: "object", properties: { a: leaf, b: leaf }, required: ["a", "b"] })).toEqual({
+		type: "object",
+		properties: { a: { type: "string" }, b: { type: "string" } },
+		required: ["a", "b"],
+		additionalProperties: false,
+	});
+});

--- a/packages/ai/test/schema-immutability.test.ts
+++ b/packages/ai/test/schema-immutability.test.ts
@@ -74,3 +74,37 @@ it("rejects frozen cycles consistently without confusing subsequent shared nodes
 		additionalProperties: false,
 	});
 });
+
+it("sends schemas carrying non-cloneable metadata to the wire without the metadata", () => {
+	const parameters: Record<string, unknown> = {
+		type: "object",
+		properties: { path: { type: "string" } },
+		required: ["path"],
+		"x-omp-coerce": (value: unknown) => value,
+	};
+	const wire = toolWireSchema({ name: "t", description: "", parameters });
+	expect(wire).toEqual({
+		type: "object",
+		properties: { path: { type: "string" } },
+		required: ["path"],
+	});
+	expect(Object.hasOwn(wire, "x-omp-coerce")).toBe(false);
+	expect(typeof parameters["x-omp-coerce"]).toBe("function");
+});
+
+function deepFreeze(value: unknown, seen = new WeakSet<object>()): void {
+	if (!value || typeof value !== "object" || seen.has(value)) return;
+	seen.add(value);
+	for (const key of Reflect.ownKeys(value)) deepFreeze((value as Record<PropertyKey, unknown>)[key], seen);
+	Object.freeze(value);
+}
+
+it("keeps traversal state off caller graphs that are deep-frozen after a first visit", () => {
+	const schema: Record<string, unknown> = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
+	const expected = { ...schema, additionalProperties: false };
+	expect(schemaNeedsDraft202012Upgrade(schema)).toBe(false);
+	expect(enforceStrictSchema(schema)).toEqual(expected);
+	deepFreeze(schema);
+	expect(schemaNeedsDraft202012Upgrade(schema)).toBe(false);
+	expect(enforceStrictSchema(schema)).toEqual(expected);
+});


### PR DESCRIPTION
## What

Tool-schema caching and cycle tracking now support sealed, frozen, and nonextensible objects, including objects frozen after their first use. Wire normalization clones raw schemas before modifying them.

## Why

Schema stamps and cycle tracking must work with nonextensible caller-owned objects without mutating raw wire input.

## Testing

- [x] 291 schema/provider tests; all five new regressions fail on the original implementation.
- [x] AI `bun check` and independent review.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
