### PR TITLE
perf(ai): drain unused completion stream events

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced memory retained by `complete()` and `completeSimple()` while streaming responses.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed
@@ -10,9 +14,6 @@
 - GitHub Copilot sign-in uses the minimal-grant OpenCode OAuth app again (`read:user` only): GitHub renders each app's existing per-user grant on the consent page, so Enterprise organizations that block the Copilot CLI app's broad historic grant can log in as on 18.1.4. API request identity still mimics the Copilot CLI, and tokens minted by either app keep working ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - GitHub Copilot plan/model-policy 403s no longer count as credential failures for credential-lifetime decisions: the token is valid, so stored credentials are preserved instead of wiped ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - Fixed custom `google-generative-ai` providers failing mid-turn model fallback when Gemini 3 tool calls are replayed without their original thought signature ([#11270](https://github.com/can1357/oh-my-pi/issues/11270)).
-### Fixed
-
-- Reduced memory retained by `complete()` and `completeSimple()` while streaming responses.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 - GitHub Copilot sign-in uses the minimal-grant OpenCode OAuth app again (`read:user` only): GitHub renders each app's existing per-user grant on the consent page, so Enterprise organizations that block the Copilot CLI app's broad historic grant can log in as on 18.1.4. API request identity still mimics the Copilot CLI, and tokens minted by either app keep working ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - GitHub Copilot plan/model-policy 403s no longer count as credential failures for credential-lifetime decisions: the token is valid, so stored credentials are preserved instead of wiped ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - Fixed custom `google-generative-ai` providers failing mid-turn model fallback when Gemini 3 tool calls are replayed without their original thought signature ([#11270](https://github.com/can1357/oh-my-pi/issues/11270)).
+### Fixed
+
+- Reduced memory retained by `complete()` and `completeSimple()` while streaming responses.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1060,7 +1060,11 @@ async function resolveWithThinkingLoopRetries(
 	onAttempt?: (message: AssistantMessage) => void,
 ): Promise<AssistantMessage> {
 	const dispatchAttempt = async (): Promise<AssistantMessage> => {
-		const message = await dispatch().result();
+		const response = dispatch();
+		for await (const _event of response) {
+			// Completion callers do not consume deltas; drain them as they arrive to avoid retaining the response history.
+		}
+		const message = await response.result();
 		onAttempt?.(message);
 		return message;
 	};

--- a/packages/ai/test/completion-retention.test.ts
+++ b/packages/ai/test/completion-retention.test.ts
@@ -1,43 +1,28 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
-import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
-import { complete, completeSimple } from "@oh-my-pi/pi-ai/stream";
-import type { AssistantMessageEvent } from "@oh-my-pi/pi-ai/types";
-import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
-
-afterEach(() => {
-	clearCustomApis();
-});
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 
 describe("completion event retention", () => {
-	for (const completion of [complete, completeSimple]) {
-		test(`${completion.name} releases streamed events while preserving the final response`, async () => {
-			registerMockApi();
-			const mock = createMockModel({ responses: [{ content: ["first", "second", "third"] }] });
-			const streams = new Set<AssistantMessageEventStream>();
-			const push = AssistantMessageEventStream.prototype.push;
-			const observer = spyOn(AssistantMessageEventStream.prototype, "push").mockImplementation(function (
-				this: AssistantMessageEventStream,
-				event: AssistantMessageEvent,
-			) {
-				streams.add(this);
-				push.call(this, event);
-			});
-			try {
-				const message = await completion(mock.model, {
-					systemPrompt: [],
-					messages: [{ role: "user", content: "go", timestamp: 0 }],
-				});
-				expect(message.content).toEqual([
-					{ type: "text", text: "first" },
-					{ type: "text", text: "second" },
-					{ type: "text", text: "third" },
-				]);
-				expect(message.stopReason).toBe("stop");
-				expect([...streams].flatMap(stream => stream.queue)).toEqual([]);
-			} finally {
-				observer.mockRestore();
-			}
-		});
+	for (const completion of ["complete", "completeSimple"]) {
+		for (const outcome of ["success", "failure"]) {
+			test(`${completion} releases events before ${outcome} settles the response`, async () => {
+				const child = Bun.spawn(
+					[process.execPath, path.join(import.meta.dir, "fixtures/completion-retention.ts"), completion, outcome],
+					{ stdout: "pipe", stderr: "pipe" },
+				);
+				const timeout = setTimeout(() => child.kill(), 10_000);
+				try {
+					const [stdout, stderr, exitCode] = await Promise.all([
+						new Response(child.stdout).text(),
+						new Response(child.stderr).text(),
+						child.exited,
+					]);
+					expect({ exitCode, stderr, stdout }).toEqual({ exitCode: 0, stderr: "", stdout: "verified\n" });
+				} finally {
+					clearTimeout(timeout);
+					child.kill();
+					await child.exited;
+				}
+			}, 15_000);
+		}
 	}
 });

--- a/packages/ai/test/completion-retention.test.ts
+++ b/packages/ai/test/completion-retention.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { complete, completeSimple } from "@oh-my-pi/pi-ai/stream";
+import type { AssistantMessageEvent } from "@oh-my-pi/pi-ai/types";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+
+afterEach(() => {
+	clearCustomApis();
+});
+
+describe("completion event retention", () => {
+	for (const completion of [complete, completeSimple]) {
+		test(`${completion.name} releases streamed events while preserving the final response`, async () => {
+			registerMockApi();
+			const mock = createMockModel({ responses: [{ content: ["first", "second", "third"] }] });
+			const streams = new Set<AssistantMessageEventStream>();
+			const push = AssistantMessageEventStream.prototype.push;
+			const observer = spyOn(AssistantMessageEventStream.prototype, "push").mockImplementation(function (
+				this: AssistantMessageEventStream,
+				event: AssistantMessageEvent,
+			) {
+				streams.add(this);
+				push.call(this, event);
+			});
+			try {
+				const message = await completion(mock.model, {
+					systemPrompt: [],
+					messages: [{ role: "user", content: "go", timestamp: 0 }],
+				});
+				expect(message.content).toEqual([
+					{ type: "text", text: "first" },
+					{ type: "text", text: "second" },
+					{ type: "text", text: "third" },
+				]);
+				expect(message.stopReason).toBe("stop");
+				expect([...streams].flatMap(stream => stream.queue)).toEqual([]);
+			} finally {
+				observer.mockRestore();
+			}
+		});
+	}
+});

--- a/packages/ai/test/fixtures/completion-retention.ts
+++ b/packages/ai/test/fixtures/completion-retention.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { registerCustomApi } from "../../src/api-registry";
+import { createMockModel } from "../../src/providers/mock";
+import { complete, completeSimple } from "../../src/stream";
+import type { AssistantMessage, AssistantMessageEvent } from "../../src/types";
+import { AssistantMessageEventStream } from "../../src/utils/event-stream";
+
+const completion = process.argv[2] === "complete" ? complete : completeSimple;
+// Exempt this local provider from leaked-thinking healing, which replaces event identities.
+const model = { ...createMockModel().model, provider: "openai", baseUrl: "https://api.openai.com/v1" };
+const response = new AssistantMessageEventStream();
+const started = Promise.withResolvers<void>();
+registerCustomApi(model.api, () => {
+	started.resolve();
+	return response;
+});
+
+const message: AssistantMessage = {
+	role: "assistant",
+	content: [{ type: "text", text: "first second" }],
+	api: model.api,
+	provider: model.provider,
+	model: model.id,
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: 0,
+};
+
+function emit(): WeakRef<AssistantMessageEvent>[] {
+	const events: AssistantMessageEvent[] = [
+		{ type: "start", partial: message },
+		{ type: "text_start", contentIndex: 0, partial: message },
+		{ type: "text_delta", contentIndex: 0, delta: "first ", partial: message },
+	];
+	const references = events.map(event => new WeakRef(event));
+	for (const event of events) response.push(event);
+	// An async iterator may retain its latest yield while waiting for the next event.
+	response.push({ type: "text_delta", contentIndex: 0, delta: "second", partial: message });
+	return references;
+}
+
+let settled = false;
+const result = completion(model, { messages: [{ role: "user", content: "go", timestamp: 0 }] });
+void result.then(
+	() => {
+		settled = true;
+		started.reject(new Error("completion settled before provider dispatch"));
+	},
+	error => {
+		settled = true;
+		started.reject(error);
+	},
+);
+await started.promise;
+const references = emit();
+const deadline = performance.now() + 5_000;
+let collected = false;
+do {
+	// WeakRef targets survive the job that dereferences them; collect in a later turn.
+	await Bun.sleep(0);
+	Bun.gc(true);
+	collected = references.every(reference => reference.deref() === undefined);
+} while (!collected && performance.now() < deadline);
+assert.equal(settled, false, "completion settled before the producer sent a terminal event");
+assert.equal(collected, true, "completion retained earlier events while the producer was paused");
+
+if (process.argv[3] === "failure") {
+	const failure = new Error("producer disconnected before completion");
+	response.fail(failure);
+	await assert.rejects(result, error => error === failure);
+} else {
+	response.push({ type: "done", reason: "stop", message });
+	response.end();
+	assert.deepEqual((await result).content, [{ type: "text", text: "first second" }]);
+	assert.equal((await result).stopReason, "stop");
+}
+process.stdout.write("verified\n");


### PR DESCRIPTION
## What

`complete()` and `completeSimple()` consume streamed events as they arrive instead of retaining them until the request ends. Final responses, terminal errors, and thinking-loop retries retain their existing behavior.

## Why

Completion-only callers need the final response but otherwise retain unused stream events until the request ends.

## Testing

- [x] 49 stream, completion, and thinking-loop tests; both retention regressions fail on the original implementation.
- [x] AI `bun check`; independent review also verifies failure and terminal-result paths.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
