### PR TITLE
fix(collab): exclude advisor transcripts from shared sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Shared-session guests can no longer fetch private advisor transcripts by agent ID.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -641,11 +641,12 @@ export class CollabHost {
 	async #handleFetchTranscript(reqId: number, agentId: string, fromByte: number, fromPeer: number): Promise<void> {
 		const reply = (text: string, newSize: number, error?: string) =>
 			this.#socket?.send({ t: "transcript", reqId, text, newSize, error }, fromPeer);
-		const file = AgentRegistry.global().get(agentId)?.sessionFile;
-		if (!file) {
+		const ref = AgentRegistry.global().get(agentId);
+		if (!ref?.sessionFile || ref.kind === "advisor") {
 			reply("", fromByte, "no transcript available");
 			return;
 		}
+		const file = ref.sessionFile;
 		try {
 			const stat = await fs.stat(file);
 			if (stat.size <= fromByte) {

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -16,6 +16,7 @@ import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
 
 // In-memory transport: FakeWebSocket + InMemoryRelay (see ./helpers/in-memory-relay)
@@ -169,6 +170,35 @@ afterAll(async () => {
 });
 
 describe("collab read-only links", () => {
+	for (const kind of ["advisor", "main", "sub"] as const) {
+		it(`${kind === "advisor" ? "denies" : "serves"} ${kind} transcripts requested by a view-link guest`, async () => {
+			await using dir = await TempDir.create("@pi-collab-transcript-");
+			const id = `transcript-${kind}-${crypto.randomUUID()}`;
+			const text = `${JSON.stringify({ type: "message", content: id })}\n`;
+			const file = dir.join("session.jsonl");
+			await Bun.write(file, text);
+			const registry = AgentRegistry.global();
+			const ref = registry.register({ id, displayName: id, kind, session: null, sessionFile: file });
+			try {
+				const guest = await joinAsGuest(host.viewLink, `reader-${kind}`);
+				guestCleanups.push(() => guest.socket.close());
+				const welcome = await guest.nextFrame();
+				if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+				guest.socket.send({ t: "fetch-transcript", reqId: 1, agentId: id, fromByte: 0 });
+				const reply = await guest.nextFrame();
+				if (reply.t !== "transcript") throw new Error(`expected transcript, got ${reply.t}`);
+				if (kind === "advisor") {
+					expect(reply.text).not.toContain(id);
+					expect(reply).toMatchObject({ reqId: 1, text: "", newSize: 0, error: "no transcript available" });
+				} else {
+					expect(reply).toEqual({ t: "transcript", reqId: 1, text, newSize: Buffer.byteLength(text) });
+				}
+			} finally {
+				registry.unregister(id, ref);
+			}
+		});
+	}
+
 	it("welcomes view-link guests read-only and refuses their mutating frames", async () => {
 		const { prompts, aborts } = harness;
 		expect(host.viewLink).not.toBe(host.link);


### PR DESCRIPTION
## What

Transcript requests now apply the same advisor exclusion as the shared roster and controls, before opening the transcript file. Main and subagent transcripts remain available to guests.

## Why

Advisor exclusion from the roster did not prevent guests from requesting a transcript directly by agent ID.

## Testing

- [x] The original handler exposes a unique advisor marker; the corrected encrypted handler denies it.
- [x] 82 collab tests, coding-agent `bun check`, and independent review.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
