### PR TITLE
perf(tui): reduce retained thinking snapshot data

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Long reasoning streams retain less memory while preserving scrollback and terminal-width replay.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/bench/thinking-retention.bench.ts
+++ b/packages/coding-agent/bench/thinking-retention.bench.ts
@@ -1,0 +1,61 @@
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { heapStats } from "bun:jsc";
+import { Settings } from "../src/config/settings";
+import { AssistantMessageComponent } from "../src/modes/components/assistant-message";
+import { initTheme } from "../src/modes/theme/theme";
+
+const steps = Number(process.argv[2] ?? 500);
+if (!Number.isSafeInteger(steps) || steps <= 0) throw new Error("Expected a positive publication count");
+await initTheme(false);
+await Settings.init({ inMemory: true });
+
+function stream(count: number): AssistantMessageComponent {
+	const component = new AssistantMessageComponent();
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "benchmark",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+	let thinking = "";
+	for (let step = 0; step < count; step++) {
+		thinking += `Paragraph ${step}: consider **correctness**, memory use, and terminal replay before selecting an implementation.\n\n`;
+		component.updateContent(
+			{ ...message, content: [{ type: "thinking", thinking: `${thinking}Pending paragraph` }] },
+			{ transient: true },
+		);
+		component.render(100);
+	}
+	return component;
+}
+
+stream(20);
+Bun.gc(true);
+const before = heapStats().heapSize;
+const started = performance.now();
+const cpuStarted = process.cpuUsage();
+const component = stream(steps);
+const elapsedMs = performance.now() - started;
+const cpu = process.cpuUsage(cpuStarted);
+const cpuMs = (cpu.user + cpu.system) / 1000;
+Bun.gc(true);
+const retainedBytes = heapStats().heapSize - before;
+const publications = component.getTranscriptStableRows().length;
+const identityBytes = component.getTranscriptStableRows().reduce((total, row) => total + row.key.length * 2, 0);
+const replayStarted = performance.now();
+const replayRows = component.renderTranscriptStableRows(publications, 50).length;
+const replayMs = performance.now() - replayStarted;
+console.log(
+	JSON.stringify({ steps, publications, retainedBytes, identityBytes, elapsedMs, cpuMs, replayRows, replayMs }),
+);

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -13,6 +13,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { resolveImageOptions } from "../../tools/render-utils";
@@ -47,18 +48,19 @@ type StableThinkingPart = { kind: "thinking"; text: string } | { kind: "spacer" 
  * contract that lets them retire into native scrollback mid-stream.
  */
 interface ThinkingStableSnapshot {
-	readonly key: string;
-	readonly parts: readonly StableThinkingPart[];
+	// Earlier parts are immutable; only the final part needs a historical offset.
+	readonly partCount: number;
+	readonly lastTextLength: number;
 }
 
-function isSnapshotExtension(previous: ThinkingStableSnapshot, current: ThinkingStableSnapshot): boolean {
-	if (previous.parts.length > current.parts.length) return false;
-	for (let index = 0; index < previous.parts.length; index++) {
-		const before = previous.parts[index]!;
-		const after = current.parts[index]!;
+function isSnapshotExtension(previous: readonly StableThinkingPart[], current: readonly StableThinkingPart[]): boolean {
+	if (previous.length > current.length) return false;
+	for (let index = 0; index < previous.length; index++) {
+		const before = previous[index]!;
+		const after = current[index]!;
 		if (before.kind !== after.kind) return false;
 		if (before.kind === "spacer" || after.kind === "spacer") continue;
-		const isLast = index === previous.parts.length - 1;
+		const isLast = index === previous.length - 1;
 		if (isLast ? !after.text.startsWith(before.text) : after.text !== before.text) return false;
 	}
 	return true;
@@ -246,9 +248,11 @@ export class AssistantMessageComponent extends Container {
 	#lastTokenTime = 0;
 	/** Published width-independent thinking prefixes; grows only, never retracts. */
 	#stableSnapshots: ThinkingStableSnapshot[] = [];
+	#stableParts: readonly StableThinkingPart[] = [];
+	#nextStableRowId = 0;
 	#transcriptStableRows: TranscriptStableRow[] = [];
-	/** Rendered stable rows memoized by `${count}:${width}`, insertion-evicted. */
-	#stableRenderCache = new Map<string, readonly string[]>();
+	/** Keep the previous and current render, not every cumulative published prefix. */
+	#stableRenderCache = new LRUCache<string, readonly string[]>({ max: 2 });
 	/** Provider-reported tokens in the live thinking block — reasoning tokens when
 	 *  the provider streams them, else total output — shown dimmed beside the
 	 *  speed badge. 0 when no thinking is streaming. */
@@ -567,6 +571,7 @@ export class AssistantMessageComponent extends Container {
 	 */
 	resetTranscriptStableRows(): void {
 		this.#stableSnapshots = [];
+		this.#stableParts = [];
 		this.#transcriptStableRows = [];
 		this.#stableRenderCache.clear();
 	}
@@ -577,13 +582,14 @@ export class AssistantMessageComponent extends Container {
 		const key = `${index}:${width}`;
 		const cached = this.#stableRenderCache.get(key);
 		if (cached) return cached;
-		const rows = this.#renderStableSnapshot(this.#stableSnapshots[index - 1]!, width);
-		this.#stableRenderCache.set(key, rows);
-		// Bounded: the container re-requests only recent counts at live widths.
-		if (this.#stableRenderCache.size > 64) {
-			const oldest = this.#stableRenderCache.keys().next().value;
-			if (oldest !== undefined) this.#stableRenderCache.delete(oldest);
+		const snapshot = this.#stableSnapshots[index - 1]!;
+		const parts = this.#stableParts.slice(0, snapshot.partCount);
+		const last = parts.at(-1);
+		if (last?.kind === "thinking") {
+			parts[parts.length - 1] = { kind: "thinking", text: last.text.slice(0, snapshot.lastTextLength) };
 		}
+		const rows = this.#renderStableSnapshot(parts, width);
+		this.#stableRenderCache.set(key, rows);
 		return rows;
 	}
 
@@ -596,12 +602,15 @@ export class AssistantMessageComponent extends Container {
 	 * ever retracts it.
 	 */
 	#publishStableSnapshot(rendered: readonly string[], width: number): void {
-		const snapshot = this.#currentStableSnapshot();
-		if (!snapshot) return;
+		const parts = this.#currentStableSnapshot();
+		if (!parts) return;
+		const last = parts.at(-1);
+		if (last?.kind !== "thinking") return;
+		const snapshot = { partCount: parts.length, lastTextLength: last.text.length };
 		const previous = this.#stableSnapshots.at(-1);
-		if (previous?.key === snapshot.key) return;
-		if (previous && !isSnapshotExtension(previous, snapshot)) return;
-		const currentRows = this.#renderStableSnapshot(snapshot, width);
+		if (previous && !isSnapshotExtension(this.#stableParts, parts)) return;
+		if (previous?.partCount === snapshot.partCount && previous.lastTextLength === snapshot.lastTextLength) return;
+		const currentRows = this.#renderStableSnapshot(parts, width);
 		// The container verifies stable rows against the blank-trimmed render.
 		if (!isRowPrefix(currentRows, trimBlankEdges(rendered))) return;
 		const previousRows = previous
@@ -610,8 +619,9 @@ export class AssistantMessageComponent extends Container {
 		if (!isRowPrefix(previousRows, currentRows)) return;
 		// Each stable row must add at least one physical row at every width.
 		if (currentRows.length === previousRows.length) return;
+		this.#stableParts = parts;
 		this.#stableSnapshots.push(snapshot);
-		this.#transcriptStableRows.push({ key: snapshot.key });
+		this.#transcriptStableRows.push({ key: `thinking:${this.#nextStableRowId++}` });
 		this.#stableRenderCache.set(`${this.#stableSnapshots.length}:${width}`, currentRows);
 	}
 
@@ -622,7 +632,7 @@ export class AssistantMessageComponent extends Container {
 	 * still change (finalized or non-transient renders, marker rows, extension
 	 * components, hidden thinking, or no frozen prefix yet).
 	 */
-	#currentStableSnapshot(): ThinkingStableSnapshot | undefined {
+	#currentStableSnapshot(): readonly StableThinkingPart[] | undefined {
 		if (this.#transcriptBlockFinalized || !this.#lastUpdateTransient) return undefined;
 		if (this.#markerSlot.children.length > 0) return undefined;
 		const items = this.#fastPathItems;
@@ -658,12 +668,12 @@ export class AssistantMessageComponent extends Container {
 		}
 		while (parts.at(-1)?.kind === "spacer") parts.pop();
 		if (!parts.some(part => part.kind === "thinking")) return undefined;
-		return { key: JSON.stringify(parts), parts };
+		return parts;
 	}
 
-	#renderStableSnapshot(snapshot: ThinkingStableSnapshot, width: number): readonly string[] {
+	#renderStableSnapshot(parts: readonly StableThinkingPart[], width: number): readonly string[] {
 		const rows: string[] = [];
-		for (const part of snapshot.parts) {
+		for (const part of parts) {
 			if (part.kind === "spacer") {
 				rows.push("");
 				continue;
@@ -691,6 +701,7 @@ export class AssistantMessageComponent extends Container {
 
 	markTranscriptBlockFinalized(): void {
 		this.#transcriptBlockFinalized = true;
+		this.#stableRenderCache.clear();
 		this.#stopThinkingAnimation();
 		// If the live pulse was on screen when the block sealed, drop the fast path
 		// and rebuild so the placeholder is removed — finalized blocks never animate.

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
@@ -54,6 +54,76 @@ afterEach(() => {
 // the same message — at every step. If they ever diverge, the optimization
 // silently corrupts the transcript.
 describe("AssistantMessageComponent streaming fast path", () => {
+	it("replays retired thinking prefixes after cache eviction, reflow, and finalization", () => {
+		const component = new AssistantMessageComponent();
+		const widths = [36, W];
+		const prefixes: Array<{ count: number; rows: readonly string[][] }> = [];
+		let thinking = "";
+		for (let step = 0; step < 80; step++) {
+			thinking += `Paragraph ${step} has **emphasis** and enough words to wrap at narrow widths.\n\n`;
+			component.updateContent(msg([{ type: "thinking", thinking: `${thinking}Pending paragraph` }]), {
+				transient: true,
+			});
+			component.render(W);
+			const count = component.getTranscriptStableRows().length;
+			if (count > (prefixes.at(-1)?.count ?? 0)) {
+				prefixes.push({
+					count,
+					rows: widths.map(width => [...component.renderTranscriptStableRows(count, width)]),
+				});
+			}
+		}
+		expect(prefixes.length).toBeGreaterThan(64);
+		const keys = component.getTranscriptStableRows().map(row => row.key);
+		expect(keys.reduce((length, key) => length + key.length, 0)).toBeLessThan(keys.length * 32);
+		component.updateContent(
+			msg([
+				{ type: "thinking", thinking },
+				{ type: "text", text: "Final answer" },
+			]),
+		);
+		component.markTranscriptBlockFinalized();
+		for (const prefix of prefixes) {
+			for (const [index, width] of widths.entries()) {
+				expect(component.renderTranscriptStableRows(prefix.count, width)).toEqual(prefix.rows[index]);
+			}
+		}
+		expect(component.getTranscriptStableRows().map(row => row.key)).toEqual(keys);
+	});
+
+	it("keeps earlier block boundaries immutable when later thinking blocks grow or revise", () => {
+		const component = new AssistantMessageComponent();
+		const first = "First reasoning paragraph.\n\nSecond paragraph.\n\nStill thinking";
+		component.updateContent(msg([{ type: "thinking", thinking: first }]), { transient: true });
+		component.render(W);
+		const firstCount = component.getTranscriptStableRows().length;
+		expect(firstCount).toBeGreaterThan(0);
+		const firstRows = [...component.renderTranscriptStableRows(firstCount, 40)];
+		const content: AssistantMessage["content"] = [
+			{ type: "thinking", thinking: first },
+			{ type: "thinking", thinking: "Another block.\n\nMore reasoning.\n\nPending" },
+		];
+		component.updateContent(msg(content), { transient: true });
+		component.render(W);
+		const count = component.getTranscriptStableRows().length;
+		expect(count).toBeGreaterThan(firstCount);
+		const rows = [...component.renderTranscriptStableRows(count, 40)];
+		component.updateContent(msg([{ type: "thinking", thinking: `Rewritten ${first}` }]), { transient: true });
+		component.render(W);
+		expect(component.getTranscriptStableRows()).toHaveLength(count);
+		component.renderTranscriptStableRows(count, 60);
+		component.renderTranscriptStableRows(count, 80);
+		expect(component.renderTranscriptStableRows(firstCount, 40)).toEqual(firstRows);
+		expect(component.renderTranscriptStableRows(count, 40)).toEqual(rows);
+		component.setHideThinkingBlock(true);
+		component.resetTranscriptStableRows();
+		component.updateContent(msg(content), { transient: true });
+		component.render(W);
+		expect(component.getTranscriptStableRows()).toEqual([]);
+		expect(component.renderTranscriptStableRows(count, 40)).toEqual([]);
+		component.markTranscriptBlockFinalized();
+	});
+
 	it("matches teardown output across a growing thinking + text stream", () => {
 		const reused = new AssistantMessageComponent();
 		const thinking = "Reasoning about the **problem** with `code` and a list:\n- a\n- b";


### PR DESCRIPTION
## What

Published thinking prefixes share their text and retain compact offsets, with two cached renders. In the actual-component benchmark, 1,000 publications retained 57.5 MB versus 529.4 MB before; replay remained correct. The matched sample used roughly 7% more CPU, so this is a memory tradeoff, not a speedup claim.

## Why

Repeated thinking publications retain overlapping text and rendered prefixes across scrollback snapshots.

## Testing

- [x] 71 rendering tests, including historical replay, reflow, rewrites, hidden reasoning, and finalization; package check passed.
- [x] Independent review reproduced the changed benchmark and passed 36 replay/container tests.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
