### PR TITLE
perf(agent): share finalized tool argument snapshots

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced memory and copying while streaming after large tool calls finish.
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -348,7 +348,10 @@ function snapshotToolResultProviderMetadata(value: unknown): {
 	};
 }
 
-function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantContentBlock {
+function snapshotAssistantContentBlock(
+	block: AssistantContentBlock,
+	completedToolArguments?: WeakMap<object, Record<string, unknown>>,
+): AssistantContentBlock {
 	switch (block.type) {
 		case "text":
 		case "image":
@@ -364,7 +367,7 @@ function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantC
 		case "toolCall": {
 			const snap = {
 				...block,
-				arguments: structuredCloneJSON(block.arguments),
+				arguments: completedToolArguments?.get(block.arguments) ?? structuredCloneJSON(block.arguments),
 				providerMetadata: snapshotToolCallProviderMetadata(block.providerMetadata),
 			};
 			// Object spread copies enumerable symbols in Bun, but the Cursor
@@ -376,10 +379,13 @@ function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantC
 	}
 }
 
-function snapshotAssistantMessage(message: AssistantMessage): AssistantMessage {
+function snapshotAssistantMessage(
+	message: AssistantMessage,
+	completedToolArguments?: WeakMap<object, Record<string, unknown>>,
+): AssistantMessage {
 	return {
 		...message,
-		content: message.content.map(snapshotAssistantContentBlock),
+		content: message.content.map(block => snapshotAssistantContentBlock(block, completedToolArguments)),
 		usage: {
 			...message.usage,
 			cost: { ...message.usage.cost },
@@ -1779,6 +1785,7 @@ async function streamAssistantResponse(
 			let partialMessage: AssistantMessage | null = null;
 			let addedPartial = false;
 			const completedToolCallIds = new Set<string>();
+			let completedToolArguments = new WeakMap<object, Record<string, unknown>>();
 			const argStreams = new Map<number, { id: string; stream: AgentToolArgStream }>();
 			const cancelArgStreams = (): void => {
 				for (const { id, stream: argStream } of argStreams.values()) {
@@ -1951,6 +1958,7 @@ async function streamAssistantResponse(
 
 					switch (event.type) {
 						case "start":
+							completedToolArguments = new WeakMap();
 							partialMessage = event.partial;
 							if (addedPartial) {
 								context.messages[context.messages.length - 1] = partialMessage;
@@ -1988,12 +1996,32 @@ async function streamAssistantResponse(
 								}
 								partialMessage = event.partial;
 								context.messages[context.messages.length - 1] = partialMessage;
+								if (config.onAssistantMessageEvent && !config.onAssistantMessageEventReadOnly) {
+									completedToolArguments = new WeakMap();
+								}
 								config.onAssistantMessageEvent?.(partialMessage, event);
+								if (
+									event.type === "toolcall_start" ||
+									event.type === "toolcall_delta" ||
+									event.type === "toolcall_end"
+								) {
+									const block = partialMessage.content[event.contentIndex];
+									if (block?.type === "toolCall") completedToolArguments.delete(block.arguments);
+								}
 								// `message` and `assistantMessageEvent.partial` intentionally share one
 								// immutable snapshot of the streaming partial: every message_update
 								// consumer treats both as read-only, so cloning the identical partial
 								// twice per delta was pure waste.
-								const messageSnapshot = snapshotAssistantMessage(partialMessage);
+								const messageSnapshot = snapshotAssistantMessage(partialMessage, completedToolArguments);
+								if (event.type === "toolcall_end") {
+									const source = partialMessage.content[event.contentIndex];
+									const snapshot = messageSnapshot.content[event.contentIndex];
+									if (source?.type === "toolCall" && snapshot?.type === "toolCall") {
+										// Only streaming consumers share this clone. Final dispatch hooks
+										// receive a fresh message so argument rewrites cannot change previews.
+										completedToolArguments.set(source.arguments, snapshot.arguments);
+									}
+								}
 								stream.push({
 									type: "message_update",
 									assistantMessageEvent: snapshotAssistantMessageEvent(event, messageSnapshot),

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2016,7 +2016,12 @@ async function streamAssistantResponse(
 								if (event.type === "toolcall_end") {
 									const source = partialMessage.content[event.contentIndex];
 									const snapshot = messageSnapshot.content[event.contentIndex];
-									if (source?.type === "toolCall" && snapshot?.type === "toolCall") {
+									if (
+										source?.type === "toolCall" &&
+										snapshot?.type === "toolCall" &&
+										typeof source.arguments === "object" &&
+										source.arguments !== null
+									) {
 										// Only streaming consumers share this clone. Final dispatch hooks
 										// receive a fresh message so argument rewrites cannot change previews.
 										completedToolArguments.set(source.arguments, snapshot.arguments);

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -187,6 +187,8 @@ export interface AgentOptions {
 	 * Use this when abort decisions must happen before buffered events continue flowing.
 	 */
 	onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	/** Certifies that the interceptor never mutates message or event data, allowing immutable snapshot reuse. */
+	onAssistantMessageEventReadOnly?: boolean;
 
 	/**
 	 * Called when GPT-5 Harmony protocol leakage is detected and mitigated.
@@ -420,6 +422,7 @@ export class Agent {
 	#onResponse?: SimpleStreamOptions["onResponse"];
 	#onSseEvent?: SimpleStreamOptions["onSseEvent"];
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	#onAssistantMessageEventReadOnly: boolean;
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
 	#onTurnEnd?: (messages: AgentMessage[], signal?: AbortSignal, context?: AgentTurnEndContext) => Promise<void> | void;
@@ -504,6 +507,7 @@ export class Agent {
 		this.#getToolChoice = opts.getToolChoice;
 		this.#onToolChoiceUnavailable = opts.onToolChoiceUnavailable;
 		this.#onAssistantMessageEvent = opts.onAssistantMessageEvent;
+		this.#onAssistantMessageEventReadOnly = opts.onAssistantMessageEventReadOnly ?? false;
 		this.#onHarmonyLeak = opts.onHarmonyLeak;
 		this.beforeToolCall = opts.beforeToolCall;
 		this.afterToolCall = opts.afterToolCall;
@@ -851,8 +855,10 @@ export class Agent {
 
 	setAssistantMessageEventInterceptor(
 		fn: ((message: AssistantMessage, event: AssistantMessageEvent) => void) | undefined,
+		options?: { readOnly?: boolean },
 	): void {
 		this.#onAssistantMessageEvent = fn;
+		this.#onAssistantMessageEventReadOnly = options?.readOnly ?? false;
 	}
 
 	setOnBeforeYield(fn: (() => Promise<void> | void) | undefined): void {
@@ -1473,6 +1479,7 @@ export class Agent {
 				? (message, signal) => this.transformAssistantMessage?.(message, signal)
 				: undefined,
 			onAssistantMessageEvent: this.#onAssistantMessageEvent,
+			onAssistantMessageEventReadOnly: this.#onAssistantMessageEventReadOnly,
 			onHarmonyLeak: this.#onHarmonyLeak,
 			onTurnEnd: (messages, signal, context) => this.#onTurnEnd?.(messages, signal, context),
 			getToolChoice,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -394,6 +394,8 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Callers may abort synchronously to stop consuming buffered provider events.
 	 */
 	onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	/** Certifies that the interceptor never mutates message or event data, allowing immutable snapshot reuse. */
+	onAssistantMessageEventReadOnly?: boolean;
 
 	/**
 	 * Called when GPT-5 Harmony protocol leakage is detected and mitigated.

--- a/packages/agent/test/finalized-tool-snapshots.test.ts
+++ b/packages/agent/test/finalized-tool-snapshots.test.ts
@@ -1,0 +1,183 @@
+import { expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core/agent";
+import { agentLoop } from "@oh-my-pi/pi-agent-core/agent-loop";
+import type { AgentLoopConfig, AgentMessage } from "@oh-my-pi/pi-agent-core/types";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { createAssistantMessage, createUserMessage } from "./helpers";
+
+function convertToLlm(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+it("retains one finalized argument snapshot with a read-only interceptor without exposing final rewrites", async () => {
+	const mock = createMockModel({ responses: [{ content: ["finished"] }] });
+	const args = { entries: Array.from({ length: 1000 }, (_, value) => ({ value })) };
+	const toolCall = { type: "toolCall" as const, id: "first", name: "noop", arguments: args };
+	const partial = createAssistantMessage([toolCall, { type: "text", text: "later" }], "toolUse");
+	let calls = 0;
+	const streamFn: typeof mock.stream = (model, context, options) => {
+		if (calls++ > 0) return mock.stream(model, context, options);
+		const response = new AssistantMessageEventStream();
+		response.push({ type: "start", partial });
+		response.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+		for (let i = 0; i < 100; i++) {
+			response.push({ type: "text_delta", contentIndex: 1, delta: "later", partial });
+		}
+		response.push({ type: "done", reason: "toolUse", message: partial });
+		return response;
+	};
+	const agent = new Agent({
+		initialState: { model: mock.model, systemPrompt: [], messages: [], tools: [] },
+		streamFn,
+		convertToLlm,
+		transformAssistantMessage(message) {
+			const block = message.content[0];
+			if (block?.type === "toolCall") (block.arguments.entries as { value: number }[])[0].value = -1;
+		},
+	});
+	let observed = 0;
+	agent.setAssistantMessageEventInterceptor(
+		(_message, event) => {
+			if (event.type === "toolcall_end" || event.type === "text_delta") observed++;
+		},
+		{ readOnly: true },
+	);
+	const retained = new Set<Record<string, unknown>>();
+	let updates = 0;
+	let finalArgs: Record<string, unknown> | undefined;
+	const unsubscribe = agent.subscribe(event => {
+		if (event.type !== "message_update" && event.type !== "message_end") return;
+		if (event.message.role !== "assistant") return;
+		const block = event.message.content[0];
+		if (block?.type !== "toolCall") return;
+		if (event.type === "message_update") {
+			updates++;
+			retained.add(block.arguments);
+		} else finalArgs = block.arguments;
+	});
+	try {
+		await agent.prompt("run");
+	} finally {
+		unsubscribe();
+	}
+	expect(updates).toBe(101);
+	expect(observed).toBe(102);
+	expect(retained.size).toBe(1);
+	const snapshot = [...retained][0];
+	expect(snapshot.entries).toEqual(args.entries);
+	expect(snapshot.entries).not.toBe(args.entries);
+	if (!finalArgs) throw new Error("missing finalized tool arguments");
+	expect((finalArgs.entries as { value: number }[])[0].value).toBe(-1);
+	expect((snapshot.entries as { value: number }[])[0].value).toBe(0);
+});
+
+it("isolates interleaved argument updates, reopened calls, and restarted partials", async () => {
+	const mock = createMockModel({ responses: [{ content: ["finished"] }] });
+	const first = { type: "toolCall" as const, id: "first", name: "noop", arguments: { nested: { value: 0 } } };
+	const second = { type: "toolCall" as const, id: "second", name: "noop", arguments: { nested: { value: 0 } } };
+	const partial = createAssistantMessage([first], "toolUse");
+	const response = new AssistantMessageEventStream();
+	let calls = 0;
+	const streamFn: typeof mock.stream = (model, context, options) => {
+		if (calls++ > 0) return mock.stream(model, context, options);
+		response.push({ type: "start", partial });
+		return response;
+	};
+	const steps = [
+		() => response.push({ type: "toolcall_start", contentIndex: 0, partial }),
+		() => {
+			first.arguments.nested.value = 1;
+			response.push({ type: "toolcall_delta", contentIndex: 0, delta: "1", partial });
+		},
+		() => response.push({ type: "toolcall_end", contentIndex: 0, toolCall: first, partial }),
+		() => {
+			partial.content.push(second);
+			response.push({ type: "toolcall_start", contentIndex: 1, partial });
+		},
+		() => {
+			second.arguments.nested.value = 2;
+			response.push({ type: "toolcall_delta", contentIndex: 1, delta: "2", partial });
+		},
+		() => {
+			first.arguments.nested.value = 3;
+			response.push({ type: "toolcall_delta", contentIndex: 0, delta: "3", partial });
+		},
+		() => response.push({ type: "toolcall_end", contentIndex: 0, toolCall: first, partial }),
+		() => response.push({ type: "toolcall_end", contentIndex: 1, toolCall: second, partial }),
+		() => {
+			first.arguments.nested.value = 4;
+			response.push({ type: "start", partial });
+		},
+		() => response.push({ type: "toolcall_end", contentIndex: 0, toolCall: first, partial }),
+		() => response.push({ type: "done", reason: "toolUse", message: partial }),
+	];
+	let step = 0;
+	const snapshots: Record<string, unknown>[][] = [];
+	const config: AgentLoopConfig = { model: mock.model, convertToLlm };
+	for await (const event of agentLoop(
+		[createUserMessage("run")],
+		{ systemPrompt: [], messages: [], tools: [] },
+		config,
+		undefined,
+		streamFn,
+	)) {
+		if (event.type !== "message_update" && event.type !== "message_start") continue;
+		if (event.message.role !== "assistant" || event.message.content[0]?.type !== "toolCall") continue;
+		snapshots.push(event.message.content.filter(block => block.type === "toolCall").map(block => block.arguments));
+		steps[step++]?.();
+	}
+	expect(snapshots.map(blocks => blocks.map(args => (args.nested as { value: number }).value))).toEqual([
+		[0],
+		[0],
+		[1],
+		[1],
+		[1, 0],
+		[1, 2],
+		[3, 2],
+		[3, 2],
+		[3, 2],
+		[4, 2],
+		[4, 2],
+	]);
+});
+
+it("publishes streaming-hook revisions without rewriting earlier finalized snapshots", async () => {
+	const mock = createMockModel({ responses: [{ content: ["finished"] }] });
+	const toolCall = { type: "toolCall" as const, id: "first", name: "noop", arguments: { nested: { value: 0 } } };
+	const partial = createAssistantMessage([toolCall, { type: "text", text: "later" }], "toolUse");
+	let calls = 0;
+	const streamFn: typeof mock.stream = (model, context, options) => {
+		if (calls++ > 0) return mock.stream(model, context, options);
+		const response = new AssistantMessageEventStream();
+		response.push({ type: "start", partial });
+		response.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+		response.push({ type: "text_delta", contentIndex: 1, delta: "later", partial });
+		response.push({ type: "done", reason: "toolUse", message: partial });
+		return response;
+	};
+	const config: AgentLoopConfig = {
+		model: mock.model,
+		convertToLlm,
+		onAssistantMessageEvent(message, event) {
+			const block = message.content[0];
+			if (event.type === "text_delta" && block?.type === "toolCall") {
+				(block.arguments.nested as { value: number }).value = 1;
+			}
+		},
+	};
+	const snapshots: Record<string, unknown>[] = [];
+	for await (const event of agentLoop(
+		[createUserMessage("run")],
+		{ systemPrompt: [], messages: [], tools: [] },
+		config,
+		undefined,
+		streamFn,
+	)) {
+		if (event.type !== "message_update" || event.message.role !== "assistant") continue;
+		const block = event.message.content[0];
+		if (block?.type === "toolCall") snapshots.push(block.arguments);
+	}
+	expect(snapshots.map(args => (args.nested as { value: number }).value)).toEqual([0, 1]);
+});

--- a/packages/agent/test/finalized-tool-snapshots.test.ts
+++ b/packages/agent/test/finalized-tool-snapshots.test.ts
@@ -11,6 +11,48 @@ function convertToLlm(messages: AgentMessage[]): Message[] {
 	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
 }
 
+it("streams past raw JSON tool arguments and lets the final transform normalize them", async () => {
+	const mock = createMockModel({
+		responses: [
+			{ content: [{ type: "toolCall", id: "raw", name: "noop", arguments: '{"value":1}' }, "later"] },
+			{ content: ["finished"] },
+		],
+	});
+	const config: AgentLoopConfig = {
+		model: mock.model,
+		convertToLlm,
+		transformAssistantMessage(message) {
+			for (const block of message.content) {
+				if (block.type === "toolCall" && typeof block.arguments === "string") {
+					block.arguments = JSON.parse(block.arguments);
+				}
+			}
+		},
+	};
+	let laterText = "";
+	let finalArguments: Record<string, unknown> | undefined;
+	let ended = false;
+	for await (const event of agentLoop(
+		[createUserMessage("run")],
+		{ systemPrompt: [], messages: [], tools: [] },
+		config,
+		undefined,
+		mock.stream,
+	)) {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			laterText += event.assistantMessageEvent.delta;
+		}
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			const block = event.message.content.find(block => block.type === "toolCall");
+			if (block?.type === "toolCall") finalArguments = block.arguments;
+		}
+		if (event.type === "agent_end") ended = true;
+	}
+	expect(laterText).toContain("later");
+	expect(finalArguments).toEqual({ value: 1 });
+	expect(ended).toBe(true);
+});
+
 it("retains one finalized argument snapshot with a read-only interceptor without exposing final rewrites", async () => {
 	const mock = createMockModel({ responses: [{ content: ["finished"] }] });
 	const args = { entries: Array.from({ length: 1000 }, (_, value) => ({ value })) };

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced repeated copying of completed tool arguments while later response content streams.
+
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
@@ -34,9 +38,6 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
-### Changed
-
-- Reduced repeated copying of completed tool arguments while later response content streams.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
+### Changed
+
+- Reduced repeated copying of completed tool arguments while later response content streams.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1675,16 +1675,19 @@ export class AgentSession {
 				build: buildAsyncResultBatchMessage,
 			});
 		}
-		this.agent.setAssistantMessageEventInterceptor((message, assistantMessageEvent) => {
-			const event: AgentEvent = {
-				type: "message_update",
-				message,
-				assistantMessageEvent,
-			};
-			this.#streamingEditGuard.preCache(event);
-			this.#streamingEditGuard.maybeAbort(event);
-			this.#loopGuards.onAssistantEvent(message, assistantMessageEvent);
-		});
+		this.agent.setAssistantMessageEventInterceptor(
+			(message, assistantMessageEvent) => {
+				const event: AgentEvent = {
+					type: "message_update",
+					message,
+					assistantMessageEvent,
+				};
+				this.#streamingEditGuard.preCache(event);
+				this.#streamingEditGuard.maybeAbort(event);
+				this.#loopGuards.onAssistantEvent(message, assistantMessageEvent);
+			},
+			{ readOnly: true },
+		);
 		// Tool-result hook owns synchronous post-tool actions that must affect the current loop.
 		this.agent.afterToolCall = ctx => this.#afterToolCall(ctx);
 		// Pre-scheduling tool_call wiring: extension handlers run at arg-prep

--- a/packages/coding-agent/test/agent-session-finalized-tool-snapshots.test.ts
+++ b/packages/coding-agent/test/agent-session-finalized-tool-snapshots.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+it("reuses completed argument snapshots while session streaming guards observe later text", async () => {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+	const args = { nested: { value: 0 } };
+	const mock = createMockModel({
+		responses: [
+			{
+				content: [{ type: "toolCall", id: "first", name: "noop", arguments: args }, "after", "later"],
+			},
+			{ content: ["done"] },
+		],
+	});
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: [], tools: [] },
+		convertToLlm,
+		streamFn: mock.stream,
+	});
+	const authStorage = await AuthStorage.create(":memory:");
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated(),
+		modelRegistry: new ModelRegistry(authStorage),
+		agentId: "Main",
+	});
+	const retained = new Set<Record<string, unknown>>();
+	const unsubscribe = agent.subscribe(event => {
+		if (event.type !== "message_update" || event.message.role !== "assistant") return;
+		if (event.assistantMessageEvent.type !== "text_delta") return;
+		const block = event.message.content[0];
+		if (block?.type === "toolCall" && block.id === "first") retained.add(block.arguments);
+	});
+	try {
+		await agent.prompt("run");
+		expect(retained.size).toBe(1);
+		expect([...retained][0]).toEqual(args);
+	} finally {
+		unsubscribe();
+		await session.dispose();
+		authStorage.close();
+	}
+});


### PR DESCRIPTION
## What

Later deltas reuse completed argument snapshots while active or reopened calls still receive fresh copies. The CLI's streaming guards opt into an explicit read-only interceptor contract; existing mutating interceptors retain conservative cloning. Final tool rewrites cannot alter previously emitted snapshots.

## Why

Completed tool arguments were copied again for subsequent deltas, including normal CLI sessions with streaming guards.

## Testing

- [x] A 100-delta workload retains one argument copy instead of 101; the actual `AgentSession` regression fails on baseline.
- [x] 541 agent tests, nine CLI/guard tests, both package checks, and a clean second independent review.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

Post-rebase verification on this branch passed 387 snapshot/advisor/selector tests, coding-agent `bun check`, and the isolated CLI worker/dashboard smoke.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
