### PR TITLE
fix(lsp): bound JSON-RPC framing and reject malformed streams

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- LSP and debugger connections reject oversized or invalid frames instead of accumulating stdout indefinitely; fragmented headers decode without rescanning previous bytes.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import { isEnoent, logger, ptree } from "@oh-my-pi/pi-utils";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
-import { MessageFramer } from "../jsonrpc/message-framing";
+import { MessageFramer, MessageFramingError } from "../jsonrpc/message-framing";
 import { ToolAbortError } from "../tools/tool-errors";
 import type {
 	DapCapabilities,
@@ -594,6 +594,7 @@ export class DapClient {
 		const framer = new MessageFramer(this.#messageBuffer);
 
 		let closeError: Error | undefined;
+		let framingFailed = false;
 		try {
 			while (true) {
 				const { done, value } = await reader.read();
@@ -633,6 +634,7 @@ export class DapClient {
 				}
 			}
 		} catch (error) {
+			framingFailed = error instanceof MessageFramingError;
 			closeError = new Error(`DAP connection closed: ${toErrorMessage(error)}`);
 		} finally {
 			// Persist any unparsed remainder so a restarted reader resumes mid-message.
@@ -646,6 +648,14 @@ export class DapClient {
 		// in-flight request and event waiter so callers see an immediate error
 		// instead of waiting out their own timeout.
 		this.#failConnection(closeError ?? new Error(`DAP connection closed: ${this.adapter.name} transport ended`));
+		if (framingFailed) {
+			await this.dispose().catch(error => {
+				logger.warn("Failed to dispose DAP adapter after invalid framing", {
+					adapter: this.adapter.name,
+					error: toErrorMessage(error),
+				});
+			});
+		}
 	}
 
 	#handleResponse(message: DapResponseMessage): void {

--- a/packages/coding-agent/src/jsonrpc/message-framing.ts
+++ b/packages/coding-agent/src/jsonrpc/message-framing.ts
@@ -10,30 +10,18 @@
 // Reused for all full (non-streaming) decodes; each decode() resets state, so a
 // single instance is safe and avoids per-message TextDecoder allocation.
 const MESSAGE_DECODER = new TextDecoder("utf-8");
+const HEADER_TERMINATOR = [13, 10, 13, 10];
 
-/**
- * Locate the `\r\n\r\n` header terminator across the pending chunk list.
- * Returns the absolute byte index of the first `\r`, or -1 when not present.
- * Equivalent to scanning the contiguous concatenation of the chunks.
- */
-function findHeaderEndInChunks(chunks: Buffer[]): number {
-	let global = 0;
-	let b0 = -1;
-	let b1 = -1;
-	let b2 = -1;
-	for (const chunk of chunks) {
-		for (let i = 0; i < chunk.length; i++) {
-			const b3 = chunk[i];
-			if (b0 === 13 && b1 === 10 && b2 === 13 && b3 === 10) {
-				return global - 3;
-			}
-			b0 = b1;
-			b1 = b2;
-			b2 = b3;
-			global++;
-		}
+// Headers carry a length and optional content type; bodies can contain entire
+// source files, workspace diagnostics, or base64 debugger memory responses.
+const MAX_HEADER_BYTES = 16 * 1024;
+const MAX_CONTENT_BYTES = 256 * 1024 * 1024;
+
+export class MessageFramingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "MessageFramingError";
 	}
-	return -1;
 }
 
 /** Copy the byte range [from, to) out of the pending chunk list into one Buffer. */
@@ -55,21 +43,6 @@ function copyChunkRange(chunks: Buffer[], from: number, to: number): Buffer {
 	return out;
 }
 
-/** Drop the first `count` bytes from the pending chunk list in place. */
-function dropChunkFront(chunks: Buffer[], count: number): void {
-	let removed = 0;
-	while (chunks.length > 0) {
-		const head = chunks[0];
-		if (removed + head.length <= count) {
-			removed += head.length;
-			chunks.shift();
-		} else {
-			chunks[0] = head.subarray(count - removed);
-			break;
-		}
-	}
-}
-
 /**
  * Incremental Content-Length frame decoder for a JSON message byte stream.
  *
@@ -83,17 +56,23 @@ function dropChunkFront(chunks: Buffer[], count: number): void {
 export class MessageFramer {
 	readonly #pendingChunks: Buffer[] = [];
 	#pendingLen = 0;
+	#scanChunk = 0;
+	#scanOffset = 0;
+	#scanned = 0;
+	#matched = 0;
+	#messageStart = 0;
+	#contentLength: number | undefined;
+	#failure: MessageFramingError | undefined;
 
 	/** Seed the buffer with any unparsed remainder left by a previous reader. */
 	constructor(seed: Buffer) {
-		if (seed.length > 0) {
-			this.#pendingChunks.push(seed);
-			this.#pendingLen = seed.length;
-		}
+		this.push(seed);
 	}
 
 	/** Append a freshly read chunk to the pending buffer. */
 	push(chunk: Buffer): void {
+		if (this.#failure) throw this.#failure;
+		if (chunk.length === 0) return;
 		this.#pendingChunks.push(chunk);
 		this.#pendingLen += chunk.length;
 	}
@@ -106,32 +85,81 @@ export class MessageFramer {
 	 * stalling on the same junk header forever.
 	 */
 	*drain(onResync: (headerText: string) => void): Generator<string> {
+		if (this.#failure) throw this.#failure;
 		while (true) {
-			const headerEnd = findHeaderEndInChunks(this.#pendingChunks);
-			if (headerEnd === -1) break;
-
-			const headerText = MESSAGE_DECODER.decode(copyChunkRange(this.#pendingChunks, 0, headerEnd));
-			const contentLengthMatch = headerText.match(/Content-Length: (\d+)/i);
-			if (!contentLengthMatch) {
-				onResync(headerText);
-				dropChunkFront(this.#pendingChunks, headerEnd + 4);
-				this.#pendingLen -= headerEnd + 4;
-				continue;
+			if (this.#contentLength === undefined) {
+				const headerEnd = this.#findHeaderEnd();
+				if (headerEnd === -1) break;
+				const headerText = MESSAGE_DECODER.decode(copyChunkRange(this.#pendingChunks, 0, headerEnd));
+				const lengths = [...headerText.matchAll(/^Content-Length:[ \t]*([^\r\n]*)$/gim)];
+				if (lengths.length === 0) {
+					this.#dropFront(headerEnd + 4);
+					onResync(headerText);
+					continue;
+				}
+				const rawLength = lengths[0][1].trim();
+				if (lengths.length !== 1 || !/^\d+$/.test(rawLength)) {
+					this.#fail("Invalid or duplicate JSON-RPC Content-Length");
+				}
+				const contentLength = Number(rawLength);
+				if (!Number.isSafeInteger(contentLength) || contentLength > MAX_CONTENT_BYTES) {
+					this.#fail(`JSON-RPC Content-Length exceeds ${MAX_CONTENT_BYTES}-byte limit`);
+				}
+				this.#contentLength = contentLength;
+				this.#messageStart = headerEnd + 4;
 			}
 
-			const contentLength = Number.parseInt(contentLengthMatch[1], 10);
-			const messageStart = headerEnd + 4; // Skip \r\n\r\n
-			const messageEnd = messageStart + contentLength;
+			const messageEnd = this.#messageStart + this.#contentLength;
 			if (this.#pendingLen < messageEnd) break;
-
-			const messageText = MESSAGE_DECODER.decode(copyChunkRange(this.#pendingChunks, messageStart, messageEnd));
-			dropChunkFront(this.#pendingChunks, messageEnd);
-			this.#pendingLen -= messageEnd;
-			yield messageText;
+			const text = MESSAGE_DECODER.decode(copyChunkRange(this.#pendingChunks, this.#messageStart, messageEnd));
+			this.#dropFront(messageEnd);
+			yield text;
 		}
 	}
 
-	/** The unparsed remainder, to persist when the reader stops. */
+	#findHeaderEnd(): number {
+		while (this.#scanChunk < this.#pendingChunks.length) {
+			const chunk = this.#pendingChunks[this.#scanChunk];
+			while (this.#scanOffset < chunk.length) {
+				const byte = chunk[this.#scanOffset++];
+				this.#scanned++;
+				this.#matched = byte === HEADER_TERMINATOR[this.#matched] ? this.#matched + 1 : byte === 13 ? 1 : 0;
+				if (this.#matched === 4) return this.#scanned - 4;
+				if (this.#scanned >= MAX_HEADER_BYTES) {
+					this.#fail(`JSON-RPC header exceeds ${MAX_HEADER_BYTES}-byte limit`);
+				}
+			}
+			this.#scanChunk++;
+			this.#scanOffset = 0;
+		}
+		return -1;
+	}
+
+	#dropFront(count: number): void {
+		let consumed = 0;
+		let remaining = count;
+		while (consumed < this.#pendingChunks.length && this.#pendingChunks[consumed].length <= remaining) {
+			remaining -= this.#pendingChunks[consumed++].length;
+		}
+		this.#pendingChunks.splice(0, consumed);
+		if (remaining > 0) this.#pendingChunks[0] = this.#pendingChunks[0].subarray(remaining);
+		this.#pendingLen -= count;
+		this.#scanChunk = 0;
+		this.#scanOffset = 0;
+		this.#scanned = 0;
+		this.#matched = 0;
+		this.#messageStart = 0;
+		this.#contentLength = undefined;
+	}
+
+	#fail(message: string): never {
+		this.#pendingChunks.length = 0;
+		this.#pendingLen = 0;
+		this.#failure = new MessageFramingError(message);
+		throw this.#failure;
+	}
+
+	/** Includes the current header so another reader can resume mid-body. */
 	remainder(): Buffer {
 		return this.#pendingChunks.length === 0
 			? Buffer.alloc(0)

--- a/packages/coding-agent/src/lsp/mux/daemon.ts
+++ b/packages/coding-agent/src/lsp/mux/daemon.ts
@@ -78,21 +78,27 @@ function requestOnSocket(
 		reject(new Error(`LSP mux ${request.method} timed out`));
 	}, timeoutMs);
 	const onData = (chunk: Buffer) => {
-		framer.push(chunk);
-		for (const text of framer.drain(() => {})) {
-			let message: LspJsonRpcResponse;
-			try {
-				message = JSON.parse(text);
-			} catch (error) {
+		try {
+			framer.push(chunk);
+			for (const text of framer.drain(() => {})) {
+				let message: LspJsonRpcResponse;
+				try {
+					message = JSON.parse(text);
+				} catch (error) {
+					cleanup();
+					reject(error instanceof Error ? error : new Error(String(error)));
+					return;
+				}
+				if (message.id !== request.id) continue;
 				cleanup();
-				reject(error instanceof Error ? error : new Error(String(error)));
+				if (message.error) reject(new Error(`LSP mux ${request.method} failed: ${message.error.message}`));
+				else resolve({ response: message, leftover: framer.remainder() });
 				return;
 			}
-			if (message.id !== request.id) continue;
+		} catch (error) {
 			cleanup();
-			if (message.error) reject(new Error(`LSP mux ${request.method} failed: ${message.error.message}`));
-			else resolve({ response: message, leftover: framer.remainder() });
-			return;
+			socket.destroy();
+			reject(error instanceof Error ? error : new Error(String(error)));
 		}
 	};
 	const onClose = () => {

--- a/packages/coding-agent/src/lsp/mux/server.ts
+++ b/packages/coding-agent/src/lsp/mux/server.ts
@@ -277,19 +277,24 @@ export class LspMuxServer {
 		this.#sessions.add(session);
 		this.#disarmMuxIdle();
 		socket.on("data", chunk => {
-			session.framer.push(Buffer.from(chunk));
-			for (const text of session.framer.drain(header => {
-				logger.warn("LSP mux client framing resync", { header: header.slice(0, 200) });
-			})) {
-				try {
-					const parsed: unknown = JSON.parse(text);
-					if (!isRecord(parsed) || parsed.jsonrpc !== "2.0") throw new Error("invalid JSON-RPC message");
-					void this.#fromSession(session, parsed as unknown as RpcMessage).catch(error => {
-						logger.warn("LSP mux client message handling failed", { error: String(error) });
-					});
-				} catch (error) {
-					logger.warn("LSP mux client sent malformed JSON", { error: String(error) });
+			try {
+				session.framer.push(Buffer.from(chunk));
+				for (const text of session.framer.drain(header => {
+					logger.warn("LSP mux client framing resync", { header: header.slice(0, 200) });
+				})) {
+					try {
+						const parsed: unknown = JSON.parse(text);
+						if (!isRecord(parsed) || parsed.jsonrpc !== "2.0") throw new Error("invalid JSON-RPC message");
+						void this.#fromSession(session, parsed as unknown as RpcMessage).catch(error => {
+							logger.warn("LSP mux client message handling failed", { error: String(error) });
+						});
+					} catch (error) {
+						logger.warn("LSP mux client sent malformed JSON", { error: String(error) });
+					}
 				}
+			} catch (error) {
+				logger.warn("LSP mux client framing failed", { error: String(error) });
+				socket.destroy();
 			}
 		});
 		socket.on("error", error => logger.warn("LSP mux session socket error", { error: error.message }));
@@ -472,6 +477,7 @@ export class LspMuxServer {
 			}
 		} catch (error) {
 			logger.warn("LSP mux server reader failed", { server: server.key, error: String(error) });
+			this.#killServer(server);
 		} finally {
 			reader.releaseLock();
 		}

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -14,7 +14,7 @@ import type {
 } from "@oh-my-pi/pi-coding-agent/dap/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { DebugTool } from "@oh-my-pi/pi-coding-agent/tools/debug";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries, withTimeout } from "@oh-my-pi/pi-utils";
 
 const TEST_ADAPTER: DapResolvedAdapter = {
 	name: "lldb-dap",
@@ -29,6 +29,42 @@ const TEST_ADAPTER: DapResolvedAdapter = {
 	connectMode: "stdio",
 	acceptsDirectoryProgram: false,
 };
+
+it("rejects pending DAP work and terminates an adapter with invalid framing", async () => {
+	const client = await DapClient.spawn({
+		adapter: {
+			...TEST_ADAPTER,
+			command: process.execPath,
+			resolvedCommand: process.execPath,
+			args: ["run", path.join(import.meta.dir, "../fixtures/malformed-jsonrpc-peer.ts")],
+		},
+		cwd: process.cwd(),
+	});
+	try {
+		const request = client.sendRequest("initialize", {}, undefined, 60_000);
+		const event = client.waitForEvent("stopped", undefined, undefined, 60_000);
+		const results = await withTimeout(
+			Promise.allSettled([request, event]),
+			5_000,
+			"Invalid framing did not reject pending DAP work",
+		);
+		for (const result of results) {
+			expect(result.status).toBe("rejected");
+			if (result.status === "rejected") {
+				expect(result.reason).toBeInstanceOf(Error);
+				expect((result.reason as Error).message).toMatch(/Content-Length.*limit/);
+			}
+		}
+		await expect(client.sendRequest("threads", {})).rejects.toThrow(/not running/);
+		await withTimeout(
+			client.proc.exited.catch(() => {}),
+			5_000,
+			"Malformed adapter remained alive",
+		);
+	} finally {
+		await client.dispose();
+	}
+}, 10_000);
 
 const DELAYED_UNIX_SOCKET_ADAPTER = `
 const listenPrefix = "--listen=unix:";

--- a/packages/coding-agent/test/fixtures/malformed-jsonrpc-peer.ts
+++ b/packages/coding-agent/test/fixtures/malformed-jsonrpc-peer.ts
@@ -1,0 +1,4 @@
+process.stdin.once("data", () => {
+	process.stdout.write("Content-Length: 268435457\r\n\r\n");
+});
+await Bun.sleep(60_000);

--- a/packages/coding-agent/test/lsp-mux.test.ts
+++ b/packages/coding-agent/test/lsp-mux.test.ts
@@ -90,6 +90,10 @@ class MuxTestClient {
 		this.#write({ jsonrpc: "2.0", method, params });
 	}
 
+	sendRaw(bytes: Buffer): void {
+		this.#socket.write(bytes);
+	}
+
 	async nextNotification<T>(method: string): Promise<T> {
 		const queued = this.#notifications.get(method);
 		const message = queued?.shift();
@@ -211,6 +215,33 @@ describe("LspMuxServer", () => {
 		const connected = await client.request<MuxConnectResult>(MUX_CONNECT_METHOD, connectParams);
 		return { client, connected };
 	}
+
+	it.skipIf(process.platform === "win32")(
+		"disconnects a malformed link without terminating other sessions",
+		async () => {
+			const healthy = await link();
+			await initialize(healthy.client);
+			const malformed = await MuxTestClient.connect(socketPath);
+			clients.push(malformed);
+			const closed = malformed.waitForClose();
+			malformed.sendRaw(Buffer.alloc(16 * 1024, 97));
+			await closed;
+			expect(await healthy.client.request<{ alive: boolean }>("test/echo", { alive: true })).toEqual({
+				alive: true,
+			});
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"terminates a language server that declares an oversized response",
+		async () => {
+			connectParams.args = ["run", path.join(import.meta.dir, "fixtures", "malformed-jsonrpc-peer.ts")];
+			const { client } = await link();
+			await expect(withTimeout(initialize(client), "invalid server frame")).rejects.toThrow("Mux socket closed");
+			await pollUntil(() => Promise.resolve(server.serverKeys.length === 0), "malformed server exit");
+			expect(server.sessionCount).toBe(0);
+		},
+	);
 
 	it.skipIf(process.platform === "win32")(
 		"spawns one server per concurrent link",

--- a/packages/coding-agent/test/message-framing.test.ts
+++ b/packages/coding-agent/test/message-framing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { MessageFramer } from "../src/jsonrpc/message-framing";
+
+function frame(text: string): Buffer {
+	return Buffer.from(`Content-Length: ${Buffer.byteLength(text)}\r\n\r\n${text}`);
+}
+
+describe("MessageFramer", () => {
+	it("recognizes a header terminator split into single-byte reads", () => {
+		const framer = new MessageFramer(Buffer.alloc(0));
+		const bytes = Buffer.from(
+			"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\ncontent-length:\t2\r\n\r\n{}",
+		);
+		const messages: string[] = [];
+		for (const byte of bytes) {
+			framer.push(Buffer.from([byte]));
+			messages.push(...framer.drain(() => {}));
+		}
+		expect(messages).toEqual(["{}"]);
+	});
+
+	it("accepts a header at the size limit and rejects one byte beyond it", () => {
+		const suffix = "\r\nContent-Length: 2\r\n\r\n";
+		const header = "X-Trace: ".padEnd(16 * 1024 - suffix.length, "x") + suffix;
+		const accepted = new MessageFramer(Buffer.from(`${header}{}`));
+		expect([...accepted.drain(() => {})]).toEqual(["{}"]);
+		const rejected = new MessageFramer(Buffer.from(`X${header}{}`));
+		expect(() => [...rejected.drain(() => {})]).toThrow(/header.*limit/i);
+	});
+	it("preserves UTF-8 and coalesced messages at every byte boundary", () => {
+		const texts = ['{"text":"🌍你好"}', '{"id":2}'];
+		const input = Buffer.concat(texts.map(frame));
+		for (let split = 0; split <= input.length; split++) {
+			const framer = new MessageFramer(input.subarray(0, split));
+			const output = [...framer.drain(() => {})];
+			framer.push(input.subarray(split));
+			output.push(...framer.drain(() => {}));
+			expect(output).toEqual(texts);
+			expect(framer.remainder()).toEqual(Buffer.alloc(0));
+		}
+	});
+
+	it("resumes from an incomplete body after a reader restart", () => {
+		const text = '{"text":"αβγ"}';
+		const input = frame(text);
+		const framer = new MessageFramer(input.subarray(0, input.length - 3));
+		expect([...framer.drain(() => {})]).toEqual([]);
+		const resumed = new MessageFramer(framer.remainder());
+		resumed.push(input.subarray(input.length - 3));
+		expect([...resumed.drain(() => {})]).toEqual([text]);
+	});
+
+	it("resynchronizes after bounded stdout noise", () => {
+		const framer = new MessageFramer(Buffer.concat([Buffer.from("wrapper log\r\n\r\n"), frame("{}")]));
+		const headers: string[] = [];
+		expect([...framer.drain(header => headers.push(header))]).toEqual(["{}"]);
+		expect(headers).toEqual(["wrapper log"]);
+	});
+
+	it("rejects oversized incomplete headers and releases their bytes", () => {
+		const framer = new MessageFramer(Buffer.alloc(0));
+		framer.push(Buffer.alloc(16 * 1024, 97));
+		expect(() => [...framer.drain(() => {})]).toThrow(/header.*limit/i);
+		expect(framer.remainder()).toEqual(Buffer.alloc(0));
+		expect(() => framer.push(frame("{}"))).toThrow(/header.*limit/i);
+	});
+
+	for (const length of ["268435457", "-1", "1.5"]) {
+		it(`rejects invalid or excessive Content-Length ${length} before receiving a body`, () => {
+			const framer = new MessageFramer(Buffer.from(`Content-Length: ${length}\r\n\r\n`));
+			expect(() => [...framer.drain(() => {})]).toThrow(/Content-Length/);
+			expect(framer.remainder()).toEqual(Buffer.alloc(0));
+		});
+	}
+
+	it("rejects ambiguous duplicate lengths", () => {
+		const framer = new MessageFramer(Buffer.from("Content-Length: 2\r\nContent-Length: 3\r\n\r\n{}x"));
+		expect(() => [...framer.drain(() => {})]).toThrow(/Content-Length/);
+	});
+
+	it("decodes large valid messages incrementally without confusing body delimiters for headers", () => {
+		const text = JSON.stringify({ text: "🌍\r\n\r\n".repeat(512 * 1024) });
+		const input = frame(text);
+		const framer = new MessageFramer(Buffer.alloc(0));
+		const output: string[] = [];
+		for (let offset = 0; offset < input.length; offset += 4096) {
+			framer.push(input.subarray(offset, offset + 4096));
+			output.push(...framer.drain(() => {}));
+		}
+		expect(output).toEqual([text]);
+	});
+});


### PR DESCRIPTION
## What

Header scanning advances incrementally and stops at 16 KiB; bodies are limited to 256 MiB. Invalid or ambiguous lengths release retained input and terminate the affected mux or DAP connection, rejecting pending work. Healthy mux peers remain usable.

## Why

Fragmented or malformed streams can repeatedly rescan headers or retain unbounded input while pending requests wait.

## Testing

- [x] 173 parser, mux, LSP, and DAP tests; package check passed.
- [x] Independent review passed 55 tests and 2,000 randomized chunking cases. Combined framing/shutdown integration tests also passed.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
