### PR TITLE
perf(session): avoid repeated copies of incomplete journal records

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Large session records load faster without repeatedly copying unfinished JSONL rows.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -216,6 +216,13 @@ export async function visitEntriesFromFileStream(
 			// Parsing before the chunk closes a line re-scans the unfinished record
 			// on every chunk, which is quadratic for large records.
 			if (chunk.lastIndexOf(0x0a) === -1) {
+				// Skipping drain() also skips the only enforcement of the record cap,
+				// so re-check it here: a delimiter-free file would otherwise be read
+				// and buffered in full despite an exhausted budget.
+				if (recordsSeen >= maxRecords) {
+					stopped = true;
+					break;
+				}
 				sink.append(chunk);
 				await yieldToMacrotask();
 				continue;

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
+import { ConcatSink, getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
 import { buildSessionContext } from "./session-context";
@@ -13,6 +13,8 @@ import {
 	type SessionTitleUpdate,
 	titleUpdateFromSlot,
 } from "./session-title-slot";
+
+const LF = new Uint8Array([0x0a]);
 
 const STREAM_LOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
 const STREAM_YIELD_BYTES = 1 * 1024 * 1024;
@@ -103,11 +105,11 @@ export async function visitEntriesFromFileStream(
 	const yieldEveryBytes = Math.max(0, options.yieldEveryBytes ?? STREAM_YIELD_BYTES);
 	const yieldEveryEntries = Math.max(0, options.yieldEveryEntries ?? STREAM_YIELD_ENTRIES);
 	const maxBytes = Math.max(0, options.maxBytes ?? Number.POSITIVE_INFINITY);
-	// Keep unfinished records as bytes until a newline arrives: copying or
-	// parsing the growing prefix per chunk is quadratic for large records.
-	let buffer: Uint8Array = new Uint8Array();
-	let pending: Uint8Array[] = [];
-	let pendingBytes = 0;
+	// Bytes, not text: a multibyte UTF-8 sequence straddling a chunk boundary
+	// stays intact, and Bun.JSONL.parseChunk takes typed arrays directly. Only
+	// the unconsumed remainder is held (≤ one record + a chunk), so the ≥8MiB
+	// memory guard holds — the file is never fully loaded.
+	const sink = new ConcatSink();
 	const decoder = new TextDecoder();
 
 	const yieldToMacrotask = async (): Promise<void> => {
@@ -123,6 +125,19 @@ export async function visitEntriesFromFileStream(
 	};
 
 	const drain = async (): Promise<void> => {
+		const view = sink.flush();
+		if (!view) return;
+		// Only newline-terminated bytes may reach the parser: a trailing fragment
+		// in the same call turns an end-of-input `done` into a syntax error at the
+		// preceding newline, which would then be miscounted as a malformed record.
+		const lastNewline = view.lastIndexOf(0x0a);
+		if (lastNewline === -1) return;
+		let buffer: Uint8Array = view.subarray(0, lastNewline + 1);
+		let consumed = 0;
+		const advance = (count: number): void => {
+			consumed += count;
+			buffer = buffer.subarray(count);
+		};
 		while (buffer.length > 0 && !stopped) {
 			if (recordsSeen >= maxRecords) {
 				stopped = true;
@@ -175,7 +190,7 @@ export async function visitEntriesFromFileStream(
 				}
 				if (nonWhitespace) options.onMalformedRecord?.();
 				recordsSeen++;
-				buffer = buffer.subarray(nextNewline + 1);
+				advance(nextNewline + 1);
 				if (recordsSeen >= maxRecords) {
 					stopped = true;
 					break;
@@ -183,12 +198,13 @@ export async function visitEntriesFromFileStream(
 				continue;
 			}
 			if (read === 0) break; // incomplete record awaiting more data
-			buffer = buffer.subarray(read);
+			advance(read);
 			if (done) {
-				buffer = new Uint8Array();
+				advance(buffer.length);
 				break;
 			}
 		}
+		sink.consume(consumed);
 	};
 
 	try {
@@ -197,57 +213,43 @@ export async function visitEntriesFromFileStream(
 		for await (const chunk of source.stream()) {
 			if (stopped) break;
 			bytesSinceYield += chunk.byteLength;
-			const lastNewline = chunk.lastIndexOf(0x0a);
-			if (lastNewline === -1) {
-				pending.push(chunk);
-				pendingBytes += chunk.byteLength;
+			// Parsing before the chunk closes a line re-scans the unfinished record
+			// on every chunk, which is quadratic for large records.
+			if (chunk.lastIndexOf(0x0a) === -1) {
+				sink.append(chunk);
 				await yieldToMacrotask();
 				continue;
 			}
-			const complete = chunk.subarray(0, lastNewline + 1);
-			if (pending.length === 0) {
-				buffer = complete;
-			} else {
-				pending.push(complete);
-				buffer = Buffer.concat(pending, pendingBytes + complete.byteLength);
-			}
-			pending = [];
-			pendingBytes = chunk.byteLength - complete.byteLength;
-			if (pendingBytes > 0) pending.push(chunk.subarray(complete.byteLength));
+			sink.append(chunk);
 			// The optional fixed-width title slot is a physical first line that is
 			// NOT JSON; peel it before the parser would (correctly) reject it. The
 			// first line ends at a '\n' byte, so it is a complete UTF-8 sequence and
 			// safe to decode. A non-slot first line is a real entry and is left for
 			// the parser; a blank first line is left for the parser to skip.
 			if (!sawFirstLine) {
-				const newline = buffer.indexOf(0x0a);
+				const buffered = sink.flush()!;
+				const newline = buffered.indexOf(0x0a);
 				if (newline !== -1) {
 					sawFirstLine = true;
-					const firstLine = decoder.decode(buffer.subarray(0, newline)).trim();
+					const firstLine = decoder.decode(buffered.subarray(0, newline)).trim();
 					if (firstLine) {
 						const slot = parseTitleSlotLine(firstLine);
 						if (slot) {
 							titleSlot = titleUpdateFromSlot(slot);
-							buffer = buffer.subarray(newline + 1);
+							sink.consume(newline + 1);
 						}
 					}
 				}
 			}
+			// parseChunk can leave a value unfinished even after a newline; the
+			// sink keeps that remainder for the next chunk.
 			await drain();
-			// parseChunk can leave a value unfinished even after a newline.
-			if (buffer.length > 0 && !stopped) {
-				pending.unshift(buffer);
-				pendingBytes += buffer.byteLength;
-				buffer = new Uint8Array();
-			}
 			await yieldToMacrotask();
 		}
 		// A trailing record without a final newline: terminate it so the parser
 		// can complete it (readline yielded it; parseChunk needs the delimiter).
-		if (!stopped && pendingBytes > 0) {
-			pending.push(new Uint8Array([0x0a]));
-			buffer = Buffer.concat(pending, pendingBytes + 1);
-			pending = [];
+		if (!stopped && !sink.isEmpty) {
+			sink.append(LF);
 			await drain();
 		}
 	} catch (err) {

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -103,12 +103,11 @@ export async function visitEntriesFromFileStream(
 	const yieldEveryBytes = Math.max(0, options.yieldEveryBytes ?? STREAM_YIELD_BYTES);
 	const yieldEveryEntries = Math.max(0, options.yieldEveryEntries ?? STREAM_YIELD_ENTRIES);
 	const maxBytes = Math.max(0, options.maxBytes ?? Number.POSITIVE_INFINITY);
-	// Byte buffer (NOT a decoded string): multibyte UTF-8 sequences that straddle
-	// a stream-chunk boundary stay intact, and Bun.JSONL.parseChunk accepts typed
-	// arrays directly. Only the unconsumed remainder is held (≤ one record + a
-	// chunk), so the ≥8MiB memory guard is preserved (the file is never fully
-	// loaded into memory).
+	// Keep unfinished records as bytes until a newline arrives: copying or
+	// parsing the growing prefix per chunk is quadratic for large records.
 	let buffer: Uint8Array = new Uint8Array();
+	let pending: Uint8Array[] = [];
+	let pendingBytes = 0;
 	const decoder = new TextDecoder();
 
 	const yieldToMacrotask = async (): Promise<void> => {
@@ -198,7 +197,23 @@ export async function visitEntriesFromFileStream(
 		for await (const chunk of source.stream()) {
 			if (stopped) break;
 			bytesSinceYield += chunk.byteLength;
-			buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+			const lastNewline = chunk.lastIndexOf(0x0a);
+			if (lastNewline === -1) {
+				pending.push(chunk);
+				pendingBytes += chunk.byteLength;
+				await yieldToMacrotask();
+				continue;
+			}
+			const complete = chunk.subarray(0, lastNewline + 1);
+			if (pending.length === 0) {
+				buffer = complete;
+			} else {
+				pending.push(complete);
+				buffer = Buffer.concat(pending, pendingBytes + complete.byteLength);
+			}
+			pending = [];
+			pendingBytes = chunk.byteLength - complete.byteLength;
+			if (pendingBytes > 0) pending.push(chunk.subarray(complete.byteLength));
 			// The optional fixed-width title slot is a physical first line that is
 			// NOT JSON; peel it before the parser would (correctly) reject it. The
 			// first line ends at a '\n' byte, so it is a complete UTF-8 sequence and
@@ -219,12 +234,20 @@ export async function visitEntriesFromFileStream(
 				}
 			}
 			await drain();
+			// parseChunk can leave a value unfinished even after a newline.
+			if (buffer.length > 0 && !stopped) {
+				pending.unshift(buffer);
+				pendingBytes += buffer.byteLength;
+				buffer = new Uint8Array();
+			}
 			await yieldToMacrotask();
 		}
 		// A trailing record without a final newline: terminate it so the parser
 		// can complete it (readline yielded it; parseChunk needs the delimiter).
-		if (!stopped && buffer.length > 0 && buffer[buffer.length - 1] !== 0x0a) {
-			buffer = Buffer.concat([buffer, new Uint8Array([0x0a])]);
+		if (!stopped && pendingBytes > 0) {
+			pending.push(new Uint8Array([0x0a]));
+			buffer = Buffer.concat(pending, pendingBytes + 1);
+			pending = [];
 			await drain();
 		}
 	} catch (err) {

--- a/packages/coding-agent/test/session-loader-stream.test.ts
+++ b/packages/coding-agent/test/session-loader-stream.test.ts
@@ -315,7 +315,7 @@ describe("loadEntriesFromFileStream (Bun.JSONL parity)", () => {
 						bytesRead += chunk.byteLength;
 						yield chunk;
 					}
-				})() as unknown as ReturnType<typeof realStream>;
+				})() as unknown as ReadableStream<Uint8Array<ArrayBuffer>>;
 			return handle;
 		});
 

--- a/packages/coding-agent/test/session-loader-stream.test.ts
+++ b/packages/coding-agent/test/session-loader-stream.test.ts
@@ -246,6 +246,70 @@ describe("loadEntriesFromFileStream (Bun.JSONL parity)", () => {
 		}
 	});
 
+	it("preserves a large multibyte record and its signature around malformed records", async () => {
+		const text = "✓🚀こんにちは".repeat(256 * 1024);
+		const signature = "signed-provider-payload";
+		const largeMessage: FileEntry = {
+			type: "message",
+			id: "large",
+			parentId: "s1",
+			timestamp: ISO,
+			message: {
+				role: "user",
+				content: [{ type: "text", text, textSignature: signature }],
+				timestamp: 0,
+			},
+		};
+		const content = [
+			JSON.stringify(HEADER),
+			JSON.stringify(largeMessage),
+			`{ malformed ${"x".repeat(256 * 1024)}`,
+			JSON.stringify(msg("tail", "large", "after large record")),
+		].join("\n");
+		const file = await writeTemp(content);
+		const loaded = await sessionLoader.loadEntriesFromFileStream(file);
+
+		expect(entryIds(loaded.entries)).toEqual(["s1", "large", "tail"]);
+		expect(messageTexts(loaded.entries)).toEqual([text, "after large record"]);
+		expect(loaded.entries[1]).toEqual(largeMessage);
+		expect(loaded.malformedRecords).toBe(1);
+	});
+
+	it("counts an incomplete large record at the byte limit without visiting the file tail", async () => {
+		const prefix = `${JSON.stringify(HEADER)}\n`;
+		const content = `${prefix}${JSON.stringify(msg("large", "s1", "🚀".repeat(256 * 1024)))}\n${JSON.stringify(msg("tail", "large", "outside byte limit"))}`;
+		const file = await writeTemp(content);
+		const visited: FileEntry[] = [];
+		let malformedRecords = 0;
+		await sessionLoader.visitEntriesFromFileStream(file, entry => void visited.push(entry), {
+			maxBytes: Buffer.byteLength(prefix) + 256 * 1024 + 1,
+			onMalformedRecord: () => {
+				malformedRecords++;
+			},
+		});
+
+		expect(entryIds(visited)).toEqual(["s1"]);
+		expect(malformedRecords).toBe(1);
+	});
+
+	it("retains an unfinished value across embedded newlines before the trailing fragment", async () => {
+		const content = `${JSON.stringify(HEADER)}\n{\n"type":"message","id":"multiline","parentId":"s1","timestamp":"${ISO}","message":{"role":"user","content":"continued","timestamp":0}}`;
+		const file = await writeTemp(content);
+		const loaded = await sessionLoader.loadEntriesFromFileStream(file);
+
+		expect(entryIds(loaded.entries)).toEqual(["s1", "multiline"]);
+		expect(loaded.malformedRecords).toBe(0);
+	});
+
+	it("counts an unfinished malformed record across chunks before a valid trailing record", async () => {
+		const content = `${JSON.stringify(HEADER)}\n{${" ".repeat(128 * 1024)}\n${JSON.stringify(msg("tail", "s1", "x".repeat(128 * 1024)))}\n`;
+		const file = await writeTemp(content);
+		const loaded = await sessionLoader.loadEntriesFromFileStream(file);
+
+		expect(entryIds(loaded.entries)).toEqual(["s1", "tail"]);
+		expect(loaded.malformedRecords).toBe(1);
+	});
+
 	it("returns empty for a missing file (ENOENT)", async () => {
 		const missing = path.join(os.tmpdir(), `does-not-exist-${Date.now()}.jsonl`);
 		const stream = await sessionLoader.loadEntriesFromFileStream(missing);

--- a/packages/coding-agent/test/session-loader-stream.test.ts
+++ b/packages/coding-agent/test/session-loader-stream.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -290,6 +290,45 @@ describe("loadEntriesFromFileStream (Bun.JSONL parity)", () => {
 
 		expect(entryIds(visited)).toEqual(["s1"]);
 		expect(malformedRecords).toBe(1);
+	});
+
+	it("stops after the first chunk of a delimiter-free file when the record cap is zero", async () => {
+		// No newline until EOF: the streaming loop's delimiter-free fast path skips
+		// the parser, so the record cap has to be enforced before buffering or the
+		// whole journal is read despite a zero budget.
+		const content = `{"type":"session","version":3,"id":"s1","timestamp":"${ISO}","cwd":"/tmp","pad":"${"z".repeat(4 * 1024 * 1024)}"}`;
+		expect(content).not.toInclude("\n");
+		const file = await writeTemp(content);
+
+		let bytesRead = 0;
+		let firstChunkBytes = 0;
+		const realBunFile = Bun.file.bind(Bun);
+		const bunFileSpy = spyOn(Bun, "file").mockImplementation((arg: unknown, opts?: BlobPropertyBag) => {
+			const handle = realBunFile(arg as string, opts);
+			const realStream = handle.stream.bind(handle);
+			// An async generator, not a piped stream: it is strictly pull-driven, so
+			// the count reflects what the loader asked for and not read-ahead.
+			handle.stream = () =>
+				(async function* () {
+					for await (const chunk of realStream() as AsyncIterable<Uint8Array>) {
+						if (firstChunkBytes === 0) firstChunkBytes = chunk.byteLength;
+						bytesRead += chunk.byteLength;
+						yield chunk;
+					}
+				})() as unknown as ReturnType<typeof realStream>;
+			return handle;
+		});
+
+		try {
+			const visited: FileEntry[] = [];
+			await sessionLoader.visitEntriesFromFileStream(file, entry => void visited.push(entry), { maxRecords: 0 });
+
+			expect(visited).toEqual([]);
+			expect(firstChunkBytes).toBeLessThan(Buffer.byteLength(content));
+			expect(bytesRead).toBe(firstChunkBytes);
+		} finally {
+			bunFileSpy.mockRestore();
+		}
 	});
 
 	it("retains an unfinished value across embedded newlines before the trailing fragment", async () => {

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -56,11 +56,16 @@ export async function* readJsonl<T>(stream: ReadableStream<Uint8Array>, signal?:
 	}
 }
 
-// =============================================================================
-// SSE (Server-Sent Events)
-// =============================================================================
-
-class ConcatSink {
+/**
+ * Amortized byte accumulator for chunked stream readers.
+ *
+ * Holds the unconsumed tail of a stream in a single growing `Buffer` so that
+ * appending N chunks costs O(total bytes) instead of re-copying the whole
+ * prefix per chunk. Backs {@link readLines}, {@link readJsonl} and
+ * {@link readSseEvents}; also usable directly when a reader needs its own
+ * framing loop (see `consume` and `flush`).
+ */
+export class ConcatSink {
 	#space?: Buffer;
 	#length = 0;
 
@@ -100,9 +105,24 @@ class ConcatSink {
 		return this.#length === 0;
 	}
 
+	/**
+	 * The buffered bytes as a live view — invalidated by the next `append`,
+	 * `reset` or `consume`.
+	 */
 	flush(): Uint8Array | undefined {
 		if (!this.#length) return undefined;
 		return this.#space!.subarray(0, this.#length);
+	}
+
+	/** Drop the first `count` buffered bytes, keeping the remainder. */
+	consume(count: number) {
+		if (count <= 0) return;
+		if (count >= this.#length) {
+			this.#length = 0;
+			return;
+		}
+		this.#space!.copyWithin(0, count, this.#length);
+		this.#length -= count;
 	}
 
 	clear() {
@@ -196,6 +216,10 @@ class ConcatSink {
 		this.#length = rem;
 	}
 }
+
+// =============================================================================
+// SSE (Server-Sent Events)
+// =============================================================================
 
 /**
  * Stream parsed JSON objects from SSE `data:` lines.

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 import {
+	ConcatSink,
 	parseJsonlLenient,
 	readJsonl,
 	readLines,
@@ -143,6 +144,54 @@ describe("readJsonl", () => {
 
 		const output = await collectAsync(readJsonl(readable));
 		expect(output).toEqual([{ z: 9 }]);
+	});
+});
+
+describe("ConcatSink", () => {
+	const text = (sink: ConcatSink) => new TextDecoder().decode(sink.flush());
+
+	it("accumulates appended chunks in order", () => {
+		const sink = new ConcatSink();
+		sink.append(encoder.encode("abc"));
+		sink.append(encoder.encode("de"));
+		expect(sink.isEmpty).toBe(false);
+		expect(text(sink)).toBe("abcde");
+	});
+
+	it("keeps the remainder after consuming a prefix", () => {
+		const sink = new ConcatSink();
+		sink.append(encoder.encode("abcde"));
+		sink.consume(2);
+		expect(text(sink)).toBe("cde");
+		sink.append(encoder.encode("fg"));
+		expect(text(sink)).toBe("cdefg");
+	});
+
+	it("empties when consuming at or past the buffered length", () => {
+		const sink = new ConcatSink();
+		sink.append(encoder.encode("abc"));
+		sink.consume(3);
+		expect(sink.isEmpty).toBe(true);
+		expect(sink.flush()).toBeUndefined();
+
+		sink.append(encoder.encode("xy"));
+		sink.consume(99);
+		expect(sink.isEmpty).toBe(true);
+	});
+
+	it("ignores non-positive consume counts", () => {
+		const sink = new ConcatSink();
+		sink.append(encoder.encode("abc"));
+		sink.consume(0);
+		sink.consume(-5);
+		expect(text(sink)).toBe("abc");
+	});
+
+	it("preserves multibyte sequences split across appends", () => {
+		const bytes = encoder.encode("é🚀");
+		const sink = new ConcatSink();
+		for (const byte of bytes) sink.append(new Uint8Array([byte]));
+		expect(text(sink)).toBe("é🚀");
 	});
 });
 


### PR DESCRIPTION
## What

Large JSONL records retain byte fragments until parsing can advance, preserving unconsumed parser input, UTF-8, and corruption counts. The 32 MiB single-record benchmark fell from 757 ms to roughly 52–66 ms across measured runs.

## Why

Parsing each incoming fragment recopies an unfinished large record's entire prefix.

## Testing

- [x] Loader, listing, large-session, and signature suites; package check passed.
- [x] A second independent review verified the incomplete-newline corruption counterexample; combined loader/hydration tests passed.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
