### PR TITLE
perf(session): hydrate only retained read-only history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Read-only transcripts skip image blobs from hidden history, and session blob loading limits concurrent reads.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -450,6 +450,15 @@ export async function loadSessionMessagesReadOnly(filePath: string): Promise<Age
 		transcript: true,
 		collapseCompactedHistory: true,
 	});
-	await resolveBlobRefs(messages, new BlobStore(getBlobsDir()));
-	return messages;
+	// A collapsed summary carries the remote-compaction replacement history for
+	// provider replay only; this transcript is never replayed, and the renderer
+	// reads just the summary. Dropping it keeps hydration off every image blob
+	// buried in that hidden history.
+	const displayMessages = messages.map(message =>
+		message.role === "compactionSummary" && message.providerPayload !== undefined
+			? { ...message, providerPayload: undefined }
+			: message,
+	);
+	await resolveBlobRefs(displayMessages, new BlobStore(getBlobsDir()));
+	return displayMessages;
 }

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBlobsDir, isEnoent, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
+import { Semaphore } from "../task/parallel";
 import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./blob-store";
 import { buildSessionContext } from "./session-context";
 import type { FileEntry, RawFileEntry, SessionEntry, SessionHeader } from "./session-entries";
@@ -17,6 +18,7 @@ import {
 const STREAM_LOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
 const STREAM_YIELD_BYTES = 1 * 1024 * 1024;
 const STREAM_YIELD_ENTRIES = 8_192;
+const BLOB_READ_CONCURRENCY = 8;
 
 export interface VisitEntriesFromFileStreamOptions {
 	/** Stop after the visitor returns `false`. */
@@ -331,14 +333,16 @@ function hasImageUrl(value: unknown): value is { image_url: string } {
 	return typeof value === "object" && value !== null && "image_url" in value && typeof value.image_url === "string";
 }
 
-async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, key?: string): Promise<void> {
+type BlobReferenceResolver = (data: string, asDataUrl?: boolean) => Promise<string>;
+
+async function resolvePersistedBlobRefs(value: unknown, resolve: BlobReferenceResolver, key?: string): Promise<void> {
 	if (isExternalizableImagePosition(value, key) && isBlobRef(value.data)) {
-		value.data = await resolveImageData(blobStore, value.data);
+		value.data = await resolve(value.data);
 		return;
 	}
 
 	if (Array.isArray(value)) {
-		await Promise.all(value.map(item => resolvePersistedBlobRefs(item, blobStore, key)));
+		await Promise.all(value.map(item => resolvePersistedBlobRefs(item, resolve, key)));
 		return;
 	}
 
@@ -350,15 +354,15 @@ async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, ke
 		typeof value.result === "string" &&
 		isBlobRef(value.result)
 	) {
-		value.result = await resolveImageData(blobStore, value.result);
+		value.result = await resolve(value.result);
 	}
 
 	if (hasImageUrl(value) && isBlobRef(value.image_url)) {
-		value.image_url = await resolveImageDataUrl(blobStore, value.image_url);
+		value.image_url = await resolve(value.image_url, true);
 	}
 
 	await Promise.all(
-		Object.entries(value).map(([childKey, item]) => resolvePersistedBlobRefs(item, blobStore, childKey)),
+		Object.entries(value).map(([childKey, item]) => resolvePersistedBlobRefs(item, resolve, childKey)),
 	);
 }
 
@@ -404,18 +408,28 @@ function repairTruncatedSnapcompactFrames(entry: FileEntry): void {
 	});
 }
 
-export async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
+async function resolveBlobRefs(values: readonly unknown[], blobStore: BlobStore): Promise<void> {
+	const semaphore = new Semaphore(BLOB_READ_CONCURRENCY);
+	const resolve: BlobReferenceResolver = async (data, asDataUrl = false) => {
+		await semaphore.acquire();
+		try {
+			return await (asDataUrl ? resolveImageDataUrl(blobStore, data) : resolveImageData(blobStore, data));
+		} finally {
+			semaphore.release();
+		}
+	};
 	const pending: Promise<void>[] = [];
-	// Interleave precheck + initiation per entry so a positive entry begins resolution at the same
-	// relative point as the old filter+map schedule (no scan-all-first pass that could observe a
-	// later entry before an earlier resolution mutates it).
-	for (const entry of entries) {
-		if (entry.type === "session") continue;
-		repairTruncatedSnapcompactFrames(entry);
-		if (!containsBlobRef(entry)) continue;
-		pending.push(resolvePersistedBlobRefs(entry, blobStore));
+	for (const value of values) {
+		if (!containsBlobRef(value)) continue;
+		pending.push(resolvePersistedBlobRefs(value, resolve));
 	}
 	await Promise.all(pending);
+}
+
+export async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
+	const sessionEntries = entries.filter(entry => entry.type !== "session");
+	for (const entry of sessionEntries) repairTruncatedSnapcompactFrames(entry);
+	await resolveBlobRefs(sessionEntries, blobStore);
 }
 
 /**
@@ -430,10 +444,12 @@ export async function loadSessionMessagesReadOnly(filePath: string): Promise<Age
 	const entries = await loadEntriesFromFile(filePath);
 	if (entries.length === 0) return [];
 	migrateToCurrentVersion(entries);
-	await resolveBlobRefsInEntries(entries, new BlobStore(getBlobsDir()));
+	for (const entry of entries) repairTruncatedSnapcompactFrames(entry);
 	const sessionEntries = entries.filter((e): e is SessionEntry => e.type !== "session");
-	return buildSessionContext(sessionEntries, undefined, undefined, {
+	const { messages } = buildSessionContext(sessionEntries, undefined, undefined, {
 		transcript: true,
 		collapseCompactedHistory: true,
-	}).messages;
+	});
+	await resolveBlobRefs(messages, new BlobStore(getBlobsDir()));
+	return messages;
 }

--- a/packages/coding-agent/test/session-read-only-hydration.test.ts
+++ b/packages/coding-agent/test/session-read-only-hydration.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import * as path from "node:path";
+import { BlobStore } from "@oh-my-pi/pi-coding-agent/session/blob-store";
+import type {
+	CompactionEntry,
+	FileEntry,
+	SessionMessageEntry,
+} from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import {
+	loadSessionMessagesReadOnly,
+	resolveBlobRefsInEntries,
+} from "@oh-my-pi/pi-coding-agent/session/session-loader";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+
+const timestamp = new Date(0).toISOString();
+const header = { type: "session", version: 3, id: "session", timestamp, cwd: "/tmp" };
+
+function imageEntry(id: string, parentId: string | null, data: string): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp,
+		message: { role: "user", content: [{ type: "image", data, mimeType: "image/png" }], timestamp: 0 },
+	};
+}
+
+describe("read-only session blob hydration", () => {
+	it("reads only retained branch images after a clear boundary and preserves URL and missing-blob fallbacks", async () => {
+		using dir = TempDir.createSync("@read-only-hydration-");
+		const store = new BlobStore(path.join(dir.path(), "blobs"));
+		const discarded = await store.put(Buffer.from("discarded"));
+		const retained = await store.put(Buffer.from("retained"));
+		const dataUrl = "data:image/png;base64,aW1hZ2U=";
+		const url = await store.put(Buffer.from(dataUrl));
+		const missing = `blob:sha256:${"0".repeat(64)}`;
+		const visible = imageEntry("visible", "reset", retained.ref);
+		if (visible.message.role !== "user") throw new Error("Expected user fixture");
+		visible.message.providerPayload = {
+			type: "openaiResponsesHistory",
+			provider: "openai",
+			items: [{ type: "message", role: "user", content: [{ type: "input_image", image_url: url.ref }] }],
+		};
+		const entries: FileEntry[] = [
+			imageEntry("old", null, discarded.ref),
+			{ type: "reset_boundary", id: "reset", parentId: "old", timestamp },
+			imageEntry("sibling", "reset", discarded.ref),
+			visible,
+			imageEntry("missing", "visible", missing),
+		];
+		const file = path.join(dir.path(), "session.jsonl");
+		await Bun.write(file, [header, ...entries].map(value => JSON.stringify(value)).join("\n"));
+		const get = store.get.bind(store);
+		const reads: string[] = [];
+		const readSpy = spyOn(BlobStore.prototype, "get").mockImplementation(async hash => {
+			reads.push(hash);
+			return get(hash);
+		});
+		try {
+			const messages = await loadSessionMessagesReadOnly(file);
+			expect(reads).not.toContain(discarded.hash);
+			expect(reads.toSorted()).toEqual([retained.hash, url.hash, "0".repeat(64)].toSorted());
+			expect(messages).toHaveLength(2);
+			expect(messages[0]).toMatchObject({
+				content: [{ type: "image", data: Buffer.from("retained").toString("base64") }],
+				providerPayload: { items: [{ content: [{ image_url: dataUrl }] }] },
+			});
+			expect(messages[1]).toMatchObject({ content: [{ type: "image", data: missing }] });
+		} finally {
+			readSpy.mockRestore();
+		}
+	});
+
+	it("does not read compacted-away images or archived frames in a collapsed transcript", async () => {
+		using dir = TempDir.createSync("@read-only-compaction-");
+		const store = new BlobStore(path.join(dir.path(), "blobs"));
+		const discarded = await store.put(Buffer.from("archived"));
+		const compaction: CompactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: "keep",
+			timestamp,
+			firstKeptEntryId: "keep",
+			summary: "summary",
+			tokensBefore: 1000,
+			preserveData: {
+				[snapcompact.PRESERVE_KEY]: {
+					frames: [{ data: discarded.ref, mimeType: "image/png", cols: 1, rows: 1, chars: 1 }],
+					totalChars: 1,
+					truncatedChars: 0,
+					text: "archived source",
+				},
+			},
+		};
+		const file = path.join(dir.path(), "session.jsonl");
+		await Bun.write(
+			file,
+			[
+				header,
+				imageEntry("old", null, discarded.ref),
+				{
+					type: "message",
+					id: "keep",
+					parentId: "old",
+					timestamp,
+					message: { role: "user", content: "keep", timestamp: 0 },
+				},
+				compaction,
+			]
+				.map(value => JSON.stringify(value))
+				.join("\n"),
+		);
+		const get = store.get.bind(store);
+		const reads: string[] = [];
+		const readSpy = spyOn(BlobStore.prototype, "get").mockImplementation(async hash => {
+			reads.push(hash);
+			return get(hash);
+		});
+		try {
+			const messages = await loadSessionMessagesReadOnly(file);
+			expect(reads).toEqual([]);
+			expect(messages).toHaveLength(2);
+			expect(messages[0]).toMatchObject({ role: "user", content: "keep" });
+			expect(messages[1]).toMatchObject({ role: "compactionSummary", summary: "summary" });
+		} finally {
+			readSpy.mockRestore();
+		}
+	});
+
+	it("bounds simultaneous blob reads inside one large frame archive", async () => {
+		using dir = TempDir.createSync("@archive-hydration-limit-");
+		const store = new BlobStore(path.join(dir.path(), "blobs"));
+		const blob = await store.put(Buffer.from("frame"));
+		const archive: snapcompact.Archive = {
+			frames: Array.from({ length: 48 }, () => ({
+				data: blob.ref,
+				mimeType: "image/png",
+				cols: 1,
+				rows: 1,
+				chars: 1,
+			})),
+			totalChars: 48,
+			truncatedChars: 0,
+		};
+		const entry: CompactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: null,
+			timestamp,
+			firstKeptEntryId: "none",
+			summary: "summary",
+			tokensBefore: 1000,
+			preserveData: { [snapcompact.PRESERVE_KEY]: archive },
+		};
+		const get = store.get.bind(store);
+		let active = 0;
+		let peak = 0;
+		const readSpy = spyOn(store, "get").mockImplementation(async hash => {
+			active++;
+			peak = Math.max(peak, active);
+			try {
+				await Bun.sleep(1);
+				return await get(hash);
+			} finally {
+				active--;
+			}
+		});
+		try {
+			await resolveBlobRefsInEntries([entry], store);
+			expect(peak).toBeLessThanOrEqual(8);
+			expect(archive.frames.map(frame => frame.data)).toEqual(
+				Array(48).fill(Buffer.from("frame").toString("base64")),
+			);
+		} finally {
+			readSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/session-read-only-hydration.test.ts
+++ b/packages/coding-agent/test/session-read-only-hydration.test.ts
@@ -6,6 +6,7 @@ import type {
 	FileEntry,
 	SessionMessageEntry,
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { formatSessionHistoryMarkdown } from "@oh-my-pi/pi-coding-agent/session/session-history-format";
 import {
 	loadSessionMessagesReadOnly,
 	resolveBlobRefsInEntries,
@@ -123,6 +124,62 @@ describe("read-only session blob hydration", () => {
 			expect(messages).toHaveLength(2);
 			expect(messages[0]).toMatchObject({ role: "user", content: "keep" });
 			expect(messages[1]).toMatchObject({ role: "compactionSummary", summary: "summary" });
+		} finally {
+			readSpy.mockRestore();
+		}
+	});
+
+	it("does not read images hidden in a remote-compaction replacement history", async () => {
+		using dir = TempDir.createSync("@read-only-remote-compaction-");
+		const store = new BlobStore(path.join(dir.path(), "blobs"));
+		const hidden = await store.put(Buffer.from("data:image/png;base64,aGlkZGVu"));
+		const generated = await store.put(Buffer.from("generated"));
+		const compaction: CompactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: "keep",
+			timestamp,
+			firstKeptEntryId: "keep",
+			summary: "remote summary",
+			tokensBefore: 1000,
+			preserveData: {
+				openaiRemoteCompaction: {
+					provider: "openai-codex",
+					replacementHistory: [
+						{ type: "message", role: "user", content: [{ type: "input_image", image_url: hidden.ref }] },
+						{ type: "image_generation_call", id: "ig_1", result: generated.ref },
+					],
+				},
+			},
+		};
+		const file = path.join(dir.path(), "session.jsonl");
+		await Bun.write(
+			file,
+			[
+				header,
+				{
+					type: "message",
+					id: "keep",
+					parentId: null,
+					timestamp,
+					message: { role: "user", content: "keep", timestamp: 0 },
+				},
+				compaction,
+			]
+				.map(value => JSON.stringify(value))
+				.join("\n"),
+		);
+		const get = store.get.bind(store);
+		const reads: string[] = [];
+		const readSpy = spyOn(BlobStore.prototype, "get").mockImplementation(async hash => {
+			reads.push(hash);
+			return get(hash);
+		});
+		try {
+			const messages = await loadSessionMessagesReadOnly(file);
+			expect(reads).toEqual([]);
+			expect(messages.map(message => message.role)).toEqual(["user", "compactionSummary"]);
+			expect(formatSessionHistoryMarkdown(messages)).toContain("[compaction] remote summary");
 		} finally {
 			readSpy.mockRestore();
 		}


### PR DESCRIPTION
## What

Read-only transcript loading selects the existing collapsed context before resolving blobs, avoiding discarded branches and pre-clear image data. Each load allows at most eight concurrent blob resolutions, including nested archive frames. Full historical storage and synchronous SDK APIs remain unchanged.

## Why

Read-only loading resolved blobs from discarded history before selecting the context it would return.

## Testing

- [x] Three regressions fail on baseline: discarded history, compacted archives, and 48 concurrent nested reads.
- [x] 19 focused tests, package check, and independent review; combined loader integration passes.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
