### PR TITLE
fix(rpc): preserve output under backpressure and stdin EOF

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -26,7 +26,7 @@ Behavior notes:
 - RPC/ACP host defaults cover task isolation/execution, memory, advisor, tier, async-job, and bash auto-background settings. They are applied only when a path is not explicitly configured; project/global config, `--config`, and isolated settings remain authoritative. Todo settings are not host-defaulted.
 - The process claims stdin before extension discovery, then parses it one non-empty JSONL line at a time. Malformed JSON emits a recoverable `command: "parse"` failure and does not terminate the loop.
 - At startup it writes a `ready` frame before processing commands. The frame advertises supported protocol versions and transport limits.
-- When stdin closes, pending extension UI, host-tool, and host-URI requests are rejected; accepted commands are drained, the session is disposed, and the process exits with code `0`.
+- When stdin closes, pending extension UI, host-tool, and host-URI requests are rejected; accepted commands are drained, the session is disposed, pending stdout is delivered, and the process exits with code `0`.
 - Responses/events are written as one JSON object per line.
 
 ## Transport and Framing
@@ -67,6 +67,10 @@ After the success response, oversized stdout objects are emitted losslessly as a
 Clients MUST validate `chunkId`, `index`, `count`, and `byteLength`, reject interleaved or interrupted sequences, enforce the advertised reassembly limit, concatenate decoded bytes in index order, decode them as strict UTF-8, and parse the result as one JSON object. The TypeScript `RpcFrameDecoder`, exported from `@oh-my-pi/pi-coding-agent/modes/rpc/rpc-frame`, implements this validation. The bundled TypeScript and Python `RpcClient` implementations negotiate v2 automatically when the ready frame advertises it.
 
 Legacy clients may ignore the added ready fields and remain on v1. V1 retains its bounded fallback behavior for oversized output. Frames above the v2 reassembly ceiling still fail explicitly; large history APIs should use pagination rather than depending on arbitrarily large logical frames.
+
+Output goes directly to stdout while the reader keeps up. Under backpressure, the server spills pending bytes to a private temporary file and drains it in 64 KiB blocks, preserving frame order. This limits queued output memory at the cost of disk I/O and temporary disk usage, which can grow until the reader catches up. The file is removed when the backlog drains or the process shuts down. Output or spool failures are logged, dispose the session, and exit with code `1`.
+
+Clients MUST continue reading stdout after closing stdin. Normal EOF and extension-requested shutdown wait for pending output delivery; a client that keeps its stdout pipe open without reading can delay exit indefinitely.
 
 ### Outbound frame categories (stdout)
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
+### Fixed
+
+- RPC output spills to temporary disk storage for slow readers instead of retaining an unbounded memory queue, and drains final responses before shutdown.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- RPC output spills to temporary disk storage for slow readers instead of retaining an unbounded memory queue, and drains final responses before shutdown.
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
@@ -34,9 +35,6 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
-### Fixed
-
-- RPC output spills to temporary disk storage for slow readers instead of retaining an unbounded memory queue, and drains final responses before shutdown.
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -10,10 +10,9 @@
  * - Events: AgentSessionEvent objects streamed as they occur
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
-import { once } from "node:events";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, isRecord, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -44,6 +43,7 @@ import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput, readRpcInputFrames } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import { RpcOutputWriter } from "./rpc-output";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -783,21 +783,11 @@ export async function runRpcMode(
 	process.env.PI_NOTIFICATIONS = "off";
 
 	const frameEncoder = new RpcFrameEncoder();
-	// Ordered stdout writer honoring backpressure: chunked v2 frames are produced
-	// lazily by the encoder and written one physical line at a time, so a near-limit
-	// logical frame never materializes its full base64 transport in memory.
-	let stdoutQueue: Promise<void> = Promise.resolve();
-	const writeFrames = (frames: Iterable<string>) => {
-		stdoutQueue = stdoutQueue
-			.then(async () => {
-				for (const line of frames) {
-					if (!process.stdout.write(line)) await once(process.stdout, "drain");
-				}
-			})
-			// stdout gone (host exited) — nothing left to deliver; keep the queue alive.
-			.catch(() => {});
-	};
-	writeFrames(
+	const outputWriter = new RpcOutputWriter(process.stdout, failure => {
+		logger.error("RPC output delivery failed", { error: String(failure) });
+		void session.dispose().finally(() => process.exit(1));
+	});
+	outputWriter.write(
 		frameEncoder.encodeFrames({
 			type: "ready",
 			protocolVersion: 1,
@@ -807,7 +797,7 @@ export async function runRpcMode(
 		}),
 	);
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		writeFrames(frameEncoder.encodeFrames(obj));
+		outputWriter.write(frameEncoder.encodeFrames(obj));
 		if (isRecord(obj) && obj.type === "response" && obj.command === "negotiate_protocol" && obj.success === true)
 			frameEncoder.setProtocolVersion(2);
 	};
@@ -1578,6 +1568,7 @@ export async function runRpcMode(
 			// must NOT emit it separately here or the event fires twice. Skipping
 			// dispose left OMP-owned Chromium alive after RPC shutdown (#5643).
 			await session.dispose();
+			await outputWriter.close();
 			process.exit(0);
 		},
 	});
@@ -1623,5 +1614,6 @@ export async function runRpcMode(
 	// prior pi.shutdown() through the coordinator makes this await settle
 	// immediately.
 	await session.dispose();
+	await outputWriter.close();
 	process.exit(0);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-output.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-output.ts
@@ -1,0 +1,159 @@
+import * as fs from "node:fs";
+import type { Writable } from "node:stream";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
+
+const READ_BYTES = 64 * 1024;
+
+interface Spool {
+	dir: TempDir;
+	file: string;
+	fd: number;
+	read: number;
+	written: number;
+}
+
+/** Synchronous event producers spill to disk while the RPC reader applies backpressure. */
+export class RpcOutputWriter {
+	#spool: Spool | undefined;
+	#blocked = false;
+	#pumping = false;
+	#pendingWrites = 0;
+	#failure: Error | undefined;
+	#closing = false;
+	#completion: { promise: Promise<void>; resolve: () => void; reject: (error: Error) => void } | undefined;
+
+	constructor(
+		private readonly sink: Writable,
+		private readonly onFailure: (error: Error) => void,
+	) {
+		sink.on("drain", this.#onDrain);
+		sink.on("error", this.#onError);
+		sink.on("close", this.#onClose);
+		process.once("exit", this.#onExit);
+	}
+
+	write(frames: Iterable<string>): void {
+		if (this.#failure || this.#closing) return;
+		try {
+			for (const line of frames) {
+				if (this.#blocked || this.#pumping || this.#spool) this.#append(line);
+				else this.#write(line);
+			}
+		} catch (error) {
+			this.#fail(error);
+		}
+	}
+
+	async close(): Promise<void> {
+		this.#closing = true;
+		if (this.#failure) throw this.#failure;
+		if (this.#pendingWrites || this.#spool || this.#pumping) {
+			this.#completion ??= Promise.withResolvers<void>();
+			await this.#completion.promise;
+		}
+		this.sink.off("drain", this.#onDrain);
+		this.sink.off("error", this.#onError);
+		this.sink.off("close", this.#onClose);
+		process.off("exit", this.#onExit);
+	}
+
+	#write(bytes: string | Uint8Array): void {
+		this.#pendingWrites++;
+		this.#blocked = !this.sink.write(bytes, error => {
+			this.#pendingWrites--;
+			if (error) this.#fail(error);
+			else this.#settle();
+		});
+	}
+
+	#append(line: string): void {
+		if (!this.#spool) {
+			const dir = TempDir.createSync("@omp-rpc-output-");
+			try {
+				const file = dir.join("output");
+				this.#spool = { dir, file, fd: fs.openSync(file, "wx+", 0o600), read: 0, written: 0 };
+			} catch (error) {
+				dir.removeSync();
+				throw error;
+			}
+		}
+		const spool = this.#spool;
+		const bytes = Buffer.from(line);
+		let offset = 0;
+		// Event callbacks cannot await a disk write without retaining an unbounded queue.
+		while (offset < bytes.length) {
+			const written = fs.writeSync(spool.fd, bytes, offset, bytes.length - offset, spool.written);
+			if (written === 0) throw new Error("RPC output spool write made no progress");
+			offset += written;
+			spool.written += written;
+		}
+	}
+
+	#onDrain = (): void => {
+		this.#blocked = false;
+		void this.#pump();
+	};
+
+	#onError = (error: Error): void => this.#fail(error);
+	#onClose = (): void => this.#fail(new Error("RPC output closed before delivery completed"));
+	#onExit = (): void => {
+		try {
+			this.#removeSpool();
+		} catch (error) {
+			logger.warn("RPC output spool cleanup failed", { error: String(error) });
+		}
+	};
+
+	async #pump(): Promise<void> {
+		if (this.#pumping || this.#failure) return;
+		this.#pumping = true;
+		try {
+			while (this.#spool && !this.#blocked && !this.#failure) {
+				const spool = this.#spool;
+				const end = Math.min(spool.written, spool.read + READ_BYTES);
+				const bytes = await Bun.file(spool.file).slice(spool.read, end).bytes();
+				if (this.#failure) break;
+				if (bytes.length !== end - spool.read) throw new Error("RPC output spool ended before delivery completed");
+				spool.read = end;
+				this.#write(bytes);
+				if (spool.read === spool.written) this.#removeSpool();
+			}
+		} catch (error) {
+			this.#fail(error);
+		} finally {
+			this.#pumping = false;
+			this.#settle();
+		}
+	}
+
+	#removeSpool(): void {
+		const spool = this.#spool;
+		if (!spool) return;
+		this.#spool = undefined;
+		try {
+			fs.closeSync(spool.fd);
+		} finally {
+			spool.dir.removeSync();
+		}
+	}
+
+	#settle(): void {
+		if (!this.#pendingWrites && !this.#spool && !this.#pumping && !this.#failure) this.#completion?.resolve();
+	}
+
+	#fail(error: unknown): void {
+		if (this.#failure) return;
+		this.#failure = error instanceof Error ? error : new Error(String(error));
+		try {
+			this.#removeSpool();
+		} catch (cleanupError) {
+			this.#failure = new AggregateError(
+				[this.#failure, cleanupError],
+				"RPC output failed and spool cleanup failed",
+			);
+		}
+		this.#completion?.reject(this.#failure);
+		process.off("exit", this.#onExit);
+		this.onFailure(this.#failure);
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-output.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-output.ts
@@ -1,12 +1,13 @@
 import * as fs from "node:fs";
 import type { Writable } from "node:stream";
 import { logger, TempDir } from "@oh-my-pi/pi-utils";
+import type { BunFile } from "bun";
 
 const READ_BYTES = 64 * 1024;
 
 interface Spool {
 	dir: TempDir;
-	file: string;
+	file: BunFile;
 	fd: number;
 	read: number;
 	written: number;
@@ -71,7 +72,8 @@ export class RpcOutputWriter {
 			const dir = TempDir.createSync("@omp-rpc-output-");
 			try {
 				const file = dir.join("output");
-				this.#spool = { dir, file, fd: fs.openSync(file, "wx+", 0o600), read: 0, written: 0 };
+				const handle = Bun.file(file);
+				this.#spool = { dir, file: handle, fd: fs.openSync(file, "wx+", 0o600), read: 0, written: 0 };
 			} catch (error) {
 				dir.removeSync();
 				throw error;
@@ -111,7 +113,7 @@ export class RpcOutputWriter {
 			while (this.#spool && !this.#blocked && !this.#failure) {
 				const spool = this.#spool;
 				const end = Math.min(spool.written, spool.read + READ_BYTES);
-				const bytes = await Bun.file(spool.file).slice(spool.read, end).bytes();
+				const bytes = await spool.file.slice(spool.read, end).bytes();
 				if (this.#failure) break;
 				if (bytes.length !== end - spool.read) throw new Error("RPC output spool ended before delivery completed");
 				spool.read = end;

--- a/packages/coding-agent/test/rpc-output.test.ts
+++ b/packages/coding-agent/test/rpc-output.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Writable } from "node:stream";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { RpcFrameDecoder, RpcFrameEncoder } from "../src/modes/rpc/rpc-frame";
+import { RpcOutputWriter } from "../src/modes/rpc/rpc-output";
+
+afterEach(() => {
+	mock.restore();
+});
+
+it("drains RPC command responses after stdin EOF while the real stdout pipe is backpressured", async () => {
+	const child = Bun.spawn(
+		[
+			process.execPath,
+			path.join(import.meta.dir, "../src/cli.ts"),
+			"--mode",
+			"rpc",
+			"--no-extensions",
+			"--no-skills",
+			"--no-tools",
+			"--no-session",
+			"--provider",
+			"anthropic",
+			"--model",
+			"claude-sonnet-4-5",
+		],
+		{
+			cwd: import.meta.dir,
+			env: { ...process.env, PI_NO_TITLE: "1" },
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+	const stderr = new Response(child.stderr).text();
+	const reader = child.stdout.getReader();
+	const chunks: Uint8Array[] = [];
+	try {
+		const ready = await reader.read();
+		if (ready.done) throw new Error(`RPC exited before ready: ${await stderr}`);
+		chunks.push(ready.value);
+		for (let id = 0; id < 128; id++) {
+			child.stdin.write(`${JSON.stringify({ type: "get_state", id: `${id}:${"x".repeat(32768)}` })}\n`);
+		}
+		await child.stdin.flush();
+		child.stdin.end();
+		await Bun.sleep(300);
+		while (true) {
+			const next = await reader.read();
+			if (next.done) break;
+			chunks.push(next.value);
+		}
+		const output = Buffer.concat(chunks).toString();
+		const replies: { id: string; type: string; success?: boolean }[] = output
+			.trimEnd()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(replies.filter(reply => reply.type === "response").map(reply => reply.id.split(":")[0])).toEqual(
+			Array.from({ length: 128 }, (_, id) => String(id)),
+		);
+		expect(await child.exited).toBe(0);
+	} finally {
+		reader.releaseLock();
+		child.kill();
+		await child.exited.catch(() => {});
+		await stderr;
+	}
+}, 30_000);
+
+it("delivers ordered v1 and chunked v2 frames through a slow sink before close completes", async () => {
+	const chunks: Buffer[] = [];
+	const sink = new Writable({
+		highWaterMark: 1024,
+		write(chunk, _encoding, callback) {
+			chunks.push(Buffer.from(chunk));
+			void Bun.sleep(1).then(() => callback());
+		},
+	});
+	const errors: Error[] = [];
+	const writer = new RpcOutputWriter(sink, error => errors.push(error));
+	const encoder = new RpcFrameEncoder();
+	const expected: object[] = [{ type: "ready" }, { type: "response", command: "negotiate_protocol", success: true }];
+	for (const frame of expected) writer.write(encoder.encodeFrames(frame));
+	encoder.setProtocolVersion(2);
+	for (let id = 0; id < 32; id++) {
+		const frame = { type: "response", id, data: `${id}:${"🌍".repeat(id === 4 ? 300_000 : 8192)}` };
+		expected.push(frame);
+		writer.write(encoder.encodeFrames(frame));
+	}
+	const final = { type: "agent_end", messages: [] };
+	expected.push(final);
+	writer.write(encoder.encodeFrames(final));
+	await writer.close();
+	const decoder = new RpcFrameDecoder();
+	const actual = Buffer.concat(chunks)
+		.toString()
+		.trimEnd()
+		.split("\n")
+		.map(line => decoder.push(JSON.parse(line)))
+		.filter(frame => frame !== undefined);
+	expect(actual).toEqual(expected);
+	expect(errors).toEqual([]);
+});
+
+it("fails promptly and removes spilled output when the reader disconnects", async () => {
+	await using dir = await TempDir.create("@rpc-output-disconnect-");
+	spyOn(TempDir, "createSync").mockReturnValue(dir);
+	const sink = new Writable({ highWaterMark: 1, write() {} });
+	const failure = Promise.withResolvers<Error>();
+	const writer = new RpcOutputWriter(sink, failure.resolve);
+	writer.write(["first\n", "pending\n"]);
+	const closed = writer.close();
+	sink.destroy(new Error("reader disconnected"));
+	await expect(closed).rejects.toThrow("reader disconnected");
+	expect((await failure.promise).message).toBe("reader disconnected");
+	expect(await Bun.file(dir.join("output")).exists()).toBe(false);
+});
+
+it("reports disk exhaustion and removes the partial spool instead of silently dropping accepted output", async () => {
+	await using dir = await TempDir.create("@rpc-output-enospc-");
+	spyOn(TempDir, "createSync").mockReturnValue(dir);
+	spyOn(fs, "writeSync").mockImplementation(() => {
+		throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+	});
+	const sink = new Writable({ highWaterMark: 1, write() {} });
+	const failures: Error[] = [];
+	const writer = new RpcOutputWriter(sink, error => failures.push(error));
+	writer.write(["first\n", "pending\n"]);
+	await expect(writer.close()).rejects.toThrow("disk full");
+	expect(failures.map(error => error.message)).toEqual(["disk full"]);
+	expect(await Bun.file(dir.join("output")).exists()).toBe(false);
+	sink.destroy();
+});
+
+it("reports a truncated spool during delivery instead of completing a partial protocol stream", async () => {
+	await using dir = await TempDir.create("@rpc-output-truncated-");
+	spyOn(TempDir, "createSync").mockReturnValue(dir);
+	let release: (() => void) | undefined;
+	const sink = new Writable({
+		highWaterMark: 1,
+		write(_chunk, _encoding, callback) {
+			release = callback;
+		},
+	});
+	const failures: Error[] = [];
+	const writer = new RpcOutputWriter(sink, error => failures.push(error));
+	writer.write(["first\n", "pending\n"]);
+	const closed = writer.close();
+	fs.truncateSync(dir.join("output"), 0);
+	release?.();
+	await expect(closed).rejects.toThrow("spool ended before delivery completed");
+	expect(failures.map(error => error.message)).toEqual(["RPC output spool ended before delivery completed"]);
+	expect(await Bun.file(dir.join("output")).exists()).toBe(false);
+	sink.destroy();
+});


### PR DESCRIPTION
## What

RPC writes directly while stdout accepts data, then spools backlog to a private temporary file instead of retaining a promise chain. EOF and shutdown drain queued responses before exit. Slow readers can consume temporary disk space and delay exit; clients must keep reading stdout after closing stdin.

## Why

Slow readers retain output in memory, and stdin EOF can end the CLI before all responses are written.

## Testing

- [x] The actual CLI delivers all 128 responses after stdin EOF; baseline delivered 80.
- [x] 36 RPC tests, package check, and independent review cover ordering, disconnect, disk exhaustion, and truncated spools.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
