### PR TITLE
perf(natives): bound filesystem scan-cache memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6469,7 +6469,6 @@ dependencies = [
 name = "pi-walker"
 version = "18.1.15"
 dependencies = [
- "dashmap",
  "globset",
  "ignore",
  "libc",

--- a/crates/pi-walker/Cargo.toml
+++ b/crates/pi-walker/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-dashmap.workspace = true
 globset.workspace = true
 ignore.workspace = true
 parking_lot.workspace = true

--- a/crates/pi-walker/examples/scan-cache-bench.rs
+++ b/crates/pi-walker/examples/scan-cache-bench.rs
@@ -1,0 +1,61 @@
+use std::{
+	hint::black_box,
+	path::PathBuf,
+	time::{Duration, Instant},
+};
+
+use pi_walker::{CollectedEntry, WalkOptions, collect_entries_without_heartbeat, invalidate_all};
+
+fn main() -> Result<(), String> {
+	let root = PathBuf::from(
+		std::env::args_os()
+			.nth(1)
+			.ok_or("usage: scan-cache-bench ROOT")?,
+	);
+	let options = WalkOptions {
+		cache: true,
+		skip_git: true,
+		skip_node_modules: true,
+		..WalkOptions::default()
+	};
+	let initial = collect_entries_without_heartbeat(&root, WalkOptions { cache: false, ..options })
+		.map_err(|error| error.to_string())?;
+	let payload_bytes = initial.entries.capacity() * size_of::<CollectedEntry>()
+		+ initial
+			.entries
+			.iter()
+			.map(|entry| entry.path.capacity())
+			.sum::<usize>();
+	let count = initial.entries.len();
+	let started = Instant::now();
+	for _ in 0..16 {
+		black_box(initial.entries.clone());
+	}
+	println!(
+		"entries={count} scan_payload_bytes={payload_bytes} clone_16_ms={:.3}",
+		started.elapsed().as_secs_f64() * 1000.0
+	);
+	drop(initial);
+	invalidate_all();
+	for depth in 32..48 {
+		black_box(
+			collect_entries_without_heartbeat(&root, WalkOptions { max_depth: depth, ..options })
+				.map_err(|error| error.to_string())?,
+		);
+	}
+	std::thread::sleep(Duration::from_millis(2));
+	let started = Instant::now();
+	let mut hits = 0;
+	for depth in (32..48).rev() {
+		let scan =
+			collect_entries_without_heartbeat(&root, WalkOptions { max_depth: depth, ..options })
+				.map_err(|error| error.to_string())?;
+		hits += usize::from(scan.cache_age_ms > 0);
+		black_box(scan);
+	}
+	println!(
+		"second_pass_cache_hits={hits}/16 second_pass_ms={:.3}",
+		started.elapsed().as_secs_f64() * 1000.0
+	);
+	Ok(())
+}

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -688,11 +688,24 @@ mod tests {
 		};
 		let mut first = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
 		first.entries[0].path = "changed-by-caller".to_owned();
+		std::thread::sleep(Duration::from_millis(2));
 		let second = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+		assert!(second.cache_age_ms > 0, "second collection must use the cached snapshot");
 		assert_eq!(second.entries[0].path, "real.txt");
 		let cancelled = super::collect_entries(root.path(), options, || Err("cancelled"));
 		assert!(
 			matches!(cancelled, Err(crate::WalkError::Interrupted(error)) if error == "cancelled")
+		);
+		let heartbeat_calls = AtomicU64::new(0);
+		let cancelled_after_copy = super::collect_entries(root.path(), options, || {
+			if heartbeat_calls.fetch_add(1, Ordering::Relaxed) == 0 {
+				Ok(())
+			} else {
+				Err("cancelled after copy")
+			}
+		});
+		assert!(
+			matches!(cancelled_after_copy, Err(crate::WalkError::Interrupted(error)) if error == "cancelled after copy")
 		);
 		super::invalidate_path(root.path());
 	}

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -2,13 +2,14 @@
 
 use std::{
 	borrow::Cow,
+	collections::HashMap,
 	fmt,
 	path::{Path, PathBuf},
-	sync::LazyLock,
+	sync::{Arc, LazyLock},
 	time::{Duration, Instant},
 };
 
-use dashmap::DashMap;
+use parking_lot::Mutex;
 use rayon::{ThreadPool, prelude::*};
 
 use crate::{CollectedEntries, CollectedEntry, FileType, WalkError, WalkOptions};
@@ -22,7 +23,96 @@ struct CacheKey {
 #[derive(Clone)]
 struct CacheEntry {
 	created_at: Instant,
-	entries:    Vec<CollectedEntry>,
+	entries:    Arc<Vec<CollectedEntry>>,
+	bytes:      usize,
+}
+
+struct ScanCache {
+	entries:     HashMap<CacheKey, CacheEntry>,
+	bytes:       usize,
+	generation:  u64,
+	ttl:         Duration,
+	max_entries: usize,
+	max_bytes:   usize,
+}
+
+impl ScanCache {
+	fn new(ttl: Duration, max_entries: usize, max_bytes: usize) -> Self {
+		Self { entries: HashMap::new(), bytes: 0, generation: 0, ttl, max_entries, max_bytes }
+	}
+
+	fn remove(&mut self, key: &CacheKey) {
+		if let Some(entry) = self.entries.remove(key) {
+			self.bytes -= entry.bytes;
+		}
+	}
+
+	fn expire(&mut self, now: Instant) {
+		self.entries.retain(|_, entry| {
+			if now.saturating_duration_since(entry.created_at) < self.ttl {
+				true
+			} else {
+				self.bytes -= entry.bytes;
+				false
+			}
+		});
+	}
+
+	fn get(&mut self, key: &CacheKey, now: Instant) -> Option<CacheEntry> {
+		self.expire(now);
+		self.entries.get(key).cloned()
+	}
+
+	fn insert(&mut self, key: CacheKey, entry: CacheEntry, generation: u64, now: Instant) {
+		self.expire(now);
+		if generation != self.generation
+			|| self.max_entries == 0
+			|| entry.bytes > self.max_bytes
+			|| self.max_bytes == 0
+			|| now.saturating_duration_since(entry.created_at) >= self.ttl
+			|| self
+				.entries
+				.get(&key)
+				.is_some_and(|cached| cached.created_at > entry.created_at)
+		{
+			return;
+		}
+		self.remove(&key);
+		while self.entries.len() >= self.max_entries || self.bytes > self.max_bytes - entry.bytes {
+			let oldest = self
+				.entries
+				.iter()
+				.min_by_key(|(_, value)| value.created_at)
+				.map(|(key, _)| key.clone());
+			if let Some(oldest) = oldest {
+				self.remove(&oldest);
+			} else {
+				break;
+			}
+		}
+		self.bytes += entry.bytes;
+		self.entries.insert(key, entry);
+	}
+
+	fn invalidate(&mut self, target: Option<&Path>) {
+		self.generation = self.generation.wrapping_add(1);
+		self.entries.retain(|key, entry| {
+			if target.is_none_or(|target| target.starts_with(&key.root)) {
+				self.bytes -= entry.bytes;
+				false
+			} else {
+				true
+			}
+		});
+	}
+}
+
+fn entry_bytes(entries: &[CollectedEntry], capacity: usize) -> usize {
+	entries
+		.iter()
+		.fold(capacity.saturating_mul(size_of::<CollectedEntry>()), |bytes, entry| {
+			bytes.saturating_add(entry.path.capacity())
+		})
 }
 
 static CACHE_TTL_MS: LazyLock<u64> =
@@ -31,6 +121,8 @@ static EMPTY_RECHECK_MS: LazyLock<u64> =
 	LazyLock::new(|| env_uint("FS_SCAN_EMPTY_RECHECK_MS", 200, 0, u64::MAX));
 static MAX_CACHE_ENTRIES: LazyLock<usize> =
 	LazyLock::new(|| env_uint("FS_SCAN_CACHE_MAX_ENTRIES", 16, 0, usize::MAX));
+static MAX_CACHE_BYTES: LazyLock<usize> =
+	LazyLock::new(|| env_uint("FS_SCAN_CACHE_MAX_BYTES", 64 * 1024 * 1024, 0, usize::MAX));
 const DEFAULT_WALK_WORKERS: usize = 4;
 
 static WALK_WORKERS: LazyLock<usize> = LazyLock::new(|| {
@@ -47,7 +139,13 @@ static WALK_POOL: LazyLock<Option<ThreadPool>> = LazyLock::new(|| {
 		.build()
 		.ok()
 });
-static SCAN_CACHE: LazyLock<DashMap<CacheKey, CacheEntry>> = LazyLock::new(DashMap::new);
+static SCAN_CACHE: LazyLock<Mutex<ScanCache>> = LazyLock::new(|| {
+	Mutex::new(ScanCache::new(
+		Duration::from_millis(*CACHE_TTL_MS),
+		*MAX_CACHE_ENTRIES,
+		*MAX_CACHE_BYTES,
+	))
+});
 
 fn env_uint<T>(name: &str, default: T, min: T, max: T) -> T
 where
@@ -152,17 +250,6 @@ where
 			.try_for_each(|item| operation(&mut state, item));
 	}
 	with_walk_pool(|| items.par_iter().try_for_each_init(init, operation))
-}
-
-fn evict_oldest() {
-	if SCAN_CACHE.len() > *MAX_CACHE_ENTRIES
-		&& let Some(oldest_key) = SCAN_CACHE
-			.iter()
-			.min_by_key(|entry| entry.value().created_at)
-			.map(|entry| entry.key().clone())
-	{
-		SCAN_CACHE.remove(&oldest_key);
-	}
 }
 
 fn cache_key(root: &Path, mut options: WalkOptions) -> CacheKey {
@@ -285,29 +372,41 @@ where
 	H: Fn() -> std::result::Result<(), E> + Sync,
 	E: fmt::Display,
 {
-	let ttl = *CACHE_TTL_MS;
-	if ttl == 0 {
+	if *CACHE_TTL_MS == 0 || *MAX_CACHE_ENTRIES == 0 || *MAX_CACHE_BYTES == 0 {
 		return collect_entries_uncached(root, options, heartbeat);
 	}
 
+	heartbeat().map_err(|err| WalkError::Interrupted(err.to_string()))?;
 	let key = cache_key(root, options);
 	let now = Instant::now();
-	if let Some(entry) = SCAN_CACHE.get(&key) {
-		let age = now.duration_since(entry.created_at);
-		if age < Duration::from_millis(ttl) {
-			return Ok(CollectedEntries {
-				entries:      entry.entries.clone(),
-				cache_age_ms: age.as_millis() as u64,
-			});
-		}
-		drop(entry);
-		SCAN_CACHE.remove(&key);
+	let (cached, generation) = {
+		let mut cache = SCAN_CACHE.lock();
+		(cache.get(&key, now), cache.generation)
+	};
+	if let Some(entry) = cached {
+		let entries = entry.entries.as_ref().clone();
+		heartbeat().map_err(|err| WalkError::Interrupted(err.to_string()))?;
+		return Ok(CollectedEntries {
+			entries,
+			cache_age_ms: now.saturating_duration_since(entry.created_at).as_millis() as u64,
+		});
 	}
 
 	let scan = collect_entries_uncached(root, options, heartbeat)?;
-	SCAN_CACHE.insert(key, CacheEntry { created_at: now, entries: scan.entries.clone() });
-	evict_oldest();
-	Ok(CollectedEntries { entries: scan.entries, cache_age_ms: 0 })
+	let bytes = entry_bytes(&scan.entries, scan.entries.capacity());
+	if bytes > *MAX_CACHE_BYTES {
+		return Ok(scan);
+	}
+	let entries = Arc::new(scan.entries);
+	SCAN_CACHE.lock().insert(
+		key,
+		CacheEntry { created_at: now, entries: Arc::clone(&entries), bytes },
+		generation,
+		Instant::now(),
+	);
+	let entries = Arc::unwrap_or_clone(entries);
+	heartbeat().map_err(|err| WalkError::Interrupted(err.to_string()))?;
+	Ok(CollectedEntries { entries, cache_age_ms: 0 })
 }
 
 pub fn collect_entries<H, E>(
@@ -328,14 +427,7 @@ where
 
 /// Invalidate cache entries whose root contains `target`.
 pub fn invalidate_path(target: &Path) {
-	let keys_to_remove: Vec<CacheKey> = SCAN_CACHE
-		.iter()
-		.filter(|entry| target.starts_with(&entry.key().root))
-		.map(|entry| entry.key().clone())
-		.collect();
-	for key in keys_to_remove {
-		SCAN_CACHE.remove(&key);
-	}
+	SCAN_CACHE.lock().invalidate(Some(target));
 }
 
 /// Resolve a possibly relative path and invalidate matching cache roots.
@@ -362,7 +454,7 @@ pub fn invalidate_path_string(path: &str) {
 
 /// Clear the entire scan cache.
 pub fn invalidate_all() {
-	SCAN_CACHE.clear();
+	SCAN_CACHE.lock().invalidate(None);
 }
 
 #[cfg(test)]
@@ -432,6 +524,177 @@ mod tests {
 		assert_eq!(super::normalize_worker_count_with_available(0, 0), 1);
 		assert_eq!(super::normalize_worker_count_with_available(1, 8), 1);
 		assert_eq!(super::normalize_worker_count_with_available(4, 8), 4);
+	}
+
+	fn cached_entry(
+		path: &str,
+		spare_bytes: usize,
+		created_at: std::time::Instant,
+	) -> super::CacheEntry {
+		let mut value = String::with_capacity(path.len() + spare_bytes);
+		value.push_str(path);
+		let entries = vec![CollectedEntry {
+			path:      value,
+			file_type: FileType::File,
+			mtime:     None,
+			size:      None,
+		}];
+		let bytes = super::entry_bytes(&entries, entries.capacity());
+		super::CacheEntry { created_at, entries: std::sync::Arc::new(entries), bytes }
+	}
+
+	fn key(name: &str) -> super::CacheKey {
+		super::cache_key(Path::new(name), crate::WalkOptions::default())
+	}
+
+	#[test]
+	fn cache_evicts_oldest_by_allocated_bytes_and_rejects_oversized_scans() {
+		let now = std::time::Instant::now();
+		let a = cached_entry("a", 512, now);
+		let b = cached_entry("b", 512, now + Duration::from_millis(1));
+		let c = cached_entry("c", 512, now + Duration::from_millis(2));
+		let mut cache = super::ScanCache::new(Duration::from_secs(60), 16, a.bytes + b.bytes);
+		cache.insert(key("a"), a, 0, now);
+		cache.insert(key("b"), b, 0, now);
+		cache.insert(key("c"), c, 0, now);
+		assert!(cache.get(&key("a"), now).is_none());
+		assert_eq!(cache.get(&key("b"), now).unwrap().entries[0].path, "b");
+		assert_eq!(cache.get(&key("c"), now).unwrap().entries[0].path, "c");
+		let oversized = cached_entry("too-large", cache.max_bytes, now);
+		cache.insert(key("oversized"), oversized, 0, now);
+		assert!(cache.get(&key("oversized"), now).is_none());
+		assert_eq!(cache.entries.len(), 2);
+		assert!(cache.bytes <= cache.max_bytes);
+	}
+
+	#[test]
+	fn cache_replacements_release_budget_and_old_scans_do_not_replace_newer_results() {
+		let now = std::time::Instant::now();
+		let large = cached_entry("old", 512, now);
+		let mut cache = super::ScanCache::new(Duration::from_secs(60), 16, large.bytes);
+		cache.insert(key("root"), large, 0, now);
+		cache.insert(key("root"), cached_entry("new", 0, now + Duration::from_millis(1)), 0, now);
+		cache.insert(key("other"), cached_entry("other", 0, now), 0, now);
+		cache.insert(key("root"), cached_entry("stale", 0, now), 0, now);
+		assert_eq!(cache.get(&key("root"), now).unwrap().entries[0].path, "new");
+		assert_eq!(cache.get(&key("other"), now).unwrap().entries[0].path, "other");
+		assert_eq!(
+			cache.bytes,
+			cache
+				.entries
+				.values()
+				.map(|entry| entry.bytes)
+				.sum::<usize>()
+		);
+	}
+
+	#[test]
+	fn cache_miss_releases_all_expired_payloads_and_rejects_already_expired_scans() {
+		let now = std::time::Instant::now();
+		let ttl = Duration::from_millis(10);
+		let mut cache = super::ScanCache::new(ttl, 16, 4096);
+		let expired = cached_entry("expired", 0, now);
+		let weak = std::sync::Arc::downgrade(&expired.entries);
+		cache.insert(key("expired"), expired, 0, now);
+		cache.insert(
+			key("fresh"),
+			cached_entry("fresh", 0, now + Duration::from_millis(1)),
+			0,
+			now + Duration::from_millis(1),
+		);
+		assert!(cache.get(&key("missing"), now + ttl).is_none());
+		assert!(weak.upgrade().is_none());
+		cache.insert(key("slow"), cached_entry("slow", 0, now), 0, now + ttl);
+		assert!(cache.get(&key("slow"), now + ttl).is_none());
+		assert_eq!(cache.get(&key("fresh"), now + ttl).unwrap().entries[0].path, "fresh");
+	}
+
+	#[test]
+	fn invalidation_prevents_inflight_scan_repopulation() {
+		let now = std::time::Instant::now();
+		let cache = std::sync::Arc::new(parking_lot::Mutex::new(super::ScanCache::new(
+			Duration::from_secs(60),
+			16,
+			4096,
+		)));
+		let scanned = std::sync::Arc::new(std::sync::Barrier::new(2));
+		let invalidated = std::sync::Arc::new(std::sync::Barrier::new(2));
+		let worker = {
+			let cache = std::sync::Arc::clone(&cache);
+			let scanned = std::sync::Arc::clone(&scanned);
+			let invalidated = std::sync::Arc::clone(&invalidated);
+			std::thread::spawn(move || {
+				let generation = cache.lock().generation;
+				let entry = cached_entry("stale", 0, now);
+				scanned.wait();
+				invalidated.wait();
+				cache.lock().insert(key("root"), entry, generation, now);
+			})
+		};
+		scanned.wait();
+		cache.lock().invalidate(Some(Path::new("root/changed")));
+		invalidated.wait();
+		worker.join().unwrap();
+		let mut cache = cache.lock();
+		assert!(cache.get(&key("root"), now).is_none());
+		let generation = cache.generation;
+		cache.insert(key("root"), cached_entry("fresh", 0, now), generation, now);
+		assert_eq!(cache.get(&key("root"), now).unwrap().entries[0].path, "fresh");
+	}
+
+	#[test]
+	fn concurrent_inserts_enforce_count_and_byte_limits_without_mutating_snapshots() {
+		let now = std::time::Instant::now();
+		let cache = std::sync::Arc::new(parking_lot::Mutex::new(super::ScanCache::new(
+			Duration::from_secs(60),
+			3,
+			2048,
+		)));
+		let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+		let workers: Vec<_> = (0..16)
+			.map(|index| {
+				let cache = std::sync::Arc::clone(&cache);
+				let barrier = std::sync::Arc::clone(&barrier);
+				std::thread::spawn(move || {
+					let name = index.to_string();
+					let entry = cached_entry(&name, 512, now + Duration::from_millis(index));
+					let snapshot = std::sync::Arc::clone(&entry.entries);
+					barrier.wait();
+					let mut cache = cache.lock();
+					cache.insert(key(&name), entry, 0, now);
+					assert!(cache.bytes <= 2048);
+					assert!(cache.entries.len() <= 3);
+					drop(cache);
+					assert_eq!(snapshot[0].path, name);
+				})
+			})
+			.collect();
+		for worker in workers {
+			worker.join().unwrap();
+		}
+		let mut cache = cache.lock();
+		cache.invalidate(None);
+		assert_eq!(cache.bytes, 0);
+		assert!(cache.entries.is_empty());
+	}
+
+	#[test]
+	fn cache_hits_preserve_owned_results_and_respect_cancellation() {
+		let root = TempDirGuard::new();
+		fs::write(root.path().join("real.txt"), "ok").unwrap();
+		let options = crate::WalkOptions {
+			cache: true,
+			..scan_options(true, false, crate::WalkDetail::Minimal)
+		};
+		let mut first = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+		first.entries[0].path = "changed-by-caller".to_owned();
+		let second = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+		assert_eq!(second.entries[0].path, "real.txt");
+		let cancelled = super::collect_entries(root.path(), options, || Err("cancelled"));
+		assert!(
+			matches!(cancelled, Err(crate::WalkError::Interrupted(error)) if error == "cancelled")
+		);
+		super::invalidate_path(root.path());
 	}
 
 	fn scan_options(

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -350,6 +350,44 @@ pub fn resolve_search_path(path: &str) -> Result<PathBuf, WalkError<String>> {
 	Ok(std::fs::canonicalize(&root).unwrap_or(root))
 }
 
+#[cfg(not(test))]
+const fn scan_seam() {}
+
+#[cfg(test)]
+thread_local! {
+	static SCAN_SEAM: std::cell::RefCell<Option<std::rc::Rc<dyn Fn()>>> =
+		const { std::cell::RefCell::new(None) };
+}
+
+/// Pause point reached once a walk has produced its entries but before any
+/// caller can observe them, so a test can hold its own scan in flight. Thread
+/// local so an installed seam never reaches a scan some other test is running.
+#[cfg(test)]
+fn scan_seam() {
+	let seam = SCAN_SEAM.with_borrow(Clone::clone);
+	if let Some(seam) = seam {
+		seam();
+	}
+}
+
+#[cfg(test)]
+struct ScanSeamGuard;
+
+#[cfg(test)]
+impl ScanSeamGuard {
+	fn install(seam: impl Fn() + 'static) -> Self {
+		SCAN_SEAM.with_borrow_mut(|slot| *slot = Some(std::rc::Rc::new(seam)));
+		Self
+	}
+}
+
+#[cfg(test)]
+impl Drop for ScanSeamGuard {
+	fn drop(&mut self) {
+		SCAN_SEAM.with_borrow_mut(|slot| *slot = None);
+	}
+}
+
 fn collect_entries_uncached<H, E>(
 	root: &Path,
 	mut options: WalkOptions,
@@ -360,7 +398,10 @@ where
 	E: fmt::Display,
 {
 	options.cache = false;
-	crate::collect_entries_native(root, options, || heartbeat().map_err(|err| err.to_string()))
+	let scan =
+		crate::collect_entries_native(root, options, || heartbeat().map_err(|err| err.to_string()))?;
+	scan_seam();
+	Ok(scan)
 }
 
 fn get_or_scan<H, E>(
@@ -547,6 +588,12 @@ mod tests {
 		super::cache_key(Path::new(name), crate::WalkOptions::default())
 	}
 
+	fn sorted_paths(entries: &[CollectedEntry]) -> Vec<&str> {
+		let mut paths: Vec<&str> = entries.iter().map(|entry| entry.path.as_str()).collect();
+		paths.sort_unstable();
+		paths
+	}
+
 	#[test]
 	fn cache_evicts_oldest_by_allocated_bytes_and_rejects_oversized_scans() {
 		let now = std::time::Instant::now();
@@ -610,36 +657,62 @@ mod tests {
 	}
 
 	#[test]
-	fn invalidation_prevents_inflight_scan_repopulation() {
+	fn cache_rejects_inserts_carrying_a_pre_invalidation_generation() {
 		let now = std::time::Instant::now();
-		let cache = std::sync::Arc::new(parking_lot::Mutex::new(super::ScanCache::new(
-			Duration::from_secs(60),
-			16,
-			4096,
-		)));
-		let scanned = std::sync::Arc::new(std::sync::Barrier::new(2));
-		let invalidated = std::sync::Arc::new(std::sync::Barrier::new(2));
-		let worker = {
-			let cache = std::sync::Arc::clone(&cache);
-			let scanned = std::sync::Arc::clone(&scanned);
-			let invalidated = std::sync::Arc::clone(&invalidated);
-			std::thread::spawn(move || {
-				let generation = cache.lock().generation;
-				let entry = cached_entry("stale", 0, now);
-				scanned.wait();
-				invalidated.wait();
-				cache.lock().insert(key("root"), entry, generation, now);
-			})
-		};
-		scanned.wait();
-		cache.lock().invalidate(Some(Path::new("root/changed")));
-		invalidated.wait();
-		worker.join().unwrap();
-		let mut cache = cache.lock();
+		let mut cache = super::ScanCache::new(Duration::from_secs(60), 16, 4096);
+		let generation = cache.generation;
+		cache.invalidate(Some(Path::new("root/changed")));
+		cache.insert(key("root"), cached_entry("stale", 0, now), generation, now);
 		assert!(cache.get(&key("root"), now).is_none());
 		let generation = cache.generation;
 		cache.insert(key("root"), cached_entry("fresh", 0, now), generation, now);
 		assert_eq!(cache.get(&key("root"), now).unwrap().entries[0].path, "fresh");
+	}
+
+	#[test]
+	fn collect_entries_discards_a_scan_invalidated_while_in_flight() {
+		let root = TempDirGuard::new();
+		fs::write(root.path().join("before.txt"), "ok").unwrap();
+		let options = crate::WalkOptions {
+			cache: true,
+			..scan_options(true, false, crate::WalkDetail::Minimal)
+		};
+
+		let paused = std::sync::Arc::new(std::sync::Barrier::new(2));
+		let resume = std::sync::Arc::new(std::sync::Barrier::new(2));
+		let scanner = {
+			let root = root.path().to_path_buf();
+			let paused = std::sync::Arc::clone(&paused);
+			let resume = std::sync::Arc::clone(&resume);
+			std::thread::spawn(move || {
+				let _seam = super::ScanSeamGuard::install(move || {
+					paused.wait();
+					resume.wait();
+				});
+				super::collect_entries(&root, options, ok_heartbeat)
+			})
+		};
+
+		paused.wait();
+		fs::write(root.path().join("after.txt"), "ok").unwrap();
+		super::invalidate_path(&root.path().join("after.txt"));
+		resume.wait();
+
+		let inflight = scanner.join().unwrap().unwrap();
+		assert_eq!(inflight.cache_age_ms, 0);
+		assert_eq!(sorted_paths(&inflight.entries), ["before.txt"]);
+
+		let refreshed = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+		assert_eq!(
+			sorted_paths(&refreshed.entries),
+			["after.txt", "before.txt"],
+			"the invalidated in-flight scan must not repopulate the cache"
+		);
+
+		std::thread::sleep(Duration::from_millis(2));
+		let repopulated = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+		assert!(repopulated.cache_age_ms > 0, "scans after invalidation must cache again");
+		super::invalidate_path(root.path());
 	}
 
 	#[test]

--- a/docs/fs-scan-cache-architecture.md
+++ b/docs/fs-scan-cache-architecture.md
@@ -47,13 +47,15 @@ Global environment-overridable policy:
 - `FS_SCAN_CACHE_TTL_MS` — default `1000`
 - `FS_SCAN_EMPTY_RECHECK_MS` — default `200`
 - `FS_SCAN_CACHE_MAX_ENTRIES` — default `16`
+- `FS_SCAN_CACHE_MAX_BYTES` — default `67108864` (64 MiB of retained vector and path-string allocations)
 
 With caching enabled:
 
-- TTL `0` bypasses cache and returns a fresh scan with `cache_age_ms = 0`.
-- A hit younger than TTL clones the stored entries and reports its age.
-- An expired entry is removed and replaced by a fresh scan.
-- After insertion, entries above the configured maximum are evicted oldest-first by creation time.
+- TTL, entry limit, or byte limit `0` bypasses the cache and returns a fresh scan with `cache_age_ms = 0`.
+- A hit younger than TTL clones the stored entries outside the cache lock and reports its age. Cancellation is checked before and after copying.
+- Each lookup or insertion removes all expired entries. Idle processes retain at most the configured payload budget until the next cache operation; there is no background expiration thread.
+- Insertion evicts oldest entries until both limits are satisfied. The byte budget counts vector capacity and string capacity; it excludes allocator overhead, bounded map metadata, and caller-owned results.
+- An oversized scan or one already older than TTL is returned without retaining another copy. Concurrent scans cannot replace a newer scan with an older result.
 
 With caching disabled, collection scans fresh and neither reads nor populates the shared cache. It does not evict an existing cached entry for the same key.
 
@@ -90,6 +92,8 @@ The TUI `@`-mention autocomplete opts into cached `fuzzyFind`. Coding-agent's gr
 - with no path, clears all entries
 - with a path, removes every entry whose cached root is a prefix of the target
 
+Invalidation also prevents scans already in flight from repopulating the cache. A path-specific invalidation conservatively prevents admission of other concurrent scans, while preserving existing unrelated entries.
+
 Relative paths resolve against cwd. Invalidation canonicalizes the target; when it no longer exists, it attempts to canonicalize the parent and reattach the filename. This supports create, delete, and rename invalidation.
 
 Coding-agent helpers:
@@ -110,7 +114,11 @@ Current write, hashline, patch, replace, auto-repair, sloppy-edit, and ACP-bridg
 
 ## Boundaries
 
-- The `DashMap` cache is process-local and is not persisted.
+- The cache is process-local and is not persisted. A mutex makes admission, eviction, expiration, and invalidation atomic; reference-counted payloads allow copying outside that lock.
 - Entries are full owned scan results, not final tool results.
 - Cache hits clone the stored entry vector.
 - Sharing occurs only for the same canonical root and complete effective traversal options.
+
+## Measuring the budget
+
+Run `FS_SCAN_CACHE_TTL_MS=60000 cargo run -p pi-walker --example scan-cache-bench -- /path/to/tree` to measure scan allocation bytes, owned-vector copying, and cache hits across 16 traversal-option partitions. Set `FS_SCAN_CACHE_MAX_BYTES` to compare budgets. The example leaves the supplied tree unchanged; use an optimized Cargo profile for timing comparisons.

--- a/docs/natives-text-search-pipeline.md
+++ b/docs/natives-text-search-pipeline.md
@@ -175,6 +175,7 @@ Configuration is read from environment once:
 - `FS_SCAN_CACHE_TTL_MS`: cache TTL, default `1000`.
 - `FS_SCAN_EMPTY_RECHECK_MS`: cached-empty recheck age, default `200`.
 - `FS_SCAN_CACHE_MAX_ENTRIES`: maximum entries in the cache map, default `16`.
+- `FS_SCAN_CACHE_MAX_BYTES`: maximum retained vector and path-string allocation bytes, default `67108864` (64 MiB).
 - `PI_WALK_WORKERS`: walker Rayon pool size, default `4`.
 
 ### Cache state transitions

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed C++ language inference excluding CUDA header (`.cuh`) files ([#10782](https://github.com/can1357/oh-my-pi/pull/10782) by [@alphastorm](https://github.com/alphastorm)).
+### Fixed
+
+- Bounded filesystem scan cache memory and prevented stale scans from repopulating the cache after file changes.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded filesystem scan cache memory and prevented stale scans from repopulating the cache after file changes.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed
 
 - Fixed C++ language inference excluding CUDA header (`.cuh`) files ([#10782](https://github.com/can1357/oh-my-pi/pull/10782) by [@alphastorm](https://github.com/alphastorm)).
-### Fixed
-
-- Bounded filesystem scan cache memory and prevented stale scans from repopulating the cache after file changes.
 
 ## [18.1.9] - 2026-09-04
 


### PR DESCRIPTION
## What

The scan cache has a configurable 64 MiB payload budget alongside its 16-entry cap. Expired entries are swept on access, oversized scans bypass retention, and invalidation prevents stale in-flight scans from repopulating the cache. Callers still receive independently mutable vectors; copying happens outside the cache lock.

## Why

An entry-count limit alone does not bound retained bytes, and invalidation can race an in-flight scan.

## Testing

- [x] Six new cache regressions, rebuilt native addon, 60 native tests, `bun run check:rs`, and independent source review.
- [x] Full Rust run: 2,762 pass, six failures, six skips. Five failures reproduce on baseline; one shell timeout did not reproduce in baseline/changed focused comparisons. Doctests were not reached.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
