### PR TITLE
docs: clarify SDK runtime and lazy resource reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Unless user tells you exactly what to write:
 
 - No `any` unless absolutely necessary.
 - **NEVER use `ReturnType<>`** — use the actual type name.
-- **NEVER use inline imports** — no `await import()`, no `import("pkg").Type` in type positions, no dynamic type imports. Always top-level.
+- **Imports**: keep type imports and ordinary module dependencies top-level; never use `import("pkg").Type` in type positions. Runtime `import()` is allowed at deliberate lazy-loading and optional-dependency boundaries, such as CLI dispatch and provider loaders, so unused subsystems do not increase startup cost.
 - Check `node_modules` for external API types instead of guessing.
 - **Barrel exports**: prefer `export * from "./module"` over named re-exports, including `export type { ... } from`. In pure `index.ts` barrels, use star re-exports even for single-specifier cases. If stars create ambiguity, remove the redundant export path; do not keep duplicates.
 - **Class privacy**: use ES `#private` fields; leave externally accessible members bare. **No `private`/`protected`/`public` keyword on fields or methods**, except on **constructor parameter properties** where TypeScript requires it (e.g. `constructor(private readonly session: ToolSession)`).

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Inside `pi-natives`, the per-module breakdown (glue and tests omitted):
 
 ## Four entry points: _interactive_, _one-shot_, RPC, and ACP.
 
-Same engine, four wrappers. `omp` runs the TUI. `omp -p` answers a single prompt and exits. The Node SDK embeds the session in your process. `omp --mode rpc` and `omp acp` hand the wheel to another program over stdio.
+Same engine, four wrappers. `omp` runs the TUI. `omp -p` answers a single prompt and exits. The Bun SDK embeds the session in your process. `omp --mode rpc` and `omp acp` hand the wheel to another program over stdio.
 
 ### Interactive — when in doubt, the agent asks
 
@@ -503,11 +503,11 @@ The same prompt cards surface over ACP, so editors get the picker without writin
 
 ![omp TUI showing a multi-select question from the ask tool.](assets/ask.webp)
 
-### SDK — embed in Node
+### SDK — embed in Bun
 
 `@oh-my-pi/pi-coding-agent`
 
-Node and TypeScript hosts pull the engine in directly. The package exposes `ModelRegistry`, `SessionManager`, `createAgentSession`, and `discoverAuthStorage`; the session emits typed events you subscribe to.
+Your Bun process can import the engine directly from JavaScript or TypeScript. The package exposes `ModelRegistry`, `SessionManager`, `createAgentSession`, and `discoverAuthStorage`; the session emits typed events you subscribe to. Requires Bun 1.3.14 or newer.
 
 ```ts
 import {
@@ -533,7 +533,7 @@ await session.prompt("list .ts files");
 
 `omp --mode rpc`
 
-For non-Node embedders, or when you want process isolation. NDJSON commands in, response and event frames out. `--mode rpc-ui` adds tool cards, selectors, and dialogs as `extension_ui_request` frames the host must answer.
+Use RPC from other runtimes, including Node, or when you want process isolation. NDJSON commands in, response and event frames out. `--mode rpc-ui` adds tool cards, selectors, and dialogs as `extension_ui_request` frames the host must answer.
 
 ```
 $ omp --mode rpc --no-session

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3846,7 +3846,7 @@ export const SETTINGS_SCHEMA = {
 			group: "LSP",
 			label: "Shared Language Servers",
 			description:
-				"Share one language server per project across omp instances via the daemon broker (falls back to private servers when unavailable)",
+				"Reuse idle language servers across omp instances for the same project. Concurrent sessions use separate servers; falls back to private servers when the daemon is unavailable.",
 		},
 	},
 


### PR DESCRIPTION
## What

Document Bun ≥1.3.14 for SDK embedding, deliberate runtime imports at lazy-loading boundaries, and idle LSP reuse with separate servers for concurrent sessions. These descriptions now match the implementation.

## Why

The documented import, runtime, and reuse rules did not match the implemented contracts.

## Testing

- [x] Verified provider/CLI loaders, SDK engines/docs, and mux allocation/fallback paths.
- [x] Coding-agent package check and independent documentation review passed.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
