### PR TITLE
fix(tui): evict retired Kitty images from terminal memory

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Inline image limits now bound Kitty graphics retained from earlier frames and fullscreen overlays; older scrollback images are evicted until replayed.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -260,10 +260,13 @@ export class ImageBudget {
 		this.#stablePass = stable;
 		this.#surface = altScreen ? "alt" : "screen";
 		this.#split = altScreen ? this.#altSplit : this.#screenSplit;
-		// The alternate buffer holds a frame only while it is the current surface:
-		// TUI#doRender routes every alt-buffer owner (fullscreen overlay, resize
-		// borrow) away from the normal-screen paths, so composing for the screen
-		// means nothing stands on alt to protect.
+		// Composing for the screen means the alternate buffer holds no frame to
+		// protect: live renders reach the normal-screen paths only when
+		// TUI#doRender has ruled out both alt-buffer owners, and the one caller
+		// outside that dispatch — the shutdown history flush — writes `?1049l`
+		// first. Note that leaving alt mode is not the same as unstacking a
+		// fullscreen overlay: the flush must exclude one that is still stacked
+		// from the pass itself, which is that caller's job, not this line's.
 		if (!altScreen) this.#liveIds.alt.clear();
 		this.#applyingReset = !stable && this.#cap > 0 && this.#split.planned > this.#split.onTerminal;
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -87,6 +87,14 @@ function newSurfaceSplit(): SurfaceSplit {
 	return { onTerminal: 0, planned: 0, lastTotal: 0, suppressedIds: new Set() };
 }
 
+/** Return a split to "nothing has been painted on this surface yet", in place. */
+function resetSurfaceSplit(split: SurfaceSplit): void {
+	split.onTerminal = 0;
+	split.planned = 0;
+	split.lastTotal = 0;
+	split.suppressedIds = new Set();
+}
+
 let nextImageBudgetSeed = Math.floor(Math.random() * 0xffffff);
 function nextImageIdSeed(): number {
 	nextImageBudgetSeed = (nextImageBudgetSeed + 0x10000) & 0xffffff;
@@ -216,6 +224,21 @@ export class ImageBudget {
 		const id = this.#nextId;
 		this.#nextId = (this.#nextId + 1) & 0xffffff || 1;
 		return id;
+	}
+
+	/**
+	 * Start an alternate-buffer lifecycle. Call once per `?1049h`, before the
+	 * first pass of the fullscreen overlay or resize borrow that owns the buffer.
+	 *
+	 * The alt split is a claim about the frame standing on that surface, and
+	 * `?1049h` hands over a cleared one: the previous occupant's threshold would
+	 * suppress this buffer's leading images against a frame that no longer
+	 * exists, painting them as text until a corrective render lands. Passes
+	 * *within* one lifecycle must keep sharing the split — that is what lets an
+	 * over-cap discovery pass converge before the frame is emitted.
+	 */
+	beginAltScreenLifecycle(): void {
+		resetSurfaceSplit(this.#altSplit);
 	}
 
 	/**

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -122,6 +122,13 @@ function nextImageIdSeed(): number {
  * bounded across passes. Evicting retired graphics removes their scrollback
  * placements; a later replay can render or demote those images again.
  *
+ * `cap` bounds one surface's live images, not the terminal's whole store. A
+ * fullscreen overlay's frame and the normal screen standing behind it are both
+ * on the terminal, and neither may delete the other's graphics — see
+ * {@link limitResidentImages} — so while a modal is up the store legitimately
+ * holds up to `cap` per surface. Read `cap` as "how many images one frame shows
+ * as graphics", not as a hard residency ceiling.
+ *
  * `cap <= 0` disables budgeting: every image stays a live graphic.
  */
 export class ImageBudget {
@@ -134,6 +141,12 @@ export class ImageBudget {
 	#passIds: number[] = [];
 	/** Per-id suppression decision from the first observation in this pass. */
 	#passSuppression = new Map<number, boolean>();
+	/**
+	 * Display index each observation was decided at, so {@link #passShowsLive}
+	 * can re-check it against a reconciled threshold without scanning
+	 * {@link #passIds} once per image.
+	 */
+	#passIndex = new Map<number, number>();
 	/** Live/text split of the normal screen. */
 	#screenSplit = newSurfaceSplit();
 	/** Live/text split of the alternate buffer (fullscreen overlay, resize borrow). */
@@ -146,6 +159,12 @@ export class ImageBudget {
 	 */
 	#applyingReset = false;
 	#purgeIds: number[] = [];
+	/**
+	 * Deletions that belong to a pending destructive reset, kept out of
+	 * {@link #purgeIds} so only that reset's own repaint can emit them. See
+	 * {@link forgetTransmitted}.
+	 */
+	#resetPurgeIds: number[] = [];
 	/** Image ids whose data is believed to be loaded in the terminal's store. */
 	#transmitted = new Set<number>();
 	/** Transmit sequences (full base64) to write once, before this frame's placements. */
@@ -257,6 +276,7 @@ export class ImageBudget {
 	beginPass(stable = false, altScreen = false): void {
 		this.#passIds.length = 0;
 		this.#passSuppression.clear();
+		this.#passIndex.clear();
 		this.#stablePass = stable;
 		this.#surface = altScreen ? "alt" : "screen";
 		this.#split = altScreen ? this.#altSplit : this.#screenSplit;
@@ -293,6 +313,7 @@ export class ImageBudget {
 		this.#passIds.push(imageId);
 		const suppressed = this.#cap > 0 && index < this.#split.planned;
 		this.#passSuppression.set(imageId, suppressed);
+		this.#passIndex.set(imageId, index);
 		if (suppressed) this.#forgetKeyForId(imageId);
 		return suppressed;
 	}
@@ -332,12 +353,34 @@ export class ImageBudget {
 	 * the next pass on the *other* surface knows what it may not destroy.
 	 */
 	limitResidentImages(): void {
-		this.#liveIds[this.#surface] = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
+		this.#liveIds[this.#surface] = new Set(this.#passIds.filter(id => this.#passShowsLive(id)));
 		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
 		for (const id of this.#transmitted) {
 			if (this.#transmitted.size <= this.#cap) break;
 			this.#retire(id);
 		}
+	}
+
+	/**
+	 * Whether this pass leaves `imageId` on its surface as a live graphic.
+	 *
+	 * Not simply "was not suppressed". A pass decides suppression from the
+	 * threshold standing at {@link beginPass}, and {@link endPass} may then
+	 * reconcile that threshold *downwards* — the frame is emitted with a text
+	 * fallback the very next frame will replace with the graphic again. Reading
+	 * such a decision as retirement would delete an image the surface is about to
+	 * show, and `d=I` takes placements no repaint can restore. So a suppression
+	 * the reconcile has since undercut counts as live.
+	 */
+	#passShowsLive(imageId: number): boolean {
+		const suppressed = this.#passSuppression.get(imageId);
+		if (suppressed === undefined) return false;
+		if (!suppressed) return true;
+		// Absent (a `stable` pass replays the committed split rather than deriving
+		// an order) counts as live, so an unknown decision never authorises a
+		// delete.
+		const index = this.#passIndex.get(imageId);
+		return index === undefined || index >= this.#split.planned;
 	}
 
 	/**
@@ -352,7 +395,7 @@ export class ImageBudget {
 	 * surface this pass is not repainting does. Returns whether it was retired.
 	 */
 	#retire(imageId: number): boolean {
-		if (this.#passSuppression.get(imageId) === false) return false;
+		if (this.#passShowsLive(imageId)) return false;
 		for (const surface of SURFACES) {
 			if (surface !== this.#surface && this.#liveIds[surface].has(imageId)) return false;
 		}
@@ -363,6 +406,17 @@ export class ImageBudget {
 		this.#deletePlacementState(imageId);
 		this.#forgetKeyForId(imageId);
 		return true;
+	}
+
+	/**
+	 * Image ids a destructive reset must delete explicitly, alongside its `d=A`.
+	 * Emit only from that reset's repaint; clears the queue.
+	 */
+	takeResetPurgeIds(): readonly number[] {
+		if (this.#resetPurgeIds.length === 0) return EMPTY_IDS;
+		const ids = this.#resetPurgeIds;
+		this.#resetPurgeIds = [];
+		return ids;
 	}
 
 	/** Image ids to delete from the terminal this frame; clears the pending set. */
@@ -379,6 +433,7 @@ export class ImageBudget {
 		const ids = [...this.#transmitted];
 		this.#transmitted.clear();
 		this.#purgeIds = [];
+		this.#resetPurgeIds = [];
 		this.#pendingTransmits.clear();
 		this.#keyToId.clear();
 		this.#idToKey.clear();
@@ -558,8 +613,17 @@ export class ImageBudget {
 	forgetTransmitted(): void {
 		if (this.#transmitted.size === 0 && this.#pendingTransmits.size === 0) return;
 		for (const id of this.#transmitted) {
-			if (!this.#pendingTransmits.has(id)) this.#purgeIds.push(id);
+			if (!this.#pendingTransmits.has(id)) this.#resetPurgeIds.push(id);
 		}
+		// The ids go to #resetPurgeIds, drained only by the destructive repaint
+		// itself — never to #purgeIds, which any frame drains. That is how a
+		// deletion used to ride out on an alternate-buffer frame and leave the
+		// normal screen blank with no repaint left to restore it.
+		//
+		// `d=A` alone is not enough to skip these: Kitty excludes *virtual*
+		// placements from it, and erasing placeholder text does not remove the
+		// prototype either. Forgetting drops the id from tracking, so without an
+		// explicit `d=I` no later sweep can ever find that placement again.
 		this.#transmitted.clear();
 		this.#pendingTransmits.clear();
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -564,7 +564,20 @@ export class ImageBudget {
 		this.#pendingTransmits.clear();
 	}
 
+	/**
+	 * Release `id`'s stable key so a component recreated under it gets a fresh id
+	 * — but only once the terminal no longer holds `id`'s data, because a key must
+	 * never resolve to an id whose graphic is gone.
+	 *
+	 * Key lifetime follows residency, not the live/text split. The two usually
+	 * agree: an image shown as text has had its graphic purged. They diverge when
+	 * {@link #retire} refuses, which leaves a suppressed image resident on another
+	 * surface — and releasing a resident id's key orphans it. The recreation mints
+	 * a new id, nothing observes the old one again, and the next pass retires it,
+	 * deleting every placement it ever made including scrollback copies.
+	 */
 	#forgetKeyForId(id: number): void {
+		if (this.#transmitted.has(id)) return;
 		const key = this.#idToKey.get(id);
 		if (key === undefined) return;
 		this.#idToKey.delete(id);

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -121,6 +121,13 @@ export class ImageBudget {
 	// full, correctly-ordered walk.
 	#suppressedIds = new Set<number>();
 	/**
+	 * Image ids rendered as live graphics in the last frame painted on the normal
+	 * screen. A fullscreen overlay borrows the alternate buffer without walking
+	 * that frame, so its pass would otherwise report every normal-buffer image as
+	 * retired; see {@link limitResidentImages}.
+	 */
+	#screenLiveIds = new Set<number>();
+	/**
 	 * Per-image direct-placement emit state: source pixel geometry for the
 	 * renderer's clipped source rectangle, plus the placement-id epoch (see
 	 * {@link resolvePlacementEmit}). Entries deliberately live as long as the
@@ -247,16 +254,29 @@ export class ImageBudget {
 		// passes replay this per id (see #stablePass) instead of re-deriving it
 		// from a reversed, tail-only walk.
 		this.#suppressedIds = new Set(this.#passIds.slice(0, this.#onTerminal));
-		if (!retry) this.#limitResidentImages();
 		return retry;
 	}
 
-	#limitResidentImages(): void {
-		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
+	/**
+	 * Bound the terminal's image store to `cap` once the frame's complete image
+	 * set is known — the renderer calls this at emit time, not at
+	 * {@link endPass}, because overlays composite into the window after the pass
+	 * closes and their {@link observe} calls land in the same pass record.
+	 *
+	 * Eviction removes the image's scrollback placements too, and a frame diff
+	 * only rewrites rows whose text changed, so an image still shown on the
+	 * screen can never be a candidate. `altScreen` marks a frame painted on the
+	 * alternate buffer: the normal screen keeps its placements standing behind
+	 * the modal and is restored verbatim on exit, so that frame's live set is
+	 * not authoritative for the normal buffer and merely adds to it.
+	 */
+	limitResidentImages(altScreen: boolean): void {
 		const liveIds = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
+		if (!altScreen) this.#screenLiveIds = liveIds;
+		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
 		for (const id of this.#transmitted) {
 			if (this.#transmitted.size <= this.#cap) break;
-			if (liveIds.has(id)) continue;
+			if (liveIds.has(id) || this.#screenLiveIds.has(id)) continue;
 			if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
 			this.#transmitted.delete(id);
 			this.#deletePlacementState(id);
@@ -283,6 +303,7 @@ export class ImageBudget {
 		this.#idToKey.clear();
 		this.#placementState.clear();
 		this.#watchedPlacements.clear();
+		this.#screenLiveIds.clear();
 		return ids;
 	}
 

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -76,6 +76,9 @@ function nextImageIdSeed(): number {
  * rewritten) plus an explicit graphics purge of the demoted ids. {@link Image}
  * reports display order via {@link observe}; when that reveals a stricter split,
  * the TUI repeats the pass before emitting its terminal frame.
+ * Retired frames no longer observe their images, so the resident store is also
+ * bounded across passes. Evicting retired graphics removes their scrollback
+ * placements; a later replay can render or demote those images again.
  *
  * `cap <= 0` disables budgeting: every image stays a live graphic.
  */
@@ -155,7 +158,7 @@ export class ImageBudget {
 		const next = normalizeCap(cap);
 		if (next === this.#cap) return;
 		this.#cap = next;
-		this.#reconcile(this.#lastTotal);
+		if (!this.#reconcile(this.#lastTotal)) this.#requestRender();
 	}
 
 	/**
@@ -244,7 +247,21 @@ export class ImageBudget {
 		// passes replay this per id (see #stablePass) instead of re-deriving it
 		// from a reversed, tail-only walk.
 		this.#suppressedIds = new Set(this.#passIds.slice(0, this.#onTerminal));
+		if (!retry) this.#limitResidentImages();
 		return retry;
+	}
+
+	#limitResidentImages(): void {
+		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
+		const liveIds = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
+		for (const id of this.#transmitted) {
+			if (this.#transmitted.size <= this.#cap) break;
+			if (liveIds.has(id)) continue;
+			if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
+			this.#transmitted.delete(id);
+			this.#deletePlacementState(id);
+			this.#forgetKeyForId(id);
+		}
 	}
 
 	/** Image ids to delete from the terminal this frame; clears the pending set. */
@@ -439,6 +456,9 @@ export class ImageBudget {
 	 */
 	forgetTransmitted(): void {
 		if (this.#transmitted.size === 0 && this.#pendingTransmits.size === 0) return;
+		for (const id of this.#transmitted) {
+			if (!this.#pendingTransmits.has(id)) this.#purgeIds.push(id);
+		}
 		this.#transmitted.clear();
 		this.#pendingTransmits.clear();
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -57,6 +57,36 @@ interface PlacementEmitState {
 	 */
 	cellsArchived: boolean;
 }
+
+/**
+ * The live/text split of one drawing surface. The normal screen and the
+ * alternate buffer hold separate frames with separate display orders, so each
+ * carries its own thresholds: a modal's split describes the modal, and applying
+ * it to the transcript would demote — and purge — images the modal never showed.
+ */
+interface SurfaceSplit {
+	/**
+	 * Suppress threshold reflected in the frame currently on this surface: images
+	 * at display indices `[0, onTerminal)` are shown as text there.
+	 */
+	onTerminal: number;
+	/** Suppress threshold the current/next render of this surface should apply. */
+	planned: number;
+	/** Images the last full pass on this surface observed. */
+	lastTotal: number;
+	/**
+	 * Image ids shown as text in the frame currently on this surface: the
+	 * display-order prefix [0, onTerminal) of its last full pass, snapshotted by
+	 * id so a partial pass reproduces the on-screen live/text split without a
+	 * full, correctly-ordered walk.
+	 */
+	suppressedIds: Set<number>;
+}
+
+function newSurfaceSplit(): SurfaceSplit {
+	return { onTerminal: 0, planned: 0, lastTotal: 0, suppressedIds: new Set() };
+}
+
 let nextImageBudgetSeed = Math.floor(Math.random() * 0xffffff);
 function nextImageIdSeed(): number {
 	nextImageBudgetSeed = (nextImageBudgetSeed + 0x10000) & 0xffffff;
@@ -92,19 +122,17 @@ export class ImageBudget {
 	#passIds: number[] = [];
 	/** Per-id suppression decision from the first observation in this pass. */
 	#passSuppression = new Map<number, boolean>();
-	/**
-	 * Suppress threshold reflected in the frame currently on the terminal: images
-	 * at display indices `[0, #onTerminal)` are shown as text there.
-	 */
-	#onTerminal = 0;
-	/** Suppress threshold the current/next render should apply. */
-	#planned = 0;
+	/** Live/text split of the normal screen. */
+	#screenSplit = newSurfaceSplit();
+	/** Live/text split of the alternate buffer (fullscreen overlay, resize borrow). */
+	#altSplit = newSurfaceSplit();
+	/** The split the in-flight pass reads and writes; selected by {@link beginPass}. */
+	#split = this.#screenSplit;
 	/**
 	 * True while the in-flight pass applies a stricter threshold than the terminal
 	 * shows — the demotion frame that must purge graphics and fully repaint.
 	 */
 	#applyingReset = false;
-	#lastTotal = 0;
 	#purgeIds: number[] = [];
 	/** Image ids whose data is believed to be loaded in the terminal's store. */
 	#transmitted = new Set<number>();
@@ -115,11 +143,6 @@ export class ImageBudget {
 	// tail, bottom-up. Such a pass cannot derive display order from observe()
 	// call order, so its suppression decisions replay the committed split below.
 	#stablePass = false;
-	// Image ids shown as text in the frame currently on the terminal: the
-	// display-order prefix [0, #onTerminal) of the last full pass, snapshotted by
-	// id so a partial pass reproduces the on-screen live/text split without a
-	// full, correctly-ordered walk.
-	#suppressedIds = new Set<number>();
 	/**
 	 * Image ids rendered as live graphics in the last frame painted on the normal
 	 * screen. A fullscreen overlay borrows the alternate buffer without walking
@@ -172,7 +195,7 @@ export class ImageBudget {
 		const next = normalizeCap(cap);
 		if (next === this.#cap) return;
 		this.#cap = next;
-		if (!this.#reconcile(this.#lastTotal)) this.#requestRender();
+		if (!this.#reconcile(this.#split.lastTotal)) this.#requestRender();
 	}
 
 	/**
@@ -203,16 +226,18 @@ export class ImageBudget {
 	 * call order, and the pass must NOT be closed with {@link endPass}.
 	 *
 	 * Pass `altScreen: true` when the frame is painted on the alternate buffer
-	 * (fullscreen overlay, resize borrow). The pass then walks only that buffer's
-	 * content while the normal screen keeps its placements, so its live set adds
-	 * to the recorded normal-screen one instead of replacing it.
+	 * (fullscreen overlay, resize borrow). The pass then reads and writes that
+	 * surface's own {@link SurfaceSplit} and its live set adds to the recorded
+	 * normal-screen one instead of replacing it, so a modal's threshold never
+	 * reaches the transcript standing behind it.
 	 */
 	beginPass(stable = false, altScreen = false): void {
 		this.#passIds.length = 0;
 		this.#passSuppression.clear();
 		this.#stablePass = stable;
 		this.#altScreenPass = altScreen;
-		this.#applyingReset = !stable && this.#cap > 0 && this.#planned > this.#onTerminal;
+		this.#split = altScreen ? this.#altSplit : this.#screenSplit;
+		this.#applyingReset = !stable && this.#cap > 0 && this.#split.planned > this.#split.onTerminal;
 	}
 
 	/**
@@ -221,21 +246,21 @@ export class ImageBudget {
 	 * on a cache hit, so the image keeps its display-order slot.
 	 *
 	 * During a `stable` pass ({@link beginPass}) the call order and visible subset
-	 * are not authoritative, so the decision is the committed on-terminal split
-	 * (`#suppressedIds`) keyed by id — order- and partiality-independent.
+	 * are not authoritative, so the decision is the surface's committed
+	 * on-terminal split, keyed by id — order- and partiality-independent.
 	 */
 	observe(imageId: number): boolean {
 		const existing = this.#passSuppression.get(imageId);
 		if (existing !== undefined) return existing;
 		if (this.#stablePass) {
-			const suppressed = this.#cap > 0 && this.#suppressedIds.has(imageId);
+			const suppressed = this.#cap > 0 && this.#split.suppressedIds.has(imageId);
 			this.#passSuppression.set(imageId, suppressed);
 			if (suppressed) this.#forgetKeyForId(imageId);
 			return suppressed;
 		}
 		const index = this.#passIds.length;
 		this.#passIds.push(imageId);
-		const suppressed = this.#cap > 0 && index < this.#planned;
+		const suppressed = this.#cap > 0 && index < this.#split.planned;
 		this.#passSuppression.set(imageId, suppressed);
 		if (suppressed) this.#forgetKeyForId(imageId);
 		return suppressed;
@@ -247,9 +272,10 @@ export class ImageBudget {
 	 */
 	endPass(): boolean {
 		const total = this.#passIds.length;
-		this.#lastTotal = total;
+		const split = this.#split;
+		split.lastTotal = total;
 		if (this.#applyingReset) {
-			for (let i = this.#onTerminal; i < this.#planned && i < total; i++) {
+			for (let i = split.onTerminal; i < split.planned && i < total; i++) {
 				const id = this.#passIds[i];
 				// The modal renders its own copy as text, but deleting the graphic
 				// would take the normal buffer's placement of the same id with it —
@@ -262,15 +288,15 @@ export class ImageBudget {
 				this.#deletePlacementState(id);
 				this.#forgetKeyForId(id);
 			}
-			this.#onTerminal = this.#planned;
+			split.onTerminal = split.planned;
 			this.#applyingReset = false;
 		}
 		const retry = this.#reconcile(total);
 		// Snapshot the committed display-order suppression by id: the prefix
-		// [0, #onTerminal) is what the terminal currently shows as text. Partial
+		// [0, onTerminal) is what this surface currently shows as text. Partial
 		// passes replay this per id (see #stablePass) instead of re-deriving it
 		// from a reversed, tail-only walk.
-		this.#suppressedIds = new Set(this.#passIds.slice(0, this.#onTerminal));
+		split.suppressedIds = new Set(this.#passIds.slice(0, split.onTerminal));
 		return retry;
 	}
 
@@ -459,18 +485,17 @@ export class ImageBudget {
 	}
 
 	/**
-	 * True when the budget has nothing in flight: no live images observed on
-	 * the last pass, no queued transmits, no pending purges, and no stricter
-	 * threshold left to apply. A component-scoped frame may skip the observe
-	 * pass only then — a partial tree walk would under-count display order.
+	 * True when the budget has nothing in flight on either surface: no live images
+	 * observed on the last pass, no queued transmits, no pending purges, and no
+	 * stricter threshold left to apply. A component-scoped frame may skip the
+	 * observe pass only then — a partial tree walk would under-count display order.
 	 */
 	get quiescent(): boolean {
-		return (
-			this.#lastTotal === 0 &&
-			this.#pendingTransmits.size === 0 &&
-			this.#purgeIds.length === 0 &&
-			this.#planned === this.#onTerminal
-		);
+		if (this.#pendingTransmits.size > 0 || this.#purgeIds.length > 0) return false;
+		for (const split of [this.#screenSplit, this.#altSplit]) {
+			if (split.lastTotal !== 0 || split.planned !== split.onTerminal) return false;
+		}
+		return true;
 	}
 
 	/** Transmit sequences to write before this frame's placements; clears the queue. */
@@ -506,21 +531,22 @@ export class ImageBudget {
 	}
 
 	#reconcile(total: number): boolean {
+		const split = this.#split;
 		const desired = this.#cap > 0 ? Math.max(0, total - this.#cap) : 0;
-		if (desired === this.#planned) {
+		if (desired === split.planned) {
 			// Budget relaxed without a stricter frame (cap raised or images
 			// removed): surviving graphics are untouched and re-exposed rows
 			// repaint normally, so just track the looser threshold.
-			if (this.#planned < this.#onTerminal) this.#onTerminal = this.#planned;
+			if (split.planned < split.onTerminal) split.onTerminal = split.planned;
 			return false;
 		}
-		const retry = desired > this.#onTerminal;
-		this.#planned = desired;
+		const retry = desired > split.onTerminal;
+		split.planned = desired;
 		// More images must be demoted than the terminal shows: schedule the purge +
 		// full-redraw frame. Fewer: no ghosts to clear, so just catch the tracking
 		// up — a normal repaint re-exposes the un-demoted images. Either way a
 		// render is needed to apply the new threshold.
-		if (desired <= this.#onTerminal) this.#onTerminal = desired;
+		if (desired <= split.onTerminal) split.onTerminal = desired;
 		this.#requestRender();
 		return retry;
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -58,6 +58,10 @@ interface PlacementEmitState {
 	cellsArchived: boolean;
 }
 
+/** A surface the renderer paints frames on. */
+type Surface = "screen" | "alt";
+const SURFACES: readonly Surface[] = ["screen", "alt"];
+
 /**
  * The live/text split of one drawing surface. The normal screen and the
  * alternate buffer hold separate frames with separate display orders, so each
@@ -151,20 +155,15 @@ export class ImageBudget {
 	// tail, bottom-up. Such a pass cannot derive display order from observe()
 	// call order, so its suppression decisions replay the committed split below.
 	#stablePass = false;
+	/** The surface the in-flight pass composes for; selected by {@link beginPass}. */
+	#surface: Surface = "screen";
 	/**
-	 * Image ids rendered as live graphics in the last frame painted on the normal
-	 * screen. A fullscreen overlay borrows the alternate buffer without walking
-	 * that frame, so its pass would otherwise report every normal-buffer image as
-	 * retired; see {@link limitResidentImages}.
+	 * Image ids rendered as live graphics by the frame standing on each surface.
+	 * A pass walks one surface, so the other's entry is what stops {@link #retire}
+	 * from deleting a graphic that is merely out of view — the transcript behind a
+	 * fullscreen overlay keeps its placements and is restored from cache on exit.
 	 */
-	#screenLiveIds = new Set<number>();
-	/**
-	 * True while the in-flight pass composes a frame for the alternate buffer.
-	 * Its live/text split describes the modal only: the normal screen keeps its
-	 * own placements standing behind it, so neither the demotion purge nor the
-	 * store bound may destroy a graphic {@link #screenLiveIds} still shows.
-	 */
-	#altScreenPass = false;
+	#liveIds: Record<Surface, Set<number>> = { screen: new Set(), alt: new Set() };
 	/**
 	 * Per-image direct-placement emit state: source pixel geometry for the
 	 * renderer's clipped source rectangle, plus the placement-id epoch (see
@@ -239,6 +238,7 @@ export class ImageBudget {
 	 */
 	beginAltScreenLifecycle(): void {
 		resetSurfaceSplit(this.#altSplit);
+		this.#liveIds.alt.clear();
 	}
 
 	/**
@@ -258,8 +258,13 @@ export class ImageBudget {
 		this.#passIds.length = 0;
 		this.#passSuppression.clear();
 		this.#stablePass = stable;
-		this.#altScreenPass = altScreen;
+		this.#surface = altScreen ? "alt" : "screen";
 		this.#split = altScreen ? this.#altSplit : this.#screenSplit;
+		// The alternate buffer holds a frame only while it is the current surface:
+		// TUI#doRender routes every alt-buffer owner (fullscreen overlay, resize
+		// borrow) away from the normal-screen paths, so composing for the screen
+		// means nothing stands on alt to protect.
+		if (!altScreen) this.#liveIds.alt.clear();
 		this.#applyingReset = !stable && this.#cap > 0 && this.#split.planned > this.#split.onTerminal;
 	}
 
@@ -298,18 +303,10 @@ export class ImageBudget {
 		const split = this.#split;
 		split.lastTotal = total;
 		if (this.#applyingReset) {
+			// This frame replaced these with their text fallback, so their graphics
+			// are retired as far as this surface is concerned.
 			for (let i = split.onTerminal; i < split.planned && i < total; i++) {
-				const id = this.#passIds[i];
-				// The modal renders its own copy as text, but deleting the graphic
-				// would take the normal buffer's placement of the same id with it —
-				// and that frame is restored from cache, so its row is never rewritten.
-				if (this.#altScreenPass && this.#screenLiveIds.has(id)) continue;
-				// A transmit queued by a discarded discovery pass never reached
-				// the terminal, so cancel it instead of transmitting then purging.
-				if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
-				this.#transmitted.delete(id);
-				this.#deletePlacementState(id);
-				this.#forgetKeyForId(id);
+				this.#retire(this.#passIds[i]);
 			}
 			split.onTerminal = split.planned;
 			this.#applyingReset = false;
@@ -328,23 +325,41 @@ export class ImageBudget {
 	 * retires the graphics this frame replaced with text; this sweeps the ones no
 	 * frame shows any more — images the pass simply stopped observing.
 	 *
-	 * Eviction removes the image's scrollback placements too, and a frame diff
-	 * only rewrites rows whose text changed, so an image still shown on the
-	 * screen can never be a candidate — on the normal buffer or, while an
-	 * alt-screen pass ({@link beginPass}) covers it, behind the modal.
+	 * Also records what this frame leaves standing on its surface, which is how
+	 * the next pass on the *other* surface knows what it may not destroy.
 	 */
 	limitResidentImages(): void {
-		const liveIds = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
-		if (!this.#altScreenPass) this.#screenLiveIds = liveIds;
+		this.#liveIds[this.#surface] = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
 		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
 		for (const id of this.#transmitted) {
 			if (this.#transmitted.size <= this.#cap) break;
-			if (liveIds.has(id) || this.#screenLiveIds.has(id)) continue;
-			if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
-			this.#transmitted.delete(id);
-			this.#deletePlacementState(id);
-			this.#forgetKeyForId(id);
+			this.#retire(id);
 		}
+	}
+
+	/**
+	 * Drop `imageId` from the terminal's image store: queue its `d=I` (or cancel
+	 * a transmit that never went out) and forget its placement ledger and key.
+	 *
+	 * The single gate on every destruction path. `d=I` removes an image's
+	 * placements everywhere, scrollback included, and a frame diff only rewrites
+	 * rows whose text changed — so a graphic some standing frame still shows
+	 * cannot be repaired once deleted, and must never be a candidate. Refuses
+	 * when the in-flight pass renders the image live, or when the frame on any
+	 * surface this pass is not repainting does. Returns whether it was retired.
+	 */
+	#retire(imageId: number): boolean {
+		if (this.#passSuppression.get(imageId) === false) return false;
+		for (const surface of SURFACES) {
+			if (surface !== this.#surface && this.#liveIds[surface].has(imageId)) return false;
+		}
+		// A transmit queued by a discarded discovery pass never reached the
+		// terminal, so cancel it instead of transmitting then purging.
+		if (!this.#pendingTransmits.delete(imageId)) this.#purgeIds.push(imageId);
+		this.#transmitted.delete(imageId);
+		this.#deletePlacementState(imageId);
+		this.#forgetKeyForId(imageId);
+		return true;
 	}
 
 	/** Image ids to delete from the terminal this frame; clears the pending set. */
@@ -366,7 +381,7 @@ export class ImageBudget {
 		this.#idToKey.clear();
 		this.#placementState.clear();
 		this.#watchedPlacements.clear();
-		this.#screenLiveIds.clear();
+		for (const surface of SURFACES) this.#liveIds[surface].clear();
 		return ids;
 	}
 

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -128,6 +128,13 @@ export class ImageBudget {
 	 */
 	#screenLiveIds = new Set<number>();
 	/**
+	 * True while the in-flight pass composes a frame for the alternate buffer.
+	 * Its live/text split describes the modal only: the normal screen keeps its
+	 * own placements standing behind it, so neither the demotion purge nor the
+	 * store bound may destroy a graphic {@link #screenLiveIds} still shows.
+	 */
+	#altScreenPass = false;
+	/**
 	 * Per-image direct-placement emit state: source pixel geometry for the
 	 * renderer's clipped source rectangle, plus the placement-id epoch (see
 	 * {@link resolvePlacementEmit}). Entries deliberately live as long as the
@@ -194,11 +201,17 @@ export class ImageBudget {
 	 * whole tree in display order (the resize viewport fast path): {@link observe}
 	 * then replays the last committed per-id decision instead of one derived from
 	 * call order, and the pass must NOT be closed with {@link endPass}.
+	 *
+	 * Pass `altScreen: true` when the frame is painted on the alternate buffer
+	 * (fullscreen overlay, resize borrow). The pass then walks only that buffer's
+	 * content while the normal screen keeps its placements, so its live set adds
+	 * to the recorded normal-screen one instead of replacing it.
 	 */
-	beginPass(stable = false): void {
+	beginPass(stable = false, altScreen = false): void {
 		this.#passIds.length = 0;
 		this.#passSuppression.clear();
 		this.#stablePass = stable;
+		this.#altScreenPass = altScreen;
 		this.#applyingReset = !stable && this.#cap > 0 && this.#planned > this.#onTerminal;
 	}
 
@@ -238,6 +251,10 @@ export class ImageBudget {
 		if (this.#applyingReset) {
 			for (let i = this.#onTerminal; i < this.#planned && i < total; i++) {
 				const id = this.#passIds[i];
+				// The modal renders its own copy as text, but deleting the graphic
+				// would take the normal buffer's placement of the same id with it —
+				// and that frame is restored from cache, so its row is never rewritten.
+				if (this.#altScreenPass && this.#screenLiveIds.has(id)) continue;
 				// A transmit queued by a discarded discovery pass never reached
 				// the terminal, so cancel it instead of transmitting then purging.
 				if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
@@ -265,14 +282,12 @@ export class ImageBudget {
 	 *
 	 * Eviction removes the image's scrollback placements too, and a frame diff
 	 * only rewrites rows whose text changed, so an image still shown on the
-	 * screen can never be a candidate. `altScreen` marks a frame painted on the
-	 * alternate buffer: the normal screen keeps its placements standing behind
-	 * the modal and is restored verbatim on exit, so that frame's live set is
-	 * not authoritative for the normal buffer and merely adds to it.
+	 * screen can never be a candidate — on the normal buffer or, while an
+	 * alt-screen pass ({@link beginPass}) covers it, behind the modal.
 	 */
-	limitResidentImages(altScreen: boolean): void {
+	limitResidentImages(): void {
 		const liveIds = new Set(this.#passIds.filter(id => !this.#passSuppression.get(id)));
-		if (!altScreen) this.#screenLiveIds = liveIds;
+		if (!this.#altScreenPass) this.#screenLiveIds = liveIds;
 		if (this.#cap <= 0 || this.#transmitted.size <= this.#cap) return;
 		for (const id of this.#transmitted) {
 			if (this.#transmitted.size <= this.#cap) break;

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -275,10 +275,9 @@ export class ImageBudget {
 	}
 
 	/**
-	 * Bound the terminal's image store to `cap` once the frame's complete image
-	 * set is known — the renderer calls this at emit time, not at
-	 * {@link endPass}, because overlays composite into the window after the pass
-	 * closes and their {@link observe} calls land in the same pass record.
+	 * Bound the terminal's image store to `cap`. Demotion ({@link endPass}) already
+	 * retires the graphics this frame replaced with text; this sweeps the ones no
+	 * frame shows any more — images the pass simply stopped observing.
 	 *
 	 * Eviction removes the image's scrollback placements too, and a frame diff
 	 * only rewrites rows whose text changed, so an image still shown on the

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2610,12 +2610,12 @@ export class TUI extends Container {
 			buffer += encodeKittyDeleteAllImages();
 			this.#imageBudget.resetPlacementEpochs();
 		}
-		for (const sequence of this.#imageBudget.takeTransmits()) buffer += sequence;
 		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
 			for (const id of this.#imageBudget.takePurgeIds()) buffer += encodeKittyDeleteImage(id);
 		} else {
 			this.#imageBudget.takePurgeIds();
 		}
+		for (const sequence of this.#imageBudget.takeTransmits()) buffer += sequence;
 		// ED2 MUST precede ED3: tmux implements ED2 by scrolling the live screen
 		// into pane history (so cleared content stays reachable), so erasing
 		// history first would let ED2 refill it with a copy of the old screen —
@@ -2792,6 +2792,7 @@ export class TUI extends Container {
 			// repaint so no stale frame can become visible between writes.
 			if (this.#clearScrollbackOnNextRender) {
 				this.#pendingAltExit = exitSequence;
+				if (TERMINAL.imageProtocol === ImageProtocol.Kitty) this.#imageBudget.forgetTransmitted();
 			} else {
 				this.#noteAltBufferToggle();
 				this.terminal.write(exitSequence);
@@ -3139,7 +3140,11 @@ export class TUI extends Container {
 	#renderAltFrame(width: number, height: number): void {
 		// oxlint-disable-next-line unicorn/no-new-array -- alt-frame length preallocation
 		const base: string[] = new Array(Math.max(0, height)).fill("");
-		let lines = this.#compositeOverlaysIntoWindow(base, width, height);
+		let lines: string[];
+		do {
+			this.#imageBudget.beginPass();
+			lines = this.#compositeOverlaysIntoWindow(base, width, height);
+		} while (this.#imageBudget.endPass());
 		this.#extractCursorMarkers(lines);
 		lines = this.#prepareLinesArray(lines, width);
 		this.#emitAltFrame(lines, width, height);
@@ -3160,6 +3165,10 @@ export class TUI extends Container {
 		// ahead of its paint; without this, an image first shown inside a
 		// fullscreen overlay (e.g. the settings shape preview) would render as
 		// blank placeholder cells until the overlay closed.
+		const purgeIds = this.#imageBudget.takePurgeIds();
+		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
+			for (const id of purgeIds) this.terminal.write(encodeKittyDeleteImage(id));
+		}
 		const imageTransmits = this.#imageBudget.takeTransmits();
 		if (imageTransmits.length > 0) {
 			let transmitBuffer = "";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1391,6 +1391,7 @@ export class TUI extends Container {
 				this.#parkedViewportOffset = 0;
 			}
 			this.#noteAltBufferToggle();
+			this.#imageBudget.beginAltScreenLifecycle();
 			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementEnter()}`);
 		}
 		this.#resizeSettleTimer?.cancel();
@@ -2791,6 +2792,7 @@ export class TUI extends Container {
 			// fullscreen overlays (Ghostty/kitty/iTerm2).
 			this.#noteAltBufferToggle();
 			const mouseEnter = wantMouseTracking ? MOUSE_TRACKING_ON : "";
+			this.#imageBudget.beginAltScreenLifecycle();
 			this.terminal.write(`\x1b[?1049h${this.#keyboardEnhancementEnter()}${mouseEnter}`);
 			setAltScreenActive(true);
 			this.terminal.hideCursor();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1761,6 +1761,18 @@ export class TUI extends Container {
 		this.#paintEndSequence = enabled ? PAINT_END : PAINT_END_NO_SYNC;
 	}
 
+	/**
+	 * Retire every eligible history batch into native scrollback before quitting.
+	 *
+	 * The only frame path that deliberately does not composite overlays. Its
+	 * output is the transcript the shell prompt lands under, and it forces
+	 * commits that {@link #compositeOverlaysIntoWindow} otherwise relies on being
+	 * frozen while an overlay is up — so a modal painted here would leave debris
+	 * above the prompt and could reach native scrollback. `stop()` drops the
+	 * alternate buffer without unstacking the overlay, so leaving it in would also
+	 * charge a no-longer-painted modal's images against the cap and delete the
+	 * transcript's visible graphics on the way out.
+	 */
 	#flushHistoryBeforeStop(): void {
 		const provider = this.#frameProvider;
 		if (provider?.beginHistoryFlush === undefined) return;
@@ -1776,7 +1788,6 @@ export class TUI extends Container {
 				plan = provider.renderFrame({ columns: width, rows: height });
 				viewport = Array.from(plan.viewport);
 				if (viewport.length > height) viewport = viewport.slice(0, height);
-				viewport = this.#compositeVisibleOverlays(viewport, width, height);
 			} while (this.#imageBudget.endPass());
 			if (plan.history === undefined) return;
 			const acceptedBefore = this.#acceptedHistoryBatchId;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2562,6 +2562,9 @@ export class TUI extends Container {
 			while (viewport.length < height) viewport.push("");
 			viewport = this.#compositeOverlaysIntoWindow(viewport, width, height);
 		}
+		// Every image of this frame — overlays included — has now been observed,
+		// so the store bound can tell a retired graphic from a displayed one.
+		this.#imageBudget.limitResidentImages(false);
 		const history = offered !== undefined && offered.id > this.#acceptedHistoryBatchId ? offered : undefined;
 		if (offered !== undefined && offered.id <= this.#acceptedHistoryBatchId) provider?.acknowledgeHistory(offered.id);
 
@@ -3159,6 +3162,9 @@ export class TUI extends Container {
 		// oxlint-disable-next-line unicorn/no-new-array -- alt-frame length preallocation
 		const fitted: string[] = new Array(height);
 		for (let r = 0; r < height; r++) fitted[r] = lines[r] ?? "";
+		// Alt-buffer frame: the normal screen keeps its own placements behind this
+		// one and is restored verbatim on exit, so its images are not retired.
+		this.#imageBudget.limitResidentImages(true);
 		// Flush queued image-data transmits (`a=t`, no visible output) before the
 		// paint so id-keyed placements and placeholder cells composed into this
 		// frame resolve against loaded data. The normal-screen path flushes these

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1590,7 +1590,7 @@ export class TUI extends Container {
 		const provider = this.#frameProvider;
 		let rendered: readonly string[];
 		do {
-			this.#imageBudget.beginPass();
+			this.#imageBudget.beginPass(false, true);
 			rendered =
 				provider?.renderResizeFrame?.({ columns: width, rows: height }) ??
 				(provider ? provider.renderFrame({ columns: width, rows: height }).viewport : this.render(width));
@@ -2564,7 +2564,7 @@ export class TUI extends Container {
 		}
 		// Every image of this frame — overlays included — has now been observed,
 		// so the store bound can tell a retired graphic from a displayed one.
-		this.#imageBudget.limitResidentImages(false);
+		this.#imageBudget.limitResidentImages();
 		const history = offered !== undefined && offered.id > this.#acceptedHistoryBatchId ? offered : undefined;
 		if (offered !== undefined && offered.id <= this.#acceptedHistoryBatchId) provider?.acknowledgeHistory(offered.id);
 
@@ -3145,7 +3145,7 @@ export class TUI extends Container {
 		const base: string[] = new Array(Math.max(0, height)).fill("");
 		let lines: string[];
 		do {
-			this.#imageBudget.beginPass();
+			this.#imageBudget.beginPass(false, true);
 			lines = this.#compositeOverlaysIntoWindow(base, width, height);
 		} while (this.#imageBudget.endPass());
 		this.#extractCursorMarkers(lines);
@@ -3162,9 +3162,9 @@ export class TUI extends Container {
 		// oxlint-disable-next-line unicorn/no-new-array -- alt-frame length preallocation
 		const fitted: string[] = new Array(height);
 		for (let r = 0; r < height; r++) fitted[r] = lines[r] ?? "";
-		// Alt-buffer frame: the normal screen keeps its own placements behind this
-		// one and is restored verbatim on exit, so its images are not retired.
-		this.#imageBudget.limitResidentImages(true);
+		// The pass that composed this frame ran with `altScreen`, so the normal
+		// screen's own placements behind it are not treated as retired.
+		this.#imageBudget.limitResidentImages();
 		// Flush queued image-data transmits (`a=t`, no visible output) before the
 		// paint so id-keyed placements and placeholder cells composed into this
 		// frame resolve against loaded data. The normal-screen path flushes these

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1769,13 +1769,15 @@ export class TUI extends Container {
 		provider.beginHistoryFlush();
 		while (true) {
 			let plan: TerminalFramePlan;
+			let viewport: string[];
 			do {
 				this.#imageBudget.beginPass();
 				plan = provider.renderFrame({ columns: width, rows: height });
+				viewport = Array.from(plan.viewport);
+				if (viewport.length > height) viewport = viewport.slice(0, height);
+				viewport = this.#compositeVisibleOverlays(viewport, width, height);
 			} while (this.#imageBudget.endPass());
 			if (plan.history === undefined) return;
-			let viewport = Array.from(plan.viewport);
-			if (viewport.length > height) viewport = viewport.slice(0, height);
 			const acceptedBefore = this.#acceptedHistoryBatchId;
 			this.#emitPlanFrame(width, height, viewport, plan.history, provider);
 			if (plan.history.id > acceptedBefore && this.#acceptedHistoryBatchId === acceptedBefore) {
@@ -2294,6 +2296,19 @@ export class TUI extends Container {
 	 * frozen while an overlay is visible, so overlay pixels can never enter
 	 * native scrollback.
 	 */
+	/**
+	 * Composite the visible overlays onto a full-height copy of `viewport`, or
+	 * hand it back untouched when nothing is stacked. Callers run this inside
+	 * their image-budget pass so the frame's whole image set — transcript plus
+	 * modal — reaches one reconcile, instead of leaving the overlay's graphics
+	 * outside the cap for as long as it stays up.
+	 */
+	#compositeVisibleOverlays(viewport: string[], width: number, height: number): string[] {
+		if (this.#getTopmostVisibleOverlay() === undefined) return viewport;
+		while (viewport.length < height) viewport.push("");
+		return this.#compositeOverlaysIntoWindow(viewport, width, height);
+	}
+
 	#compositeOverlaysIntoWindow(window: string[], termWidth: number, termHeight: number): string[] {
 		const result = [...window];
 		for (const entry of this.overlayStack) {
@@ -2445,17 +2460,19 @@ export class TUI extends Container {
 		if (!provider || width <= 0 || height <= 0) return;
 		this.#debugNextWindowTop = 0;
 		let plan: TerminalFramePlan;
+		let viewport: string[];
 		do {
 			this.#imageBudget.beginPass();
 			plan = provider.renderFrame({ columns: width, rows: height });
+			viewport = Array.from(plan.viewport);
+			if (viewport.length > height) {
+				const message = `Frame provider returned ${viewport.length} rows for a ${height}-row viewport`;
+				if (Bun.env.NODE_ENV === "test" || Bun.env.NODE_ENV === "development") throw new Error(message);
+				logger.error("TUI layout contract violated", { rows: viewport.length, height });
+				viewport = viewport.slice(0, height);
+			}
+			viewport = this.#compositeVisibleOverlays(viewport, width, height);
 		} while (this.#imageBudget.endPass());
-		let viewport = Array.from(plan.viewport);
-		if (viewport.length > height) {
-			const message = `Frame provider returned ${viewport.length} rows for a ${height}-row viewport`;
-			if (Bun.env.NODE_ENV === "test" || Bun.env.NODE_ENV === "development") throw new Error(message);
-			logger.error("TUI layout contract violated", { rows: viewport.length, height });
-			viewport = viewport.slice(0, height);
-		}
 		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
 		this.#emitPlanFrame(width, height, viewport, plan.history, provider);
 	}
@@ -2557,13 +2574,11 @@ export class TUI extends Container {
 		offered: HistoryBatch | undefined,
 		provider: TerminalFrameProvider | undefined,
 	): void {
+		// Callers composite their overlays inside the budget pass, so `viewportRows`
+		// is already the complete frame. Bound the store here rather than at
+		// endPass(): this is the last point before the purge and transmit bytes go
+		// out, and it runs once per emitted frame instead of once per retry.
 		let viewport = viewportRows;
-		if (this.#getTopmostVisibleOverlay() !== undefined) {
-			while (viewport.length < height) viewport.push("");
-			viewport = this.#compositeOverlaysIntoWindow(viewport, width, height);
-		}
-		// Every image of this frame — overlays included — has now been observed,
-		// so the store bound can tell a retired graphic from a displayed one.
 		this.#imageBudget.limitResidentImages();
 		const history = offered !== undefined && offered.id > this.#acceptedHistoryBatchId ? offered : undefined;
 		if (offered !== undefined && offered.id <= this.#acceptedHistoryBatchId) provider?.acknowledgeHistory(offered.id);
@@ -2839,14 +2854,15 @@ export class TUI extends Container {
 	 * mutable viewport. Nothing is ever appended to terminal history.
 	 */
 	#renderChildrenFrame(width: number, height: number): void {
-		let composed: readonly string[];
+		let viewport: string[];
 		do {
 			this.#imageBudget.beginPass();
-			composed = this.render(width);
+			const composed = this.render(width);
+			this.#debugNextWindowTop = Math.max(0, composed.length - height);
+			viewport = composed.length > height ? composed.slice(composed.length - height) : Array.from(composed);
+			viewport = this.#compositeVisibleOverlays(viewport, width, height);
 		} while (this.#imageBudget.endPass());
 		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
-		this.#debugNextWindowTop = Math.max(0, composed.length - height);
-		const viewport = composed.length > height ? composed.slice(composed.length - height) : Array.from(composed);
 		this.#emitPlanFrame(width, height, viewport, undefined, undefined);
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1971,7 +1971,6 @@ export class TUI extends Container {
 	#prepareForcedRender(clearScrollback: boolean): void {
 		if (clearScrollback && !this.#clearScrollbackOnNextRender) {
 			this.#frameProvider?.beginHistoryReplay?.();
-			if (TERMINAL.imageProtocol === ImageProtocol.Kitty) this.#imageBudget.forgetTransmitted();
 		}
 		this.#clearScrollbackOnNextRender ||= clearScrollback;
 		this.#forceViewportRepaintOnNextRender = true;
@@ -2638,6 +2637,11 @@ export class TUI extends Container {
 			// explicitly destructive, so remove every placement—not only the ones
 			// this TUI tracked—then resend images composed for the clean replay.
 			buffer += encodeKittyDeleteAllImages();
+			// `d=A` spares virtual placements, and erasing the placeholder text it
+			// leaves behind does not remove the prototype either. The ids this
+			// reset forgot are named explicitly here — their tracking is gone, so
+			// nothing downstream could find them again.
+			for (const id of this.#imageBudget.takeResetPurgeIds()) buffer += encodeKittyDeleteImage(id);
 			this.#imageBudget.resetPlacementEpochs();
 		}
 		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
@@ -2823,7 +2827,6 @@ export class TUI extends Container {
 			// repaint so no stale frame can become visible between writes.
 			if (this.#clearScrollbackOnNextRender) {
 				this.#pendingAltExit = exitSequence;
-				if (TERMINAL.imageProtocol === ImageProtocol.Kitty) this.#imageBudget.forgetTransmitted();
 			} else {
 				this.#noteAltBufferToggle();
 				this.terminal.write(exitSequence);
@@ -2853,12 +2856,35 @@ export class TUI extends Container {
 			this.#renderAltFrame(width, height);
 			return;
 		}
+		// #prepareResizeReplay can latch this frame's reset itself (a settled
+		// rebuild-mode resize does), so it runs before the gate; the gate then runs
+		// before either arm composes anything.
+		if (this.#frameProvider !== undefined) this.#prepareResizeReplay(width, height);
+		this.#forgetTransmittedForPendingReset();
 		if (this.#frameProvider !== undefined) {
-			this.#prepareResizeReplay(width, height);
 			this.#renderProviderFrame(width, height);
 			return;
 		}
 		this.#renderChildrenFrame(width, height);
+	}
+
+	/**
+	 * Drop transmit tracking when a destructive repaint is about to compose the
+	 * normal screen, so the pass re-sends every image's data alongside its
+	 * placement. That repaint opens with `d=A`, which is what removes the store —
+	 * queueing per-id deletes when the reset was merely *latched* lets them ride
+	 * out on an unrelated frame instead, and a frame painted on the alternate
+	 * buffer carries them off without the repaint that restores them. A latch that
+	 * never reaches a repaint — `stop()` drops it — then deletes nothing.
+	 *
+	 * Must run after everything that can latch the reset for this frame and before
+	 * anything composes it — one call on the normal-screen dispatch path, ahead of
+	 * the arm split, so a new arm cannot be added without it.
+	 */
+	#forgetTransmittedForPendingReset(): void {
+		if (!this.#clearScrollbackOnNextRender) return;
+		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty) return;
+		this.#imageBudget.forgetTransmitted();
 	}
 
 	/**

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -770,12 +770,24 @@ describe("TUI inline-image budget", () => {
 	 * still have a placement on screen: an eviction that deletes a visible image
 	 * is only repaired if the frame re-emits its placement, and the frame diff
 	 * skips rows whose text is unchanged.
+	 *
+	 * `deleted` is append-only because `d=I` drops every placement of the id,
+	 * scrollback copies included, and only the current frame is ever repainted —
+	 * so a later re-place does not undo it.
 	 */
-	function trackKittyGraphics(term: VirtualTerminal): { resident: Set<number>; placed: Set<number> } {
+	function trackKittyGraphics(term: VirtualTerminal): {
+		resident: Set<number>;
+		placed: Set<number>;
+		deleted: number[];
+		writes: string[];
+	} {
 		const resident = new Set<number>();
 		const placed = new Set<number>();
+		const deleted: number[] = [];
+		const writes: string[] = [];
 		const realWrite = term.write.bind(term);
 		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
 			for (const match of data.matchAll(/\x1b_G([^;\x1b]+)(?:;[^\x1b]*)?\x1b\\/g)) {
 				const fields = new Map(match[1]!.split(",").map(field => field.split("=") as [string, string]));
 				const id = Number(fields.get("i"));
@@ -785,15 +797,17 @@ describe("TUI inline-image budget", () => {
 				if (action === "d" && fields.get("d") === "I") {
 					resident.delete(id);
 					placed.delete(id);
+					deleted.push(id);
 				}
 				if (action === "d" && fields.get("d") === "A") {
+					deleted.push(...resident);
 					resident.clear();
 					placed.clear();
 				}
 			}
 			realWrite(data);
 		});
-		return { resident, placed };
+		return { resident, placed, deleted, writes };
 	}
 
 	it("keeps normal-buffer placements visible across a fullscreen overlay pass", async () => {
@@ -881,6 +895,51 @@ describe("TUI inline-image budget", () => {
 
 			expect(placed.has(sharedId)).toBe(true);
 			expect(resident.has(sharedId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("does not demote transcript images under a closing overlay's suppression threshold", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { placed, deleted, writes } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = [makeImage(tui.imageBudget, "behind-0"), makeImage(tui.imageBudget, "behind-1")];
+		const behindIds = behind.map((_, i) => tui.imageBudget.acquireId(`behind-${i}`));
+		// Three modal images against a cap of 2: the overlay's own pass demotes one
+		// and leaves a stricter threshold behind for whichever pass runs next.
+		const modalImages = Array.from({ length: 3 }, (_, i) => makeImage(tui.imageBudget, `modal-${i}`));
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: behind.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(behindIds.every(id => placed.has(id))).toBe(true);
+
+			const overlay = tui.showOverlay(
+				{ render: width => modalImages.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+
+			writes.length = 0;
+			overlay.hide();
+			await settle(term);
+
+			// The modal's split must not reach the transcript. A `d=I` here also
+			// takes the id's scrollback placements, which no repaint restores, and
+			// the retransmit that follows is the visible placement/text flicker.
+			expect(deleted.filter(id => behindIds.includes(id))).toEqual([]);
+			expect(behindIds.every(id => placed.has(id))).toBe(true);
+			expect(writes.join("")).not.toContain(BASE64_ONE_PIXEL_PNG);
 		} finally {
 			tui.stop();
 			setKittyGraphics(originalGraphics);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -841,6 +841,52 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("keeps a shared image placed when an over-cap fullscreen overlay demotes it", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { resident, placed } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = makeImage(tui.imageBudget, "behind");
+		const shared = makeImage(tui.imageBudget, "shared");
+		const sharedId = tui.imageBudget.acquireId("shared");
+		// Same imageKey, so the modal's copy carries the transcript's graphics id.
+		// Rendering it first puts that id in the over-cap demotion prefix while its
+		// normal-buffer placement still stands behind the alt screen.
+		const modalImages = [
+			makeImage(tui.imageBudget, "shared"),
+			makeImage(tui.imageBudget, "modal-0"),
+			makeImage(tui.imageBudget, "modal-1"),
+		];
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: [behind, shared].flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(placed.has(sharedId)).toBe(true);
+
+			const overlay = tui.showOverlay(
+				{ render: width => modalImages.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+
+			overlay.hide();
+			await settle(term);
+
+			expect(placed.has(sharedId)).toBe(true);
+			expect(resident.has(sharedId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
 	it("keeps a non-fullscreen overlay image placed while the provider frame fills the cap", async () => {
 		const originalGraphics = { ...getKittyGraphics() };
 		const term = new VirtualTerminal(40, 12);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -695,6 +695,76 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	for (const fullscreen of [false, true]) {
+		it(`bounds resident graphics across ${fullscreen ? "fullscreen overlay" : "retired provider"} frames and replays evicted images`, async () => {
+			const term = new VirtualTerminal(40, 12);
+			const resident = new Set<number>();
+			let peak = 0;
+			const realWrite = term.write.bind(term);
+			vi.spyOn(term, "write").mockImplementation(data => {
+				for (const match of data.matchAll(/\x1b_G([^;\x1b]+)(?:;[^\x1b]*)?\x1b\\/g)) {
+					const fields = new Map(match[1]!.split(",").map(field => field.split("=") as [string, string]));
+					const id = Number(fields.get("i"));
+					if (fields.get("a") === "t") resident.add(id);
+					if (fields.get("a") === "d" && fields.get("d") === "I") resident.delete(id);
+					if (fields.get("a") === "d" && fields.get("d") === "A") resident.clear();
+					peak = Math.max(peak, resident.size);
+				}
+				realWrite(data);
+			});
+			const tui = new TUI(term);
+			tui.setMaxInlineImages(2);
+			const images = Array.from({ length: 5 }, (_, i) => makeImage(tui.imageBudget, `retired-${i}`));
+			const ids = images.map((_, i) => tui.imageBudget.acquireId(`retired-${i}`));
+			let current = 0;
+			tui.setFrameProvider({
+				renderFrame: size => ({ viewport: images[current]!.render(size.columns) }),
+				acknowledgeHistory: () => {},
+			});
+			const overlay = fullscreen
+				? tui.showOverlay(
+						{ render: width => images[current]!.render(width), invalidate: () => {} },
+						{ fullscreen: true },
+					)
+				: undefined;
+			try {
+				tui.start();
+				await settle(term);
+				for (current = 1; current < images.length; current++) {
+					tui.requestRender();
+					await settle(term);
+					if (current === 1) {
+						expect([...resident]).toEqual(ids.slice(0, 2));
+						tui.resetDisplay();
+						await settle(term);
+						expect([...resident]).toEqual([ids[1]!]);
+					}
+				}
+				expect([...resident]).toEqual(ids.slice(-2));
+				expect(peak).toBe(2);
+				current = 0;
+				tui.requestRender();
+				await settle(term);
+				expect(resident.has(ids[0]!)).toBe(true);
+				expect(resident.size).toBe(2);
+				tui.setMaxInlineImages(1);
+				await settle(term);
+				expect([...resident]).toEqual([ids[0]!]);
+				tui.resetDisplay();
+				await settle(term);
+				expect([...resident]).toEqual([ids[0]!]);
+				if (overlay) {
+					overlay.hide();
+					await settle(term);
+					expect([...resident]).toEqual([ids[0]!]);
+				}
+			} finally {
+				current = 0;
+				tui.stop();
+			}
+		});
+	}
+
 	it("applies the image budget before emitting the first frame", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -738,7 +738,13 @@ describe("TUI inline-image budget", () => {
 						expect([...resident]).toEqual(ids.slice(0, 2));
 						tui.resetDisplay();
 						await settle(term);
-						expect([...resident]).toEqual([ids[1]!]);
+						// A latched reset deletes nothing until its own repaint runs. In
+						// the fullscreen arm the overlay is installed before start(),
+						// so no normal frame is ever painted and that repaint never
+						// comes: both ids stay resident, still within the cap. The
+						// retired one here belongs to an earlier alternate frame — this
+						// fixture says nothing about normal-buffer placements.
+						expect([...resident]).toEqual(fullscreen ? ids.slice(0, 2) : [ids[1]!]);
 					}
 				}
 				expect([...resident]).toEqual(ids.slice(-2));
@@ -779,11 +785,13 @@ describe("TUI inline-image budget", () => {
 	function trackKittyGraphics(term: VirtualTerminal): {
 		resident: Set<number>;
 		placed: Set<number>;
+		virtual: Set<number>;
 		deleted: number[];
 		writes: string[];
 	} {
 		const resident = new Set<number>();
 		const placed = new Set<number>();
+		const virtual = new Set<number>();
 		const deleted: number[] = [];
 		const writes: string[] = [];
 		const realWrite = term.write.bind(term);
@@ -794,21 +802,33 @@ describe("TUI inline-image budget", () => {
 				const id = Number(fields.get("i"));
 				const action = fields.get("a");
 				if (action === "t") resident.add(id);
-				if (action === "p" && resident.has(id)) placed.add(id);
+				if (action === "p") {
+					if (fields.get("U") === "1") virtual.add(id);
+					if (resident.has(id)) placed.add(id);
+				}
 				if (action === "d" && fields.get("d") === "I") {
 					resident.delete(id);
 					placed.delete(id);
+					virtual.delete(id);
 					deleted.push(id);
 				}
 				if (action === "d" && fields.get("d") === "A") {
-					deleted.push(...resident);
-					resident.clear();
-					placed.clear();
+					// Kitty's `d=A` deletes images and their placements but spares
+					// *virtual* placements, so a placeholder image survives it. Model
+					// that: an oracle that clears everything here reports an id as
+					// gone when the terminal still holds it, and then a missing
+					// explicit delete looks like no leak at all.
+					for (const held of resident) {
+						if (virtual.has(held)) continue;
+						deleted.push(held);
+						resident.delete(held);
+						placed.delete(held);
+					}
 				}
 			}
 			realWrite(data);
 		});
-		return { resident, placed, deleted, writes };
+		return { resident, placed, virtual, deleted, writes };
 	}
 
 	it("keeps normal-buffer placements visible across a fullscreen overlay pass", async () => {
@@ -896,6 +916,198 @@ describe("TUI inline-image budget", () => {
 
 			expect(placed.has(sharedId)).toBe(true);
 			expect(resident.has(sharedId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("spares a screen image whose suppression the reconcile undercut", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { placed, deleted } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(1);
+		const older = makeImage(tui.imageBudget, "older");
+		const kept = makeImage(tui.imageBudget, "kept");
+		const keptId = tui.imageBudget.acquireId("kept");
+		const modal = makeImage(tui.imageBudget, "modal");
+		const modalId = tui.imageBudget.acquireId("modal");
+		let transcript = [older, kept];
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: transcript.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(placed.has(keptId)).toBe(true);
+
+			const overlay = tui.showOverlay(
+				{ render: width => modal.render(width), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+
+			// Dropping the older image relaxes the threshold, but the pass already
+			// decided suppression under the old one. That stale text fallback lasts
+			// a frame; deleting the graphic behind it lasts forever.
+			overlay.hide();
+			transcript = [kept];
+			await settle(term);
+
+			expect(deleted).not.toContain(keptId);
+			expect(placed.has(keptId)).toBe(true);
+			expect(tui.imageBudget.acquireId("kept")).toBe(keptId);
+			// The modal's image really is retired, so the store still comes down.
+			expect(deleted).toContain(modalId);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("names forgotten placeholder images in a reset's own deletions", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { writes } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: true });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(3);
+		const gone = makeImage(tui.imageBudget, "gone");
+		const goneId = tui.imageBudget.acquireId("gone");
+		let showImage = true;
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: showImage ? [...gone.render(size.columns)] : ["transcript"] }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(writes.join("")).toContain(BASE64_ONE_PIXEL_PNG);
+
+			// Drop it from the frame, then reset. `d=A` spares virtual placements
+			// and erasing placeholder text leaves the prototype, so the reset has to
+			// name this id: forgetting drops it from tracking, and no later sweep
+			// can reach a placement it no longer knows about.
+			showImage = false;
+			writes.length = 0;
+			tui.resetDisplay();
+			await settle(term);
+
+			const output = writes.join("");
+			const deleteAll = output.indexOf("\x1b_Ga=d,d=A");
+			expect(deleteAll).toBeGreaterThanOrEqual(0);
+			expect(output).toContain(`\x1b_Ga=d,d=I,i=${goneId}`);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("holds a reset's deletions until the repaint that restores them", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { placed, deleted } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(3);
+		const transcript = makeImage(tui.imageBudget, "transcript");
+		const transcriptId = tui.imageBudget.acquireId("transcript");
+		tui.addChild(transcript);
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(placed.has(transcriptId)).toBe(true);
+
+			// The modal carries no images of its own, so nothing on the alternate
+			// buffer has any claim on the transcript's graphic.
+			tui.showOverlay(new Text("MODAL", 0, 0), { fullscreen: true });
+			await settle(term);
+			tui.resetDisplay();
+			await settle(term);
+			expect(deleted).not.toContain(transcriptId);
+
+			// stop() restores the normal screen and drops the reset latch, so no
+			// destructive repaint ever runs — a deletion issued at latch time would
+			// leave the transcript blank with nothing left to re-place it.
+			tui.stop();
+			await settle(term);
+			expect(deleted).not.toContain(transcriptId);
+			expect(placed.has(transcriptId)).toBe(true);
+		} finally {
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	/** Deterministic scheduler so a settled resize can be driven step by step. */
+	class StepScheduler {
+		#now = 0;
+		#pending = new Set<() => void>();
+
+		now(): number {
+			return this.#now;
+		}
+
+		scheduleImmediate(callback: () => void): void {
+			callback();
+		}
+
+		scheduleRender(callback: () => void, _delayMs: number) {
+			this.#pending.add(callback);
+			return { cancel: () => this.#pending.delete(callback) };
+		}
+
+		settle(): void {
+			this.#now += 120;
+			const pending = [...this.#pending];
+			this.#pending.clear();
+			for (const callback of pending) callback();
+		}
+	}
+
+	it("retransmits images through a rebuild-mode resize's destructive repaint", () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 8);
+		const { writes } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const scheduler = new StepScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		tui.setMaxInlineImages(2);
+		const shown = makeImage(tui.imageBudget, "shown");
+		tui.setResizeScrollback("rebuild");
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: [...shown.render(size.columns)] }),
+			acknowledgeHistory: () => {},
+			beginHistoryReplay: () => {},
+		});
+
+		try {
+			tui.start();
+			expect(writes.join("")).toContain(BASE64_ONE_PIXEL_PNG);
+
+			writes.length = 0;
+			term.resize(30, 8);
+			scheduler.settle();
+			scheduler.settle();
+			scheduler.settle();
+
+			// A settled rebuild latches its own reset partway through the dispatch
+			// that paints it. The repaint opens with `d=A`, so unless transmit
+			// tracking is dropped after that latch the frame places an image whose
+			// data it just deleted.
+			const output = writes.join("");
+			const deleteAll = output.indexOf("\x1b_Ga=d,d=A");
+			expect(deleteAll).toBeGreaterThanOrEqual(0);
+			expect(output.indexOf(BASE64_ONE_PIXEL_PNG)).toBeGreaterThan(deleteAll);
 		} finally {
 			tui.stop();
 			setKittyGraphics(originalGraphics);
@@ -1125,6 +1337,9 @@ describe("TUI inline-image budget", () => {
 			expect(deleted.filter(id => behindIds.includes(id))).toEqual([]);
 			expect(behindIds.every(id => placed.has(id))).toBe(true);
 			expect(writes.join("")).not.toContain(BASE64_ONE_PIXEL_PNG);
+			// Nor may the modal's threshold flip one to its text fallback for a
+			// frame on the way: each surface reconciles against its own split.
+			expect(writes.join("")).not.toContain(imageFallback("image/png", { widthPx: 1, heightPx: 1 }));
 		} finally {
 			tui.stop();
 			setKittyGraphics(originalGraphics);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -902,6 +902,88 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("releases a demoted image's key once its graphic is actually retired", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 20);
+		trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const transcript = Array.from({ length: 3 }, (_, i) => makeImage(tui.imageBudget, `row-${i}`));
+		const oldestId = tui.imageBudget.acquireId("row-0");
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: transcript.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+
+			// Over cap, so the oldest is demoted and its graphic really is gone.
+			// Its key must not hand that id back to a recreated component.
+			expect(tui.imageBudget.acquireId("row-0")).not.toBe(oldestId);
+			expect(tui.imageBudget.acquireId("row-2")).toBe(tui.imageBudget.acquireId("row-2"));
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("keeps a shared image's key when the overlay's demotion is refused", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { placed, deleted } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const other = makeImage(tui.imageBudget, "other");
+		const shared = makeImage(tui.imageBudget, "shared");
+		const sharedId = tui.imageBudget.acquireId("shared");
+		// Rendered first inside an over-cap modal, so the alt pass suppresses this
+		// id while the transcript behind still shows its graphic.
+		const modalImages = [
+			makeImage(tui.imageBudget, "shared"),
+			makeImage(tui.imageBudget, "modal-0"),
+			makeImage(tui.imageBudget, "modal-1"),
+		];
+		let transcript = [shared, other];
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: transcript.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(placed.has(sharedId)).toBe(true);
+
+			const overlay = tui.showOverlay(
+				{ render: width => modalImages.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+			overlay.hide();
+			await settle(term);
+
+			// Suppression is not retirement: the graphic survived, so the key must
+			// still resolve to it. A fresh id here orphans the old one, and the next
+			// pass deletes every placement it ever made, scrollback included.
+			transcript = [makeImage(tui.imageBudget, "shared"), other];
+			expect(tui.imageBudget.acquireId("shared")).toBe(sharedId);
+
+			tui.requestRender();
+			await settle(term);
+			expect(deleted).not.toContain(sharedId);
+			expect(placed.has(sharedId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
 	it("starts each alternate-buffer lifecycle without the previous overlay's split", async () => {
 		const originalGraphics = { ...getKittyGraphics() };
 		const term = new VirtualTerminal(40, 12);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -15,6 +15,7 @@ import {
 	encodeKittyPlacement,
 	encodeKittyTransmit,
 	getCellDimensions,
+	imageFallback,
 	ImageProtocol,
 	setCellDimensions,
 	TERMINAL,
@@ -895,6 +896,55 @@ describe("TUI inline-image budget", () => {
 
 			expect(placed.has(sharedId)).toBe(true);
 			expect(resident.has(sharedId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("starts each alternate-buffer lifecycle without the previous overlay's split", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { writes } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		tui.setFrameProvider({
+			renderFrame: () => ({ viewport: ["transcript"] }),
+			acknowledgeHistory: () => {},
+		});
+		// Over cap, so its own pass settles at a stricter threshold.
+		const firstModal = Array.from({ length: 3 }, (_, i) => makeImage(tui.imageBudget, `first-${i}`));
+		const secondModal = makeImage(tui.imageBudget, "second");
+		const secondId = tui.imageBudget.acquireId("second");
+		const fallback = imageFallback("image/png", { widthPx: 1, heightPx: 1 });
+
+		try {
+			tui.start();
+			await settle(term);
+
+			const first = tui.showOverlay(
+				{ render: width => firstModal.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+			first.hide();
+			await settle(term);
+
+			writes.length = 0;
+			const second = tui.showOverlay(
+				{ render: width => secondModal.render(width), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+
+			// `?1049h` starts a cleared buffer, so the previous modal's split says
+			// nothing about this one. Carrying it renders the sole image as text for
+			// a frame and drops its key on the way.
+			expect(writes.join("")).not.toContain(fallback);
+			expect(tui.imageBudget.acquireId("second")).toBe(secondId);
+			second.hide();
 		} finally {
 			tui.stop();
 			setKittyGraphics(originalGraphics);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -951,6 +951,59 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("keeps transcript placements when the shutdown flush runs under a fullscreen overlay", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { placed, deleted } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = [makeImage(tui.imageBudget, "behind-0"), makeImage(tui.imageBudget, "behind-1")];
+		const behindIds = behind.map((_, i) => tui.imageBudget.acquireId(`behind-${i}`));
+		const modalImages = [makeImage(tui.imageBudget, "modal-0"), makeImage(tui.imageBudget, "modal-1")];
+		let flushing = false;
+		let nextHistoryId = 1;
+		let pendingHistory: string[] | undefined = ["retired row"];
+		tui.setFrameProvider({
+			renderFrame: size => ({
+				history: flushing && pendingHistory !== undefined ? { id: nextHistoryId, rows: pendingHistory } : undefined,
+				viewport: behind.flatMap(image => image.render(size.columns)),
+			}),
+			acknowledgeHistory: id => {
+				if (id !== nextHistoryId) return;
+				pendingHistory = undefined;
+				nextHistoryId++;
+			},
+			beginHistoryFlush: () => {
+				flushing = true;
+			},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(behindIds.every(id => placed.has(id))).toBe(true);
+
+			tui.showOverlay(
+				{ render: width => modalImages.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+
+			// stop() leaves the alternate buffer but not the overlay stack, so the
+			// flush must not count a modal that is no longer painted: its images
+			// would push the transcript's over the cap and delete them for good.
+			tui.stop();
+			await settle(term);
+
+			expect(deleted.filter(id => behindIds.includes(id))).toEqual([]);
+			expect(behindIds.every(id => placed.has(id))).toBe(true);
+		} finally {
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
 	it("does not demote transcript images under a closing overlay's suppression threshold", async () => {
 		const originalGraphics = { ...getKittyGraphics() };
 		const term = new VirtualTerminal(40, 12);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -765,6 +765,117 @@ describe("TUI inline-image budget", () => {
 		});
 	}
 
+	/**
+	 * Track what the terminal's graphics store actually holds and which images
+	 * still have a placement on screen: an eviction that deletes a visible image
+	 * is only repaired if the frame re-emits its placement, and the frame diff
+	 * skips rows whose text is unchanged.
+	 */
+	function trackKittyGraphics(term: VirtualTerminal): { resident: Set<number>; placed: Set<number> } {
+		const resident = new Set<number>();
+		const placed = new Set<number>();
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			for (const match of data.matchAll(/\x1b_G([^;\x1b]+)(?:;[^\x1b]*)?\x1b\\/g)) {
+				const fields = new Map(match[1]!.split(",").map(field => field.split("=") as [string, string]));
+				const id = Number(fields.get("i"));
+				const action = fields.get("a");
+				if (action === "t") resident.add(id);
+				if (action === "p" && resident.has(id)) placed.add(id);
+				if (action === "d" && fields.get("d") === "I") {
+					resident.delete(id);
+					placed.delete(id);
+				}
+				if (action === "d" && fields.get("d") === "A") {
+					resident.clear();
+					placed.clear();
+				}
+			}
+			realWrite(data);
+		});
+		return { resident, placed };
+	}
+
+	it("keeps normal-buffer placements visible across a fullscreen overlay pass", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { resident, placed } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = [makeImage(tui.imageBudget, "behind-0"), makeImage(tui.imageBudget, "behind-1")];
+		const behindIds = behind.map((_, i) => tui.imageBudget.acquireId(`behind-${i}`));
+		const modal = makeImage(tui.imageBudget, "modal");
+		const modalId = tui.imageBudget.acquireId("modal");
+		const ascending = (a: number, b: number) => a - b;
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: behind.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect([...placed].sort(ascending)).toEqual([...behindIds].sort(ascending));
+
+			// The modal's own image is a third graphic while the transcript's two
+			// stay untouched behind the alt buffer. Paying for it by deleting one
+			// of them blanks a row the restored normal frame never rewrites.
+			const overlay = tui.showOverlay(
+				{ render: width => modal.render(width), invalidate: () => {} },
+				{ fullscreen: true },
+			);
+			await settle(term);
+			expect(resident.has(modalId)).toBe(true);
+
+			overlay.hide();
+			await settle(term);
+
+			expect([...placed].sort(ascending)).toEqual([...behindIds].sort(ascending));
+			expect(resident.has(modalId)).toBe(false);
+			expect(resident.size).toBe(2);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("keeps a non-fullscreen overlay image placed while the provider frame fills the cap", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { resident, placed } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = [makeImage(tui.imageBudget, "behind-0"), makeImage(tui.imageBudget, "behind-1")];
+		const modal = makeImage(tui.imageBudget, "modal");
+		const modalId = tui.imageBudget.acquireId("modal");
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: behind.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			tui.showOverlay({ render: width => modal.render(width), invalidate: () => {} }, { anchor: "center" });
+			await settle(term);
+			expect(placed.has(modalId)).toBe(true);
+
+			// Overlays composite after the budget pass closes, so a later repaint
+			// that leaves them byte-identical must not mistake them for retired.
+			tui.requestRender();
+			await settle(term);
+			expect(placed.has(modalId)).toBe(true);
+			expect(resident.has(modalId)).toBe(true);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
 	it("applies the image budget before emitting the first frame", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -922,6 +922,53 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("holds the cap over a provider frame plus its non-fullscreen overlay", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const { resident, placed } = trackKittyGraphics(term);
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(2);
+		const behind = [makeImage(tui.imageBudget, "behind-0"), makeImage(tui.imageBudget, "behind-1")];
+		const modalImages = [makeImage(tui.imageBudget, "modal-0"), makeImage(tui.imageBudget, "modal-1")];
+		const modalIds = modalImages.map((_, i) => tui.imageBudget.acquireId(`modal-${i}`));
+		tui.setFrameProvider({
+			renderFrame: size => ({ viewport: behind.flatMap(image => image.render(size.columns)) }),
+			acknowledgeHistory: () => {},
+		});
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(resident.size).toBe(2);
+
+			const overlay = tui.showOverlay(
+				{ render: width => modalImages.flatMap(image => image.render(width)), invalidate: () => {} },
+				{ anchor: "center" },
+			);
+			await settle(term);
+
+			// The overlay's images are the newest in display order, so the cap keeps
+			// them and demotes the transcript's — it may not simply stop counting.
+			const sizes: number[] = [];
+			for (let i = 0; i < 4; i++) {
+				tui.requestRender();
+				await settle(term);
+				sizes.push(resident.size);
+			}
+			expect(sizes).toEqual([2, 2, 2, 2]);
+			expect(modalIds.every(id => placed.has(id))).toBe(true);
+
+			overlay.hide();
+			await settle(term);
+			expect(resident.size).toBe(2);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
 	it("applies the image budget before emitting the first frame", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];


### PR DESCRIPTION
## What

Image limits now include Kitty graphics retained from earlier frames and fullscreen overlays. Reset and replay delete old uploads before retransmission. Evicted scrollback images return when replayed; iTerm2 and Sixel behavior is unchanged.

## Why

A per-frame budget does not account for graphics that the terminal retains after retirement or overlay transitions.

## Testing

- [x] Full TUI suite: 1,453 tests, 7,708 assertions; package check passed.
- [x] Second independent review reproduces the reset/overlay regression and verifies peak residency stays at two images with a two-image limit.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
