### PR TITLE
perf(natives): prune excluded workspace trees before scanning

### DIFF
--- a/crates/pi-natives/src/workspace.rs
+++ b/crates/pi-natives/src/workspace.rs
@@ -7,7 +7,7 @@
 //! walker.
 
 use std::{
-	collections::HashSet,
+	collections::{BTreeMap, BTreeSet, HashSet},
 	path::{Path, PathBuf},
 	sync::LazyLock,
 };
@@ -88,6 +88,31 @@ struct WorkspaceConfig {
 	collect_agents_md: bool,
 }
 
+#[derive(Default)]
+struct WorkspaceResults {
+	entries:         BTreeMap<String, GlobMatch>,
+	agents_md_files: BTreeSet<String>,
+	truncated:       bool,
+}
+
+impl WorkspaceResults {
+	fn insert_entry(&mut self, entry: GlobMatch) {
+		self.entries.entry(entry.path.clone()).or_insert(entry);
+		if self.entries.len() > MAX_ENTRIES {
+			self.entries.pop_last();
+			self.truncated = true;
+		}
+	}
+
+	fn insert_agents_md(&mut self, path: String) {
+		self.agents_md_files.insert(path);
+		if self.agents_md_files.len() > AGENTS_MD_LIMIT {
+			self.agents_md_files.pop_last();
+			self.truncated = true;
+		}
+	}
+}
+
 fn build_workspace_walk_request(config: &WorkspaceConfig) -> pi_walker::WalkRequest {
 	pi_walker::WalkRequest::new(config.root.clone())
 		.hidden(config.include_hidden)
@@ -147,8 +172,7 @@ fn collect_agents_md_in_directory(
 	config: &WorkspaceConfig,
 	directory: &Path,
 	directory_depth: usize,
-	entries: &mut Vec<GlobMatch>,
-	agents_md_files: &mut Vec<String>,
+	results: &mut WorkspaceResults,
 ) {
 	if !config.collect_agents_md {
 		return;
@@ -162,76 +186,55 @@ fn collect_agents_md_in_directory(
 	}
 	let tree_depth = directory_depth + 1;
 	if tree_depth <= config.max_depth {
-		entries.push(entry.clone());
+		results.insert_entry(entry.clone());
 	}
 	// AGENTS.md directory depth: root AGENTS.md is depth 0, child dir AGENTS.md
 	// is depth 1, and so on. We only surface files in depth 1..=4.
 	if (AGENTS_MD_MIN_DEPTH..=AGENTS_MD_MAX_DEPTH).contains(&directory_depth) {
-		agents_md_files.push(entry.path);
+		results.insert_agents_md(entry.path);
 	}
-}
-
-fn sort_dedup_entries(entries: &mut Vec<GlobMatch>) {
-	entries.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-	entries.dedup_by(|a, b| a.path == b.path);
-}
-
-fn sort_dedup_paths(paths: &mut Vec<String>) {
-	paths.sort_unstable();
-	paths.dedup();
 }
 
 fn run_list_workspace(
 	config: WorkspaceConfig,
 	ct: task::CancelToken,
 ) -> Result<ListWorkspaceResult> {
-	let mut entries = Vec::new();
-	let mut agents_md_files = Vec::new();
-	collect_agents_md_in_directory(&config, &config.root, 0, &mut entries, &mut agents_md_files);
-
-	let outcome = build_workspace_walk_request(&config)
-		.collect_with_heartbeat(|| ct.heartbeat())
+	let mut results = WorkspaceResults::default();
+	collect_agents_md_in_directory(&config, &config.root, 0, &mut results);
+	build_workspace_walk_request(&config)
+		.for_each_entry_with_heartbeat(
+			|| ct.heartbeat(),
+			|entry| {
+				let file_type = iofs::from_walker_file_type(entry.file_type);
+				if is_excluded_workspace_entry(entry.relative_path, file_type) {
+					return Ok(pi_walker::WalkDecision::SkipDescend);
+				}
+				if file_type == FileType::Dir {
+					collect_agents_md_in_directory(
+						&config,
+						&entry.absolute_path,
+						entry.depth,
+						&mut results,
+					);
+				}
+				if entry.depth <= config.max_depth {
+					results.insert_entry(GlobMatch {
+						path: entry.relative_path.to_owned(),
+						file_type,
+						mtime: entry.mtime,
+						size: entry.size,
+					});
+				}
+				Ok(pi_walker::WalkDecision::Include)
+			},
+			|_| Ok(pi_walker::WalkDecision::Include),
+		)
 		.map_err(iofs::map_walker_error)?;
 
-	for entry in outcome.entries {
-		let file_type = iofs::from_walker_file_type(entry.file_type);
-		if is_excluded_workspace_entry(&entry.path, file_type) {
-			continue;
-		}
-
-		let entry_depth = entry.depth();
-		if file_type == FileType::Dir {
-			let directory = entry.absolute_path(&config.root);
-			collect_agents_md_in_directory(
-				&config,
-				&directory,
-				entry_depth,
-				&mut entries,
-				&mut agents_md_files,
-			);
-		}
-
-		if entry_depth <= config.max_depth {
-			entries.push(entry.into());
-		}
-	}
-
-	sort_dedup_entries(&mut entries);
-	sort_dedup_paths(&mut agents_md_files);
-
-	let entries_truncated = entries.len() > MAX_ENTRIES;
-	if entries_truncated {
-		entries.truncate(MAX_ENTRIES);
-	}
-	let agents_md_truncated = agents_md_files.len() > AGENTS_MD_LIMIT;
-	if agents_md_truncated {
-		agents_md_files.truncate(AGENTS_MD_LIMIT);
-	}
-
 	Ok(ListWorkspaceResult {
-		entries,
-		agents_md_files,
-		truncated: entries_truncated || agents_md_truncated,
+		entries:         results.entries.into_values().collect(),
+		agents_md_files: results.agents_md_files.into_iter().collect(),
+		truncated:       results.truncated,
 	})
 }
 
@@ -273,4 +276,48 @@ pub fn list_workspace(options: ListWorkspaceOptions<'_>) -> task::Promise<ListWo
 			ct,
 		)
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn file(path: String) -> GlobMatch {
+		GlobMatch { path, file_type: FileType::File, mtime: None, size: None }
+	}
+
+	#[test]
+	fn workspace_entry_cap_deduplicates_and_keeps_late_lexical_winners() {
+		let mut results = WorkspaceResults::default();
+		for index in (1..=MAX_ENTRIES).rev() {
+			let path = format!("{index:06}");
+			results.insert_entry(file(path.clone()));
+			results.insert_entry(file(path));
+		}
+		assert!(!results.truncated);
+		results.insert_entry(file("000000".to_owned()));
+		assert!(results.truncated);
+		assert_eq!(results.entries.len(), MAX_ENTRIES);
+		assert_eq!(results.entries.first_key_value().unwrap().0, "000000");
+		assert_eq!(results.entries.last_key_value().unwrap().0, "099999");
+		results.insert_entry(file("zzzzzz".to_owned()));
+		assert_eq!(results.entries.len(), MAX_ENTRIES);
+		assert_eq!(results.entries.last_key_value().unwrap().0, "099999");
+	}
+
+	#[test]
+	fn workspace_agents_cap_deduplicates_and_keeps_late_lexical_winners() {
+		let mut results = WorkspaceResults::default();
+		for index in (1..=AGENTS_MD_LIMIT).rev() {
+			let path = format!("{index:03}/AGENTS.md");
+			results.insert_agents_md(path.clone());
+			results.insert_agents_md(path);
+		}
+		assert!(!results.truncated);
+		results.insert_agents_md("000/AGENTS.md".to_owned());
+		assert!(results.truncated);
+		assert_eq!(results.agents_md_files.len(), AGENTS_MD_LIMIT);
+		assert_eq!(results.agents_md_files.first().unwrap(), "000/AGENTS.md");
+		assert_eq!(results.agents_md_files.last().unwrap(), "199/AGENTS.md");
+	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Workspace startup scans skip excluded build directories and retain a bounded set of entries and directory rules.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/natives/bench/workspace.ts
+++ b/packages/natives/bench/workspace.ts
@@ -1,0 +1,19 @@
+import { listWorkspace } from "../native";
+
+const root = Bun.argv[2];
+if (!root) throw new Error("Usage: bun bench/workspace.ts DIRECTORY");
+for (let iteration = 0; iteration < 5; iteration++) {
+	const started = performance.now();
+	const result = await listWorkspace({ path: root, maxDepth: 5, hidden: true, collectAgentsMd: true });
+	console.log(
+		JSON.stringify({
+			iteration,
+			elapsedMs: performance.now() - started,
+			entries: result.entries.length,
+			first: result.entries[0]?.path,
+			last: result.entries.at(-1)?.path,
+			agentsMdFiles: result.agentsMdFiles,
+			truncated: result.truncated,
+		}),
+	);
+}

--- a/packages/natives/test/workspace.test.ts
+++ b/packages/natives/test/workspace.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FileType, listWorkspace } from "../native";
+
+it("keeps excluded-name files while pruning directories and finding ignored rules beyond tree depth", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-pruning-"));
+	try {
+		await Bun.write(path.join(root, ".gitignore"), "**/AGENTS.md\nignored/\n");
+		for (const directory of ["src/a/b/c/d", "build/nested", ".DS_Store/nested", "ignored/nested"]) {
+			await fs.mkdir(path.join(root, directory), { recursive: true });
+		}
+		for (const directory of [
+			"src",
+			"src/a/b/c",
+			"src/a/b/c/d",
+			"build/nested",
+			".DS_Store/nested",
+			"ignored/nested",
+		]) {
+			await Bun.write(path.join(root, directory, "AGENTS.md"), "rules");
+		}
+		await Bun.write(path.join(root, "dist"), "ordinary file");
+		const result = await listWorkspace({ path: root, maxDepth: 1, hidden: true, collectAgentsMd: true });
+		expect(result.entries.map(entry => entry.path)).toEqual([".gitignore", "dist", "src"]);
+		expect(result.agentsMdFiles).toEqual(["src/AGENTS.md", "src/a/b/c/AGENTS.md"]);
+		expect(result.truncated).toBe(false);
+		const disabled = await listWorkspace({ path: root, maxDepth: 0, collectAgentsMd: false });
+		expect(disabled).toEqual({ entries: [], agentsMdFiles: [], truncated: false });
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+it("caps directory rules lexically without counting duplicate discoveries as truncation", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-rules-cap-"));
+	try {
+		const paths = Array.from({ length: 200 }, (_, index) => `${String(index).padStart(3, "0")}/AGENTS.md`);
+		for (const relative of paths.toReversed()) await Bun.write(path.join(root, relative), "rules");
+		const exact = await listWorkspace({ path: root, maxDepth: 2, collectAgentsMd: true });
+		expect(exact.agentsMdFiles).toEqual(paths);
+		expect(exact.entries.filter(entry => entry.path.endsWith("/AGENTS.md")).map(entry => entry.path)).toEqual(paths);
+		const firstRulesStat = await fs.stat(path.join(root, paths[0]!));
+		expect(exact.entries.find(entry => entry.path === paths[0])?.mtime).toBe(Math.trunc(firstRulesStat.mtimeMs));
+		expect(exact.truncated).toBe(false);
+		await Bun.write(path.join(root, "zzz/AGENTS.md"), "overflow");
+		const overflow = await listWorkspace({ path: root, maxDepth: 0, collectAgentsMd: true });
+		expect(overflow.entries).toEqual([]);
+		expect(overflow.agentsMdFiles).toEqual(paths);
+		expect(overflow.truncated).toBe(true);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+it.skipIf(process.platform === "win32")("finds file symlink rules without traversing directory symlinks", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-symlinks-"));
+	try {
+		await Bun.write(path.join(root, "source/rules.txt"), "rules");
+		await fs.symlink("rules.txt", path.join(root, "source/AGENTS.md"));
+		await fs.symlink("source", path.join(root, "linked"));
+		const result = await listWorkspace({ path: root, maxDepth: 3, collectAgentsMd: true });
+		expect(result.entries.map(entry => entry.path)).toEqual([
+			"linked",
+			"source",
+			"source/AGENTS.md",
+			"source/rules.txt",
+		]);
+		expect(result.agentsMdFiles).toEqual(["source/AGENTS.md"]);
+		expect(result.entries.find(entry => entry.path === "source/AGENTS.md")?.fileType).toBe(FileType.Symlink);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What

Workspace scans skip excluded directories before probing their descendants and retain at most 100,000 entries and 200 directory rules in lexical order. Required traversal, truncation, and first-seen rule metadata remain intact.

## Why

Workspace startup traversed excluded trees and materialized entries that the final output would discard.

## Testing

- [x] Native build, package check, Rust check, and independent review across 32 option combinations.
- [x] Full Rust run: 2,759 pass, five baseline WSL OAuth failures, six skips; doctests were not reached.
- [x] Seven-run medians: excluded 50,000-file tree 54.04 → 0.513 ms; normal tree 8.897 → 10.143 ms; capped-tree RSS 83,908 → 77,632 KiB.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
