### PR TITLE
perf(stats): persist parser state for incremental transcript reads

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced repeat stats-sync reads to appended transcript data while preserving service-tier accounting across restarts.
+- Rebuilt stats for replaced or truncated session files instead of retaining stale totals.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { getStatsDbPath, workerHostEntry } from "@oh-my-pi/pi-utils";
 import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
 import {
+	applySessionParseResult,
+	completeSessionSync,
 	getRecentErrors as dbGetRecentErrors,
 	getRecentRequests as dbGetRecentRequests,
 	getBehaviorByModel,
@@ -26,15 +28,17 @@ import {
 	getToolStatsByModel,
 	getToolTimeSeries,
 	initDb,
-	insertMessageStats,
-	insertToolCalls,
-	insertUserMessageStats,
 	markSessionBackfillsComplete,
-	setFileOffset,
-	updateToolResults,
-	updateUserMessageLinks,
+	prepareSessionSync,
 } from "./db";
-import { getSessionEntry, listAllSessionFiles, type ParseSessionResult, parseSessionFile } from "./parser";
+import {
+	getSessionEntry,
+	listAllSessionFiles,
+	matchesSessionFile,
+	type ParseSessionResult,
+	parseSessionFile,
+	type SessionParserState,
+} from "./parser";
 import type { SyncWorkerRequest, SyncWorkerResponse } from "./sync-worker";
 // Coding-agent binary/bundle workers route through the CLI entrypoint with a
 // hidden argv mode, so the compiled binary and npm bundle only need one
@@ -67,20 +71,6 @@ export async function withStatsSyncLock<T>(dbPath: string, fn: () => Promise<T>)
 		retryDelayMs: STATS_SYNC_LOCK_RETRY_MS,
 		retries: Math.ceil(STATS_SYNC_LOCK_WAIT_MS / STATS_SYNC_LOCK_RETRY_MS),
 	});
-}
-
-/**
- * Apply a freshly parsed result to the database. Runs entirely on the
- * main thread so the single SQLite handle owns every write.
- */
-function applyParseResult(sessionFile: string, lastModified: number, result: ParseSessionResult): number {
-	if (result.stats.length > 0) insertMessageStats(result.stats);
-	if (result.userStats.length > 0) insertUserMessageStats(result.userStats);
-	if (result.userLinks.length > 0) updateUserMessageLinks(result.userLinks);
-	if (result.toolCalls.length > 0) insertToolCalls(result.toolCalls);
-	if (result.toolResults.length > 0) updateToolResults(result.toolResults);
-	setFileOffset(sessionFile, result.newOffset, lastModified);
-	return result.stats.length + result.userStats.length;
 }
 
 /**
@@ -239,20 +229,34 @@ export async function smokeTestSyncWorker({ timeoutMs = 5_000 }: { timeoutMs?: n
  * bar walks at a steady rate).
  */
 export async function syncAllSessions(opts?: SyncOptions): Promise<{ processed: number; files: number }> {
-	return withStatsSyncLock(getStatsDbPath(), () => syncAllSessionsLocked(opts));
+	return withStatsSyncLock(getStatsDbPath(), async () => {
+		let processed = 0;
+		let files = 0;
+		while (true) {
+			const result = await syncAllSessionsLocked(opts);
+			processed += result.processed;
+			files += result.files;
+			if (!result.reconcile) return { processed, files };
+		}
+	});
 }
 
-async function syncAllSessionsLocked(opts?: SyncOptions): Promise<{ processed: number; files: number }> {
+async function syncAllSessionsLocked(
+	opts?: SyncOptions,
+): Promise<{ processed: number; files: number; reconcile: boolean }> {
 	await initDb();
+	const replay = prepareSessionSync();
 
 	const files = await listAllSessionFiles();
 	let totalProcessed = 0;
 	let filesProcessed = 0;
 	let completed = 0;
 	let cursor = 0;
+	let reconcile = false;
 	const finish = () => {
+		completeSessionSync(reconcile);
 		markSessionBackfillsComplete();
-		return { processed: totalProcessed, files: filesProcessed };
+		return { processed: totalProcessed, files: filesProcessed, reconcile };
 	};
 	if (files.length === 0) return finish();
 
@@ -268,7 +272,12 @@ async function syncAllSessionsLocked(opts?: SyncOptions): Promise<{ processed: n
 
 	const processFile = async (
 		sessionFile: string,
-		parse: (sessionFile: string, fromOffset: number) => Promise<ParseSessionResult>,
+		parse: (
+			sessionFile: string,
+			fromOffset: number,
+			state?: SessionParserState,
+			replay?: boolean,
+		) => Promise<ParseSessionResult>,
 	): Promise<void> => {
 		let fileStats: fs.Stats;
 		try {
@@ -279,14 +288,24 @@ async function syncAllSessionsLocked(opts?: SyncOptions): Promise<{ processed: n
 		}
 		const lastModified = fileStats.mtimeMs;
 		const stored = getFileOffset(sessionFile);
-		if (stored && stored.lastModified >= lastModified) {
+		if (
+			!replay &&
+			stored?.parserState &&
+			stored.lastModified === lastModified &&
+			stored.parserState.size === fileStats.size &&
+			matchesSessionFile(stored.parserState, fileStats)
+		) {
 			report(sessionFile);
 			return;
 		}
 
-		const fromOffset = stored?.offset ?? 0;
-		const result = await parse(sessionFile, fromOffset);
-		const inserted = applyParseResult(sessionFile, lastModified, result);
+		const unknownIdentity = stored !== null && !stored.parserState;
+		const fromOffset = unknownIdentity ? 0 : (stored?.offset ?? 0);
+		const result = await parse(sessionFile, fromOffset, stored?.parserState, replay);
+		if (unknownIdentity && result.parserState) result.reset = true;
+		const applied = applySessionParseResult(sessionFile, result, replay || !stored?.parserState);
+		const inserted = applied.processed;
+		if (applied.reconcile) reconcile = true;
 		if (inserted > 0) {
 			totalProcessed += inserted;
 			filesProcessed++;
@@ -312,7 +331,9 @@ async function syncAllSessionsLocked(opts?: SyncOptions): Promise<{ processed: n
 			const idx = cursor++;
 			if (idx >= files.length) return;
 			const sessionFile = files[idx];
-			await processFile(sessionFile, (file, fromOffset) => dispatch(handle, { sessionFile: file, fromOffset }));
+			await processFile(sessionFile, (file, fromOffset, parserState, replay) =>
+				dispatch(handle, { sessionFile: file, fromOffset, parserState, replay }),
+			);
 		}
 	}
 

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -9,7 +9,7 @@ import {
 } from "@oh-my-pi/pi-catalog/models";
 import type { ModelCost } from "@oh-my-pi/pi-catalog/types";
 import { getConfigRootDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
-import { classifyAgentType } from "./parser";
+import { classifyAgentType, type ParseSessionResult, type SessionParserState } from "./parser";
 import type {
 	AgentType,
 	AgentTypeStats,
@@ -192,7 +192,8 @@ export async function initDb(): Promise<Database> {
 		CREATE TABLE IF NOT EXISTS file_offsets (
 			session_file TEXT PRIMARY KEY,
 			offset INTEGER NOT NULL,
-			last_modified INTEGER NOT NULL
+			last_modified INTEGER NOT NULL,
+			parser_state TEXT
 		);
 
 		CREATE TABLE IF NOT EXISTS user_messages (
@@ -244,6 +245,10 @@ export async function initDb(): Promise<Database> {
 		);
 	`);
 
+	const offsetColumns = db.prepare("PRAGMA table_info(file_offsets)").all() as { name: string }[];
+	if (!offsetColumns.some(column => column.name === "parser_state")) {
+		db.run("ALTER TABLE file_offsets ADD COLUMN parser_state TEXT");
+	}
 	const messageColumns = db.prepare("PRAGMA table_info(messages)").all() as { name: string }[];
 	if (!messageColumns.some(column => column.name === "premium_requests")) {
 		db.run("ALTER TABLE messages ADD COLUMN premium_requests REAL NOT NULL DEFAULT 0");
@@ -484,26 +489,104 @@ function backfillNoCacheInputCosts(database: Database): void {
 /**
  * Get the stored offset for a session file.
  */
-export function getFileOffset(sessionFile: string): { offset: number; lastModified: number } | null {
+export function getFileOffset(
+	sessionFile: string,
+): { offset: number; lastModified: number; parserState?: SessionParserState } | null {
 	if (!db) return null;
 
-	const stmt = db.prepare("SELECT offset, last_modified FROM file_offsets WHERE session_file = ?");
-	const row = stmt.get(sessionFile) as { offset: number; last_modified: number } | undefined;
-
-	return row ? { offset: row.offset, lastModified: row.last_modified } : null;
+	const stmt = db.prepare("SELECT offset, last_modified, parser_state FROM file_offsets WHERE session_file = ?");
+	const row = stmt.get(sessionFile) as
+		| { offset: number; last_modified: number; parser_state: string | null }
+		| undefined;
+	if (!row) return null;
+	let parserState: SessionParserState | undefined;
+	if (row.parser_state) {
+		try {
+			const state = JSON.parse(row.parser_state) as SessionParserState;
+			if (state?.version === 1 && state.offset === row.offset) parserState = state;
+		} catch {
+			/* A missing cursor is reconstructed from the transcript. */
+		}
+	}
+	return { offset: row.offset, lastModified: row.last_modified, parserState };
 }
 
 /**
  * Update the stored offset for a session file.
  */
-export function setFileOffset(sessionFile: string, offset: number, lastModified: number): void {
+export function setFileOffset(
+	sessionFile: string,
+	offset: number,
+	lastModified: number,
+	parserState?: SessionParserState,
+): void {
 	if (!db) return;
 
 	const stmt = db.prepare(`
-		INSERT OR REPLACE INTO file_offsets (session_file, offset, last_modified)
-		VALUES (?, ?, ?)
+		INSERT OR REPLACE INTO file_offsets (session_file, offset, last_modified, parser_state)
+		VALUES (?, ?, ?, ?)
 	`);
-	stmt.run(sessionFile, offset, lastModified);
+	stmt.run(sessionFile, offset, lastModified, parserState ? JSON.stringify(parserState) : null);
+}
+
+export function applySessionParseResult(
+	sessionFile: string,
+	result: ParseSessionResult,
+	rebuild = false,
+): { processed: number; reconcile: boolean } {
+	const parserState = result.parserState;
+	if (!db || !parserState) return { processed: 0, reconcile: false };
+	const database = db;
+	return database.transaction(() => {
+		let reconcile = result.reset ?? false;
+		if (result.reset || rebuild) {
+			const retainedMessages = new Set(result.stats.map(row => JSON.stringify([row.entryId, row.timestamp])));
+			const retainedUsers = new Set(result.userStats.map(row => JSON.stringify([row.entryId, row.timestamp])));
+			const retainedTools = new Set(
+				result.toolCalls.map(row => JSON.stringify([row.entryId, row.timestamp, row.toolCallId])),
+			);
+			const messages = database
+				.prepare("SELECT entry_id, timestamp FROM messages WHERE session_file = ?")
+				.all(sessionFile) as {
+				entry_id: string;
+				timestamp: number;
+			}[];
+			const users = database
+				.prepare("SELECT entry_id, timestamp FROM user_messages WHERE session_file = ?")
+				.all(sessionFile) as { entry_id: string; timestamp: number }[];
+			const tools = database
+				.prepare("SELECT entry_id, timestamp, tool_call_id FROM tool_calls WHERE session_file = ?")
+				.all(sessionFile) as { entry_id: string; timestamp: number; tool_call_id: string }[];
+			// A removed owner may have surviving fork copies skipped earlier in this pass.
+			reconcile ||=
+				messages.some(row => !retainedMessages.has(JSON.stringify([row.entry_id, row.timestamp]))) ||
+				users.some(row => !retainedUsers.has(JSON.stringify([row.entry_id, row.timestamp]))) ||
+				tools.some(row => !retainedTools.has(JSON.stringify([row.entry_id, row.timestamp, row.tool_call_id])));
+			database.prepare("DELETE FROM messages WHERE session_file = ?").run(sessionFile);
+			database.prepare("DELETE FROM user_messages WHERE session_file = ?").run(sessionFile);
+			database.prepare("DELETE FROM tool_calls WHERE session_file = ?").run(sessionFile);
+		}
+		if (reconcile) {
+			database
+				.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('session_reconciliation', 'pending')")
+				.run();
+		}
+		if (result.stats.length > 0) insertMessageStats(result.stats);
+		if (result.userStats.length > 0) insertUserMessageStats(result.userStats);
+		if (result.userLinks.length > 0) updateUserMessageLinks(result.userLinks);
+		if (result.toolCalls.length > 0) insertToolCalls(result.toolCalls);
+		if (result.toolResults.length > 0) updateToolResults(result.toolResults);
+		setFileOffset(sessionFile, result.newOffset, parserState.mtimeMs, parserState);
+		return { processed: result.stats.length + result.userStats.length, reconcile };
+	})();
+}
+
+export function prepareSessionSync(): boolean {
+	return Boolean(db?.prepare("SELECT 1 FROM meta WHERE key = 'session_reconciliation'").get());
+}
+
+export function completeSessionSync(reconcile: boolean): void {
+	if (!reconcile) db?.prepare("DELETE FROM meta WHERE key = 'session_reconciliation'").run();
 }
 
 /**

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -1,3 +1,4 @@
+import type * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
@@ -392,22 +393,18 @@ function scanLastServiceTier(bytes: Uint8Array): ServiceTierByFamily | undefined
 	});
 	return currentServiceTier;
 }
-/**
- * Parse a session file and extract all assistant message stats.
- * Uses incremental reading with offset tracking.
- *
- * Service-tier carry-over: `currentServiceTier` is a session-scoped piece of
- * state derived from `service_tier_change` entries that affects whether
- * subsequent OpenAI assistant replies count as premium requests. Incremental
- * syncs that resume past the most-recent tier change would otherwise lose
- * that state and silently record `premiumRequests = 0` for priority traffic
- * (the coding-agent stopped folding the tier into `usage.premiumRequests`
- * after 13f59162e — the parser is now the sole source of truth). When
- * `fromOffset > 0` we therefore scan the bytes preceding `fromOffset`
- * for the latest service-tier value before parsing the unprocessed tail.
- * The scan only keeps the current tier and does not materialize prefix
- * entries, preserving offset-based memory behavior for large sessions.
- */
+export interface SessionParserState {
+	version: 1;
+	offset: number;
+	dev: number;
+	ino: number;
+	birthtimeMs: number;
+	size: number;
+	mtimeMs: number;
+	checkpoint: string;
+	serviceTier: ServiceTierByFamily | null;
+}
+
 export interface ParseSessionResult {
 	stats: MessageStats[];
 	userStats: UserMessageStats[];
@@ -415,11 +412,80 @@ export interface ParseSessionResult {
 	toolCalls: ToolCallStats[];
 	toolResults: ToolResultLink[];
 	newOffset: number;
+	parserState?: SessionParserState;
+	reset?: boolean;
 }
-export async function parseSessionFile(sessionPath: string, fromOffset = 0): Promise<ParseSessionResult> {
+
+const CHECKPOINT_BYTES = 256;
+
+async function readCheckpoint(handle: fs.FileHandle, end: number): Promise<Uint8Array> {
+	// Positional reads keep the descriptor at zero for Bun.file(fd)'s subsequent tail read.
+	const start = Math.max(0, end - CHECKPOINT_BYTES);
+	const bytes = new Uint8Array(end - start);
+	let read = 0;
+	while (read < bytes.length) {
+		const result = await handle.read(bytes, read, bytes.length - read, start + read);
+		if (result.bytesRead === 0) break;
+		read += result.bytesRead;
+	}
+	return bytes.subarray(0, read);
+}
+
+export function matchesSessionFile(state: SessionParserState, info: nodeFs.Stats): boolean {
+	return state.dev === info.dev && state.ino === info.ino && state.birthtimeMs === info.birthtimeMs;
+}
+
+/** Offset-only callers reconstruct service-tier state once; persisted cursors read only the appended tail. */
+export async function parseSessionFile(
+	sessionPath: string,
+	fromOffset = 0,
+	state?: SessionParserState,
+	replay = false,
+): Promise<ParseSessionResult> {
 	let bytes: Uint8Array;
+	let start = fromOffset;
+	let reset = false;
+	let currentServiceTier: ServiceTierByFamily | undefined;
+	let info: nodeFs.Stats;
+	let checkpoint: string;
+	let read: number;
+	let entries: SessionEntry[];
 	try {
-		bytes = await Bun.file(sessionPath).bytes();
+		const handle = await fs.open(sessionPath, "r");
+		try {
+			info = await handle.stat();
+			const file = Bun.file(handle.fd);
+			let resume = state?.version === 1 && state.offset === fromOffset;
+			if (resume && state) {
+				reset =
+					!matchesSessionFile(state, info) ||
+					info.size < state.size ||
+					(info.size === state.size && info.mtimeMs !== state.mtimeMs);
+				if (!reset) {
+					const previous = await readCheckpoint(handle, fromOffset);
+					reset = Bun.hash(previous).toString(16) !== state.checkpoint;
+				}
+				resume = !reset;
+			}
+			if (fromOffset > info.size) reset = true;
+			if (replay) resume = false;
+			start = reset || replay ? 0 : Math.max(0, fromOffset);
+			const readStart = resume ? start : 0;
+			bytes = await file.slice(readStart, info.size).bytes();
+			currentServiceTier = resume
+				? (state?.serviceTier ?? undefined)
+				: scanLastServiceTier(bytes.subarray(0, start));
+			({ entries, read } = parseSessionEntriesLenient(bytes.subarray(start - readStart)));
+			const newOffset = start + read;
+			const checkpointStart = Math.max(0, newOffset - CHECKPOINT_BYTES);
+			const previous =
+				checkpointStart >= readStart
+					? bytes.subarray(checkpointStart - readStart, newOffset - readStart)
+					: await readCheckpoint(handle, newOffset);
+			checkpoint = Bun.hash(previous).toString(16);
+		} finally {
+			await handle.close();
+		}
 	} catch (err) {
 		if (isEnoent(err))
 			return { stats: [], userStats: [], userLinks: [], toolCalls: [], toolResults: [], newOffset: fromOffset };
@@ -434,13 +500,6 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	const toolCalls: ToolCallStats[] = [];
 	const toolResults: ToolResultLink[] = [];
 	const userByEntryId = new Map<string, UserMessageStats>();
-	const start = Math.max(0, Math.min(fromOffset, bytes.length));
-	const unprocessed = bytes.subarray(start);
-	const { entries, read } = parseSessionEntriesLenient(unprocessed);
-	let currentServiceTier: ServiceTierByFamily | undefined;
-	if (start > 0) {
-		currentServiceTier = scanLastServiceTier(bytes.subarray(0, start));
-	}
 	for (const entry of entries) {
 		if (isServiceTierChange(entry)) {
 			currentServiceTier = coerceServiceTierByFamily(entry.serviceTier);
@@ -490,7 +549,27 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 		}
 	}
 
-	return { stats, userStats, userLinks, toolCalls, toolResults, newOffset: start + read };
+	const newOffset = start + read;
+	return {
+		stats,
+		userStats,
+		userLinks,
+		toolCalls,
+		toolResults,
+		newOffset,
+		reset,
+		parserState: {
+			version: 1,
+			offset: newOffset,
+			dev: info.dev,
+			ino: info.ino,
+			birthtimeMs: info.birthtimeMs,
+			size: info.size,
+			mtimeMs: info.mtimeMs,
+			checkpoint,
+			serviceTier: currentServiceTier ?? null,
+		},
+	};
 }
 
 /**

--- a/packages/stats/src/sync-worker.ts
+++ b/packages/stats/src/sync-worker.ts
@@ -1,6 +1,6 @@
 /**
  * Stateless parse worker for `syncAllSessions`. The main thread owns the
- * SQLite handle; workers receive `{ sessionFile, fromOffset }`, run
+ * SQLite handle; workers receive a session path, offset, and parser state, run
  * `parseSessionFile` (which is pure I/O + CPU, no DB), and post the
  * structured-clone-safe result back. One in-flight request per worker so
  * the main thread can fan jobs out 1:1 with the pool size.
@@ -11,9 +11,11 @@
  * for issue #1011 / PR #1027, where the worker silently failed to load).
  */
 
-import { type ParseSessionResult, parseSessionFile } from "./parser";
+import { type ParseSessionResult, parseSessionFile, type SessionParserState } from "./parser";
 
-export type SyncWorkerRequest = { kind?: "parse"; sessionFile: string; fromOffset: number } | { kind: "ping" };
+export type SyncWorkerRequest =
+	| { kind?: "parse"; sessionFile: string; fromOffset: number; parserState?: SessionParserState; replay?: boolean }
+	| { kind: "ping" };
 
 export type SyncWorkerResponse =
 	| { ok: true; kind?: "parse"; result: ParseSessionResult }
@@ -31,7 +33,12 @@ self.onmessage = async event => {
 			self.postMessage({ ok: true, kind: "pong" } satisfies SyncWorkerResponse);
 			return;
 		}
-		const result = await parseSessionFile(request.sessionFile, request.fromOffset);
+		const result = await parseSessionFile(
+			request.sessionFile,
+			request.fromOffset,
+			request.parserState,
+			request.replay,
+		);
 		self.postMessage({ ok: true, result } satisfies SyncWorkerResponse);
 	} catch (err) {
 		const error = err instanceof Error ? (err.stack ?? err.message) : String(err);

--- a/packages/stats/test/incremental-tail.test.ts
+++ b/packages/stats/test/incremental-tail.test.ts
@@ -1,0 +1,332 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { syncAllSessions } from "@oh-my-pi/omp-stats/aggregator";
+import { closeDb, getFileOffset, getOverallStats, getRecentRequests, initDb } from "@oh-my-pi/omp-stats/db";
+import { getSessionsDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+const isolation = installStatsTestIsolation("@pi-stats-tail-");
+
+beforeEach(() => {
+	const temp = isolation.current();
+	if (
+		!temp ||
+		path.resolve(os.homedir(), process.env.PI_CONFIG_DIR ?? "") !== temp.join("config") ||
+		!getStatsDbPath().startsWith(`${temp.path()}${path.sep}`)
+	) {
+		throw new Error("Stats tests require an isolated temporary configuration and database");
+	}
+});
+
+function assistant(id: string): string {
+	return `${JSON.stringify({
+		type: "message",
+		id,
+		timestamp: "2026-09-07T12:00:00Z",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.4",
+			stopReason: "stop",
+			timestamp: 0,
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		},
+	})}\n`;
+}
+
+function tier(value: string | null): string {
+	return `${JSON.stringify({ type: "service_tier_change", serviceTier: value })}\n`;
+}
+
+async function session(content: string): Promise<string> {
+	const file = path.join(getSessionsDir(), "--tmp--tail", "session.jsonl");
+	await Bun.write(file, content);
+	return file;
+}
+
+describe("incremental stats ingestion", () => {
+	for (const kind of ["message", "user", "tool", "tool-entry"] as const) {
+		const title =
+			kind === "tool-entry"
+				? "preserves forked tool calls when a replacement reuses the call ID in a different entry"
+				: `preserves forked ${kind} records when a replacement reuses an ID at a new timestamp`;
+		it(title, async () => {
+			const oldTime = Date.parse("2026-09-07T12:00:00Z");
+			const newTime = kind === "tool-entry" ? oldTime : Date.parse("2026-09-07T13:00:00Z");
+			const entry = (timestamp: number, id = "shared"): string =>
+				`${JSON.stringify({
+					type: "message",
+					id,
+					timestamp: new Date(timestamp).toISOString(),
+					message: {
+						role: kind === "user" ? "user" : "assistant",
+						timestamp,
+						content:
+							kind === "tool" || kind === "tool-entry"
+								? [{ type: "toolCall", id: "call", name: "read", arguments: { path: "README.md" } }]
+								: [{ type: "text", text: "hello" }],
+						model: "gpt-5.4",
+						provider: "openai",
+						api: "openai-responses",
+						stopReason: "stop",
+						usage:
+							kind === "message"
+								? {
+										input: 10,
+										output: 5,
+										cacheRead: 0,
+										cacheWrite: 0,
+										totalTokens: 15,
+										cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+									}
+								: undefined,
+					},
+				})}\n`;
+			const fork = path.join(getSessionsDir(), "--tmp--tail", "fork.jsonl");
+			await Bun.write(fork, "");
+			const owner = await session(entry(oldTime));
+			await syncAllSessions({ workers: 1 });
+			await Bun.write(fork, entry(oldTime));
+			await syncAllSessions({ workers: 1 });
+			const db = await initDb();
+			db.prepare("DELETE FROM meta WHERE key = 'messages_cost_reingest_v1'").run();
+			closeDb();
+			await Bun.write(`${owner}.replacement`, entry(newTime, kind === "tool-entry" ? "new-entry" : "shared"));
+			await fs.rename(`${owner}.replacement`, owner);
+			const visited: string[] = [];
+			await syncAllSessions({
+				workers: 1,
+				onProgress(progress) {
+					visited.push(progress.sessionFile);
+				},
+			});
+			expect(visited[0]).toBe(fork);
+			await syncAllSessions({ workers: 1 });
+			const table = kind === "message" ? "messages" : kind === "user" ? "user_messages" : "tool_calls";
+			const rows = (await initDb()).prepare(`SELECT timestamp FROM ${table} ORDER BY timestamp`).all() as {
+				timestamp: number;
+			}[];
+			expect(rows.map(row => row.timestamp)).toEqual([oldTime, newTime]);
+		});
+	}
+
+	it("rebuilds a replaced transcript when a database backfill invalidates its cursor", async () => {
+		const file = await session(assistant("old"));
+		await syncAllSessions({ workers: 1 });
+		const db = await initDb();
+		db.prepare("DELETE FROM meta WHERE key = 'messages_cost_reingest_v1'").run();
+		closeDb();
+		await Bun.write(`${file}.replacement`, assistant("new"));
+		await fs.rename(`${file}.replacement`, file);
+		await syncAllSessions({ workers: 1 });
+		expect(getRecentRequests().map(row => row.entryId)).toEqual(["new"]);
+	});
+
+	it("detects a second replacement after interruption without forgetting its previous file identity", async () => {
+		const fileA = await session(assistant("oldA"));
+		const fileB = path.join(path.dirname(fileA), "second.jsonl");
+		await Bun.write(fileB, assistant("oldB"));
+		await syncAllSessions({ workers: 1 });
+		await fs.writeFile(fileA, assistant("newA"));
+		await expect(
+			syncAllSessions({
+				workers: 1,
+				onProgress(progress) {
+					if (progress.sessionFile === fileA) throw new Error("interrupted after A");
+				},
+			}),
+		).rejects.toThrow("interrupted after A");
+		closeDb();
+		await fs.writeFile(
+			fileB,
+			assistant("newB") + JSON.stringify({ type: "custom", padding: "x".repeat(8192) }) + "\n",
+		);
+		await syncAllSessions({ workers: 2 });
+		expect(
+			getRecentRequests()
+				.map(row => row.entryId)
+				.sort(),
+		).toEqual(["newA", "newB"]);
+	}, 15_000);
+
+	for (const state of [null, "invalid JSON"] as const) {
+		it(`rebuilds a larger replacement when persisted parser state is ${state === null ? "missing" : "invalid"}`, async () => {
+			const file = await session(assistant("old"));
+			await syncAllSessions({ workers: 1 });
+			const db = await initDb();
+			db.prepare("UPDATE file_offsets SET parser_state = ? WHERE session_file = ?").run(state, file);
+			closeDb();
+			await fs.writeFile(
+				file,
+				assistant("new") + JSON.stringify({ type: "custom", padding: "x".repeat(8192) }) + "\n",
+			);
+			await syncAllSessions({ workers: 1 });
+			expect(getRecentRequests().map(row => row.entryId)).toEqual(["new"]);
+		});
+	}
+
+	it("reads only appended bytes after reopening the database and retains priority accounting", async () => {
+		const file = await session(
+			tier("priority") +
+				JSON.stringify({ type: "custom", padding: "x".repeat(2_000_000) }) +
+				"\n" +
+				assistant("first"),
+		);
+		await syncAllSessions({ workers: 1 });
+		closeDb();
+		const tail = assistant("second");
+		await fs.appendFile(file, tail);
+		const prototype = Object.getPrototypeOf(Bun.file(file)) as Bun.BunFile;
+		const original = prototype.bytes;
+		let readBytes = 0;
+		const observer = spyOn(prototype, "bytes").mockImplementation(async function (this: Bun.BunFile) {
+			const bytes = await original.call(this);
+			readBytes += bytes.length;
+			return bytes;
+		});
+		try {
+			await syncAllSessions({ workers: 1 });
+		} finally {
+			observer.mockRestore();
+		}
+		expect(getOverallStats().totalRequests).toBe(2);
+		expect(getOverallStats().totalPremiumRequests).toBe(2);
+		expect(readBytes).toBeLessThan(Buffer.byteLength(tail) + 4096);
+	});
+
+	for (const operation of ["replace", "truncate"] as const) {
+		it(`rebuilds derived totals after ${operation} instead of reusing the old offset and tier`, async () => {
+			const file = await session(
+				tier("priority") + assistant("old") + JSON.stringify({ type: "custom", padding: "x".repeat(8192) }) + "\n",
+			);
+			await syncAllSessions({ workers: 1 });
+			const replacement = assistant("new");
+			if (operation === "replace") {
+				await Bun.write(`${file}.new`, replacement);
+				await fs.rename(`${file}.new`, file);
+			} else {
+				await fs.writeFile(file, replacement);
+			}
+			await syncAllSessions({ workers: 1 });
+			expect(getRecentRequests().map(row => row.entryId)).toEqual(["new"]);
+			expect(getOverallStats().totalPremiumRequests).toBe(0);
+		});
+	}
+
+	it("upgrades offset-only databases without losing the active tier", async () => {
+		const file = await session(tier("priority") + assistant("first"));
+		await syncAllSessions({ workers: 1 });
+		closeDb();
+		const raw = new Database(getStatsDbPath());
+		raw.exec(
+			"ALTER TABLE file_offsets RENAME TO old_offsets; CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL); INSERT INTO file_offsets SELECT session_file, offset, last_modified FROM old_offsets; DROP TABLE old_offsets;",
+		);
+		raw.close();
+		await syncAllSessions({ workers: 1 });
+		await fs.appendFile(file, assistant("second"));
+		await syncAllSessions({ workers: 1 });
+		expect(getOverallStats().totalRequests).toBe(2);
+		expect(getOverallStats().totalPremiumRequests).toBe(2);
+	});
+
+	it("carries service-tier resets through the worker protocol and database restarts", async () => {
+		const file = await session(tier("priority") + assistant("first"));
+		await syncAllSessions({ workers: 2 });
+		closeDb();
+		await fs.appendFile(file, assistant("second") + tier(null));
+		await syncAllSessions({ workers: 2 });
+		closeDb();
+		await fs.appendFile(file, assistant("third"));
+		await syncAllSessions({ workers: 2 });
+		expect(getOverallStats().totalRequests).toBe(3);
+		expect(getOverallStats().totalPremiumRequests).toBe(2);
+	}, 15_000);
+
+	it("retries an incomplete final entry without losing its preceding service tier", async () => {
+		const reply = assistant("completed");
+		const split = Math.floor(reply.length / 2);
+		const file = await session(tier("priority") + reply.slice(0, split));
+		await syncAllSessions({ workers: 1 });
+		expect(getOverallStats().totalRequests).toBe(0);
+		await fs.appendFile(file, reply.slice(split));
+		await syncAllSessions({ workers: 1 });
+		expect(getOverallStats().totalRequests).toBe(1);
+		expect(getOverallStats().totalPremiumRequests).toBe(1);
+	});
+
+	it("detects a same-inode rewrite that grows past the previous cursor", async () => {
+		const file = await session(tier("priority") + assistant("old"));
+		await syncAllSessions({ workers: 1 });
+		await fs.writeFile(file, assistant("new") + JSON.stringify({ type: "custom", padding: "x".repeat(8192) }) + "\n");
+		await syncAllSessions({ workers: 1 });
+		expect(getRecentRequests().map(row => row.entryId)).toEqual(["new"]);
+		expect(getOverallStats().totalPremiumRequests).toBe(0);
+	});
+
+	it("rolls back replacement deletions and the cursor when a derived-row write fails", async () => {
+		const file = await session(tier("priority") + assistant("old"));
+		await syncAllSessions({ workers: 1 });
+		const oldOffset = getFileOffset(file);
+		const db = await initDb();
+		db.exec(
+			"CREATE TRIGGER reject_new BEFORE INSERT ON messages WHEN NEW.entry_id = 'new' BEGIN SELECT RAISE(ABORT, 'injected write failure'); END;",
+		);
+		await fs.writeFile(file, assistant("new"));
+		await expect(syncAllSessions({ workers: 1 })).rejects.toThrow("injected write failure");
+		expect(getRecentRequests().map(row => row.entryId)).toEqual(["old"]);
+		expect(getFileOffset(file)).toEqual(oldOffset);
+		db.exec("DROP TRIGGER reject_new");
+		await syncAllSessions({ workers: 1 });
+		expect(getRecentRequests().map(row => row.entryId)).toEqual(["new"]);
+	});
+
+	it("keeps a request still present in a fork when its original transcript is replaced", async () => {
+		const file = await session(assistant("shared"));
+		await syncAllSessions({ workers: 1 });
+		await Bun.write(path.join(path.dirname(file), "fork.jsonl"), assistant("shared"));
+		await syncAllSessions({ workers: 1 });
+		expect(getOverallStats().totalRequests).toBe(1);
+		await fs.writeFile(file, assistant("new"));
+		await syncAllSessions({ workers: 1 });
+		expect(
+			getRecentRequests()
+				.map(row => row.entryId)
+				.sort(),
+		).toEqual(["new", "shared"]);
+	});
+
+	it("resumes fork reconciliation after interruption following a committed replacement", async () => {
+		const file = await session(assistant("shared"));
+		await syncAllSessions({ workers: 1 });
+		await Bun.write(path.join(path.dirname(file), "fork.jsonl"), assistant("shared"));
+		await syncAllSessions({ workers: 1 });
+		await fs.writeFile(file, assistant("new"));
+		await expect(
+			syncAllSessions({
+				workers: 1,
+				onProgress(progress) {
+					if (progress.sessionFile === file) throw new Error("interrupted after commit");
+				},
+			}),
+		).rejects.toThrow("interrupted after commit");
+		closeDb();
+		await syncAllSessions({ workers: 1 });
+		expect(
+			getRecentRequests()
+				.map(row => row.entryId)
+				.sort(),
+		).toEqual(["new", "shared"]);
+	});
+});


### PR DESCRIPTION
## What

Depends on #11224: merge the session-writer fix first so synchronous EPERM rewrites replace file identity.

Stats sync persists service-tier state with file identity and a bounded checkpoint, so normal appends read the tail after restarts. Replacements, truncation, and cursor-invalidating migrations rebuild derived rows transactionally; interrupted reconciliation restores surviving fork records.

Arbitrary in-place edits earlier than the checkpoint can evade detection; this optimization relies on append or replacement writes. The companion storage change removes OMP's synchronous in-place rewrite fallback.

## Why

Offset tracking still reread the full prefix to reconstruct service-tier state, and replacements could leave stale totals.

## Testing

- [x] 33 focused tests, stats package check, and clean fourth independent review, including a three-fork parallel-worker convergence probe.
- [x] Integrated full stats suite: 138 pass, one baseline pricing failure (expected `0`, actual `0.00254`); no assertion changed.
- [x] A 383-byte append previously reread 2,000,852 bulk bytes; the changed regression reads under 4,479 bytes plus bounded checkpoints. No wall-time speedup claim.

Local results above were collected on `daf07999c2`. The branch was rebased onto `ff594e6d97` without implementation changes; CI on the published head is pending.

---

- [ ] Full `bun check` on the published head
- [x] Tested locally
- [x] CHANGELOG updated
