### PR TITLE
fix(lsp): implement dynamic watched-file registrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,7 @@
         "@opentelemetry/sdk-metrics": "catalog:",
         "@opentelemetry/sdk-trace-base": "catalog:",
         "@opentelemetry/sdk-trace-node": "catalog:",
+        "chokidar": "4.0.3",
         "puppeteer-core": "catalog:",
       },
       "devDependencies": {
@@ -1055,6 +1056,8 @@
 
     "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
     "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
@@ -1332,6 +1335,8 @@
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 

--- a/docs/lsp-config.md
+++ b/docs/lsp-config.md
@@ -17,6 +17,23 @@ When no config file contributes a server override, OMP auto-detects built-in ser
 
 Root-marker detection at startup is cwd-only; it does not search parent directories. Wildcard markers such as `*.cabal` match entries directly inside the cwd and do not recurse. No configuration is required for common setups; see [`defaults.json`](../packages/coding-agent/src/lsp/defaults.json) for the full built-in set.
 
+## External file changes
+
+OMP supports dynamic `workspace/didChangeWatchedFiles` registration, including
+string globs, relative patterns, and create/change/delete event masks. Registered
+watches notify the server about external edits to unopened dependencies; they are
+not limited to writes made by OMP tools.
+
+Nested `.git`, `node_modules`, and `.worktrees` directories are excluded before
+watcher traversal, and symbolic links are not followed. Generated source directories
+such as `.svelte-kit/types` remain eligible. These exclusions prevent recursive
+server requests from exhausting filesystem watches on nested checkouts.
+
+The private client owns watches for a private language server. For broker-managed
+servers, the broker owns them for the server's lifetime, including its disconnected
+retention period; attaching clients do not create duplicate watchers. Unregistration
+releases unused roots, and server shutdown or exit closes its watches.
+
 ## Config file locations
 
 OMP merges LSP config from multiple sources, lowest to highest precedence:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Svelte language-server startup exhausting filesystem watches in monorepos with nested worktrees. OMP now implements dynamic watched-file registrations with traversal exclusions and external dependency-change notifications for private and broker-managed servers.
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -70,6 +70,7 @@
     "@opentelemetry/sdk-metrics": "catalog:",
     "@opentelemetry/sdk-trace-base": "catalog:",
     "@opentelemetry/sdk-trace-node": "catalog:",
+    "chokidar": "4.0.3",
     "puppeteer-core": "catalog:"
   },
   "optionalDependencies": {

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -19,12 +19,14 @@ import type {
 	WorkspaceEdit,
 } from "./types";
 import { detectLanguageId, EquivalentUriMap, fileToUri, uriToFile } from "./utils";
+import { WATCHED_FILES_METHOD, WatchedFiles } from "./watched-files";
 
 // =============================================================================
 // Client State
 // =============================================================================
 
 const clients = new Map<string, LspClient>();
+const clientWatchers = new WeakMap<LspClient, WatchedFiles>();
 interface PendingClient {
 	promise: Promise<LspClient>;
 	cwd: string;
@@ -251,6 +253,10 @@ const CLIENT_CAPABILITIES = {
 		},
 		configuration: true,
 		workspaceFolders: true,
+		didChangeWatchedFiles: {
+			dynamicRegistration: true,
+			relativePatternSupport: true,
+		},
 		symbol: {
 			dynamicRegistration: false,
 			symbolKind: {
@@ -350,6 +356,7 @@ async function writeMessage(
  */
 function teardownWedgedClient(client: LspClient): void {
 	if (clients.get(client.name) === client) clients.delete(client.name);
+	void clientWatchers.get(client)?.close();
 	try {
 		client.proc.kill();
 	} catch {
@@ -493,6 +500,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 		client.messageBuffer = framer.remainder();
 		reader.releaseLock();
 		client.isReading = false;
+		await clientWatchers.get(client)?.close();
 		if (!readerFailed && client.proc.exitCode === null) {
 			await waitForExit(client, READER_EXIT_GRACE_MS);
 		}
@@ -745,9 +753,26 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		return;
 	}
 	if (message.method === "client/registerCapability" || message.method === "client/unregisterCapability") {
-		updateDynamicCapabilities(client, message);
-		// Some servers block semantic requests until dynamic registration succeeds.
-		await sendResponse(client, message.id, null, message.method);
+		try {
+			const params = message.params as DynamicCapabilityParams | undefined;
+			const watchers = clientWatchers.get(client);
+			if (message.method === "client/registerCapability") {
+				await watchers?.register(params?.registrations ?? []);
+			} else {
+				const unregistrations = params?.unregisterations ?? params?.unregistrations ?? [];
+				await watchers?.unregister(
+					unregistrations.flatMap(registration => (typeof registration.id === "string" ? [registration.id] : [])),
+				);
+			}
+			updateDynamicCapabilities(client, message);
+			// Some servers block semantic requests until dynamic registration succeeds.
+			await sendResponse(client, message.id, null, message.method);
+		} catch (error) {
+			await sendResponse(client, message.id, null, message.method, {
+				code: -32603,
+				message: `Capability registration failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
 		return;
 	}
 	if (message.method === "window/showMessageRequest") {
@@ -1103,9 +1128,24 @@ export async function getOrCreateClient(
 			projectLoaded,
 			resolveProjectLoaded,
 		};
+		if (!proc.sharedMux) {
+			clientWatchers.set(
+				client,
+				new WatchedFiles(cwd, async changes => {
+					for (const change of changes) client.diagnostics.delete(change.uri);
+					await sendNotification(
+						client,
+						WATCHED_FILES_METHOD,
+						{ changes },
+						AbortSignal.timeout(WATCHED_FILES_NOTIFY_TIMEOUT_MS),
+					);
+				}),
+			);
+		}
 
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(() => {
+			void clientWatchers.get(client)?.close();
 			if (clients.get(key) === client) clients.delete(key);
 			maybeStopIdleChecker();
 			if (clientLocks.get(key)?.token === lockToken) clientLocks.delete(key);
@@ -1181,6 +1221,7 @@ export async function getOrCreateClient(
 		} catch (err) {
 			// Clean up on initialization failure
 			client.status = "error";
+			await clientWatchers.get(client)?.close();
 			if (clients.get(key) === client) clients.delete(key);
 			proc.kill();
 			const message = err instanceof Error ? err.message : String(err);
@@ -1549,6 +1590,7 @@ async function waitForExit(client: LspClient, timeoutMs: number): Promise<boolea
 export async function shutdownClientInstance(client: LspClient): Promise<boolean> {
 	if (clients.get(client.name) === client) clients.delete(client.name);
 	maybeStopIdleChecker();
+	await clientWatchers.get(client)?.close();
 
 	const err = new Error("LSP client shutdown");
 	for (const pending of Array.from(client.pendingRequests.values())) {

--- a/packages/coding-agent/src/lsp/mux/server.ts
+++ b/packages/coding-agent/src/lsp/mux/server.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs/promises";
 import * as net from "node:net";
-import { isRecord, logger, postmortem, ptree, setProcessName } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, postmortem, ptree, setProcessName, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../../jsonrpc/message-framing";
 import type { LspJsonRpcId, LspJsonRpcNotification, LspJsonRpcRequest, LspJsonRpcResponse } from "../types";
+import { WATCHED_FILES_METHOD, WatchedFiles } from "../watched-files";
 import {
 	LSP_MUX_PROJECT_DIR_ENV,
 	LSP_MUX_SOCKET_ENV,
@@ -97,6 +98,7 @@ class ServerInstance {
 	nextClientId = 1;
 	lingerTimer?: NodeJS.Timeout;
 	stopping = false;
+	watchedFiles?: WatchedFiles;
 
 	constructor(key: string, params: MuxConnectParams) {
 		this.key = key;
@@ -441,6 +443,23 @@ export class LspMuxServer {
 
 	#spawnServer(key: string, params: MuxConnectParams): ServerInstance {
 		const server = new ServerInstance(key, params);
+		server.watchedFiles = new WatchedFiles(params.cwd, async changes => {
+			if (server.stopping) return;
+			for (const change of changes) server.diagnostics.delete(change.uri);
+			try {
+				await untilAborted(
+					AbortSignal.timeout(SHUTDOWN_BUDGET_MS),
+					this.#writeServer(server, {
+						jsonrpc: "2.0",
+						method: WATCHED_FILES_METHOD,
+						params: { changes },
+					}),
+				);
+			} catch (error) {
+				this.#killServer(server);
+				throw error;
+			}
+		});
 		this.#servers.add(server);
 		void this.#readServer(server);
 		server.proc.exited.then(
@@ -534,6 +553,25 @@ export class LspMuxServer {
 	}
 
 	async #handleServerRequest(server: ServerInstance, message: LspJsonRpcRequest): Promise<void> {
+		try {
+			if (message.method === "client/registerCapability" && isRecord(message.params)) {
+				const registrations = message.params.registrations;
+				if (Array.isArray(registrations)) await server.watchedFiles?.register(registrations);
+			} else if (message.method === "client/unregisterCapability" && isRecord(message.params)) {
+				const raw = message.params.unregisterations ?? message.params.unregistrations;
+				if (Array.isArray(raw)) {
+					await server.watchedFiles?.unregister(
+						raw.flatMap(item => (isRecord(item) && typeof item.id === "string" ? [item.id] : [])),
+					);
+				}
+			}
+		} catch (error) {
+			await this.#writeServer(
+				server,
+				rpcError(message.id, -32603, `Capability registration failed: ${String(error)}`),
+			);
+			return;
+		}
 		if (
 			message.method === "client/registerCapability" ||
 			message.method === "client/unregisterCapability" ||
@@ -671,6 +709,7 @@ export class LspMuxServer {
 
 	#serverExited(server: ServerInstance): void {
 		server.stopping = true;
+		void server.watchedFiles?.close();
 		this.#servers.delete(server);
 		if (server.lingerTimer) clearTimeout(server.lingerTimer);
 		server.pending.clear();
@@ -681,6 +720,7 @@ export class LspMuxServer {
 	async #stopServer(server: ServerInstance): Promise<void> {
 		if (server.stopping) return;
 		server.stopping = true;
+		await server.watchedFiles?.close();
 		if (server.lingerTimer) clearTimeout(server.lingerTimer);
 		const id = server.muxId();
 		const { promise, resolve } = Promise.withResolvers<void>();
@@ -704,6 +744,7 @@ export class LspMuxServer {
 
 	#killServer(server: ServerInstance): void {
 		server.stopping = true;
+		void server.watchedFiles?.close();
 		try {
 			server.proc.kill();
 		} catch {

--- a/packages/coding-agent/src/lsp/watched-files.ts
+++ b/packages/coding-agent/src/lsp/watched-files.ts
@@ -1,0 +1,227 @@
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isRecord, logger } from "@oh-my-pi/pi-utils";
+import { type FSWatcher, watch } from "chokidar";
+
+export const WATCHED_FILES_METHOD = "workspace/didChangeWatchedFiles";
+
+export interface FileEvent {
+	uri: string;
+	type: 1 | 2 | 3;
+}
+
+interface Pattern {
+	root: string;
+	glob: Bun.Glob;
+	absolute: boolean;
+	kind: number;
+}
+
+interface RootWatcher {
+	watcher: FSWatcher;
+	ready: Promise<void>;
+	cancel(): void;
+}
+
+// Prune before descent, not merely at notification time. In particular, nested
+// checkouts must not consume an inotify watch for every file they contain.
+const EXCLUDED_DIRECTORIES: Record<string, true> = { ".git": true, node_modules: true, ".worktrees": true };
+const READY_TIMEOUT_MS = 10_000;
+// Chokidar coalesces change events for 50 ms. Notify after that window so the
+// server reads the final contents, rather than missing a subsequent suppressed write.
+const FILE_EVENT_BATCH_MS = 75;
+
+function inside(root: string, target: string): boolean {
+	const relative = path.relative(root, target);
+	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function excluded(root: string, target: string): boolean {
+	return path
+		.relative(root, target)
+		.split(path.sep)
+		.some(segment => Object.hasOwn(EXCLUDED_DIRECTORIES, segment));
+}
+
+function compilePattern(cwd: string, value: unknown): Pattern {
+	if (!isRecord(value)) throw new Error("Invalid watched-file watcher");
+	const kind = value.kind ?? 7;
+	if (typeof kind !== "number" || !Number.isInteger(kind) || kind < 0 || kind > 7) {
+		throw new Error("Invalid watched-file kind");
+	}
+	const pattern = value.globPattern;
+	let root = cwd;
+	let text: string;
+	let absolute = false;
+	if (typeof pattern === "string") {
+		text = pattern;
+		absolute = path.isAbsolute(text);
+		if (absolute) {
+			// Watch the literal directory prefix, not the filesystem root, for
+			// absolute patterns referring to dependencies outside the workspace.
+			const magic = text.search(/[?*[{]/);
+			const prefix = magic < 0 ? text : text.slice(0, magic);
+			const directory = path.dirname(prefix.endsWith(path.sep) ? `${prefix}_` : prefix);
+			root = inside(cwd, directory) || inside(directory, cwd) ? cwd : directory;
+		}
+	} else if (isRecord(pattern) && typeof pattern.pattern === "string") {
+		const baseUri = isRecord(pattern.baseUri) ? pattern.baseUri.uri : pattern.baseUri;
+		if (typeof baseUri !== "string") throw new Error("Invalid watched-file base URI");
+		root = fileURLToPath(baseUri);
+		text = pattern.pattern;
+		if (path.isAbsolute(text) || text.split("/").includes("..")) {
+			throw new Error("Watched-file relative pattern must stay within its base URI");
+		}
+	} else {
+		throw new Error("Invalid watched-file glob pattern");
+	}
+	if (!text) throw new Error("Empty watched-file glob pattern");
+	return { root: path.resolve(root), glob: new Bun.Glob(text.split(path.sep).join("/")), absolute, kind };
+}
+
+/** One owner per language-server process, including when that process is muxed. */
+export class WatchedFiles {
+	readonly #cwd: string;
+	readonly #notify: (changes: FileEvent[]) => Promise<void>;
+	readonly #registrations = new Map<string, Pattern[]>();
+	readonly #roots = new Map<string, RootWatcher>();
+	readonly #pending: FileEvent[] = [];
+	readonly #lastPendingType = new Map<string, FileEvent["type"]>();
+	#timer?: NodeJS.Timeout;
+	#closed = false;
+
+	constructor(cwd: string, notify: (changes: FileEvent[]) => Promise<void>) {
+		this.#cwd = path.resolve(cwd);
+		this.#notify = notify;
+	}
+
+	/** Validate the entire batch and establish watches before acknowledging it. */
+	async register(registrations: readonly unknown[]): Promise<void> {
+		if (this.#closed) throw new Error("Watched-file owner is closed");
+		const additions = new Map<string, Pattern[]>();
+		for (const registration of registrations) {
+			if (!isRecord(registration) || registration.method !== WATCHED_FILES_METHOD) continue;
+			const options = registration.registerOptions;
+			if (typeof registration.id !== "string" || !isRecord(options) || !Array.isArray(options.watchers)) {
+				throw new Error("Invalid watched-file registration");
+			}
+			additions.set(
+				registration.id,
+				options.watchers.map(value => compilePattern(this.#cwd, value)),
+			);
+		}
+		try {
+			const ready: Promise<void>[] = [];
+			for (const patterns of additions.values()) {
+				for (const pattern of patterns) ready.push(this.#watchRoot(pattern.root).ready);
+			}
+			await Promise.all(ready);
+			if (this.#closed) throw new Error("Watched-file owner is closed");
+			for (const [id, patterns] of additions) this.#registrations.set(id, patterns);
+		} finally {
+			await this.#releaseUnusedRoots();
+		}
+	}
+
+	async unregister(ids: readonly string[]): Promise<void> {
+		for (const id of ids) this.#registrations.delete(id);
+		await this.#releaseUnusedRoots();
+	}
+
+	async close(): Promise<void> {
+		this.#closed = true;
+		this.#registrations.clear();
+		this.#pending.length = 0;
+		this.#lastPendingType.clear();
+		clearTimeout(this.#timer);
+		this.#timer = undefined;
+		await this.#releaseUnusedRoots();
+	}
+
+	#watchRoot(root: string): RootWatcher {
+		const existing = this.#roots.get(root);
+		if (existing) return existing;
+		const watcher = watch(root, {
+			ignoreInitial: true,
+			persistent: false,
+			followSymlinks: false,
+			ignored: target =>
+				excluded(root, path.resolve(target)) ||
+				(inside(this.#cwd, path.resolve(target)) && excluded(this.#cwd, path.resolve(target))),
+		});
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		const timer = setTimeout(
+			() => reject(new Error(`Watched-file initialization timed out: ${root}`)),
+			READY_TIMEOUT_MS,
+		);
+		watcher.once("ready", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		watcher.on("error", error => {
+			clearTimeout(timer);
+			reject(error);
+			logger.warn("LSP filesystem watcher failed", { root, error: String(error) });
+		});
+		watcher.on("add", target => this.#enqueue(target, 1));
+		watcher.on("change", target => this.#enqueue(target, 2));
+		watcher.on("unlink", target => this.#enqueue(target, 3));
+		const entry = {
+			watcher,
+			ready: promise.finally(() => clearTimeout(timer)),
+			cancel: () => {
+				clearTimeout(timer);
+				reject(new Error("Watched-file owner is closed"));
+			},
+		};
+		this.#roots.set(root, entry);
+		return entry;
+	}
+
+	#matches(target: string, type: FileEvent["type"]): boolean {
+		const mask = type === 3 ? 4 : type;
+		for (const patterns of this.#registrations.values()) {
+			for (const pattern of patterns) {
+				if (!(pattern.kind & mask) || !inside(pattern.root, target) || excluded(pattern.root, target)) continue;
+				if (inside(this.#cwd, target) && excluded(this.#cwd, target)) continue;
+				const candidate = pattern.absolute ? target : path.relative(pattern.root, target);
+				if (pattern.glob.match(candidate.split(path.sep).join("/"))) return true;
+			}
+		}
+		return false;
+	}
+
+	#enqueue(target: string, type: FileEvent["type"]): void {
+		if (this.#closed || !this.#matches(target, type)) return;
+		const uri = pathToFileURL(target).href;
+		// Overlapping roots and registrations still produce one event per change.
+		if (this.#lastPendingType.get(uri) !== type) {
+			this.#lastPendingType.set(uri, type);
+			this.#pending.push({ uri, type });
+		}
+		clearTimeout(this.#timer);
+		this.#timer = setTimeout(() => {
+			this.#timer = undefined;
+			const changes = this.#pending.filter(change => this.#matches(fileURLToPath(change.uri), change.type));
+			this.#pending.length = 0;
+			this.#lastPendingType.clear();
+			if (this.#closed || changes.length === 0) return;
+			void this.#notify(changes).catch(error => {
+				logger.warn("LSP external file notification failed", { error: String(error) });
+			});
+		}, FILE_EVENT_BATCH_MS);
+	}
+
+	async #releaseUnusedRoots(): Promise<void> {
+		const used = new Set<string>();
+		for (const patterns of this.#registrations.values()) for (const pattern of patterns) used.add(pattern.root);
+		const closing: Promise<void>[] = [];
+		for (const [root, entry] of this.#roots) {
+			if (used.has(root)) continue;
+			this.#roots.delete(root);
+			entry.cancel();
+			closing.push(entry.watcher.close());
+		}
+		await Promise.all(closing);
+	}
+}

--- a/packages/coding-agent/test/fixtures/fake-lsp-server.ts
+++ b/packages/coding-agent/test/fixtures/fake-lsp-server.ts
@@ -27,6 +27,7 @@ const didOpen: Record<string, number> = {};
 const didChange: Record<string, number[]> = {};
 const didClose: string[] = [];
 const notifications: string[] = [];
+const watchedFiles: Array<{ uri: string; type: number }> = [];
 const documents = new Map<string, { version: number; text: string }>();
 let nextServerRequestId = 1;
 const pendingServerRequests = new Map<
@@ -99,6 +100,7 @@ async function handleRequest(message: JsonRpcMessage): Promise<void> {
 				didChange: didChangeSnapshot,
 				didClose: [...didClose],
 				notifications: [...notifications],
+				watchedFiles: [...watchedFiles],
 			});
 			break;
 		}
@@ -129,6 +131,11 @@ function handleNotification(message: JsonRpcMessage): void {
 	notifications.push(message.method);
 
 	switch (message.method) {
+		case "workspace/didChangeWatchedFiles": {
+			const params = message.params as { changes: Array<{ uri: string; type: number }> };
+			watchedFiles.push(...params.changes);
+			break;
+		}
 		case "textDocument/didOpen": {
 			const params = message.params as OpenDocumentParams;
 			const { uri, version, text } = params.textDocument;

--- a/packages/coding-agent/test/lsp-mux.test.ts
+++ b/packages/coding-agent/test/lsp-mux.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { MessageFramer } from "../src/jsonrpc/message-framing";
 import {
 	MUX_CONNECT_METHOD,
@@ -29,6 +30,7 @@ interface FakeState {
 	didChange: Record<string, number[]>;
 	didClose: string[];
 	notifications: string[];
+	watchedFiles: Array<{ uri: string; type: number }>;
 }
 
 interface PublishDiagnosticsParams {
@@ -362,6 +364,51 @@ describe("LspMuxServer", () => {
 			expect(replacement.connected.spawned).toBe(true);
 			expect(replacement.connected.pid).not.toBe(first.connected.pid);
 			expect(replacement.connected.pid).not.toBe(second.connected.pid);
+		},
+		10_000,
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"keeps registered file watches with the retained server across client disconnects",
+		async () => {
+			const target = path.join(tmpDir, "dependency.ts");
+			const uri = pathToFileURL(target).href;
+			await Bun.write(target, "before");
+			const first = await link();
+			await initialize(first.client);
+			const response = await first.client.request<{ error: unknown }>("test/serverRequest", {
+				method: "client/registerCapability",
+				params: {
+					registrations: [
+						{
+							id: "dependencies",
+							method: "workspace/didChangeWatchedFiles",
+							registerOptions: { watchers: [{ globPattern: "**/*.ts" }] },
+						},
+					],
+				},
+			});
+			expect(response.error).toBeNull();
+			await Bun.write(target, "first external edit");
+			await pollUntil(async () => (await state(first.client)).watchedFiles.length === 1, "first watched-file event");
+			expect((await state(first.client)).watchedFiles).toEqual([{ uri, type: 2 }]);
+
+			const closed = first.client.waitForClose();
+			first.client.destroy();
+			await closed;
+			await Bun.write(target, "edit while detached");
+			const second = await link();
+			expect(second.connected.pid).toBe(first.connected.pid);
+			expect(second.connected.spawned).toBe(false);
+			await initialize(second.client);
+			await pollUntil(
+				async () => (await state(second.client)).watchedFiles.length === 2,
+				"detached watched-file event",
+			);
+			expect((await state(second.client)).watchedFiles).toEqual([
+				{ uri, type: 2 },
+				{ uri, type: 2 },
+			]);
 		},
 		10_000,
 	);

--- a/packages/coding-agent/test/lsp/watched-files.test.ts
+++ b/packages/coding-agent/test/lsp/watched-files.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import * as chokidar from "chokidar";
+import { type FileEvent, WATCHED_FILES_METHOD, WatchedFiles } from "../../src/lsp/watched-files";
+
+const owners: WatchedFiles[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(owners.splice(0).map(owner => owner.close()));
+	await Promise.all(directories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+	vi.restoreAllMocks();
+});
+
+async function workspace(): Promise<string> {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-watch-test-"));
+	directories.push(directory);
+	return directory;
+}
+
+function observer(root: string): {
+	owner: WatchedFiles;
+	events: FileEvent[];
+	next: (uri: string, type: FileEvent["type"], action: () => Promise<unknown>) => Promise<void>;
+} {
+	const events: FileEvent[] = [];
+	let received: ((changes: FileEvent[]) => void) | undefined;
+	const owner = new WatchedFiles(root, async changes => {
+		events.push(...changes);
+		received?.(changes);
+	});
+	owners.push(owner);
+	return {
+		owner,
+		events,
+		async next(uri, type, action) {
+			const { promise, resolve, reject } = Promise.withResolvers<void>();
+			// Real filesystem integration: this is a failure watchdog, not a settling sleep.
+			const timer = setTimeout(() => reject(new Error(`Missing file event ${type}: ${uri}`)), 3_000);
+			received = changes => {
+				if (changes.some(change => change.uri === uri && change.type === type)) resolve();
+			};
+			try {
+				await action();
+				await promise;
+			} finally {
+				clearTimeout(timer);
+				received = undefined;
+			}
+		},
+	};
+}
+
+describe("registered filesystem watches", () => {
+	it("prunes nested checkouts and dependencies before allocating watches, but watches generated Svelte types", async () => {
+		const root = await workspace();
+		for (const directory of [".worktrees/other/src", ".git/objects", "node_modules/example", ".svelte-kit/types"]) {
+			await Bun.write(path.join(root, directory, "value.ts"), "before");
+		}
+		const watch = vi.spyOn(chokidar, "watch");
+		const observed = observer(root);
+		await observed.owner.register([
+			{
+				id: "svelte",
+				method: WATCHED_FILES_METHOD,
+				registerOptions: { watchers: [{ globPattern: "**/*.{ts,json,svelte}" }] },
+			},
+		]);
+		// This guards the ENOSPC regression: filtering notifications alone is insufficient.
+		const backend = watch.mock.results[0].value as chokidar.FSWatcher;
+		const watchedDirectories = Object.keys(backend.getWatched());
+		for (const directory of [".worktrees", ".git", "node_modules"]) {
+			expect(watchedDirectories.some(target => target.startsWith(path.join(root, directory)))).toBe(false);
+		}
+		const generated = path.join(root, ".svelte-kit/types/value.ts");
+		await observed.next(pathToFileURL(generated).href, 2, () => Bun.write(generated, "after"));
+	});
+
+	it("honors relative bases and kind masks across overlapping registration removal", async () => {
+		const root = await workspace();
+		const source = path.join(root, "src");
+		await fs.mkdir(source);
+		const observed = observer(root);
+		const globPattern = { baseUri: { uri: pathToFileURL(source).href, name: "src" }, pattern: "*.ts" };
+		await observed.owner.register([
+			{ id: "created", method: WATCHED_FILES_METHOD, registerOptions: { watchers: [{ globPattern, kind: 1 }] } },
+			{ id: "changed", method: WATCHED_FILES_METHOD, registerOptions: { watchers: [{ globPattern, kind: 2 }] } },
+			{ id: "deleted", method: WATCHED_FILES_METHOD, registerOptions: { watchers: [{ globPattern, kind: 4 }] } },
+		]);
+		const target = path.join(source, "value.ts");
+		const uri = pathToFileURL(target).href;
+		await observed.next(uri, 1, () => Bun.write(target, "created"));
+		await observed.next(uri, 2, () => Bun.write(target, "changed"));
+		await observed.owner.unregister(["changed"]);
+		await observed.next(uri, 3, () => fs.unlink(target));
+		expect(observed.events).toEqual([
+			{ uri, type: 1 },
+			{ uri, type: 2 },
+			{ uri, type: 3 },
+		]);
+		await observed.owner.unregister(["created", "deleted"]);
+		await observed.owner.register([
+			{
+				id: "new",
+				method: WATCHED_FILES_METHOD,
+				registerOptions: { watchers: [{ globPattern: path.join(source, "*.ts") }] },
+			},
+		]);
+		await observed.next(uri, 1, () => Bun.write(target, "registered again"));
+	});
+
+	it("cancels initialization and releases handles when the server closes during registration", async () => {
+		const root = await workspace();
+		await Bun.write(path.join(root, "src/value.ts"), "before");
+		const watch = vi.spyOn(chokidar, "watch");
+		const observed = observer(root);
+		const registering = observed.owner.register([
+			{
+				id: "pending",
+				method: WATCHED_FILES_METHOD,
+				registerOptions: { watchers: [{ globPattern: "**/*.ts" }] },
+			},
+		]);
+		const closing = observed.owner.close();
+		await expect(registering).rejects.toThrow("closed");
+		await closing;
+		const backend = watch.mock.results[0].value as chokidar.FSWatcher;
+		expect(backend.closed).toBe(true);
+		expect(backend.getWatched()).toEqual({});
+	});
+
+	it("rejects an invalid batch without retaining partially registered watches", async () => {
+		const root = await workspace();
+		const watch = vi.spyOn(chokidar, "watch");
+		const observed = observer(root);
+		await expect(
+			observed.owner.register([
+				{ id: "valid", method: WATCHED_FILES_METHOD, registerOptions: { watchers: [{ globPattern: "**/*.ts" }] } },
+				{
+					id: "invalid",
+					method: WATCHED_FILES_METHOD,
+					registerOptions: { watchers: [{ globPattern: { baseUri: "https://example.com", pattern: "*.ts" } }] },
+				},
+			]),
+		).rejects.toThrow();
+		expect(watch).not.toHaveBeenCalled();
+		await observed.owner.close();
+		await expect(observed.owner.register([])).rejects.toThrow("closed");
+	});
+});

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1008,6 +1008,79 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("refreshes semantic results after an external dependency edit and stops after unregister", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-external-watch-");
+		const dependency = path.join(tempDir.path(), "dependency.ts");
+		await Bun.write(dependency, "before");
+		let importedValue = "before";
+		try {
+			const server = installFakeLsp(async (message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { hoverProvider: true } } });
+				} else if (message.method === "initialized") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: "watch-register",
+						method: "client/registerCapability",
+						params: {
+							registrations: [
+								{
+									id: "dependencies",
+									method: "workspace/didChangeWatchedFiles",
+									registerOptions: { watchers: [{ globPattern: "**/*.ts" }] },
+								},
+							],
+						},
+					});
+				} else if (message.method === "workspace/didChangeWatchedFiles") {
+					const params = message.params as { changes: Array<{ uri: string }> };
+					if (params.changes.some(change => change.uri === fileToUri(dependency))) {
+						importedValue = await Bun.file(dependency).text();
+					}
+				} else if (message.method === "textDocument/hover") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { contents: importedValue } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			const client = await lspClient.getOrCreateClient(
+				{ command: "fake-lsp", fileTypes: ["ts"], rootMarkers: [] },
+				tempDir.path(),
+				1_000,
+			);
+			await server.waitFor(message => message.id === "watch-register" && message.method === undefined);
+			await Bun.write(dependency, "after external edit");
+			await server.waitFor(message => message.method === "workspace/didChangeWatchedFiles");
+			expect(await lspClient.sendRequest(client, "textDocument/hover", {})).toEqual({
+				contents: "after external edit",
+			});
+			const initialize = server.received.find(message => message.method === "initialize");
+			const params = initialize?.params as {
+				capabilities: { workspace: { didChangeWatchedFiles?: { dynamicRegistration?: boolean } } };
+			};
+			expect(params.capabilities.workspace.didChangeWatchedFiles?.dynamicRegistration).toBe(true);
+
+			server.send({
+				jsonrpc: "2.0",
+				id: "watch-unregister",
+				method: "client/unregisterCapability",
+				params: { unregisterations: [{ id: "dependencies", method: "workspace/didChangeWatchedFiles" }] },
+			});
+			await server.waitFor(message => message.id === "watch-unregister" && message.method === undefined);
+			await Bun.write(dependency, "unregistered edit");
+			// Negative assertion against real OS watchers: fake timers cannot drain kernel events.
+			await Bun.sleep(150);
+			expect(await lspClient.sendRequest(client, "textDocument/hover", {})).toEqual({
+				contents: "after external edit",
+			});
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("accepts dynamic capability registration before semantic requests", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-dynamic-registration-");
 		try {


### PR DESCRIPTION
## What

### Contributor explanation

> i try instal lsp for Svelte, and I got some errors, turn out I need modified omp code to solve it. For now it patched my OMP locally; I hope my patch is the right way to fix it and can be included in a future update.

### Technical summary

Implement dynamic workspace/didChangeWatchedFiles registrations for private and broker-managed language servers. Support string and relative glob patterns, create/change/delete masks, registration removal, and watcher cleanup during initialization failure or server shutdown. Add Chokidar 4.0.3 as a runtime dependency.

Exclude nested .git, node_modules, and .worktrees directories before filesystem traversal, while keeping generated source such as .svelte-kit/types eligible. Batch change notifications beyond Chokidar's change-event throttle so dependent language-server results observe the final file contents.

## Why

On Linux with OMP 18.1.14, requesting Svelte language intelligence from a monorepo containing nested worktrees could crash svelteserver with ENOSPC: System limit for number of file watchers reached.

OMP did not advertise workspace.didChangeWatchedFiles.dynamicRegistration, so Svelte created its own recursive fallback watcher over the workspace. OMP also acknowledged registrations without implementing external filesystem watches. Advertising the capability alone would avoid the fallback but leave unopened dependencies stale.

This is distinct from nested project-root discovery in #9969 and extends the existing harness-authored file-change notification path from #4462 to external edits.

## Maintainer discussion

Opening this as a draft for iteration following discussion with Brit in Discord `#general`. After the contributor disclosed the existing AI-assisted implementation and new Chokidar dependency, Brit replied, “ideally no deps, but I'll take a look today.” When asked whether to open a draft PR for review, Brit replied, “pr would be best so we can iterate.”

The new dependency is not approved by that invitation. This draft presents the tested approach for review; a dependency-free alternative remains an open design question. No separate issue was created, in accordance with the contribution guide.

## Testing

### Upstream merge verification

Merged upstream `main` at `78b753124d` (18.2.6 source) into this branch without replacing its newer document-reconciliation or JSON-RPC framing changes. Moved this PR's changelog entry back to Unreleased and added PR/contributor attribution. The separate local `omp-patched` checkout remains unchanged.

AI-agent-executed verification on Linux with Bun 1.4.0, in an isolated worktree:

- `bun install --frozen-lockfile` succeeded; matching 18.2.6 native runtime downloaded with SHA-512 verification.
- From `packages/coding-agent`, `bun run check` passed lint, format checking, and type checking.
- `bun test test/tools/lsp-regressions.test.ts test/lsp/watched-files.test.ts test/lsp-mux.test.ts test/lsp/idle.test.ts test/tools/lsp-diagnostics-freshness.test.ts test/message-framing.test.ts test/debug/dap-launch-failures.test.ts`: **205 pass, 0 fail, 790 assertions**.
- Real Svelte server smoke using the merged OMP client in private mode, rooted at the affected monorepo: symbols and initial number hover succeeded; an external edit to an unopened imported dependency produced TS2362 and string hover; external repair cleared diagnostics and restored number hover with the same server PID. The current Svelte server uses pull diagnostics; the temporary smoke was adjusted accordingly and used explicit type annotations rather than assuming literal hovers display primitive types. Final smoke exited 0, and temporary fixtures were removed.

### Original patch verification

The following verification was executed by AI agents under the contributor's direction. It is reported separately from human contributor review and hands-on confirmation, which are not claimed complete here.

Environment: Linux, Bun 1.4.0, OMP 18.1.14 source checkout.

From packages/coding-agent:

```
bun test test/tools/lsp-regressions.test.ts test/lsp/watched-files.test.ts test/lsp-mux.test.ts test/lsp/idle.test.ts test/tools/lsp-diagnostics-freshness.test.ts
# 155 pass, 0 fail, 539 expect() calls

bun run check
# oxlint, oxfmt --check, and tsgo all passed
```

The external-dependency regression was run before wiring the fix and failed waiting for workspace/didChangeWatchedFiles; it passed after the fix.

Real interactive verification: launched a fresh patched OMP session in Herdr, rooted at the same affected Svelte monorepo. Used its actual built-in LSP tool, not imported client APIs. The session used lsp.shared=false to avoid an older broker already serving other sessions.

- Symbols succeeded for a real Svelte component and an isolated typed Svelte probe.
- Svelte and TypeScript hovers resolved number; initial Svelte diagnostics were OK.
- A separate process changed an unopened imported TypeScript dependency from number to string without sending LSP notifications. Svelte diagnostics reported TS2362 for multiplication, and hover changed to string.
- Repairing the dependency externally cleared the diagnostic and restored the number hover.
- Both language-server process IDs stayed unchanged throughout; no reload or restart was used.
- Temporary live-test fixtures were removed afterward.

Focused broker tests additionally cover retaining watched-file registration and external notifications across client disconnect/reuse. Filesystem tests verify exclusion before watch allocation, generated Svelte type updates, event masks, unregister behavior, invalid batches, and shutdown during registration.

---

- [x] `bun check` passes (package command: `bun run check`)
- [x] Tested locally by the human contributor
- [x] CHANGELOG updated

AI-assisted implementation. The contributor's explanation above is included verbatim. Submitted as a draft at the maintainer's invitation, with dependency choice and human contributor review/verification still open.
