### PR TITLE
fix(coding-agent): make Ctrl+D delete draft text before exiting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,20 @@
 - Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+### Added
+
+- Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.
+- Added `f follow up` in BTW history to continue a selected side conversation with an English input prompt, persistent multi-turn history, and no changes to the main conversation.
+- Completed inline BTW answers now support `f follow up` directly; history uses `Tab` for pane navigation and `Enter` or `f` to start a follow-up.
+- Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Codex web search now accepts valid email-only OAuth credentials without requiring or fabricating a `ChatGPT-Account-Id` header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
+- Sessions now stay alive when their working directory is removed instead of crashing while preparing shell tools ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
+- MCP tool calls spelled with the Claude Code doubled separator (`mcp__server__tool`) now reach their registered tool ([#11516](https://github.com/can1357/oh-my-pi/issues/11516) by [@oldschoola](https://github.com/oldschoola)).
+- MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
+- `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
+- Sloppy-mode edits now drop a copied `[N more lines in ...]` read notice the same way they already drop the other read-metadata rows, so a pasted projection can no longer leak into the matched pattern or the written text ([#11797](https://github.com/can1357/oh-my-pi/pull/11797) by [@vasyza](https://github.com/vasyza)).
+- `/usage` now honors a provider's configured `baseUrl` when checking credentials before any model has been discovered, so a proxy-scoped API key is no longer sent to the provider's canonical host ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
+- Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
 
 ## [18.1.18] - 2026-09-11
 
@@ -86,7 +100,6 @@
 - Hiding tool activity (its shortcut or `display.hideToolActivity` in `/settings`) now replays native history, so blocks already retired to the terminal hide on the same keypress instead of waiting for another display toggle ([#11734](https://github.com/can1357/oh-my-pi/pull/11734) by [@notnotype](https://github.com/notnotype)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
-- Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -73,6 +73,12 @@
 - Hand-authored `*.openapi.json` files can now be edited without disabling generated-file protection globally ([#11674](https://github.com/can1357/oh-my-pi/issues/11674)).
 - `models.yml` now validates the per-model `compat.stripImageInput` opt-out, so a wrong-typed value is rejected like every other declared compat key instead of being silently accepted ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
 - `/mcp reload` now distinguishes servers still connecting after the bounded reload window instead of reporting a healthy asynchronous reload as zero active servers ([#11639](https://github.com/can1357/oh-my-pi/issues/11639)).
+### Changed
+
+- The `providers.cacheRetention` `auto` setting now keeps Anthropic OAuth subscriber sessions on 1h prompt-cache retention and API keys on 5m, instead of 5m for both ([#11667](https://github.com/can1357/oh-my-pi/pull/11667) by [@camjac251](https://github.com/camjac251)).
+
+### Fixed
+
 - Fixed isolated tasks dropping nested-repo work: nested diffs persist as `<agent>.nested-*.patch` before cleanup, `apply=false` lists each file, isolated agents report as non-resumable, and runs needing manual recovery report failed ([#11343](https://github.com/can1357/oh-my-pi/pull/11343) by [@grapexy](https://github.com/grapexy)).
 - Fixed the Windows PowerShell installer (`install.ps1`) aborting on Windows PowerShell 5.1 when bun or git wrote normal progress to stderr: native commands now run with `$ErrorActionPreference` scoped to `Continue` and success is gated on the process exit code, so `$ErrorActionPreference = "Stop"`'s stderr-as-terminating-error behavior no longer kills the install ([#11675](https://github.com/can1357/oh-my-pi/issues/11675)).
 - Eval cell timeouts no longer fatally terminate the session when a browser tab worker is being recycled ([#11707](https://github.com/can1357/oh-my-pi/issues/11707)).
@@ -80,8 +86,6 @@
 - Hiding tool activity (its shortcut or `display.hideToolActivity` in `/settings`) now replays native history, so blocks already retired to the terminal hide on the same keypress instead of waiting for another display toggle ([#11734](https://github.com/can1357/oh-my-pi/pull/11734) by [@notnotype](https://github.com/notnotype)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
-### Fixed
-
 - Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -80,6 +80,12 @@
 - Hiding tool activity (its shortcut or `display.hideToolActivity` in `/settings`) now replays native history, so blocks already retired to the terminal hide on the same keypress instead of waiting for another display toggle ([#11734](https://github.com/can1357/oh-my-pi/pull/11734) by [@notnotype](https://github.com/notnotype)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
+### Fixed
+
+- Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
+
+### Fixed
+
 - Reduced memory usage during long responses while thinking is hidden ([#11632](https://github.com/can1357/oh-my-pi/pull/11632) by [@redsolver](https://github.com/redsolver)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).
@@ -53,20 +57,6 @@
 - Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
-### Added
-
-- Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.
-- Added `f follow up` in BTW history to continue a selected side conversation with an English input prompt, persistent multi-turn history, and no changes to the main conversation.
-- Completed inline BTW answers now support `f follow up` directly; history uses `Tab` for pane navigation and `Enter` or `f` to start a follow-up.
-- Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
-- Codex web search now accepts valid email-only OAuth credentials without requiring or fabricating a `ChatGPT-Account-Id` header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
-- Sessions now stay alive when their working directory is removed instead of crashing while preparing shell tools ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
-- MCP tool calls spelled with the Claude Code doubled separator (`mcp__server__tool`) now reach their registered tool ([#11516](https://github.com/can1357/oh-my-pi/issues/11516) by [@oldschoola](https://github.com/oldschoola)).
-- MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
-- `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
-- Sloppy-mode edits now drop a copied `[N more lines in ...]` read notice the same way they already drop the other read-metadata rows, so a pasted projection can no longer leak into the matched pattern or the written text ([#11797](https://github.com/can1357/oh-my-pi/pull/11797) by [@vasyza](https://github.com/vasyza)).
-- `/usage` now honors a provider's configured `baseUrl` when checking credentials before any model has been discovered, so a proxy-scoped API key is no longer sent to the provider's canonical host ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
-- Fixed Ctrl+D quitting the prompt even with draft text; it now deletes the character at the cursor like Delete, and only exits on an empty draft.
 
 ## [18.1.18] - 2026-09-11
 
@@ -87,12 +77,6 @@
 - Hand-authored `*.openapi.json` files can now be edited without disabling generated-file protection globally ([#11674](https://github.com/can1357/oh-my-pi/issues/11674)).
 - `models.yml` now validates the per-model `compat.stripImageInput` opt-out, so a wrong-typed value is rejected like every other declared compat key instead of being silently accepted ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
 - `/mcp reload` now distinguishes servers still connecting after the bounded reload window instead of reporting a healthy asynchronous reload as zero active servers ([#11639](https://github.com/can1357/oh-my-pi/issues/11639)).
-### Changed
-
-- The `providers.cacheRetention` `auto` setting now keeps Anthropic OAuth subscriber sessions on 1h prompt-cache retention and API keys on 5m, instead of 5m for both ([#11667](https://github.com/can1357/oh-my-pi/pull/11667) by [@camjac251](https://github.com/camjac251)).
-
-### Fixed
-
 - Fixed isolated tasks dropping nested-repo work: nested diffs persist as `<agent>.nested-*.patch` before cleanup, `apply=false` lists each file, isolated agents report as non-resumable, and runs needing manual recovery report failed ([#11343](https://github.com/can1357/oh-my-pi/pull/11343) by [@grapexy](https://github.com/grapexy)).
 - Fixed the Windows PowerShell installer (`install.ps1`) aborting on Windows PowerShell 5.1 when bun or git wrote normal progress to stderr: native commands now run with `$ErrorActionPreference` scoped to `Continue` and success is gated on the process exit code, so `$ErrorActionPreference = "Stop"`'s stderr-as-terminating-error behavior no longer kills the install ([#11675](https://github.com/can1357/oh-my-pi/issues/11675)).
 - Eval cell timeouts no longer fatally terminate the session when a browser tab worker is being recycled ([#11707](https://github.com/can1357/oh-my-pi/issues/11707)).
@@ -100,9 +84,6 @@
 - Hiding tool activity (its shortcut or `display.hideToolActivity` in `/settings`) now replays native history, so blocks already retired to the terminal hide on the same keypress instead of waiting for another display toggle ([#11734](https://github.com/can1357/oh-my-pi/pull/11734) by [@notnotype](https://github.com/notnotype)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
-
-### Fixed
-
 - Reduced memory usage during long responses while thinking is hidden ([#11632](https://github.com/can1357/oh-my-pi/pull/11632) by [@redsolver](https://github.com/redsolver)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1156,12 +1156,26 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured exit shortcut. Always consume the shortcut so it
-			// never reaches the parent handler; firing onExit is the controller's
-			// chance to snapshot the current text as a draft before shutting down.
+			// Intercept configured exit shortcut. When the key doubles as
+			// forward-delete (readline ^D: the default app.exit binding overlaps
+			// tui.editor.deleteCharForward) and the buffer is non-empty, fall
+			// through to the parent handler so it deletes the character at the
+			// cursor instead of quitting. Only an empty buffer exits; firing
+			// onExit is the controller's chance to snapshot the current text as
+			// a draft before shutting down. Exit keys with no forward-delete
+			// role always exit. Draft presence is read off the buffer alone:
+			// attachments live as inline chip tokens, while `pendingImages` /
+			// `pendingTexts` intentionally retain deleted records so numbering
+			// isn't recycled (see composerChips) — trusting them would make
+			// Ctrl+D a permanent no-op after the last chip is deleted.
 			if (this.#matchesAction(canonical, "app.exit")) {
-				this.onExit?.();
-				return;
+				const doublesAsForwardDelete =
+					canonical !== undefined && getKeybindings().matchesCanonical(canonical, "tui.editor.deleteCharForward");
+				const hasDraft = !this.textEquals("");
+				if (!(doublesAsForwardDelete && hasDraft)) {
+					this.onExit?.();
+					return;
+				}
 			}
 
 			// Intercept configured dequeue shortcut (restore queued message to editor)

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1158,17 +1158,18 @@ export class CustomEditor extends Editor {
 
 			// Intercept configured exit shortcut. When the key doubles as
 			// forward-delete (readline ^D: the default app.exit binding overlaps
-			// tui.editor.deleteCharForward) and the buffer is non-empty, hand it
-			// straight to the base editor so it deletes the character at the
-			// cursor instead of quitting. Routing directly (rather than falling
-			// through) keeps the exit chord's precedence slot: a later app action
-			// or extension handler that a user also bound to the same chord must
-			// not steal the keystroke, exactly as it could not steal the exit
-			// before. Only an empty buffer exits; firing onExit is the
-			// controller's chance to snapshot the current text as a draft before
-			// shutting down. Exit keys with no forward-delete role always exit.
-			// Draft presence is read off the buffer alone: attachments live as
-			// inline chip tokens, while `pendingImages` / `pendingTexts`
+			// tui.editor.deleteCharForward) and the buffer is non-empty, perform
+			// the delete here instead of quitting. Invoking the operation directly
+			// — not falling through, not redispatching the raw key — keeps the
+			// exit chord's precedence slot on both sides: a later app action or
+			// extension handler bound to the same chord cannot steal it, and
+			// neither can an earlier base-editor action (e.g. a user-bound
+			// tui.input.submit, which Editor.handleInput checks before
+			// deleteCharForward). Only an empty buffer exits; firing onExit is
+			// the controller's chance to snapshot the current text as a draft
+			// before shutting down. Exit keys with no forward-delete role always
+			// exit. Draft presence is read off the buffer alone: attachments live
+			// as inline chip tokens, while `pendingImages` / `pendingTexts`
 			// intentionally retain deleted records so numbering isn't recycled
 			// (see composerChips) — trusting them would make Ctrl+D a permanent
 			// no-op after the last chip is deleted.
@@ -1176,7 +1177,7 @@ export class CustomEditor extends Editor {
 				const doublesAsForwardDelete =
 					canonical !== undefined && getKeybindings().matchesCanonical(canonical, "tui.editor.deleteCharForward");
 				if (doublesAsForwardDelete && !this.textEquals("")) {
-					super.handleInput(data);
+					this.deleteCharForward();
 					return;
 				}
 				this.onExit?.();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1158,24 +1158,29 @@ export class CustomEditor extends Editor {
 
 			// Intercept configured exit shortcut. When the key doubles as
 			// forward-delete (readline ^D: the default app.exit binding overlaps
-			// tui.editor.deleteCharForward) and the buffer is non-empty, fall
-			// through to the parent handler so it deletes the character at the
-			// cursor instead of quitting. Only an empty buffer exits; firing
-			// onExit is the controller's chance to snapshot the current text as
-			// a draft before shutting down. Exit keys with no forward-delete
-			// role always exit. Draft presence is read off the buffer alone:
-			// attachments live as inline chip tokens, while `pendingImages` /
-			// `pendingTexts` intentionally retain deleted records so numbering
-			// isn't recycled (see composerChips) — trusting them would make
-			// Ctrl+D a permanent no-op after the last chip is deleted.
+			// tui.editor.deleteCharForward) and the buffer is non-empty, hand it
+			// straight to the base editor so it deletes the character at the
+			// cursor instead of quitting. Routing directly (rather than falling
+			// through) keeps the exit chord's precedence slot: a later app action
+			// or extension handler that a user also bound to the same chord must
+			// not steal the keystroke, exactly as it could not steal the exit
+			// before. Only an empty buffer exits; firing onExit is the
+			// controller's chance to snapshot the current text as a draft before
+			// shutting down. Exit keys with no forward-delete role always exit.
+			// Draft presence is read off the buffer alone: attachments live as
+			// inline chip tokens, while `pendingImages` / `pendingTexts`
+			// intentionally retain deleted records so numbering isn't recycled
+			// (see composerChips) — trusting them would make Ctrl+D a permanent
+			// no-op after the last chip is deleted.
 			if (this.#matchesAction(canonical, "app.exit")) {
 				const doublesAsForwardDelete =
 					canonical !== undefined && getKeybindings().matchesCanonical(canonical, "tui.editor.deleteCharForward");
-				const hasDraft = !this.textEquals("");
-				if (!(doublesAsForwardDelete && hasDraft)) {
-					this.onExit?.();
+				if (doublesAsForwardDelete && !this.textEquals("")) {
+					super.handleInput(data);
 					return;
 				}
+				this.onExit?.();
+				return;
 			}
 
 			// Intercept configured dequeue shortcut (restore queued message to editor)

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1178,6 +1178,10 @@ export class CustomEditor extends Editor {
 					canonical !== undefined && getKeybindings().matchesCanonical(canonical, "tui.editor.deleteCharForward");
 				if (doublesAsForwardDelete && !this.textEquals("")) {
 					this.deleteCharForward();
+					// Same post-edit normalization the parent dispatch runs below: an edit that
+					// leaves a bare "->"/"=>" turns it into a reserved queue header, or later
+					// typing lands on the Queueing label instead of the queue body.
+					this.#normalizeQueuePrefix(hadBareQueuePrefix);
 					return;
 				}
 				this.onExit?.();
@@ -1220,11 +1224,17 @@ export class CustomEditor extends Editor {
 
 		// Pass to parent for normal handling
 		super.handleInput(data);
-		if (!hadBareQueuePrefix && (this.textEquals("->") || this.textEquals("=>"))) {
-			const cursor = this.getCursor();
-			if (cursor.line === 0 && cursor.col === 2) {
-				this.insertText("\n");
-			}
+		this.#normalizeQueuePrefix(hadBareQueuePrefix);
+	}
+
+	/** Promote a newly formed bare `->` / `=>` prefix to a reserved header line by opening the
+	 *  queue body beneath it. `hadBareQueuePrefix` is the pre-edit state: a prompt that was
+	 *  already just the prefix is left alone so the user can keep editing it. */
+	#normalizeQueuePrefix(hadBareQueuePrefix: boolean): void {
+		if (hadBareQueuePrefix || !(this.textEquals("->") || this.textEquals("=>"))) return;
+		const cursor = this.getCursor();
+		if (cursor.line === 0 && cursor.col === 2) {
+			this.insertText("\n");
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -1,7 +1,7 @@
 Tired of typing "keep going"? Just send a '.'
 You can /btw to ask a side question
 Use /tan to fork the current conversation into a background agent
-Ctrl+D deletes the character under the cursor instead of quitting your draft — see /hotkeys for your exit key
+With default keybindings, Ctrl+D deletes the character under the cursor instead of quitting your draft — see /hotkeys for your exit key
 Find out which model you emotionally abuse the most with `omp stats`
 Try task isolation to create CoW worktrees
 Need a cheap nested model call? Use `completion(x...)`. Have a big batch of tasks? Ask clanker to use it!

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -1,7 +1,7 @@
 Tired of typing "keep going"? Just send a '.'
 You can /btw to ask a side question
 Use /tan to fork the current conversation into a background agent
-Ctrl+D deletes the character under the cursor, and exits once the prompt is empty
+Ctrl+D deletes the character under the cursor instead of quitting your draft — see /hotkeys for your exit key
 Find out which model you emotionally abuse the most with `omp stats`
 Try task isolation to create CoW worktrees
 Need a cheap nested model call? Use `completion(x...)`. Have a big batch of tasks? Ask clanker to use it!

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -1,7 +1,7 @@
 Tired of typing "keep going"? Just send a '.'
 You can /btw to ask a side question
 Use /tan to fork the current conversation into a background agent
-Ctrl+D can be used to exit, but with your draft saved!
+Ctrl+D deletes the character under the cursor, and exits once the prompt is empty
 Find out which model you emotionally abuse the most with `omp stats`
 Try task isolation to create CoW worktrees
 Need a cheap nested model call? Use `completion(x...)`. Have a big batch of tasks? Ask clanker to use it!

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -294,6 +294,11 @@ export class Composer implements TerminalFrameProvider {
 		}
 		this.#applyStatusSnapshot();
 		// Emergency controls stay active until InteractiveMode installs configured bindings.
+		// They deliberately mirror the interactive editor's contract so a stalled startup
+		// never behaves differently from a healthy one: Ctrl+C clears the draft and a second
+		// press exits 130 — the unconditional abort, draft or not; Ctrl+D exits 0 on an
+		// empty draft and otherwise forward-deletes (see CustomEditor's app.exit handling),
+		// so typing while the session loads cannot be lost to a mistyped delete.
 		this.editor.setActionKeys("app.clear", ["ctrl+c"]);
 		this.editor.setActionKeys("app.exit", ["ctrl+d"]);
 		this.editor.onClear = () => this.#handleInterrupt();

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -39,7 +39,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `Tab` | Path completion / accept autocomplete |",
 		`| \`${appKey(bindings, "app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
 		`| \`${appKey(bindings, "app.clear")}\` | Clear editor (first) / exit (second) |`,
-		`| \`${appKey(bindings, "app.exit")}\` | Exit (saves current prompt as draft) |`,
+		`| \`${appKey(bindings, "app.exit")}\` | Delete char forward (with draft) / exit (empty prompt) |`,
 		`| \`${appKey(bindings, "app.suspend")}\` | Suspend to background |`,
 		`| \`${appKey(bindings, "app.display.reset")}\` | Reset terminal display |`,
 		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -1,5 +1,11 @@
 import { canonicalKeyId } from "@oh-my-pi/pi-tui";
-import { type AppKeybinding, type KeybindingsManager, keyHintPlatform, modifierLabel } from "../../config/keybindings";
+import {
+	type AppKeybinding,
+	formatKeyHints,
+	type KeybindingsManager,
+	keyHintPlatform,
+	modifierLabel,
+} from "../../config/keybindings";
 
 export interface HotkeysMarkdownBindings {
 	keybindings: Pick<KeybindingsManager, "getDisplayString" | "getKeys" | "matchesCanonical">;
@@ -14,13 +20,28 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 	const isMac = platform === "darwin";
 	const alt = modifierLabel("alt", platform);
 	const cmd = modifierLabel("super", platform);
-	// Does the configured exit chord also carry the editor's forward-delete role? That readline
-	// `^D` overlap is what makes CustomEditor delete instead of exiting while the prompt holds a
-	// draft; a remapped exit key without the role (or Ctrl+D dropped from deleteCharForward)
-	// always exits, so the two configurations need different descriptions.
-	const exitDeletesForward = bindings.keybindings
-		.getKeys("app.exit")
-		.some(key => bindings.keybindings.matchesCanonical(canonicalKeyId(key), "tui.editor.deleteCharForward"));
+	// CustomEditor tests the chord that was actually pressed, so exit keys split by role: a key
+	// that also carries tui.editor.deleteCharForward (the readline `^D` overlap) forward-deletes
+	// while the prompt holds a draft, any other exit key quits immediately. Mixed bindings such as
+	// `["ctrl+d", "ctrl+q"]` therefore get one row per behavior instead of a single row claiming
+	// both keys delete.
+	const exitKeys = bindings.keybindings.getKeys("app.exit");
+	const deletingExitKeys = exitKeys.filter(key =>
+		bindings.keybindings.matchesCanonical(canonicalKeyId(key), "tui.editor.deleteCharForward"),
+	);
+	const quittingExitKeys = exitKeys.filter(
+		key => !bindings.keybindings.matchesCanonical(canonicalKeyId(key), "tui.editor.deleteCharForward"),
+	);
+	const exitRows: string[] = [];
+	if (deletingExitKeys.length > 0) {
+		exitRows.push(
+			`| \`${formatKeyHints(deletingExitKeys)}\` | Delete char forward (with draft) / exit (empty prompt) |`,
+		);
+	}
+	// An unbound exit action still gets its row, mirroring the `Disabled` hint every other row uses.
+	if (quittingExitKeys.length > 0 || deletingExitKeys.length === 0) {
+		exitRows.push(`| \`${formatKeyHints(quittingExitKeys) || "Disabled"}\` | Exit |`);
+	}
 	return [
 		"**Navigation**",
 		"| Key | Action |",
@@ -47,7 +68,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `Tab` | Path completion / accept autocomplete |",
 		`| \`${appKey(bindings, "app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
 		`| \`${appKey(bindings, "app.clear")}\` | Clear editor (first) / exit (second) |`,
-		`| \`${appKey(bindings, "app.exit")}\` | ${exitDeletesForward ? "Delete char forward (with draft) / exit (empty prompt)" : "Exit"} |`,
+		...exitRows,
 		`| \`${appKey(bindings, "app.suspend")}\` | Suspend to background |`,
 		`| \`${appKey(bindings, "app.display.reset")}\` | Reset terminal display |`,
 		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -1,7 +1,8 @@
+import { canonicalKeyId } from "@oh-my-pi/pi-tui";
 import { type AppKeybinding, type KeybindingsManager, keyHintPlatform, modifierLabel } from "../../config/keybindings";
 
 export interface HotkeysMarkdownBindings {
-	keybindings: Pick<KeybindingsManager, "getDisplayString">;
+	keybindings: Pick<KeybindingsManager, "getDisplayString" | "getKeys" | "matchesCanonical">;
 }
 
 function appKey(bindings: HotkeysMarkdownBindings, action: AppKeybinding): string {
@@ -13,6 +14,13 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 	const isMac = platform === "darwin";
 	const alt = modifierLabel("alt", platform);
 	const cmd = modifierLabel("super", platform);
+	// Does the configured exit chord also carry the editor's forward-delete role? That readline
+	// `^D` overlap is what makes CustomEditor delete instead of exiting while the prompt holds a
+	// draft; a remapped exit key without the role (or Ctrl+D dropped from deleteCharForward)
+	// always exits, so the two configurations need different descriptions.
+	const exitDeletesForward = bindings.keybindings
+		.getKeys("app.exit")
+		.some(key => bindings.keybindings.matchesCanonical(canonicalKeyId(key), "tui.editor.deleteCharForward"));
 	return [
 		"**Navigation**",
 		"| Key | Action |",
@@ -39,7 +47,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `Tab` | Path completion / accept autocomplete |",
 		`| \`${appKey(bindings, "app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
 		`| \`${appKey(bindings, "app.clear")}\` | Clear editor (first) / exit (second) |`,
-		`| \`${appKey(bindings, "app.exit")}\` | Delete char forward (with draft) / exit (empty prompt) |`,
+		`| \`${appKey(bindings, "app.exit")}\` | ${exitDeletesForward ? "Delete char forward (with draft) / exit (empty prompt)" : "Exit"} |`,
 		`| \`${appKey(bindings, "app.suspend")}\` | Suspend to background |`,
 		`| \`${appKey(bindings, "app.display.reset")}\` | Reset terminal display |`,
 		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -194,6 +194,26 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("zbc");
 	});
 
+	it("dismisses the spelling-assist popup on ctrl+d, like the Delete key", () => {
+		// The debounced autocomplete refresh skips assist mode, so a popup left open by the
+		// direct delete would stay on screen indefinitely.
+		const editor = new CustomEditor(getEditorTheme());
+		const onAutocompleteUpdate = vi.fn();
+		editor.onAutocompleteUpdate = onAutocompleteUpdate;
+		editor.setTextAssistProvider({
+			getWordReplacements: () => ({ line: 0, startCol: 0, endCol: 3, items: ["the", "ten"] }),
+		});
+		editor.setText("teh cat");
+		editor.moveToLineStart();
+		editor.handleInput("\x1b[46;5u"); // Ctrl+. -> spelling replacements
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		onAutocompleteUpdate.mockClear();
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(onAutocompleteUpdate).toHaveBeenCalled();
+		expect(editor.getText()).toBe("eh cat");
+	});
+
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		editor.setActionKeys("app.exit", ["ctrl+q"]);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -214,6 +214,22 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("eh cat");
 	});
 
+	it("opens the queue body when ctrl+d leaves a bare queue prefix, like the Delete key", () => {
+		// Deleting back to "->" promotes it to a reserved header line; skipping that leaves the
+		// cursor on the Queueing label, so the next characters type into the label instead.
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setText("->x");
+		editor.moveToLineStart();
+		editor.handleInput("\x1b[C"); // Right
+		editor.handleInput("\x1b[C"); // Right, cursor now before "x"
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(editor.getText()).toBe("->\n");
+		expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+		editor.handleInput("h");
+		editor.handleInput("i");
+		expect(editor.getText()).toBe("->\nhi");
+	});
+
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		editor.setActionKeys("app.exit", ["ctrl+q"]);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from "bun:test";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { getKeybindings, setKeybindings } from "@oh-my-pi/pi-tui";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -125,6 +126,28 @@ describe("CustomEditor keybindings", () => {
 		expect(onExit).not.toHaveBeenCalled();
 		expect(onDequeue).not.toHaveBeenCalled();
 		expect(customHandler).not.toHaveBeenCalled();
+	});
+
+	it("forward-deletes even when an earlier base-editor action is user-bound to the same chord", () => {
+		// Editor.handleInput checks tui.input.submit before tui.editor.deleteCharForward, so
+		// redispatching the raw key would submit the draft; the operation must be invoked directly.
+		const previous = getKeybindings();
+		setKeybindings(KeybindingsManager.inMemory({ "tui.input.submit": ["enter", "ctrl+d"] }));
+		try {
+			const editor = new CustomEditor(getEditorTheme());
+			const onExit = vi.fn();
+			const onSubmit = vi.fn();
+			editor.onExit = onExit;
+			editor.onSubmit = onSubmit;
+			editor.setText("ab");
+			editor.moveToLineStart();
+			editor.handleInput("\x04"); // Ctrl+D
+			expect(editor.getText()).toBe("b");
+			expect(onSubmit).not.toHaveBeenCalled();
+			expect(onExit).not.toHaveBeenCalled();
+		} finally {
+			setKeybindings(previous);
+		}
 	});
 
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -106,6 +106,27 @@ describe("CustomEditor keybindings", () => {
 		expect(onExit).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps the exit chord's precedence when forward-deleting: later handlers on the same chord do not fire", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onExit = vi.fn();
+		const onDequeue = vi.fn();
+		const customHandler = vi.fn();
+		editor.onExit = onExit;
+		editor.onDequeue = onDequeue;
+		// A later app action and an extension handler both user-bound to Ctrl+D while
+		// the default exit binding stays; KeybindingsManager only flags clashes between
+		// explicit user claims, so this configuration is reachable.
+		editor.setActionKeys("app.message.dequeue", ["ctrl+d"]);
+		editor.setCustomKeyHandler("ctrl+d", customHandler);
+		editor.setText("ab");
+		editor.moveToLineStart();
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(editor.getText()).toBe("b");
+		expect(onExit).not.toHaveBeenCalled();
+		expect(onDequeue).not.toHaveBeenCalled();
+		expect(customHandler).not.toHaveBeenCalled();
+	});
+
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		editor.setActionKeys("app.exit", ["ctrl+q"]);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -150,6 +150,22 @@ describe("CustomEditor keybindings", () => {
 		}
 	});
 
+	it("leaves the cursor on a grapheme after ctrl+d in vim normal mode, like the Delete key", () => {
+		// Vim maps the Delete key to `x`, which clamps the Normal-mode cursor; Ctrl+D resolves in
+		// the exit slot and must land on the same state, or the next insert goes in at the wrong
+		// column (deleting the last grapheme of "ab" then `iX` produced "aX" instead of "Xa").
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setVimMode(true);
+		editor.setText("ab");
+		editor.handleInput("\x1b"); // Escape -> Normal, cursor rests on "b"
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(editor.getText()).toBe("a");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+		editor.handleInput("i");
+		editor.handleInput("X");
+		expect(editor.getText()).toBe("Xa");
+	});
+
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		editor.setActionKeys("app.exit", ["ctrl+q"]);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -166,6 +166,34 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("Xa");
 	});
 
+	it("deletes the whole selection and leaves visual mode on ctrl+d, like the Delete key", () => {
+		// Vim maps Delete to `x`; in Visual mode that takes the selection and returns to Normal.
+		// A direct grapheme delete would instead leave the editor in Visual with a stale anchor.
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setVimMode(true);
+		editor.setText("abc");
+		editor.handleInput("\x1b"); // Escape -> Normal
+		editor.moveToLineStart();
+		editor.handleInput("v"); // Visual
+		editor.handleInput("l"); // extend over "ab"
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(editor.getText()).toBe("c");
+		expect(editor.vimMode).toBe("normal");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+	});
+
+	it("cancels a pending character jump on ctrl+d so the next key still types", () => {
+		// Any control key cancels jump mode in the base input chunk; the exit slot never reaches
+		// it, so the operation clears the state itself — otherwise "z" is eaten as a jump target.
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setText("abc");
+		editor.moveToLineStart();
+		editor.handleInput("\x1d"); // Ctrl+] -> jump forward, awaiting a target character
+		editor.handleInput("\x04"); // Ctrl+D
+		editor.handleInput("z");
+		expect(editor.getText()).toBe("zbc");
+	});
+
 	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		editor.setActionKeys("app.exit", ["ctrl+q"]);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -73,6 +73,49 @@ describe("CustomEditor keybindings", () => {
 		expect(onDisplayReset).toHaveBeenCalledTimes(1);
 		expect(onLiveToggle).toHaveBeenCalledTimes(1);
 	});
+	it("exits on ctrl+d with an empty draft", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(onExit).toHaveBeenCalledTimes(1);
+	});
+
+	it("forward-deletes instead of exiting on ctrl+d with draft text", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.setText("ab");
+		editor.moveToLineStart();
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(onExit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("b");
+	});
+
+	it("exits on ctrl+d after the last attachment chip is deleted", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.insertTextAttachment("a long pasted blob");
+		expect(editor.composerChips()).toHaveLength(1);
+		// Deleting the chip token empties the buffer; `pendingTexts` keeps the
+		// record so attachment numbering isn't recycled.
+		editor.setText("");
+		expect(editor.composerChips()).toHaveLength(0);
+		editor.handleInput("\x04"); // Ctrl+D
+		expect(onExit).toHaveBeenCalledTimes(1);
+	});
+
+	it("still exits on a remapped exit key with no forward-delete role, even with text", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setActionKeys("app.exit", ["ctrl+q"]);
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.setText("ab");
+		editor.handleInput("\x11"); // Ctrl+Q
+		expect(onExit).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("ab");
+	});
 });
 
 describe("shipped dequeue defaults", () => {

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { setKeyHintPlatform } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { KeybindingsManager, setKeyHintPlatform } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { buildHotkeysMarkdown } from "@oh-my-pi/pi-coding-agent/modes/utils/hotkeys-markdown";
+
+/** Exit-row wiring for stubs that only care about display strings: no key claims the
+ *  forward-delete role, so the exit row renders its plain "Exit" wording. */
+const noForwardDelete = { getKeys: () => [], matchesCanonical: () => false };
 
 describe("buildHotkeysMarkdown", () => {
 	afterEach(() => setKeyHintPlatform(undefined));
@@ -32,6 +36,7 @@ describe("buildHotkeysMarkdown", () => {
 		};
 		const markdown = buildHotkeysMarkdown({
 			keybindings: {
+				...noForwardDelete,
 				getDisplayString(action) {
 					return displayStrings[action] ?? "Disabled";
 				},
@@ -60,6 +65,7 @@ describe("buildHotkeysMarkdown", () => {
 	it("renders the temporary selector row as disabled when no display string is configured", () => {
 		const markdown = buildHotkeysMarkdown({
 			keybindings: {
+				...noForwardDelete,
 				getDisplayString(action) {
 					if (action === "app.model.selectTemporary") {
 						return "";
@@ -81,7 +87,9 @@ describe("buildHotkeysMarkdown", () => {
 
 	it("renders macOS static navigation rows on darwin", () => {
 		setKeyHintPlatform("darwin");
-		const markdown = buildHotkeysMarkdown({ keybindings: { getDisplayString: () => "Disabled" } });
+		const markdown = buildHotkeysMarkdown({
+			keybindings: { ...noForwardDelete, getDisplayString: () => "Disabled" },
+		});
 
 		expect(markdown).toContain("| `Option+Left/Right` | Move by word |");
 		expect(markdown).toContain("| `Ctrl+A` / `Home` / `Cmd+Left` | Start of line |");
@@ -91,12 +99,29 @@ describe("buildHotkeysMarkdown", () => {
 
 	it("drops Option/Cmd static navigation labels off darwin", () => {
 		setKeyHintPlatform("linux");
-		const markdown = buildHotkeysMarkdown({ keybindings: { getDisplayString: () => "Disabled" } });
+		const markdown = buildHotkeysMarkdown({
+			keybindings: { ...noForwardDelete, getDisplayString: () => "Disabled" },
+		});
 
 		expect(markdown).toContain("| `Alt+Left/Right` | Move by word |");
 		expect(markdown).toContain("| `Ctrl+A` / `Home` | Start of line |");
 		expect(markdown).toContain("| `Ctrl+W` / `Alt+Backspace` | Delete word backwards |");
 		expect(markdown).not.toContain("Option+");
 		expect(markdown).not.toContain("Cmd+");
+	});
+
+	it("describes the exit key per its actual forward-delete role", () => {
+		const shipped = KeybindingsManager.inMemory();
+		expect(buildHotkeysMarkdown({ keybindings: shipped })).toContain(
+			"| `Ctrl+D` | Delete char forward (with draft) / exit (empty prompt) |",
+		);
+
+		// Remapped exit with no forward-delete role: CustomEditor exits immediately, draft or not.
+		const remapped = KeybindingsManager.inMemory({ "app.exit": "ctrl+q" });
+		expect(buildHotkeysMarkdown({ keybindings: remapped })).toContain("| `Ctrl+Q` | Exit |");
+
+		// Ctrl+D kept as exit but dropped from forward-delete: exits unconditionally again.
+		const noDelete = KeybindingsManager.inMemory({ "tui.editor.deleteCharForward": "delete" });
+		expect(buildHotkeysMarkdown({ keybindings: noDelete })).toContain("| `Ctrl+D` | Exit |");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -123,5 +123,16 @@ describe("buildHotkeysMarkdown", () => {
 		// Ctrl+D kept as exit but dropped from forward-delete: exits unconditionally again.
 		const noDelete = KeybindingsManager.inMemory({ "tui.editor.deleteCharForward": "delete" });
 		expect(buildHotkeysMarkdown({ keybindings: noDelete })).toContain("| `Ctrl+D` | Exit |");
+
+		// Mixed roles: Ctrl+D forward-deletes with a draft, Ctrl+Q always quits — one row each.
+		const mixed = buildHotkeysMarkdown({
+			keybindings: KeybindingsManager.inMemory({ "app.exit": ["ctrl+d", "ctrl+q"] }),
+		});
+		expect(mixed).toContain("| `Ctrl+D` | Delete char forward (with draft) / exit (empty prompt) |");
+		expect(mixed).toContain("| `Ctrl+Q` | Exit |");
+
+		// Unbound exit keeps a row, matching the `Disabled` hint used elsewhere.
+		const unbound = buildHotkeysMarkdown({ keybindings: KeybindingsManager.inMemory({ "app.exit": [] }) });
+		expect(unbound).toContain("| `Disabled` | Exit |");
 	});
 });

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -367,18 +367,27 @@ describe("Composer prepaint", () => {
 		expect(exit).toHaveBeenCalledWith(130);
 	});
 
-	it("uses standard emergency exit before interactive keybindings load", () => {
+	it("forward-deletes a startup draft before interactive keybindings load, exiting once it is empty", () => {
 		const terminal = new CountingTerminal();
 		const exit = vi.fn();
 		const composer = new Composer({ preferences: config, terminal, exit });
 		composer.start();
 
 		terminal.sendInput("draft");
+		terminal.sendInput("\x1b[D"); // Left, so Ctrl+D has a character ahead of the cursor
+		terminal.sendInput("\x04");
+		expect(composer.editor.getExpandedText()).toBe("draf");
+		expect(exit).not.toHaveBeenCalled();
+		expect(terminal.stops).toBe(0);
+
+		for (let i = 0; i < 4; i++) terminal.sendInput("\x7f"); // Backspace the rest of the draft
+		expect(composer.editor.getExpandedText()).toBe("");
 		terminal.sendInput("\x04");
 
 		expect(exit).toHaveBeenCalledWith(0);
 		expect(terminal.stops).toBe(1);
 	});
+
 	it("keeps emergency exit live after adoption until interactive handlers replace it", () => {
 		const terminal = new CountingTerminal();
 		const exit = vi.fn();

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Editor.deleteCharForward()` exposes the `tui.editor.deleteCharForward` operation to hosts that resolve the chord themselves, applying the same transient-state teardown the key dispatch does (pending character jump, spelling-assist popup) and routing through Vim's `x` in Normal and Visual modes.
+
+### Fixed
+
+- Forward delete no longer leaves the Vim Normal-mode cursor one column past the end of a line after deleting the final grapheme.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2476,13 +2476,19 @@ export class Editor implements Component, Focusable {
 
 	/** The `tui.editor.deleteCharForward` operation, callable by hosts that resolve the chord
 	 *  themselves rather than redispatching the raw key (see CustomEditor's exit-chord overlap).
-	 *  Mirrors what the key dispatch does for this action so the two cannot diverge: a pending
-	 *  character jump is transient state that any other key cancels, and while Vim owns the
-	 *  buffer (Normal or Visual) the operation is Vim's `x` — deleting the selection and
-	 *  returning to Normal in Visual mode, the grapheme under the cursor otherwise. Only Insert
-	 *  mode and Vim-off editors delete straight through. */
+	 *  Mirrors the transient state the key dispatch tears down before this action so the two
+	 *  cannot diverge: a pending character jump is cancelled by any other key, and an open
+	 *  spelling-assist popup is dismissed by anything that is not one of its accept keys (its
+	 *  debounced refresh skips assist mode, so a surviving list would hang around forever).
+	 *  While Vim owns the buffer (Normal or Visual) the operation is Vim's `x` — deleting the
+	 *  selection and returning to Normal in Visual mode, the grapheme under the cursor
+	 *  otherwise. Only Insert mode and Vim-off editors delete straight through. */
 	deleteCharForward(): void {
 		this.#jumpMode = null;
+		if (this.#autocompleteState === "assist") {
+			this.#cancelAutocomplete();
+			this.onAutocompleteUpdate?.();
+		}
 		const vim = this.#vim;
 		if (vim !== null && vim.mode !== "insert") {
 			this.#runVimKey("x", vim);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3548,6 +3548,13 @@ export class Editor implements Component, Focusable {
 			this.#state.lines.splice(this.#state.cursorLine + 1, 1);
 		}
 
+		// Deleting the final grapheme can leave the cursor one past the end of the line, which
+		// Normal mode never allows (it rests *on* a grapheme). Vim's own `x` clamps via
+		// #applyVimCommands; callers that invoke this operation directly — hosts resolving a
+		// chord themselves, or a key bound to deleteCharForward that Vim does not map — get the
+		// same treatment here so the cursor can't sit off the buffer.
+		this.#clampVimCursor();
+
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2474,10 +2474,20 @@ export class Editor implements Component, Focusable {
 		this.#moveToMessageEnd();
 	}
 
-	/** Delete the grapheme (or whole atomic token) at the cursor, merging with the next line at
-	 *  end-of-line — the `tui.editor.deleteCharForward` operation, callable by hosts that resolve
-	 *  the chord themselves rather than redispatching the raw key. */
+	/** The `tui.editor.deleteCharForward` operation, callable by hosts that resolve the chord
+	 *  themselves rather than redispatching the raw key (see CustomEditor's exit-chord overlap).
+	 *  Mirrors what the key dispatch does for this action so the two cannot diverge: a pending
+	 *  character jump is transient state that any other key cancels, and while Vim owns the
+	 *  buffer (Normal or Visual) the operation is Vim's `x` — deleting the selection and
+	 *  returning to Normal in Visual mode, the grapheme under the cursor otherwise. Only Insert
+	 *  mode and Vim-off editors delete straight through. */
 	deleteCharForward(): void {
+		this.#jumpMode = null;
+		const vim = this.#vim;
+		if (vim !== null && vim.mode !== "insert") {
+			this.#runVimKey("x", vim);
+			return;
+		}
 		this.#handleForwardDelete();
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2474,6 +2474,13 @@ export class Editor implements Component, Focusable {
 		this.#moveToMessageEnd();
 	}
 
+	/** Delete the grapheme (or whole atomic token) at the cursor, merging with the next line at
+	 *  end-of-line — the `tui.editor.deleteCharForward` operation, callable by hosts that resolve
+	 *  the chord themselves rather than redispatching the raw key. */
+	deleteCharForward(): void {
+		this.#handleForwardDelete();
+	}
+
 	/**
 	 * Undo the last meaningful edit while ignoring transient text that is still present at the cursor.
 	 * Used for command-like autocomplete actions whose typed trigger should not count as the edit being undone.


### PR DESCRIPTION
## Summary
- treat Ctrl+D as forward-delete whenever the prompt contains draft content
- retain exit behavior for empty prompts and independently remapped exit keys
- cover empty, non-empty, and remapped key behavior with regression tests

## Verification
- `bun test ./packages/coding-agent/test/custom-editor-keybindings.test.ts`
- `bun test ./packages/coding-agent/test/modes/components/custom-editor.test.ts ./packages/coding-agent/test/modes/components/custom-editor-draft.test.ts ./packages/coding-agent/test/modes/components/custom-editor-plugin-ctor.test.ts ./packages/coding-agent/test/custom-editor-buffered-double-esc.test.ts`
- `bun run check:ts`