### PR TITLE
docs(notebook): point runtime links at the native edit implementation

### DIFF
--- a/docs/notebook-tool-runtime.md
+++ b/docs/notebook-tool-runtime.md
@@ -6,8 +6,8 @@ The critical distinction: **notebook support is file conversion/editing, not not
 
 ## Implementation files
 
-- [`src/edit/notebook.ts`](../packages/coding-agent/src/edit/notebook.ts)
-- [`src/edit/read-file.ts`](../packages/coding-agent/src/edit/read-file.ts)
+- [`crates/pi-edit/src/notebook.rs`](../crates/pi-edit/src/notebook.rs)
+- [`crates/pi-edit/src/files.rs`](../crates/pi-edit/src/files.rs)
 - [`src/tools/read.ts`](../packages/coding-agent/src/tools/read.ts)
 - [`src/tools/eval.ts`](../packages/coding-agent/src/tools/eval.ts)
 - [`src/eval/py/executor.ts`](../packages/coding-agent/src/eval/py/executor.ts)
@@ -16,7 +16,7 @@ The critical distinction: **notebook support is file conversion/editing, not not
 
 ## 1) Runtime boundary: editing vs executing
 
-## `.ipynb` file conversion (`src/edit/notebook.ts`)
+## `.ipynb` file conversion (`crates/pi-edit/src/notebook.rs`)
 
 - `read` treats `.ipynb` files as notebooks unless the selector is `:raw`.
 - The default notebook view is editable text with markers:
@@ -24,7 +24,7 @@ The critical distinction: **notebook support is file conversion/editing, not not
   - `# %% [markdown] cell:N`
   - `# %% [raw] cell:N`
 - Line selectors and multi-range selectors operate on that virtual text.
-- The edit pipeline round-trips virtual text back to notebook JSON through `serializeEditedNotebookText(...)`.
+- The edit pipeline round-trips virtual text back to notebook JSON through `serialize_edited_notebook_text(...)`.
 - Existing notebook metadata is preserved when a marker references an existing unused `cell:N`; new cells get fresh empty metadata.
 - A missing notebook passed to the serializer starts from an empty nbformat 4.5 notebook.
 - The standalone `write` tool is not notebook-aware: it replaces the file with the supplied bytes. Use it only with valid notebook JSON, not the virtual marker representation.


### PR DESCRIPTION
## Summary

`docs/notebook-tool-runtime.md` still pointed at the pre-native edit implementation. The native edit migration moved `.ipynb` conversion into `crates/pi-edit/`, so the document's links and one symbol name were stale:

- lines 9-10 linked `../packages/coding-agent/src/edit/notebook.ts` and `../packages/coding-agent/src/edit/read-file.ts` — neither file exists on `main`.
- line 27 named `serializeEditedNotebookText(...)`, which no longer exists.
- the `## \`.ipynb\` file conversion` heading named `src/edit/notebook.ts`.

Fixes #10882.

## Change

- Repoint the two implementation links at the current tracked sources: `crates/pi-edit/src/notebook.rs` and `crates/pi-edit/src/files.rs`.
- Repoint the section heading at `crates/pi-edit/src/notebook.rs`.
- Use the current Rust symbol name `serialize_edited_notebook_text(...)` (`crates/pi-edit/src/notebook.rs:320`).
- No prose, behavior, or scope changes; the issue explicitly asked to leave a broader rewrite out.

## Verification

Every relative Markdown link in the file resolves against the worktree (7 links, 0 broken), and no stale `src/edit/` or `serializeEditedNotebookText` reference remains:

```
total links: 7
broken: []
stale refs: []
serialize_edited_notebook_text in notebook.rs: True
```

No tracked Markdown-link checker exists in this repo (no docs/link job in `.github/workflows/`, no docs link task in the root `package.json`), so the check above is a throwaway script over the single edited file.

No CHANGELOG entry: this is an internal docs correction with no user-visible behavior change, matching the existing docs-only commit precedent (`20ff3d1d5a`, `c2cdf61a57`).
