### PR TITLE
fix(bash): strip inherited git repo-location overrides

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -356,6 +356,13 @@ fn run_pty_sync(
 	if let Some(cwd) = config.cwd.as_ref() {
 		cmd.cwd(cwd);
 	}
+	// `CommandBuilder` starts from this process's environment, so drop
+	// repo-location overrides before the explicit env below is applied: the
+	// terminal's `git` rediscovers the repository from `cwd`, while a
+	// caller-supplied value still wins.
+	for name in pi_shell::shell::GIT_REPO_LOCATION_ENV_VARS {
+		cmd.env_remove(name);
+	}
 	if let Some(env) = config.env.as_ref() {
 		for (key, value) in env {
 			cmd.env(key, value);

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -607,7 +607,7 @@ fn copy_env_into_shell(
 			continue;
 		};
 		let normalized_key = normalize_env_key(key);
-		if should_skip_env_var(normalized_key) {
+		if should_skip_env_var(normalized_key) || is_git_repo_location_var(normalized_key) {
 			continue;
 		}
 		if normalized_key == "PATH" {
@@ -705,7 +705,7 @@ async fn create_session_for_run(
 	if let Some(env) = config.session_env.as_ref() {
 		for (key, value) in env {
 			let normalized_key = normalize_env_key(key);
-			if should_skip_env_var(normalized_key) {
+			if should_skip_env_var(normalized_key) || is_git_repo_location_var(normalized_key) {
 				continue;
 			}
 			let mut var = ShellVariable::new(ShellValue::String(value.clone()));
@@ -1523,6 +1523,35 @@ fn is_macos_malloc_stack_logging_var(key: &str) -> bool {
 	matches!(key, "MallocStackLogging" | "MallocStackLoggingNoCompact")
 }
 
+/// Git variables that pin a repository location to the launch checkout.
+///
+/// Forwarding them into a shell makes `git` ignore the command's working
+/// directory and mutate the wrong worktree or index, so the shell rediscovers
+/// the repository from `cwd` instead. Mirrors the `env_remove` list in
+/// `crates/pi-vcs/src/git/cli.rs`.
+pub const GIT_REPO_LOCATION_ENV_VARS: [&str; 6] = [
+	"GIT_DIR",
+	"GIT_COMMON_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
+/// Windows environment lookups are case-insensitive, so `git_dir` binds there
+/// exactly like `GIT_DIR`; POSIX names are case-sensitive.
+#[cfg(windows)]
+fn is_git_repo_location_var(key: &str) -> bool {
+	GIT_REPO_LOCATION_ENV_VARS
+		.iter()
+		.any(|name| key.eq_ignore_ascii_case(name))
+}
+
+#[cfg(not(windows))]
+fn is_git_repo_location_var(key: &str) -> bool {
+	GIT_REPO_LOCATION_ENV_VARS.contains(&key)
+}
+
 fn should_skip_env_var(key: &str) -> bool {
 	if key.starts_with("BASH_FUNC_") && key.ends_with("%%") {
 		return true;
@@ -2045,6 +2074,86 @@ mod tests {
 		assert_eq!(value("HOME").as_deref(), Some("/home/tester"), "valid entry copied");
 		assert!(value("GHOSTTY_BIN_DIR").is_none(), "non-UTF-8 value must be skipped");
 		assert!(value("BAD").is_none(), "non-UTF-8 key must be skipped");
+	}
+
+	/// The strip must stay narrowly scoped: unrelated `GIT_*` names are part of
+	/// the shell contract (`GIT_EDITOR`, author identity) and must survive.
+	#[test]
+	fn git_repo_location_vars_exclude_unrelated_git_names() {
+		assert!(!is_git_repo_location_var("GIT_EDITOR"));
+		assert!(!is_git_repo_location_var("GIT_AUTHOR_NAME"));
+	}
+
+	/// Regression for issue #11082: the embedded shell copies the host
+	/// environment, and repo-location overrides in it (git hooks, `git
+	/// --git-dir` wrappers) must not reach child commands — `git` would ignore
+	/// the command's `cwd` and mutate the worktree the agent was launched from.
+	#[tokio::test(flavor = "multi_thread")]
+	async fn copy_env_skips_git_repo_location_overrides() {
+		let mut shell = BrushShell::builder()
+			.do_not_inherit_env(true)
+			.profile(ProfileLoadBehavior::Skip)
+			.rc(RcLoadBehavior::Skip)
+			.builtins(default_builtins(BuiltinSet::BashMode))
+			.build()
+			.await
+			.expect("build shell");
+
+		let entries = vec![
+			(std::ffi::OsString::from("GIT_DIR"), std::ffi::OsString::from("/primary/.git")),
+			(std::ffi::OsString::from("GIT_WORK_TREE"), std::ffi::OsString::from("/primary")),
+			(
+				std::ffi::OsString::from("GIT_INDEX_FILE"),
+				std::ffi::OsString::from("/primary/.git/index"),
+			),
+			(std::ffi::OsString::from("GIT_EDITOR"), std::ffi::OsString::from("true")),
+		];
+		copy_env_into_shell(&mut shell, entries.into_iter()).expect("copy host env");
+
+		let value = |name: &str| {
+			shell
+				.env()
+				.get(name)
+				.and_then(|(_, var)| match var.value() {
+					ShellValue::String(value) => Some(value.clone()),
+					_ => None,
+				})
+		};
+		assert!(value("GIT_DIR").is_none(), "GIT_DIR must not reach child commands");
+		assert!(value("GIT_WORK_TREE").is_none(), "GIT_WORK_TREE must not reach child commands");
+		assert!(value("GIT_INDEX_FILE").is_none(), "GIT_INDEX_FILE must not reach child commands");
+		assert_eq!(value("GIT_EDITOR").as_deref(), Some("true"), "unrelated git vars are kept");
+	}
+
+	/// The per-session env overlay is built from the same host environment, so
+	/// it must not reintroduce the repo-location overrides.
+	#[tokio::test(flavor = "multi_thread")]
+	async fn session_env_does_not_export_git_repo_location_overrides() {
+		let dir = tempfile::tempdir().expect("probe directory");
+		let out = dir.path().join("probe");
+		let mut env = HashMap::new();
+		env.insert("GIT_DIR".to_string(), "/primary/.git".to_string());
+		env.insert("OMP_GIT_ENV_PROBE".to_string(), "kept".to_string());
+		let config =
+			ShellConfig { session_env: Some(env), snapshot_path: None, minimizer: None };
+		let mut session = create_session(&config).await.expect("create_session");
+
+		let mut params = session.shell.default_exec_params();
+		params.set_fd(OpenFiles::STDIN_FD, null_file().expect("null stdin"));
+		params.set_fd(OpenFiles::STDOUT_FD, null_file().expect("null stdout"));
+		params.set_fd(OpenFiles::STDERR_FD, null_file().expect("null stderr"));
+
+		let command = format!(
+			"printf '%s|%s' \"${{GIT_DIR-unset}}\" \"$OMP_GIT_ENV_PROBE\" > {}",
+			quote_arg(out.to_str().expect("utf8 probe path"))
+		);
+		session
+			.shell
+			.run_string(command, &SourceInfo::from("pi-natives:test"), &params)
+			.await
+			.expect("run_string");
+
+		assert_eq!(fs::read_to_string(&out).expect("probe output"), "unset|kept");
 	}
 
 	#[cfg(unix)]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Bash commands whose `cwd` is a secondary Git worktree no longer inherit the agent's own `GIT_DIR`/`GIT_WORK_TREE` and related repo-location overrides, so a failed cherry-pick stays in the worktree where it ran instead of contaminating the primary one ([#11082](https://github.com/can1357/oh-my-pi/issues/11082)).
 - Extension commands now settle BTW writes before creating, switching, or branching sessions, preventing side requests from outliving their source session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Session selection and active-session deletion now settle BTW writes before switching or removing history, preventing stale saves from blocking the next session ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).
 - Escape now cancels BTW follow-ups that are still waiting for startup writes, without launching a model request ([#11335](https://github.com/can1357/oh-my-pi/pull/11335) by [@Ant39140](https://github.com/Ant39140)).

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -10,6 +10,7 @@ import {
 	stripWindowsExtendedLengthPathPrefix,
 	workerHostEntry,
 } from "@oh-my-pi/pi-utils";
+import { stripGitRepoLocationEnv } from "@oh-my-pi/pi-utils/env";
 import type { Subprocess } from "bun";
 
 /**
@@ -156,6 +157,9 @@ export function workerEnvFromParent(overlay?: Record<string, string>): Record<st
 		const value = base[key];
 		if (typeof value === "string") merged[key] = value;
 	}
+	// Inherited repo-location overrides must not reach a worker or the PTY
+	// daemons it hosts (issue #11082); an explicit overlay still wins below.
+	stripGitRepoLocationEnv(merged);
 	if (overlay) {
 		for (const key in overlay) merged[key] = overlay[key];
 	}

--- a/packages/coding-agent/test/tiny-worker-env.test.ts
+++ b/packages/coding-agent/test/tiny-worker-env.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "bun:test";
-import { nativeLibraryPathOverlay } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
+import { nativeLibraryPathOverlay, workerEnvFromParent } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
 import { tinyWorkerEnvOverlay } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 import { tinyWorkerEndpoint, tinyWorkerLogPath } from "@oh-my-pi/pi-coding-agent/tiny/title-protocol";
+
+describe("workerEnvFromParent", () => {
+	it("drops inherited git repo-location overrides but keeps an explicit overlay", () => {
+		// Managed PTY daemons are spawned from this snapshot; inheriting the
+		// agent's own GIT_DIR would make their shells target the wrong worktree
+		// (issue #11082). An explicit per-command value still wins.
+		const previous = process.env.GIT_DIR;
+		process.env.GIT_DIR = "/primary/.git";
+		try {
+			const env = workerEnvFromParent({ GIT_WORK_TREE: "/secondary", OMP_WORKER_ENV_PROBE: "kept" });
+			expect(env.GIT_DIR).toBeUndefined();
+			expect(env.GIT_WORK_TREE).toBe("/secondary");
+			expect(env.OMP_WORKER_ENV_PROBE).toBe("kept");
+		} finally {
+			if (previous === undefined) delete process.env.GIT_DIR;
+			else process.env.GIT_DIR = previous;
+		}
+	});
+});
 
 describe("tinyWorkerEnvOverlay", () => {
 	it("maps non-default settings onto the worker env vars when neither is already set", () => {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the embedded shell and PTY sessions inheriting `GIT_DIR`, `GIT_WORK_TREE`, and related repo-location overrides from the host process, which made `git` run in a secondary worktree mutate the primary one ([#11082](https://github.com/can1357/oh-my-pi/issues/11082)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 - Added public `acquireFileLock()` and `FileLockHandle` APIs for holding and explicitly releasing exclusive OS-backed file locks.
+
 ### Fixed
 
+- Fixed `filterChildShellEnv` forwarding the host process's `GIT_DIR`, `GIT_WORK_TREE`, and related repo-location overrides to child shells, where `git` would ignore the command's `cwd`.
 - Child-shell environment filtering now tolerates a removed process working directory by retaining the resolved project directory ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
 
 ## [18.1.16] - 2026-09-09
@@ -14,6 +16,8 @@
 ### Fixed
 
 - Fixed `$which` capturing `Bun.which` at import on Linux and Windows, so `Bun.which` stubs installed later (e.g. per-test spies) are honoured and PATH-only language servers no longer leak into test results.
+### Fixed
+
 
 ## [18.1.13] - 2026-09-07
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -64,6 +64,48 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	}
 	return result;
 }
+/**
+ * Git variables that pin a repository location. They describe the checkout the
+ * agent process itself was launched from (git hooks, `git --git-dir` wrappers),
+ * so forwarding them to a child shell makes `git` ignore the command's `cwd`
+ * and mutate the wrong worktree or index. Stripped from child shell envs so git
+ * rediscovers the repository from the working directory. Mirrors the
+ * `env_remove` list in `crates/pi-vcs/src/git/cli.rs`.
+ */
+const GIT_REPO_LOCATION_ENV_NAMES = [
+	"GIT_DIR",
+	"GIT_COMMON_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+] as const;
+
+/**
+ * Removes {@link GIT_REPO_LOCATION_ENV_NAMES} from a copied child env in place.
+ *
+ * Windows environment lookups are case-insensitive, so a block that spells a
+ * variable `git_dir` is just as binding there; match case-insensitively on
+ * win32 and exactly elsewhere (POSIX env names are case-sensitive).
+ */
+export function stripGitRepoLocationEnv(
+	env: Record<string, string>,
+	platform: NodeJS.Platform = process.platform,
+): void {
+	if (platform !== "win32") {
+		for (const name of GIT_REPO_LOCATION_ENV_NAMES) {
+			delete env[name];
+		}
+		return;
+	}
+	const folded = new Set<string>(GIT_REPO_LOCATION_ENV_NAMES.map(name => name.toLowerCase()));
+	for (const key of Object.keys(env)) {
+		if (folded.has(key.toLowerCase())) {
+			delete env[key];
+		}
+	}
+}
+
 // Bun autoloads the project's dotenv files into `process.env` before user code
 // runs — including inside `bun build --compile` binaries — so a snapshot of
 // `Bun.env` is only pre-dotenv when autoloading was explicitly disabled. Linux
@@ -180,6 +222,9 @@ export function filterChildShellEnv(
 			delete result[key];
 		}
 	}
+	// Last, after dotenv merging: no source (inherited, launcher, or dotenv) may
+	// pin the child shell to the agent's own repository.
+	stripGitRepoLocationEnv(result);
 	return result;
 }
 

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -4,10 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	$envExact,
+	filterChildShellEnv,
 	filterProcessEnv,
 	getDbBusyTimeoutMs,
 	parseEnvFile,
 	setInteractiveHost,
+	stripGitRepoLocationEnv,
 } from "@oh-my-pi/pi-utils/env";
 
 const tempDirs: string[] = [];
@@ -199,6 +201,28 @@ describe("filterChildShellEnv", () => {
 		expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
 	});
 
+	it("drops inherited git repo-location overrides", () => {
+		const cwd = path.dirname(writeTempEnv(""));
+		// A bash call with `cwd` in a secondary worktree must not mutate the
+		// primary one: forwarding the agent's own repo-location variables makes
+		// child `git` ignore the command's cwd (issue #11082).
+		expect(
+			filterChildShellEnv(
+				{
+					GIT_DIR: "/primary/.git",
+					GIT_COMMON_DIR: "/primary/.git",
+					GIT_WORK_TREE: "/primary",
+					GIT_INDEX_FILE: "/primary/.git/index",
+					GIT_OBJECT_DIRECTORY: "/primary/.git/objects",
+					GIT_ALTERNATE_OBJECT_DIRECTORIES: "/primary/.git/objects",
+					GIT_EDITOR: "true",
+					GIT_AUTHOR_NAME: "Agent",
+				},
+				cwd,
+			),
+		).toEqual({ GIT_EDITOR: "true", GIT_AUTHOR_NAME: "Agent" });
+	});
+
 	it("uses the launch mode when dotenv changes NODE_ENV", async () => {
 		const cwd = path.dirname(writeTempEnv("NODE_ENV=production\n"));
 		fs.writeFileSync(
@@ -265,6 +289,20 @@ describe("filterChildShellEnv", () => {
 			expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
 		},
 	);
+});
+
+describe("stripGitRepoLocationEnv", () => {
+	it("matches case-insensitively on win32 and exactly on POSIX", () => {
+		// Windows env lookups are case-insensitive, so a `git_dir` block binds
+		// there; POSIX names are case-sensitive and must not be over-stripped.
+		const win32Env: Record<string, string> = { GIT_DIR: "a", git_dir: "b", GIT_WORK_TREE: "c", KEEP: "d" };
+		stripGitRepoLocationEnv(win32Env, "win32");
+		expect(win32Env).toEqual({ KEEP: "d" });
+
+		const posixEnv: Record<string, string> = { GIT_DIR: "a", git_dir: "b", KEEP: "d" };
+		stripGitRepoLocationEnv(posixEnv, "linux");
+		expect(posixEnv).toEqual({ git_dir: "b", KEEP: "d" });
+	});
 });
 
 describe("isBunTestRuntime", () => {


### PR DESCRIPTION
## Problem

A `bash` tool call whose `cwd` pointed at a secondary Git worktree mutated the **primary** worktree's index: the failed cherry-pick state appeared in the wrong worktree ([#11082](https://github.com/can1357/oh-my-pi/issues/11082)).

## Root cause

The agent process's own git repo-location variables reached the command through four seams:

1. `pi-shell` copies the host environment into the embedded shell (`copy_env_into_shell`) and then applies the per-session overlay; the host's `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/… survived both and brush exports them to every child.
2. `pi-natives`' PTY spawner builds its command from `portable_pty::CommandBuilder`, which starts from the host environment; nothing removed the same names.
3. `@oh-my-pi/pi-utils`' `filterChildShellEnv` (used for the shell config env, the snapshot spawn, and the legacy shim) filtered unsafe and dotenv-sourced names but not repo-location overrides.
4. `workerEnvFromParent` snapshots the entire parent env for worker/PTY-daemon subprocesses, and the daemon's own overlay is applied after the PTY strip — so managed background jobs re-added the names even with (2) in place.

With `GIT_DIR` set, `git` ignores the command's `cwd`, so `git cherry-pick` aimed at the secondary worktree operated on the primary repository.

## Change

Strip exactly the six names `pi-vcs`' `git/cli.rs::apply_env` already removes — `GIT_DIR`, `GIT_COMMON_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`:

- `crates/pi-shell/src/shell.rs`: new `GIT_REPO_LOCATION_ENV_VARS` list; the ambient copy and the session-env overlay skip those names. Windows lookups are case-insensitive, so the predicate folds case there.
- `crates/pi-natives/src/pty.rs`: `env_remove` before the explicit env is applied.
- `packages/utils/src/env.ts`: exported `stripGitRepoLocationEnv(env, platform)`; `filterChildShellEnv` drops them after dotenv merging, so no source (inherited, launcher, or dotenv) can pin a child shell to the agent's repository. Case-insensitive on win32, exact on POSIX.
- `packages/coding-agent/src/subprocess/worker-client.ts`: `workerEnvFromParent` strips the inherited snapshot before applying the caller overlay.

An explicit per-command `env` overlay still wins in every seam.

## Verification

- `packages/utils/test/env.test.ts`: `drops inherited git repo-location overrides` (six keys dropped, `GIT_EDITOR`/`GIT_AUTHOR_NAME` kept) and `stripGitRepoLocationEnv` win32-vs-POSIX case behavior. 21/21 in the file; the inherited-override test fails before the change.
- `packages/coding-agent/test/tiny-worker-env.test.ts`: `workerEnvFromParent` drops an inherited `GIT_DIR` while an explicit overlay value survives.
- Rust regression tests in `crates/pi-shell/src/shell.rs`: `copy_env_skips_git_repo_location_overrides`, `session_env_does_not_export_git_repo_location_overrides`, and a negative test that unrelated `GIT_*` names are not stripped.
- `bun check:ts` clean across all workspaces.
- Rust gate verified in CI on a fork branch (`ci/rust-verify`, GitHub Actions `ubuntu-22.04`, nightly-2026-08-08): `cargo fmt --all -- --check` ✓, `cargo clippy -p pi-shell -p pi-natives --no-deps -- -D warnings` ✓, `cargo nextest run -p pi-shell` ✓ (run 34249676771). The authoring host has no Rust toolchain, so this fork-side run is the Rust evidence; the throwaway branch and its workflow are deleted afterwards.

## Note on the duplicated strip list

The six names now live in three places (the `pi-shell` const, `pi-vcs`' inline `apply_env` array, and the TS `GIT_REPO_LOCATION_ENV_NAMES`). `pi-natives` reuses the `pi-shell` const; `pi-vcs` does not depend on `pi-shell` and pulling the shell crate into the VCS crate for six strings would be a worse coupling, so the Rust copy stays a documented mirror.
