### PR TITLE
perf(read): omit duplicate body from truncation metadata

### DIFF
--- a/docs/tools/read.md
+++ b/docs/tools/read.md
@@ -61,7 +61,7 @@ Literal filesystem paths take precedence over selector interpretation, so an exi
    - `resolvedPath`
    - `suffixResolution`
    - URL fields: `url`, `finalUrl`, `contentType`, `method`, `notes`
-   - `truncation`
+   - `truncation` (`ReadTruncationStats`: counters and flags only; no duplicate `content` field)
    - `displayContent` (unprefixed text + starting line for TUI rendering)
    - `summary` (`lines`, `elidedSpans`, `elidedLines`) for structural summaries
    - `conflictCount` for `<path>:conflicts`
@@ -69,6 +69,7 @@ Literal filesystem paths take precedence over selector interpretation, so an exi
    - `meta` from `packages/coding-agent/src/tools/output-meta.ts`
 - `details.meta.source` is set to the backing path, URL, or internal URL.
 - `details.meta.truncation` carries shown range, total lines/bytes, next offset, and optional `artifactId` for cached URL output.
+- Read result bodies live in `content`; `details.displayContent` remains the unprefixed TUI representation. Extensions that previously read `details.truncation.content` must use those fields instead. Older session records containing the extra field still load and render without migration.
 - Directory/archive listings and SQLite table lists also set `details.meta.limits` when list limits trigger.
 
 ## Flow

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Read tool results no longer duplicate the body in `details.truncation.content`; use result `content` or `details.displayContent` instead.
+
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.

--- a/packages/coding-agent/src/tools/read-archive.ts
+++ b/packages/coding-agent/src/tools/read-archive.ts
@@ -16,6 +16,7 @@ import {
 	decodeUtf8Text,
 	markMarkdownContentType,
 	prependSuffixResolutionNotice,
+	toReadTruncationStats,
 } from "./read-format";
 import {
 	findSuffixMatchCached,
@@ -111,7 +112,7 @@ async function readArchiveDirectory(
 	const resultBuilder = toolResult<ReadToolDetails>(directoryDetails).text(truncation.content);
 	resultBuilder.sourcePath(archivePath).limits({ resultLimit: limitMeta.resultLimit?.reached });
 	if (truncation.truncated) {
-		directoryDetails.truncation = truncation;
+		directoryDetails.truncation = toReadTruncationStats(truncation);
 		resultBuilder.truncation(truncation, { direction: "head" });
 	}
 	return resultBuilder.done();

--- a/packages/coding-agent/src/tools/read-format.ts
+++ b/packages/coding-agent/src/tools/read-format.ts
@@ -20,11 +20,16 @@ import {
 import { buildLineEntriesWithBlockContext, type LineEntry, lineEntriesToPlainText } from "../utils/block-context";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { formatPathRelativeToCwd, type LineRange } from "./path-utils";
-import type { ReadToolDetails } from "./read";
+import type { ReadToolDetails, ReadTruncationStats } from "./read";
 import { isRawSelector, type ParsedSelector, resolveTailSelector, selToOffsetLimit } from "./read-selector";
 import { formatBytes, shortenPath } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
+
+export function toReadTruncationStats(result: TruncationResult): ReadTruncationStats {
+	const { content: _content, ...stats } = result;
+	return stats;
+}
 
 function prependLineNumbers(text: string, startNum: number): string {
 	const textLines = text.split("\n");
@@ -459,7 +464,7 @@ export function buildInMemoryTextResult(
 			)}, exceeds ${formatBytes(DEFAULT_MAX_BYTES)} limit. Unable to display a valid UTF-8 snippet.]`;
 		}
 
-		details.truncation = truncation;
+		details.truncation = toReadTruncationStats(truncation);
 		truncationInfo = {
 			result: truncation,
 			options: { direction: "head", startLine: startLineDisplay, totalFileLines: totalLines },
@@ -473,7 +478,7 @@ export function buildInMemoryTextResult(
 		} else {
 			outputText = formatLineEntries(buildLineEntries(endLineDisplay), startLineDisplay);
 		}
-		details.truncation = truncation;
+		details.truncation = toReadTruncationStats(truncation);
 		truncationInfo = {
 			result: truncation,
 			options: { direction: "head", startLine: startLineDisplay, totalFileLines: totalLines },

--- a/packages/coding-agent/src/tools/read-sqlite.ts
+++ b/packages/coding-agent/src/tools/read-sqlite.ts
@@ -5,7 +5,7 @@ import { DEFAULT_MAX_LINES, truncateHead } from "../session/streaming-output";
 import { applyListLimit } from "./list-limit";
 import { resolveReadPath } from "./path-utils";
 import type { ReadToolDetails } from "./read";
-import { prependSuffixResolutionNotice } from "./read-format";
+import { prependSuffixResolutionNotice, toReadTruncationStats } from "./read-format";
 import {
 	findSuffixMatchCached,
 	isNotFoundError,
@@ -119,7 +119,7 @@ export async function readSqlite(
 					resolvedSqlitePath.suffixResolution,
 				);
 				const truncation = truncateHead(output, { maxLines: Number.MAX_SAFE_INTEGER });
-				details.truncation = truncation.truncated ? truncation : undefined;
+				details.truncation = truncation.truncated ? toReadTruncationStats(truncation) : undefined;
 				const resultBuilder = toolResult<ReadToolDetails>(details)
 					.text(truncation.content)
 					.sourcePath(resolvedSqlitePath.absolutePath)

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -100,6 +100,7 @@ import {
 	RANGE_TRAILING_CONTEXT_LINES,
 	READ_CHUNK_SIZE,
 	readHashlineHeaderContext,
+	toReadTruncationStats,
 } from "./read-format";
 import {
 	findSuffixMatchCached,
@@ -629,9 +630,12 @@ const readSchemaWithoutMemory = type({
 
 export type ReadToolInput = typeof readSchema.infer;
 
+/** Read result metadata retains truncation statistics, not a second copy of the body. */
+export type ReadTruncationStats = Omit<TruncationResult, "content">;
+
 export interface ReadToolDetails {
 	kind?: "file" | "url";
-	truncation?: TruncationResult;
+	truncation?: ReadTruncationStats;
 	isDirectory?: boolean;
 	resolvedPath?: string;
 	suffixResolution?: { from: string; to: string };
@@ -1971,7 +1975,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								firstLineBytes,
 							)}, exceeds ${formatBytes(maxBytesForRead)} limit. Unable to display a valid UTF-8 snippet.]`;
 						}
-						details = { truncation };
+						details = { truncation: toReadTruncationStats(truncation) };
 						sourcePath = absolutePath;
 						truncationInfo = {
 							result: truncation,
@@ -1991,7 +1995,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								`:raw:${lineNumber}-${lineNumber}`,
 							)}`;
 						}
-						details = { truncation };
+						details = { truncation: toReadTruncationStats(truncation) };
 						sourcePath = absolutePath;
 						truncationInfo = {
 							result: truncation,
@@ -2385,7 +2389,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 		if (reachedEof) details.totalLines = totalFileLines;
 		if (displayContent) details.displayContent = displayContent;
-		if (truncationInfo) details.truncation = truncationInfo.result;
+		if (truncationInfo) details.truncation = toReadTruncationStats(truncationInfo.result);
 		const resultBuilder = toolResult<ReadToolDetails>(details)
 			.text(outputText)
 			.sourcePath(artifact.path)
@@ -2603,7 +2607,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 		if (truncation.truncated) {
 			resultBuilder.truncation(truncation, { direction: "head" });
-			details.truncation = truncation;
+			details.truncation = toReadTruncationStats(truncation);
 		}
 
 		return resultBuilder.done();

--- a/packages/coding-agent/test/tools/read-truncation-metadata.test.ts
+++ b/packages/coding-agent/test/tools/read-truncation-metadata.test.ts
@@ -1,0 +1,258 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getThemeByName, initTheme, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+import type { ReadToolDetails, ReadTruncationStats, ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { formatTruncationMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { ReadTool, readToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { writeArchive } from "@oh-my-pi/pi-utils/ar";
+
+function textOutput(result: AgentToolResult<ReadToolDetails>): string {
+	return result.content
+		.filter(block => block.type === "text")
+		.map(block => block.text)
+		.join("\n");
+}
+
+function persistedResult(result: AgentToolResult<ReadToolDetails>): AgentToolResult<ReadToolDetails> {
+	const persisted: AgentToolResult<ReadToolDetails> = JSON.parse(JSON.stringify(result));
+	expect(persisted.details?.truncation).toBeDefined();
+	expect(persisted.details?.truncation).not.toHaveProperty("content");
+	return persisted;
+}
+
+describe("read truncation metadata", () => {
+	let root: string;
+	let session: ToolSession;
+	let tool: ReadTool;
+	let uiTheme: Theme;
+
+	beforeAll(async () => {
+		await initTheme(false, undefined, undefined, "dark", "light");
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("Expected dark theme");
+		uiTheme = theme;
+	});
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "read-truncation-metadata-"));
+		const getArtifactsDir = () => path.join(root, "artifacts");
+		session = {
+			cwd: root,
+			hasUI: false,
+			getSessionFile: () => path.join(root, "session.jsonl"),
+			getSessionSpawns: () => "*",
+			getArtifactsDir,
+			localProtocolOptions: { getArtifactsDir },
+			settings: Settings.isolated({
+				"read.summarize.enabled": false,
+				"edit.mode": "hashline",
+				readLineNumbers: true,
+				"tools.outputMaxColumns": 0,
+			}),
+		};
+		tool = new ReadTool(session);
+	});
+
+	afterEach(async () => {
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	it("keeps byte-limited local content and its continuation without serializing a second truncation body", async () => {
+		const lines = Array.from({ length: 100 }, (_, index) => `${String(index).padStart(4, "0")}${"x".repeat(1020)}`);
+		await Bun.write(path.join(root, "bytes.txt"), lines.join("\n"));
+
+		const result = persistedResult(await tool.execute("local-bytes", { path: "bytes.txt:raw:1-100" }));
+		const expectedBody = lines.slice(0, 49).join("\n");
+		expect(textOutput(result)).toBe(expectedBody);
+		expect(result.details?.displayContent?.text).toBe(expectedBody);
+		expect(result.details?.truncation).toMatchObject({
+			truncated: true,
+			truncatedBy: "bytes",
+			totalLines: 100,
+			totalBytes: Buffer.byteLength(lines.join("\n")),
+			outputLines: 49,
+			outputBytes: Buffer.byteLength(expectedBody),
+			firstLineExceedsLimit: false,
+			lastLinePartial: false,
+		} satisfies ReadTruncationStats);
+		expect(result.details?.meta?.truncation).toMatchObject({
+			shownRange: { start: 1, end: 49 },
+			nextOffset: 50,
+		});
+		const meta = result.details?.meta?.truncation;
+		if (!meta) throw new Error("Expected continuation metadata");
+		expect(formatTruncationMetaNotice(meta)).toContain("Use :50 to continue");
+	});
+
+	it("does not turn an oversized local first line into an editable partial hashline", async () => {
+		const line = "x".repeat(DEFAULT_MAX_BYTES + 1);
+		await Bun.write(path.join(root, "wide.txt"), `${line}\nlast`);
+		const result = persistedResult(await tool.execute("local-wide", { path: "wide.txt:1-1" }));
+
+		expect(textOutput(result)).toContain("cannot emit an editable numbered preview");
+		expect(textOutput(result)).not.toContain("1:xxx");
+		expect(result.details?.truncation).toMatchObject({
+			firstLineExceedsLimit: true,
+			lastLinePartial: false,
+			totalBytes: DEFAULT_MAX_BYTES + 1,
+			outputBytes: DEFAULT_MAX_BYTES,
+		});
+		expect(result.details?.meta?.truncation).toMatchObject({ partialLine: true, shownRange: { start: 1, end: 1 } });
+		expect(result.details?.meta?.truncation?.nextOffset).toBeUndefined();
+	});
+
+	it("retains the partial UTF-8 preview and oversized-line warning for streamed artifact reads", async () => {
+		const line = "é".repeat(36_000);
+		await Bun.write(path.join(root, "artifacts", "0.read.log"), `before\n${line}\nafter`);
+		const result = persistedResult(await tool.execute("artifact-line", { path: "artifact://0:raw:2-2" }));
+		const preview = line.slice(0, DEFAULT_MAX_BYTES / 2);
+
+		expect(textOutput(result)).toBe(preview);
+		expect(result.details?.displayContent).toMatchObject({ text: preview, startLine: 2, lineNumbers: [2] });
+		expect(result.details?.truncation).toMatchObject({
+			firstLineExceedsLimit: true,
+			lastLinePartial: false,
+			totalBytes: Buffer.byteLength(line),
+			outputBytes: Buffer.byteLength(preview),
+			outputLines: 1,
+		});
+		expect(result.details?.meta?.truncation).toMatchObject({
+			partialLine: true,
+			shownRange: { start: 2, end: 2 },
+			outputBytes: Buffer.byteLength(preview),
+		});
+		expect(result.details?.meta?.truncation?.nextOffset).toBeUndefined();
+		const rendered = readToolRenderer
+			.renderResult(result, { expanded: false, isPartial: false }, uiTheme, { path: "artifact://0:raw:2-2" })
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(rendered).toContain("First line exceeds");
+		expect(rendered).not.toContain("Showing 0 of");
+	});
+
+	it("preserves the in-memory line cap and rendering of legacy metadata with or without display content", async () => {
+		const lines = Array.from(
+			{ length: DEFAULT_MAX_LINES + 5 },
+			(_, index) => `row-${String(index + 1).padStart(4, "0")}`,
+		);
+		await writeArchive(path.join(root, "rows.zip"), "zip", [["rows.txt", lines.join("\n")]]);
+		const result = persistedResult(await tool.execute("archive-lines", { path: "rows.zip:rows.txt" }));
+		const displayBody = lines.slice(0, DEFAULT_MAX_LINES).join("\n");
+		expect(textOutput(result)).toBe(
+			lines
+				.slice(0, DEFAULT_MAX_LINES)
+				.map((line, index) => `${index + 1}|${line}`)
+				.join("\n"),
+		);
+		expect(result.details?.displayContent?.text).toBe(displayBody);
+		expect(result.details?.truncation).toMatchObject({
+			truncatedBy: "lines",
+			totalLines: DEFAULT_MAX_LINES + 5,
+			outputLines: DEFAULT_MAX_LINES,
+			outputBytes: Buffer.byteLength(displayBody),
+			firstLineExceedsLimit: false,
+			lastLinePartial: false,
+		});
+		expect(result.details?.meta?.truncation).toMatchObject({
+			shownRange: { start: 1, end: DEFAULT_MAX_LINES },
+			nextOffset: DEFAULT_MAX_LINES + 1,
+		});
+
+		for (const expanded of [false, true]) {
+			for (const withDisplayContent of [false, true]) {
+				const details = {
+					...result.details,
+					displayContent: withDisplayContent ? result.details?.displayContent : undefined,
+				};
+				const legacy: AgentToolResult<ReadToolDetails> = JSON.parse(
+					JSON.stringify({
+						...result,
+						details: { ...details, truncation: { ...details.truncation, content: displayBody } },
+					}),
+				);
+				const options = { expanded, isPartial: false };
+				const args = { path: "rows.zip:rows.txt" };
+				const current = readToolRenderer.renderResult({ ...result, details }, options, uiTheme, args).render(100);
+				const previous = readToolRenderer.renderResult(legacy, options, uiTheme, args).render(100);
+				expect(current).toEqual(previous);
+				expect(current.map(line => Bun.stripANSI(line)).join("\n")).toContain("row-0001");
+			}
+		}
+	});
+
+	it("keeps in-memory oversized-first-line metadata even when no complete source line fits", async () => {
+		const line = "x".repeat(DEFAULT_MAX_BYTES + 1);
+		await writeArchive(path.join(root, "wide.zip"), "zip", [["wide.txt", `${line}\nlast`]]);
+		const result = persistedResult(await tool.execute("archive-wide", { path: "wide.zip:wide.txt:raw" }));
+
+		expect(textOutput(result)).toBe(line.slice(0, DEFAULT_MAX_BYTES));
+		expect(result.details?.displayContent?.text).toBe(line.slice(0, DEFAULT_MAX_BYTES));
+		expect(result.details?.truncation).toMatchObject({
+			firstLineExceedsLimit: true,
+			lastLinePartial: false,
+			totalLines: 2,
+			totalBytes: DEFAULT_MAX_BYTES + 6,
+			outputLines: 0,
+			outputBytes: 0,
+		});
+		expect(result.details?.meta?.truncation).toMatchObject({ partialLine: true, shownRange: { start: 1, end: 1 } });
+	});
+
+	it.each(["directory", "archive", "sqlite"] as const)(
+		"keeps byte-limited %s listings and statistics without storing a duplicate body",
+		async kind => {
+			// SQLite bounds each rendered row to 120 columns; 450 names cross the byte cap
+			// without hitting its separate 500-table cap. Other listings keep the full names.
+			const names = Array.from(
+				{ length: 450 },
+				(_, index) => `item-${String(index).padStart(4, "0")}-${"x".repeat(110)}`,
+			);
+			let target: string;
+			if (kind === "directory") {
+				target = path.join(root, "listing");
+				for (const name of names) await Bun.write(path.join(target, name), "");
+			} else if (kind === "archive") {
+				target = path.join(root, "listing.zip");
+				await writeArchive(
+					target,
+					"zip",
+					names.map(name => [name, ""] as const),
+				);
+			} else {
+				target = path.join(root, "listing.sqlite");
+				const db = new Database(target);
+				try {
+					db.transaction(() => {
+						for (const name of names) db.run(`CREATE TABLE "${name}" (id INTEGER)`);
+					})();
+				} finally {
+					db.close();
+				}
+			}
+
+			const result = persistedResult(await tool.execute(`listing-${kind}`, { path: target }));
+			const body = textOutput(result);
+			expect(body).toMatch(/item-\d{4}-x+/);
+			expect(Buffer.byteLength(body)).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+			expect(result.details?.truncation).toMatchObject({
+				truncatedBy: "bytes",
+				totalLines: names.length + (kind === "directory" ? 1 : 0),
+				outputLines: body.split("\n").length,
+				outputBytes: Buffer.byteLength(body),
+				lastLinePartial: false,
+			});
+			expect(result.details?.truncation?.totalBytes).toBeGreaterThan(DEFAULT_MAX_BYTES);
+			expect(result.details?.meta?.truncation).toMatchObject({
+				truncatedBy: "bytes",
+				outputBytes: Buffer.byteLength(body),
+			});
+		},
+	);
+});


### PR DESCRIPTION
## Author-approved rationale
This change removes the duplicated body from read truncation metadata to reduce session storage while preserving the displayed output and continuation information.

AI-assisted implementation; the submitter approved this scope and rationale before publication. The verification below was executed by the coding agent.

## Summary
Remove the duplicate body from built-in read truncation metadata. `ReadTruncationStats` retains the existing counters and flags, while the body remains in result content and the unprefixed display representation.

All read producers are covered: local and artifact reads, converted/in-memory text, directory listings, archive listings, and SQLite table lists. Runtime truncation objects and provider-facing content are unchanged.

## Compatibility
This removes the public `details.truncation.content` field from newly produced read results. Extensions should use result `content` or `details.displayContent`. The change is documented under Breaking Changes. Old session records still render without migration. No real session files are rewritten.

## Verification
- `bun run check` from packages/coding-agent: passed.
- Focused read metadata suite: 8 passed, including legacy rendering, byte/line limits, UTF-8 partial-line boundaries, and listing producers.
- Independently validated with the other three storage changes restored to the common base in a process-local source overlay: 8 passed.
- Baseline reproduction fails because serialized `details.truncation` still contains `content`; the changed implementation passes.
- Smoke: real ReadTool result retained content and truncation statistics without the duplicate field.
- The initial proposal fixture measured 158,507 -> 106,672 serialized bytes (32.7% for that fixture, not a whole-session estimate), with unchanged content/notices and four render variants.

Local verification used the already-installed 18.1.14 native addon via a temporary Bun preload because this checkout did not contain a built addon. No dependency installation or real-history modification was performed.

Related precedent: #9689 avoids persisting duplicate payloads; this change is confined to built-in read metadata rather than filtering arbitrary extension details.
