### PR TITLE
perf(gc): stream session scanning and archive I/O

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -487,6 +487,14 @@ Implementations and adapters:
 
 `SessionStorageWriter` exposes `append`, optional `appendSync`, `flush`, optional `flushSync`, `isOpen`, `close`, and `getError`.
 
+### Manual storage maintenance
+
+`omp gc` previews maintenance by default; `--apply` is required to sweep unreferenced blobs, archive eligible cold sessions, or checkpoint database WALs. Storage maintenance is separate from model-context compaction.
+
+Journal payload I/O is streamed during blob-reference scans, archive history/stats reconciliation, gzip creation, and rollback. Active `.jsonl`, recoverable `.jsonl.*.bak`, and archived `.jsonl.gz` records all participate in reference discovery, including references in malformed JSON text. Compressed scans drain and validate the complete stream before their results can authorize deletion. Archives retain the original JSONL bytes when decompressed, and artifact trees keep their existing layout.
+
+Streaming avoids materializing a whole journal; it does not make GC constant-memory. A single long record, reference sets, and history/stats identity collections still consume memory. Original files and temporary compressed output also coexist during archive publication.
+
 ## Session Discovery Utilities
 
 Discovery helpers live in `session-listing.ts`; `SessionManager` exposes project-scoped wrappers:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Storage maintenance streams large session journals and gzip archives instead of loading complete files into memory.
+
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
@@ -19,7 +23,6 @@
 
 ### Changed
 
-- Storage maintenance streams large session journals and gzip archives instead of loading complete files into memory.
 - When enabled (`task.showResolvedModelBadge`), subagent model badges show the thinking-level icon, model name, and attached-advisor eye before the agent name in task, eval, job, and HUD rows.
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changed
 
+- Storage maintenance streams large session journals and gzip archives instead of loading complete files into memory.
 - When enabled (`task.showResolvedModelBadge`), subagent model badges show the thinking-level icon, model name, and attached-advisor eye before the agent name in task, eval, job, and HUD rows.
 
 ### Fixed

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -1,7 +1,9 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { gunzipSync, gzipSync } from "node:zlib";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGunzip, createGzip } from "node:zlib";
 import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import {
 	getAgentDir,
@@ -231,14 +233,22 @@ async function statIfPresent(target: string) {
 	}
 }
 
-async function readTextIfPresent(file: string): Promise<string> {
+async function scanSessionLinesIfPresent(file: string, onLine: (line: Uint8Array) => void): Promise<void> {
+	// readLines buffers at most the largest record, including malformed records.
+	const scan = async (stream: ReadableStream<Uint8Array>): Promise<void> => {
+		for await (const line of readLines(stream)) onLine(line);
+	};
 	try {
+		const stream = Bun.file(file).stream();
 		if (file.endsWith(COMPRESSED_SESSION_SUFFIX)) {
-			return new TextDecoder().decode(gunzipSync(await Bun.file(file).bytes()));
+			await pipeline(stream, createGunzip(), async (source: NodeJS.ReadableStream) => {
+				await scan(Readable.toWeb(source, { strategy: { highWaterMark: 1 } }));
+			});
+		} else {
+			await scan(stream);
 		}
-		return await Bun.file(file).text();
 	} catch (error) {
-		if (codeOf(error) === "ENOENT") return "";
+		if (codeOf(error) === "ENOENT") return;
 		throw error;
 	}
 }
@@ -278,6 +288,7 @@ async function collectBackupJsonlFiles(root: string): Promise<string[]> {
 
 async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<string>> {
 	const hashes = new Set<string>();
+	const decoder = new TextDecoder();
 	for (const root of sessionRoots) {
 		const files = [
 			...(await collectJsonlFiles(root)),
@@ -285,11 +296,13 @@ async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<
 			...(await collectBackupJsonlFiles(root)),
 		];
 		for (const file of files) {
-			const text = await readTextIfPresent(file);
-			for (const match of text.matchAll(BLOB_REF_RE)) {
-				const hash = match[1]?.toLowerCase();
-				if (hash && BLOB_HASH_RE.test(hash)) hashes.add(hash);
-			}
+			// Keep raw-text matching: recoverable malformed records can still own blobs.
+			await scanSessionLinesIfPresent(file, line => {
+				for (const match of decoder.decode(line).matchAll(BLOB_REF_RE)) {
+					const hash = match[1]?.toLowerCase();
+					if (hash && BLOB_HASH_RE.test(hash)) hashes.add(hash);
+				}
+			});
 		}
 	}
 	return hashes;
@@ -446,11 +459,15 @@ interface SessionLineageHeader {
 	previousSessionFiles: string[];
 }
 
-function sessionLineageHeaderFromText(text: string): SessionLineageHeader | undefined {
-	let sawTitleSlot = false;
-	for (const rawLine of text.split(/\r?\n/)) {
-		const line = rawLine.trim();
-		if (!line) continue;
+class SessionLineageHeaderReader {
+	header: SessionLineageHeader | undefined;
+	done = false;
+	#sawTitleSlot = false;
+
+	read(line: string): void {
+		if (this.done) return;
+		line = line.trim();
+		if (!line) return;
 		try {
 			const record = JSON.parse(line) as {
 				type?: unknown;
@@ -458,12 +475,13 @@ function sessionLineageHeaderFromText(text: string): SessionLineageHeader | unde
 				parentSession?: unknown;
 				previousSessionFiles?: unknown;
 			};
-			if (!sawTitleSlot && record.type === "title") {
-				sawTitleSlot = true;
-				continue;
+			if (!this.#sawTitleSlot && record.type === "title") {
+				this.#sawTitleSlot = true;
+				return;
 			}
-			if (record.type !== "session" || typeof record.id !== "string" || record.id.length === 0) return undefined;
-			return {
+			this.done = true;
+			if (record.type !== "session" || typeof record.id !== "string" || record.id.length === 0) return;
+			this.header = {
 				id: record.id,
 				parentSession: typeof record.parentSession === "string" ? record.parentSession : undefined,
 				previousSessionFiles: Array.isArray(record.previousSessionFiles)
@@ -474,23 +492,35 @@ function sessionLineageHeaderFromText(text: string): SessionLineageHeader | unde
 					: [],
 			};
 		} catch {
-			return undefined;
+			this.done = true;
 		}
 	}
-	return undefined;
 }
 
 async function readSessionLineageHeader(file: string): Promise<SessionLineageHeader | undefined> {
 	const decoder = new TextDecoder();
-	const lines: string[] = [];
+	const reader = new SessionLineageHeaderReader();
 	for await (const line of readLines(Bun.file(file).stream())) {
-		const decoded = decoder.decode(line).trim();
-		if (!decoded) continue;
-		lines.push(decoded);
-		const header = sessionLineageHeaderFromText(lines.join("\n"));
-		if (header || lines.length >= 2) return header;
+		reader.read(decoder.decode(line));
+		if (reader.done) break;
 	}
-	return undefined;
+	return reader.header;
+}
+
+async function scanArchivedSession(
+	file: string,
+	identities?: Record<StatsEntryTable, StatsEntryIdentity[]>,
+): Promise<SessionLineageHeader | undefined> {
+	const decoder = new TextDecoder();
+	const reader = new SessionLineageHeaderReader();
+	// Drain even after the header: a late gzip error must invalidate the archive.
+	await scanSessionLinesIfPresent(file, line => {
+		if (reader.done && !identities) return;
+		const text = decoder.decode(line);
+		reader.read(text);
+		if (identities) addSessionStatsIdentity(text, identities);
+	});
+	return reader.header;
 }
 
 async function gzipSessionFile(source: string, destination: string): Promise<void> {
@@ -498,8 +528,12 @@ async function gzipSessionFile(source: string, destination: string): Promise<voi
 	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
 	let renamed = false;
 	try {
-		const compressed = gzipSync(await Bun.file(source).bytes(), { level: 9 });
-		await Bun.write(tempPath, compressed);
+		const output = await fs.open(tempPath, "w");
+		try {
+			await pipeline(Bun.file(source).stream(), createGzip({ level: 9 }), output.createWriteStream());
+		} finally {
+			await output.close();
+		}
 		await fs.rename(tempPath, destination);
 		renamed = true;
 		await fs.unlink(source);
@@ -512,9 +546,20 @@ async function gzipSessionFile(source: string, destination: string): Promise<voi
 
 async function restoreGzipSessionFile(source: string, destination: string): Promise<void> {
 	await fs.mkdir(path.dirname(destination), { recursive: true });
-	const decompressed = gunzipSync(await Bun.file(source).bytes());
-	await Bun.write(destination, decompressed);
-	await fs.unlink(source);
+	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
+	try {
+		const output = await fs.open(tempPath, "w");
+		try {
+			await pipeline(Bun.file(source).stream(), createGunzip(), output.createWriteStream());
+		} finally {
+			await output.close();
+		}
+		await fs.rename(tempPath, destination);
+		await fs.unlink(source);
+	} catch (error) {
+		await fs.rm(tempPath, { force: true });
+		throw error;
+	}
 }
 
 async function moveSessionWithArtifacts(candidate: ArchiveCandidate): Promise<void> {
@@ -598,7 +643,7 @@ function deleteHistoryRowsForSessions(dbPath: string, sessionIds: string[]): { d
 async function collectArchivedSessionIds(archiveRoot: string): Promise<string[]> {
 	const ids = new Set<string>();
 	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
-		const id = sessionLineageHeaderFromText(await readTextIfPresent(file))?.id;
+		const id = (await scanArchivedSession(file))?.id;
 		if (id) ids.add(id);
 	}
 	return [...ids].sort();
@@ -971,12 +1016,6 @@ function addSessionStatsIdentity(line: string, identities: Record<StatsEntryTabl
 	}
 }
 
-function collectSessionStatsIdentitiesFromText(text: string): Record<StatsEntryTable, StatsEntryIdentity[]> {
-	const identities = createStatsIdentities();
-	for (const line of text.split(/\r?\n/)) addSessionStatsIdentity(line, identities);
-	return identities;
-}
-
 async function collectSessionStatsIdentities(
 	sessionPath: string,
 ): Promise<Record<StatsEntryTable, StatsEntryIdentity[]>> {
@@ -1136,15 +1175,15 @@ async function collectArchivedStatsSessions(
 		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
 		const sourcePath = path.join(sessionsRoot, relative.slice(0, -".gz".length));
 		try {
-			const text = await readTextIfPresent(file);
-			const header = sessionLineageHeaderFromText(text);
+			const identities = createStatsIdentities();
+			const header = await scanArchivedSession(file, identities);
 			if (!header) throw new Error("archive is missing a valid session header");
 			sessions.push({
 				path: sourcePath,
 				id: header.id,
 				parentSession: header.parentSession,
 				historicalPaths: managedHistoricalSessionPaths(header, sourcePath, sessionsRoot),
-				identities: collectSessionStatsIdentitiesFromText(text),
+				identities,
 			});
 		} catch (error) {
 			onError(file, error);

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -241,8 +241,15 @@ async function scanSessionLinesIfPresent(file: string, onLine: (line: Uint8Array
 	try {
 		const stream = Bun.file(file).stream();
 		if (file.endsWith(COMPRESSED_SESSION_SUFFIX)) {
-			await pipeline(stream, createGunzip(), async (source: NodeJS.ReadableStream) => {
-				await scan(Readable.toWeb(source, { strategy: { highWaterMark: 1 } }));
+			const gunzip = createGunzip();
+			await pipeline(stream, gunzip, async (source: NodeJS.ReadableStream) => {
+				// Match the native stream's byte budget, not one arbitrary chunk or
+				// a default queue that counts each potentially large chunk as size 1.
+				await scan(
+					Readable.toWeb(source, {
+						strategy: new ByteLengthQueuingStrategy({ highWaterMark: gunzip.readableHighWaterMark }),
+					}),
+				);
 			});
 		} else {
 			await scan(stream);
@@ -528,12 +535,11 @@ async function gzipSessionFile(source: string, destination: string): Promise<voi
 	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
 	let renamed = false;
 	try {
-		const output = await fs.open(tempPath, "w");
-		try {
-			await pipeline(Bun.file(source).stream(), createGzip({ level: 9 }), output.createWriteStream());
-		} finally {
-			await output.close();
-		}
+		await pipeline(
+			Bun.file(source).stream(),
+			createGzip({ level: 9 }),
+			(await fs.open(tempPath, "w")).createWriteStream(),
+		);
 		await fs.rename(tempPath, destination);
 		renamed = true;
 		await fs.unlink(source);
@@ -548,12 +554,7 @@ async function restoreGzipSessionFile(source: string, destination: string): Prom
 	await fs.mkdir(path.dirname(destination), { recursive: true });
 	const tempPath = `${destination}.${process.pid}.${Date.now()}.tmp`;
 	try {
-		const output = await fs.open(tempPath, "w");
-		try {
-			await pipeline(Bun.file(source).stream(), createGunzip(), output.createWriteStream());
-		} finally {
-			await output.close();
-		}
+		await pipeline(Bun.file(source).stream(), createGunzip(), (await fs.open(tempPath, "w")).createWriteStream());
 		await fs.rename(tempPath, destination);
 		await fs.unlink(source);
 	} catch (error) {

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -196,6 +196,117 @@ describe("runGcCommand blob sweep", () => {
 		expect(await Bun.file(referenced).exists()).toBe(true);
 	});
 
+	test("keeps raw blob references split across chunks in journals, archives, and backups", async () => {
+		const sessionDir = path.join(getSessionsDir(root), "project");
+		const archiveDir = path.join(root, "archive", "sessions", "project");
+		const activeHash = hashFor("active-chunks");
+		const archivedHash = hashFor("archived-chunks");
+		const backupHash = hashFor("backup-chunks");
+		const orphanHash = hashFor("not-a-reference");
+		const active = await writeBlob(root, activeHash, "active");
+		const archived = await writeBlob(root, archivedHash, "archived");
+		const backup = await writeBlob(root, backupHash, "backup");
+		const orphan = await writeBlob(root, orphanHash, "orphan");
+		for (const file of [active, archived, backup, orphan]) await agePath(file);
+		const encoder = new TextEncoder();
+		const journals = new Map<string, Uint8Array<ArrayBuffer>>([
+			[path.join(sessionDir, "active.jsonl"), encoder.encode(`malformed "blob:sha256:${activeHash}`)],
+			[
+				path.join(archiveDir, "archived.jsonl.gz"),
+				gzipSync(`${" ".repeat(16 * 1024 - 20)}blob:sha256:${archivedHash}\ninvalid tail`),
+			],
+			[
+				path.join(sessionDir, "lost.jsonl.1234567890.bak"),
+				encoder.encode(`broken BLOB:SHA256:${backupHash.toUpperCase()}\r\nblob:sha256:${orphanHash}x`),
+			],
+		]);
+		for (const [file, bytes] of journals) await Bun.write(file, bytes);
+		const realFile = Bun.file.bind(Bun);
+		const fileSpy = spyOn(Bun, "file").mockImplementation((source, options) => {
+			const file = realFile(source as string, options);
+			const bytes = journals.get(String(source));
+			if (bytes) {
+				file.stream = () => {
+					let offset = 0;
+					return new ReadableStream<Uint8Array<ArrayBuffer>>({
+						pull(controller) {
+							if (offset >= bytes.length) {
+								controller.close();
+								return;
+							}
+							controller.enqueue(bytes.subarray(offset, offset + 7));
+							offset += 7;
+						},
+					});
+				};
+			}
+			return file;
+		});
+		let result: GcResult;
+		try {
+			result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
+		} finally {
+			fileSpy.mockRestore();
+		}
+
+		expect(result.blobs?.referenced).toBe(3);
+		expect(result.blobs?.deleted).toBe(1);
+		for (const file of [active, archived, backup]) expect(await Bun.file(file).exists()).toBe(true);
+		expect(await Bun.file(orphan).exists()).toBe(false);
+	});
+
+	test("aborts blob deletion when a gzip archive fails after yielding valid references", async () => {
+		const hash = hashFor("partial-archive-reference");
+		const referenced = await writeBlob(root, hash, "referenced");
+		const orphan = await writeBlob(root, hashFor("partial-archive-orphan"), "orphan");
+		await agePath(referenced);
+		await agePath(orphan);
+		const archive = path.join(root, "archive", "sessions", "project", "broken.jsonl.gz");
+		const bytes = gzipSync(`blob:sha256:${hash}\n${"{}\n".repeat(12 * 1024)}`);
+		await Bun.write(archive, bytes.subarray(0, -4));
+
+		await expect(runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } })).rejects.toThrow();
+
+		expect(await Bun.file(referenced).exists()).toBe(true);
+		expect(await Bun.file(orphan).exists()).toBe(true);
+		expect(await Bun.file(path.join(root, "gc.lock")).exists()).toBe(false);
+	});
+
+	test("aborts blob deletion when a journal read fails after a complete record", async () => {
+		const orphan = await writeBlob(root, hashFor("read-error-orphan"), "orphan");
+		await agePath(orphan);
+		const session = await writeSession(root, "project", "read-error", "complete");
+		const realFile = Bun.file.bind(Bun);
+		const fileSpy = spyOn(Bun, "file").mockImplementation((source, options) => {
+			const file = realFile(source as string, options);
+			if (source === session) {
+				file.stream = () => {
+					let yielded = false;
+					return new ReadableStream<Uint8Array<ArrayBuffer>>({
+						pull(controller) {
+							if (yielded) controller.error(Object.assign(new Error("journal read failed"), { code: "EIO" }));
+							else {
+								yielded = true;
+								controller.enqueue(new TextEncoder().encode("{}\n"));
+							}
+						},
+					});
+				};
+			}
+			return file;
+		});
+		try {
+			await expect(runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } })).rejects.toThrow(
+				"journal read failed",
+			);
+		} finally {
+			fileSpy.mockRestore();
+		}
+
+		expect(await Bun.file(orphan).exists()).toBe(true);
+		expect(await Bun.file(path.join(root, "gc.lock")).exists()).toBe(false);
+	});
+
 	test("uses configured gc selectors and retention defaults", async () => {
 		await agePath(await writeBlob(root, hashFor("orphan"), "orphan"));
 		await writeSession(root, "project", "archive-me", "complete", { ageDays: 10 });
@@ -474,6 +585,7 @@ describe("runGcCommand cold-session archive", () => {
 		const interrupted = await writeSession(root, "project", "interrupted", "interrupted", { ageDays: 90 });
 		await fs.mkdir(archiveMe.slice(0, -".jsonl".length), { recursive: true });
 		await Bun.write(path.join(archiveMe.slice(0, -".jsonl".length), "0.bash.log"), "artifact");
+		const original = await Bun.file(archiveMe).bytes();
 
 		const result = await runGcCommand({
 			flags: {
@@ -491,11 +603,180 @@ describe("runGcCommand cold-session archive", () => {
 		expect(result.archive?.skippedActive).toBe(2);
 		expect(await Bun.file(archiveMe).exists()).toBe(false);
 		expect(await Bun.file(archived).exists()).toBe(true);
-		expect(new TextDecoder().decode(gunzipSync(await Bun.file(archived).bytes()))).toContain('"archive-me"');
+		expect(new Uint8Array(gunzipSync(await Bun.file(archived).bytes()))).toEqual(original);
 		expect(await Bun.file(path.join(archived.slice(0, -".jsonl.gz".length), "0.bash.log")).exists()).toBe(true);
 		expect(await Bun.file(keepRecent).exists()).toBe(true);
 		expect(await Bun.file(pending).exists()).toBe(true);
 		expect(await Bun.file(interrupted).exists()).toBe(true);
+	});
+
+	test("keeps the source journal when compression encounters a read error", async () => {
+		const session = await writeSession(root, "project", "compression-error", "complete", { ageDays: 90 });
+		const original = await Bun.file(session).bytes();
+		const archiveDir = path.join(root, "archive", "sessions", "project");
+		const realFile = Bun.file.bind(Bun);
+		const fileSpy = spyOn(Bun, "file").mockImplementation((source, options) => {
+			const file = realFile(source as string, options);
+			if (source === session) {
+				file.stream = () => {
+					let yielded = false;
+					return new ReadableStream<Uint8Array<ArrayBuffer>>({
+						pull(controller) {
+							if (yielded) controller.error(new Error("compression read failed"));
+							else {
+								yielded = true;
+								controller.enqueue(original.subarray(0, original.length / 2));
+							}
+						},
+					});
+				};
+			}
+			return file;
+		});
+		let result: GcResult;
+		try {
+			result = await runGcCommand({
+				flags: {
+					agentDir: root,
+					archive: true,
+					apply: true,
+					coldArchiveAfterDays: 0,
+					retainNewestGlobal: 0,
+					retainNewestPerCwd: 0,
+				},
+			});
+		} finally {
+			fileSpy.mockRestore();
+		}
+
+		expect(result.archive?.archived).toBe(0);
+		expect(result.archive?.errors).toEqual([`${session}: compression read failed`]);
+		expect(await Bun.file(session).bytes()).toEqual(original);
+		expect(await fs.readdir(archiveDir)).toEqual([]);
+		expect(await Bun.file(path.join(root, "gc.lock")).exists()).toBe(false);
+	});
+
+	test("restores byte-identical journal bytes when moving artifacts fails after compression", async () => {
+		const session = await writeSession(root, "project", "rollback", "complete");
+		const header = JSON.stringify({
+			type: "session",
+			version: 3,
+			id: "rollback",
+			timestamp: "2026-01-01T00:00:00.000Z",
+			cwd: "/tmp",
+		});
+		const message = JSON.stringify({
+			type: "message",
+			message: { role: "assistant", content: [{ type: "text", text: "界".repeat(8 * 1024) }] },
+		});
+		const original = new TextEncoder().encode(`${header}\r\n${message}`);
+		await Bun.write(session, original);
+		await agePath(session, 90);
+		const artifacts = session.slice(0, -".jsonl".length);
+		await Bun.write(path.join(artifacts, "0.bash.log"), "retained artifact");
+		const archiveDir = path.join(root, "archive", "sessions", "project");
+		const rename = fs.rename.bind(fs);
+		const renameSpy = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+			if (String(source) === artifacts) throw new Error("artifact move failed");
+			await rename(source, destination);
+		});
+		let result: GcResult;
+		try {
+			result = await runGcCommand({
+				flags: {
+					agentDir: root,
+					archive: true,
+					apply: true,
+					coldArchiveAfterDays: 0,
+					retainNewestGlobal: 0,
+					retainNewestPerCwd: 0,
+				},
+			});
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		expect(result.archive?.archived).toBe(0);
+		expect(result.archive?.errors).toEqual([`${session}: artifact move failed`]);
+		expect(await Bun.file(session).bytes()).toEqual(original);
+		expect(await Bun.file(path.join(artifacts, "0.bash.log")).text()).toBe("retained artifact");
+		expect(await fs.readdir(archiveDir)).toEqual([]);
+		expect((await fs.readdir(path.dirname(session))).sort()).toEqual(["rollback", "rollback.jsonl"]);
+	});
+
+	test("does not publish a partial restored journal when rollback gzip validation fails", async () => {
+		const session = await writeSession(root, "project", "rollback-corrupt", "complete", {
+			blobRef: "界".repeat(12 * 1024),
+			ageDays: 90,
+		});
+		const artifacts = session.slice(0, -".jsonl".length);
+		await Bun.write(path.join(artifacts, "0.bash.log"), "retained artifact");
+		const archive = path.join(root, "archive", "sessions", "project", "rollback-corrupt.jsonl.gz");
+		const rename = fs.rename.bind(fs);
+		const renameSpy = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+			if (String(source) === artifacts) {
+				const bytes = await Bun.file(archive).bytes();
+				await Bun.write(archive, bytes.subarray(0, -4));
+				throw new Error("artifact move failed");
+			}
+			await rename(source, destination);
+		});
+		let result: GcResult;
+		try {
+			result = await runGcCommand({
+				flags: {
+					agentDir: root,
+					archive: true,
+					apply: true,
+					coldArchiveAfterDays: 0,
+					retainNewestGlobal: 0,
+					retainNewestPerCwd: 0,
+				},
+			});
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		expect(result.archive?.archived).toBe(0);
+		expect(result.archive?.errors).toEqual([`${session}: artifact move failed`]);
+		expect(await Bun.file(session).exists()).toBe(false);
+		expect(await Bun.file(archive).exists()).toBe(true);
+		expect(await Bun.file(path.join(artifacts, "0.bash.log")).text()).toBe("retained artifact");
+		expect(await fs.readdir(path.dirname(session))).toEqual(["rollback-corrupt"]);
+	});
+
+	test("does not publish a partial restored journal when the rollback destination fails", async () => {
+		const session = await writeSession(root, "project", "rollback-write", "complete", { ageDays: 90 });
+		const original = await Bun.file(session).bytes();
+		const artifacts = session.slice(0, -".jsonl".length);
+		await Bun.write(path.join(artifacts, "0.bash.log"), "retained artifact");
+		const archive = path.join(root, "archive", "sessions", "project", "rollback-write.jsonl.gz");
+		const rename = fs.rename.bind(fs);
+		const renameSpy = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+			if (String(source) === artifacts || String(destination) === session) throw new Error("rename failed");
+			await rename(source, destination);
+		});
+		let result: GcResult;
+		try {
+			result = await runGcCommand({
+				flags: {
+					agentDir: root,
+					archive: true,
+					apply: true,
+					coldArchiveAfterDays: 0,
+					retainNewestGlobal: 0,
+					retainNewestPerCwd: 0,
+				},
+			});
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		expect(result.archive?.archived).toBe(0);
+		expect(result.archive?.errors).toEqual([`${session}: rename failed`]);
+		expect(await Bun.file(session).exists()).toBe(false);
+		expect(new Uint8Array(gunzipSync(await Bun.file(archive).bytes()))).toEqual(original);
+		expect(await fs.readdir(path.dirname(session))).toEqual(["rollback-write"]);
 	});
 
 	test("skips archiving parent sessions with live nested sessions", async () => {
@@ -1196,7 +1477,7 @@ describe("runGcCommand cold-session archive", () => {
 		expect(rows).toEqual([]);
 	});
 
-	test("preserves shared stats through an unreadable intermediate archive", async () => {
+	test("preserves shared stats through a late-corrupt intermediate archive", async () => {
 		const sessionsDir = path.join(getSessionsDir(root), "project");
 		const archiveDir = path.join(root, "archive", "sessions", "project");
 		await fs.mkdir(sessionsDir, { recursive: true });
@@ -1213,7 +1494,7 @@ describe("runGcCommand cold-session archive", () => {
 			id: "shared-assistant",
 			parentId: null,
 			timestamp,
-			message: { role: "assistant", content: [] },
+			message: { role: "assistant", content: [{ type: "text", text: "界".repeat(8 * 1024) }] },
 		};
 		await Bun.write(
 			ancestorArchive,
@@ -1225,7 +1506,19 @@ describe("runGcCommand cold-session archive", () => {
 				].join("\n"),
 			),
 		);
-		await Bun.write(corruptArchive, "not gzip");
+		const intermediateJournal = [
+			JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "intermediate",
+				timestamp,
+				cwd: "/tmp",
+				parentSession: ancestorPath,
+			}),
+			JSON.stringify(sharedAssistant),
+			"",
+		].join("\n");
+		await Bun.write(corruptArchive, gzipSync(intermediateJournal).subarray(0, -4));
 		await Bun.write(
 			retainedPath,
 			[
@@ -1291,23 +1584,7 @@ describe("runGcCommand cold-session archive", () => {
 			{ session_file: retainedPath, offset: retainedStat.size, last_modified: retainedStat.mtimeMs },
 		]);
 
-		await Bun.write(
-			corruptArchive,
-			gzipSync(
-				[
-					JSON.stringify({
-						type: "session",
-						version: 3,
-						id: "intermediate",
-						timestamp,
-						cwd: "/tmp",
-						parentSession: ancestorPath,
-					}),
-					JSON.stringify(sharedAssistant),
-					"",
-				].join("\n"),
-			),
-		);
+		await Bun.write(corruptArchive, gzipSync(intermediateJournal));
 		const second = await runGcCommand({
 			flags: {
 				agentDir: root,
@@ -1465,6 +1742,69 @@ describe("runGcCommand cold-session archive", () => {
 		);
 		expect(statsRows).toEqual([{ session_file: historicalStatsPath }]);
 		expect(historyRows).toEqual([{ session_id: "headerless-session" }]);
+	});
+
+	test("validates the entire archived gzip before pruning history and retries after repair", async () => {
+		const archive = path.join(root, "archive", "sessions", "project", "late-corrupt.jsonl.gz");
+		const journal = [
+			JSON.stringify({ type: "title", v: 1, title: "Archived title" }),
+			JSON.stringify({ type: "session", version: 3, id: "late-corrupt", timestamp: "2026-01-01T00:00:00.000Z" }),
+			"{}\n".repeat(12 * 1024),
+		].join("\r\n");
+		const compressed = gzipSync(journal);
+		await Bun.write(archive, compressed.subarray(0, -4));
+		const dbPath = getHistoryDbPath(root);
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE history (id INTEGER PRIMARY KEY, prompt TEXT NOT NULL, session_id TEXT)");
+		db.run("INSERT INTO history (prompt, session_id) VALUES ('keep until validated', 'late-corrupt')");
+		db.close();
+
+		const first = await runGcCommand({ flags: { agentDir: root, archive: true, apply: true } });
+		const firstCheck = new Database(dbPath);
+		const firstRows = firstCheck.prepare("SELECT session_id FROM history").all();
+		firstCheck.close();
+
+		expect(first.archive?.historyRowsDeleted).toBe(0);
+		expect(first.archive?.errors.some(error => error.startsWith("history cleanup scan: "))).toBe(true);
+		expect(firstRows).toEqual([{ session_id: "late-corrupt" }]);
+
+		await Bun.write(archive, compressed);
+		const second = await runGcCommand({ flags: { agentDir: root, archive: true, apply: true } });
+		const secondCheck = new Database(dbPath);
+		const secondRows = secondCheck.prepare("SELECT session_id FROM history").all();
+		secondCheck.close();
+
+		expect(second.archive?.archived).toBe(0);
+		expect(second.archive?.historyRowsDeleted).toBe(1);
+		expect(second.archive?.errors).toEqual([]);
+		expect(secondRows).toEqual([]);
+	});
+
+	test("recognizes legacy padded archive headers when cleaning history", async () => {
+		const archive = path.join(root, "archive", "sessions", "project", "padded.jsonl.gz");
+		const title = JSON.stringify({ type: "title", v: 1, title: "Padded" });
+		const header = JSON.stringify({
+			type: "session",
+			version: 3,
+			id: "padded",
+			timestamp: "2026-01-01T00:00:00.000Z",
+		});
+		await Bun.write(archive, gzipSync(`${title}\u00a0\r\n${header}\ufeff\n`));
+		const dbPath = getHistoryDbPath(root);
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE history (id INTEGER PRIMARY KEY, prompt TEXT NOT NULL, session_id TEXT)");
+		db.run("INSERT INTO history (prompt, session_id) VALUES ('archived', 'padded')");
+		db.close();
+
+		const result = await runGcCommand({ flags: { agentDir: root, archive: true, apply: true } });
+		const check = new Database(dbPath);
+		try {
+			expect(result.archive?.errors).toEqual([]);
+			expect(result.archive?.historyRowsDeleted).toBe(1);
+			expect(check.prepare("SELECT session_id FROM history").all()).toEqual([]);
+		} finally {
+			check.close();
+		}
 	});
 
 	test("waits for the shared stats lock before archive reconciliation", async () => {


### PR DESCRIPTION
## Author-approved rationale
This change streams session scanning and archive I/O so maintaining large histories no longer requires loading entire journals into memory, while preserving existing retention and recovery behavior.

AI-assisted implementation; the submitter approved this scope and rationale before publication. The verification below was executed by the coding agent.

## Summary
Stream journal payload I/O throughout the existing manual GC command: plain/archived/backup reference scans, archived header and stats scans, gzip archive creation, and rollback decompression.

The archive layout, retention policy, dry-run/apply gate, and decompressed journal bytes are unchanged. Raw-text blob scanning still recognizes references in malformed records. Compressed scans drain the stream so a late gzip error cannot authorize deletion from a partial reference set.

## Safety and limits
Publication remains temporary-file then rename; source removal only follows successful archive publication. Rollback stages complete restored output before publishing it. Historical header whitespace normalization remains compatible.

This avoids materializing an entire journal, not all GC memory: the longest line and reference/identity collections still contribute to memory usage. Source plus temporary archive still coexist on disk.

## Verification
- `bun run check` from packages/coding-agent: passed.
- Existing and added GC tests: 50 passed in a base-isolated validation run.
- Coverage includes cross-chunk references, active/archive/recoverable backup references, malformed text, late gzip/read errors, archive byte equality, rollback failures, retry cleanup, and padded historical headers.
- Real smoke: archived a 1,049,091-byte synthetic JSONL, then decompressed and compared the complete original bytes; round-trip passed.

Local verification used an existing native addon through a temporary Bun preload. No live GC command or user-history mutation was performed.

Related: #3540 introduced the manual GC surface; #8588 changes nearby merge/archive code, but this PR changes only payload I/O and does not add merge policy.
