### PR TITLE
fix(output): report failed artifact captures without false recovery links

### DIFF
--- a/docs/blob-artifact-architecture.md
+++ b/docs/blob-artifact-architecture.md
@@ -136,7 +136,9 @@ Practical effect:
 
 If artifact I/O fails, the sink stops further capture attempts, retains the existing bounded inline output, and still closes its writer. The tool's execution result is unchanged; its output metadata and terminal warning state that full output was not saved completely, without advertising the incomplete artifact as a full recovery source. `dump()` and `dispose()` share completion so concurrent finalization cannot publish success before an asynchronous write or close failure settles. The streaming sink does not enable a disk cap or retry failed capture.
 
-The capture warning also survives background job delivery, `hub jobs`/`wait` recovery, cancellation, and transcript rebuilds. Incomplete previews are not re-spilled and advertised as full original output.
+The capture warning also survives background job delivery, `hub jobs`/`wait` recovery, cancellation, and transcript rebuilds. Capture failures belong to individual jobs, not the aggregate report. Oversized snapshots can persist the complete annotated report, including healthy jobs' results, and advertise it as a "full report" rather than a full original command log. Each source capture warning appears once in model-facing text and once on its own live or rebuilt terminal row. Individual incomplete captures are still not re-spilled and advertised as full original output.
+
+Transcript rebuilds also read capture errors from historical per-job fields. A historical aggregate warning is retained when no job identifies its source; it is not repeated when a row already carries the same failure.
 
 ## URL access model
 

--- a/docs/blob-artifact-architecture.md
+++ b/docs/blob-artifact-architecture.md
@@ -127,14 +127,16 @@ Behavior:
 4. When the in-memory tail buffer would exceed spill threshold (`DEFAULT_MAX_BYTES`, 50KB), sink marks output truncated and starts artifact mirroring if an artifact path is available.
 5. If a file sink is opened, it first writes the current buffer, then all queued/subsequent sanitized chunks.
 6. In-memory buffer is trimmed to a tail window, or to head + elision marker + tail when head retention is configured.
-7. `dump()` returns summary including `artifactId` only when file sink creation succeeded.
+7. `dump()` finalizes the capture and returns `artifactId` only when no artifact I/O failure was observed. `artifactError` records the first failed operation (`open`, `write`, `flush`, or `end`) without persisting raw filesystem error text.
 
 Practical effect:
 
 - UI/tool return shows bounded output,
 - full sanitized output is preserved in artifact file and referenced as `artifact://<id>` when file-backed artifact mirroring succeeded.
 
-If file sink creation fails (I/O error, missing path, etc.), sink falls back to in-memory truncation only; full output is not persisted.
+If artifact I/O fails, the sink stops further capture attempts, retains the existing bounded inline output, and still closes its writer. The tool's execution result is unchanged; its output metadata and terminal warning state that full output was not saved completely, without advertising the incomplete artifact as a full recovery source. `dump()` and `dispose()` share completion so concurrent finalization cannot publish success before an asynchronous write or close failure settles. The streaming sink does not enable a disk cap or retry failed capture.
+
+The capture warning also survives background job delivery, `hub jobs`/`wait` recovery, cancellation, and transcript rebuilds. Incomplete previews are not re-spilled and advertised as full original output.
 
 ## URL access model
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Background job snapshots preserve complete sibling results when a capture fails and show each capture warning only once.
 - Failed raw-output captures now show a warning without failing the command or advertising an incomplete artifact as full output.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Failed raw-output captures now show a warning without failing the command or advertising an incomplete artifact as full output.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 ### Added
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -1,6 +1,7 @@
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { StructuredSubagentOutput } from "../task/types";
+import type { OutputMeta } from "../tools/output-meta";
 
 const DELIVERY_RETRY_BASE_MS = 500;
 const DELIVERY_RETRY_MAX_MS = 30_000;
@@ -77,6 +78,8 @@ export class AsyncJobError extends Error {
 export interface AsyncJobDetails extends Record<string, unknown> {
 	/** Images recovered from command output, independent of text truncation. */
 	images?: ImageContent[];
+	/** Tool output metadata needed when a completion is delivered or recovered later. */
+	meta?: OutputMeta;
 }
 
 export interface AsyncJob {

--- a/packages/coding-agent/src/eval/backend-helpers.ts
+++ b/packages/coding-agent/src/eval/backend-helpers.ts
@@ -3,6 +3,7 @@
  * index modules): session-id namespacing, settings access, and projection of
  * executor results into the ExecutorBackend result shape.
  */
+import type { OutputArtifactError } from "../session/streaming-output";
 import type { ToolSession } from "../tools";
 import type { ExecutorBackendResult } from "./backend";
 import type { EvalDisplayOutput } from "./types";
@@ -27,6 +28,7 @@ export function toExecutorBackendResult(result: {
 	cancelled: boolean;
 	truncated: boolean;
 	artifactId?: string | undefined;
+	artifactError?: OutputArtifactError;
 	totalLines: number;
 	totalBytes: number;
 	outputLines: number;
@@ -39,6 +41,7 @@ export function toExecutorBackendResult(result: {
 		cancelled: result.cancelled,
 		truncated: result.truncated,
 		artifactId: result.artifactId,
+		artifactError: result.artifactError,
 		totalLines: result.totalLines,
 		totalBytes: result.totalBytes,
 		outputLines: result.outputLines,

--- a/packages/coding-agent/src/eval/backend.ts
+++ b/packages/coding-agent/src/eval/backend.ts
@@ -1,4 +1,5 @@
 import { buildEvalUrlRoots, type LocalProtocolOptions } from "../internal-urls";
+import type { OutputArtifactError } from "../session/streaming-output";
 import type { ToolSession } from "../tools";
 import type { BackendProbeOptions } from "./probe";
 import type { EvalDisplayOutput, EvalLanguage, EvalStatusEvent } from "./types";
@@ -38,6 +39,7 @@ export interface ExecutorBackendResult {
 	cancelled: boolean;
 	truncated: boolean;
 	artifactId: string | undefined;
+	artifactError?: OutputArtifactError;
 	totalLines: number;
 	totalBytes: number;
 	outputLines: number;

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -1,6 +1,6 @@
 import { logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
-import { OutputSink } from "../session/streaming-output";
+import { type OutputArtifactError, OutputSink } from "../session/streaming-output";
 import type { ToolSession } from "../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { EVAL_TIMEOUT_PAUSE_OP, EVAL_TIMEOUT_RESUME_OP, isEvalTimeoutControlEvent } from "./bridge-timeout";
@@ -54,6 +54,7 @@ export interface KernelExecutionResult {
 	cancelled: boolean;
 	truncated: boolean;
 	artifactId: string | undefined;
+	artifactError?: OutputArtifactError;
 	totalLines: number;
 	totalBytes: number;
 	outputLines: number;
@@ -532,6 +533,7 @@ export async function executeWithKernelBase<
 				truncated: dumped.truncated,
 				output: dumped.output,
 				artifactId: dumped.artifactId ?? undefined,
+				artifactError: dumped.artifactError,
 				totalLines: dumped.totalLines,
 				totalBytes: dumped.totalBytes,
 				outputLines: dumped.outputLines,
@@ -549,6 +551,7 @@ export async function executeWithKernelBase<
 				truncated: dumped.truncated,
 				output: dumped.output,
 				artifactId: dumped.artifactId ?? undefined,
+				artifactError: dumped.artifactError,
 				totalLines: dumped.totalLines,
 				totalBytes: dumped.totalBytes,
 				outputLines: dumped.outputLines,
@@ -566,6 +569,7 @@ export async function executeWithKernelBase<
 			truncated: dumped.truncated,
 			output: dumped.output,
 			artifactId: dumped.artifactId ?? undefined,
+			artifactError: dumped.artifactError,
 			totalLines: dumped.totalLines,
 			totalBytes: dumped.totalBytes,
 			outputLines: dumped.outputLines,
@@ -585,6 +589,7 @@ export async function executeWithKernelBase<
 				truncated: dumped.truncated,
 				output: dumped.output,
 				artifactId: dumped.artifactId ?? undefined,
+				artifactError: dumped.artifactError,
 				totalLines: dumped.totalLines,
 				totalBytes: dumped.totalBytes,
 				outputLines: dumped.outputLines,

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MAX_BYTES, OutputSink } from "../../session/streaming-output";
+import { DEFAULT_MAX_BYTES, type OutputArtifactError, OutputSink } from "../../session/streaming-output";
 import type { ToolSession } from "../../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../../tools/output-meta";
 import { isEvalTimeoutControlEvent } from "../bridge-timeout";
@@ -36,6 +36,7 @@ export interface JsResult {
 	cancelled: boolean;
 	truncated: boolean;
 	artifactId?: string;
+	artifactError?: OutputArtifactError;
 	totalLines: number;
 	totalBytes: number;
 	outputLines: number;
@@ -131,6 +132,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 			cancelled: false,
 			truncated: summary.truncated,
 			artifactId: summary.artifactId,
+			artifactError: summary.artifactError,
 			totalLines: summary.totalLines,
 			totalBytes: summary.totalBytes,
 			outputLines: summary.outputLines,
@@ -150,6 +152,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 				cancelled: true,
 				truncated: summary.truncated,
 				artifactId: summary.artifactId,
+				artifactError: summary.artifactError,
 				totalLines: summary.totalLines,
 				totalBytes: summary.totalBytes,
 				outputLines: summary.outputLines,
@@ -166,6 +169,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 			cancelled: false,
 			truncated: summary.truncated,
 			artifactId: summary.artifactId,
+			artifactError: summary.artifactError,
 			totalLines: summary.totalLines,
 			totalBytes: summary.totalBytes,
 			outputLines: summary.outputLines,

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 
 import { getProjectDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import type { OutputArtifactError } from "../../session/streaming-output";
 import type { ToolSession } from "../../tools";
 import {
 	buildManagedKernelEnv,
@@ -145,6 +146,7 @@ export interface PythonResult {
 	truncated: boolean;
 	/** Artifact ID if full output was saved to artifact storage */
 	artifactId?: string;
+	artifactError?: OutputArtifactError;
 	/** Total number of lines in the output stream */
 	totalLines: number;
 	/** Total number of bytes in the output stream */

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -729,28 +729,31 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			};
 		}
 
-		// When the native minimizer rewrote the output, swap the sink's accumulated
-		// raw stream for the minimized text, persist the original as a session
-		// artifact, and splice an `artifact://<id>` footer into the visible text so
-		// the agent can retrieve the raw bytes losslessly.
+		// When the native minimizer rewrote the output, persist the original and
+		// swap the sink's accumulated raw stream for the minimized text with an
+		// `artifact://<id>` footer so the agent can retrieve the raw bytes
+		// losslessly. The minimized text is a lossy summary, so substitute it
+		// only once the original is addressable — a caller that returns no id
+		// (or an unavailable allocator) must keep the raw stream rather than
+		// silently dropping the diagnostics the summary elided.
 		const minimized = winner.result.minimized;
 		if (minimized && minimized.text !== minimized.originalText) {
-			// The decoder above already owns image extraction from the streamed
-			// lossless output. Scrub any graphics frames repeated by the native
-			// minimizer without feeding them back into that decoder.
-			const minimizedGraphics = new TerminalGraphicsDecoder();
-			const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
-			sink.replace(minimizedText);
-			if (options?.onMinimizedSave) {
-				const artifactId = await options.onMinimizedSave(minimized.originalText, {
-					filter: minimized.filter,
-					inputBytes: minimized.inputBytes,
-					outputBytes: minimized.outputBytes,
-				});
-				if (artifactId) {
-					const sep = minimizedText.endsWith("\n") ? "" : "\n";
-					sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
-				}
+			const artifactId = options?.onMinimizedSave
+				? await options.onMinimizedSave(minimized.originalText, {
+						filter: minimized.filter,
+						inputBytes: minimized.inputBytes,
+						outputBytes: minimized.outputBytes,
+					})
+				: undefined;
+			if (artifactId) {
+				// The decoder above already owns image extraction from the streamed
+				// lossless output. Scrub any graphics frames repeated by the native
+				// minimizer without feeding them back into that decoder.
+				const minimizedGraphics = new TerminalGraphicsDecoder();
+				const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
+				sink.replace(minimizedText);
+				const sep = minimizedText.endsWith("\n") ? "" : "\n";
+				sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
 			}
 		}
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -9,7 +9,7 @@ import { type MinimizerOptions, PtySession, Shell, type ShellRunResult } from "@
 import { $env } from "@oh-my-pi/pi-utils/env";
 import { isCmdShell, isExecutable, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
-import { OutputSink, type OutputSummary } from "../session/streaming-output";
+import { type OutputArtifactError, OutputSink, type OutputSummary } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { TerminalGraphicsDecoder } from "../utils/terminal-graphics";
@@ -67,6 +67,7 @@ export interface BashResult {
 	outputLines: number;
 	outputBytes: number;
 	artifactId?: string;
+	artifactError?: OutputArtifactError;
 	workingDir?: string;
 	/** Terminal graphics extracted from raw stdout before sanitization or truncation. */
 	images?: ImageContent[];
@@ -728,31 +729,28 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			};
 		}
 
-		// When the native minimizer rewrote the output, persist the original and
-		// swap the sink's accumulated raw stream for the minimized text with an
-		// `artifact://<id>` footer so the agent can retrieve the raw bytes
-		// losslessly. The minimized text is a lossy summary, so substitute it
-		// only once the original is addressable — a caller that returns no id
-		// (or an unavailable allocator) must keep the raw stream rather than
-		// silently dropping the diagnostics the summary elided.
+		// When the native minimizer rewrote the output, swap the sink's accumulated
+		// raw stream for the minimized text, persist the original as a session
+		// artifact, and splice an `artifact://<id>` footer into the visible text so
+		// the agent can retrieve the raw bytes losslessly.
 		const minimized = winner.result.minimized;
 		if (minimized && minimized.text !== minimized.originalText) {
-			const artifactId = options?.onMinimizedSave
-				? await options.onMinimizedSave(minimized.originalText, {
-						filter: minimized.filter,
-						inputBytes: minimized.inputBytes,
-						outputBytes: minimized.outputBytes,
-					})
-				: undefined;
-			if (artifactId) {
-				// The decoder above already owns image extraction from the streamed
-				// lossless output. Scrub any graphics frames repeated by the native
-				// minimizer without feeding them back into that decoder.
-				const minimizedGraphics = new TerminalGraphicsDecoder();
-				const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
-				sink.replace(minimizedText);
-				const sep = minimizedText.endsWith("\n") ? "" : "\n";
-				sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
+			// The decoder above already owns image extraction from the streamed
+			// lossless output. Scrub any graphics frames repeated by the native
+			// minimizer without feeding them back into that decoder.
+			const minimizedGraphics = new TerminalGraphicsDecoder();
+			const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
+			sink.replace(minimizedText);
+			if (options?.onMinimizedSave) {
+				const artifactId = await options.onMinimizedSave(minimized.originalText, {
+					filter: minimized.filter,
+					inputBytes: minimized.inputBytes,
+					outputBytes: minimized.outputBytes,
+				});
+				if (artifactId) {
+					const sep = minimizedText.endsWith("\n") ? "" : "\n";
+					sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -20,6 +20,7 @@ import {
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { Terminal as XtermTerminalType } from "@oh-my-pi/pi-utils/vterm";
 import { theme } from "../../modes/theme/theme";
+import type { OutputArtifactError } from "../../session/streaming-output";
 import { loadXtermTerminal } from "../../tools/bash-interactive";
 import type { TruncationMeta } from "../../tools/output-meta";
 import { resolveImageOptions } from "../../tools/render-utils";
@@ -61,6 +62,7 @@ export class BashExecutionComponent extends Container {
 	#exitCode: number | undefined = undefined;
 	#loader: Loader;
 	#truncation?: TruncationMeta;
+	#artifactError?: OutputArtifactError;
 	#expanded = false;
 	// Post-finalize mutation counter (FinalizableBlock.getTranscriptBlockVersion):
 	// a completed command's block still mutates on expansion toggles, and the
@@ -255,6 +257,7 @@ export class BashExecutionComponent extends Container {
 		options?: {
 			output?: string;
 			truncation?: TruncationMeta;
+			artifactError?: OutputArtifactError;
 			images?: readonly ImageContent[];
 			showImages?: boolean;
 		},
@@ -262,6 +265,7 @@ export class BashExecutionComponent extends Container {
 		this.#exitCode = exitCode;
 		this.#status = resolveExecutionStatus(exitCode, cancelled);
 		this.#truncation = options?.truncation;
+		this.#artifactError = options?.artifactError;
 		this.#images = options?.images ?? [];
 		this.#showImages = options?.showImages ?? true;
 		if (options?.output !== undefined && !this.#ptyMode) {
@@ -353,6 +357,7 @@ export class BashExecutionComponent extends Container {
 				status: this.#status,
 				exitCode: this.#exitCode,
 				truncation: this.#truncation,
+				artifactError: this.#artifactError,
 				hiddenLineCount,
 				suppressHiddenCount: hasSixelOutput,
 			});

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -321,6 +321,7 @@ export class ChatTranscriptBuilder {
 				if (message.output) component.appendOutput(message.output);
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
+					artifactError: message.meta?.artifactError,
 					images: message.images,
 					showImages: settings.get("terminal.showImages"),
 				});
@@ -330,7 +331,10 @@ export class ChatTranscriptBuilder {
 			case "pythonExecution": {
 				const component = new EvalExecutionComponent(message.code, this.deps.ui, message.excludeFromContext);
 				if (message.output) component.appendOutput(message.output);
-				component.setComplete(message.exitCode, message.cancelled, { truncation: message.meta?.truncation });
+				component.setComplete(message.exitCode, message.cancelled, {
+					truncation: message.meta?.truncation,
+					artifactError: message.meta?.artifactError,
+				});
 				this.container.addChild(component);
 				break;
 			}

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -6,6 +6,7 @@
 import { Container, type Loader, Text, type TUI } from "@oh-my-pi/pi-tui";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import { highlightCode, theme } from "../../modes/theme/theme";
+import type { OutputArtifactError } from "../../session/streaming-output";
 import type { TruncationMeta } from "../../tools/output-meta";
 import {
 	buildExecutionFrame,
@@ -27,6 +28,7 @@ export class EvalExecutionComponent extends Container {
 	#exitCode: number | undefined = undefined;
 	#loader: Loader;
 	#truncation?: TruncationMeta;
+	#artifactError?: OutputArtifactError;
 	#expanded = false;
 	// Post-finalize mutation counter (FinalizableBlock.getTranscriptBlockVersion):
 	// a completed cell's block still mutates on expansion toggles, and the
@@ -108,11 +110,12 @@ export class EvalExecutionComponent extends Container {
 	setComplete(
 		exitCode: number | undefined,
 		cancelled: boolean,
-		options?: { output?: string; truncation?: TruncationMeta },
+		options?: { output?: string; truncation?: TruncationMeta; artifactError?: OutputArtifactError },
 	): void {
 		this.#exitCode = exitCode;
 		this.#status = resolveExecutionStatus(exitCode, cancelled);
 		this.#truncation = options?.truncation;
+		this.#artifactError = options?.artifactError;
 		if (options?.output !== undefined) {
 			this.#setOutput(options.output);
 		}
@@ -150,6 +153,7 @@ export class EvalExecutionComponent extends Container {
 				status: this.#status,
 				exitCode: this.#exitCode,
 				truncation: this.#truncation,
+				artifactError: this.#artifactError,
 				hiddenLineCount,
 			});
 			if (footer) this.#contentContainer.addChild(footer);

--- a/packages/coding-agent/src/modes/components/execution-shared.ts
+++ b/packages/coding-agent/src/modes/components/execution-shared.ts
@@ -9,7 +9,8 @@
 
 import { type Component, Container, Loader, Text, type TUI } from "@oh-my-pi/pi-tui";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
-import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
+import type { OutputArtifactError } from "../../session/streaming-output";
+import { formatArtifactErrorNotice, formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -68,6 +69,7 @@ export function buildStatusFooter(opts: {
 	status: ExecutionStatus;
 	exitCode: number | undefined;
 	truncation: TruncationMeta | undefined;
+	artifactError?: OutputArtifactError;
 	hiddenLineCount: number;
 	/** Suppress the "… N more lines" hint (used when sixel passthrough renders the full output). */
 	suppressHiddenCount?: boolean;
@@ -84,6 +86,9 @@ export function buildStatusFooter(opts: {
 	}
 	if (opts.truncation) {
 		parts.push(theme.fg("warning", formatTruncationMetaNotice(opts.truncation)));
+	}
+	if (opts.artifactError) {
+		parts.push(theme.fg("warning", formatArtifactErrorNotice(opts.artifactError)));
 	}
 
 	if (parts.length === 0) return undefined;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1357,6 +1357,7 @@ export class CommandController {
 				this.ctx.bashComponent.setComplete(result.exitCode, result.cancelled, {
 					output: result.output,
 					truncation: meta?.truncation,
+					artifactError: meta?.artifactError,
 					images: result.images,
 					showImages: this.ctx.settings.get("terminal.showImages"),
 				});
@@ -1446,6 +1447,7 @@ export class CommandController {
 				this.ctx.pythonComponent.setComplete(result.exitCode, result.cancelled, {
 					output: result.output,
 					truncation: meta?.truncation,
+					artifactError: meta?.artifactError,
 				});
 			}
 		} catch (error) {

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -38,7 +38,7 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): ToolActivit
 			type?: AsyncJobType;
 			label?: string;
 			durationMs?: number;
-			jobs?: Array<{ jobId?: string; type?: AsyncJobType; label?: string; durationMs?: number }>;
+			jobs?: Array<{ jobId?: string; type?: AsyncJobType; label?: string; durationMs?: number; meta?: OutputMeta }>;
 			meta?: OutputMeta;
 		}>
 	).details;
@@ -67,6 +67,9 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): ToolActivit
 			.filter(Boolean)
 			.join(" ");
 		block.addChild(new Text(line, 1, 0));
+		if (job.meta?.artifactError) {
+			block.addChild(new Text(theme.fg("warning", formatArtifactErrorNotice(job.meta.artifactError)), 1, 0));
+		}
 	}
 	if (details?.meta?.artifactError) {
 		block.addChild(new Text(theme.fg("warning", formatArtifactErrorNotice(details.meta.artifactError)), 1, 0));

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -16,6 +16,7 @@ import {
 	shouldRenderAbortReason,
 } from "../../session/messages";
 import { createIrcMessageCard } from "../../tools/hub";
+import { formatArtifactErrorNotice, type OutputMeta } from "../../tools/output-meta";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { ToolActivityContainer } from "../components/tool-activity";
@@ -38,6 +39,7 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): ToolActivit
 			label?: string;
 			durationMs?: number;
 			jobs?: Array<{ jobId?: string; type?: AsyncJobType; label?: string; durationMs?: number }>;
+			meta?: OutputMeta;
 		}>
 	).details;
 	const jobs =
@@ -65,6 +67,9 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): ToolActivit
 			.filter(Boolean)
 			.join(" ");
 		block.addChild(new Text(line, 1, 0));
+	}
+	if (details?.meta?.artifactError) {
+		block.addChild(new Text(theme.fg("warning", formatArtifactErrorNotice(details.meta.artifactError)), 1, 0));
 	}
 	return new ToolActivityContainer(block);
 }

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -173,6 +173,7 @@ export class UiHelpers {
 				}
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
+					artifactError: message.meta?.artifactError,
 					images: message.images,
 					showImages: settings.get("terminal.showImages"),
 				});
@@ -186,6 +187,7 @@ export class UiHelpers {
 				}
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
+					artifactError: message.meta?.artifactError,
 				});
 				this.ctx.chatContainer.addChild(component);
 				break;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -259,6 +259,8 @@ import type {
 	UsageFallbackConfirmer,
 } from "./agent-session-types";
 import { writeArtifact } from "./artifacts";
+import { formatArtifactErrorNotice } from "../tools/output-meta";
+import type { OutputArtifactError } from "./streaming-output";
 import {
 	ASYNC_INLINE_RESULT_MAX_CHARS,
 	ASYNC_PREVIEW_MAX_CHARS,
@@ -385,12 +387,6 @@ import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
 const PLAN_MODE_REMINDER_MAX = 3;
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
-const EXPERIMENTAL_CONTEXT_REQUIRED_TOOLS: Record<string, true> = {
-	context_notes: true,
-	new_context: true,
-	read: true,
-	grep: true,
-};
 
 /** Internal marker for hook messages queued through the agent loop */
 // ============================================================================
@@ -605,8 +601,6 @@ export class AgentSession {
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#queuedMessageDrainScheduled = false;
-	/** A single model-only notebook reminder queued for the current prompt generation. */
-	#experimentalContextNotesReminder: { prompt: string; generation: number } | undefined;
 	#planModeState: PlanModeState | undefined;
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
@@ -636,14 +630,6 @@ export class AgentSession {
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
 	#workPoolYieldItems: readonly WorkPoolYieldItem[] = [];
-	/** Item set matching the last successfully rebuilt provider prompt. The base
-	 *  prompt starts consistent with the empty set; every later value is a
-	 *  snapshot taken after a prompt rebuild resolves. Rollback restores this —
-	 *  never the merely requested previous set, which may belong to a transition
-	 *  that itself failed. Never mutated in place; replaced wholesale. */
-	#lastPublishedWorkPoolYieldItems: readonly WorkPoolYieldItem[] = [];
-	/** Serialized tail of pooled-turn yield contract transitions; never rejects. */
-	#workPoolYieldTransition: Promise<void> = Promise.resolve();
 	#replanTitleRefreshInFlight: Promise<void> | undefined = undefined;
 	/** Resolved TITLE_SYSTEM.md override applied to every automatic session-title
 	 *  generation path. Refresh via {@link AgentSession.setTitleSystemPrompt} when
@@ -926,13 +912,6 @@ export class AgentSession {
 		if (this.#modeExitDrainSuppressionDepth > 0 || this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) {
 			return;
 		}
-		// A pooled yield contract means a pool turn owns this worker (installed,
-		// dispatching, or dispatch-imminent). Waking here would either emit keyed
-		// yields against its items or re-queue into the deferral path forever, so
-		// leave the records pending until the contract clears.
-		if (this.#workPoolYieldItems.length > 0) {
-			return;
-		}
 		// Session transitions call #disconnectFromAgent() BEFORE `await abort()`, and only bump
 		// #sessionGeneration/clear the IRC queue several awaits later once they reach agent.reset().
 		// A normalization await that resolves in that gap sees an unchanged generation and an idle,
@@ -940,9 +919,7 @@ export class AgentSession {
 		// and race the transition's own reset — same rationale as #drainStrandedQueuedMessages.
 		if (this.#unsubscribeAgent === undefined) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
-		// Parked wake records resume alongside ordinary stranded asides; they were
-		// already decided wake-intended at deferral time.
-		const records = [...this.#irc.drainDeferredWakes(), ...this.#irc.drainPending()];
+		const records = this.#irc.drainPending();
 		if (this.#planModeState?.enabled) {
 			// Plan mode: fold stranded IRC asides into context without waking an
 			// autonomous turn. Convergence to ask/resolve stays user-driven.
@@ -1022,10 +999,12 @@ export class AgentSession {
 			this.agent.replaceQueues([...this.agent.peekSteeringQueue()], []);
 			if (parkedQueueDrainBlocked) this.#queuedMessageDrainBlocked = false;
 		}
-		// The wake observer is attached only once prompt ownership is won below: a
-		// deferred wake runs no turn, so observing it would capture the next
-		// turn's yield/output and relay it as this wake's reply.
 		let finishObservation: ((error?: unknown) => void | Promise<void>) | undefined;
+		try {
+			finishObservation = this.#ircWakeTurnObserver?.(records);
+		} catch (error) {
+			logger.warn("IRC wake turn observer failed to start", { error: String(error) });
+		}
 		this.#resetPromptMaintenanceState();
 		// Capture the generation before the wake so its post-prompt recovery wait
 		// bails the instant an abort (which bumps #promptGeneration) supersedes
@@ -1036,52 +1015,9 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		this.#beginInFlight();
 		let turnError: unknown;
-		// A pooled-turn yield transition (item-set mutation + prompt rebuild) may be
-		// in flight when the wake lands. Starting the turn on the stale prompt would
-		// advertise one yield schema while the runtime enforces the other, so join
-		// the transition before building the turn from a consistent contract.
-		void this.whenWorkPoolYieldSettled()
-			.then(() => {
-				// Synchronous ownership check, atomic with the dispatch below:
-				// agent.prompt() claims streaming with no await in between, and the
-				// yield contract above mutates synchronously, so no install can
-				// interleave here.
-				if (this.#workPoolYieldItems.length > 0) {
-					// A pooled turn owns this worker (installed, running, or
-					// dispatch-imminent): park wake-intended records where pooled
-					// turns cannot flush them, for a monitored wake after clearing.
-					// Flushing them as ordinary asides would feed them to the batch
-					// with no observer to reply to the sender.
-					this.#irc.queueDeferredWake(records);
-					logger.debug("IRC wake turn parked while pooled");
-					return;
-				}
-				if (this.agent.state.isStreaming) {
-					this.#irc.queueAside(records);
-					logger.debug("IRC wake turn deferred behind the running turn");
-					return;
-				}
-				try {
-					finishObservation = this.#ircWakeTurnObserver?.(records);
-				} catch (error) {
-					logger.warn("IRC wake turn observer failed to start", { error: String(error) });
-				}
-				return this.agent.prompt(records);
-			})
+		void this.agent
+			.prompt(records)
 			.catch(error => {
-				if (error instanceof AgentBusyError) {
-					// Lost the prompt race after passing the checks above: an
-					// ordinary running turn takes these as asides, but a pooled
-					// turn must not flush them, so park them instead.
-					if (this.#workPoolYieldItems.length > 0) {
-						this.#irc.queueDeferredWake(records);
-						logger.debug("IRC wake turn parked while pooled");
-					} else {
-						this.#irc.queueAside(records);
-						logger.debug("IRC wake turn deferred behind the running turn");
-					}
-					return;
-				}
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
 			})
@@ -1546,19 +1482,6 @@ export class AgentSession {
 			// Mid-run todo reconciliation — evaluated at injection time so a turn
 			// that flips a todo just before this poll suppresses the nudge.
 			thunks.push(() => this.#todo.takeMidRunNudge());
-			const contextNotesReminder = this.#experimentalContextNotesReminder;
-			if (contextNotesReminder) {
-				this.#experimentalContextNotesReminder = undefined;
-				if (contextNotesReminder.generation === this.#promptGeneration) {
-					thunks.push(() => ({
-						role: "custom",
-						customType: "experimental-context-notes-reminder",
-						content: contextNotesReminder.prompt,
-						display: false,
-						timestamp: Date.now(),
-					}));
-				}
-			}
 			return thunks;
 		});
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
@@ -1826,31 +1749,6 @@ export class AgentSession {
 			goalModeState: () => this.#goalModeState,
 			planReferencePath: () => this.#planReferencePath,
 			nonMessageTokenSource: () => this,
-			hasExperimentalContextRolloverTools: () => {
-				const enabled = this.#tools.getEnabledToolNames();
-				for (const name in EXPERIMENTAL_CONTEXT_REQUIRED_TOOLS) {
-					if (!enabled.includes(name) || !this.#tools.getToolByName(name)) return false;
-				}
-				return true;
-			},
-			takeExperimentalContextRolloverRequest: context => {
-				for (const toolResult of context?.toolResults ?? []) {
-					if (toolResult.isError) continue;
-					const dispatch = writeDeviceDispatch(toolResult.toolName, toolResult);
-					const details =
-						toolResult.toolName === "new_context"
-							? toolResult.details
-							: dispatch?.mode === "execute" && dispatch.tool === "new_context"
-								? dispatch.inner
-								: undefined;
-					if (isRecord(details) && details.requested === true) return true;
-				}
-				return false;
-			},
-			queueExperimentalContextNotesReminder: prompt => {
-				if (this.#isDisposed) return;
-				this.#experimentalContextNotesReminder = { prompt, generation: this.#promptGeneration };
-			},
 			memoryBackendSession: () => this,
 			emitSessionEvent: (event, options) => this.#emitSessionEvent(event, options),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
@@ -2296,7 +2194,7 @@ export class AgentSession {
 		// must not enqueue — the suppression marker alone is unreliable because
 		// job-id reuse clears it.
 		const epoch = this.#asyncDeliveryEpoch;
-		const formatted = await this.#formatAsyncResultForFollowUp(text);
+		const formatted = await this.#formatAsyncResultForFollowUp(text, job?.latestDetails?.meta?.artifactError);
 		if (this.#isDisposed) return;
 		if (epoch !== this.#asyncDeliveryEpoch) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
@@ -2310,11 +2208,12 @@ export class AgentSession {
 		});
 	}
 
-	async #formatAsyncResultForFollowUp(result: string): Promise<string> {
+	async #formatAsyncResultForFollowUp(result: string, artifactError?: OutputArtifactError): Promise<string> {
 		if (result.length <= ASYNC_INLINE_RESULT_MAX_CHARS) {
 			return result;
 		}
 		const preview = `${result.slice(0, ASYNC_PREVIEW_MAX_CHARS)}\n\n[Output truncated. Showing first ${ASYNC_PREVIEW_MAX_CHARS.toLocaleString()} characters.]`;
+		if (artifactError) return `${preview}\n[${formatArtifactErrorNotice(artifactError)}]`;
 		try {
 			const { path: artifactPath, id: artifactId } = await this.sessionManager.allocateArtifactPath("async");
 			if (artifactPath && artifactId) {
@@ -3347,17 +3246,14 @@ export class AgentSession {
 			// expired/revoked token) so stale tokens aren't reused on the next request.
 			// Account usage caps and concurrency caps leave the credential valid: the
 			// former rotates until its reset window, while the latter is retried after
-			// a short backoff without touching the credential pool. Model-policy 403s
-			// (plan, model policy, org restriction) also preserve the credential: the
-			// token is valid, and wiping it hides the provider from `/model` (#11275).
+			// a short backoff without touching the credential pool.
 			if (msg.stopReason === "error" && msg.provider === "github-copilot") {
 				const errorId = AIError.classifyMessage(msg);
 				const isConcurrencyCap = AIError.parseRateLimitReason(msg.errorMessage ?? "") === "CONCURRENT_LIMIT";
 				if (
 					AIError.is(errorId, AIError.Flag.AuthFailed) &&
 					!AIError.is(errorId, AIError.Flag.UsageLimit) &&
-					!isConcurrencyCap &&
-					!AIError.isGitHubCopilotPolicyDenial(msg.provider, msg.errorStatus, msg.errorMessage)
+					!isConcurrencyCap
 				) {
 					await this.#modelRegistry.authStorage.remove("github-copilot");
 				}
@@ -4912,7 +4808,6 @@ export class AgentSession {
 		// calls, and error state. agent.reset() keeps the model and system prompt.
 		this.agent.reset();
 		this.#pendingNextTurnMessages = [];
-		this.#experimentalContextNotesReminder = undefined;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		// Reset the session_stop continuation chain: the queued continuation
 		// message is gone with the conversation, but the counters would otherwise
@@ -7487,67 +7382,9 @@ export class AgentSession {
 		return this.#workPoolYieldItems;
 	}
 
-	/** Replace the pooled-turn yield contract and rebuild the provider prompt when it changes. */
-	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
-		// Publish the new contract synchronously: prompt dispatchers (IRC wakes,
-		// follow-up turns) decide on live state in await-free sections, so the
-		// mutation must be visible before the first await. Live state is always
-		// post-last-call, so the change check cannot go stale; the prompt rebuild
-		// stays async on the serialized tail below.
-		const current = this.#workPoolYieldItems;
-		if (
-			current.length === items.length &&
-			current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
-		) {
-			return this.#workPoolYieldTransition;
-		}
-		const applied = items.map(item => ({ ...item }));
-		this.#workPoolYieldItems = applied;
-		const run = this.#workPoolYieldTransition.then(async () => {
-			try {
-				await this.refreshBaseSystemPrompt();
-			} catch (error) {
-				// Roll back to the last successfully published contract so gated
-				// readers never observe a half-applied runtime/provider pair. A
-				// newer transition may have replaced the set meanwhile; only
-				// restore what this one installed. `previous` is deliberately not
-				// the target: when overlapping transitions fail in sequence, it can
-				// belong to a transition whose caller already saw a rejection.
-				if (this.#workPoolYieldItems === applied) {
-					this.#workPoolYieldItems = this.#lastPublishedWorkPoolYieldItems;
-					// Republish inline so waiters gated on this transition observe
-					// the restored pair: a trailing entry would settle those
-					// waiters before the repair runs. An overlapping refresh may
-					// already have published newer bytes, and the equality fast
-					// path would otherwise never repair the mismatch. A republish
-					// failure only warns since the caller already sees error.
-					try {
-						await this.refreshBaseSystemPrompt();
-					} catch (republishError) {
-						logger.warn("WorkPool yield contract republish failed", {
-							error: republishError instanceof Error ? republishError.message : String(republishError),
-						});
-						throw error;
-					}
-					this.#resumeStrandedIrcAsides();
-				}
-				throw error;
-			}
-			// Record what this rebuild published for future rollbacks: the live set
-			// as of success. Then drain any wake parked while pooled.
-			this.#lastPublishedWorkPoolYieldItems = this.#workPoolYieldItems.map(item => ({ ...item }));
-			// A deferred wake may be parked while pooled; now that the fresh
-			// contract is published, let it wake (or stay parked when pooled).
-			this.#resumeStrandedIrcAsides();
-		});
-		this.#workPoolYieldTransition = run.catch(() => {});
-		return run;
-	}
-
-	/** Settles when any in-flight yield prompt rebuild completes. Wake-turn entry
-	 *  joins it so a turn never builds from stale provider bytes. */
-	whenWorkPoolYieldSettled(): Promise<void> {
-		return this.#workPoolYieldTransition;
+	/** Replace the item labels before starting a pooled turn. */
+	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): void {
+		this.#workPoolYieldItems = items.map(item => ({ ...item }));
 	}
 
 	#buildReplanTitleContext(): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -387,6 +387,12 @@ import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
 const PLAN_MODE_REMINDER_MAX = 3;
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
+const EXPERIMENTAL_CONTEXT_REQUIRED_TOOLS: Record<string, true> = {
+	context_notes: true,
+	new_context: true,
+	read: true,
+	grep: true,
+};
 
 /** Internal marker for hook messages queued through the agent loop */
 // ============================================================================
@@ -601,6 +607,8 @@ export class AgentSession {
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#queuedMessageDrainScheduled = false;
+	/** A single model-only notebook reminder queued for the current prompt generation. */
+	#experimentalContextNotesReminder: { prompt: string; generation: number } | undefined;
 	#planModeState: PlanModeState | undefined;
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
@@ -630,6 +638,14 @@ export class AgentSession {
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
 	#workPoolYieldItems: readonly WorkPoolYieldItem[] = [];
+	/** Item set matching the last successfully rebuilt provider prompt. The base
+	 *  prompt starts consistent with the empty set; every later value is a
+	 *  snapshot taken after a prompt rebuild resolves. Rollback restores this —
+	 *  never the merely requested previous set, which may belong to a transition
+	 *  that itself failed. Never mutated in place; replaced wholesale. */
+	#lastPublishedWorkPoolYieldItems: readonly WorkPoolYieldItem[] = [];
+	/** Serialized tail of pooled-turn yield contract transitions; never rejects. */
+	#workPoolYieldTransition: Promise<void> = Promise.resolve();
 	#replanTitleRefreshInFlight: Promise<void> | undefined = undefined;
 	/** Resolved TITLE_SYSTEM.md override applied to every automatic session-title
 	 *  generation path. Refresh via {@link AgentSession.setTitleSystemPrompt} when
@@ -912,6 +928,13 @@ export class AgentSession {
 		if (this.#modeExitDrainSuppressionDepth > 0 || this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) {
 			return;
 		}
+		// A pooled yield contract means a pool turn owns this worker (installed,
+		// dispatching, or dispatch-imminent). Waking here would either emit keyed
+		// yields against its items or re-queue into the deferral path forever, so
+		// leave the records pending until the contract clears.
+		if (this.#workPoolYieldItems.length > 0) {
+			return;
+		}
 		// Session transitions call #disconnectFromAgent() BEFORE `await abort()`, and only bump
 		// #sessionGeneration/clear the IRC queue several awaits later once they reach agent.reset().
 		// A normalization await that resolves in that gap sees an unchanged generation and an idle,
@@ -919,7 +942,9 @@ export class AgentSession {
 		// and race the transition's own reset — same rationale as #drainStrandedQueuedMessages.
 		if (this.#unsubscribeAgent === undefined) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
-		const records = this.#irc.drainPending();
+		// Parked wake records resume alongside ordinary stranded asides; they were
+		// already decided wake-intended at deferral time.
+		const records = [...this.#irc.drainDeferredWakes(), ...this.#irc.drainPending()];
 		if (this.#planModeState?.enabled) {
 			// Plan mode: fold stranded IRC asides into context without waking an
 			// autonomous turn. Convergence to ask/resolve stays user-driven.
@@ -999,12 +1024,10 @@ export class AgentSession {
 			this.agent.replaceQueues([...this.agent.peekSteeringQueue()], []);
 			if (parkedQueueDrainBlocked) this.#queuedMessageDrainBlocked = false;
 		}
+		// The wake observer is attached only once prompt ownership is won below: a
+		// deferred wake runs no turn, so observing it would capture the next
+		// turn's yield/output and relay it as this wake's reply.
 		let finishObservation: ((error?: unknown) => void | Promise<void>) | undefined;
-		try {
-			finishObservation = this.#ircWakeTurnObserver?.(records);
-		} catch (error) {
-			logger.warn("IRC wake turn observer failed to start", { error: String(error) });
-		}
 		this.#resetPromptMaintenanceState();
 		// Capture the generation before the wake so its post-prompt recovery wait
 		// bails the instant an abort (which bumps #promptGeneration) supersedes
@@ -1015,9 +1038,52 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		this.#beginInFlight();
 		let turnError: unknown;
-		void this.agent
-			.prompt(records)
+		// A pooled-turn yield transition (item-set mutation + prompt rebuild) may be
+		// in flight when the wake lands. Starting the turn on the stale prompt would
+		// advertise one yield schema while the runtime enforces the other, so join
+		// the transition before building the turn from a consistent contract.
+		void this.whenWorkPoolYieldSettled()
+			.then(() => {
+				// Synchronous ownership check, atomic with the dispatch below:
+				// agent.prompt() claims streaming with no await in between, and the
+				// yield contract above mutates synchronously, so no install can
+				// interleave here.
+				if (this.#workPoolYieldItems.length > 0) {
+					// A pooled turn owns this worker (installed, running, or
+					// dispatch-imminent): park wake-intended records where pooled
+					// turns cannot flush them, for a monitored wake after clearing.
+					// Flushing them as ordinary asides would feed them to the batch
+					// with no observer to reply to the sender.
+					this.#irc.queueDeferredWake(records);
+					logger.debug("IRC wake turn parked while pooled");
+					return;
+				}
+				if (this.agent.state.isStreaming) {
+					this.#irc.queueAside(records);
+					logger.debug("IRC wake turn deferred behind the running turn");
+					return;
+				}
+				try {
+					finishObservation = this.#ircWakeTurnObserver?.(records);
+				} catch (error) {
+					logger.warn("IRC wake turn observer failed to start", { error: String(error) });
+				}
+				return this.agent.prompt(records);
+			})
 			.catch(error => {
+				if (error instanceof AgentBusyError) {
+					// Lost the prompt race after passing the checks above: an
+					// ordinary running turn takes these as asides, but a pooled
+					// turn must not flush them, so park them instead.
+					if (this.#workPoolYieldItems.length > 0) {
+						this.#irc.queueDeferredWake(records);
+						logger.debug("IRC wake turn parked while pooled");
+					} else {
+						this.#irc.queueAside(records);
+						logger.debug("IRC wake turn deferred behind the running turn");
+					}
+					return;
+				}
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
 			})
@@ -1482,6 +1548,19 @@ export class AgentSession {
 			// Mid-run todo reconciliation — evaluated at injection time so a turn
 			// that flips a todo just before this poll suppresses the nudge.
 			thunks.push(() => this.#todo.takeMidRunNudge());
+			const contextNotesReminder = this.#experimentalContextNotesReminder;
+			if (contextNotesReminder) {
+				this.#experimentalContextNotesReminder = undefined;
+				if (contextNotesReminder.generation === this.#promptGeneration) {
+					thunks.push(() => ({
+						role: "custom",
+						customType: "experimental-context-notes-reminder",
+						content: contextNotesReminder.prompt,
+						display: false,
+						timestamp: Date.now(),
+					}));
+				}
+			}
 			return thunks;
 		});
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
@@ -1749,6 +1828,31 @@ export class AgentSession {
 			goalModeState: () => this.#goalModeState,
 			planReferencePath: () => this.#planReferencePath,
 			nonMessageTokenSource: () => this,
+			hasExperimentalContextRolloverTools: () => {
+				const enabled = this.#tools.getEnabledToolNames();
+				for (const name in EXPERIMENTAL_CONTEXT_REQUIRED_TOOLS) {
+					if (!enabled.includes(name) || !this.#tools.getToolByName(name)) return false;
+				}
+				return true;
+			},
+			takeExperimentalContextRolloverRequest: context => {
+				for (const toolResult of context?.toolResults ?? []) {
+					if (toolResult.isError) continue;
+					const dispatch = writeDeviceDispatch(toolResult.toolName, toolResult);
+					const details =
+						toolResult.toolName === "new_context"
+							? toolResult.details
+							: dispatch?.mode === "execute" && dispatch.tool === "new_context"
+								? dispatch.inner
+								: undefined;
+					if (isRecord(details) && details.requested === true) return true;
+				}
+				return false;
+			},
+			queueExperimentalContextNotesReminder: prompt => {
+				if (this.#isDisposed) return;
+				this.#experimentalContextNotesReminder = { prompt, generation: this.#promptGeneration };
+			},
 			memoryBackendSession: () => this,
 			emitSessionEvent: (event, options) => this.#emitSessionEvent(event, options),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
@@ -3246,14 +3350,17 @@ export class AgentSession {
 			// expired/revoked token) so stale tokens aren't reused on the next request.
 			// Account usage caps and concurrency caps leave the credential valid: the
 			// former rotates until its reset window, while the latter is retried after
-			// a short backoff without touching the credential pool.
+			// a short backoff without touching the credential pool. Model-policy 403s
+			// (plan, model policy, org restriction) also preserve the credential: the
+			// token is valid, and wiping it hides the provider from `/model` (#11275).
 			if (msg.stopReason === "error" && msg.provider === "github-copilot") {
 				const errorId = AIError.classifyMessage(msg);
 				const isConcurrencyCap = AIError.parseRateLimitReason(msg.errorMessage ?? "") === "CONCURRENT_LIMIT";
 				if (
 					AIError.is(errorId, AIError.Flag.AuthFailed) &&
 					!AIError.is(errorId, AIError.Flag.UsageLimit) &&
-					!isConcurrencyCap
+					!isConcurrencyCap &&
+					!AIError.isGitHubCopilotPolicyDenial(msg.provider, msg.errorStatus, msg.errorMessage)
 				) {
 					await this.#modelRegistry.authStorage.remove("github-copilot");
 				}
@@ -4808,6 +4915,7 @@ export class AgentSession {
 		// calls, and error state. agent.reset() keeps the model and system prompt.
 		this.agent.reset();
 		this.#pendingNextTurnMessages = [];
+		this.#experimentalContextNotesReminder = undefined;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		// Reset the session_stop continuation chain: the queued continuation
 		// message is gone with the conversation, but the counters would otherwise
@@ -7382,9 +7490,67 @@ export class AgentSession {
 		return this.#workPoolYieldItems;
 	}
 
-	/** Replace the item labels before starting a pooled turn. */
-	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): void {
-		this.#workPoolYieldItems = items.map(item => ({ ...item }));
+	/** Replace the pooled-turn yield contract and rebuild the provider prompt when it changes. */
+	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
+		// Publish the new contract synchronously: prompt dispatchers (IRC wakes,
+		// follow-up turns) decide on live state in await-free sections, so the
+		// mutation must be visible before the first await. Live state is always
+		// post-last-call, so the change check cannot go stale; the prompt rebuild
+		// stays async on the serialized tail below.
+		const current = this.#workPoolYieldItems;
+		if (
+			current.length === items.length &&
+			current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
+		) {
+			return this.#workPoolYieldTransition;
+		}
+		const applied = items.map(item => ({ ...item }));
+		this.#workPoolYieldItems = applied;
+		const run = this.#workPoolYieldTransition.then(async () => {
+			try {
+				await this.refreshBaseSystemPrompt();
+			} catch (error) {
+				// Roll back to the last successfully published contract so gated
+				// readers never observe a half-applied runtime/provider pair. A
+				// newer transition may have replaced the set meanwhile; only
+				// restore what this one installed. `previous` is deliberately not
+				// the target: when overlapping transitions fail in sequence, it can
+				// belong to a transition whose caller already saw a rejection.
+				if (this.#workPoolYieldItems === applied) {
+					this.#workPoolYieldItems = this.#lastPublishedWorkPoolYieldItems;
+					// Republish inline so waiters gated on this transition observe
+					// the restored pair: a trailing entry would settle those
+					// waiters before the repair runs. An overlapping refresh may
+					// already have published newer bytes, and the equality fast
+					// path would otherwise never repair the mismatch. A republish
+					// failure only warns since the caller already sees error.
+					try {
+						await this.refreshBaseSystemPrompt();
+					} catch (republishError) {
+						logger.warn("WorkPool yield contract republish failed", {
+							error: republishError instanceof Error ? republishError.message : String(republishError),
+						});
+						throw error;
+					}
+					this.#resumeStrandedIrcAsides();
+				}
+				throw error;
+			}
+			// Record what this rebuild published for future rollbacks: the live set
+			// as of success. Then drain any wake parked while pooled.
+			this.#lastPublishedWorkPoolYieldItems = this.#workPoolYieldItems.map(item => ({ ...item }));
+			// A deferred wake may be parked while pooled; now that the fresh
+			// contract is published, let it wake (or stay parked when pooled).
+			this.#resumeStrandedIrcAsides();
+		});
+		this.#workPoolYieldTransition = run.catch(() => {});
+		return run;
+	}
+
+	/** Settles when any in-flight yield prompt rebuild completes. Wake-turn entry
+	 *  joins it so a turn never builds from stale provider bytes. */
+	whenWorkPoolYieldSettled(): Promise<void> {
+		return this.#workPoolYieldTransition;
 	}
 
 	#buildReplanTitleContext(): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -259,8 +259,7 @@ import type {
 	UsageFallbackConfirmer,
 } from "./agent-session-types";
 import { writeArtifact } from "./artifacts";
-import { formatArtifactErrorNotice } from "../tools/output-meta";
-import type { OutputArtifactError } from "./streaming-output";
+import { formatArtifactErrorNotice, type OutputMeta, stripOutputNotice } from "../tools/output-meta";
 import {
 	ASYNC_INLINE_RESULT_MAX_CHARS,
 	ASYNC_PREVIEW_MAX_CHARS,
@@ -2298,7 +2297,7 @@ export class AgentSession {
 		// must not enqueue — the suppression marker alone is unreliable because
 		// job-id reuse clears it.
 		const epoch = this.#asyncDeliveryEpoch;
-		const formatted = await this.#formatAsyncResultForFollowUp(text, job?.latestDetails?.meta?.artifactError);
+		const formatted = await this.#formatAsyncResultForFollowUp(text, job?.latestDetails?.meta);
 		if (this.#isDisposed) return;
 		if (epoch !== this.#asyncDeliveryEpoch) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
@@ -2312,12 +2311,15 @@ export class AgentSession {
 		});
 	}
 
-	async #formatAsyncResultForFollowUp(result: string, artifactError?: OutputArtifactError): Promise<string> {
+	async #formatAsyncResultForFollowUp(result: string, meta?: OutputMeta): Promise<string> {
 		if (result.length <= ASYNC_INLINE_RESULT_MAX_CHARS) {
 			return result;
 		}
-		const preview = `${result.slice(0, ASYNC_PREVIEW_MAX_CHARS)}\n\n[Output truncated. Showing first ${ASYNC_PREVIEW_MAX_CHARS.toLocaleString()} characters.]`;
-		if (artifactError) return `${preview}\n[${formatArtifactErrorNotice(artifactError)}]`;
+		// Strip the already-rendered source notice before taking the smaller preview,
+		// then retain its capture warning once even when the original footer is elided.
+		const body = meta?.artifactError ? stripOutputNotice(result, meta).trimEnd() : result;
+		const preview = `${body.slice(0, ASYNC_PREVIEW_MAX_CHARS)}\n\n[Output truncated. Showing first ${ASYNC_PREVIEW_MAX_CHARS.toLocaleString()} characters.]`;
+		if (meta?.artifactError) return `${preview}\n[${formatArtifactErrorNotice(meta.artifactError)}]`;
 		try {
 			const { path: artifactPath, id: artifactId } = await this.sessionManager.allocateArtifactPath("async");
 			if (artifactPath && artifactId) {

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -47,6 +47,8 @@ type AsyncResultJobDetails = {
 	type?: AsyncJobType;
 	label?: string;
 	durationMs?: number;
+	/** Source capture metadata belongs to this job, not to the enclosing delivery report. */
+	meta?: OutputMeta;
 	/** Full structured payload (source/mode/status/data/error), when the job used an output schema. */
 	schema?: StructuredSubagentOutput;
 };
@@ -92,6 +94,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 			type: entry.job?.type,
 			label: entry.job?.label,
 			durationMs: entry.durationMs,
+			meta: entry.job?.latestDetails?.meta,
 			structured,
 			structuredJson,
 			hasStructuredData,
@@ -100,15 +103,14 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 			schemaValid: structured?.status === "valid",
 		};
 	});
-	const artifactError = entries.find(entry => entry.job?.latestDetails?.meta?.artifactError)?.job?.latestDetails?.meta
-		?.artifactError;
 	const details: AsyncResultDetails = {
-		...(artifactError ? { meta: { artifactError } } : {}),
+		meta: { source: { type: "report", value: "background job delivery" } },
 		jobs: jobs.map(job => ({
 			jobId: job.jobId,
 			type: job.type,
 			label: job.label,
 			durationMs: job.durationMs,
+			...(job.meta ? { meta: job.meta } : {}),
 			...(job.structured ? { schema: job.structured } : {}),
 		})),
 	};

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -13,6 +13,7 @@ import type { AsyncJob, AsyncJobType } from "../async";
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
 import type { StructuredSubagentOutput } from "../task/types";
 import type { CustomMessage } from "./messages";
+import type { OutputMeta } from "../tools/output-meta";
 import { truncateMiddle } from "./streaming-output";
 
 /**
@@ -52,6 +53,7 @@ type AsyncResultJobDetails = {
 
 export type AsyncResultDetails = {
 	jobs: AsyncResultJobDetails[];
+	meta?: OutputMeta;
 };
 
 /**
@@ -98,7 +100,10 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 			schemaValid: structured?.status === "valid",
 		};
 	});
+	const artifactError = entries.find(entry => entry.job?.latestDetails?.meta?.artifactError)?.job?.latestDetails?.meta
+		?.artifactError;
 	const details: AsyncResultDetails = {
+		...(artifactError ? { meta: { artifactError } } : {}),
 		jobs: jobs.map(job => ({
 			jobId: job.jobId,
 			type: job.type,

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -254,6 +254,7 @@ function normalizeSessionMessageForProviderReplay(message: AgentMessage): unknow
 				meta: message.meta
 					? {
 							truncation: normalizeProviderReplayValue(message.meta.truncation),
+							artifactError: message.meta.artifactError,
 							limits: normalizeProviderReplayValue(message.meta.limits),
 							diagnostics: message.meta.diagnostics
 								? normalizeProviderReplayValue({
@@ -275,6 +276,7 @@ function normalizeSessionMessageForProviderReplay(message: AgentMessage): unknow
 				meta: message.meta
 					? {
 							truncation: normalizeProviderReplayValue(message.meta.truncation),
+							artifactError: message.meta.artifactError,
 							limits: normalizeProviderReplayValue(message.meta.limits),
 							diagnostics: message.meta.diagnostics
 								? normalizeProviderReplayValue({

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -28,6 +28,9 @@ const ELLIPSIS = "…";
 // Interfaces
 // =============================================================================
 
+/** First failed artifact I/O operation; safe to persist without exposing filesystem errors. */
+export type OutputArtifactError = "open" | "write" | "flush" | "end";
+
 export interface OutputSummary {
 	output: string;
 	truncated: boolean;
@@ -47,6 +50,8 @@ export interface OutputSummary {
 	columnMax?: number;
 	/** Artifact ID for internal URL access (artifact://<id>) when truncated */
 	artifactId?: string;
+	/** Full raw output was not completely saved; artifactId is unavailable. */
+	artifactError?: OutputArtifactError;
 }
 
 export interface OutputSinkOptions {
@@ -806,6 +811,9 @@ export class OutputSink {
 	#fileCreation?: Promise<void>;
 	/** Set once the spill file has been closed; guards double-close and post-finalize resurrection. */
 	#finalized = false;
+	#fileFinalization?: Promise<void>;
+	#artifactError?: OutputArtifactError;
+	#pendingArtifactWrites?: Set<Promise<void>>;
 
 	readonly #artifactPath?: string;
 	readonly #artifactId?: string;
@@ -1067,6 +1075,7 @@ export class OutputSink {
 	 * `#artifactMaxBytes` on disk.
 	 */
 	#writeToFile(chunk: string): void {
+		if (this.#artifactError) return;
 		if (this.#fileReady && this.#file) {
 			this.#emitToSink(chunk);
 			return;
@@ -1094,15 +1103,15 @@ export class OutputSink {
 	 * contract.
 	 */
 	#emitToSink(chunk: string): void {
-		if (!this.#file || chunk.length === 0) return;
+		if (!this.#file || this.#artifactError || chunk.length === 0) return;
 		if (this.#artifactMaxBytes === 0) {
-			this.#file.sink.write(chunk);
+			this.#writeArtifact(chunk);
 			return;
 		}
 		const chunkBytes = Buffer.byteLength(chunk, "utf-8");
 		const room = this.#artifactHeadClosed ? 0 : this.#artifactHeadBudget - this.#artifactHeadBytesWritten;
 		if (room >= chunkBytes) {
-			this.#file.sink.write(chunk);
+			this.#writeArtifact(chunk);
 			this.#artifactHeadBytesWritten += chunkBytes;
 			return;
 		}
@@ -1110,7 +1119,7 @@ export class OutputSink {
 		if (room > 0) {
 			const headSlice = truncateHeadBytes(chunk, room);
 			if (headSlice.bytes > 0) {
-				this.#file.sink.write(headSlice.text);
+				this.#writeArtifact(headSlice.text);
 				this.#artifactHeadBytesWritten += headSlice.bytes;
 			}
 			// Even when UTF-8 boundary safety leaves a few bytes of nominal room,
@@ -1130,6 +1139,7 @@ export class OutputSink {
 	}
 
 	#pushArtifactTail(chunk: string): void {
+		if (this.#artifactError) return;
 		const chunkBytes = Buffer.byteLength(chunk, "utf-8");
 		this.#artifactTailIncomingBytes += chunkBytes;
 		const budget = this.#artifactTailBudget;
@@ -1149,8 +1159,37 @@ export class OutputSink {
 		}
 	}
 
+	#recordArtifactError(operation: OutputArtifactError): void {
+		this.#artifactError ??= operation;
+		this.#pendingFileWrites = undefined;
+		this.#artifactTailRing = "";
+		this.#artifactTailRingBytes = 0;
+	}
+
+	#writeArtifact(chunk: string, operation: OutputArtifactError = "write"): void {
+		if (!this.#file || this.#artifactError) return;
+		try {
+			const written = this.#file.sink.write(chunk);
+			if (typeof written !== "number") {
+				const writes = (this.#pendingArtifactWrites ??= new Set());
+				const pending = written.then(
+					() => {
+						writes.delete(pending);
+					},
+					() => {
+						writes.delete(pending);
+						this.#recordArtifactError(operation);
+					},
+				);
+				writes.add(pending);
+			}
+		} catch {
+			this.#recordArtifactError(operation);
+		}
+	}
+
 	async #createFileSink(): Promise<void> {
-		if (!this.#artifactPath || this.#fileReady) return;
+		if (!this.#artifactPath || this.#fileReady || this.#artifactError) return;
 		try {
 			const sink = Bun.file(this.#artifactPath).writer();
 			this.#file = { path: this.#artifactPath, artifactId: this.#artifactId, sink };
@@ -1176,14 +1215,7 @@ export class OutputSink {
 				this.#pendingFileWrites = undefined;
 			}
 		} catch {
-			try {
-				await this.#file?.sink?.end();
-			} catch {
-				/* ignore */
-			}
-			this.#file = undefined;
-			this.#pendingFileWrites = undefined;
-			this.#fileReady = false;
+			this.#recordArtifactError("open");
 		}
 	}
 
@@ -1280,7 +1312,7 @@ export class OutputSink {
 	 * tail ring empty).
 	 */
 	#flushArtifactTailIfCapped(): void {
-		if (!this.#file) return;
+		if (!this.#file || this.#artifactError) return;
 		if (this.#artifactMaxBytes === 0) return;
 		const tailBytes = this.#artifactTailRingBytes;
 		const droppedBytes = Math.max(0, this.#artifactTailIncomingBytes - tailBytes);
@@ -1294,10 +1326,10 @@ export class OutputSink {
 			const notice =
 				`${headSep}[ARTIFACT TRUNCATED: kept first ${formatBytes(headWritten)} + last ${formatBytes(tailBytes)} ` +
 				`of ${formatBytes(totalCapped)}; ${formatBytes(droppedBytes)} elided from the middle]${tailSep}`;
-			this.#file.sink.write(notice);
+			this.#writeArtifact(notice, "flush");
 		}
 		if (tailBytes > 0) {
-			this.#file.sink.write(this.#artifactTailRing);
+			this.#writeArtifact(this.#artifactTailRing, "flush");
 		}
 	}
 
@@ -1373,7 +1405,8 @@ export class OutputSink {
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
 			columnMax: this.#columnTruncatedLines > 0 ? this.#maxColumns : undefined,
-			artifactId: this.#file?.artifactId,
+			artifactId: this.#artifactError ? undefined : this.#file?.artifactId,
+			artifactError: this.#artifactError,
 		};
 	}
 
@@ -1385,27 +1418,32 @@ export class OutputSink {
 	 * bailed through {@link dispose}. `#file` is left set so {@link dump} can
 	 * still read `artifactId` for its summary.
 	 */
-	async #finalizeFile(): Promise<void> {
-		if (this.#finalized) return;
+	#finalizeFile(): Promise<void> {
+		if (this.#fileFinalization) return this.#fileFinalization;
 		this.#finalized = true;
+		return (this.#fileFinalization = this.#closeFile());
+	}
+
+	async #closeFile(): Promise<void> {
 		if (this.#fileCreation) {
-			await this.#fileCreation.catch(() => undefined);
+			await this.#fileCreation;
 		}
+		if (this.#pendingArtifactWrites?.size) await Promise.all(this.#pendingArtifactWrites);
 		const file = this.#file;
 		if (!file) return;
-		// The tail/notice replay writes to the sink and can throw (e.g. a disk
-		// write error). Closing the descriptor MUST still happen — otherwise the
-		// fd leaks and the replay error masks the original tool error that put us
-		// on this path. Both failures are swallowed so dispose() never throws.
+		// Capture failures must not replace the command's result. Always close,
+		// even when tail replay or flushing fails, and never advertise that file.
 		try {
 			this.#flushArtifactTailIfCapped();
+			if (this.#pendingArtifactWrites?.size) await Promise.all(this.#pendingArtifactWrites);
+			if (!this.#artifactError) await file.sink.flush();
 		} catch {
-			/* ignore */
+			this.#recordArtifactError("flush");
 		} finally {
 			try {
 				await file.sink.end();
 			} catch {
-				/* ignore */
+				this.#recordArtifactError("end");
 			}
 		}
 	}

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -1413,7 +1413,7 @@ export class OutputSink {
 	/**
 	 * Flush any capped artifact tail and close the spill file descriptor,
 	 * awaiting an in-flight sink creation so a descriptor opened by a late
-	 * chunk is still released. Idempotent via {@link #finalized}: the artifact
+	 * chunk is still released. Idempotent via {@link #fileFinalization}: the artifact
 	 * is finalized exactly once whether the caller reached {@link dump} or
 	 * bailed through {@link dispose}. `#file` is left set so {@link dump} can
 	 * still read `artifactId` for its summary.

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -46,6 +46,8 @@ import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-ski
 import { resolveEvalBackends } from "./eval-backends";
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
 import {
+	formatArtifactErrorNotice,
+	formatOutputNotice,
 	formatStyledTruncationWarning,
 	type OutputMeta,
 	resolveInlineByteCapBudget,
@@ -747,22 +749,23 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		timeoutSec: number | undefined,
 		outputText: string,
 	): void {
+		const captureNotice = result.artifactError ? `\n\n[${formatArtifactErrorNotice(result.artifactError)}]` : "";
 		if (result.cancelled) {
 			// Local executor output already carries a leading `[Command cancelled]`
 			// notice from the sink; PTY/bridge output does not, so annotate only
 			// the latter.
 			const out = normalizeResultOutput(result);
 			const annotated = out.startsWith("[Command cancelled]") ? out : out ? `${out}\n\n[Command aborted]` : out;
-			throw new ToolError(annotated || "Command aborted");
+			throw new ToolError(`${annotated || "Command aborted"}${captureNotice}`);
 		}
 		if (result.timedOut === true) {
 			const out = normalizeResultOutput(result);
 			const message =
 				timeoutSec === undefined ? "Command timed out" : `Command timed out after ${timeoutSec} seconds`;
-			throw new ToolError(out ? `${out}\n\n[${message}]` : message);
+			throw new ToolError(`${out ? `${out}\n\n[${message}]` : message}${captureNotice}`);
 		}
 		if (result.exitCode === undefined) {
-			throw new ToolError(`${outputText}\n\nCommand failed: missing exit status`);
+			throw new ToolError(`${outputText}\n\nCommand failed: missing exit status${captureNotice}`);
 		}
 	}
 
@@ -824,7 +827,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		// `[raw output: artifact://N]` footer and the truncation notice agree.
 		const inlineCap = {
 			maxBytes: resolveInlineByteCapBudget(this.session.settings),
-			saveArtifact: (full: string) => result.artifactId ?? saveBashOriginalArtifact(this.session, full),
+			saveArtifact: result.artifactError
+				? undefined
+				: (full: string) => result.artifactId ?? saveBashOriginalArtifact(this.session, full),
 		};
 
 		if (isTimeout) {
@@ -890,7 +895,8 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 	}
 
 	#extractTextResult(result: AgentToolResult<BashToolDetails>): string {
-		return result.content.find(block => block.type === "text")?.text ?? "";
+		const text = result.content.find(block => block.type === "text")?.text ?? "";
+		return text + formatOutputNotice(result.details?.meta);
 	}
 
 	#startManagedBashJob(options: {
@@ -939,6 +945,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 						},
 						onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
 					});
+					if (result.artifactError) latestProgressDetails = { meta: { artifactError: result.artifactError } };
 					const wallTimeMs = performance.now() - wallTimeStart;
 					const finalResult = await this.#buildCompletedResult(result, options.timeoutSec, {
 						requestedTimeoutSec: options.requestedTimeoutSec,
@@ -1551,11 +1558,12 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				const out = normalizeResultOutput(result);
 				// The local executor already prepends `[Command cancelled]`; PTY
 				// output does not, so preserve one cancellation notice in either case.
-				const message = out.startsWith("[Command cancelled]")
+				let message = out.startsWith("[Command cancelled]")
 					? out
 					: out
 						? `${out}\n\n[Command aborted]`
 						: "Command aborted";
+				if (result.artifactError) message += `\n\n[${formatArtifactErrorNotice(result.artifactError)}]`;
 				if (signal?.aborted) {
 					throw new ToolAbortError(message);
 				}
@@ -1805,7 +1813,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								)
 							: undefined;
 					let warningLine: string | undefined;
-					if (details?.meta?.truncation && !showingFullOutput) {
+					if (details?.meta?.artifactError || (details?.meta?.truncation && !showingFullOutput)) {
 						warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;
 					}
 

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -10,14 +10,14 @@
  * initialization`.
  */
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Markdown, Text } from "@oh-my-pi/pi-tui";
-import { formatNumber } from "@oh-my-pi/pi-utils";
-import { settings } from "../config/settings";
+import { Markdown, Text, visibleWidth } from "@oh-my-pi/pi-tui";
+import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import type { EvalCellResult, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
+import { parseConfiguredThinkingLevel } from "../thinking";
 import { markFramedBlockComponent, outputBlockContentWidth, renderCodeCell } from "../tui";
 import { formatEvalCodeForDisplay } from "./eval-format";
 import {
@@ -31,10 +31,13 @@ import {
 } from "./json-tree";
 import { formatStyledTruncationWarning, stripOutputNotice } from "./output-meta";
 import {
+	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
 	formatDuration,
+	formatFeedModelBadge,
 	formatStatusIcon,
 	formatTitle,
+	isFeedModelBadgeEnabled,
 	previewWindowRows,
 	replaceTabs,
 	shortenPath,
@@ -138,7 +141,7 @@ function agentEventStatus(value: unknown): AgentEventStatus {
 	}
 }
 
-/** Append the toolCount · context · cost · model stat run, mirroring the task tool. */
+/** Append the toolCount · context · cost stat run, mirroring the task tool. */
 function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	let line = "";
 	const toolCount = eventNumber(event.toolCount);
@@ -158,10 +161,6 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	if (cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${cost.toFixed(2)}`)}`;
 	}
-	const model = eventString(event.model);
-	if (model && settings.get("task.showResolvedModelBadge")) {
-		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(model), 30))}`;
-	}
 	return line;
 }
 
@@ -170,7 +169,12 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
  * subagent: a status line (icon · id · stats) plus, while running, the current
  * tool/intent. Drawn below the cell box so progress streams live.
  */
-function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spinnerFrame?: number): string[] {
+function renderAgentProgressEvents(
+	events: EvalStatusEvent[],
+	theme: Theme,
+	width: number,
+	spinnerFrame?: number,
+): string[] {
 	const lines: string[] = [];
 	for (let i = 0; i < events.length; i++) {
 		const event = events[i];
@@ -196,12 +200,30 @@ function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spin
 				? theme.styledSymbol("tool.eval", "accent")
 				: theme.fg(iconColor, formatStatusIcon(iconStatus, theme, status === "running" ? spinnerFrame : undefined));
 
-		const id = eventString(event.id) ?? "agent";
-		let line = `${prefix} ${icon} ${theme.fg("accent", theme.bold(id))}`;
-
-		if (status === "failed" || status === "aborted") {
-			line += ` ${formatBadge(status, iconColor, theme)}`;
-		}
+		const lead = `${prefix} ${icon} `;
+		const statusSuffix =
+			status === "failed" || status === "aborted" ? ` ${formatBadge(status, iconColor, theme)}` : "";
+		const id = truncateToWidth(
+			sanitizeText(eventString(event.id) ?? "agent").replace(/\s+/g, " "),
+			Math.max(0, width - visibleWidth(lead) - visibleWidth(statusSuffix)),
+		);
+		const model = eventString(event.resolvedModelIdentity ?? event.model ?? event.resolvedModel);
+		const thinkingLevel = parseConfiguredThinkingLevel(eventString(event.resolvedThinkingLevel));
+		const modelPrefix =
+			model && isFeedModelBadgeEnabled()
+				? formatFeedModelBadge(
+						model,
+						thinkingLevel,
+						event.advisor === true,
+						theme,
+						Math.min(
+							FEED_MODEL_BADGE_WIDTH,
+							width - visibleWidth(lead) - visibleWidth(id) - visibleWidth(statusSuffix) - 1,
+						),
+					)
+				: "";
+		const modelLead = modelPrefix ? `${modelPrefix} ` : "";
+		let line = `${lead}${modelLead}${theme.fg("accent", theme.bold(id))}${statusSuffix}`;
 
 		const currentTool = eventString(event.currentTool);
 		const lastIntent = eventString(event.lastIntent);
@@ -215,16 +237,22 @@ function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spin
 			const durationMs = eventNumber(event.durationMs);
 			if (durationMs > 0) line += `${theme.sep.dot}${theme.fg("dim", formatDuration(durationMs))}`;
 		}
-		lines.push(line);
+		// Do not let optional stats replace the end of the reserved failure status with an ellipsis.
+		lines.push(truncateToWidth(line, width, ""));
 
 		if (status === "running") {
 			if (currentTool) {
 				let toolLine = `${cont}${theme.tree.hook} ${theme.fg("muted", currentTool)}`;
 				const detail = lastIntent ?? eventString(event.currentToolArgs);
 				if (detail) toolLine += `: ${theme.fg("dim", truncateToWidth(replaceTabs(detail), 48))}`;
-				lines.push(toolLine);
+				lines.push(truncateToWidth(toolLine, width));
 			} else if (lastIntent) {
-				lines.push(`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`);
+				lines.push(
+					truncateToWidth(
+						`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`,
+						width,
+					),
+				);
 			}
 		}
 	}
@@ -663,7 +691,7 @@ export const evalToolRenderer = {
 						);
 						lines.push(...cellLines);
 						if (agentEvents.length > 0) {
-							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, options.spinnerFrame));
+							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, width, options.spinnerFrame));
 						}
 						if (i < cellResults.length - 1) {
 							lines.push("");

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -10,14 +10,14 @@
  * initialization`.
  */
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Markdown, Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
+import { Markdown, Text } from "@oh-my-pi/pi-tui";
+import { formatNumber } from "@oh-my-pi/pi-utils";
+import { settings } from "../config/settings";
 import type { EvalCellResult, EvalLanguage, EvalStatusEvent, EvalToolDetails } from "../eval/types";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
-import { parseConfiguredThinkingLevel } from "../thinking";
 import { markFramedBlockComponent, outputBlockContentWidth, renderCodeCell } from "../tui";
 import { formatEvalCodeForDisplay } from "./eval-format";
 import {
@@ -31,13 +31,10 @@ import {
 } from "./json-tree";
 import { formatStyledTruncationWarning, stripOutputNotice } from "./output-meta";
 import {
-	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
 	formatDuration,
-	formatFeedModelBadge,
 	formatStatusIcon,
 	formatTitle,
-	isFeedModelBadgeEnabled,
 	previewWindowRows,
 	replaceTabs,
 	shortenPath,
@@ -141,7 +138,7 @@ function agentEventStatus(value: unknown): AgentEventStatus {
 	}
 }
 
-/** Append the toolCount · context · cost stat run, mirroring the task tool. */
+/** Append the toolCount · context · cost · model stat run, mirroring the task tool. */
 function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	let line = "";
 	const toolCount = eventNumber(event.toolCount);
@@ -161,6 +158,10 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
 	if (cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${cost.toFixed(2)}`)}`;
 	}
+	const model = eventString(event.model);
+	if (model && settings.get("task.showResolvedModelBadge")) {
+		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(model), 30))}`;
+	}
 	return line;
 }
 
@@ -169,12 +170,7 @@ function formatAgentStats(event: EvalStatusEvent, theme: Theme): string {
  * subagent: a status line (icon · id · stats) plus, while running, the current
  * tool/intent. Drawn below the cell box so progress streams live.
  */
-function renderAgentProgressEvents(
-	events: EvalStatusEvent[],
-	theme: Theme,
-	width: number,
-	spinnerFrame?: number,
-): string[] {
+function renderAgentProgressEvents(events: EvalStatusEvent[], theme: Theme, spinnerFrame?: number): string[] {
 	const lines: string[] = [];
 	for (let i = 0; i < events.length; i++) {
 		const event = events[i];
@@ -200,30 +196,12 @@ function renderAgentProgressEvents(
 				? theme.styledSymbol("tool.eval", "accent")
 				: theme.fg(iconColor, formatStatusIcon(iconStatus, theme, status === "running" ? spinnerFrame : undefined));
 
-		const lead = `${prefix} ${icon} `;
-		const statusSuffix =
-			status === "failed" || status === "aborted" ? ` ${formatBadge(status, iconColor, theme)}` : "";
-		const id = truncateToWidth(
-			sanitizeText(eventString(event.id) ?? "agent").replace(/\s+/g, " "),
-			Math.max(0, width - visibleWidth(lead) - visibleWidth(statusSuffix)),
-		);
-		const model = eventString(event.resolvedModelIdentity ?? event.model ?? event.resolvedModel);
-		const thinkingLevel = parseConfiguredThinkingLevel(eventString(event.resolvedThinkingLevel));
-		const modelPrefix =
-			model && isFeedModelBadgeEnabled()
-				? formatFeedModelBadge(
-						model,
-						thinkingLevel,
-						event.advisor === true,
-						theme,
-						Math.min(
-							FEED_MODEL_BADGE_WIDTH,
-							width - visibleWidth(lead) - visibleWidth(id) - visibleWidth(statusSuffix) - 1,
-						),
-					)
-				: "";
-		const modelLead = modelPrefix ? `${modelPrefix} ` : "";
-		let line = `${lead}${modelLead}${theme.fg("accent", theme.bold(id))}${statusSuffix}`;
+		const id = eventString(event.id) ?? "agent";
+		let line = `${prefix} ${icon} ${theme.fg("accent", theme.bold(id))}`;
+
+		if (status === "failed" || status === "aborted") {
+			line += ` ${formatBadge(status, iconColor, theme)}`;
+		}
 
 		const currentTool = eventString(event.currentTool);
 		const lastIntent = eventString(event.lastIntent);
@@ -237,22 +215,16 @@ function renderAgentProgressEvents(
 			const durationMs = eventNumber(event.durationMs);
 			if (durationMs > 0) line += `${theme.sep.dot}${theme.fg("dim", formatDuration(durationMs))}`;
 		}
-		// Do not let optional stats replace the end of the reserved failure status with an ellipsis.
-		lines.push(truncateToWidth(line, width, ""));
+		lines.push(line);
 
 		if (status === "running") {
 			if (currentTool) {
 				let toolLine = `${cont}${theme.tree.hook} ${theme.fg("muted", currentTool)}`;
 				const detail = lastIntent ?? eventString(event.currentToolArgs);
 				if (detail) toolLine += `: ${theme.fg("dim", truncateToWidth(replaceTabs(detail), 48))}`;
-				lines.push(truncateToWidth(toolLine, width));
+				lines.push(toolLine);
 			} else if (lastIntent) {
-				lines.push(
-					truncateToWidth(
-						`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`,
-						width,
-					),
-				);
+				lines.push(`${cont}${theme.tree.hook} ${theme.fg("dim", truncateToWidth(replaceTabs(lastIntent), 48))}`);
 			}
 		}
 	}
@@ -617,7 +589,7 @@ export const evalToolRenderer = {
 				? uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme))
 				: undefined;
 		let warningLine: string | undefined;
-		if (details?.meta?.truncation) {
+		if (details?.meta?.truncation || details?.meta?.artifactError) {
 			warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;
 		}
 		const noticeLine = details?.notice ? uiTheme.fg("dim", wrapBrackets(details.notice, uiTheme)) : undefined;
@@ -691,7 +663,7 @@ export const evalToolRenderer = {
 						);
 						lines.push(...cellLines);
 						if (agentEvents.length > 0) {
-							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, width, options.spinnerFrame));
+							lines.push(...renderAgentProgressEvents(agentEvents, uiTheme, options.spinnerFrame));
 						}
 						if (i < cellResults.length - 1) {
 							lines.push("");

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -28,7 +28,7 @@ import { truncateForPrompt } from "./approval";
 import { type EvalBackendsAllowance, resolveEvalBackends } from "./eval-backends";
 import { generateCodeModeDeclarations } from "./eval-format/code-mode-declarations";
 import { upsertStatusEvent } from "./eval-render";
-import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "./output-meta";
+import { formatOutputNotice, resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "./output-meta";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -492,7 +492,9 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 						void reportProgress(text, { async: { state: "running", jobId, type: "eval" } });
 						if (forwardUpdates) emitToolUpdate?.(text, details);
 					});
-					const finalText = result.content.find(block => block.type === "text")?.text ?? "";
+					const finalText =
+						(result.content.find(block => block.type === "text")?.text ?? "") +
+						formatOutputNotice(result.details?.meta);
 					latestText = finalText;
 					latestDetails = result.details;
 					// Hand the full result (images included) to the foreground waiter
@@ -946,6 +948,7 @@ async function summarizeFinal(
 		outputLines,
 		outputBytes,
 		artifactId: rawSummary.artifactId,
+		artifactError: rawSummary.artifactError,
 		columnDroppedBytes: rawSummary.columnDroppedBytes,
 		columnTruncatedLines: rawSummary.columnTruncatedLines,
 		columnMax: rawSummary.columnMax,

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -6,13 +6,14 @@
 
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import type { AsyncJob, AsyncJobManager, AsyncJobType } from "../../async";
+import { Text } from "@oh-my-pi/pi-tui";
+import type { AsyncJob, AsyncJobDetails, AsyncJobManager, AsyncJobType } from "../../async";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
 import { renderStructuredJson } from "../../session/async-job-delivery";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
+import { formatArtifactErrorNotice } from "../output-meta";
 import type { StructuredSubagentOutput } from "../../task/types";
 import { parseConfiguredThinkingLevel } from "../../thinking";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
@@ -154,7 +155,7 @@ interface TrackedJobLike {
 	status: string;
 	label: string;
 	startTime: number;
-	latestDetails?: Record<string, unknown>;
+	latestDetails?: AsyncJobDetails;
 	resultText?: string;
 	errorText?: string;
 	structured?: StructuredSubagentOutput;
@@ -212,6 +213,9 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			...(advisor ? { advisor: true } : {}),
 			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
 			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
+			...(!resultConsumed && latest.latestDetails?.meta?.artifactError
+				? { artifactError: latest.latestDetails.meta.artifactError }
+				: {}),
 			...(!resultConsumed && latest.structured
 				? { structured: latest.structured, agentUrlId: current?.agentId ?? latest.id }
 				: {}),
@@ -236,6 +240,7 @@ export function buildJobResult(
 	});
 	const jobResults = snapshotJobs(session, uniqueJobs);
 	const alreadyConsumed = new Set(jobResults.filter(job => manager.isJobResultConsumed(job.id)).map(job => job.id));
+	const artifactError = jobResults.find(job => job.artifactError)?.artifactError;
 
 	manager.consumeJobResults(jobResults.filter(j => j.status !== "running").map(j => j.id));
 
@@ -308,6 +313,7 @@ export function buildJobResult(
 
 	const details: CoordinationDetails = {
 		op,
+		...(artifactError ? { meta: { artifactError } } : {}),
 		jobs: jobResults,
 		...(cancelOutcomes.length ? { cancelled: cancelOutcomes.map(({ id, status }) => ({ id, status })) } : {}),
 		...(agents.length ? { agents } : {}),
@@ -742,7 +748,11 @@ export function jobsRenderResult(
 							);
 						}
 
-						const preview = flattenStructuredPreview(
+						if (job.artifactError) {
+			lines.push(uiTheme.fg("warning", truncateToWidth(formatArtifactErrorNotice(job.artifactError), width)));
+		}
+
+		const preview = flattenStructuredPreview(
 							stripTaskResultEnvelope(job.errorText?.trim() || job.resultText?.trim() || ""),
 						);
 						if (preview) {

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -17,7 +17,7 @@ import type { StructuredSubagentOutput } from "../../task/types";
 import { parseConfiguredThinkingLevel } from "../../thinking";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import type { ToolSession } from "..";
-import { formatArtifactErrorNotice } from "../output-meta";
+import { formatArtifactErrorNotice, stripOutputNotice } from "../output-meta";
 import {
 	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
@@ -213,9 +213,7 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			...(advisor ? { advisor: true } : {}),
 			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
 			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
-			...(!resultConsumed && latest.latestDetails?.meta?.artifactError
-				? { artifactError: latest.latestDetails.meta.artifactError }
-				: {}),
+			...(!resultConsumed && latest.latestDetails?.meta ? { meta: latest.latestDetails.meta } : {}),
 			...(!resultConsumed && latest.structured
 				? { structured: latest.structured, agentUrlId: current?.agentId ?? latest.id }
 				: {}),
@@ -240,7 +238,6 @@ export function buildJobResult(
 	});
 	const jobResults = snapshotJobs(session, uniqueJobs);
 	const alreadyConsumed = new Set(jobResults.filter(job => manager.isJobResultConsumed(job.id)).map(job => job.id));
-	const artifactError = jobResults.find(job => job.artifactError)?.artifactError;
 
 	manager.consumeJobResults(jobResults.filter(j => j.status !== "running").map(j => j.id));
 
@@ -313,7 +310,8 @@ export function buildJobResult(
 
 	const details: CoordinationDetails = {
 		op,
-		...(artifactError ? { meta: { artifactError } } : {}),
+		// The report is complete even when an individual job's raw capture failed.
+		meta: { source: { type: "report", value: "background jobs snapshot" } },
 		jobs: jobResults,
 		...(cancelOutcomes.length ? { cancelled: cancelOutcomes.map(({ id, status }) => ({ id, status })) } : {}),
 		...(agents.length ? { agents } : {}),
@@ -642,6 +640,16 @@ export function jobsRenderResult(
 		uiTheme,
 	);
 
+	const outputMeta = result.details?.meta;
+	// Historical snapshots promoted a job failure to the root. Render it there
+	// only when no row identifies that failure; new report capture errors are distinct.
+	const aggregateArtifactError =
+		outputMeta?.artifactError &&
+		(outputMeta.source?.type === "report" ||
+			!jobs.some(job => (job.meta?.artifactError ?? job.artifactError) === outputMeta.artifactError))
+			? outputMeta.artifactError
+			: undefined;
+
 	// Sort: running first (so user sees what's still pending), then failed, then completed/cancelled.
 	const statusOrder: Record<JobSnapshot["status"], number> = {
 		running: 0,
@@ -747,14 +755,23 @@ export function jobsRenderResult(
 								`  ${uiTheme.fg("toolOutput", truncateToWidth(visibleLabelLines[i]!, continuationWidth))}`,
 							);
 						}
-						if (job.artifactError) {
+						const artifactError = job.meta?.artifactError ?? job.artifactError;
+						if (artifactError) {
 							lines.push(
-								uiTheme.fg("warning", truncateToWidth(formatArtifactErrorNotice(job.artifactError), rowWidth)),
+								uiTheme.fg("warning", truncateToWidth(formatArtifactErrorNotice(artifactError), rowWidth)),
 							);
 						}
 
+						// Legacy rows did not retain full metadata. Strip the known warning
+						// footer so the dedicated row/root warning remains the only copy.
+						const previewError =
+							artifactError ?? (outputMeta?.source?.type !== "report" ? outputMeta?.artifactError : undefined);
+						const previewMeta = job.meta ?? (previewError ? { artifactError: previewError } : undefined);
+
 						const preview = flattenStructuredPreview(
-							stripTaskResultEnvelope(job.errorText?.trim() || job.resultText?.trim() || ""),
+							stripTaskResultEnvelope(
+								stripOutputNotice(job.errorText?.trim() || job.resultText?.trim() || "", previewMeta).trim(),
+							),
 						);
 						if (preview) {
 							const maxLines = expanded ? PREVIEW_LINES_EXPANDED : PREVIEW_LINES_COLLAPSED;
@@ -816,7 +833,12 @@ export function jobsRenderResult(
 							uiTheme,
 						);
 
-			const all = [header, ...itemLines, ...agentLines].map(l => truncateToWidth(l, width, Ellipsis.Unicode));
+			const all = [header];
+			if (aggregateArtifactError) {
+				all.push(uiTheme.fg("warning", formatArtifactErrorNotice(aggregateArtifactError)));
+			}
+			all.push(...itemLines, ...agentLines);
+			for (let i = 0; i < all.length; i++) all[i] = truncateToWidth(all[i]!, width, Ellipsis.Unicode);
 			cached = { key, lines: all };
 			return all;
 		},

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -6,18 +6,18 @@
 
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { Text } from "@oh-my-pi/pi-tui";
+import { Text, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { AsyncJob, AsyncJobDetails, AsyncJobManager, AsyncJobType } from "../../async";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
 import { renderStructuredJson } from "../../session/async-job-delivery";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
-import { formatArtifactErrorNotice } from "../output-meta";
 import type { StructuredSubagentOutput } from "../../task/types";
 import { parseConfiguredThinkingLevel } from "../../thinking";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import type { ToolSession } from "..";
+import { formatArtifactErrorNotice } from "../output-meta";
 import {
 	FEED_MODEL_BADGE_WIDTH,
 	formatBadge,
@@ -747,12 +747,13 @@ export function jobsRenderResult(
 								`  ${uiTheme.fg("toolOutput", truncateToWidth(visibleLabelLines[i]!, continuationWidth))}`,
 							);
 						}
-
 						if (job.artifactError) {
-			lines.push(uiTheme.fg("warning", truncateToWidth(formatArtifactErrorNotice(job.artifactError), width)));
-		}
+							lines.push(
+								uiTheme.fg("warning", truncateToWidth(formatArtifactErrorNotice(job.artifactError), rowWidth)),
+							);
+						}
 
-		const preview = flattenStructuredPreview(
+						const preview = flattenStructuredPreview(
 							stripTaskResultEnvelope(job.errorText?.trim() || job.resultText?.trim() || ""),
 						);
 						if (preview) {

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -10,6 +10,7 @@ import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
 import type { OutputArtifactError } from "../../session/streaming-output";
 import type { OutputMeta } from "../output-meta";
 import type { StructuredSubagentOutput } from "../../task/types";
+import type { ConfiguredThinkingLevel } from "../../thinking";
 import type { LaunchParams, LaunchToolDetails } from "./launch";
 
 /**
@@ -67,6 +68,12 @@ export interface JobSnapshot {
 	durationMs: number;
 	/** Effective task model selector, including an explicit reasoning suffix when configured. */
 	resolvedModel?: string;
+	/** Provider/id including routing, with no added thinking suffix. */
+	resolvedModelIdentity?: string;
+	/** Explicit thinking metadata, independent of the model identity. */
+	resolvedThinkingLevel?: ConfiguredThinkingLevel;
+	/** True when the task progress reports an attached live advisor. */
+	advisor?: boolean;
 	resultText?: string;
 	errorText?: string;
 	artifactError?: OutputArtifactError;

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -7,8 +7,9 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AsyncJobType } from "../../async";
 import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
+import type { OutputArtifactError } from "../../session/streaming-output";
+import type { OutputMeta } from "../output-meta";
 import type { StructuredSubagentOutput } from "../../task/types";
-import type { ConfiguredThinkingLevel } from "../../thinking";
 import type { LaunchParams, LaunchToolDetails } from "./launch";
 
 /**
@@ -66,14 +67,9 @@ export interface JobSnapshot {
 	durationMs: number;
 	/** Effective task model selector, including an explicit reasoning suffix when configured. */
 	resolvedModel?: string;
-	/** Provider/id including routing, with no added thinking suffix. */
-	resolvedModelIdentity?: string;
-	/** Explicit thinking metadata, independent of the model identity. */
-	resolvedThinkingLevel?: ConfiguredThinkingLevel;
-	/** True when the task progress reports an attached live advisor. */
-	advisor?: boolean;
 	resultText?: string;
 	errorText?: string;
+	artifactError?: OutputArtifactError;
 	structured?: StructuredSubagentOutput;
 	/**
 	 * `agent://<id>` handle backing this job's artifacts — the job-row's
@@ -115,6 +111,7 @@ export interface AgentActivitySnapshot {
 
 /** Result details for messaging and job ops; fields are disjoint per op. */
 export interface CoordinationDetails {
+	meta?: OutputMeta;
 	op: HubOp;
 	from?: string;
 	to?: string;

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -7,7 +7,6 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AsyncJobType } from "../../async";
 import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
-import type { OutputArtifactError } from "../../session/streaming-output";
 import type { OutputMeta } from "../output-meta";
 import type { StructuredSubagentOutput } from "../../task/types";
 import type { ConfiguredThinkingLevel } from "../../thinking";
@@ -76,7 +75,10 @@ export interface JobSnapshot {
 	advisor?: boolean;
 	resultText?: string;
 	errorText?: string;
-	artifactError?: OutputArtifactError;
+	/** Source-output metadata retained for per-job warnings and persisted row rendering. */
+	meta?: OutputMeta;
+	/** Capture error in historical snapshots; new snapshots store source metadata in `meta`. */
+	artifactError?: OutputMeta["artifactError"];
 	structured?: StructuredSubagentOutput;
 	/**
 	 * `agent://<id>` handle backing this job's artifacts — the job-row's

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -64,7 +64,9 @@ export interface TruncationMeta {
 export type SourceMeta =
 	| { type: "path"; value: string }
 	| { type: "url"; value: string }
-	| { type: "internal"; value: string };
+	| { type: "internal"; value: string }
+	/** A complete aggregate report, whose entries may contain incomplete source captures. */
+	| { type: "report"; value: string };
 
 /**
  * LSP diagnostic info (for edit/write tools).
@@ -89,7 +91,7 @@ export interface LimitsMeta {
  */
 export interface OutputMeta {
 	truncation?: TruncationMeta;
-	/** Artifact capture failed independently of command execution or inline truncation. */
+	/** Capture failure of this output itself; aggregate reports keep source failures on their entries. */
 	artifactError?: OutputArtifactError;
 	source?: SourceMeta;
 	diagnostics?: DiagnosticMeta;
@@ -492,8 +494,14 @@ export function stripGeneratedOutputNotice(text: string): string {
 	return trimmed.slice(0, lineStart === -1 ? 0 : lineStart).trimEnd();
 }
 
-export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
+export function formatTruncationMetaNotice(truncation: TruncationMeta, source?: SourceMeta): string {
 	let notice: string;
+	const artifactReference =
+		truncation.artifactId == null
+			? undefined
+			: source?.type === "report"
+				? `Read artifact://${truncation.artifactId} for full report (${source.value})`
+				: formatFullOutputReference(truncation.artifactId);
 
 	if (truncation.direction === "middle") {
 		const head = truncation.headRange;
@@ -513,8 +521,8 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 		if (truncation.nextOffset != null) {
 			notice += `. Use :${truncation.nextOffset} to continue`;
 		}
-		if (truncation.artifactId != null) {
-			notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
+		if (artifactReference) {
+			notice += `. ${artifactReference}`;
 		}
 		return notice;
 	}
@@ -522,8 +530,8 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 	if (truncation.partialLine) {
 		const line = truncation.shownRange?.start ?? 1;
 		notice = `Showing line ${line} (partial, ${formatBytes(truncation.outputBytes)} of ${formatBytes(truncation.totalBytes)}) of ${truncation.totalLines}`;
-		if (truncation.artifactId != null) {
-			notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
+		if (artifactReference) {
+			notice += `. ${artifactReference}`;
 		}
 		return notice;
 	}
@@ -544,8 +552,8 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 		notice += `. Use :${truncation.nextOffset} to continue`;
 	}
 
-	if (truncation.artifactId != null) {
-		notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
+	if (artifactReference) {
+		notice += `. ${artifactReference}`;
 	}
 
 	return notice;
@@ -574,7 +582,7 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 
 	// Truncation notice
 	if (meta.truncation) {
-		parts.push(formatTruncationMetaNotice(meta.truncation));
+		parts.push(formatTruncationMetaNotice(meta.truncation, meta.source));
 	}
 	if (meta.artifactError) {
 		parts.push(formatArtifactErrorNotice(meta.artifactError));
@@ -615,7 +623,7 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 export function formatStyledTruncationWarning(meta: OutputMeta | undefined, theme: Theme): string | null {
 	if (!meta?.truncation && !meta?.artifactError) return null;
 	const parts: string[] = [];
-	if (meta.truncation) parts.push(formatTruncationMetaNotice(meta.truncation));
+	if (meta.truncation) parts.push(formatTruncationMetaNotice(meta.truncation, meta.source));
 	if (meta.artifactError) parts.push(formatArtifactErrorNotice(meta.artifactError));
 	return theme.fg("warning", wrapBrackets(parts.join(". "), theme));
 }

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -16,7 +16,13 @@ import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import { getDefault, type Settings } from "../config/settings";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
 import type { Theme } from "../modes/theme/theme";
-import { type OutputSummary, type TruncationResult, truncateMiddle, truncateTail } from "../session/streaming-output";
+import {
+	type OutputArtifactError,
+	type OutputSummary,
+	type TruncationResult,
+	truncateMiddle,
+	truncateTail,
+} from "../session/streaming-output";
 import { formatBytes, wrapBrackets } from "./render-utils";
 import { renderError } from "./tool-errors";
 
@@ -83,6 +89,8 @@ export interface LimitsMeta {
  */
 export interface OutputMeta {
 	truncation?: TruncationMeta;
+	/** Artifact capture failed independently of command execution or inline truncation. */
+	artifactError?: OutputArtifactError;
 	source?: SourceMeta;
 	diagnostics?: DiagnosticMeta;
 	limits?: LimitsMeta;
@@ -229,8 +237,9 @@ export class OutputMetaBuilder {
 		return this;
 	}
 
-	/** Add truncation info from OutputSummary. No-op if not truncated. */
+	/** Add truncation, column limits, and capture failures from OutputSummary. */
 	truncationFromSummary(summary: OutputSummary, options: TruncationSummaryOptions): this {
+		if (summary.artifactError) this.#meta.artifactError = summary.artifactError;
 		// A per-line column cap only trims individual lines (with a `…` marker);
 		// it is not a window/byte truncation, so surface it as its own limit
 		// notice rather than a "Showing lines X-Y … limit" range. This runs even
@@ -242,6 +251,7 @@ export class OutputMetaBuilder {
 
 		const { direction, startLine = 1, totalFileLines } = options;
 		const totalLines = totalFileLines ?? summary.totalLines;
+		const artifactId = summary.artifactError ? undefined : summary.artifactId;
 
 		// Middle elision: the sink retained head + tail with an elision marker.
 		if (summary.elidedBytes != null && summary.elidedBytes > 0) {
@@ -260,7 +270,7 @@ export class OutputMetaBuilder {
 				tailRange: tailLines > 0 ? { start: totalLines - tailLines + 1, end: totalLines } : undefined,
 				elidedBytes: summary.elidedBytes,
 				elidedLines,
-				artifactId: summary.artifactId,
+				artifactId,
 			};
 			return this;
 		}
@@ -291,7 +301,7 @@ export class OutputMetaBuilder {
 			outputLines: summary.outputLines,
 			outputBytes: summary.outputBytes,
 			shownRange: { start: shownStart, end: shownEnd },
-			artifactId: summary.artifactId,
+			artifactId,
 			nextOffset: direction === "head" ? shownEnd + 1 : undefined,
 		};
 
@@ -549,6 +559,10 @@ export function formatStyledArtifactReference(artifactId: string, theme: Theme):
 	return theme.fg("warning", formatFullOutputReference(artifactId));
 }
 
+export function formatArtifactErrorNotice(error: OutputArtifactError): string {
+	return `Full output was not saved completely (artifact ${error} failed)`;
+}
+
 /**
  * Format notices from OutputMeta for LLM consumption.
  * Returns empty string if no notices needed.
@@ -561,6 +575,9 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 	// Truncation notice
 	if (meta.truncation) {
 		parts.push(formatTruncationMetaNotice(meta.truncation));
+	}
+	if (meta.artifactError) {
+		parts.push(formatArtifactErrorNotice(meta.artifactError));
 	}
 
 	// Limit notices
@@ -592,13 +609,15 @@ export function formatOutputNotice(meta: OutputMeta | undefined): string {
 }
 
 /**
- * Format a styled truncation warning message.
- * Returns null if no truncation metadata present.
+ * Format styled truncation and artifact capture warnings.
+ * Returns null if neither warning is present.
  */
 export function formatStyledTruncationWarning(meta: OutputMeta | undefined, theme: Theme): string | null {
-	if (!meta?.truncation) return null;
-	const message = formatTruncationMetaNotice(meta.truncation);
-	return theme.fg("warning", wrapBrackets(message, theme));
+	if (!meta?.truncation && !meta?.artifactError) return null;
+	const parts: string[] = [];
+	if (meta.truncation) parts.push(formatTruncationMetaNotice(meta.truncation));
+	if (meta.artifactError) parts.push(formatArtifactErrorNotice(meta.artifactError));
+	return theme.fg("warning", wrapBrackets(parts.join(". "), theme));
 }
 
 /**
@@ -766,13 +785,17 @@ async function spillLargeResultToArtifact(
 	// `enforceInlineByteCap`: always truncate past the threshold, and only
 	// attach the `artifact://` recovery link when the save actually succeeded.
 	let artifactId: string | undefined;
-	try {
-		artifactId = await sessionManager.saveArtifact(fullText, toolName);
-	} catch (error) {
-		logger.warn("Failed to spill large tool result to artifact", {
-			tool: toolName,
-			error: error instanceof Error ? error.message : String(error),
-		});
+	// A failed stream capture only left a preview here. Saving that preview
+	// would invent a misleading full-output recovery link, not recover the log.
+	if (!existingMeta?.artifactError) {
+		try {
+			artifactId = await sessionManager.saveArtifact(fullText, toolName);
+		} catch (error) {
+			logger.warn("Failed to spill large tool result to artifact", {
+				tool: toolName,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	// Truncate: middle elision when a head budget is configured, otherwise tail-only.

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -15,6 +15,8 @@ import type { AsyncJob } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+import { buildAsyncResultBlock } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import {
 	buildAsyncResultBatchMessage,
@@ -118,6 +120,71 @@ describe("AgentSession owner-routed async delivery", () => {
 			),
 		);
 		expect(deliveredImages).toEqual([image]);
+	});
+
+	it("does not spill an incomplete background capture as full output during follow-up delivery", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({});
+		const sessionManager = SessionManager.inMemory();
+		const allocate = vi.spyOn(sessionManager, "allocateArtifactPath");
+		AsyncJobManager.setInstance(manager);
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "CaptureOwner",
+			asyncJobManager: manager,
+		});
+		try {
+			manager.register(
+				"bash",
+				"failed capture",
+				async ({ reportProgress }) => {
+					const text = "preview-only ".repeat(2000);
+					await reportProgress(text, { meta: { artifactError: "write" } });
+					return text;
+				},
+				{ id: "capture-job", ownerId: "CaptureOwner" },
+			);
+			await session.settleAsyncWork();
+			const delivered = mock.calls
+				.flatMap(call => call.context.messages)
+				.map(message =>
+					typeof message.content === "string"
+						? message.content
+						: message.content.map(block => (block.type === "text" ? block.text : "")).join("\n"),
+				)
+				.find(text => text.includes("preview-only"));
+			expect(delivered).toContain("not saved completely");
+			expect(delivered).not.toContain("Full output: artifact://");
+			expect(allocate).not.toHaveBeenCalled();
+			const custom = agent.state.messages.find(
+				message => message.role === "custom" && message.customType === "async-result",
+			);
+			if (!custom || custom.role !== "custom") throw new Error("Expected async delivery message");
+			await initTheme(false, undefined, undefined, "dark", "light");
+			const persisted = JSON.parse(JSON.stringify(custom)) as typeof custom;
+			for (const message of [custom, persisted]) {
+				const rendered = buildAsyncResultBlock(message)
+					.render(100)
+					.map(line => Bun.stripANSI(line))
+					.join("\n");
+				expect(rendered).toContain("not saved completely");
+			}
+		} finally {
+			allocate.mockRestore();
+		}
 	});
 
 	it("carries a schema-valid background task's structured output as a pointer only", () => {

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -6,6 +6,7 @@
  * run quiescence the task executor's barrier is built on.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
@@ -18,14 +19,19 @@ import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/lau
 import { buildAsyncResultBlock } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { ArtifactManager } from "@oh-my-pi/pi-coding-agent/session/artifacts";
 import {
 	buildAsyncResultBatchMessage,
 	type AsyncResultEntry,
 } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { convertToLlm, type CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { formatOutputNotice, type OutputMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { TempDir } from "@oh-my-pi/pi-utils";
 function observeAsyncResultEnqueue(session: AgentSession): Promise<void> {
 	const queued = Promise.withResolvers<void>();
 	const enqueue = session.yieldQueue.enqueueWithReceipt.bind(session.yieldQueue);
@@ -151,8 +157,9 @@ describe("AgentSession owner-routed async delivery", () => {
 				"bash",
 				"failed capture",
 				async ({ reportProgress }) => {
-					const text = "preview-only ".repeat(2000);
-					await reportProgress(text, { meta: { artifactError: "write" } });
+					const meta = { artifactError: "write" } as const;
+					const text = "preview-only ".repeat(2000) + formatOutputNotice(meta);
+					await reportProgress(text, { meta });
 					return text;
 				},
 				{ id: "capture-job", ownerId: "CaptureOwner" },
@@ -166,7 +173,7 @@ describe("AgentSession owner-routed async delivery", () => {
 						: message.content.map(block => (block.type === "text" ? block.text : "")).join("\n"),
 				)
 				.find(text => text.includes("preview-only"));
-			expect(delivered).toContain("not saved completely");
+			expect(delivered?.match(/not saved completely/g)).toHaveLength(1);
 			expect(delivered).not.toContain("Full output: artifact://");
 			expect(allocate).not.toHaveBeenCalled();
 			const custom = agent.state.messages.find(
@@ -184,6 +191,131 @@ describe("AgentSession owner-routed async delivery", () => {
 			}
 		} finally {
 			allocate.mockRestore();
+		}
+	});
+
+	it("keeps healthy follow-up output recoverable when another job's capture failed", async () => {
+		await using temp = await TempDir.create("@capture-followup-mixed-");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({});
+		AsyncJobManager.setInstance(manager);
+		const store = SessionManager.inMemory(temp.path());
+		store.adoptArtifactManager(new ArtifactManager(path.join(temp.path(), "artifacts")));
+		const settings = Settings.isolated();
+		session = new AgentSession({
+			agent,
+			sessionManager: store,
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "MixedCaptureOwner",
+			asyncJobManager: manager,
+		});
+		const complete = `${"healthy output\n".repeat(600)}FOLLOWUP-UNIQUE-MIDDLE\n${"healthy tail\n".repeat(600)}`;
+		try {
+			const failedId = manager.register(
+				"bash",
+				"failed capture",
+				async ({ reportProgress }) => {
+					const meta = { artifactError: "write" } as const;
+					const text = "incomplete preview" + formatOutputNotice(meta);
+					await reportProgress(text, { meta });
+					return text;
+				},
+				{ id: "incomplete-followup", ownerId: "MixedCaptureOwner" },
+			);
+			const completeId = manager.register("bash", "complete capture", async () => complete, {
+				id: "complete-followup",
+				ownerId: "MixedCaptureOwner",
+			});
+			await session.settleAsyncWork();
+			const messages = agent.state.messages.filter(
+				(message): message is CustomMessage => message.role === "custom" && message.customType === "async-result",
+			);
+			const text = messages
+				.map(message =>
+					typeof message.content === "string"
+						? message.content
+						: message.content.map(block => (block.type === "text" ? block.text : "")).join("\n"),
+				)
+				.join("\n");
+			expect(text.match(/artifact write failed/g)).toHaveLength(1);
+			expect(text).not.toContain("FOLLOWUP-UNIQUE-MIDDLE");
+			expect(manager.isJobResultConsumed(failedId)).toBe(true);
+			expect(manager.isJobResultConsumed(completeId)).toBe(true);
+			expect(manager.getJob(failedId)?.status).toBe("completed");
+			const artifactUrl = text.match(/artifact:\/\/\d+/)?.[0];
+			if (!artifactUrl) throw new Error("Expected complete job recovery artifact");
+			const readSession: ToolSession = {
+				cwd: temp.path(),
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => null,
+				settings,
+				localProtocolOptions: {
+					getArtifactsDir: () => store.getArtifactsDir(),
+					getSessionId: () => store.getSessionId(),
+				},
+			};
+			const read = await new ReadTool(readSession).execute("recover-followup", {
+				path: `${artifactUrl}:raw:1-1500`,
+			});
+			expect(read.content.map(block => (block.type === "text" ? block.text : "")).join("\n")).toContain(
+				complete.trimEnd(),
+			);
+		} finally {
+			await session.dispose();
+			await store.close();
+		}
+	});
+
+	it("retains every capture warning on its own live and rebuilt async batch row", async () => {
+		const entries = ["open", "write", undefined].map((artifactError, index): AsyncResultEntry => {
+			const meta: OutputMeta | undefined =
+				artifactError === "open" || artifactError === "write" ? { artifactError } : undefined;
+			const jobId = `batch-${index}`;
+			const result = `result-${index}` + formatOutputNotice(meta);
+			return {
+				jobId,
+				result,
+				durationMs: 1000,
+				epoch: 0,
+				job: {
+					id: jobId,
+					type: "bash",
+					label: jobId,
+					status: "completed",
+					startTime: Date.now(),
+					abortController: new AbortController(),
+					promise: Promise.resolve(),
+					resultText: result,
+					latestDetails: { meta },
+				},
+			};
+		});
+		const batch = buildAsyncResultBatchMessage(entries);
+		if (!batch || typeof batch.content !== "string") throw new Error("Expected async batch text");
+		expect(batch.content.match(/artifact open failed/g)).toHaveLength(1);
+		expect(batch.content.match(/artifact write failed/g)).toHaveLength(1);
+		await initTheme(false, undefined, undefined, "dark", "light");
+		const persisted = JSON.parse(JSON.stringify(batch)) as typeof batch;
+		for (const message of [batch, persisted]) {
+			const rendered = buildAsyncResultBlock(message)
+				.render(160)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered).toMatch(/batch-0[^]*artifact open failed[^]*batch-1[^]*artifact write failed[^]*batch-2/);
+			expect(rendered.match(/artifact open failed/g)).toHaveLength(1);
+			expect(rendered.match(/artifact write failed/g)).toHaveLength(1);
 		}
 	});
 

--- a/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
+++ b/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
@@ -2,8 +2,11 @@ import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { OutputSink } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { bashToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/bash";
+import { formatOutputNotice, outputMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { removeWithRetries, sanitizeText } from "@oh-my-pi/pi-utils";
 
 const createdTempDirs: string[] = [];
 
@@ -28,6 +31,18 @@ function spill(sink: OutputSink): void {
 	sink.push(`${"x".repeat(64)}\n`);
 }
 
+/** Substitute only this artifact's writer, retaining real file/descriptor behavior. */
+function instrumentArtifact(artifactPath: string): Bun.FileSink {
+	const file = Bun.file(artifactPath);
+	const writer = file.writer();
+	vi.spyOn(file, "writer").mockReturnValue(writer);
+	const realFile = Bun.file.bind(Bun);
+	vi.spyOn(Bun, "file").mockImplementation((source, options) => {
+		if (source === artifactPath) return file;
+		return realFile(source as string, options);
+	});
+	return writer;
+}
 describe("OutputSink fd lifecycle", () => {
 	test("dispose() releases the spill descriptor on error/abort paths that skip dump()", async () => {
 		const dir = await createTempDir();
@@ -84,37 +99,18 @@ describe("OutputSink fd lifecycle", () => {
 		expect(content).not.toContain("y".repeat(64));
 	});
 
-	test("dispose() closes the descriptor even when the capped tail replay write throws", async () => {
+	test("dispose() preserves cancellation cleanup when capped tail replay fails", async () => {
 		const dir = await createTempDir();
 		const artifactPath = path.join(dir, "capped.txt");
-
-		let ended = false;
-		// Mock FileSink: head bytes ("h") write fine; the tail replay (the
-		// `[ARTIFACT TRUNCATED …]` notice + "t" ring) throws, mirroring a disk
-		// write error while closing a capped artifact. Cast to the sink type — a
-		// full FileSink has methods OutputSink never calls.
-		const fakeSink = {
-			write(chunk: string): number {
-				if (chunk.includes("[ARTIFACT TRUNCATED") || chunk.includes("t")) {
-					throw new Error("simulated disk write failure");
-				}
-				return Buffer.byteLength(chunk, "utf-8");
-			},
-			end(): Promise<number> {
-				ended = true;
-				return Promise.resolve(0);
-			},
-		} as unknown as Bun.FileSink;
-		const fakeFile = { writer: () => fakeSink } as unknown as Bun.BunFile;
-
-		const realFile = Bun.file.bind(Bun);
-		vi.spyOn(Bun, "file").mockImplementation((source, options) => {
-			if (source === artifactPath) return fakeFile;
-			return realFile(source as string, options);
+		const writer = instrumentArtifact(artifactPath);
+		const write = writer.write.bind(writer);
+		vi.spyOn(writer, "write").mockImplementation(chunk => {
+			if (typeof chunk === "string" && chunk.includes("[ARTIFACT TRUNCATED")) {
+				throw new Error("simulated disk write failure");
+			}
+			return write(chunk);
 		});
-
-		// Small on-disk cap so head fills, the rest overflows into the tail ring,
-		// and #flushArtifactTailIfCapped replays a truncation notice on close.
+		const end = vi.spyOn(writer, "end");
 		const sink = new OutputSink({
 			artifactPath,
 			artifactId: "capped",
@@ -124,10 +120,151 @@ describe("OutputSink fd lifecycle", () => {
 		});
 		sink.push("h".repeat(30));
 		sink.push("t".repeat(60));
+		await sink.dispose();
+		await sink.dispose();
+		sink.push("late callback");
 
-		// The tail replay throws, but dispose() must still close the sink and must
-		// not surface the replay error (it would mask the original tool error).
-		await expect(sink.dispose()).resolves.toBeUndefined();
-		expect(ended).toBe(true);
+		const summary = await sink.dump();
+		expect(summary.output).toBe("t".repeat(16));
+		expect(summary.artifactId).toBeUndefined();
+		expect(summary.artifactError).toBe("flush");
+		expect(end).toHaveBeenCalledTimes(1);
+		expect(await Bun.file(artifactPath).text()).toBe("h".repeat(20));
+		expect(formatOutputNotice(outputMeta().truncationFromSummary(summary, { direction: "tail" }).get())).toContain(
+			"not saved completely",
+		);
+	});
+
+	test("an artifact open failure is terminal even when its target becomes writable", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "blocked");
+		await fs.mkdir(artifactPath);
+		const sink = new OutputSink({ artifactPath, artifactId: "incomplete", spillThreshold: 4 });
+		sink.push("lost-before-failure");
+		await fs.rmdir(artifactPath);
+		sink.push("tail");
+		const summary = await sink.dump();
+		const notice = formatOutputNotice(outputMeta().truncationFromSummary(summary, { direction: "tail" }).get());
+
+		expect(summary.output).toBe("tail");
+		expect(summary.artifactError).toBe("open");
+		expect(summary.artifactId).toBeUndefined();
+		expect(notice).toContain("not saved completely");
+		expect(notice).not.toContain("artifact://");
+		expect(await Bun.file(artifactPath).exists()).toBe(false);
+	});
+
+	test("a write failure preserves bounded output and stops subsequent capture writes", async () => {
+		const dir = await createTempDir();
+		const writer = instrumentArtifact(path.join(dir, "write.txt"));
+		const sink = new OutputSink({
+			artifactPath: path.join(dir, "write.txt"),
+			artifactId: "write",
+			spillThreshold: 4,
+		});
+		sink.push("prefix");
+		const write = vi.spyOn(writer, "write").mockImplementation(() => {
+			throw new Error("write failed");
+		});
+		const end = vi.spyOn(writer, "end");
+		sink.push("failed");
+		sink.push("tail");
+		const summary = await sink.dump();
+		await sink.dispose();
+
+		expect(summary.output).toBe("tail");
+		expect(summary.totalBytes).toBe(16);
+		expect(summary.artifactError).toBe("write");
+		expect(summary.artifactId).toBeUndefined();
+		expect(write).toHaveBeenCalledTimes(1);
+		expect(end).toHaveBeenCalledTimes(1);
+		expect(await Bun.file(path.join(dir, "write.txt")).text()).toBe("prefix");
+	});
+
+	test("dump waits for rejected asynchronous writes before reporting recovery availability", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "async.txt");
+		const writer = instrumentArtifact(artifactPath);
+		const pendingWrite = Promise.withResolvers<number>();
+		vi.spyOn(writer, "write").mockReturnValue(pendingWrite.promise);
+		const end = vi.spyOn(writer, "end");
+		const sink = new OutputSink({ artifactPath, artifactId: "async", spillThreshold: 4 });
+		sink.push("prefix");
+		const dumping = sink.dump();
+		pendingWrite.reject(new Error("asynchronous write failed"));
+		const summary = await dumping;
+
+		expect(summary.output).toBe("efix");
+		expect(summary.artifactError).toBe("write");
+		expect(summary.artifactId).toBeUndefined();
+		expect(end).toHaveBeenCalledTimes(1);
+	});
+
+	test("flush failure still closes the writer and is surfaced without a recovery link", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "flush.txt");
+		const writer = instrumentArtifact(artifactPath);
+		vi.spyOn(writer, "flush").mockImplementation(() => {
+			throw new Error("flush failed");
+		});
+		const end = vi.spyOn(writer, "end");
+		const sink = new OutputSink({ artifactPath, artifactId: "flush", spillThreshold: 4 });
+		sink.push("prefix");
+		const summary = await sink.dump();
+		await sink.dispose();
+
+		expect(summary.artifactError).toBe("flush");
+		expect(summary.artifactId).toBeUndefined();
+		expect(end).toHaveBeenCalledTimes(1);
+		expect(formatOutputNotice(outputMeta().truncationFromSummary(summary, { direction: "tail" }).get())).toContain(
+			"not saved completely",
+		);
+	});
+
+	test("concurrent finalization waits for end failure even after output was minimized", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "end.txt");
+		const writer = instrumentArtifact(artifactPath);
+		const close = writer.end.bind(writer);
+		const closing = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const end = vi.spyOn(writer, "end").mockImplementation(async () => {
+			await close();
+			closing.resolve();
+			await release.promise;
+			throw new Error("end failed");
+		});
+		const sink = new OutputSink({ artifactPath, artifactId: "end", spillThreshold: 4 });
+		sink.push("prefix");
+		sink.replace("ok");
+		const disposing = sink.dispose();
+		await closing.promise;
+		const dumping = sink.dump();
+		release.resolve();
+		await disposing;
+		const summary = await dumping;
+		await sink.dispose();
+		const notice = formatOutputNotice(outputMeta().truncationFromSummary(summary, { direction: "tail" }).get());
+
+		expect(summary.output).toBe("ok");
+		expect(summary.truncated).toBe(false);
+		expect(summary.artifactError).toBe("end");
+		expect(summary.artifactId).toBeUndefined();
+		expect(notice).toContain("not saved completely");
+		expect(notice).not.toContain("artifact://");
+		expect(end).toHaveBeenCalledTimes(1);
+		expect(await Bun.file(artifactPath).text()).toBe("prefix");
+		const meta = outputMeta().truncationFromSummary(summary, { direction: "tail" }).get();
+		const uiTheme = await getThemeByName("dark");
+		if (!uiTheme) throw new Error("Expected dark theme");
+		const component = bashToolRenderer.renderResult(
+			{ content: [{ type: "text", text: summary.output + notice }], details: { meta }, isError: false },
+			{ expanded: true, isPartial: false, renderContext: { isFullOutput: true } },
+			uiTheme,
+			{ command: "printf ok" },
+		);
+		const rendered = sanitizeText(component.render(160).join("\n"));
+		expect(rendered).toContain("not saved completely");
+		expect(rendered).not.toContain("artifact://");
 	});
 });

--- a/packages/coding-agent/test/tools/capture-background.test.ts
+++ b/packages/coding-agent/test/tools/capture-background.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as evalIndex from "@oh-my-pi/pi-coding-agent/eval";
+import * as bashExecutor from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
+import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { HubTool } from "@oh-my-pi/pi-coding-agent/tools/hub";
+import { wrapToolWithMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function sessionFor(root: string, manager?: AsyncJobManager): ToolSession {
+	return {
+		cwd: root,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(root, "artifacts"),
+		getSessionId: () => "capture-regression",
+		allocateOutputArtifact: async () => ({ path: root, id: "failed" }),
+		asyncJobManager: manager,
+		settings: Settings.isolated({
+			"async.enabled": true,
+			"bashInterceptor.enabled": false,
+			"bash.autoBackground.enabled": false,
+			"eval.autoBackground.enabled": true,
+			"eval.autoBackground.thresholdMs": 0,
+			"tools.outputMaxColumns": 8,
+		}),
+	};
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("capture failure across background and cancellation boundaries", () => {
+	it("retains the capture warning on a foreground bash abort", async () => {
+		await using temp = await TempDir.create("@capture-abort-");
+		const controller = new AbortController();
+		vi.spyOn(bashExecutor, "executeBash").mockImplementation(async () => {
+			controller.abort();
+			return {
+				output: "partial command output",
+				exitCode: undefined,
+				cancelled: true,
+				timedOut: false,
+				truncated: true,
+				totalBytes: 1000,
+				totalLines: 1,
+				outputBytes: 22,
+				outputLines: 1,
+				artifactError: "open",
+			};
+		});
+		let error: unknown;
+		try {
+			await new BashTool(sessionFor(temp.path())).execute("cancel", { command: "echo example" }, controller.signal);
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toBeInstanceOf(ToolAbortError);
+		if (!(error instanceof Error)) throw new Error("Expected cancellation error");
+		expect(error.message).toContain("partial command output");
+		expect(error.message).toContain("not saved completely");
+		expect(error.message).not.toContain("artifact://");
+	});
+
+	it("delivers capture warnings for successful async bash and keeps recovery snapshots bounded", async () => {
+		await using temp = await TempDir.create("@capture-background-bash-");
+		const deliveries: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (_id, text) => {
+				deliveries.push(text);
+			},
+		});
+		const session = sessionFor(temp.path(), manager);
+		const sessionManager = SessionManager.inMemory(temp.path());
+		try {
+			vi.spyOn(bashExecutor, "executeBash").mockResolvedValue({
+				output: "x".repeat(20_000),
+				exitCode: 0,
+				cancelled: false,
+				timedOut: false,
+				truncated: true,
+				totalBytes: 200_000,
+				totalLines: 1,
+				outputBytes: 20_000,
+				outputLines: 1,
+				artifactError: "write",
+			});
+			const result = await new BashTool(session).execute("background", { command: "echo example", async: true });
+			const jobId = result.details?.async?.jobId;
+			if (!jobId) throw new Error("Expected background job");
+			await manager.getJob(jobId)?.promise;
+			await manager.drainDeliveries();
+			expect(manager.getJob(jobId)?.status).toBe("completed");
+			expect(deliveries[0]).toContain("not saved completely");
+			expect(deliveries[0]).not.toContain("artifact://");
+			const recoveryGate = Promise.withResolvers<bashExecutor.BashResult>();
+			vi.spyOn(bashExecutor, "executeBash").mockReturnValue(recoveryGate.promise);
+			const pending = await new BashTool(session).execute("recover-background", {
+				command: "echo second",
+				async: true,
+			});
+			const recoveryJobId = pending.details?.async?.jobId;
+			if (!recoveryJobId) throw new Error("Expected recoverable background job");
+			manager.acknowledgeDeliveries([recoveryJobId]);
+			recoveryGate.resolve({
+				output: "x".repeat(20_000),
+				exitCode: 0,
+				cancelled: false,
+				truncated: true,
+				totalBytes: 200_000,
+				totalLines: 1,
+				outputBytes: 20_000,
+				outputLines: 1,
+				artifactError: "write",
+			});
+			await manager.getJob(recoveryJobId)?.promise;
+			// Deliberately force hub's final inline cap: a failed raw capture must not
+			// be replaced by a new artifact containing just its remaining preview.
+			session.settings.override("tools.artifactSpillThreshold", 1024);
+			const save = vi.spyOn(sessionManager, "saveArtifact");
+			const snapshot = await wrapToolWithMetaNotice(new HubTool(session)).execute(
+				"snapshot",
+				{ op: "jobs" },
+				undefined,
+				undefined,
+				{ sessionManager, settings: session.settings } as unknown as AgentToolContext,
+			);
+			const text = snapshot.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(text).toContain("not saved completely");
+			expect(text).not.toContain("artifact://");
+			expect(save).not.toHaveBeenCalled();
+		} finally {
+			await manager.dispose();
+			await sessionManager.close();
+		}
+	});
+
+	it("delivers an eval background capture failure without failing the completed cell", async () => {
+		await using temp = await TempDir.create("@capture-background-eval-");
+		const deliveries: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (_id, text) => {
+				deliveries.push(text);
+			},
+		});
+		try {
+			const gate = Promise.withResolvers<void>();
+			vi.spyOn(evalIndex.jsBackend, "execute").mockImplementation(async (_code, options) => {
+				options.onChunk("x".repeat(80));
+				await gate.promise;
+				return {
+					output: "completed cell",
+					exitCode: 0,
+					cancelled: false,
+					truncated: false,
+					totalLines: 1,
+					totalBytes: 80,
+					outputLines: 1,
+					outputBytes: 14,
+					displayOutputs: [],
+					artifactId: undefined,
+				};
+			});
+			const result = await new EvalTool(sessionFor(temp.path(), manager)).execute("eval", {
+				language: "js",
+				code: "display('example')",
+			});
+			const jobId = result.details?.async?.jobId;
+			if (!jobId) throw new Error("Expected background eval");
+			gate.resolve();
+			await manager.getJob(jobId)?.promise;
+			await manager.drainDeliveries();
+			expect(manager.getJob(jobId)?.status).toBe("completed");
+			expect(deliveries[0]).toContain("completed cell");
+			expect(deliveries[0]).toContain("not saved completely");
+			expect(deliveries[0]).not.toContain("artifact://");
+		} finally {
+			await manager.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/tools/capture-background.test.ts
+++ b/packages/coding-agent/test/tools/capture-background.test.ts
@@ -5,12 +5,20 @@ import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as evalIndex from "@oh-my-pi/pi-coding-agent/eval";
 import * as bashExecutor from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { ArtifactManager } from "@oh-my-pi/pi-coding-agent/session/artifacts";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
 import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
-import { HubTool } from "@oh-my-pi/pi-coding-agent/tools/hub";
-import { wrapToolWithMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { HubTool, hubToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/hub";
+import type { CoordinationDetails, JobSnapshot } from "@oh-my-pi/pi-coding-agent/tools/hub/types";
+import {
+	formatOutputNotice,
+	type OutputMeta,
+	wrapToolWithMetaNotice,
+} from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -33,6 +41,37 @@ function sessionFor(root: string, manager?: AsyncJobManager): ToolSession {
 			"tools.outputMaxColumns": 8,
 		}),
 	};
+}
+
+function snapshotSessionFor(root: string, manager: AsyncJobManager, store: SessionManager): ToolSession {
+	store.adoptArtifactManager(new ArtifactManager(path.join(root, "artifacts")));
+	const session = sessionFor(root, manager);
+	session.settings.override("tools.artifactSpillThreshold", 1);
+	session.settings.override("tools.artifactHeadBytes", 1);
+	session.settings.override("tools.artifactTailBytes", 1);
+	session.settings.override("tools.artifactTailLines", 10);
+	session.settings.override("tools.outputMaxColumns", 0);
+	session.localProtocolOptions = {
+		getArtifactsDir: () => store.getArtifactsDir(),
+		getSessionId: () => store.getSessionId(),
+	};
+	return session;
+}
+
+function registerResult(manager: AsyncJobManager, id: string, text: string, meta?: OutputMeta, failed = false): string {
+	const jobId = manager.register(
+		"bash",
+		id,
+		async ({ reportProgress }) => {
+			const result = text + formatOutputNotice(meta);
+			await reportProgress(result, { meta });
+			if (failed) throw new Error(result);
+			return result;
+		},
+		{ id },
+	);
+	manager.acknowledgeDeliveries([jobId]);
+	return jobId;
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -69,7 +108,7 @@ describe("capture failure across background and cancellation boundaries", () => 
 		expect(error.message).not.toContain("artifact://");
 	});
 
-	it("delivers capture warnings for successful async bash and keeps recovery snapshots bounded", async () => {
+	it("delivers capture warnings for successful async bash without changing its outcome", async () => {
 		await using temp = await TempDir.create("@capture-background-bash-");
 		const deliveries: string[] = [];
 		const manager = new AsyncJobManager({
@@ -100,45 +139,216 @@ describe("capture failure across background and cancellation boundaries", () => 
 			expect(manager.getJob(jobId)?.status).toBe("completed");
 			expect(deliveries[0]).toContain("not saved completely");
 			expect(deliveries[0]).not.toContain("artifact://");
-			const recoveryGate = Promise.withResolvers<bashExecutor.BashResult>();
-			vi.spyOn(bashExecutor, "executeBash").mockReturnValue(recoveryGate.promise);
-			const pending = await new BashTool(session).execute("recover-background", {
-				command: "echo second",
-				async: true,
-			});
-			const recoveryJobId = pending.details?.async?.jobId;
-			if (!recoveryJobId) throw new Error("Expected recoverable background job");
-			manager.acknowledgeDeliveries([recoveryJobId]);
-			recoveryGate.resolve({
-				output: "x".repeat(20_000),
-				exitCode: 0,
-				cancelled: false,
-				truncated: true,
-				totalBytes: 200_000,
-				totalLines: 1,
-				outputBytes: 20_000,
-				outputLines: 1,
-				artifactError: "write",
-			});
-			await manager.getJob(recoveryJobId)?.promise;
-			// Deliberately force hub's final inline cap: a failed raw capture must not
-			// be replaced by a new artifact containing just its remaining preview.
-			session.settings.override("tools.artifactSpillThreshold", 1024);
-			const save = vi.spyOn(sessionManager, "saveArtifact");
-			const snapshot = await wrapToolWithMetaNotice(new HubTool(session)).execute(
-				"snapshot",
-				{ op: "jobs" },
-				undefined,
-				undefined,
-				{ sessionManager, settings: session.settings } as unknown as AgentToolContext,
-			);
-			const text = snapshot.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
-			expect(text).toContain("not saved completely");
-			expect(text).not.toContain("artifact://");
-			expect(save).not.toHaveBeenCalled();
 		} finally {
 			await manager.dispose();
 			await sessionManager.close();
+		}
+	});
+
+	it("keeps a mixed snapshot's complete job result recoverable after both results are consumed", async () => {
+		await using temp = await TempDir.create("@capture-mixed-snapshot-");
+		const deliveries: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: (_id, text) => {
+				deliveries.push(text);
+			},
+		});
+		const store = SessionManager.inMemory(temp.path());
+		const session = snapshotSessionFor(temp.path(), manager, store);
+		const context = { sessionManager: store, settings: session.settings } as unknown as AgentToolContext;
+		const tool = wrapToolWithMetaNotice(new HubTool(session));
+		const reader = wrapToolWithMetaNotice(new ReadTool(session));
+		const marker = "COMPLETE-JOB-UNIQUE-MIDDLE-MARKER";
+		const complete = `${"healthy head line\n".repeat(300)}${marker}\n${"healthy tail line\n".repeat(300)}`;
+		const failedCaptureId = registerResult(manager, "failed-capture", "surviving preview", {
+			artifactError: "write",
+		});
+		const completeId = registerResult(manager, "complete-capture", complete);
+		try {
+			await Promise.all([manager.getJob(failedCaptureId)!.promise, manager.getJob(completeId)!.promise]);
+			const snapshot = await tool.execute("mixed", { op: "jobs" }, undefined, undefined, context);
+			const text = snapshot.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(text).not.toContain(marker);
+			expect(text).toMatch(/artifact:\/\/\d+ for full report/);
+			expect(text).not.toMatch(/artifact:\/\/\d+ for full output/);
+			expect(text.match(/not saved completely/g)).toHaveLength(1);
+			expect(manager.isJobResultConsumed(failedCaptureId)).toBe(true);
+			expect(manager.isJobResultConsumed(completeId)).toBe(true);
+			expect(manager.getJob(failedCaptureId)?.status).toBe("completed");
+			await manager.drainDeliveries();
+			expect(deliveries).toEqual([]);
+
+			const artifactUrl = text.match(/artifact:\/\/\d+/)?.[0];
+			if (!artifactUrl) throw new Error("Expected recoverable snapshot report");
+			const read = await reader.execute(
+				"recover",
+				{ path: `${artifactUrl}:raw:1-1000` },
+				undefined,
+				undefined,
+				context,
+			);
+			const recovered = read.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(recovered).toContain(complete);
+			expect(recovered).toContain("surviving preview");
+			expect(recovered.match(/not saved completely/g)).toHaveLength(1);
+
+			const next = await tool.execute("consumed", { op: "jobs" }, undefined, undefined, context);
+			const nextText = next.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(nextText).toContain("already delivered or recovered");
+			expect(nextText).not.toContain("surviving preview");
+			expect(nextText).not.toContain(marker);
+			const reread = await reader.execute("recover-again", { path: `${artifactUrl}:raw:1-1000` });
+			expect(reread.content.map(block => (block.type === "text" ? block.text : "")).join("\n")).toContain(complete);
+		} finally {
+			await manager.dispose();
+			await store.close();
+		}
+	});
+
+	it("shows each short job capture warning once in model text and live or rebuilt Hub rows", async () => {
+		await using temp = await TempDir.create("@capture-short-snapshot-");
+		const manager = new AsyncJobManager({});
+		const store = SessionManager.inMemory(temp.path());
+		const session = snapshotSessionFor(temp.path(), manager, store);
+		const successful = registerResult(manager, "successful-command", "success preview", { artifactError: "open" });
+		const failed = registerResult(
+			manager,
+			"failed-command",
+			"Command exited with code 7",
+			{ artifactError: "write" },
+			true,
+		);
+		try {
+			await Promise.all([manager.getJob(successful)!.promise, manager.getJob(failed)!.promise]);
+			const snapshot = await wrapToolWithMetaNotice(new HubTool(session)).execute(
+				"short",
+				{ op: "jobs" },
+				undefined,
+				undefined,
+				{ sessionManager: store, settings: session.settings } as unknown as AgentToolContext,
+			);
+			const text = snapshot.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(text).not.toContain("artifact://");
+			expect(text.match(/artifact open failed/g)).toHaveLength(1);
+			expect(text.match(/artifact write failed/g)).toHaveLength(1);
+			expect(text).toContain("successful-command [bash] — completed");
+			expect(text).toContain("failed-command [bash] — failed");
+			expect(text).toContain("Command exited with code 7");
+			const uiTheme = await getThemeByName("dark");
+			if (!uiTheme) throw new Error("Expected dark theme");
+			const persisted = JSON.parse(JSON.stringify(snapshot)) as typeof snapshot;
+			for (const result of [snapshot, persisted]) {
+				for (const expanded of [false, true]) {
+					const rendered = hubToolRenderer
+						.renderResult(result, { expanded, isPartial: false }, uiTheme)
+						.render(180)
+						.map(line => Bun.stripANSI(line))
+						.join("\n");
+					expect(rendered.match(/artifact open failed/g)).toHaveLength(1);
+					expect(rendered.match(/artifact write failed/g)).toHaveLength(1);
+				}
+			}
+		} finally {
+			await manager.dispose();
+			await store.close();
+		}
+	});
+
+	it("retains each legacy Hub capture warning once when rebuilding short and truncated rows", async () => {
+		const jobs: JobSnapshot[] = [
+			{
+				id: "legacy-short",
+				type: "bash",
+				status: "completed",
+				label: "short command",
+				durationMs: 1,
+				artifactError: "open",
+				resultText: "short preview" + formatOutputNotice({ artifactError: "open" }),
+			},
+			{
+				id: "legacy-long",
+				type: "bash",
+				status: "failed",
+				label: "long command",
+				durationMs: 1,
+				artifactError: "write",
+				errorText: "long preview\n".repeat(20) + formatOutputNotice({ artifactError: "write" }),
+			},
+		];
+		const details = JSON.parse(
+			JSON.stringify({ op: "jobs", meta: { artifactError: "open" }, jobs }),
+		) as CoordinationDetails;
+		const uiTheme = await getThemeByName("dark");
+		if (!uiTheme) throw new Error("Expected dark theme");
+		for (const expanded of [false, true]) {
+			const rendered = hubToolRenderer
+				.renderResult({ content: [], details }, { expanded, isPartial: false }, uiTheme)
+				.render(180)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered.match(/artifact open failed/g)).toHaveLength(1);
+			expect(rendered.match(/artifact write failed/g)).toHaveLength(1);
+		}
+	});
+
+	it("retains a historical Hub aggregate warning when no persisted row identifies the failed capture", async () => {
+		const details: CoordinationDetails = {
+			op: "jobs",
+			meta: { artifactError: "end" },
+			jobs: [
+				{
+					id: "legacy-root",
+					type: "bash",
+					status: "completed",
+					label: "legacy command",
+					durationMs: 1,
+					resultText: "long preview\n".repeat(20) + formatOutputNotice({ artifactError: "end" }),
+				},
+			],
+		};
+		const uiTheme = await getThemeByName("dark");
+		if (!uiTheme) throw new Error("Expected dark theme");
+		for (const expanded of [false, true]) {
+			const rendered = hubToolRenderer
+				.renderResult({ content: [], details }, { expanded, isPartial: false }, uiTheme)
+				.render(180)
+				.map(line => Bun.stripANSI(line))
+				.join("\n");
+			expect(rendered.match(/artifact end failed/g)).toHaveLength(1);
+		}
+	});
+
+	it("spills a single incomplete job as a report without advertising its preview as the full command log", async () => {
+		await using temp = await TempDir.create("@capture-single-snapshot-");
+		const manager = new AsyncJobManager({});
+		const store = SessionManager.inMemory(temp.path());
+		const session = snapshotSessionFor(temp.path(), manager, store);
+		const preview = `${"surviving head\n".repeat(100)}PREVIEW-MIDDLE\n${"surviving tail\n".repeat(100)}Command exited with code 7`;
+		const id = registerResult(manager, "single-failed-command", preview, { artifactError: "end" }, true);
+		try {
+			await manager.getJob(id)!.promise;
+			const snapshot = await wrapToolWithMetaNotice(new HubTool(session)).execute(
+				"single",
+				{ op: "wait", ids: [id] },
+				undefined,
+				undefined,
+				{ sessionManager: store, settings: session.settings } as unknown as AgentToolContext,
+			);
+			const text = snapshot.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(text).not.toContain("PREVIEW-MIDDLE");
+			expect(text).toMatch(/artifact:\/\/\d+ for full report/);
+			expect(text).not.toMatch(/artifact:\/\/\d+ for full output/);
+			expect(text.match(/artifact end failed/g)).toHaveLength(1);
+			expect(manager.getJob(id)?.status).toBe("failed");
+			const artifactUrl = text.match(/artifact:\/\/\d+/)?.[0];
+			if (!artifactUrl) throw new Error("Expected recoverable snapshot report");
+			const read = await new ReadTool(session).execute("recover-single", { path: `${artifactUrl}:raw` });
+			const recovered = read.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+			expect(recovered).toContain(preview);
+			expect(recovered.match(/artifact end failed/g)).toHaveLength(1);
+		} finally {
+			await manager.dispose();
+			await store.close();
 		}
 	});
 

--- a/packages/coding-agent/test/tools/eval-streaming-output.test.ts
+++ b/packages/coding-agent/test/tools/eval-streaming-output.test.ts
@@ -1,10 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as evalIndex from "@oh-my-pi/pi-coding-agent/eval";
 import type { EvalToolDetails } from "@oh-my-pi/pi-coding-agent/eval/types";
+import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
-import { formatOutputNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval-render";
+import {
+	formatOutputNotice,
+	stripOutputNotice,
+	wrapToolWithMetaNotice,
+} from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import { removeWithRetries, sanitizeText } from "@oh-my-pi/pi-utils";
 
 function makeSession(settings = Settings.isolated()): ToolSession {
 	return {
@@ -108,4 +120,77 @@ describe("EvalTool live stdout streaming", () => {
 		expect(result.details?.meta?.truncation).toBeUndefined();
 		expect(formatOutputNotice(result.details?.meta)).toContain("Some lines truncated to 8 chars");
 	});
+
+	it.each([
+		{ scenario: "without window truncation", bytes: 50, respilled: false, cancelled: false },
+		{ scenario: "when the wrapper caps the preview", bytes: 2 * 1024, respilled: true, cancelled: false },
+		{ scenario: "when the cell was cancelled", bytes: 50, respilled: false, cancelled: true },
+	])(
+		"reports capture failure $scenario without changing the cell outcome",
+		async ({ bytes, respilled, cancelled }) => {
+			const dir = await fs.mkdtemp(path.join(os.tmpdir(), "eval-artifact-failure-"));
+			const sessionManager = SessionManager.inMemory(dir);
+			try {
+				const settings = Settings.isolated({
+					"tools.outputMaxColumns": 8,
+					"tools.artifactSpillThreshold": 1,
+					"tools.artifactTailBytes": 1,
+					"tools.artifactHeadBytes": 0,
+				});
+				const session = makeSession(settings);
+				session.allocateOutputArtifact = async () => ({ path: dir, id: "failed-stream" });
+				const saveArtifact = vi.spyOn(sessionManager, "saveArtifact");
+				const output = "x".repeat(bytes);
+				vi.spyOn(evalIndex.jsBackend, "execute").mockImplementation(async (_code, options) => {
+					options.onChunk(output);
+					return {
+						output,
+						exitCode: cancelled ? undefined : 0,
+						cancelled,
+						truncated: false,
+						artifactId: undefined,
+						totalLines: 1,
+						totalBytes: output.length,
+						outputLines: 1,
+						outputBytes: output.length,
+						displayOutputs: [],
+					};
+				});
+				const tool = wrapToolWithMetaNotice(new EvalTool(session));
+				const context = { sessionManager, settings } as unknown as AgentToolContext;
+				const result = await tool.execute(
+					"capture-failure",
+					{ language: "js", code: "print('output')" },
+					undefined,
+					undefined,
+					context,
+				);
+				const text = result.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+				const body = stripOutputNotice(text, result.details?.meta);
+
+				expect(Boolean(result.isError)).toBe(cancelled);
+				expect(result.details?.cells?.[0]?.status).toBe(cancelled ? "error" : "complete");
+				expect(result.details?.cells?.[0]?.exitCode).toBe(cancelled ? undefined : 0);
+				expect(text).toContain("not saved completely");
+				expect(text).not.toContain("artifact://");
+				expect(Buffer.byteLength(body)).toBeLessThanOrEqual(1024);
+				expect(Boolean(result.details?.meta?.truncation)).toBe(respilled);
+				expect(saveArtifact).not.toHaveBeenCalled();
+
+				const uiTheme = await getThemeByName("dark");
+				if (!uiTheme) throw new Error("Expected dark theme");
+				const rendered = sanitizeText(
+					evalToolRenderer
+						.renderResult(result, { expanded: false, isPartial: false }, uiTheme)
+						.render(160)
+						.join("\n"),
+				);
+				expect(rendered).toContain("not saved completely");
+				expect(rendered).not.toContain("artifact://");
+			} finally {
+				await sessionManager.close();
+				await removeWithRetries(dir);
+			}
+		},
+	);
 });


### PR DESCRIPTION
## Author-approved rationale
This change reports incomplete artifact captures across foreground and background execution, preventing misleading full-output recovery links without changing the command’s actual outcome.

AI-assisted implementation; the submitter approved this scope and rationale before publication. The verification below was executed by the coding agent.

## Summary
Track the first streaming artifact I/O failure (`open`, `write`, `flush`, or `end`) without turning a successful command into an execution failure. Keep the bounded inline result, stop further capture attempts, finalize once, and do not advertise an incomplete file as full output.

The warning is carried through bash/eval summaries, minimized output, cancellation, managed background jobs, hub recovery snapshots, async follow-up delivery, and live/persisted transcript rendering. A remaining preview is not re-spilled and mislabeled as the complete original capture.

Default artifact retention remains lossless/unbounded. This does not enable a cap, add quotas, retry failed capture, or change the direct-write fetch/gh sites covered by #10642.

## Verification
- `bun run check` from packages/coding-agent: passed.
- Capture-focused suites run independently of the other storage PRs: 29 passed.
- Combined regression run before the final async TUI assertion: 339 passed across 22 files. The final async delivery/rendering and background capture run: 15 passed.
- Additional adjacent coverage includes native bash, Python projections, output notices/caps, cancellation, async ownership, and raw artifact lifecycle.
- Baseline open-failure regression failed: no failure state was reported and the capture could reopen after the target became writable. The changed implementation passes.
- Real smoke: a directory used as artifact target failed capture; the sink kept a 64-byte inline preview, reported incomplete saving, and advertised no full-output artifact link.
- Integration regressions cover async write rejection, flush/end failure, concurrent dump/dispose, aborted bash, completed/cancelled eval, hub no-respill recovery, and async follow-up JSON round-trip rendering.

Local verification used the already-installed native addon through a temporary Bun preload. Failed-I/O tests use isolated fixtures and instance-scoped spies, not real disk exhaustion.

Related: #9649/#10642 harden non-streaming artifact publication. This PR covers the separate incremental sink and its delivery paths.
