### PR TITLE
fix(bash): keep raw diagnostics when a minimized failure cannot be persisted

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Bash results no longer replace a failing command's output with the shell minimizer's lossy summary when the original capture cannot be persisted as an artifact; the raw diagnostics are kept so a failure stays actionable ([#11081](https://github.com/can1357/oh-my-pi/issues/11081)).
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.
 - Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -728,28 +728,31 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			};
 		}
 
-		// When the native minimizer rewrote the output, swap the sink's accumulated
-		// raw stream for the minimized text, persist the original as a session
-		// artifact, and splice an `artifact://<id>` footer into the visible text so
-		// the agent can retrieve the raw bytes losslessly.
+		// When the native minimizer rewrote the output, persist the original and
+		// swap the sink's accumulated raw stream for the minimized text with an
+		// `artifact://<id>` footer so the agent can retrieve the raw bytes
+		// losslessly. The minimized text is a lossy summary, so substitute it
+		// only once the original is addressable — a caller that returns no id
+		// (or an unavailable allocator) must keep the raw stream rather than
+		// silently dropping the diagnostics the summary elided.
 		const minimized = winner.result.minimized;
 		if (minimized && minimized.text !== minimized.originalText) {
-			// The decoder above already owns image extraction from the streamed
-			// lossless output. Scrub any graphics frames repeated by the native
-			// minimizer without feeding them back into that decoder.
-			const minimizedGraphics = new TerminalGraphicsDecoder();
-			const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
-			sink.replace(minimizedText);
-			if (options?.onMinimizedSave) {
-				const artifactId = await options.onMinimizedSave(minimized.originalText, {
-					filter: minimized.filter,
-					inputBytes: minimized.inputBytes,
-					outputBytes: minimized.outputBytes,
-				});
-				if (artifactId) {
-					const sep = minimizedText.endsWith("\n") ? "" : "\n";
-					sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
-				}
+			const artifactId = options?.onMinimizedSave
+				? await options.onMinimizedSave(minimized.originalText, {
+						filter: minimized.filter,
+						inputBytes: minimized.inputBytes,
+						outputBytes: minimized.outputBytes,
+					})
+				: undefined;
+			if (artifactId) {
+				// The decoder above already owns image extraction from the streamed
+				// lossless output. Scrub any graphics frames repeated by the native
+				// minimizer without feeding them back into that decoder.
+				const minimizedGraphics = new TerminalGraphicsDecoder();
+				const minimizedText = minimizedGraphics.push(minimized.text) + minimizedGraphics.finish();
+				sink.replace(minimizedText);
+				const sep = minimizedText.endsWith("\n") ? "" : "\n";
+				sink.push(`${sep}[raw output: artifact://${artifactId}]\n`);
 			}
 		}
 

--- a/packages/coding-agent/test/bash-failure-result.test.ts
+++ b/packages/coding-agent/test/bash-failure-result.test.ts
@@ -97,6 +97,40 @@ describe("BashTool execution results", () => {
 		expect(text).not.toContain("Command exited with code");
 	});
 
+	it("keeps the raw diagnostics when a minimized failure cannot be persisted as an artifact", async () => {
+		// The native minimizer streams the raw bytes live, then reports a lossy
+		// summary. This session has no artifact allocator (the `ToolSession`
+		// contract makes it optional), so the original capture has nowhere to go:
+		// substituting the summary would silently drop every actionable line.
+		const rawOutput =
+			"test/event-cache.e2e-spec.ts:281:5 error TS2304 Cannot find name 'foo'\n" +
+			"test/event-cache.e2e-spec.ts:300:9 error TS2345 Argument of type 'string' is not assignable\n";
+		spyOn(Shell.prototype, "run").mockImplementation(function (this: Shell, options, onChunk) {
+			onChunk?.(null, rawOutput);
+			return Promise.resolve({
+				exitCode: 1,
+				cancelled: false,
+				timedOut: false,
+				workingDir: process.cwd(),
+				minimized: {
+					filter: "lint",
+					text: "test/event-cache.e2e-spec.ts:281-405 multiple ... errors\n",
+					originalText: rawOutput,
+					inputBytes: Buffer.byteLength(rawOutput, "utf-8"),
+					outputBytes: 54,
+				},
+			});
+		});
+
+		const tool = new BashTool(makeSession());
+		const result = await tool.execute("call-minimized-unpersisted", { command: "pnpm lint" });
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.exitCode).toBe(1);
+		const text = result.content.find(c => c.type === "text")?.text ?? "";
+		expect(text).toContain("TS2304 Cannot find name 'foo'");
+	});
+
 	it("preserves final-stage output when a pipeline ends in head or tail", async () => {
 		const tool = new BashTool(makeSession());
 


### PR DESCRIPTION
## Problem

A failed command could surface only the native shell minimizer's lossy summary, with no actionable diagnostics and no artifact URI ([#11081](https://github.com/can1357/oh-my-pi/issues/11081)).

## Root cause

`executeBash` applied the minimizer's summary to the output sink *before* knowing whether the lossless original had been persisted:

```ts
sink.replace(minimizedText);          // raw bytes discarded here
if (options?.onMinimizedSave) { ... } // footer only; save may return no id
```

`onMinimizedSave` is the optional `ToolSession.allocateOutputArtifact` seam, and `saveBashOriginalArtifact` swallows allocation/write failures and returns `undefined`. In both cases the raw output was already gone, so a failure that the minimizer folded into a summary (e.g. a TypeScript error list collapsed to `N multiple ... errors`) reached the model with nothing to act on and no `artifact://` reference.

## Change

Persist first, substitute only when a non-empty artifact id comes back; otherwise keep the raw stream in the sink. The minimized-text graphics scrub and the `[raw output: artifact://<id>]` footer now happen inside the artifact-id branch, and the minimized-text decode is deferred until it is actually used.

## Verification

- New regression test `packages/coding-agent/test/bash-failure-result.test.ts` → `keeps the raw diagnostics when a minimized failure cannot be persisted as an artifact`. Independently re-verified on this branch: with the source fix reverted it fails (5 pass / 1 fail, result text is only the summary); with the fix it passes (6 pass / 0 fail).
- `bun run check:types` in `packages/coding-agent` clean.
- `test/bash-executor.test.ts` + `test/bash-failure-result.test.ts` + `test/bash-execution-clamp.test.ts`: 101 pass, 2 skip, 0 fail; plus the `onMinimizedSave`-success and artifact-footer paths via `agent-session-bash-session-ownership`, `streaming-output`, `output-caps`, `bash-sixel-render`, `task/render`: 113 pass, 0 fail.

## Requirements from the issue already satisfied (left untouched)

- Failed results already carry final status and the key failure signal (`isError`, `details.exitCode`, verbatim `Command exited with code N`, `timedOut`).
- The truncation path already emits a stable `artifact://<id>` with head/tail ranges; only the minimized path was lossy.
