### PR TITLE
fix(task): terminalize subagents when their final result is accepted

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Subagents no longer remain `running` after their final result is accepted; a finished run reaches a terminal state without the parent having to send a status message ([#11079](https://github.com/can1357/oh-my-pi/issues/11079)).
+
 ### Added
 
 - `/usage` now shows prepaid credit balances (e.g. Charm Hyper's `100 credits left`) on the provider cards and account summaries instead of `no data` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -52,6 +52,22 @@ export interface AgentMetricsSummary {
 	contextWindow?: number;
 }
 
+/**
+ * Run lifecycle milestones, stamped as they happen and scoped to the CURRENT
+ * run: they are cleared when the ref re-enters `running` for a follow-up or
+ * wake turn. Launch is the ref's `createdAt`; these are the post-launch
+ * boundaries the parent needs to tell a genuinely working agent from one whose
+ * accepted result never terminalized.
+ */
+export interface AgentRunLifecycle {
+	/** When the run produced its final response (an accepted terminal `yield`). */
+	responseAt?: number;
+	/** When the run's final result was accepted by its driver. */
+	acceptedAt?: number;
+	/** When the ref last left `running` for a terminal status. */
+	terminalAt?: number;
+}
+
 /** Historical identity and telemetry that remain available after the live session is disposed. */
 export interface AgentHistorySummary {
 	agent?: string;
@@ -86,6 +102,8 @@ export interface AgentRef {
 	activity?: string;
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
+	/** Run lifecycle milestones (launch is {@link createdAt}). */
+	lifecycle?: AgentRunLifecycle;
 }
 
 export type AgentRefExpectation = AgentRef | AgentSession;
@@ -114,6 +132,8 @@ export interface RegisterInput {
 	lastActivity?: number;
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
+	/** Run lifecycle milestones restored from persisted history, when known. */
+	lifecycle?: AgentRunLifecycle;
 }
 
 export class AgentRegistry {
@@ -157,6 +177,7 @@ export class AgentRegistry {
 			lastActivity: input.lastActivity ?? now,
 			activity: input.activity,
 			history: input.history,
+			lifecycle: input.lifecycle,
 		};
 		this.#refs.set(ref.id, ref);
 		this.#emit({ type: "registered", ref });
@@ -199,13 +220,67 @@ export class AgentRegistry {
 			return status === "aborted" || this.#rejectStatusUpdate(id, status, "aborted-is-terminal");
 		}
 		if (ref.status === status) return true;
+		const leftRunning = ref.status === "running";
 		ref.status = status;
 		// Activity describes current work; it is meaningless once the agent
 		// leaves `running`, so drop it to avoid showing stale work in rosters.
 		if (status !== "running") ref.activity = undefined;
 		ref.lastActivity = Date.now();
+		if (status === "running") {
+			// Milestones are run-scoped. A ref reused by a follow-up or wake
+			// turn must not carry the previous run's response/acceptance into
+			// the new run, or a later yield-less turn would look accepted.
+			ref.lifecycle = undefined;
+		} else if (leftRunning) {
+			ref.lifecycle = { ...ref.lifecycle, terminalAt: ref.lastActivity };
+		}
 		this.#emit({ type: "status_changed", ref });
 		return true;
+	}
+
+	/**
+	 * Record that this agent's run produced and handed over its final result,
+	 * and terminalize the ref when no turn is in flight. Acceptance is the
+	 * executor's run boundary: the result is settled, so a ref still `running`
+	 * with nothing streaming is a missed terminal transition the parent's
+	 * `hub` wait would otherwise keep blocking on. A ref with a genuinely
+	 * streaming session (a wake turn started at the boundary) stays `running`
+	 * and is surfaced by {@link staleAcceptedRuns} instead.
+	 *
+	 * Milestones are run-scoped: `responseAt` is the CURRENT call's response
+	 * time (never a previous run's, which {@link setStatus} cleared when the
+	 * ref re-entered `running`).
+	 *
+	 * Returns false when the id is gone, aborted, or no longer owned by
+	 * `expected`; those cases must not stamp a newer generation.
+	 */
+	markResultAccepted(id: string, expected?: AgentRefExpectation, responseAt?: number): boolean {
+		const ref = this.#refs.get(id);
+		if (!ref || ref.status === "aborted" || !this.#matchesExpected(ref, expected)) return false;
+		const now = Date.now();
+		ref.lifecycle = {
+			...ref.lifecycle,
+			responseAt: responseAt ?? now,
+			acceptedAt: now,
+		};
+		if (ref.status === "running" && ref.session?.isStreaming !== true) {
+			this.setStatus(id, "idle", ref);
+		} else {
+			this.#emit({ type: "metadata_changed", ref });
+		}
+		return true;
+	}
+
+	/**
+	 * Accepted-but-running refs: the run's final result was handed over but the
+	 * ref never left `running`, and no turn is in flight. This is the lifecycle
+	 * leak `hub`'s running-agents roster reports so the parent can cancel it
+	 * instead of waiting on a run that already finished.
+	 */
+	staleAcceptedRuns(): AgentRef[] {
+		return this.list().filter(
+			ref => ref.status === "running" && ref.lifecycle?.acceptedAt !== undefined && !this.isRunning(ref),
+		);
 	}
 
 	/**

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1031,6 +1031,8 @@ interface SubagentRunMonitor {
 	readonly accumulatedUsage: Usage;
 	hasUsage(): boolean;
 	yieldCalled(): boolean;
+	/** Epoch ms when the run's terminal `yield` was recorded; undefined while none is latched. */
+	yieldAcceptedAt(): number | undefined;
 	runtimeLimitExceeded(): boolean;
 	/** True once the soft-budget stop fired: the free-running turn was aborted and the run is being driven to a forced final yield. */
 	budgetStopRequested(): boolean;
@@ -1140,6 +1142,8 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let yieldCalled = false;
 	let yieldCallPending = false;
 	let yieldInvalidatedByAsync = false;
+	/** Epoch ms the current terminal yield was recorded; cleared when it is invalidated. */
+	let yieldAcceptedAt: number | undefined;
 	let yieldTurnStopRequested = false;
 	let yieldTurnStopPromise: Promise<void> | null = null;
 
@@ -1467,7 +1471,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			const incremental = Array.isArray(item?.type) && item.type.length > 0;
 			yieldCalled = !incremental || item?.complete === true || item?.status === "aborted";
 			yieldCallPending = false;
-			if (yieldCalled) yieldInvalidatedByAsync = false;
+			if (yieldCalled) {
+				yieldInvalidatedByAsync = false;
+				yieldAcceptedAt = Date.now();
+			}
 		}
 	};
 
@@ -1490,6 +1497,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				if (yieldCalled && !abortSignal.aborted && isAsyncResultInjection(event.message)) {
 					yieldCalled = false;
 					yieldInvalidatedByAsync = true;
+					yieldAcceptedAt = undefined;
 				}
 				break;
 
@@ -1874,6 +1882,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		accumulatedUsage,
 		hasUsage: () => hasUsage,
 		yieldCalled: () => yieldCalled,
+		yieldAcceptedAt: () => yieldAcceptedAt,
 		runtimeLimitExceeded: () => runtimeLimitExceeded,
 		terminalError: () => terminalError,
 		hasExplicitAbortReason: () =>
@@ -2645,6 +2654,12 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 							: String(turnError)
 						: undefined;
 			turnMonitor.finish();
+			if (yielded) {
+				// Acceptance boundary for an autonomous wake turn (#11079): the
+				// turn's terminal yield is settled, so terminalize the ref here
+				// even when the run-state mirror never delivers `idle`.
+				AgentRegistry.global().markResultAccepted(id, session, turnMonitor.yieldAcceptedAt());
+			}
 			// Read before finalization: a schema-bearing agent that answered in
 			// prose gets a missing-yield warning prepended to `result.output`.
 			const turnText = turnMonitor.rawOutput() || (turnMonitor.lastAssistantSalvageText() ?? "");
@@ -2965,6 +2980,11 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 			await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 			attemptUnsubscribe = monitor.attach(session);
 		});
+		if (monitor.yieldCalled()) {
+			// A follow-up turn's accepted yield is the run's final result too:
+			// terminalize the ref here, not just on the initial run (#11079).
+			AgentRegistry.global().markResultAccepted(id, session, monitor.yieldAcceptedAt());
+		}
 	} finally {
 		try {
 			await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
@@ -3749,6 +3769,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			readyAt = performance.now();
 			const outcome = await driveSessionToYield(session, monitor, task);
+			// Acceptance boundary (#11079): the run's final result is settled, so
+			// stamp the lifecycle and terminalize a ref the run-state mirror left
+			// `running` before the (possibly slow) cleanup below.
+			if (monitor.yieldCalled()) {
+				AgentRegistry.global().markResultAccepted(id, session, monitor.yieldAcceptedAt());
+			}
 			exitCode = outcome.exitCode;
 			error = outcome.error;
 			aborted = outcome.aborted;

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -115,16 +115,21 @@ export function runningAgentsOutsideJobs(session: ToolSession): AgentActivitySna
 		}
 	}
 	const now = Date.now();
+	// Accepted runs that never terminalized: reported as actionable state
+	// instead of a generic stale-registration hint (#11079).
+	const staleAccepted = new Set(registry.staleAcceptedRuns().map(ref => ref.id));
 	const out: AgentActivitySnapshot[] = [];
 	for (const ref of registry.list()) {
 		if (ref.kind !== "sub" || ref.status !== "running") continue;
 		if (ref.id === selfId || covered.has(ref.id)) continue;
+		const acceptedAt = staleAccepted.has(ref.id) ? ref.lifecycle?.acceptedAt : undefined;
 		out.push({
 			id: ref.id,
 			...(ref.parentId ? { parentId: ref.parentId } : {}),
 			...(ref.activity ? { activity: ref.activity } : {}),
 			ageMs: Math.max(0, now - ref.createdAt),
 			live: registry.isRunning(ref),
+			...(acceptedAt !== undefined ? { acceptedAt } : {}),
 		});
 	}
 	return out;
@@ -136,7 +141,14 @@ function describeAgents(agents: AgentActivitySnapshot[]): string[] {
 	for (const agent of agents) {
 		const parent = agent.parentId ? ` (spawned by \`${agent.parentId}\`)` : "";
 		const activity = agent.activity ? ` — ${agent.activity}` : "";
-		const stale = agent.live ? "" : " — no turn in flight (stale registration?)";
+		// An accepted final result with no turn in flight is the #11079 leak:
+		// the run is over but the ref never terminalized, so say so actionably
+		// instead of the generic stale-registration hint.
+		const stale = agent.live
+			? ""
+			: agent.acceptedAt !== undefined
+				? ` — final result accepted ${formatDuration(Math.max(0, Date.now() - agent.acceptedAt))} ago but still running; clear it with \`hub\` cancel`
+				: " — no turn in flight (stale registration?)";
 		lines.push(`- \`${agent.id}\`${parent} — up ${formatDuration(agent.ageMs)}${activity}${stale}`);
 	}
 	lines.push("", "These agents have no job entry; message them via `hub` send, transcripts at `history://<id>`.");

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -111,6 +111,12 @@ export interface AgentActivitySnapshot {
 	 * wiring up or a stale registration that `hub cancel <id>` clears (#8634).
 	 */
 	live: boolean;
+	/**
+	 * Acceptance time of the agent's final result, when the registry recorded
+	 * one. With `live: false` this is an accepted run the parent may cancel
+	 * instead of waiting on (#11079).
+	 */
+	acceptedAt?: number;
 }
 
 /** Result details for messaging and job ops; fields are disjoint per op. */

--- a/packages/coding-agent/test/registry/agent-result-acceptance.test.ts
+++ b/packages/coding-agent/test/registry/agent-result-acceptance.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Accepted-final-result contract (#11079): once a run's final result is
+ * accepted, the agent ref must reach a terminal status and the run lifecycle
+ * milestones must be recorded. Milestones are run-scoped, so a ref reused by a
+ * follow-up or wake turn never reports a previous run's acceptance.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+/** Minimal session: the registry only reads `isStreaming` for liveness corroboration. */
+function sessionStub(isStreaming: boolean): AgentSession {
+	return { isStreaming } as unknown as AgentSession;
+}
+
+describe("AgentRegistry final-result acceptance", () => {
+	let registry: AgentRegistry;
+
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		registry = AgentRegistry.global();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	function registerRunning(id: string, session: AgentSession | null) {
+		return registry.register({ id, displayName: id, kind: "sub", session, status: "running" });
+	}
+
+	it("terminalizes a settled run and stamps response, acceptance, and terminal milestones", () => {
+		const ref = registerRunning("PolicyCommand", sessionStub(false));
+		const respondedAt = ref.createdAt + 5;
+
+		expect(registry.markResultAccepted("PolicyCommand", ref, respondedAt)).toBe(true);
+
+		const settled = registry.get("PolicyCommand");
+		expect(settled?.status).toBe("idle");
+		expect(settled?.lifecycle?.responseAt).toBe(respondedAt);
+		expect(settled?.lifecycle?.acceptedAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeGreaterThanOrEqual(settled?.lifecycle?.acceptedAt ?? 0);
+		expect(registry.staleAcceptedRuns()).toEqual([]);
+	});
+
+	it("does not report a follow-up turn that produced no accepted result", () => {
+		const ref = registerRunning("PolicyCommand", sessionStub(false));
+		expect(registry.markResultAccepted("PolicyCommand", ref, ref.createdAt)).toBe(true);
+
+		// The next turn starts: run-scoped milestones rotate away.
+		registry.setStatus("PolicyCommand", "running", ref);
+
+		expect(registry.get("PolicyCommand")?.lifecycle).toBeUndefined();
+		expect(registry.staleAcceptedRuns()).toEqual([]);
+	});
+
+	it("records the current run's response and acceptance when a ref is reused", () => {
+		const ref = registerRunning("PolicyCommand", sessionStub(false));
+		const firstResponseAt = ref.createdAt + 1;
+		const secondResponseAt = ref.createdAt + 2;
+
+		expect(registry.markResultAccepted("PolicyCommand", ref, firstResponseAt)).toBe(true);
+		expect(registry.get("PolicyCommand")?.lifecycle?.responseAt).toBe(firstResponseAt);
+
+		// Second turn on the same ref: the first run's milestones must not leak.
+		registry.setStatus("PolicyCommand", "running", ref);
+		expect(registry.markResultAccepted("PolicyCommand", ref, secondResponseAt)).toBe(true);
+
+		const settled = registry.get("PolicyCommand");
+		expect(settled?.status).toBe("idle");
+		expect(settled?.lifecycle?.responseAt).toBe(secondResponseAt);
+		expect(settled?.lifecycle?.acceptedAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeNumber();
+	});
+
+	it("reports an accepted run whose turn never went idle", () => {
+		let streaming = true;
+		const session = {
+			get isStreaming(): boolean {
+				return streaming;
+			},
+		} as unknown as AgentSession;
+		const ref = registerRunning("PolicyCommand", session);
+
+		// Acceptance lands while a wake turn is still in flight: not terminal yet.
+		expect(registry.markResultAccepted("PolicyCommand", ref, ref.createdAt)).toBe(true);
+		expect(registry.get("PolicyCommand")?.status).toBe("running");
+		expect(registry.staleAcceptedRuns()).toEqual([]);
+
+		// The turn ends without the run-state mirror ever delivering `idle`.
+		streaming = false;
+
+		expect(registry.staleAcceptedRuns().map(stale => stale.id)).toEqual(["PolicyCommand"]);
+		registry.setStatus("PolicyCommand", "idle", ref);
+		expect(registry.staleAcceptedRuns()).toEqual([]);
+	});
+
+	it("ignores acceptance from a session the ref no longer owns", () => {
+		const ref = registerRunning("PolicyCommand", sessionStub(false));
+
+		expect(registry.markResultAccepted("PolicyCommand", sessionStub(false), ref.createdAt)).toBe(false);
+		expect(registry.get("PolicyCommand")?.lifecycle?.acceptedAt).toBeUndefined();
+		expect(registry.get("PolicyCommand")?.status).toBe("running");
+	});
+});

--- a/packages/coding-agent/test/task/executor-result-acceptance.test.ts
+++ b/packages/coding-agent/test/task/executor-result-acceptance.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Acceptance-boundary contract (#11079): a subagent whose terminal `yield` was
+ * accepted must leave `running` and carry its run lifecycle milestones without
+ * any parent message or extra poll — on the initial run, on a follow-up turn,
+ * and on an autonomous IRC wake turn.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import {
+	attachIrcWakeTurnMonitor,
+	runSubagentFollowUpTurn,
+	runSubprocess,
+} from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+const AGENT_ID = "accepted-result";
+
+const baseAgent: AgentDefinition = {
+	name: "task",
+	description: "test",
+	systemPrompt: "test",
+	source: "bundled",
+};
+
+function assistantStopMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+interface SessionHarness {
+	session: AgentSession;
+	/** Emit a successful terminal `yield` tool result through the session event stream. */
+	emitTerminalYield: (data: unknown) => void;
+	/** The observer factory installed by {@link attachIrcWakeTurnMonitor}, if any. */
+	wakeObserver: () =>
+		| ((records: AgentMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined)
+		| undefined;
+}
+
+/**
+ * Minimal session that satisfies the executor's run surface. `prompt` submits a
+ * terminal `yield` (so `runSubprocess` / `runSubagentFollowUpTurn` settle), and
+ * `subscribeRunState` never fires — the run-state mirror omits `idle`, which is
+ * exactly the leak the acceptance boundary must cover.
+ */
+function createHarness(): SessionHarness {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const messages: AssistantMessage[] = [];
+	let yieldSeq = 0;
+	let wakeObserver: ((records: AgentMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined;
+	const emit = (event: AgentSessionEvent) => {
+		// oxlint-disable-next-line unicorn/no-useless-spread -- listeners may change during dispatch
+		for (const listener of [...listeners]) listener(event);
+	};
+	const emitTerminalYield = (data: unknown) => {
+		yieldSeq += 1;
+		emit({
+			type: "tool_execution_end",
+			toolCallId: `yield-${yieldSeq}`,
+			toolName: "yield",
+			result: {
+				content: [{ type: "text", text: "Result submitted." }],
+				details: { status: "success", data },
+			},
+		} as AgentSessionEvent);
+	};
+	const session = {
+		state: { messages },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read", "yield"],
+		getEnabledToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		setWorkPoolYieldItems: () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (text: string) => {
+			const message = assistantStopMessage("submitting");
+			messages.push(message);
+			emit({ type: "message_end", message } as AgentSessionEvent);
+			emitTerminalYield({ report: text });
+		},
+		waitForIdle: async () => {},
+		isAdvisorActive: () => false,
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async () => true,
+		getLastAssistantMessage: () => messages[messages.length - 1],
+		hasPendingAsyncWork: () => false,
+		getAsyncJobSnapshot: () => ({ running: [], recent: [] }),
+		settleAsyncWork: async () => {},
+		abort: async () => {},
+		dispose: async () => {},
+		setIrcWakeTurnObserver: (
+			observer: ((records: AgentMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined,
+		) => {
+			wakeObserver = observer;
+		},
+		trackIrcReply: () => {},
+		subscribeRunState: () => () => {},
+	};
+	return {
+		session: session as unknown as AgentSession,
+		emitTerminalYield,
+		wakeObserver: () => wakeObserver,
+	};
+}
+
+function registerRunning(session: AgentSession) {
+	return AgentRegistry.global().register({
+		id: AGENT_ID,
+		displayName: AGENT_ID,
+		kind: "sub",
+		session,
+		status: "running",
+	});
+}
+
+describe("runSubprocess result acceptance", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("terminalizes the ref and stamps the run lifecycle when the yield is accepted", async () => {
+		const harness = createHarness();
+		const ref = registerRunning(harness.session);
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+			session: harness.session,
+			extensionsResult: {} as unknown as LoadExtensionsResult,
+			setToolUIContext: () => {},
+			eventBus: new EventBus(),
+		} as CreateAgentSessionResult);
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do the work",
+			index: 0,
+			id: AGENT_ID,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const settled = AgentRegistry.global().get(AGENT_ID);
+		expect(settled?.status).not.toBe("running");
+		expect(settled?.lifecycle?.responseAt).toBeNumber();
+		expect(settled?.lifecycle?.acceptedAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeNumber();
+		expect(AgentRegistry.global().staleAcceptedRuns()).toEqual([]);
+		// Launch milestone is the registration timestamp the acceptance must not move.
+		expect(settled?.createdAt).toBe(ref.createdAt);
+	});
+
+	it("terminalizes an existing ref on a follow-up turn whose run-state mirror omits idle", async () => {
+		const harness = createHarness();
+		registerRunning(harness.session);
+
+		const result = await runSubagentFollowUpTurn({
+			id: AGENT_ID,
+			agent: baseAgent,
+			message: "continue",
+		});
+
+		expect(result.exitCode).toBe(0);
+		const settled = AgentRegistry.global().get(AGENT_ID);
+		expect(settled?.status).not.toBe("running");
+		expect(settled?.lifecycle?.responseAt).toBeNumber();
+		expect(settled?.lifecycle?.acceptedAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeNumber();
+	});
+
+	it("terminalizes the ref when an autonomous wake turn's yield is accepted", async () => {
+		const harness = createHarness();
+		registerRunning(harness.session);
+		attachIrcWakeTurnMonitor(harness.session, { id: AGENT_ID, agent: baseAgent });
+		const observer = harness.wakeObserver();
+		expect(observer).toBeDefined();
+
+		const finish = observer?.([
+			{
+				role: "custom",
+				customType: "irc:incoming",
+				content: "wake",
+				display: false,
+				attribution: "user",
+				timestamp: Date.now(),
+			} as unknown as AgentMessage,
+		]);
+		expect(finish).toBeDefined();
+		harness.emitTerminalYield({ report: "answered while woken" });
+		await finish?.(undefined);
+
+		const settled = AgentRegistry.global().get(AGENT_ID);
+		expect(settled?.status).not.toBe("running");
+		expect(settled?.lifecycle?.responseAt).toBeNumber();
+		expect(settled?.lifecycle?.acceptedAt).toBeNumber();
+		expect(settled?.lifecycle?.terminalAt).toBeNumber();
+	});
+});

--- a/packages/coding-agent/test/tools/hub-accepted-agent.test.ts
+++ b/packages/coding-agent/test/tools/hub-accepted-agent.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Hub watchdog surface (#11079): an agent whose final result was accepted but
+ * that never reached a terminal status must be reported as actionable state by
+ * `hub`'s running-agents snapshot, not silently left in the running roster.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { noMatchingJobsResult } from "@oh-my-pi/pi-coding-agent/tools/hub/jobs";
+
+const SELF_ID = "Main";
+
+describe("hub accepted-agent watchdog", () => {
+	let registry: AgentRegistry;
+
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		registry = AgentRegistry.global();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	function makeSession(): ToolSession {
+		// Structurally-partial test session: the running-agents snapshot only
+		// touches the registry and the caller id.
+		return {
+			agentRegistry: registry,
+			asyncJobManager: undefined,
+			getAgentId: () => SELF_ID,
+		} as unknown as ToolSession;
+	}
+
+	function registerLeakedAcceptedRun(): void {
+		let streaming = true;
+		const session = {
+			get isStreaming(): boolean {
+				return streaming;
+			},
+		} as never;
+		const ref = registry.register({
+			id: "PolicyCommand",
+			displayName: "PolicyCommand",
+			kind: "sub",
+			parentId: SELF_ID,
+			session,
+			status: "running",
+		});
+		// Acceptance lands while the wake turn is in flight, so the ref is not
+		// terminalized yet; the turn then ends without the mirror delivering
+		// `idle` — the leak the roster must report.
+		registry.markResultAccepted("PolicyCommand", ref, ref.createdAt);
+		streaming = false;
+	}
+
+	it("surfaces an accepted-but-running agent with its acceptance age and a cancel hint", () => {
+		registerLeakedAcceptedRun();
+
+		const result = noMatchingJobsResult(makeSession(), ["PolicyCommand"]);
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("final result accepted");
+		expect(text).toContain("hub` cancel");
+		expect(result.details?.agents?.map(agent => agent.id)).toEqual(["PolicyCommand"]);
+		expect(result.details?.agents?.[0]?.acceptedAt).toBeNumber();
+	});
+});


### PR DESCRIPTION
## Problem

A subagent could stay `running` after its final result was accepted, so the parent's `hub wait` kept blocking on a run that had already finished ([#11079](https://github.com/can1357/oh-my-pi/issues/11079)).

## Root cause

Ref status was driven only by the session run-state mirror (`syncSessionStatus` → `setStatus`) and by `finalizeSubagentLifecycle`. Nothing transitioned the ref at the *acceptance* boundary. If the mirror's `idle` notification is missed — or a straggler `running` notification arrives after it with no matching `idle` — the ref stays `running` with `session.isStreaming === false` forever. `AgentLifecycleManager` clears its idle TTL on `running` and only re-arms on `idle`, so nothing ever terminalized it and the roster had no acceptance timestamp to explain why.

## Change

- `AgentRef.lifecycle: { responseAt?, acceptedAt?, terminalAt? }`, **run-scoped**: `setStatus` clears it when a ref enters `running` (a follow-up or wake turn is a new run) and stamps `terminalAt` when a ref leaves `running`. Launch stays `createdAt`.
- `AgentRegistry.markResultAccepted(id, expected?, responseAt?)` records the current run's response and acceptance milestones and, when no turn is in flight (`session.isStreaming !== true`), terminalizes the ref to `idle`. It refuses aborted/missing/replaced refs so a stale acceptance cannot stamp a newer generation, and it does not clobber a genuinely streaming (re-woken) agent.
- `AgentRegistry.staleAcceptedRuns()` exposes the leak: accepted-but-running refs with no turn in flight.
- The acceptance boundary is applied at **every** settled run: the initial run (`runSubprocess`), an explicit follow-up turn (`runSubagentFollowUpTurn`), and an autonomous `hub`/IRC wake turn (`attachIrcWakeTurnMonitor`'s completion), using the monitor's `yieldAcceptedAt()` so the response timestamp is the run's own.
- `hub` running-agents roster surfaces a leaked accepted run with its acceptance age and a `hub` cancel hint.

## Verification

- 9 new tests across `test/registry/agent-result-acceptance.test.ts`, `test/task/executor-result-acceptance.test.ts`, `test/tools/hub-accepted-agent.test.ts`. Independently re-verified on this branch: with the source fix reverted all 9 fail (0 pass / 9 fail); with the fix 9 pass / 0 fail. Coverage includes two turns on the same ref (no carry-over), a follow-up turn whose run-state mirror omits `idle`, and an autonomous wake turn.
- `bun run check:types` in `packages/coding-agent` clean; `bunx oxfmt --check` on every changed file clean.
- `test/registry/` + `test/tools/hub*.test.ts` + `test/task/executor-result-acceptance.test.ts`: 106 pass, 0 fail.
