### PR TITLE
fix(hub): recover from stale daemon broker leases instead of failing hub start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `/move` now checks BTW migration availability before confirming or creating a missing target directory, preventing leftover directories after a refused move.
 - BTW errors now shorten embedded home paths and sanitize control characters and oversized text before display, while retaining original diagnostic errors.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Fixed `hub start` failing with a raw `connect ENOENT …/broker.sock` when the project daemon broker's lease was stale: the lease is now a process-owned lock the OS releases however the broker dies, a stale lease no longer blocks startup, and a broker that still cannot start reports its scope path plus recovery commands ([#11080](https://github.com/can1357/oh-my-pi/issues/11080)).
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -2,8 +2,8 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
-import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
+import { FileLock, Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
+import { isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
 import { TerminalQueryResponder } from "@oh-my-pi/pi-utils/vterm";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
@@ -47,6 +47,13 @@ const RESTART_BACKOFF_BASE_MS = 1_000;
 const MAX_TERMINAL_DAEMONS_LISTED = 10;
 const TOKEN_FILE = "broker.token";
 const PID_FILE = "broker.pid";
+/**
+ * How long a live lease left by a broker without the native lock is given to
+ * bind its endpoint before the lease is treated as stale (issue #11080).
+ */
+const LEASE_HANDOFF_GRACE_MS = 500;
+/** Connect budget for the endpoint probe that answers "is a broker serving this scope?". */
+const LEASE_PROBE_TIMEOUT_MS = 250;
 const META_FILE = "meta.json";
 const LOG_FILE = "output.log";
 const PREVIOUS_LOG_FILE = "output.previous.log";
@@ -94,7 +101,8 @@ interface ManagedDaemon {
 
 interface BrokerLease {
 	path: string;
-	instanceId: string;
+	/** Process-owned native lock; the OS drops it however this broker exits. */
+	lock: FileLock;
 }
 
 interface DaemonLogRead {
@@ -287,47 +295,83 @@ class DaemonLog {
 	}
 }
 
-async function acquireBrokerLease(runtimeDir: string): Promise<BrokerLease | null> {
-	const pidPath = path.join(runtimeDir, PID_FILE);
-	for (let attempt = 0; attempt < 2; attempt++) {
-		try {
-			const handle = await fs.open(pidPath, "wx", 0o600);
-			const instanceId = crypto.randomUUID();
-			try {
-				await handle.writeFile(JSON.stringify({ pid: process.pid, instanceId }), "utf8");
-			} finally {
-				await handle.close();
-			}
-			return { path: pidPath, instanceId };
-		} catch (error) {
-			if (!isEexist(error)) throw error;
-			try {
-				const raw: unknown = await Bun.file(pidPath).json();
-				if (typeof raw === "object" && raw !== null && "pid" in raw && typeof raw.pid === "number") {
-					try {
-						process.kill(raw.pid, 0);
-						return null;
-					} catch {
-						// Stale PID file; the next loop iteration claims it.
-					}
-				}
-			} catch {
-				// Malformed or partially-written PID files are stale.
-			}
-			await fs.rm(pidPath, { force: true });
-		}
+/** Whether a broker is accepting connections on the scope endpoint right now. */
+function probeBrokerEndpoint(endpoint: string): Promise<boolean> {
+	const { promise, resolve } = Promise.withResolvers<boolean>();
+	const socket = net.createConnection({ path: endpoint });
+	let settled = false;
+	const finish = (connected: boolean): void => {
+		if (settled) return;
+		settled = true;
+		socket.destroy();
+		resolve(connected);
+	};
+	socket.once("connect", () => finish(true));
+	socket.once("error", () => finish(false));
+	socket.setTimeout(LEASE_PROBE_TIMEOUT_MS, () => finish(false));
+	return promise;
+}
+
+/**
+ * Whether a live lease left by a broker that predates the native lock still
+ * owns this scope. The recorded PID alone cannot answer it: PID reuse by an
+ * unrelated process looks exactly like a live broker, while a real broker only
+ * becomes observable when it binds the endpoint — milliseconds after writing
+ * the lease. Probe, allow one startup grace, then probe again.
+ */
+async function holdsLiveForeignLease(pidPath: string, endpoint: string): Promise<boolean> {
+	let pid: number | undefined;
+	try {
+		// `fs.readFile` (libuv) rather than `Bun.file().json()`: the CLI entry runs
+		// as a floating promise, so an await that completes without an active
+		// libuv handle lets Bun exit this worker before it ever listens — exactly
+		// what happens on the cold-start path when broker.pid is absent.
+		const raw: unknown = JSON.parse(await fs.readFile(pidPath, "utf8"));
+		if (typeof raw === "object" && raw !== null && "pid" in raw && typeof raw.pid === "number") pid = raw.pid;
+	} catch {
+		// Missing or torn lease: nothing to honor.
 	}
-	return null;
+	if (pid === undefined || pid === process.pid) return false;
+	try {
+		process.kill(pid, 0);
+	} catch {
+		return false; // Dead PID: the lease outlived its broker.
+	}
+	if (await probeBrokerEndpoint(endpoint)) return true;
+	await Bun.sleep(LEASE_HANDOFF_GRACE_MS);
+	return probeBrokerEndpoint(endpoint);
+}
+
+/**
+ * Claim the one-broker-per-scope lease. The native lock is process-owned, so
+ * the OS releases it however the broker dies — a crashed broker can never wedge
+ * the scope behind a stale lease again (issue #11080). `broker.pid` stays as
+ * human-readable metadata for `omp ps` and dead-scope pruning.
+ */
+async function acquireBrokerLease(runtimeDir: string, endpoint: string): Promise<BrokerLease | null> {
+	const pidPath = path.join(runtimeDir, PID_FILE);
+	const lock = FileLock.tryAcquire(pidPath);
+	if (!lock.acquired) return null;
+	try {
+		// A broker from a build without the native lock cannot be seen through it;
+		// adopt the scope instead of starting a duplicate supervisor.
+		if (await holdsLiveForeignLease(pidPath, endpoint)) {
+			lock.release();
+			return null;
+		}
+		await fs.writeFile(pidPath, JSON.stringify({ pid: process.pid }), { mode: 0o600 });
+		return { path: pidPath, lock };
+	} catch (error) {
+		lock.release();
+		throw error;
+	}
 }
 
 async function releaseBrokerLease(lease: BrokerLease): Promise<void> {
 	try {
-		const raw: unknown = await Bun.file(lease.path).json();
-		if (typeof raw === "object" && raw !== null && "instanceId" in raw && raw.instanceId === lease.instanceId) {
-			await fs.rm(lease.path, { force: true });
-		}
-	} catch (error) {
-		if (!isEnoent(error)) throw error;
+		await fs.rm(lease.path, { force: true });
+	} finally {
+		lease.lock.release();
 	}
 }
 
@@ -1409,7 +1453,10 @@ export async function startDaemonBrokerFromEnvironment(options: DaemonBrokerStar
 			? requestedRestartBackoffBaseMs
 			: RESTART_BACKOFF_BASE_MS;
 	await fs.mkdir(runtimeDir, { recursive: true, mode: 0o700 });
-	const lease = await acquireBrokerLease(runtimeDir);
+	const endpoint = daemonBrokerEndpoint(projectDir, runtimeDir);
+	// Hold the lease for the whole broker lifetime: it is a native lock the OS
+	// releases on exit, so keeping `lease` referenced keeps the scope owned.
+	const lease = await acquireBrokerLease(runtimeDir, endpoint);
 	if (!lease) return;
 	setProcessName("omp daemon broker");
 	// Record the scope's project dir so `omp ps` can map this hash-keyed runtime

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -287,8 +287,9 @@ class SocketDaemonClient implements DaemonBrokerClient {
 			this.#bindSocket(await openSocket(this.#endpoint, 250));
 			return;
 		} catch {
-			// No live broker. Multiple clients may race to spawn; the broker's PID
-			// lease selects one winner before any candidate touches the socket.
+			// No live broker. Multiple clients may race to spawn; the broker's
+			// process-owned lease selects one winner before any candidate touches
+			// the socket.
 		}
 		this.#spawnBroker();
 		const deadline = Date.now() + CONNECT_TIMEOUT_MS;
@@ -302,7 +303,11 @@ class SocketDaemonClient implements DaemonBrokerClient {
 				await Bun.sleep(CONNECT_RETRY_MS);
 			}
 		}
-		throw new Error(`Failed to start daemon broker: ${lastError?.message ?? "socket unavailable"}`);
+		throw new Error(
+			`Failed to start daemon broker at ${this.#endpoint} after ${CONNECT_TIMEOUT_MS / 1000}s: ` +
+				`${lastError?.message ?? "socket unavailable"}. Scope: ${this.#runtimeDir}. ` +
+				"Run `omp --smoke-test` to verify broker startup, or `omp ps` to inspect supervised processes.",
+		);
 	}
 
 	#spawnBroker(): void {

--- a/packages/coding-agent/test/launch/daemon-stale-lease-recovery.test.ts
+++ b/packages/coding-agent/test/launch/daemon-stale-lease-recovery.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createDaemonBrokerClient, type DaemonBrokerClient } from "../../src/launch/client";
+
+const TEST_TIMEOUT_MS = 30_000;
+
+async function waitForFileGone(filePath: string, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (!(await Bun.file(filePath).exists())) return true;
+		if (Date.now() >= deadline) return false;
+		await Bun.sleep(50);
+	}
+}
+
+/** Run one client against a private scope, then shut the broker down again. */
+async function withScope(
+	projectDir: string,
+	runtimeDir: string,
+	body: (client: DaemonBrokerClient) => Promise<void>,
+): Promise<void> {
+	await fs.mkdir(projectDir, { recursive: true });
+	await fs.mkdir(runtimeDir, { recursive: true });
+	const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 1_000 });
+	try {
+		await body(client);
+	} finally {
+		try {
+			await client.request({ op: "shutdown" });
+		} catch {
+			// The last-client grace may already have stopped the broker.
+		}
+		client.close();
+	}
+}
+
+describe("daemon broker lease recovery", () => {
+	it(
+		"starts a broker when broker.pid records a live but unrelated PID (issue #11080)",
+		async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-stale-lease-"));
+			const pidPath = path.join(root, "run", "broker.pid");
+			try {
+				await fs.mkdir(path.join(root, "run"), { recursive: true });
+				// A broker killed before it could clean up leaves its lease behind,
+				// and the OS can later hand that PID to an unrelated live process.
+				// Liveness of the recorded PID therefore says nothing about the broker.
+				await Bun.write(pidPath, JSON.stringify({ pid: process.pid, instanceId: "crashed-broker" }));
+
+				await withScope(path.join(root, "project"), path.join(root, "run"), async client => {
+					const ping = await client.request({ op: "ping" });
+					if (ping.op !== "ping") throw new Error(`unexpected daemon result ${ping.op}`);
+					expect(ping.projectDir).toBe(client.projectDir);
+
+					const lease = (await Bun.file(pidPath).json()) as { pid?: number };
+					expect(lease.pid).toBeDefined();
+					expect(lease.pid).not.toBe(process.pid);
+				});
+
+				// Cleanup semantics survive recovery: the lease goes with the broker.
+				expect(await waitForFileGone(pidPath, 5_000)).toBe(true);
+			} finally {
+				await fs.rm(root, { recursive: true, force: true });
+			}
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"starts a broker from a cold scope with no broker.pid",
+		async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cold-lease-"));
+			try {
+				await withScope(path.join(root, "project"), path.join(root, "run"), async client => {
+					const ping = await client.request({ op: "ping" });
+					if (ping.op !== "ping") throw new Error(`unexpected daemon result ${ping.op}`);
+					expect(ping.projectDir).toBe(client.projectDir);
+				});
+			} finally {
+				await fs.rm(root, { recursive: true, force: true });
+			}
+		},
+		TEST_TIMEOUT_MS,
+	);
+});


### PR DESCRIPTION
## Problem

`hub start` failed with a raw `connect ENOENT /home/agent/.omp/run/daemons/<hash>/broker.sock` when the daemon broker's lease outlived its process ([#11080](https://github.com/can1357/oh-my-pi/issues/11080)).

## Root cause

`acquireBrokerLease` (`packages/coding-agent/src/launch/broker.ts`) treated any live PID recorded in `<runtimeDir>/broker.pid` as a running broker. A broker killed before cleanup (crashes, `SIGKILL`, host restarts) leaves the file behind; when the OS reuses that PID for an unrelated process, `process.kill(pid, 0)` succeeds, every new broker candidate assumes the scope is owned, and all candidates exit without binding the endpoint.

Clients retried for 10 s and surfaced the raw connection error (`client.ts` `#connectOnce`), with the socket absent because no broker ever listened.

## Change

- Scope lease is now backed by a process-owned native `FileLock` (`FileLock.tryAcquire`, `@oh-my-pi/pi-natives`). The OS releases the lock when the process exits under any condition, so a crashed broker can never wedge the scope.
- `broker.pid` is kept as metadata for `omp ps`/pruning and rewritten on claim.
- A lease left by an older build (which takes no native lock) is honored only while its endpoint actually serves connections (`probeBrokerEndpoint` + one 500 ms startup grace), so no duplicate supervisor is started.
- Terminal start failures now name the endpoint, elapsed time, scope directory, and actionable recovery commands (`omp --smoke-test`, `omp ps`).

## Verification

- New test `packages/coding-agent/test/launch/daemon-stale-lease-recovery.test.ts` covers (1) broker starts when `broker.pid` records a live unrelated PID (fails before the change with `connect ENOENT` after 10 s, passes after in <1 s); (2) cold-scope start with no `broker.pid`.
- `bun run check:types` in `packages/coding-agent` clean.
- `test/launch/` (39 pass), `test/tools/hub/` + `test/blob-broker.test.ts` (65 pass).
