### PR TITLE
fix(usage): consolidate Antigravity shared quota rows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Antigravity quota summaries now identify Claude/GPT routing copies as one shared upstream pool while preserving model-specific quota selection ([#11268](https://github.com/can1357/oh-my-pi/issues/11268)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -220,6 +220,7 @@ const usageScopeSchema = type({
 	"tier?": "string",
 	"windowId?": "string",
 	"shared?": "boolean",
+	"sharedGroup?": "string",
 });
 
 const usageLimitSchema = type({

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -54,6 +54,8 @@ export interface UsageScope {
 	tier?: string;
 	windowId?: string;
 	shared?: boolean;
+	/** Stable identity shared by routing-specific copies of one upstream quota. */
+	sharedGroup?: string;
 }
 
 /** Normalized limit entry for a single window or quota bucket. */
@@ -271,6 +273,7 @@ export const usageScopeSchema = type({
 	"tier?": "string",
 	"windowId?": "string",
 	"shared?": "boolean",
+	"sharedGroup?": "string",
 });
 
 export const usageLimitSchema = type({

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -355,18 +355,24 @@ function buildQuotaSummaryReport(
 		);
 		const amount = buildQuotaSummaryAmount(bucket);
 		const counterKeys = getQuotaSummaryCounterKeys(group, bucket);
+		const sharedGroup =
+			counterKeys.length > 1
+				? `${bucket.bucketId ?? group?.displayName ?? "third-party"}:${window?.id ?? bucket.window ?? "default"}`
+				: undefined;
 		for (const counterKey of counterKeys) {
 			const counterName = getQuotaSummaryCounterName(counterKey);
 			const windowId = window?.id ?? bucket.window ?? bucket.bucketId ?? "default";
+			const label =
+				sharedGroup !== undefined ? "Claude & GPT (shared)" : counterKey === "google" ? "Gemini" : counterName;
 			limits.push({
 				id: `${params.provider}:${counterKey}:default:${bucket.bucketId ?? windowId}`,
-				label: counterName ? `Usage (${counterName})` : (group?.displayName ?? bucket.displayName ?? "Usage"),
+				label: label ?? group?.displayName ?? bucket.displayName ?? "Usage",
 				scope: {
 					provider: params.provider,
 					accountId: params.credential.accountId,
 					projectId: params.credential.projectId,
 					windowId,
-					...(counterKeys.length > 1 ? { shared: true } : {}),
+					...(sharedGroup !== undefined ? { shared: true, sharedGroup } : {}),
 				},
 				window,
 				amount,

--- a/packages/ai/test/auth-broker-wire-schema-contract.test.ts
+++ b/packages/ai/test/auth-broker-wire-schema-contract.test.ts
@@ -64,7 +64,13 @@ const USAGE_REPORT = {
 		{
 			id: "rolling",
 			label: "Rolling window",
-			scope: { provider: "anthropic", windowId: "rolling", providerExtension: true },
+			scope: {
+				provider: "anthropic",
+				windowId: "rolling",
+				shared: true,
+				sharedGroup: "3p:rolling",
+				providerExtension: true,
+			},
 			window: { id: "rolling", label: "5 hour", durationMs: 18_000_000 },
 			amount: { used: 1, limit: 10, remaining: 9, unit: "tokens", providerExtension: "kept" },
 			status: "ok",

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -147,12 +147,18 @@ describe("antigravity usage provider", () => {
 		expect(fiveHour?.window?.label).toBe("5 Hour");
 		expect(fiveHour?.window?.durationMs).toBe(5 * 60 * 60 * 1000);
 
+		expect(googleLimits.every(limit => limit.label === "Gemini")).toBeTrue();
 		const claudeLimits = scopeAntigravityLimitsForModel(report!, { modelId: "claude-sonnet-4-6" });
 		const gptLimits = scopeAntigravityLimitsForModel(report!, { modelId: "gpt-oss-120b" });
 		expect(claudeLimits).toHaveLength(2);
 		expect(gptLimits).toHaveLength(2);
 		expect(claudeLimits.every(limit => limit.scope.shared === true)).toBeTrue();
 		expect(gptLimits.every(limit => limit.scope.shared === true)).toBeTrue();
+		expect(claudeLimits.every(limit => limit.label === "Claude & GPT (shared)")).toBeTrue();
+		expect(gptLimits.every(limit => limit.label === "Claude & GPT (shared)")).toBeTrue();
+		expect(claudeLimits.map(limit => limit.scope.sharedGroup).sort()).toEqual(
+			gptLimits.map(limit => limit.scope.sharedGroup).sort(),
+		);
 	});
 
 	it("merges two models with same tier into one limit", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Antigravity usage views now show the shared Claude/GPT five-hour and weekly quotas once per account instead of duplicating Anthropic and OpenAI rows ([#11268](https://github.com/can1357/oh-my-pi/issues/11268)).
 - Bash results no longer replace a failing command's output with the shell minimizer's lossy summary when the original capture cannot be persisted as an artifact; the raw diagnostics are kept so a failure stays actionable ([#11081](https://github.com/can1357/oh-my-pi/issues/11081)).
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -24,6 +24,7 @@ import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
 import { discoverAuthStorage } from "../sdk";
 import { resolveAuthBrokerConfig } from "../session/auth-broker-config";
+import { collapseSharedUsageReports } from "../utils/usage-display";
 
 const BAR_WIDTH = 28;
 
@@ -639,13 +640,14 @@ export function formatUsageBreakdown(
 	redaction?: Map<string, string>,
 	disabled: DisabledCredentialSummary[] = [],
 ): string {
+	const displayReports = collapseSharedUsageReports(reports);
 	const reportsByProvider = new Map<string, UsageReport[]>();
-	for (const report of reports) {
+	for (const report of displayReports) {
 		const list = reportsByProvider.get(report.provider) ?? [];
 		list.push(report);
 		reportsByProvider.set(report.provider, list);
 	}
-	const unreported = collectUnreportedAccounts(reports, accounts);
+	const unreported = collectUnreportedAccounts(displayReports, accounts);
 	const unreportedByProvider = new Map<string, UsageAccountIdentity[]>();
 	for (const account of unreported) {
 		const list = unreportedByProvider.get(account.provider) ?? [];
@@ -665,7 +667,7 @@ export function formatUsageBreakdown(
 	].sort((a, b) => a.localeCompare(b));
 
 	const lines: string[] = [];
-	const latestFetchedAt = Math.max(0, ...reports.map(report => report.fetchedAt ?? 0));
+	const latestFetchedAt = Math.max(0, ...displayReports.map(report => report.fetchedAt ?? 0));
 	const headerSuffix = latestFetchedAt ? chalk.dim(` · fetched ${formatDuration(nowMs - latestFetchedAt)} ago`) : "";
 	lines.push(`${chalk.bold("Usage")}${headerSuffix}`);
 

--- a/packages/coding-agent/src/modes/components/usage-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/usage-dashboard.ts
@@ -18,6 +18,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { colorLuma, formatDuration, hexToRgb, rgbToHex, sanitizeText } from "@oh-my-pi/pi-utils";
 import { formatProviderName } from "../../slash-commands/helpers/format";
+import { collapseSharedUsageReports } from "../../utils/usage-display";
 import { colorToAnsi } from "../theme/color";
 import { theme } from "../theme/theme";
 import {
@@ -142,8 +143,9 @@ function aggregateRowStatus(windows: CardWindowRow[]): UsageLimit["status"] {
  * what's burning is on top-left; fully idle providers collapse into a tick.
  */
 export function buildProviderCards(reports: UsageReport[], nowMs: number): ProviderCard[] {
+	const displayReports = collapseSharedUsageReports(reports);
 	const grouped = new Map<string, UsageReport[]>();
-	for (const report of reports) {
+	for (const report of displayReports) {
 		const list = grouped.get(report.provider) ?? [];
 		list.push(report);
 		grouped.set(report.provider, list);

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -66,6 +66,7 @@ import {
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { collapseSharedUsageReports } from "../../utils/usage-display";
 
 function formatCreditValue(value: number): string {
 	return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
@@ -2037,12 +2038,13 @@ export function renderUsageReports(
 	resolveActiveAccount?: (provider: string) => OAuthAccountIdentity | undefined,
 	usageModelSelectors: readonly string[] = [],
 ): string {
+	const displayReports = collapseSharedUsageReports(reports);
 	const lines: string[] = [];
 	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
 	const headerSuffix = latestFetchedAt ? ` (${formatDuration(nowMs - latestFetchedAt)} ago)` : "";
 	lines.push(uiTheme.bold(uiTheme.fg("accent", `Usage${headerSuffix}`)));
 	const grouped = new Map<string, UsageReport[]>();
-	for (const report of reports) {
+	for (const report of displayReports) {
 		const list = grouped.get(report.provider) ?? [];
 		list.push(report);
 		grouped.set(report.provider, list);

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -1,6 +1,7 @@
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { OAuthAccountIdentity } from "../../session/auth-storage";
+import { collapseSharedUsageReports } from "../../utils/usage-display";
 import type { SlashCommandRuntime } from "../types";
 import { reportMatchesActiveAccount } from "./active-oauth-account";
 import { formatDuration, formatProviderName, renderAsciiBar } from "./format";
@@ -58,10 +59,11 @@ function renderUsageReports(
 	resolveActiveAccount?: (provider: string) => OAuthAccountIdentity | undefined,
 	usageModelSelectors: readonly string[] = [],
 ): string {
-	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
+	const displayReports = collapseSharedUsageReports(reports);
+	const latestFetchedAt = Math.max(...displayReports.map(report => report.fetchedAt ?? 0));
 	const lines = [`Usage${latestFetchedAt ? ` (${formatDuration(nowMs - latestFetchedAt)} ago)` : ""}`];
 	const grouped = new Map<string, UsageReport[]>();
-	for (const report of reports) {
+	for (const report of displayReports) {
 		const providerReports = grouped.get(report.provider) ?? [];
 		providerReports.push(report);
 		grouped.set(report.provider, providerReports);

--- a/packages/coding-agent/src/utils/usage-display.ts
+++ b/packages/coding-agent/src/utils/usage-display.ts
@@ -1,0 +1,36 @@
+import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
+
+function collapseSharedLimits(limits: UsageLimit[]): UsageLimit[] {
+	const seenGroups = new Set<string>();
+	let collapsed: UsageLimit[] | undefined;
+
+	for (let index = 0; index < limits.length; index++) {
+		const limit = limits[index]!;
+		const group = limit.scope.sharedGroup;
+		if (group !== undefined && seenGroups.has(group)) {
+			collapsed ??= limits.slice(0, index);
+			continue;
+		}
+		if (group !== undefined) seenGroups.add(group);
+		collapsed?.push(limit);
+	}
+
+	return collapsed ?? limits;
+}
+
+/** Collapse routing-specific copies of a shared quota for user-facing usage views. */
+export function collapseSharedUsageReports(reports: UsageReport[]): UsageReport[] {
+	let collapsed: UsageReport[] | undefined;
+
+	for (let index = 0; index < reports.length; index++) {
+		const report = reports[index]!;
+		const limits = collapseSharedLimits(report.limits);
+		const displayReport = limits === report.limits ? report : { ...report, limits };
+		if (displayReport !== report) {
+			collapsed ??= reports.slice(0, index);
+		}
+		collapsed?.push(displayReport);
+	}
+
+	return collapsed ?? reports;
+}

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -95,4 +95,46 @@ describe("renderUsageReports content", () => {
 		expect(output).toContain(`(${futureIso.slice(0, 10)})`);
 		expect(output).toContain(`expired (${expiredIso.slice(0, 10)})`);
 	});
+
+	it("renders each marked Antigravity shared quota once in expanded details", () => {
+		const quota = (
+			counter: "google" | "anthropic" | "openai",
+			windowId: "5h" | "weekly",
+		): UsageReport["limits"][number] => {
+			const sharedGroup = counter === "google" ? undefined : `3p-${windowId}`;
+			return {
+				id: `google-antigravity:${counter}:default:${counter === "google" ? "gemini" : "3p"}-${windowId}`,
+				label: counter === "google" ? "Gemini" : "Claude & GPT (shared)",
+				scope: {
+					provider: "google-antigravity",
+					accountId: "account",
+					windowId,
+					...(sharedGroup !== undefined ? { shared: true, sharedGroup } : {}),
+				},
+				window: { id: windowId, label: windowId === "5h" ? "5 Hour" : "Weekly" },
+				amount: { unit: "percent", usedFraction: 0.25 },
+				status: "ok",
+			};
+		};
+		const reports: UsageReport[] = [
+			{
+				provider: "google-antigravity",
+				fetchedAt: Date.now(),
+				limits: [
+					quota("google", "5h"),
+					quota("google", "weekly"),
+					quota("anthropic", "5h"),
+					quota("openai", "5h"),
+					quota("anthropic", "weekly"),
+					quota("openai", "weekly"),
+				],
+				metadata: { email: "user@example.test" },
+			},
+		];
+
+		const output = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+
+		expect(output.match(/Claude & GPT \(shared\)/g)).toHaveLength(2);
+		expect(output.match(/Gemini/g)).toHaveLength(2);
+	});
 });

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -16,6 +16,7 @@ const SEVEN_DAYS = 7 * 24 * HOUR;
 
 function makeLimit(opts: {
 	id: string;
+	label?: string;
 	usedFraction: number;
 	durationMs?: number;
 	windowId?: string;
@@ -23,15 +24,17 @@ function makeLimit(opts: {
 	accountId?: string;
 	provider?: string;
 	notes?: string[];
+	sharedGroup?: string;
 }): UsageReport["limits"][number] {
 	return {
 		id: opts.id,
-		label: opts.id,
+		label: opts.label ?? opts.id,
 		scope: {
 			provider: opts.provider ?? "anthropic",
 			windowId: opts.windowId,
 			tier: opts.tier,
 			accountId: opts.accountId,
+			...(opts.sharedGroup !== undefined ? { shared: true, sharedGroup: opts.sharedGroup } : {}),
 		},
 		window:
 			opts.durationMs !== undefined
@@ -338,6 +341,47 @@ describe("formatUsageBreakdown", () => {
 		expect(text).toContain("Cerebras");
 		expect(text).toContain("API key — no usage data");
 		expect(text).toContain("capacity: 5h → 1.34/2 accounts used (0.66× quota left)");
+	});
+
+	it("renders marked Antigravity shared quotas once per account", () => {
+		const antigravity = makeReport("google-antigravity", "user@example.test", [
+			makeLimit({
+				id: "google-antigravity:google:default:gemini-5h",
+				label: "Gemini",
+				provider: "google-antigravity",
+				usedFraction: 0.25,
+				durationMs: FIVE_HOURS,
+				windowId: "5h",
+			}),
+			makeLimit({
+				id: "google-antigravity:google:default:gemini-weekly",
+				label: "Gemini",
+				provider: "google-antigravity",
+				usedFraction: 0.25,
+				durationMs: SEVEN_DAYS,
+				windowId: "weekly",
+			}),
+			...(["5h", "weekly"] as const).flatMap((windowId, index) =>
+				(["anthropic", "openai"] as const).map(counter =>
+					makeLimit({
+						id: `google-antigravity:${counter}:default:3p-${windowId}`,
+						label: "Claude & GPT (shared)",
+						provider: "google-antigravity",
+						usedFraction: 0.25,
+						durationMs: index === 0 ? FIVE_HOURS : SEVEN_DAYS,
+						windowId,
+						sharedGroup: `3p-${windowId}`,
+					}),
+				),
+			),
+		]);
+
+		const text = stripVTControlCharacters(formatUsageBreakdown([antigravity], [], Date.now()));
+
+		expect(text.match(/Claude & GPT \(shared\)/g)).toHaveLength(2);
+		expect(text.match(/Gemini/g)).toHaveLength(2);
+		expect(text).not.toContain("Usage (Anthropic)");
+		expect(text).not.toContain("Usage (OpenAI)");
 	});
 
 	it("keeps near-exhausted capacity fractional instead of rounding it to an exact need", () => {

--- a/packages/coding-agent/test/usage-dashboard.test.ts
+++ b/packages/coding-agent/test/usage-dashboard.test.ts
@@ -114,6 +114,36 @@ describe("buildProviderCards", () => {
 		const unlimited = cards.find(card => card.provider === "ollama-cloud");
 		expect(unlimited?.unlimited).toBe(true);
 	});
+
+	it("shows each marked shared quota once without merging independent buckets", () => {
+		const sharedLimit = (counter: "anthropic" | "openai", windowId: "5h" | "7d") => {
+			const value = limit("google-antigravity", "account", windowId, "Claude & GPT (shared)", 0.25, "ok");
+			return {
+				...value,
+				id: `google-antigravity:${counter}:default:3p-${windowId}`,
+				scope: { ...value.scope, shared: true, sharedGroup: `3p-${windowId}` },
+			};
+		};
+		const reports = [
+			report("google-antigravity", "user@example.test", [
+				limit("google-antigravity", "account", "5h", "Gemini", 0.25, "ok"),
+				limit("google-antigravity", "account", "7d", "Gemini", 0.25, "ok"),
+				sharedLimit("anthropic", "5h"),
+				sharedLimit("openai", "5h"),
+				sharedLimit("anthropic", "7d"),
+				sharedLimit("openai", "7d"),
+			]),
+		];
+
+		const windows = buildProviderCards(reports, now)[0].windows;
+
+		expect(windows.map(window => `${window.label} — ${window.windowTag}`).sort()).toEqual([
+			"Claude & GPT (shared) — 5h",
+			"Claude & GPT (shared) — 7d",
+			"Gemini — 5h",
+			"Gemini — 7d",
+		]);
+	});
 });
 describe("UsageDashboardComponent", () => {
 	beforeAll(async () => {


### PR DESCRIPTION
## Repro
`bun test packages/ai/test/google-antigravity-usage.test.ts --test-name-pattern "reports the official five-hour and weekly quota summary"` confirms the official four-bucket summary becomes six routing limits: two Gemini limits plus Anthropic and OpenAI copies of both shared `3p-*` buckets. Before this fix, the usage renderers grouped those six limits by routing-specific labels and displayed six quota rows.

## Cause
`buildQuotaSummaryReport` in `packages/ai/src/usage/google-antigravity.ts` intentionally emits Anthropic and OpenAI copies so `scopeAntigravityLimitsForModel` can rank Claude and GPT credentials independently, but `buildProviderCards`, `renderUsageReports`, and `formatUsageBreakdown` had no counter-independent identity indicating that each pair represents one upstream pool.

## Fix
- Mark routing-specific copies with a stable `UsageScope.sharedGroup` and label official summary groups as `Gemini` and `Claude & GPT (shared)`.
- Collapse only limits carrying the same shared-group identity in compact, expanded, CLI, and ACP usage renderers; leave the underlying report and routing IDs unchanged.
- Cover provider routing preservation plus compact, expanded, and CLI row consolidation.

## Verification
`bun test packages/ai/test/google-antigravity-usage.test.ts packages/coding-agent/test/usage-dashboard.test.ts packages/coding-agent/test/usage-cli.test.ts packages/coding-agent/test/modes/controllers/usage-command.test.ts packages/coding-agent/test/pr-3318-repro.test.ts` passes: 64 tests, 225 assertions. A provider-to-renderer smoke run retained six routing limits and two scoped limits each for Claude and GPT while both overview and CLI output contained four display rows. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #11268