### PR TITLE
fix(catalog): applied gemini wire policy to custom providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom `google-generative-ai` providers failing mid-turn model fallback when Gemini 3 tool calls are replayed without their original thought signature ([#11270](https://github.com/can1357/oh-my-pi/issues/11270)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/ai/test/google-gemini3-unsigned-tool-call.test.ts
+++ b/packages/ai/test/google-gemini3-unsigned-tool-call.test.ts
@@ -134,4 +134,12 @@ describe("Gemini 3 unsigned tool-call signatures (#9638, #10602)", () => {
 		expect(parallelCalls[1]?.thoughtSignature).toBe(SENTINEL);
 		expect(parallelCalls[2]?.thoughtSignature).toBe(SENTINEL);
 	});
+
+	it("uses the public Gemini bypass for custom google-generative-ai providers", () => {
+		const model = buildGeminiModel("google-generative-ai", "build", "gemini-3.7-flash");
+		const unsigned = unsignedFirstCall("google-generative-ai", "build", "gemini-3.7-flash");
+
+		expect(model.identity.class).toBe("gemini");
+		expect(toolCallParts(model, unsigned)[0]?.thoughtSignature).toBe(SENTINEL);
+	});
 });

--- a/packages/catalog/scripts/compat-compiler/compile-cascade.ts
+++ b/packages/catalog/scripts/compat-compiler/compile-cascade.ts
@@ -2,12 +2,11 @@
  * Compiles `rules/classes/*.kdl` + `rules/providers/*.kdl` into
  * {@link CompiledCascade}.
  *
- * Faithful port of the o2 reference (`cascade.rs`): nested selector scopes
- * (`class` / `provider` / `on` / `family` / `revision` / `models`) collapse
- * into flat conjunction rules; axis directives are validated against the
- * closed vocabulary in `src/compat/axes.ts` and emitted keyed by resolved
- * camelCase field. Duplicate axes in one block and misplaced selectors are
- * hard errors.
+ * Nested selector scopes (`class` / `provider` / `on` / `on-api` / `family` /
+ * `revision` / `models`) collapse into flat conjunction rules; axis directives
+ * are validated against the closed vocabulary in `src/compat/axes.ts` and
+ * emitted keyed by resolved camelCase field. Duplicate axes in one block and
+ * misplaced selectors are hard errors.
  */
 import { AXES, type AxisDef } from "../../src/compat/axes";
 import { parseRevisionConstraint } from "../../src/compat/revision";
@@ -19,8 +18,9 @@ const CHILD_CLASS = 1 << 1;
 const CHILD_FAMILY = 1 << 2;
 const CHILD_REVISION = 1 << 3;
 const CHILD_MODELS = 1 << 4;
-const CLASS_CHILDREN = CHILD_ON | CHILD_FAMILY | CHILD_REVISION | CHILD_MODELS;
-const CLASS_ON_CHILDREN = CHILD_FAMILY | CHILD_REVISION | CHILD_MODELS;
+const CHILD_API = 1 << 5;
+const CLASS_CHILDREN = CHILD_ON | CHILD_API | CHILD_FAMILY | CHILD_REVISION | CHILD_MODELS;
+const CLASS_FILTER_CHILDREN = CHILD_FAMILY | CHILD_REVISION | CHILD_MODELS;
 const PROVIDER_CHILDREN = CHILD_CLASS | CHILD_MODELS;
 const FAMILY_CHILDREN = CHILD_REVISION | CHILD_MODELS;
 const REVISION_CHILDREN = CHILD_MODELS;
@@ -28,6 +28,7 @@ const REVISION_CHILDREN = CHILD_MODELS;
 interface RuleScope {
 	class?: string;
 	providers?: string[];
+	apis?: string[];
 	family?: string;
 	revision?: CompiledRule["revision"];
 	models?: CompiledSelector[];
@@ -169,11 +170,15 @@ function parseScope(node: KdlNodeView, scope: RuleScope, allowed: number, rules:
 		switch (child.name) {
 			case "on":
 				kind = CHILD_ON;
-				nextAllowed = CLASS_ON_CHILDREN;
+				nextAllowed = CLASS_FILTER_CHILDREN;
+				break;
+			case "on-api":
+				kind = CHILD_API;
+				nextAllowed = CLASS_FILTER_CHILDREN;
 				break;
 			case "class":
 				kind = CHILD_CLASS;
-				nextAllowed = CLASS_ON_CHILDREN;
+				nextAllowed = CLASS_FILTER_CHILDREN;
 				break;
 			case "family":
 				kind = CHILD_FAMILY;
@@ -199,6 +204,9 @@ function parseScope(node: KdlNodeView, scope: RuleScope, allowed: number, rules:
 				break;
 			case CHILD_CLASS:
 				nested.class = requiredName(child);
+				break;
+			case CHILD_API:
+				nested.apis = stringArguments(child);
 				break;
 			case CHILD_FAMILY:
 				nested.family = requiredName(child);
@@ -228,6 +236,7 @@ function parseScope(node: KdlNodeView, scope: RuleScope, allowed: number, rules:
 	const rule: CompiledRule = { source: `${node.file}:${node.line}` };
 	if (scope.class !== undefined) rule.class = scope.class;
 	if (scope.providers !== undefined) rule.providers = scope.providers;
+	if (scope.apis !== undefined) rule.apis = scope.apis;
 	if (scope.family !== undefined) rule.family = scope.family;
 	if (scope.revision !== undefined) rule.revision = scope.revision;
 	if (scope.models !== undefined) rule.models = scope.models;

--- a/packages/catalog/src/compat/cascade.ts
+++ b/packages/catalog/src/compat/cascade.ts
@@ -3,7 +3,7 @@
  * for one structured model target from the compiled rule tree.
  *
  * Faithful port of the o2 reference resolver (`cascade.rs`): rules are
- * conjunctions over `(class, provider, family, revision, models)`; per axis
+ * conjunctions over `(class, provider, api, family, revision, models)`; per axis
  * the matching rule with the greatest `(model-selector exactness,
  * constrained-dimension count, priority)` tuple wins, and an equal-tuple
  * same-axis contest throws {@link AmbiguousOverlapError}. Declaration and
@@ -74,6 +74,7 @@ function buildRuleIndex(cascade: CompiledCascade): IndexedRule[] {
 		const dimensions =
 			Number(compiled.class !== undefined) +
 			Number(compiled.providers !== undefined) +
+			Number(compiled.apis !== undefined) +
 			Number(compiled.family !== undefined) +
 			Number(compiled.revision !== undefined) +
 			Number(compiled.models !== undefined);
@@ -117,6 +118,7 @@ function rankRule(
 	const { compiled } = rule;
 	if (compiled.class !== undefined && compiled.class !== target.class) return undefined;
 	if (compiled.providers !== undefined && !compiled.providers.includes(target.provider)) return undefined;
+	if (compiled.apis !== undefined && !compiled.apis.includes(target.api)) return undefined;
 	if (compiled.family !== undefined && compiled.family !== target.family) return undefined;
 	if (rule.revision !== undefined && (!revision || !revisionSatisfies(revision, rule.revision))) return undefined;
 	let exactness = 0;

--- a/packages/catalog/src/compat/delegation.ts
+++ b/packages/catalog/src/compat/delegation.ts
@@ -27,6 +27,7 @@ export function resolveDelegationBias(model: Model): DelegationBias {
 	const { identity } = model;
 	const bias = resolveCascade({
 		provider: model.provider,
+		api: model.api,
 		class: identity.class,
 		model: model.id,
 		reasoning: Boolean(model.reasoning),

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -1173,6 +1173,7 @@ function fillExplicitThinking<TApi extends Api>(
 function buildResolveTarget<TApi extends Api>(spec: ModelSpec<TApi>, identity: ModelIdentity): ResolveTarget {
 	const target: ResolveTarget = {
 		provider: spec.provider,
+		api: spec.api,
 		class: identity.class,
 		model: spec.id,
 		reasoning: Boolean(spec.reasoning),

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4822,11 +4822,10 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:94",
+				"source": "classes/gemini.kdl:96",
 				"class": "gemini",
-				"providers": [
-					"google",
-					"opencode-zen"
+				"apis": [
+					"google-generative-ai"
 				],
 				"revision": [
 					{
@@ -4840,7 +4839,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:100",
+				"source": "classes/gemini.kdl:102",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity",

--- a/packages/catalog/src/compat/rules/README.md
+++ b/packages/catalog/src/compat/rules/README.md
@@ -5,7 +5,7 @@ This tree is the checked-in source of model identity and compatibility policy. A
 There are three ownership strata:
 
 - `taxonomy/*.kdl` defines identity: class membership, product families, revision extraction, reviewed exact corrections, and suffix collapse.
-- `classes/*.kdl` defines model-lineage truths: behavior inherent to a model line, optionally scoped to the providers where the census established it.
+- `classes/*.kdl` defines model-lineage truths: behavior inherent to a model line, optionally scoped to the providers or request adapters where the census established it.
 - `providers/*.kdl` defines deployment contracts: behavior imposed by a host, plus documented per-model residue that taxonomy cannot express exactly.
 - `runtime/behavior.kdl` defines heuristics used before or outside exact model lookup: responses routing, API routes, quota tiers, plan requirements, model limits, roster exclusions, hosted defaults, pricing peers.
 - `auth/<provider>.kdl` defines the provider's auth contract: display name, env-var fallback, credential storage/format, and the declarative login / refresh flow that `@oh-my-pi/pi-ai`'s registry engines interpret (see [Auth grammar](#auth-grammar)).
@@ -151,10 +151,15 @@ discovery {
 
 ## Cascade grammar
 
-A cascade document starts with `class` or `provider`. Every selector adds a conjunct to the current rule. Axis directives may appear directly in any permitted scope, and nested selector blocks may appear alongside them.
+A cascade document starts with `class` or `provider`. Every selector adds a conjunct to the current rule. `on` scopes by deployment provider; `on-api` scopes by request adapter, including custom provider names. Axis directives may appear directly in any permitted scope, and nested selector blocks may appear alongside them.
 
 ```kdl
 class "gemini" {
+    on-api "google-generative-ai" {
+        revision ">=3" {
+            requires-skip-thought-signature #true
+        }
+    }
     on "google" "google-vertex" "openrouter" {
         family "flash" {
             revision ">=2.5 <3.8" {
@@ -175,14 +180,15 @@ provider "openrouter" {
 
 | Selector | Form | Matching semantics |
 | --- | --- | --- |
-| `class` | `class "id" { ... }` | Exact class ID. At document root it may contain `on`, `family`, `revision`, and `models`. Under `provider` it may contain `family`, `revision`, and `models`. |
+| `class` | `class "id" { ... }` | Exact class ID. At document root it may contain `on`, `on-api`, `family`, `revision`, and `models`. Under `provider` it may contain `family`, `revision`, and `models`. |
 | `provider` | `provider "id" { ... }` | Exact provider ID. It is root-only and may contain `class` and `models`. |
 | `on` | `on "provider-a" "provider-b" { ... }` | One or more provider IDs, combined as OR. It is allowed only under a root `class`, and may contain `family`, `revision`, and `models`. |
+| `on-api` | `on-api "adapter-a" "adapter-b" { ... }` | One or more request adapter IDs, combined as OR. It is allowed only under a root `class`, and may contain `family`, `revision`, and `models`. |
 | `family` | `family "id" { ... }` | Exact classified family ID. It may contain `revision` and `models`. A target with no family does not match. |
 | `revision` | `revision ">=2.5 <4" { ... }` | A non-empty, whitespace-separated conjunction of comparisons. It may contain `models`. A target with no revision does not match. |
 | `models` | `models "id" "vendor/*" { ... }` | One or more alternatives, combined as OR. It cannot contain another selector. `token="name"` matches an ASCII-case-insensitive token bounded by non-alphanumerics. |
 
-Class, provider/`on`, and family selector values are compared exactly and case-sensitively to the structured resolve target. Revision operators are `>=`, `>`, `<=`, `<`, and `=`; operands have one to three dot-separated unsigned 8-bit components, omitted components zero.
+Class, provider/`on`, `on-api`, and family selector values are compared exactly and case-sensitively to the structured resolve target. Revision operators are `>=`, `>`, `<=`, `<`, and `=`; operands have one to three dot-separated unsigned 8-bit components, omitted components zero.
 
 A `models` string without `*` is an exact, case-sensitive match against the provider-relative model identifier. A string containing `*` is an anchored, ASCII-case-insensitive wildcard match. Prefer taxonomy ranks; retain exact/glob lists only when they isolate the census member set exactly, and keep a `// residue:` comment explaining why ranks do not.
 
@@ -212,7 +218,7 @@ Rules resolve independently per axis. A matching rule is ranked by:
 The tuple is compared lexicographically, greatest first:
 
 - model exactness is `2` when any matching `models` selector is exact, `1` when the best matching selector is a glob or token, and `0` when the rule has no `models` selector;
-- dimension count is the number of present dimensions among class, provider/`on`, family, revision, and models;
+- dimension count is the number of present dimensions among class, provider/`on`, API/`on-api`, family, revision, and models;
 - priority is the local block's `priority`, defaulting to `0`.
 
 The highest-ranked matching assignment wins for that axis. Two distinct rules that tie on all three components and assign the same axis are an ambiguity error even if their values are equal. File and declaration order never resolve the tie; add an explicit priority only after confirming the overlap is intentional.

--- a/packages/catalog/src/compat/rules/classes/gemini.kdl
+++ b/packages/catalog/src/compat/rules/classes/gemini.kdl
@@ -88,9 +88,11 @@ class "gemini" {
 		// Replaces the Gemini 3+ mandatory-reasoning fallback.
 		thinking-requires-effort #true
 	}
-	// Public Gemini requires the bypass sentinel on every unsigned call. The
-	// Cloud Code Assist first-call variant is a host contract in providers/.
-	on "google" "opencode-zen" {
+	// Public Gemini requires the bypass sentinel on every unsigned call and
+	// supports function-part ids. Scope by adapter so custom providers using
+	// the same wire protocol inherit both contracts. The Cloud Code Assist
+	// first-call variant is a host contract in providers/.
+	on-api "google-generative-ai" {
 		revision ">=3" {
 			requires-skip-thought-signature #true
 			supports-function-part-id #true

--- a/packages/catalog/src/compat/types.ts
+++ b/packages/catalog/src/compat/types.ts
@@ -198,6 +198,8 @@ export interface CompiledRule {
 	source: string;
 	class?: string;
 	providers?: string[];
+	/** Request adapter identifiers matched by an `on-api` selector. */
+	apis?: string[];
 	family?: string;
 	revision?: CompiledRevisionTerm[];
 	models?: CompiledSelector[];
@@ -568,6 +570,8 @@ export interface ModelIdentity {
 export interface ResolveTarget {
 	/** Deployment provider hosting the model. */
 	provider: string;
+	/** Request adapter used to serialize the model. */
+	api: string;
 	/** Centrally classified vendor lineage. */
 	class: string;
 	/** Classified product family within the class, when known. */

--- a/packages/catalog/test/compat-cascade.test.ts
+++ b/packages/catalog/test/compat-cascade.test.ts
@@ -9,6 +9,7 @@ function compile(text: string) {
 
 const target = (overrides: Partial<ResolveTarget>): ResolveTarget => ({
 	provider: "prov",
+	api: "api",
 	class: "cls",
 	model: "model-1",
 	reasoning: true,
@@ -47,6 +48,21 @@ describe("cascade rank precedence", () => {
 		);
 		expect(resolveCascadeRules(cascade, target({ family: "fam" })).wire.supportsStore).toBe(false);
 		expect(resolveCascadeRules(cascade, target({})).wire.supportsStore).toBe(true);
+	});
+
+	test("API selectors match independently of custom provider names", () => {
+		const cascade = compile(
+			`class "cls" {
+				on-api "google-generative-ai" {
+					requires-skip-thought-signature #true
+				}
+			}`,
+		);
+
+		expect(resolveCascadeRules(cascade, target({ api: "google-generative-ai" })).wire).toMatchObject({
+			requiresSkipThoughtSignature: true,
+		});
+		expect(resolveCascadeRules(cascade, target({ api: "google-vertex" })).wire).toEqual({});
 	});
 
 	test("priority breaks intentional equal-specificity overlap", () => {
@@ -115,6 +131,7 @@ describe("resolveCascade over committed rules", () => {
 	test("bundled rules resolve thinking for a reasoning glm target", () => {
 		const resolved = resolveCascade({
 			provider: "opencode-zen",
+			api: "openai-completions",
 			class: "glm",
 			model: "glm-5.2",
 			reasoning: true,
@@ -128,6 +145,7 @@ describe("resolveCascade over committed rules", () => {
 		// classes/glm.kdl revision >=5.2 ladder and throw AmbiguousOverlapError.
 		const resolved = resolveCascade({
 			provider: "alibaba-coding-plan",
+			api: "openai-completions",
 			class: "glm",
 			model: "glm-5.2",
 			revision: "5.2",


### PR DESCRIPTION
## Repro
A custom `build/gemini-3.7-flash` model using `api: google-generative-ai` serialized an unsigned mid-turn tool-call replay without a `thoughtSignature`. `bun test packages/ai/test/google-gemini3-unsigned-tool-call.test.ts` reproduced the failure: expected `skip_thought_signature_validator`, received `undefined`.

## Cause
`buildResolveTarget` in `packages/catalog/src/compat/resolve.ts` supplied provider and model identity to the KDL cascade but not the request adapter. The Gemini 3 bypass rule in `packages/catalog/src/compat/rules/classes/gemini.kdl` was therefore scoped to the built-in `google` and `opencode-zen` provider IDs, so a differently named custom provider could not inherit the `google-generative-ai` wire contract even though its model identity was correctly `gemini`.

## Fix
- Added `on-api` selectors to the compatibility cascade compiler and resolver.
- Scoped the Gemini 3 public-API signature and function-part-ID policy to `google-generative-ai`, covering custom provider names without changing Vertex or Cloud Code Assist behavior.
- Added cascade and serialization regressions, regenerated `rules.json`, and documented the selector.

## Verification
`bun test packages/ai/test/google-gemini3-unsigned-tool-call.test.ts packages/catalog/test/compat-cascade.test.ts packages/catalog/test/compat-compile.test.ts packages/catalog/test/compat-conformance.test.ts packages/catalog/test/compat-parity.test.ts` passes: 35 tests, 0 failures. `bun run check:ts` passes across all TypeScript workspaces. `bun check` fails identically on clean `origin/main` because this runner lacks `cmake` for `audiopus_sys`; the pre-publish gate was skipped for that unrelated environment failure.

Fixes #11270