### PR TITLE
fix(copilot): minimal-grant OAuth app and preserve creds on 403

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub Copilot sign-in uses the minimal-grant OpenCode OAuth app again (`read:user` only): GitHub renders each app's existing per-user grant on the consent page, so Enterprise organizations that block the Copilot CLI app's broad historic grant can log in as on 18.1.4. API request identity still mimics the Copilot CLI, and tokens minted by either app keep working ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
+- GitHub Copilot plan/model-policy 403s no longer count as credential failures for credential-lifetime decisions: the token is valid, so stored credentials are preserved instead of wiped ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -694,6 +694,26 @@ export function isClinePassSurfaceGateMessage(errorMessage: string | undefined):
 	return errorMessage !== undefined && CLINE_PASS_SURFACE_GATE_PATTERN.test(errorMessage);
 }
 
+const GITHUB_COPILOT_POLICY_DENIAL_PATTERN = /GitHub Copilot access denied \(HTTP 403\)/;
+
+/**
+ * GitHub Copilot 403s are plan/model-policy/org denials against a valid token —
+ * never a revoked credential (those arrive as 401). Wiping stored credentials
+ * on them hides the whole provider from `/model` and forces a pointless
+ * re-login, so credential-lifetime decisions must exempt them even though
+ * they still classify as `Flag.AuthFailed` (issue #11275). Mirrors the 403
+ * contract in `rewriteCopilotError` (`utils/http-inspector.ts`).
+ */
+export function isGitHubCopilotPolicyDenial(
+	provider: string | undefined,
+	status: number | undefined,
+	errorMessage: string | undefined,
+): boolean {
+	if (provider !== "github-copilot") return false;
+	if (status === 403) return true;
+	return errorMessage !== undefined && GITHUB_COPILOT_POLICY_DENIAL_PATTERN.test(errorMessage);
+}
+
 export function classifyMessage(message: {
 	api?: Api;
 	provider?: string;

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -1,5 +1,13 @@
 /**
- * GitHub Copilot OAuth flow using the official Copilot CLI app.
+ * GitHub Copilot OAuth flow (OpenCode OAuth app, minimal read:user grant).
+ *
+ * The device flow intentionally uses the OpenCode app identity rather than
+ * the official Copilot CLI app: GitHub renders each app's existing per-user
+ * grant (Existing access) on the consent page, and Enterprise orgs that
+ * restrict OAuth apps block the CLI app's broad historic grant
+ * (repo/gist/codespace) no matter what scope this request asks for
+ * (issue #11275). API request identity still mimics the Copilot CLI via
+ * COPILOT_API_HEADERS.
  */
 import { scheduler } from "node:timers/promises";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
@@ -15,7 +23,7 @@ import * as AIError from "../../error";
 import type { FetchImpl } from "../../types";
 import type { OAuthController, OAuthCredentials } from "./types";
 
-const CLIENT_ID = "Ov23ctDVkRmgkPke0Mmm";
+const CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const OAUTH_SCOPE = "read:user";
 const OAUTH_HEADERS = {
 	Accept: "application/json",
@@ -207,7 +215,7 @@ const FAR_FUTURE_MS = Date.now() + 10 * 365.25 * 24 * 60 * 60 * 1000;
 
 /**
  * Refresh GitHub Copilot token.
- * GitHub OAuth tokens from both the former OpenCode app and the Copilot CLI app
+ * GitHub OAuth tokens from both the OpenCode app and the Copilot CLI app
  * remain directly usable, so existing logins need no token exchange or migration.
  */
 export function refreshGitHubCopilotToken(
@@ -335,8 +343,8 @@ export async function loginGitHubCopilot(options: GitHubCopilotLoginOptions): Pr
 
 	const apiEndpoint = await discoverGitHubCopilotApiEndpoint(githubAccessToken, fetchImpl);
 
-	// Keep storing the GitHub token directly so credentials minted by the former
-	// OpenCode OAuth app remain valid alongside new Copilot CLI app logins.
+	// Keep storing the GitHub token directly so credentials minted by the
+	// Copilot CLI OAuth app remain valid alongside new OpenCode app logins.
 	const credentials: OAuthCredentials = {
 		refresh: githubAccessToken,
 		access: githubAccessToken,

--- a/packages/ai/test/github-copilot-error.test.ts
+++ b/packages/ai/test/github-copilot-error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { isGitHubCopilotPolicyDenial } from "@oh-my-pi/pi-ai/error";
 import { rewriteCopilotError } from "@oh-my-pi/pi-ai/utils/http-inspector";
 
 function errorWithStatus(
@@ -48,5 +49,27 @@ describe("rewriteCopilotError", () => {
 		expect(result).toContain("GitHub Copilot access denied (HTTP 403)");
 		expect(result).not.toContain("GitHub Copilot authentication failed");
 		expect(result).not.toContain("/login github-copilot");
+	});
+});
+
+describe("isGitHubCopilotPolicyDenial", () => {
+	it("exempts Copilot 403s by status so credentials survive plan/model denials", () => {
+		expect(isGitHubCopilotPolicyDenial("github-copilot", 403, "403 Forbidden")).toBe(true);
+	});
+
+	it("matches the 403 rewrite text when no status is attached", () => {
+		const rewritten = rewriteCopilotError("403 Forbidden", errorWithStatus(403), "github-copilot");
+		expect(isGitHubCopilotPolicyDenial("github-copilot", undefined, rewritten)).toBe(true);
+	});
+
+	it("does not exempt Copilot 401s (revoked credentials must still be wiped)", () => {
+		const rewritten = rewriteCopilotError("401 Unauthorized", errorWithStatus(401), "github-copilot");
+		expect(isGitHubCopilotPolicyDenial("github-copilot", 401, rewritten)).toBe(false);
+	});
+
+	it("does not exempt other providers or non-403 Copilot failures", () => {
+		expect(isGitHubCopilotPolicyDenial("openai", 403, "403 Forbidden")).toBe(false);
+		expect(isGitHubCopilotPolicyDenial("github-copilot", 500, "server error")).toBe(false);
+		expect(isGitHubCopilotPolicyDenial("github-copilot", undefined, undefined)).toBe(false);
 	});
 });

--- a/packages/ai/test/github-copilot-login.test.ts
+++ b/packages/ai/test/github-copilot-login.test.ts
@@ -32,7 +32,7 @@ function accessTokenResponse(token = "ghu_test") {
 	};
 }
 
-function expectOfficialOAuthRequest(init: RequestInit | undefined, body: Record<string, string>) {
+function expectOAuthRequest(init: RequestInit | undefined, body: Record<string, string>) {
 	const headers = new Headers(init?.headers);
 	expect(headers.get("Accept")).toBe("application/json");
 	expect(headers.get("Content-Type")).toBe("application/x-www-form-urlencoded");
@@ -48,14 +48,14 @@ function modelPolicyOk() {
 }
 
 describe("loginGitHubCopilot", () => {
-	it("requests only the scopes needed for Copilot API access", async () => {
+	it("uses the minimal-grant OpenCode app with read:user only", async () => {
 		let pollCount = 0;
 		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			const url = typeof input === "string" ? input : input.toString();
 			if (url === "https://github.com/login/device/code") {
 				expect(init?.method).toBe("POST");
-				expectOfficialOAuthRequest(init, {
-					client_id: "Ov23ctDVkRmgkPke0Mmm",
+				expectOAuthRequest(init, {
+					client_id: "Ov23li8tweQw6odWQebz",
 					scope: "read:user",
 				});
 				return new Response(JSON.stringify(deviceCodeResponse()), {
@@ -65,8 +65,8 @@ describe("loginGitHubCopilot", () => {
 			}
 			if (url === "https://github.com/login/oauth/access_token") {
 				pollCount++;
-				expectOfficialOAuthRequest(init, {
-					client_id: "Ov23ctDVkRmgkPke0Mmm",
+				expectOAuthRequest(init, {
+					client_id: "Ov23li8tweQw6odWQebz",
 					device_code: "dc_test",
 					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
 				});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub Copilot model-policy 403s (plan, model policy, org restriction) no longer delete stored credentials, so the provider stays listed in `/model` after a per-model access denial instead of disappearing until the next `/login` ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
+
 ### Added
 
 - Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3243,14 +3243,17 @@ export class AgentSession {
 			// expired/revoked token) so stale tokens aren't reused on the next request.
 			// Account usage caps and concurrency caps leave the credential valid: the
 			// former rotates until its reset window, while the latter is retried after
-			// a short backoff without touching the credential pool.
+			// a short backoff without touching the credential pool. Model-policy 403s
+			// (plan, model policy, org restriction) also preserve the credential: the
+			// token is valid, and wiping it hides the provider from `/model` (#11275).
 			if (msg.stopReason === "error" && msg.provider === "github-copilot") {
 				const errorId = AIError.classifyMessage(msg);
 				const isConcurrencyCap = AIError.parseRateLimitReason(msg.errorMessage ?? "") === "CONCURRENT_LIMIT";
 				if (
 					AIError.is(errorId, AIError.Flag.AuthFailed) &&
 					!AIError.is(errorId, AIError.Flag.UsageLimit) &&
-					!isConcurrencyCap
+					!isConcurrencyCap &&
+					!AIError.isGitHubCopilotPolicyDenial(msg.provider, msg.errorStatus, msg.errorMessage)
 				) {
 					await this.#modelRegistry.authStorage.remove("github-copilot");
 				}


### PR DESCRIPTION
Device flow uses the OpenCode OAuth app (`read:user`) again: GitHub renders each app's existing per-user grant on the consent page, so Enterprise orgs blocking the Copilot CLI app's broad historic grant can log in as on 18.1.4. CLI wire headers unchanged; either app's tokens keep working.

Copilot model-policy 403s no longer wipe stored credentials, so the provider stays in `/model` after a per-model denial instead of disappearing until re-login.

Fixes #11275