### PR TITLE
fix(todos): persist canonical state across lifecycle changes

### DIFF
--- a/docs/tools/todo.md
+++ b/docs/tools/todo.md
@@ -8,7 +8,7 @@
 - Key collaborators:
   - `packages/coding-agent/src/tools/index.ts` — registers tool, exposes session hooks, gates availability.
   - `packages/coding-agent/src/modes/controllers/event-controller.ts` — updates the visible todo UI on tool completion.
-  - `packages/coding-agent/src/session/agent-session.ts` — stores cached phases, strips done/dropped tasks on session resume, emits failure reminders.
+  - `packages/coding-agent/src/session/agent-session.ts` and `todo-tracker.ts` — own canonical phases, journal replay, accepted completion, and bounded model-context restoration.
   - `packages/coding-agent/src/modes/controllers/todo-command-controller.ts` — `/todo` command path, custom-entry persistence, transcript reminder injection.
   - `packages/coding-agent/src/tools/render-utils.ts` — collapsed-preview cap for renderer trees.
 
@@ -115,7 +115,7 @@ The same file also exposes non-tool helpers used by `/todo`:
 - Session state (transcript, memory, jobs, checkpoints, registries)
   - Mutates the session todo cache through `setTodoPhases`.
   - `storage` reports whether the session has a backing session file, but the tool does not append a custom session entry itself.
-  - Successful tool-result messages carry `details.phases`; `getLatestTodoPhasesFromEntries(...)` can reconstruct state later from those transcript entries.
+  - Successful native results and `write xd://todo` execution details carry canonical phases. `getLatestTodoPhasesFromEntries(...)` reconstructs the latest successful snapshot from the active journal branch; errors and unrelated device details do not replace it.
   - Failed `todo` results cause `agent-session` to enqueue a hidden next-turn reminder (`customType: "todo-error-reminder"`).
 - User-visible prompts / interactive UI
   - Transcript block is rendered by `todoToolRenderer` and merged with the call line.
@@ -161,9 +161,9 @@ The same file also exposes non-tool helpers used by `/todo`:
 - `findTaskByContent(...)` returns the first matching task across phases. Duplicate task contents make later targeted ops ambiguous.
 - `normalizeInProgressTask(...)` runs once after the op, not mid-op. A single op (e.g. `init`) can build an intermediate invalid state and rely on final normalization.
 - `storage: "session"` means the session has a session-file backing; it does not mean this tool wrote a durable custom entry.
-- Reload persistence differs by path:
-  - plain `todo` calls survive in transcript tool-result details;
-  - `/todo` command edits additionally append `customType: "user_todo_edit"` entries and inject a visible-to-model `<system-reminder>` developer message describing the manual edit.
-- On session resume, `AgentSession.#syncTodoPhasesFromBranch()` strips `completed` and `abandoned` tasks before restoring the cached list. The `/todo` command works around that by reading the latest transcript/custom-entry state so historical done/dropped tasks still appear to the user.
+- Native/device tool results persist through their normal result entry. Manual `/todo` edits, RPC `set_todos`, and accepted out-of-band completion use the existing `user_todo_edit` snapshot path. Ordinary tool operations do not gain duplicate custom snapshots.
+- Replay retains completed, abandoned, and blocked work, including blocker notes. Unqualified `rm` clears tasks while retaining phase headings; an explicit empty snapshot remains authoritative. An explicit context clear must not resurrect earlier context or stale child bindings.
+- Automatic acceptance requires an exact, unique actionable task bound to an observed owning child and current parent-call provenance. Changed plans, stale/failed children, and blocked/abandoned work require explicit parent handling; fuzzy display associations are not durable acceptance.
+- Context restoration adds at most one bounded `<todo-state>` projection when canonical state is missing from the model context. It includes current/pending/blocked work, blocker notes, separate terminal counts, omission notices, and `todo view` for the complete list. The projection does not create another store or change compaction method order. It protects checklist availability, not the semantic fidelity of a generated narrative summary.
 - Tool availability is gated by `todo.enabled`, and the registry excludes it when `includeYield` is enabled unless the session is prewalk-armed (`packages/coding-agent/src/tools/index.ts`).
 - Subagents do not inherit `todo`; `packages/coding-agent/src/task/executor.ts` also filters it from the active set as a parent-owned tool. Exception (both layers): prewalk-armed subagents keep it — the prewalk plan nudge and todo gate require the child to commit its own todo list before the hand-off.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.
 - Headless browser tabs now freeze when a turn settles so idle animated/WebGL pages stop burning CPU/GPU, resuming automatically on next use; tabs idle past `browser.idleCloseSec` (default 30 minutes) are closed. `persist: true` on `browser.open` opts a tab out of both ([#8246](https://github.com/can1357/oh-my-pi/issues/8246) by [@H4vC](https://github.com/H4vC)).
+- Added bounded canonical todo reminders after lossy context restoration without recreating cleared work or growing repeated reminders.
 
 ### Fixed
 
@@ -15,6 +16,7 @@
 - Advisor notes now report rate limiting accurately, blockers always interrupt even after a lower-severity note in the same update, and deferred notes flush when the primary run completes, including after advisor quota exhaustion ([#11062](https://github.com/can1357/oh-my-pi/issues/11062)).
 - Fixed the built-in clangd registration omitting CUDA source and header files (`.cu` and `.cuh`) ([#10782](https://github.com/can1357/oh-my-pi/pull/10782) by [@alphastorm](https://github.com/alphastorm)).
 - Fixed `ast_grep` skipping CUDA headers and ignoring an explicit `lang` override for ambiguous file extensions ([#10782](https://github.com/can1357/oh-my-pi/pull/10782) by [@alphastorm](https://github.com/alphastorm)).
+- Fixed native/device/RPC todo snapshots and accepted child completions losing state during journal replay; blocked and abandoned work remain distinct.
 ### Fixed
 
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -10,7 +10,7 @@ import type {
 import { parseXdUrl } from "../../internal-urls/xd-protocol";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { resolveToCwd, splitPathAndSelPreferringLiteralSync } from "../../tools/path-utils";
-import type { TodoStatus } from "../../tools/todo";
+import { readTodoResultDetails, type TodoStatus } from "../../tools/todo";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 
 interface MessageProgress {
@@ -418,68 +418,22 @@ function mapTodoStatus(status: TodoStatus): "pending" | "in_progress" | "complet
 function mapTodoResultToPlanUpdate(
 	event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>,
 ): SessionUpdate | undefined {
-	if (event.toolName !== "todo" || event.isError) {
-		return undefined;
-	}
-	const phases = extractTodoPhases(event.result);
-	if (!Array.isArray(phases)) {
-		return undefined;
-	}
+	if (event.isError || event.result.isError) return undefined;
+	const details = readTodoResultDetails(event.toolName, event.result);
+	if (!details) return undefined;
 	return {
 		sessionUpdate: "plan",
-		entries: extractTodoEntries(phases).map(todo => ({
-			content: todo.content,
-			priority: "medium" as const,
-			status: mapTodoStatus(todo.status),
-		})),
+		entries: details.phases
+			.flatMap(phase => phase.tasks)
+			.filter(todo => todo.content.length > 0)
+			.map(todo => ({
+				content: todo.content,
+				priority: "medium" as const,
+				status: mapTodoStatus(todo.status),
+			})),
 	};
 }
 
-function extractTodoPhases(result: unknown): unknown {
-	if (typeof result !== "object" || result === null || !("details" in result)) {
-		return undefined;
-	}
-	const details = (result as { details?: unknown }).details;
-	if (typeof details !== "object" || details === null || !("phases" in details)) {
-		return undefined;
-	}
-	return (details as { phases?: unknown }).phases;
-}
-
-function extractTodoEntries(phases: unknown[]): Array<{ content: string; status: TodoStatus }> {
-	const entries: Array<{ content: string; status: TodoStatus }> = [];
-	for (const phase of phases) {
-		if (typeof phase !== "object" || phase === null || !("tasks" in phase)) {
-			continue;
-		}
-		const tasks = (phase as { tasks?: unknown }).tasks;
-		if (!Array.isArray(tasks)) {
-			continue;
-		}
-		for (const task of tasks) {
-			if (typeof task !== "object" || task === null || !("content" in task)) {
-				continue;
-			}
-			const content = (task as { content?: unknown }).content;
-			if (typeof content !== "string" || content.length === 0) {
-				continue;
-			}
-			const status = (task as { status?: TodoStatus }).status;
-			entries.push({ content, status: isTodoStatus(status) ? status : "pending" });
-		}
-	}
-	return entries;
-}
-
-function isTodoStatus(status: unknown): status is TodoStatus {
-	return (
-		status === "pending" ||
-		status === "in_progress" ||
-		status === "completed" ||
-		status === "abandoned" ||
-		status === "blocked"
-	);
-}
 export function buildToolCallStartUpdate(input: {
 	toolCallId: string;
 	toolName: string;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -23,7 +23,7 @@ import {
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
 import { createUsageRowBlock, turnElapsedMs } from "../../modes/components/usage-row";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
-import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
+import type { InteractiveModeContext } from "../../modes/types";
 import idleRecapPrompt from "../../prompts/system/recap-user.md" with { type: "text" };
 import type { AgentSessionEvent } from "../../session/agent-session";
 import {
@@ -36,7 +36,7 @@ import {
 import { type ApprovalMode, resolveApproval } from "../../tools/approval";
 import { previewLine, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { PROPOSE_DEVICE_NAME, writeDeviceDispatch } from "../../tools/resolve";
-import { nextActionableTask } from "../../tools/todo";
+import { nextActionableTask, readTodoResultDetails } from "../../tools/todo";
 import { SpeechEnhancer } from "../../tts/speech-enhancer";
 import { vocalizer } from "../../tts/vocalizer";
 import { canonicalizeMessage } from "../../utils/thinking-display";
@@ -1824,13 +1824,12 @@ export class EventController {
 			}
 		}
 		if (syntheticFailureCard) this.#syntheticFailureCards.set(event.toolCallId, syntheticFailureCard);
-		// Update todo display when todo tool completes
-		if (event.toolName === "todo" && !event.isError) {
-			const details = event.result.details as { phases?: TodoPhase[] } | undefined;
-			if (details?.phases) {
-				this.ctx.setTodos(details.phases);
-			}
-		} else if (event.toolName === "todo" && event.isError) {
+		// Native calls and write xd://todo share the same canonical snapshot.
+		const todoDetails = readTodoResultDetails(event.toolName, event.result);
+		const todoFailed = event.isError || event.result.isError === true;
+		if (todoDetails && !todoFailed) {
+			this.ctx.setTodos(todoDetails.phases);
+		} else if ((event.toolName === "todo" || todoDetails) && todoFailed) {
 			const textContent = event.result.content.find(
 				(content: { type: string; text?: string }) => content.type === "text",
 			)?.text;

--- a/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/todo-command-controller.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs/promises";
+import { prompt } from "@oh-my-pi/pi-utils";
+import todoUserEditPrompt from "../../prompts/system/todo-user-edit.md" with { type: "text" };
 import {
 	applyOpsToPhases,
-	getLatestTodoPhasesFromEntries,
+	getLatestTodoSnapshotFromEntries,
 	markdownToPhases,
 	phasesToMarkdown,
 	resolveTodoMarkdownPath,
@@ -119,17 +121,12 @@ function findTaskFuzzy(phases: TodoPhase[], query: string): { task: TodoItem; ph
 // =============================================================================
 
 function buildSystemReminder(action: string, phases: TodoPhase[], removed = false): string {
-	const md = phases.length === 0 ? "(empty)" : phasesToMarkdown(phases).trimEnd();
-	const lines = ["<system-reminder>", `The user manually modified the todo list (${action}).`];
-	if (removed) {
-		lines.push(
-			phases.length === 0
-				? "The user intentionally cleared the todo list. Do NOT recreate or re-populate it unless the user explicitly asks; continue the current request without a todo list."
-				: "The user intentionally removed the entries no longer shown below. Do NOT re-add them unless the user explicitly asks.",
-		);
-	}
-	lines.push("Current todo list:", "", md, "</system-reminder>");
-	return lines.join("\n");
+	return prompt.render(todoUserEditPrompt, {
+		action,
+		removed,
+		empty: phases.length === 0,
+		markdown: phases.length === 0 ? "(empty)" : phasesToMarkdown(phases).trimEnd(),
+	});
 }
 
 export class TodoCommandController {
@@ -140,9 +137,10 @@ export class TodoCommandController {
 	 * entries or falls back to the active session state.
 	 */
 	#currentPhases(): TodoPhase[] {
-		const fromEntries = getLatestTodoPhasesFromEntries(this.ctx.sessionManager.getBranch());
-		if (fromEntries.length > 0) return fromEntries;
-		return this.ctx.session.getTodoPhases();
+		return (
+			getLatestTodoSnapshotFromEntries(this.ctx.sessionManager.getBranch())?.phases ??
+			this.ctx.session.getTodoPhases()
+		);
 	}
 
 	async handleTodoCommand(args: string): Promise<void> {
@@ -449,20 +447,32 @@ export class TodoCommandController {
 		this.ctx.setTodos(nextPhases);
 
 		// 2. Persist for reload survival via custom session entry.
-		this.ctx.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: nextPhases });
+		const todoSnapshotId = this.ctx.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, {
+			phases: nextPhases,
+		});
 
 		// 3. Inject system reminder so the agent learns about the change next turn.
 		//    Removals carry explicit intent so the agent does not rebuild the
 		//    cleared/removed items on its next turn (issue #5258).
 		const reminderText = buildSystemReminder(action, nextPhases, opts?.removed ?? false);
 		const message = {
-			role: "developer" as const,
-			content: [{ type: "text" as const, text: reminderText }],
+			role: "custom" as const,
+			customType: USER_TODO_EDIT_CUSTOM_TYPE,
+			content: reminderText,
+			details: { todoSnapshotId },
+			display: false,
 			attribution: "user" as const,
 			timestamp: Date.now(),
 		};
 		this.ctx.agent.appendMessage(message);
-		this.ctx.sessionManager.appendMessage(message);
+		this.ctx.sessionManager.appendCustomMessageEntry(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+			message.attribution,
+			message.timestamp,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -208,11 +208,7 @@ import {
 } from "./loop-limit";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { getRunningSubagentBadgeAgentIds, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
-import {
-	type ObservableSession,
-	type SessionObserverChangeKind,
-	SessionObserverRegistry,
-} from "./session-observer-registry";
+import { type ObservableSession, SessionObserverRegistry } from "./session-observer-registry";
 import { createSessionTeardown, type SessionTeardown } from "./session-teardown";
 import { runProviderSetupWizard } from "./setup-wizard/lazy";
 import { sanitizeStatusText } from "./shared";
@@ -617,6 +613,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * focus attach.
 	 */
 	#todoPhasesOwner?: AgentSession;
+	readonly #subagentTodoCompletions = new WeakMap<
+		ObservableSession,
+		{ owner: AgentSession; accept: () => boolean } | null
+	>();
 	hideThinkingBlock = false;
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
 	/** Whether the visible session has produced thinking content the user can reveal. */
@@ -831,7 +831,6 @@ export class InteractiveMode implements InteractiveModeContext {
 	#subagentEventBus?: EventBus;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
-	#observerUiSyncNeedsTodoReconcile = false;
 	#agentRegistryUnsubscribe?: () => void;
 	#agentRegistrySubscriptionTarget?: AgentRegistry;
 	#mcpStatusOrder: string[] = [];
@@ -1237,7 +1236,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry.setMainSession(this.sessionManager.getSessionFile() ?? undefined);
 		this.syncRunningSubagentBadge();
 		this.#observerRegistry.onChange(kind => {
-			this.#scheduleObserverUiSync(kind);
+			if (kind === "lifecycle") this.#reconcileTodosWithSubagents();
+			this.#scheduleObserverUiSync();
 		});
 		// Let the transient todo tool result light up pending todos executed by a
 		// live subagent, matching the sticky HUD's active set (#5873).
@@ -2435,55 +2435,36 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	/**
-	 * Auto-complete any open todo (pending/in_progress/blocked) whose content
-	 * matches a subagent that has finished successfully. Fires on every observer
-	 * `onChange` so the visual state stays in sync with subagent lifecycle
-	 * without requiring the agent to issue a follow-up `todo`. A todo `block`ed
-	 * while waiting on a detached subagent is included: that subagent completing
-	 * is exactly the unblock signal, and blocked todos are excluded from the stop
-	 * reminder, so leaving it blocked would strand it silently. Failed and aborted
-	 * subagents are intentionally NOT auto-completed — those stay open so the user
-	 * (or the next agent turn) can decide what to do.
-	 *
-	 * Idempotent: only flips open tasks, never re-touches completed ones.
+	 * Journal accepted child completions once, against their captured owner and
+	 * plan revision. Fuzzy description matching remains display-only: neither an
+	 * unrelated successful child nor a finished run from an old plan may close
+	 * arbitrary parent work. Blocked tasks require explicit blocker resolution.
+	 * Settle each run synchronously before a reused child can start again; only
+	 * HUD rendering is debounced.
 	 */
 	#reconcileTodosWithSubagents(): void {
-		const completedDescs: string[] = [];
-		for (const session of this.#observerRegistry.getSessions()) {
-			if (session.kind !== "subagent") continue;
-			if (session.status !== "completed") continue;
-			const candidate =
-				session.description?.trim() || session.progress?.description?.trim() || session.label?.trim();
-			if (candidate) completedDescs.push(candidate);
+		const visibleOwner = this.#todoPhasesOwner ?? this.session;
+		let visibleChanged = false;
+		for (const child of this.#observerRegistry.getSessions()) {
+			if (child.kind !== "subagent") continue;
+			if (child.status === "active") {
+				if (this.#subagentTodoCompletions.has(child)) continue;
+				const description = child.description?.trim();
+				const accept =
+					description && child.parentToolCallId
+						? visibleOwner.captureTodoCompletion(description, child.parentToolCallId)
+						: undefined;
+				this.#subagentTodoCompletions.set(child, accept ? { owner: visibleOwner, accept } : null);
+				continue;
+			}
+			const completion = this.#subagentTodoCompletions.get(child);
+			this.#subagentTodoCompletions.delete(child);
+			if (!completion) continue;
+			if (child.status === "completed" && completion.accept() && completion.owner === visibleOwner)
+				visibleChanged = true;
 		}
-		if (completedDescs.length === 0) return;
-
-		let mutated = false;
-		const next: TodoPhase[] = this.todoPhases.map(phase => ({
-			name: phase.name,
-			tasks: phase.tasks.map(task => {
-				if (task.status !== "pending" && task.status !== "in_progress" && task.status !== "blocked") {
-					return task;
-				}
-				if (!todoMatchesAnyDescription(task.content, completedDescs)) return task;
-				mutated = true;
-				// Drop any blocker note along with the blocked status — the wait the
-				// note described is over.
-				return { content: task.content, status: "completed" as const };
-			}),
-		}));
-		if (!mutated) return;
-		// Persist into the session that owns the snapshot we derived `next` from,
-		// not `viewSession`: the two diverge mid focus-attach, and writing to the
-		// destination there would clobber its canonical plan. Leaving the owner
-		// bound (rather than routing through `setTodos`, which rebinds it to
-		// `viewSession`) keeps a follow-up reconcile in the same window correct.
-		const owner = this.#todoPhasesOwner ?? this.session;
-		owner.setTodoPhases(next);
-		this.todoPhases = next;
-		this.#syncTodoAutoClearTimer();
-		this.#renderTodoList();
-		this.ui.requestRender();
+		if (!visibleChanged) return;
+		this.todoPhases = visibleOwner.getTodoPhases();
 	}
 
 	#cancelTodoAutoClearTimer(): void {
@@ -2575,10 +2556,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		return active ?? nonEmpty[nonEmpty.length - 1];
 	}
 
-	#scheduleObserverUiSync(kind: SessionObserverChangeKind): void {
-		if (kind !== "progress") {
-			this.#observerUiSyncNeedsTodoReconcile = true;
-		}
+	#scheduleObserverUiSync(): void {
 		if (this.#observerUiSyncTimer) return;
 		this.#observerUiSyncTimer = setTimeout(() => {
 			this.#observerUiSyncTimer = undefined;
@@ -2589,10 +2567,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#flushObserverUiSync(): void {
 		this.syncRunningSubagentBadge({ requestRender: false });
-		if (this.#observerUiSyncNeedsTodoReconcile) {
-			this.#observerUiSyncNeedsTodoReconcile = false;
-			this.#reconcileTodosWithSubagents();
-		}
 		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 		this.#renderSubagentList();
@@ -2604,7 +2578,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			clearTimeout(this.#observerUiSyncTimer);
 			this.#observerUiSyncTimer = undefined;
 		}
-		this.#observerUiSyncNeedsTodoReconcile = false;
 	}
 
 	#renderTodoList(): void {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -36,6 +36,7 @@ import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/m
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands } from "../../slash-commands/available-commands";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
+import { USER_TODO_EDIT_CUSTOM_TYPE } from "../../tools/todo";
 import type { EventBus } from "../../utils/event-bus";
 import { calculateTokensPerSecond } from "../../utils/token-rate";
 import { initializeExtensions } from "../runtime-init";
@@ -1237,7 +1238,9 @@ export async function runRpcMode(
 
 			case "set_todos": {
 				session.setTodoPhases(command.phases);
-				return success(id, "set_todos", { todoPhases: session.getTodoPhases() });
+				const phases = session.getTodoPhases();
+				session.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases });
+				return success(id, "set_todos", { todoPhases: phases });
 			}
 
 			case "set_host_tools": {

--- a/packages/coding-agent/src/prompts/system/todo-state.md
+++ b/packages/coding-agent/src/prompts/system/todo-state.md
@@ -1,0 +1,21 @@
+<todo-state>
+Canonical todo state restored from the session journal. This state is authoritative, independent of any conversation summary. Preserve phase grouping and blocked/abandoned status; a successful child run alone does not prove that parent work was accepted.
+{{#if empty}}
+The todo list is intentionally empty. Do not recreate cleared work unless the user explicitly asks.
+{{else}}
+Overall: {{counts.in_progress}} in progress, {{counts.pending}} pending, {{counts.blocked}} blocked; {{counts.completed}} completed and {{counts.abandoned}} abandoned.
+{{#each phases}}
+- {{name}}: {{inProgress}} in progress, {{pending}} pending, {{blocked}} blocked; {{completed}} completed, {{abandoned}} abandoned.
+{{#each tasks}}
+  - [{{status}}] {{content}}{{#if blocker}} — blocker: {{blocker}}{{/if}}
+{{/each}}
+{{#if omitted}}
+  - {{omitted}} additional open item(s) omitted.
+{{/if}}
+{{/each}}
+{{#if omittedPhases}}
+{{omittedPhases}} additional phase(s) omitted.
+{{/if}}
+This is a bounded reminder, not a replacement list. Labels and blocker notes may be shortened. Use `{{toolRefs.todo}}` with `op: "view"` for the complete canonical state before changing omitted or shortened work. Do not reopen abandoned items or treat blocked items as actionable without resolving their blocker.
+{{/if}}
+</todo-state>

--- a/packages/coding-agent/src/prompts/system/todo-user-edit.md
+++ b/packages/coding-agent/src/prompts/system/todo-user-edit.md
@@ -1,0 +1,13 @@
+<system-reminder>
+The user manually modified the todo list ({{action}}).
+{{#if removed}}
+{{#if empty}}
+The user intentionally cleared the todo list. Do NOT recreate or re-populate it unless the user explicitly asks; continue the current request without a todo list.
+{{else}}
+The user intentionally removed the entries no longer shown below. Do NOT re-add them unless the user explicitly asks.
+{{/if}}
+{{/if}}
+Current todo list:
+
+{{markdown}}
+</system-reminder>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -221,7 +221,7 @@ import {
 	writeDeviceDispatch,
 } from "../tools/resolve";
 import { supportsExternalThinking } from "../tools/think";
-import type { TodoPhase } from "../tools/todo";
+import { readTodoResultDetails, type TodoPhase } from "../tools/todo";
 import { ToolError } from "../tools/tool-errors";
 import type { WorkPoolYieldItem } from "../task/workpool-yield";
 import { parseCommandArgs } from "../utils/command-args";
@@ -627,6 +627,7 @@ export class AgentSession {
 	#planModeReminderCount = 0;
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
+	#todoContextRestorePending = false;
 	#workPoolYieldItems: readonly WorkPoolYieldItem[] = [];
 	#replanTitleRefreshInFlight: Promise<void> | undefined = undefined;
 	/** Resolved TITLE_SYSTEM.md override applied to every automatic session-title
@@ -1426,6 +1427,17 @@ export class AgentSession {
 			await this.#prewalk.advanceAtTurnEnd(messages, context);
 			await this.#advisors.onPrimaryTurnEnd(messages, context?.willContinue, signal);
 			await this.#maintenance.maintainContextMidRun(messages, signal, context);
+			// Model replacement can occur inside prewalk or a tool-loop turn. The
+			// loop owns a separate message array, so synchronize only when that
+			// lifecycle actually restored missing todo context.
+			if (this.#todoContextRestorePending) {
+				this.#todoContextRestorePending = false;
+				const restored = this.#todo.withRestoredContext(messages);
+				if (restored !== messages) {
+					messages.splice(0, messages.length, ...restored);
+					this.agent.replaceMessages(messages);
+				}
+			}
 		});
 		this.yieldQueue = new YieldQueue({
 			isStreaming: () => this.isStreaming,
@@ -1615,6 +1627,7 @@ export class AgentSession {
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#syncAgentSessionId();
 		this.#todo.syncFromBranch();
+		this.#restoreTodoContext();
 		this.#goalRuntime = new GoalRuntime({
 			getState: () => this.#goalModeState,
 			setState: state => {
@@ -2831,7 +2844,10 @@ export class AgentSession {
 		// and only successful mutating tools tick — read-only exploration is
 		// not progress an agent could mark done.
 		if (event.type === "message_end" && event.message.role === "toolResult") {
-			this.#todo.onToolResult(event.message.toolName, event.message.isError);
+			const toolName = readTodoResultDetails(event.message.toolName, event.message)
+				? "todo"
+				: event.message.toolName;
+			this.#todo.onToolResult(toolName, event.message.isError);
 		}
 		// Track the settled assistant turn synchronously as well: agent_end
 		// maintenance reads `#lastAssistantMessage`, and when a turn's events all
@@ -3113,13 +3129,13 @@ export class AgentSession {
 			}
 			if (event.message.role === "toolResult") {
 				const { toolName, toolCallId, isError, content } = event.message;
-				const details = isRecord(event.message.details) ? event.message.details : undefined;
+				const todoDetails = readTodoResultDetails(toolName, event.message);
 				const semanticResult = semanticToolResult(toolName, event.message);
 				const semanticDetails = isRecord(semanticResult?.details) ? semanticResult.details : undefined;
-				if (toolName === "todo" && !isError && details && this.#todo.onTodoResultDetails(details, toolCallId)) {
+				if (!isError && todoDetails && this.#todo.onTodoResultDetails(todoDetails, toolCallId)) {
 					this.#scheduleReplanTitleRefresh();
 				}
-				if (toolName === "todo" && isError) {
+				if ((toolName === "todo" || todoDetails) && isError) {
 					const errorText = content.find(part => part.type === "text")?.text;
 					const reminderText = [
 						"<system-reminder>",
@@ -4752,6 +4768,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		this.agent.appendOnlyContext?.invalidateForModelChange();
+		this.#restoreTodoContext();
 		return {
 			previousSessionId,
 			sessionId: this.sessionId,
@@ -4849,6 +4866,7 @@ export class AgentSession {
 		// on-disk record and the plain `transcript:true` export path keep the full
 		// pre-reset history.
 		this.sessionManager.appendResetBoundary();
+		this.#todo.invalidateCompletions();
 
 		resetCapabilities();
 		await this.refreshBaseSystemPrompt();
@@ -5378,7 +5396,9 @@ export class AgentSession {
 	}
 
 	buildDisplaySessionContext(): SessionContext {
-		return this.#providerBoundary.buildDisplaySessionContext();
+		const context = this.#providerBoundary.buildDisplaySessionContext();
+		context.messages = this.#todo.withRestoredContext(context.messages);
+		return context;
 	}
 
 	/**
@@ -7374,6 +7394,18 @@ export class AgentSession {
 		this.#todo.setPhases(phases);
 	}
 
+	/** Capture a guarded, journaled completion for a child owned by this branch. */
+	captureTodoCompletion(content: string, parentToolCallId: string): (() => boolean) | undefined {
+		return this.#todo.captureCompletion(content, parentToolCallId);
+	}
+
+	#restoreTodoContext(): void {
+		const messages = this.#todo.withRestoredContext(this.agent.state.messages);
+		if (messages === this.agent.state.messages) return;
+		this.agent.replaceMessages(messages);
+		this.#todoContextRestorePending ||= this.agent.state.isStreaming;
+	}
+
 	/** Active item labels accepted by this pooled turn's incremental yield tool. */
 	getWorkPoolYieldItems(): readonly WorkPoolYieldItem[] {
 		return this.#workPoolYieldItems;
@@ -8306,6 +8338,7 @@ export class AgentSession {
 		// add an extension-delivery await inside every model switch — including
 		// retry-fallback on the error path.
 		if (isChanging) {
+			this.#restoreTodoContext();
 			this.#emit({ type: "model_changed" });
 		}
 
@@ -8352,6 +8385,7 @@ export class AgentSession {
 		}
 
 		this.#closeProviderSessionsForModelSwitch(currentModel, currentModel);
+		this.#restoreTodoContext();
 		this.agent.appendOnlyContext?.invalidateForModelChange();
 		logger.debug("Reset Responses provider session after stale replay error", {
 			provider: currentModel.provider,
@@ -9678,7 +9712,7 @@ export class AgentSession {
 		// Update agent state — build display context to populate agent messages.
 		const stateContext = this.sessionManager.buildSessionContext();
 		const displayContext = deobfuscateSessionContext(stateContext, this.#obfuscator);
-		this.agent.replaceMessages(displayContext.messages);
+		this.agent.replaceMessages(this.#todo.withRestoredContext(displayContext.messages));
 		this.#rehydrateCheckpointRewindState();
 		this.#advisors.resetSessionState({ preserveCost: true });
 		this.#todo.syncFromBranch();

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -13,6 +13,7 @@ import prewalkPlanPrompt from "../prompts/system/prewalk-plan.md" with { type: "
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop } from "../thinking";
 import { isMCPToolName } from "../tools/builtin-names";
 import type { PlanProposalHandler } from "../tools/resolve";
+import { readTodoResultDetails } from "../tools/todo";
 import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
 import { PREWALK_PLAN_MESSAGE_TYPE } from "./messages";
@@ -147,7 +148,12 @@ export class PrewalkCoordinator {
 			this.#disarmNoop(prewalk);
 			return;
 		}
-		if (context.toolResults.some(result => result.toolName === "todo" && !result.isError)) this.#todoSeen = true;
+		if (
+			context.toolResults.some(
+				result => !result.isError && (result.toolName === "todo" || readTodoResultDetails(result.toolName, result)),
+			)
+		)
+			this.#todoSeen = true;
 
 		const hasToolResults = context.toolResults.length > 0;
 		if (this.#planInjected && hasToolResults) {

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -1,13 +1,26 @@
 import type { Agent, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Message, Model, TextContent, ToolChoice } from "@oh-my-pi/pi-ai";
-import { isRecord, logger, prompt, stringProperty } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, stringProperty, truncate } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
 import eagerTodoPrompt from "../prompts/system/eager-todo.md" with { type: "text" };
 import midRunTodoNudgePrompt from "../prompts/system/mid-run-todo-nudge.md" with { type: "text" };
-import { getLatestTodoPhasesFromEntries, isTodoPhase, type TodoItem, type TodoPhase } from "../tools/todo";
+import todoStatePrompt from "../prompts/system/todo-state.md" with { type: "text" };
+import {
+	formatTodoSummary,
+	getLatestTodoPhasesFromEntries,
+	getLatestTodoSnapshotFromEntries,
+	isTodoPhase,
+	phasesToMarkdown,
+	readTodoResultDetails,
+	type TodoItem,
+	type TodoPhase,
+	type TodoStatus,
+	USER_TODO_EDIT_CUSTOM_TYPE,
+} from "../tools/todo";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { AgentSessionEvent } from "./agent-session-events";
+import type { CustomMessage } from "./messages";
 import type { SessionManager } from "./session-manager";
 
 const MID_RUN_NUDGE_MUTATION_THRESHOLD = 12;
@@ -20,6 +33,11 @@ const MUTATING_TOOLS: Record<string, true> = {
 	ast_edit: true,
 };
 const MID_RUN_NUDGE_MESSAGE_TYPE = "mid-run-todo-nudge";
+const TODO_STATE_MESSAGE_TYPE = "todo-state";
+const TODO_STATE_MAX_PHASES = 12;
+const TODO_STATE_MAX_TASKS = 24;
+const TODO_STATE_MAX_LABEL_CHARS = 240;
+const TODO_STATE_OPEN_STATUSES = ["in_progress", "blocked", "pending"] as const;
 const MARKDOWN_PROMPT_PREFIX_RE = /^(?:>\s*)?(?:(?:[-*+]|\d+[.)])\s+)*/;
 const PROMPT_LABEL_RE = /^(?:q(?:uestion)?|ask)\s*\d*\s*[:.)-]\s*/i;
 const QUESTION_PROMPT_RE =
@@ -66,6 +84,8 @@ export interface TodoTrackerHost {
 export class TodoTracker {
 	readonly #host: TodoTrackerHost;
 	#phases: TodoPhase[] = [];
+	#revision = 0;
+	#completionBoundaryId: string | null = null;
 	#reminderCount = 0;
 	#reminderAwaitingProgress = false;
 	#mutationsSinceLastTouch = 0;
@@ -83,16 +103,234 @@ export class TodoTracker {
 	/** Replaces todo phases with a defensive clone. */
 	setPhases(phases: TodoPhase[]): void {
 		this.#phases = this.#clonePhases(phases);
+		this.invalidateCompletions();
 	}
 
 	/** Rehydrates todo phases from the current transcript branch. */
 	syncFromBranch(): void {
-		this.setPhases(getLatestTodoPhasesFromEntries(this.#host.sessionManager.getBranch()));
+		this.#phases = getLatestTodoPhasesFromEntries(this.#host.sessionManager.getBranch());
+		this.invalidateCompletions();
+	}
+
+	/** Invalidate child acceptance across a context clear without changing todo state. */
+	invalidateCompletions(): void {
+		this.#revision++;
+		this.#completionBoundaryId = this.#host.sessionManager.getLeafId();
 	}
 
 	/** Returns a defensive clone suitable for snapshots and branch state. */
 	clonePhases(phases: TodoPhase[]): TodoPhase[] {
 		return this.#clonePhases(phases);
+	}
+
+	/**
+	 * Bind one exact, unambiguous open task to an observed child run. Any external
+	 * todo edit or branch restore invalidates the binding; a later child success
+	 * must never overwrite a newer plan, an intentional clear, or a blocker.
+	 */
+	captureCompletion(content: string, parentToolCallId: string): (() => boolean) | undefined {
+		const entries = this.#host.sessionManager.getBranch();
+		let ownsCall = false;
+		for (let index = entries.length - 1; index >= 0; index--) {
+			const entry = entries[index];
+			// A delayed start notification from before the latest edit/restore
+			// cannot bind to an identically named item in a replacement plan.
+			if (entry.id === this.#completionBoundaryId || entry.type === "reset_boundary") break;
+			if (
+				entry.type === "message" &&
+				entry.message.role === "assistant" &&
+				entry.message.content.some(block => block.type === "toolCall" && block.id === parentToolCallId)
+			) {
+				ownsCall = true;
+				break;
+			}
+		}
+		if (!ownsCall) return undefined;
+		let target: { phase: number; task: number } | undefined;
+		for (let phase = 0; phase < this.#phases.length; phase++) {
+			for (let task = 0; task < this.#phases[phase].tasks.length; task++) {
+				if (this.#phases[phase].tasks[task].content !== content) continue;
+				if (target) return undefined;
+				target = { phase, task };
+			}
+		}
+		if (!target) return undefined;
+		const task = this.#phases[target.phase].tasks[target.task];
+		if (task.status !== "pending" && task.status !== "in_progress") return undefined;
+		const revision = this.#revision;
+		const sessionId = this.#host.sessionManager.getSessionId();
+		const { phase: phaseIndex, task: taskIndex } = target;
+		let consumed = false;
+		return () => {
+			if (consumed) return false;
+			consumed = true;
+			if (this.#revision !== revision || this.#host.sessionManager.getSessionId() !== sessionId) return false;
+			const current = this.#phases[phaseIndex]?.tasks[taskIndex];
+			if (!current || (current.status !== "pending" && current.status !== "in_progress")) return false;
+			const next = this.phases;
+			next[phaseIndex].tasks[taskIndex] = { content: current.content, status: "completed" };
+			// Tool executions already journal their successful result. Only this
+			// out-of-band mutation needs the existing explicit snapshot mechanism.
+			this.#host.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: next });
+			this.#phases = next;
+			return true;
+		};
+	}
+
+	/**
+	 * Project at most one bounded canonical snapshot into a restored context.
+	 * Never journal this derived prompt or reconstruct state from summary text.
+	 */
+	withRestoredContext(messages: AgentMessage[]): AgentMessage[] {
+		const entries = this.#host.sessionManager.getBranch();
+		const snapshot = getLatestTodoSnapshotFromEntries(entries);
+		const priorReminders = messages.filter(
+			message => message.role === "custom" && message.customType === TODO_STATE_MESSAGE_TYPE,
+		);
+		const withoutReminders =
+			priorReminders.length > 0
+				? messages.filter(message => message.role !== "custom" || message.customType !== TODO_STATE_MESSAGE_TYPE)
+				: messages;
+		// /clear deliberately removes all model context. Do not cross that boundary
+		// to reintroduce old work; a later explicit todo update can establish state.
+		if (
+			!this.#host.settings.get("todo.enabled") ||
+			!snapshot ||
+			entries.findLastIndex(entry => entry.type === "reset_boundary") > entries.indexOf(snapshot.entry)
+		) {
+			return withoutReminders;
+		}
+		let summary: string | undefined;
+		let markdown: string | undefined;
+		const timestamp = Date.parse(snapshot.entry.timestamp);
+		const source =
+			snapshot.entry.type === "message" && snapshot.entry.message.role === "toolResult"
+				? snapshot.entry.message
+				: undefined;
+		const nextEntry = entries[entries.indexOf(snapshot.entry) + 1];
+		const legacyReminder =
+			snapshot.entry.type === "custom" && nextEntry?.type === "message" && nextEntry.message.role === "developer"
+				? nextEntry.message
+				: undefined;
+		for (const message of withoutReminders) {
+			if (
+				source &&
+				message.role === "toolResult" &&
+				message.toolCallId === source.toolCallId &&
+				!message.isError &&
+				!message.prunedAt &&
+				readTodoResultDetails(message.toolName, message)
+			) {
+				summary ??= formatTodoSummary(snapshot.phases, []);
+				if (
+					message.content.some(
+						block =>
+							block.type === "text" &&
+							(block.text === summary ||
+								(snapshot.phases.length === 0 && block.text === formatTodoSummary([], [], true))),
+					)
+				) {
+					return withoutReminders;
+				}
+			}
+			// Retained /todo edit reminders already contain the complete checklist.
+			// Do not infer state from prose or from a lossy compaction summary.
+			if (
+				(message.role === "custom" &&
+					message.customType === USER_TODO_EDIT_CUSTOM_TYPE &&
+					isRecord(message.details) &&
+					message.details.todoSnapshotId === snapshot.entry.id) ||
+				(message.role === "developer" && message === legacyReminder)
+			) {
+				markdown ??= snapshot.phases.length > 0 ? phasesToMarkdown(snapshot.phases).trimEnd() : "(empty)";
+				const checklist = markdown;
+				if (
+					typeof message.content === "string"
+						? message.content.includes(checklist)
+						: message.content.some(block => block.type === "text" && block.text.includes(checklist))
+				)
+					return withoutReminders;
+			}
+		}
+		const reminder = this.#buildStateReminder(snapshot.phases, snapshot.entry.id, timestamp);
+		const previous = priorReminders.length === 1 ? priorReminders[0] : undefined;
+		if (
+			previous?.role === "custom" &&
+			previous.content === reminder.content &&
+			isRecord(previous.details) &&
+			previous.details.todoSnapshotId === snapshot.entry.id
+		) {
+			return messages;
+		}
+		return [...withoutReminders, reminder];
+	}
+
+	#buildStateReminder(phases: TodoPhase[], entryId: string, timestamp: number): CustomMessage {
+		const counts: Record<TodoStatus, number> = { pending: 0, in_progress: 0, blocked: 0, completed: 0, abandoned: 0 };
+		const phaseSummaries = phases.map((phase, index) => {
+			const phaseCounts: Record<TodoStatus, number> = {
+				pending: 0,
+				in_progress: 0,
+				blocked: 0,
+				completed: 0,
+				abandoned: 0,
+			};
+			for (const task of phase.tasks) {
+				counts[task.status]++;
+				phaseCounts[task.status]++;
+			}
+			return {
+				index,
+				name: truncate(phase.name, TODO_STATE_MAX_LABEL_CHARS),
+				inProgress: phaseCounts.in_progress,
+				pending: phaseCounts.pending,
+				blocked: phaseCounts.blocked,
+				completed: phaseCounts.completed,
+				abandoned: phaseCounts.abandoned,
+				rank: phaseCounts.in_progress > 0 ? 0 : phaseCounts.blocked > 0 ? 1 : phaseCounts.pending > 0 ? 2 : 3,
+				tasks: [] as TodoItem[],
+				omitted: phaseCounts.in_progress + phaseCounts.pending + phaseCounts.blocked,
+			};
+		});
+		// Prefer current and blocked work over old closed phases, but present the
+		// selected phases in canonical order so the reminder never renumbers work.
+		const selected = phaseSummaries
+			.sort((a, b) => a.rank - b.rank || a.index - b.index)
+			.slice(0, TODO_STATE_MAX_PHASES)
+			.sort((a, b) => a.index - b.index);
+		let remaining = TODO_STATE_MAX_TASKS;
+		for (const status of TODO_STATE_OPEN_STATUSES) {
+			for (const phase of selected) {
+				for (const task of phases[phase.index].tasks) {
+					if (remaining === 0) break;
+					if (task.status !== status) continue;
+					phase.tasks.push({
+						content: truncate(task.content, TODO_STATE_MAX_LABEL_CHARS),
+						status,
+						...(status === "blocked" && task.blocker !== undefined
+							? { blocker: truncate(task.blocker, TODO_STATE_MAX_LABEL_CHARS) }
+							: {}),
+					});
+					phase.omitted--;
+					remaining--;
+				}
+			}
+		}
+		return {
+			role: "custom",
+			customType: TODO_STATE_MESSAGE_TYPE,
+			content: prompt.render(todoStatePrompt, {
+				counts,
+				phases: selected,
+				empty: phases.every(phase => phase.tasks.length === 0),
+				omittedPhases: phases.length - selected.length,
+				toolRefs: this.#buildEagerPreludeContext().toolRefs,
+			}),
+			details: { todoSnapshotId: entryId },
+			display: false,
+			attribution: "agent",
+			timestamp,
+		};
 	}
 
 	/** Resets per-prompt reminder and mutation budgets. */
@@ -136,6 +374,8 @@ export class TodoTracker {
 		const mode = this.#host.settings.get("todo.eager");
 		if (mode === "default" || !this.#host.settings.get("todo.enabled")) return undefined;
 		if (this.#host.planModeEnabled() || this.#phases.length > 0) return undefined;
+		// A cleared list is still an accepted snapshot, not permission to recreate it.
+		if (getLatestTodoSnapshotFromEntries(this.#host.sessionManager.getBranch())) return undefined;
 		// An actionable prewalk drives todo creation in a plan-first-then-todo order;
 		// the forced eager prelude's "call todo first this turn" contradicts it (#10510).
 		if (this.#host.prewalkWillHandoff()) return undefined;

--- a/packages/coding-agent/src/slash-commands/helpers/todo.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/todo.ts
@@ -1,7 +1,7 @@
 import type { TodoPhase } from "../../tools/todo";
 import {
 	applyOpsToPhases,
-	getLatestTodoPhasesFromEntries,
+	getLatestTodoSnapshotFromEntries,
 	markdownToPhases,
 	phasesToMarkdown,
 	resolveTodoMarkdownPath,
@@ -91,8 +91,9 @@ function findTaskFuzzy(phases: TodoPhase[], query: string): TodoTaskMatch | unde
 }
 
 function currentPhases(runtime: SlashCommandRuntime): TodoPhase[] {
-	const fromEntries = getLatestTodoPhasesFromEntries(runtime.sessionManager.getBranch());
-	return fromEntries.length > 0 ? fromEntries : runtime.session.getTodoPhases();
+	return (
+		getLatestTodoSnapshotFromEntries(runtime.sessionManager.getBranch())?.phases ?? runtime.session.getTodoPhases()
+	);
 }
 
 function commitTodos(runtime: SlashCommandRuntime, phases: TodoPhase[]): void {

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -6,6 +6,7 @@ import { Text } from "@oh-my-pi/pi-tui";
 import { isRecord, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { stripXdUrlPrefix } from "../internal-urls/xd-protocol";
 import type { Theme } from "../modes/theme/theme";
 import todoDescription from "../prompts/tools/todo.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
@@ -13,6 +14,7 @@ import type { SessionEntry } from "../session/session-entries";
 import { framedBlock, renderStatusLine, renderTreeList } from "../tui";
 import { normalizePathLikeInput, resolveToCwd } from "./path-utils";
 import { formatErrorDetail, formatMoreItems, PREVIEW_LIMITS, pluralize, replaceTabs } from "./render-utils";
+import { writeDeviceDispatch } from "./resolve";
 
 // =============================================================================
 // Types
@@ -41,6 +43,7 @@ export function isTodoPhase(value: unknown): value is TodoPhase {
 		task =>
 			isRecord(task) &&
 			typeof task.content === "string" &&
+			(task.blocker === undefined || typeof task.blocker === "string") &&
 			(task.status === "pending" ||
 				task.status === "in_progress" ||
 				task.status === "completed" ||
@@ -174,27 +177,50 @@ export function nextActionableTask(phases: readonly TodoPhase[]): TodoItem | und
 
 export const USER_TODO_EDIT_CUSTOM_TYPE = "user_todo_edit";
 
-export function getLatestTodoPhasesFromEntries(entries: SessionEntry[]): TodoPhase[] {
+/** Read canonical todo details from either a native result or an xd:// dispatch. */
+export function readTodoResultDetails(
+	toolName: string,
+	result: unknown,
+): (Record<string, unknown> & { phases: TodoPhase[] }) | undefined {
+	let details: unknown;
+	if (stripXdUrlPrefix(toolName) === "todo") {
+		details = isRecord(result) ? result.details : undefined;
+	} else {
+		const dispatch = writeDeviceDispatch(toolName, result);
+		if (dispatch?.mode !== "execute" || dispatch.tool !== "todo") return undefined;
+		details = dispatch.inner;
+	}
+	if (!isRecord(details) || !Array.isArray(details.phases) || !details.phases.every(isTodoPhase)) return undefined;
+	return details as Record<string, unknown> & { phases: TodoPhase[] };
+}
+
+/** Latest accepted journal snapshot, including an intentional empty list. */
+export function getLatestTodoSnapshotFromEntries(
+	entries: SessionEntry[],
+): { entry: SessionEntry; phases: TodoPhase[] } | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
+		let phases: TodoPhase[];
 		if (entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE) {
-			const data = entry.data as { phases?: unknown } | undefined;
-			if (data && Array.isArray(data.phases)) {
-				return clonePhases(data.phases as TodoPhase[]);
-			}
+			const data = entry.data;
+			if (!isRecord(data) || !Array.isArray(data.phases) || !data.phases.every(isTodoPhase)) continue;
+			phases = data.phases;
+		} else if (entry.type === "message") {
+			const message = entry.message;
+			if (message.role !== "toolResult" || message.isError) continue;
+			const details = readTodoResultDetails(message.toolName, message);
+			if (!details) continue;
+			phases = details.phases;
+		} else {
 			continue;
 		}
-		if (entry.type !== "message") continue;
-		const message = entry.message as { role?: string; toolName?: string; details?: unknown; isError?: boolean };
-		if (message.role !== "toolResult" || message.toolName !== "todo" || message.isError) continue;
-
-		const details = message.details as { phases?: unknown } | undefined;
-		if (!details || !Array.isArray(details.phases)) continue;
-
-		return clonePhases(details.phases as TodoPhase[]);
+		return { entry, phases: clonePhases(phases) };
 	}
+	return undefined;
+}
 
-	return [];
+export function getLatestTodoPhasesFromEntries(entries: SessionEntry[]): TodoPhase[] {
+	return getLatestTodoSnapshotFromEntries(entries)?.phases ?? [];
 }
 
 /** Minimum overlap (after normalization) required for a substring match.
@@ -717,7 +743,7 @@ export function markdownToPhases(md: string): { phases: TodoPhase[]; errors: str
 	return { phases, errors };
 }
 
-function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false): string {
+export function formatTodoSummary(phases: TodoPhase[], errors: string[], readOnly = false): string {
 	const tasks = phases.flatMap(phase => phase.tasks);
 	if (tasks.length === 0) {
 		if (errors.length > 0) return `Errors: ${errors.join("; ")}`;
@@ -892,7 +918,7 @@ export class TodoTool implements AgentTool<typeof todoSchema, TodoToolDetails> {
 		if (completedTasks.length > 0) details.completedTasks = completedTasks;
 
 		return {
-			content: [{ type: "text", text: formatSummary(effective, errors, readOnly) }],
+			content: [{ type: "text", text: formatTodoSummary(effective, errors, readOnly) }],
 			details,
 			isError: errors.length > 0 ? true : undefined,
 		};

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -56,6 +56,60 @@ function expectAcpNotifications(updates: SessionNotification[]): void {
 	}
 }
 
+it("projects successful todo device results into ACP plans without reopening abandoned work", () => {
+	const result = {
+		content: [{ type: "text" as const, text: "Updated todos" }],
+		details: {
+			xdev: {
+				tool: "todo",
+				mode: "execute",
+				inner: {
+					phases: [
+						{
+							name: "Work",
+							tasks: [
+								{ content: "Accept release", status: "blocked", blocker: "owner approval" },
+								{ content: "Old implementation", status: "abandoned" },
+							],
+						},
+					],
+				},
+			},
+		},
+	};
+	const event: Extract<AgentSessionEvent, { type: "tool_execution_end" }> = {
+		type: "tool_execution_end",
+		toolCallId: "device-todo",
+		toolName: "write",
+		result,
+		isError: false,
+	};
+	const updates = mapAgentSessionEventToAcpSessionUpdates(event, "todo-session");
+	expect(updates.map(update => update.update)).toContainEqual({
+		sessionUpdate: "plan",
+		entries: [
+			{ content: "Accept release", priority: "medium", status: "pending" },
+			{ content: "Old implementation", priority: "medium", status: "completed" },
+		],
+	});
+	const failed = mapAgentSessionEventToAcpSessionUpdates(
+		{ ...event, result: { ...result, isError: true } },
+		"todo-session",
+	);
+	expect(failed.some(update => update.update.sessionUpdate === "plan")).toBe(false);
+	const other = mapAgentSessionEventToAcpSessionUpdates(
+		{
+			...event,
+			result: {
+				...result,
+				details: { xdev: { tool: "some-other-tool", mode: "execute", inner: result.details.xdev.inner } },
+			},
+		},
+		"todo-session",
+	);
+	expect(other.some(update => update.update.sessionUpdate === "plan")).toBe(false);
+});
+
 const TEST_MODEL: Model = buildModel({
 	id: "claude-sonnet-4-20250514",
 	name: "Claude Sonnet",

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -159,6 +159,60 @@ describe("AgentSession prewalk", () => {
 		expect(session.model?.id).toBe(target.id);
 	});
 
+	it("opens the todo gate through read-tier xd execution without handing off until a real write", async () => {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+		let writes = 0;
+		const deviceWrite: AgentTool = {
+			name: "write",
+			label: "Write",
+			description: "Synthetic write and todo device",
+			parameters: writeToolSchema,
+			execute: async () => {
+				writes++;
+				return writes === 1
+					? {
+							content: [{ type: "text", text: "listed" }],
+							details: {
+								xdev: {
+									tool: "todo",
+									mode: "execute",
+									tier: "read",
+									inner: {
+										phases: [{ name: "Work", tasks: [{ content: "Apply the plan", status: "pending" }] }],
+									},
+								},
+							},
+						}
+					: { content: [{ type: "text", text: "wrote" }] };
+			},
+		};
+		const scripted = createMockModel({
+			responses: [toolCall("device-todo", "write"), toolCall("real-write", "write"), { content: ["done"] }],
+		});
+		const calls: string[] = [];
+		const tools = [todoTool as AgentTool, deviceWrite];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: primary, systemPrompt: ["Test"], tools, messages: [], thinkingLevel: Effort.Medium },
+			convertToLlm,
+			streamFn: (model, context, options) => {
+				calls.push(model.id);
+				return scripted.stream(model, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated({ "compaction.enabled": false, "title.refreshOnReplan": false }),
+			modelRegistry,
+			toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+			prewalk: { target },
+		});
+		await session.prompt("Carry out the plan using the todo device");
+		expect(calls).toEqual([primary.id, primary.id, target.id]);
+	});
+
 	it("an edit before any todo call does not switch while a todo tool exists; the next edit after todo does", async () => {
 		const primary = modelOrThrow("claude-sonnet-4-5");
 		const target = modelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-todo-restoration.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-restoration.test.ts
@@ -1,0 +1,495 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { Effort, type Message, type ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TodoCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/todo-command-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import {
+	formatTodoSummary,
+	getLatestTodoPhasesFromEntries,
+	phasesToMarkdown,
+	TodoTool,
+	type TodoPhase,
+	type ToolSession,
+	USER_TODO_EDIT_CUSTOM_TYPE,
+} from "@oh-my-pi/pi-coding-agent/tools";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage, createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+const canonical: TodoPhase[] = [
+	{
+		name: "Delivery",
+		tasks: [
+			{ content: "Integrate accepted changes", status: "in_progress" },
+			{ content: "Check release package", status: "pending" },
+			{ content: "Obtain release approval", status: "blocked", blocker: "waiting for owner sign-off" },
+		],
+	},
+	{
+		name: "Earlier work",
+		tasks: [
+			{ content: "Completed implementation", status: "completed" },
+			{ content: "Superseded approach", status: "abandoned" },
+		],
+	},
+];
+
+function textOf(message: Message): string {
+	return typeof message.content === "string"
+		? message.content
+		: message.content
+				.flatMap(block =>
+					block.type === "text" && "text" in block && typeof block.text === "string" ? [block.text] : [],
+				)
+				.join("\n");
+}
+
+function restoredTexts(messages: Message[]): string[] {
+	return messages
+		.filter(message => message.role === "developer")
+		.map(textOf)
+		.filter(text => text.startsWith("<todo-state>"));
+}
+
+function seedTodoHistory(
+	manager: SessionManager,
+	phases: TodoPhase[] = canonical,
+): { keptId: string; result: ToolResultMessage } {
+	manager.appendMessage({ role: "user", content: "Carry out the release plan", timestamp: Date.now() });
+	const call = createAssistantMessage("");
+	call.content = [{ type: "toolCall", id: "todo-snapshot", name: "todo", arguments: { op: "view" } }];
+	call.stopReason = "toolUse";
+	manager.appendMessage(call);
+	const result: ToolResultMessage = {
+		role: "toolResult",
+		toolName: "todo",
+		toolCallId: "todo-snapshot",
+		isError: false,
+		content: [{ type: "text", text: formatTodoSummary(phases, [], true) }],
+		details: { op: "view", phases, storage: "session" },
+		timestamp: Date.now(),
+	};
+	manager.appendMessage(result);
+	manager.appendMessage(createAssistantMessage("Older work details. ".repeat(500)));
+	const keptId = manager.appendMessage({ role: "user", content: "Continue the same work", timestamp: Date.now() });
+	return { keptId, result };
+}
+
+describe("canonical todo context restoration", () => {
+	let dir: TempDir;
+	let auth: AuthStorage;
+	let registry: ModelRegistry;
+	const sessions: AgentSession[] = [];
+
+	beforeEach(() => {
+		dir = TempDir.createSync("@pi-todo-restoration-");
+		auth = createInMemoryAuthStorage();
+		auth.setRuntimeApiKey("anthropic", "synthetic-key");
+		registry = new ModelRegistry(auth, path.join(dir.path(), "models.yml"));
+	});
+
+	afterEach(async () => {
+		for (const session of sessions) await session.dispose();
+		sessions.length = 0;
+		auth.close();
+		await dir.remove();
+		vi.restoreAllMocks();
+	});
+
+	function createHarness(
+		manager: SessionManager,
+		overrides: Record<string, unknown> = {},
+		additionalTools: AgentTool[] = [],
+	) {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled synthetic-test model");
+		const requests: Message[][] = [];
+		const settings = Settings.isolated({
+			"todo.enabled": true,
+			"todo.reminders": false,
+			"todo.eager": "default",
+			"task.eager": "default",
+			"compaction.enabled": true,
+			"compaction.asyncEnabled": false,
+			"compaction.autoContinue": false,
+			"compaction.methodOrder": ["soft"],
+			"compaction.keepRecentTokens": 1,
+			"title.refreshOnReplan": false,
+			...overrides,
+		});
+		const toolSession: ToolSession = {
+			cwd: dir.path(),
+			hasUI: false,
+			settings,
+			getSessionFile: () => manager.getSessionFile() ?? null,
+			getSessionSpawns: () => "*",
+			getTodoPhases: () => session.getTodoPhases(),
+			setTodoPhases: phases => session.setTodoPhases(phases),
+		};
+		const todo = new TodoTool(toolSession);
+		const tools = [todo as unknown as AgentTool, ...additionalTools];
+		const agent = new Agent({
+			initialState: {
+				model,
+				thinkingLevel: Effort.Medium,
+				systemPrompt: ["Synthetic todo restoration"],
+				tools,
+				messages: manager.buildSessionContext().messages,
+			},
+			getApiKey: () => "synthetic-key",
+			convertToLlm,
+			streamFn: (_model, context) => {
+				requests.push(context.messages.slice());
+				const response = createAssistantMessage("Synthetic turn complete");
+				response.provider = _model.provider;
+				response.model = _model.id;
+				response.api = _model.api;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+		const session: AgentSession = new AgentSession({
+			agent,
+			sessionManager: manager,
+			settings,
+			modelRegistry: registry,
+			toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+			sideStreamFn: () => {
+				throw new Error("Unexpected provider request in synthetic todo fixture");
+			},
+		});
+		sessions.push(session);
+		return { session, todo, requests };
+	}
+
+	it("exposes the canonical journal state once after shared summary compaction, independently of summary claims", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		const { keptId } = seedTodoHistory(manager);
+		const { session, requests } = createHarness(manager);
+		vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "All tasks are completed; no approval remains.",
+			shortSummary: undefined,
+			firstKeptEntryId: keptId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		await session.compact();
+		await session.prompt("Continue the release work");
+		await session.prompt("Continue without replacing the plan");
+		expect(requests).toHaveLength(2);
+		for (const request of requests) {
+			const restored = restoredTexts(request);
+			expect(restored).toHaveLength(1);
+			expect(restored[0]).toContain("Delivery");
+			expect(restored[0]).toContain("[in_progress] Integrate accepted changes");
+			expect(restored[0]).toContain("[pending] Check release package");
+			expect(restored[0]).toContain("[blocked] Obtain release approval");
+			expect(restored[0]).toContain("waiting for owner sign-off");
+			expect(restored[0]).toContain("1 completed");
+			expect(restored[0]).toContain("1 abandoned");
+			expect(restored[0]).not.toContain("Superseded approach");
+		}
+		expect(session.getTodoPhases()).toEqual(canonical);
+		expect(
+			manager.getBranch().filter(entry => entry.type === "custom_message" && entry.customType === "todo-state"),
+		).toEqual([]);
+	});
+
+	it("restores a shaken todo result whose hidden phases survived but visible checklist was elided", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		const { result } = seedTodoHistory(manager);
+		const { session, requests } = createHarness(manager);
+		expect(restoredTexts(await session.convertMessagesToLlm(session.messages))).toEqual([]);
+		const outcome = await session.shake("elide", {
+			config: { ...compactionModule.AGGRESSIVE_SHAKE_CONFIG, protectTokens: 0 },
+		});
+		expect(outcome.toolResultsDropped).toBe(1);
+		expect(result.prunedAt).toBeDefined();
+		expect(textOf(result)).not.toContain("waiting for owner sign-off");
+		expect(requests).toEqual([]);
+		await session.prompt("Continue after shake");
+		const restored = restoredTexts(requests[0]);
+		expect(restored).toHaveLength(1);
+		expect(restored[0]).toContain("waiting for owner sign-off");
+		expect(session.getTodoPhases()).toEqual(canonical);
+	});
+
+	it("restores after file resume with provider replacement history that omitted the todo list", async () => {
+		const manager = SessionManager.create(dir.path(), dir.path());
+		const { keptId } = seedTodoHistory(manager);
+		manager.appendCompaction("Lossy provider summary", undefined, keptId, 1000, {
+			preserveData: {
+				openaiRemoteCompaction: {
+					provider: "openai",
+					replacementHistory: [
+						{ type: "message", role: "user", content: [{ type: "input_text", text: "Continue work" }] },
+						{ type: "compaction", encrypted_content: "synthetic-compaction-payload" },
+					],
+				},
+			},
+		});
+		await manager.flush();
+		const file = manager.getSessionFile();
+		if (!file) throw new Error("Expected temporary journal path");
+		const reopened = await SessionManager.open(file, dir.path());
+		const { session, requests } = createHarness(reopened);
+		await session.prompt("Continue from the reopened session");
+		expect(restoredTexts(requests[0])).toHaveLength(1);
+		expect(restoredTexts(requests[0])[0]).toContain("waiting for owner sign-off");
+		expect(session.getTodoPhases()).toEqual(canonical);
+	});
+
+	it("preserves explicit clears across summary restoration and does not revive eager todo creation", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		const { keptId } = seedTodoHistory(manager);
+		manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+		manager.appendMessage({
+			role: "toolResult",
+			toolName: "todo",
+			toolCallId: "failed-old-snapshot",
+			isError: true,
+			content: [{ type: "text", text: "failed" }],
+			details: { phases: canonical },
+			timestamp: Date.now(),
+		});
+		manager.appendCompaction("Continue the old release checklist", undefined, keptId, 1000);
+		const { session, requests } = createHarness(manager, { "todo.eager": "always" });
+		await session.prompt("Continue without recreating cleared work");
+		expect(restoredTexts(requests[0])).toHaveLength(1);
+		expect(restoredTexts(requests[0])[0]).toContain("intentionally empty");
+		expect(requests[0].map(textOf).join("\n")).not.toContain("[blocked] Obtain release approval");
+		expect(
+			session.messages.some(message => message.role === "custom" && message.customType === "eager-todo-prelude"),
+		).toBe(false);
+		expect(session.getTodoPhases()).toEqual([]);
+		await session.resetSessionContext();
+		await session.prompt("A new context without old todos");
+		expect(restoredTexts(requests[1])).toEqual([]);
+	});
+
+	it("restores the selected tree branch instead of reopening its deliberately cleared sibling", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		manager.appendMessage({ role: "user", content: "Release work", timestamp: Date.now() });
+		const workBranch = manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: canonical });
+		const clearedBranch = manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+		const { session, requests } = createHarness(manager);
+		await session.navigateTree(workBranch, { summarize: false });
+		await session.prompt("Continue this selected work branch");
+		expect(restoredTexts(requests[0])[0]).toContain("waiting for owner sign-off");
+		expect(session.getTodoPhases()).toEqual(canonical);
+		await session.navigateTree(clearedBranch, { summarize: false });
+		await session.prompt("Keep the selected cleared branch empty");
+		expect(restoredTexts(requests[1])).toHaveLength(1);
+		expect(restoredTexts(requests[1])[0]).toContain("intentionally empty");
+		expect(session.getTodoPhases()).toEqual([]);
+	});
+
+	it("does not duplicate a retained manual-edit reminder that already represents the current snapshot", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		seedTodoHistory(manager);
+		const { session, requests } = createHarness(manager);
+		const ctx = {
+			session,
+			sessionManager: manager,
+			agent: session.agent,
+			setTodos: () => {},
+			showStatus: () => {},
+		} as unknown as InteractiveModeContext;
+		await new TodoCommandController(ctx).handleTodoCommand("rm");
+		session.freshSession();
+		await session.prompt("Continue without restoring the removed list");
+		expect(restoredTexts(requests[0])).toEqual([]);
+		expect(requests[0].map(textOf).filter(text => text.includes("intentionally cleared the todo list"))).toHaveLength(
+			1,
+		);
+		expect(session.getTodoPhases()).toEqual([]);
+	});
+
+	it("recognizes a retained legacy developer checklist paired with the latest journal edit", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: canonical });
+		manager.appendMessage({
+			role: "developer",
+			content: [{ type: "text", text: phasesToMarkdown(canonical) }],
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+		const { session, requests } = createHarness(manager);
+		session.freshSession();
+		await session.prompt("Continue from the retained checklist");
+		expect(restoredTexts(requests[0])).toEqual([]);
+		expect(requests[0].map(textOf).filter(text => text.includes("waiting for owner sign-off"))).toHaveLength(1);
+		expect(session.getTodoPhases()).toEqual(canonical);
+	});
+
+	it("delivers missing canonical state to the next provider request after a mid-turn model replacement", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		seedTodoHistory(manager);
+		const target = getBundledModel("anthropic", "claude-sonnet-4-6");
+		if (!target) throw new Error("Expected bundled replacement model");
+		const replace: AgentTool = {
+			name: "replace_provider",
+			label: "Replace provider",
+			description: "Synthetic model replacement",
+			parameters: type({}),
+			execute: async () => {
+				const phases = session.getTodoPhases();
+				phases[0].tasks[2].blocker = "a newly recorded release gate";
+				session.setTodoPhases(phases);
+				manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases });
+				await session.setModelTemporary(target, undefined, { ephemeral: true });
+				return { content: [{ type: "text", text: "Replaced provider" }] };
+			},
+		};
+		const harness = createHarness(manager, { "compaction.enabled": false }, [replace]);
+		const session: AgentSession = harness.session;
+		const stream = session.agent.streamFn;
+		let called = false;
+		session.agent.streamFn = (model, context, options) => {
+			if (called) return stream(model, context, options);
+			called = true;
+			harness.requests.push(context.messages.slice());
+			const response = createAssistantMessage("");
+			response.model = model.id;
+			response.api = model.api;
+			response.provider = model.provider;
+			response.content = [{ type: "toolCall", id: "replace-provider", name: replace.name, arguments: {} }];
+			response.stopReason = "toolUse";
+			const events = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				events.push({ type: "start", partial: response });
+				events.push({ type: "done", reason: "toolUse", message: response });
+			});
+			return events;
+		};
+		await session.prompt("Replace the provider and continue this tool loop");
+		expect(harness.requests).toHaveLength(2);
+		expect(restoredTexts(harness.requests[0])).toEqual([]);
+		expect(restoredTexts(harness.requests[1])).toHaveLength(1);
+		expect(restoredTexts(harness.requests[1])[0]).toContain("a newly recorded release gate");
+	});
+
+	it("keeps a single projection across provider reset and retains a complete todo view behind its bounds", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		const phases: TodoPhase[] = Array.from({ length: 20 }, (_, index) => ({
+			name: `Closed phase ${index}`,
+			tasks: [{ content: "Closed label ".repeat(100), status: "completed" }],
+		}));
+		phases.push({
+			name: "Current phase",
+			tasks: [
+				{ content: "Current task", status: "in_progress" },
+				{ content: "Blocked task", status: "blocked", blocker: "Sign-off detail ".repeat(100) },
+				...Array.from({ length: 60 }, (_, index) => ({
+					content: `Pending ${index} ${"work detail ".repeat(100)}`,
+					status: "pending" as const,
+				})),
+			],
+		});
+		manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases });
+		const { session, todo, requests } = createHarness(manager);
+		session.freshSession();
+		session.freshSession();
+		await session.prompt("Continue the current phase");
+		const restored = restoredTexts(requests[0]);
+		expect(restored).toHaveLength(1);
+		expect(restored[0].length).toBeLessThan(20_000);
+		expect(restored[0]).toContain("[in_progress] Current task");
+		expect(restored[0]).toContain("[blocked] Blocked task");
+		expect(restored[0]).toContain("Sign-off detail");
+		expect(restored[0]).toContain("omitted");
+		const full = await todo.execute("complete-view", { op: "view" });
+		expect(full.details?.phases).toEqual(phases);
+		expect(full.content.some(block => block.type === "text" && block.text.includes("Pending 59"))).toBe(true);
+	});
+
+	it("does not mistake an older matching tool result for the current state after intervening edits", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		seedTodoHistory(manager);
+		const changed = canonical.map(phase => ({
+			name: phase.name,
+			tasks: phase.tasks.map(task => ({ content: task.content, status: "completed" as const })),
+		}));
+		manager.appendMessage({
+			role: "toolResult",
+			toolName: "todo",
+			toolCallId: "later-completion",
+			isError: false,
+			content: [{ type: "text", text: formatTodoSummary(changed, []) }],
+			details: { phases: changed },
+			timestamp: Date.now(),
+		});
+		manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: canonical });
+		const { session, requests } = createHarness(manager);
+		await session.prompt("Continue the most recently restored plan");
+		expect(restoredTexts(requests[0])).toHaveLength(1);
+		expect(restoredTexts(requests[0])[0]).toContain("[blocked] Obtain release approval");
+		expect(session.getTodoPhases()).toEqual(canonical);
+	});
+
+	it("journals one normal result per native or device operation and replays the device clear", async () => {
+		const manager = SessionManager.inMemory(dir.path());
+		const { session, todo } = createHarness(manager);
+		const initial = await todo.execute("native-init", {
+			op: "init",
+			list: [
+				{ phase: "Work", items: ["Native task"] },
+				{ phase: "Verification", items: ["Check the native task"] },
+			],
+		});
+		session.agent.emitExternalEvent({
+			type: "message_end",
+			message: {
+				role: "toolResult",
+				toolName: "todo",
+				toolCallId: "native-init",
+				content: initial.content,
+				details: initial.details,
+				isError: false,
+				timestamp: Date.now(),
+			},
+		});
+		await session.waitForIdle();
+		const cleared = await todo.execute("device-clear", { op: "rm" });
+		session.agent.emitExternalEvent({
+			type: "message_end",
+			message: {
+				role: "toolResult",
+				toolName: "write",
+				toolCallId: "device-clear",
+				content: cleared.content,
+				details: {
+					xdev: { tool: "todo", mode: "execute", args: { op: "rm" }, tier: "read", inner: cleared.details },
+				},
+				isError: false,
+				timestamp: Date.now(),
+			},
+		});
+		await session.waitForIdle();
+		// Whole-list rm clears every task while retaining the phase headings.
+		expect(getLatestTodoPhasesFromEntries(manager.getBranch()).flatMap(phase => phase.tasks)).toEqual([]);
+		expect(
+			manager.getBranch().filter(entry => entry.type === "message" && entry.message.role === "toolResult"),
+		).toHaveLength(2);
+		expect(
+			manager
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toEqual([]);
+		expect(session.getTodoPhases().flatMap(phase => phase.tasks)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/event-controller-cursor-todo.test.ts
+++ b/packages/coding-agent/test/event-controller-cursor-todo.test.ts
@@ -104,6 +104,33 @@ function todoFailure(text: string): Extract<AgentSessionEvent, { type: "tool_exe
 }
 
 describe("EventController + Cursor todo bridge", () => {
+	it("updates the canonical HUD from write xd://todo and ignores failed device clears", async () => {
+		const f = createFixture();
+		const phases = [
+			{
+				name: "Release",
+				tasks: [
+					{ content: "Get approval", status: "blocked", blocker: "owner sign-off" },
+					{ content: "Old approach", status: "abandoned" },
+				],
+			},
+		];
+		const event = todoEnd("device-todo", phases);
+		event.toolName = "write";
+		event.result.details = { xdev: { tool: "todo", mode: "execute", inner: { phases } } };
+		await f.controller.handleEvent(event);
+		expect(f.ctx.setTodos).toHaveBeenCalledWith(phases);
+		await f.controller.handleEvent({
+			...event,
+			toolCallId: "failed-device-todo",
+			result: {
+				content: [{ type: "text", text: "rejected" }],
+				isError: true,
+				details: { xdev: { tool: "todo", mode: "execute", inner: { phases: [] } } },
+			},
+		});
+		expect(f.ctx.setTodos).toHaveBeenCalledTimes(1);
+	});
 	it("sanitizes provider error text before it reaches the status line", async () => {
 		// The bridge forwards the server's error string verbatim, so this text is
 		// untrusted terminal input. Raw tabs punch holes in the single-line status

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -10,9 +10,15 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task";
-import type { TodoItem, TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
+import {
+	getLatestTodoPhasesFromEntries,
+	type TodoItem,
+	type TodoPhase,
+	USER_TODO_EDIT_CUSTOM_TYPE,
+} from "@oh-my-pi/pi-coding-agent/tools/todo";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 function renderTodos(mode: InteractiveMode): string {
 	return Bun.stripANSI(mode.todoContainer.render(120).join("\n"));
@@ -25,6 +31,22 @@ describe("InteractiveMode todo HUD persistence", () => {
 	let mode: InteractiveMode;
 	let eventBus: EventBus;
 	let modelRegistry: ModelRegistry;
+
+	function startChild(owner: AgentSession, id: string, description: string, parentToolCallId = `${id}-call`): void {
+		const message = createAssistantMessage("");
+		message.content = [{ type: "toolCall", id: parentToolCallId, name: "task", arguments: { description } }];
+		message.stopReason = "toolUse";
+		owner.sessionManager.appendMessage(message);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id,
+			index: 0,
+			agent: "task",
+			description,
+			parentToolCallId,
+			status: "started",
+			detached: true,
+		});
+	}
 
 	async function replaceMode(): Promise<void> {
 		if (mode) {
@@ -203,30 +225,156 @@ describe("InteractiveMode todo HUD persistence", () => {
 		expect(renderTodos(mode)).not.toContain("done task");
 	});
 
-	it("marks todos complete when subagent reconciliation reports a finished agent", async () => {
+	it("journals accepted child completion once and replays blocked and abandoned work unchanged", async () => {
 		await replaceMode();
 		setTodoClearDelay(-1);
 		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
-		session.setTodoPhases([
-			{ name: "Implementation", tasks: [{ content: "Fix review comments", status: "pending" }] },
-		]);
+		const phases: TodoPhase[] = [
+			{
+				name: "Implementation",
+				tasks: [
+					{ content: "Fix review comments", status: "pending" },
+					{ content: "Release approval", status: "blocked", blocker: "waiting for release sign-off" },
+					{ content: "Superseded implementation", status: "abandoned" },
+				],
+			},
+		];
+		session.setTodoPhases(phases);
+		session.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases });
 		mode.setTodos(session.getTodoPhases());
-
 		await mode.init();
-		// Subagent lifecycle changes coalesce behind a 100ms observer UI sync
-		// timer before todo reconciliation runs; flush it deterministically.
 		vi.useFakeTimers();
-		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+		startChild(session, "ReviewFixer", "Fix review comments");
+		const completed = {
 			id: "ReviewFixer",
 			index: 0,
 			agent: "task",
 			description: "Fix review comments",
+			parentToolCallId: "ReviewFixer-call",
 			status: "completed",
 			detached: true,
-		});
+		};
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, completed);
 		vi.advanceTimersByTime(100);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, { ...completed });
+		vi.advanceTimersByTime(100);
+		const accepted: TodoPhase[] = [
+			{
+				...phases[0],
+				tasks: [{ content: "Fix review comments", status: "completed" }, ...phases[0].tasks.slice(1)],
+			},
+		];
+		expect(session.getTodoPhases()).toEqual(accepted);
+		expect(
+			session.sessionManager
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toHaveLength(2);
+		vi.useRealTimers();
+		await session.sessionManager.flush();
+		const sessionFile = session.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a temporary session journal");
+		const replayManager = await SessionManager.open(sessionFile, tempDir.path());
+		const replay = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: session.model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: replayManager.buildSessionContext().messages,
+				},
+			}),
+			sessionManager: replayManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		try {
+			expect(replay.getTodoPhases()).toEqual(accepted);
+		} finally {
+			await replay.dispose();
+		}
+	});
 
-		expect(session.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+	it("keeps failed work open when the same child restarts before observer rendering", async () => {
+		await replaceMode();
+		setTodoClearDelay(-1);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		const phases: TodoPhase[] = [
+			{
+				name: "Implementation",
+				tasks: [
+					{ content: "Attempt task A", status: "pending" },
+					{ content: "Attempt task B", status: "pending" },
+				],
+			},
+		];
+		session.setTodoPhases(phases);
+		session.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases });
+		mode.setTodos(session.getTodoPhases());
+		await mode.init();
+		vi.useFakeTimers();
+		startChild(session, "ReusedWorker", "Attempt task A", "ReusedWorker-A-call");
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "ReusedWorker",
+			index: 0,
+			agent: "task",
+			description: "Attempt task A",
+			parentToolCallId: "ReusedWorker-A-call",
+			status: "failed",
+			detached: true,
+		});
+		startChild(session, "ReusedWorker", "Attempt task B", "ReusedWorker-B-call");
+		// A's terminal event and B's start both precede the first observer flush.
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual(phases);
+		expect(
+			session.sessionManager
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toHaveLength(1);
+
+		const completed = {
+			id: "ReusedWorker",
+			index: 0,
+			agent: "task",
+			description: "Attempt task B",
+			parentToolCallId: "ReusedWorker-B-call",
+			status: "completed",
+			detached: true,
+		};
+		const accepted: TodoPhase[] = [
+			{
+				...phases[0],
+				tasks: [phases[0].tasks[0], { content: "Attempt task B", status: "completed" }],
+			},
+		];
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, completed);
+		// Acceptance and journaling cannot wait for a mutable observer snapshot.
+		expect(session.getTodoPhases()).toEqual(accepted);
+		expect(getLatestTodoPhasesFromEntries(session.sessionManager.getBranch())).toEqual(accepted);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, completed);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, { ...completed });
+		vi.advanceTimersByTime(100);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, { ...completed });
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual(accepted);
+		expect(renderTodos(mode)).toContain("1/2");
+		expect(
+			session.sessionManager
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toHaveLength(2);
+		vi.useRealTimers();
+		await session.sessionManager.flush();
+		const sessionFile = session.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a temporary session journal");
+		const reopened = await SessionManager.open(sessionFile, tempDir.path());
+		expect(getLatestTodoPhasesFromEntries(reopened.getBranch())).toEqual(accepted);
+		expect(
+			reopened
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toHaveLength(2);
 	});
 
 	it("reconciles focused worker todos without overwriting the main session", async () => {
@@ -275,6 +423,7 @@ describe("InteractiveMode todo HUD persistence", () => {
 			expect(renderTodos(mode)).toContain("apply nested review fixes");
 
 			vi.useFakeTimers();
+			startChild(focusedSession, `${agentId}/NestedFixer`, "apply nested review fixes");
 			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
 				id: `${agentId}/NestedFixer`,
 				index: 0,
@@ -286,6 +435,9 @@ describe("InteractiveMode todo HUD persistence", () => {
 			vi.advanceTimersByTime(100);
 
 			expect(focusedSession.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+			expect(getLatestTodoPhasesFromEntries(focusedSession.sessionManager.getBranch())).toEqual(
+				focusedSession.getTodoPhases(),
+			);
 			expect(session.getTodoPhases()).toEqual(mainPhases);
 			expect(renderTodos(mode)).toContain("1/2");
 
@@ -336,6 +488,7 @@ describe("InteractiveMode todo HUD persistence", () => {
 			expect(renderTodos(mode)).toContain("run the delegated fix");
 
 			vi.useFakeTimers();
+			startChild(workerSession, "DelegatedFixer", "run the delegated fix");
 			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
 				id: "DelegatedFixer",
 				index: 0,
@@ -347,6 +500,9 @@ describe("InteractiveMode todo HUD persistence", () => {
 			vi.advanceTimersByTime(100);
 
 			expect(workerSession.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
+			expect(getLatestTodoPhasesFromEntries(workerSession.sessionManager.getBranch())).toEqual(
+				workerSession.getTodoPhases(),
+			);
 			expect(session.getTodoPhases()).toEqual(mainPhases);
 			expect(renderTodos(mode)).toContain("1/1");
 		} finally {
@@ -356,37 +512,110 @@ describe("InteractiveMode todo HUD persistence", () => {
 		}
 	});
 
-	it("completes a blocked todo when the detached subagent it waits on finishes", async () => {
+	it("does not turn a matching child's success into acceptance of blocked or abandoned parent work", async () => {
 		await replaceMode();
 		setTodoClearDelay(-1);
 		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
-		// A todo blocked while waiting on a detached subagent. Blocked todos are
-		// excluded from the stop reminder, so if reconciliation skipped them this
-		// would strand silently after the subagent completes.
-		session.setTodoPhases([
+		const phases: TodoPhase[] = [
 			{
 				name: "Implementation",
-				tasks: [{ content: "Fix review comments", status: "blocked", blocker: "waiting on ReviewFixer" }],
+				tasks: [
+					{ content: "Fix review comments", status: "blocked", blocker: "waiting on independent sign-off" },
+					{ content: "Old approach", status: "abandoned" },
+				],
 			},
-		]);
+		];
+		session.setTodoPhases(phases);
 		mode.setTodos(session.getTodoPhases());
-
 		await mode.init();
 		vi.useFakeTimers();
+		startChild(session, "ReviewFixer", "Fix review comments");
+		startChild(session, "OldWorker", "Old approach");
+		for (const [id, description] of [
+			["ReviewFixer", "Fix review comments"],
+			["OldWorker", "Old approach"],
+		]) {
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id,
+				index: 0,
+				agent: "task",
+				description,
+				status: "completed",
+				detached: true,
+			});
+		}
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual(phases);
+		expect(
+			session.sessionManager
+				.getBranch()
+				.filter(entry => entry.type === "custom" && entry.customType === USER_TODO_EDIT_CUSTOM_TYPE),
+		).toEqual([]);
+	});
+
+	it("keeps fuzzy and stale completed children from closing a replacement plan", async () => {
+		await replaceMode();
+		setTodoClearDelay(-1);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		const phases: TodoPhase[] = [
+			{ name: "Review", tasks: [{ content: "Review database migration", status: "pending" }] },
+		];
+		session.setTodoPhases(phases);
+		mode.setTodos(session.getTodoPhases());
+		await mode.init();
+		vi.useFakeTimers();
+		startChild(session, "FuzzyReviewer", "database migration");
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-			id: "ReviewFixer",
+			id: "FuzzyReviewer",
 			index: 0,
 			agent: "task",
-			description: "Fix review comments",
+			description: "database migration",
 			status: "completed",
-			detached: true,
 		});
 		vi.advanceTimersByTime(100);
-
-		const task = session.getTodoPhases()[0]?.tasks[0];
-		expect(task?.status).toBe("completed");
-		// The blocker note is dropped with the blocked status — the wait is over.
-		expect(task?.blocker).toBeUndefined();
+		expect(session.getTodoPhases()).toEqual(phases);
+		startChild(session, "OldReviewer", "Review database migration");
+		session.setTodoPhases([]);
+		session.sessionManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "OldReviewer",
+			index: 0,
+			agent: "task",
+			description: "Review database migration",
+			status: "completed",
+		});
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual([]);
+		expect(getLatestTodoPhasesFromEntries(session.sessionManager.getBranch())).toEqual([]);
+		session.setTodoPhases(phases);
+		mode.setTodos(phases);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "OldReviewer",
+			index: 0,
+			agent: "task",
+			description: "Review database migration",
+			status: "completed",
+		});
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual(phases);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "LateReviewer",
+			index: 0,
+			agent: "task",
+			description: "Review database migration",
+			parentToolCallId: "OldReviewer-call",
+			status: "started",
+		});
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "LateReviewer",
+			index: 0,
+			agent: "task",
+			description: "Review database migration",
+			parentToolCallId: "OldReviewer-call",
+			status: "completed",
+		});
+		vi.advanceTimersByTime(100);
+		expect(session.getTodoPhases()).toEqual(phases);
 	});
 });
 

--- a/packages/coding-agent/test/modes/controllers/todo-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/todo-command-controller.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { TodoCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/todo-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { type TodoPhase, USER_TODO_EDIT_CUSTOM_TYPE } from "@oh-my-pi/pi-coding-agent/tools";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -18,7 +19,7 @@ function createContext(cwd: string, phases: TodoPhase[]): InteractiveModeContext
 		},
 		sessionManager: {
 			appendCustomEntry: vi.fn(),
-			appendMessage: vi.fn(),
+			appendCustomMessageEntry: vi.fn(),
 			getBranch: () => [],
 			getCwd: () => cwd,
 		},
@@ -35,17 +36,6 @@ describe("TodoCommandController", () => {
 	afterEach(async () => {
 		if (tempRoot) await removeWithRetries(tempRoot);
 		tempRoot = "";
-	});
-
-	it("advertises optional default todo import and export paths", async () => {
-		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-tui-todo-help-"));
-		const ctx = createContext(tempRoot, []);
-		const controller = new TodoCommandController(ctx);
-
-		await controller.handleTodoCommand("help");
-
-		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("/todo export [<path>]"));
-		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("/todo import [<path>]"));
 	});
 
 	it("exports the default TODO.md under the active session cwd", async () => {
@@ -91,8 +81,6 @@ describe("TodoCommandController", () => {
 		expect(ctx.sessionManager.appendCustomEntry).toHaveBeenCalledWith(USER_TODO_EDIT_CUSTOM_TYPE, {
 			phases: expected,
 		});
-		expect(ctx.agent.appendMessage).toHaveBeenCalledWith(expect.objectContaining({ role: "developer" }));
-		expect(ctx.sessionManager.appendMessage).toHaveBeenCalledWith(expect.objectContaining({ role: "developer" }));
 		expect(ctx.showStatus).toHaveBeenCalledWith(`Imported 1 phase(s), 1 task(s) from ${target}.`);
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
@@ -153,10 +141,24 @@ describe("TodoCommandController", () => {
 		expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining("internal scheme"));
 	});
 
+	it("appends only new work when the journal intentionally cleared a stale in-memory list", async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-tui-todo-clear-precedence-"));
+		const ctx = createContext(tempRoot, [
+			{ name: "Old phase", tasks: [{ content: "Removed task", status: "pending" }] },
+		]);
+		const manager = SessionManager.inMemory(tempRoot);
+		manager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+		vi.spyOn(ctx.sessionManager, "getBranch").mockImplementation(() => manager.getBranch());
+		const controller = new TodoCommandController(ctx);
+		await controller.handleTodoCommand('append "Fresh task"');
+		const set = ctx.session.setTodoPhases as Mock<(phases: TodoPhase[]) => void>;
+		expect(set.mock.calls[0][0].flatMap(phase => phase.tasks.map(task => task.content))).toEqual(["Fresh task"]);
+	});
+
 	function reminderTextFrom(ctx: InteractiveModeContext): string {
 		const appendMessage = ctx.agent.appendMessage as unknown as Mock<(message: unknown) => void>;
-		const message = appendMessage.mock.calls[0][0] as { content: Array<{ text: string }> };
-		return message.content[0].text;
+		const message = appendMessage.mock.calls[0][0] as { content: string };
+		return message.content;
 	}
 
 	it("tells the model not to recreate the list after /todo rm (all)", async () => {


### PR DESCRIPTION
Draft opened at the contributor's request. Human-authored explanation and personal verification are still pending; the technical description and recorded checks below are agent-assisted. Maintainer discussion is pending, not represented as prior approval. Keep this draft until the author completes the placeholders.

## What

Keep native todo state authoritative across device invocation, RPC edits, replay, context restoration, and accepted child completion, using the existing session journal rather than adding another todo store.

- Normalize successful native `todo` and `write xd://todo` execution results through one canonical result reader. Session tracking, prewalk, the interactive HUD, ACP projection, and journal replay recognize the same accepted snapshot; failed results and unrelated device details do not replace it.
- Preserve all five native task states and blocker notes on replay. An explicit empty snapshot is distinct from no snapshot and wins over stale in-memory state. Ordinary native/device tool results remain journaled once through their normal result entries; manual edits, RPC `set_todos`, and accepted out-of-band completions use the existing `user_todo_edit` snapshot mechanism.
- Restore at most one bounded model-context projection when the latest canonical checklist is missing after lossy context restoration or a provider/model lifecycle change. It prioritizes current, blocked, and pending work, retains separate completed/abandoned counts, reports omissions, and directs the model to the complete native todo view. The derived reminder is not another persisted checklist.
- Bind automatic child completion to one exact, unique actionable parent task, the owning session/branch, current plan revision, and parent tool-call provenance. Edits, clears, branch restoration, reset boundaries, stale or failed children, duplicate descriptions, and blocked/abandoned tasks do not become automatic acceptance. Fuzzy matching remains display-only.
- Capture and settle those bindings synchronously on child lifecycle notifications; debounce only HUD rendering. Successful acceptance journals one snapshot and duplicate terminal notifications remain idempotent.

Existing RPC command/result shapes and the native phase/task schema remain unchanged. ACP continues using its existing narrower status projection rather than inventing additional protocol values. No compaction-method ordering, tool-availability defaults, or execution permissions are changed. Explicit context clear does not reintroduce an earlier checklist; intentionally cleared work is not recreated by eager todo creation.

## Why

Todo state should not depend on the spelling of the transport call or on whether an update happened to be visible in the current UI. Previously, consumers that recognized only a tool named `todo` could miss the same native operation dispatched through `write xd://todo`. RPC `set_todos` updated the live state without recording the snapshot needed for replay. Treating an empty result as absence could then revive a stale list.

Long-running sessions also cannot rely on a narrative summary to reproduce structured work accurately. Compaction, shaking, provider replacement, or resumed history can omit the visible checklist even when canonical journal data survives. A bounded projection from that journal preserves access to the actual checklist without making summary text authoritative, repeatedly growing reminders, or introducing another store to reconcile.

Child success is a related ownership problem, not proof that arbitrary matching parent work was accepted. Fuzzy descriptions or old child observations must not close a changed plan or clear an independent blocker. The corrected acceptance path therefore records only a narrowly bound current task.

There was also a concrete lifecycle race: child run A could fail, then the same mutable observed child could start run B before the 100 ms UI debounce flushed. If settlement waited for rendering, A's binding could survive while B was active, and B's eventual success could mark A complete. Synchronous terminal settlement deletes the failed run's binding before that child can be reused; the new run captures its own binding. Only presentation remains delayed.

## Testing

Fresh standalone-branch package `bun run check` passed lint, formatting and types; 154 focused tests / 622 assertions passed across ten files. These include durable journal replay, explicit-clear precedence, bounded restoration, and failed-child/reused-child lifecycle schedules. Automated evidence does not establish the contributor's required personal review/use. The older combined-runtime evidence below is retained separately and must not be added to this count:

- The combined coding-agent change set passed 322 targeted tests / 1,720 assertions across 18 files. Package `bun run check` passed lint, formatting checks, and types from `packages/coding-agent`.
- After the lifecycle-race correction, `bun test test/interactive-mode-todo-clear.test.ts test/subagent-hud-render.test.ts test/agent-session-todo-restoration.test.ts` passed 43 tests / 220 assertions. Package checks passed again. This is an overlapping focused run, not 43 additional unique tests to add to the aggregate.
- The failed-A/reused-child-B regression schedules A's failure and B's restart before the first observer render. A stays open; B alone completes; duplicate terminal notifications add no further accepted snapshot. Both in-memory and reopened-journal state are checked.
- An actual source RPC process accepted a rich blocked/abandoned todo snapshot and then an explicit clear on a saved synthetic conversation. Its journal contained exactly two `user_todo_edit` entries. Reopening through `SessionManager.open` and `getLatestTodoPhasesFromEntries` restored the final empty list. No provider call was used for that probe.
- Other exercised cases cover native/device replay, failed device clears, intentional-clear precedence, retained manual and legacy reminders, compaction/shake restoration, selected-branch restoration, bounded full-view fallback, mid-turn model replacement, focused-child ownership, stale/fuzzy child observations, and blocked/abandoned work remaining distinct.

Limitations: the earlier RPC proof used an already saved conversation; an empty pre-conversation session retains existing lazy-save behavior. Structured checklist restoration does not prove that a generated narrative summary is semantically faithful. No deployment or daemon restart is part of this standalone submission. Fresh package/test results apply to this independent branch; previous combined-runtime evidence is attributed separately. Human end-to-end verification remains unconfirmed.

---

- [ ] `bun check` passes — standalone package-level `bun run check` passed; full root-workspace check was not run.
- [ ] Tested locally — automated native RPC replay and deterministic lifecycle scenarios passed as described above; the contributor's own required feature use remains unconfirmed
- [x] CHANGELOG updated (if user-facing)
