### PR TITLE
fix(copilot): keep official OAuth client for enterprise domains

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- GitHub Copilot sign-in keeps the GitHub-owned Copilot CLI OAuth app on Enterprise domains: private instances run their own OAuth registry and reject the github.com-registered OpenCode client, which is now used only for public github.com sign-ins ([#11285](https://github.com/can1357/oh-my-pi/pull/11285) by [@H4vC](https://github.com/H4vC))
 - GitHub Copilot sign-in uses the minimal-grant OpenCode OAuth app again (`read:user` only): GitHub renders each app's existing per-user grant on the consent page, so Enterprise organizations that block the Copilot CLI app's broad historic grant can log in as on 18.1.4. API request identity still mimics the Copilot CLI, and tokens minted by either app keep working ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - GitHub Copilot plan/model-policy 403s no longer count as credential failures for credential-lifetime decisions: the token is valid, so stored credentials are preserved instead of wiped ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 - Fixed custom `google-generative-ai` providers failing mid-turn model fallback when Gemini 3 tool calls are replayed without their original thought signature ([#11270](https://github.com/can1357/oh-my-pi/issues/11270)).

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -7,7 +7,9 @@
  * restrict OAuth apps block the CLI app's broad historic grant
  * (repo/gist/codespace) no matter what scope this request asks for
  * (issue #11275). API request identity still mimics the Copilot CLI via
- * COPILOT_API_HEADERS.
+ * COPILOT_API_HEADERS. Enterprise domains keep the GitHub-owned Copilot CLI
+ * client: private instances run their own OAuth registry and reject the
+ * github.com-registered OpenCode client.
  */
 import { scheduler } from "node:timers/promises";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
@@ -23,7 +25,18 @@ import * as AIError from "../../error";
 import type { FetchImpl } from "../../types";
 import type { OAuthController, OAuthCredentials } from "./types";
 
-const CLIENT_ID = "Ov23li8tweQw6odWQebz";
+const OPENCODE_CLIENT_ID = "Ov23li8tweQw6odWQebz";
+const COPILOT_CLI_CLIENT_ID = "Ov23ctDVkRmgkPke0Mmm";
+
+/**
+ * OAuth client for the device flow. Public github.com uses the minimal-grant
+ * OpenCode app (narrow consent, issue #11275); private GitHub Enterprise
+ * instances run their own OAuth registry, which does not know that github.com
+ * registration, so they keep the GitHub-owned Copilot CLI client.
+ */
+function resolveOAuthClientId(domain: string): string {
+	return isPublicGitHubHost(domain) ? OPENCODE_CLIENT_ID : COPILOT_CLI_CLIENT_ID;
+}
 const OAUTH_SCOPE = "read:user";
 const OAUTH_HEADERS = {
 	Accept: "application/json",
@@ -90,7 +103,7 @@ async function startDeviceFlow(domain: string, fetchImpl: FetchImpl): Promise<De
 			method: "POST",
 			headers: OAUTH_HEADERS,
 			body: new URLSearchParams({
-				client_id: CLIENT_ID,
+				client_id: resolveOAuthClientId(domain),
 				scope: OAUTH_SCOPE,
 			}),
 		},
@@ -164,7 +177,7 @@ async function pollForGitHubAccessToken(
 				method: "POST",
 				headers: OAUTH_HEADERS,
 				body: new URLSearchParams({
-					client_id: CLIENT_ID,
+					client_id: resolveOAuthClientId(domain),
 					device_code: deviceCode,
 					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
 				}),

--- a/packages/ai/test/github-copilot-login.test.ts
+++ b/packages/ai/test/github-copilot-login.test.ts
@@ -177,16 +177,25 @@ describe("loginGitHubCopilot", () => {
 		});
 	});
 
-	it("enterprise domain", async () => {
-		const fetchMock = vi.fn(async (input: string | URL) => {
+	it("enterprise domains keep the GitHub-owned Copilot CLI client", async () => {
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			const url = typeof input === "string" ? input : input.toString();
 			if (url === "https://ghe.example.com/login/device/code") {
+				expectOAuthRequest(init, {
+					client_id: "Ov23ctDVkRmgkPke0Mmm",
+					scope: "read:user",
+				});
 				return new Response(JSON.stringify(deviceCodeResponse()), {
 					status: 200,
 					headers: { "Content-Type": "application/json" },
 				});
 			}
 			if (url === "https://ghe.example.com/login/oauth/access_token") {
+				expectOAuthRequest(init, {
+					client_id: "Ov23ctDVkRmgkPke0Mmm",
+					device_code: "dc_test",
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				});
 				return new Response(JSON.stringify(accessTokenResponse()), {
 					status: 200,
 					headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Follow-up to #11280 (review nit): private GitHub Enterprise instances run their own OAuth registry, which rejects the github.com-registered OpenCode client at their device-code endpoint. The device flow now resolves the OAuth client per domain — minimal-grant OpenCode app for public github.com, GitHub-owned Copilot CLI app for enterprise hosts. Enterprise device + poll bodies pinned to the official client in tests.