### PR TITLE
fix(task): relay failed/cancelled/empty wake turns to the waker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - GitHub Copilot model-policy 403s (plan, model policy, org restriction) no longer delete stored credentials, so the provider stays listed in `/model` after a per-model access denial instead of disappearing until the next `/login` ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
+- A revived subagent whose wake turn fails, is cancelled, or produces no output now relays a distinct notice (with the attributed `[provider/model]` error and a `history://<id>` pointer) to whoever woke it, so a `hub send await:true` waiter learns why there is no answer instead of a generic "stopped without replying" ([#11290](https://github.com/can1357/oh-my-pi/issues/11290)).
 
 ### Added
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2484,18 +2484,23 @@ async function relayWakeTurnOutput(args: {
 	records: AgentMessage[];
 	turnStartTime: number;
 	yielded: boolean;
-	result: SingleResult;
+	result: SingleResult | undefined;
 	turnText: string;
+	/** Attributed provider/model error text when the turn died on a provider error. */
+	error: string | undefined;
+	/** Whether the turn was aborted (runtime limit, cancellation, hard abort). */
+	aborted: boolean;
+	/** Reason text for an aborted turn, from {@link SubagentRunMonitor.resolveAbortReasonText}. */
+	abortReason: string | undefined;
+	/** A {@link finalizeRunResult} throw, so the waiter is notified instead of stranded. */
+	finalizeError: unknown;
 }): Promise<void> {
 	const bus = IrcBus.global();
 	const pending = wakeSources(args.records, args.id).filter(
 		source => !bus.sentSince(args.id, source.from, args.turnStartTime),
 	);
 	if (pending.length === 0) return;
-	const body =
-		args.yielded && args.result.outputPath
-			? formatTaskResultSummary(args.result, { totalDurationMs: args.result.durationMs })
-			: args.turnText.trim();
+	const body = buildWakeRelayBody(args);
 	if (!body) return;
 	for (const source of pending) {
 		const receipt = await bus.send({
@@ -2509,6 +2514,45 @@ async function relayWakeTurnOutput(args: {
 			logger.warn("IRC wake-turn relay failed", { from: args.id, to: source.from, error: receipt.error });
 		}
 	}
+}
+
+/**
+ * Body for a wake-turn relay, distinguishing the terminal outcomes a waiter
+ * would otherwise see as the same generic "stopped without replying" note:
+ * a real answer (yield summary or turn text), a provider failure carrying the
+ * attributed `[provider/model] <error>`, a cancellation with its reason, a
+ * finalization throw, or a turn that ran and produced nothing. Every
+ * non-answer notice carries a `history://<id>` pointer so the peer can inspect
+ * the transcript.
+ */
+function buildWakeRelayBody(args: {
+	id: string;
+	yielded: boolean;
+	result: SingleResult | undefined;
+	turnText: string;
+	error: string | undefined;
+	aborted: boolean;
+	abortReason: string | undefined;
+	finalizeError: unknown;
+}): string {
+	const transcript = `See history://${args.id} for details.`;
+	if (args.error) {
+		return `Wake turn failed: ${args.error}. No answer was produced — ${transcript}`;
+	}
+	if (args.aborted) {
+		const reason = args.abortReason?.trim();
+		return `Wake turn was cancelled${reason ? `: ${reason}` : ""}. No answer was produced — ${transcript}`;
+	}
+	const answer =
+		args.yielded && args.result?.outputPath
+			? formatTaskResultSummary(args.result, { totalDurationMs: args.result.durationMs })
+			: args.turnText.trim();
+	if (answer) return answer;
+	if (args.finalizeError) {
+		const message = args.finalizeError instanceof Error ? args.finalizeError.message : String(args.finalizeError);
+		return `Wake turn failed to finalize: ${message}. No answer was produced — ${transcript}`;
+	}
+	return `Wake turn produced no output. ${transcript}`;
 }
 
 /**
@@ -2612,14 +2656,17 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			// Read before finalization: a schema-bearing agent that answered in
 			// prose gets a missing-yield warning prepended to `result.output`.
 			const turnText = turnMonitor.rawOutput() || (turnMonitor.lastAssistantSalvageText() ?? "");
+			const abortReason = aborted ? turnMonitor.resolveAbortReasonText() : undefined;
+			let result: SingleResult | undefined;
+			let finalizeError: unknown;
 			try {
-				const result = await finalizeRunResult({
+				result = await finalizeRunResult({
 					monitor: turnMonitor,
 					done: {
 						exitCode: aborted || error ? 1 : 0,
 						error,
 						aborted,
-						abortReason: aborted ? turnMonitor.resolveAbortReasonText() : undefined,
+						abortReason,
 						durationMs: Date.now() - turnStartTime,
 					},
 					index,
@@ -2640,16 +2687,37 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 					sessionFile,
 					startTime: turnStartTime,
 				});
-				if (!aborted && !error) {
-					await relayWakeTurnOutput({ id, records, turnStartTime, yielded, result, turnText });
-				}
-			} catch (finalizeError) {
+			} catch (caught) {
+				finalizeError = caught;
 				logger.warn("IRC subagent turn finalization failed", {
 					id,
-					error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
+					error: caught instanceof Error ? caught.message : String(caught),
 				});
 			} finally {
-				relay.resolve();
+				// Unconditional: a failed, cancelled, empty, or even un-finalized
+				// wake turn must still tell whoever woke it, or a `send await:true`
+				// waiter mistakes a dead peer for a healthy-but-silent one.
+				try {
+					await relayWakeTurnOutput({
+						id,
+						records,
+						turnStartTime,
+						yielded,
+						result,
+						turnText,
+						error,
+						aborted,
+						abortReason,
+						finalizeError,
+					});
+				} catch (relayError) {
+					logger.warn("IRC wake-turn relay threw", {
+						id,
+						error: relayError instanceof Error ? relayError.message : String(relayError),
+					});
+				} finally {
+					relay.resolve();
+				}
 			}
 		};
 	});

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2486,7 +2486,7 @@ async function relayWakeTurnOutput(args: {
 	yielded: boolean;
 	result: SingleResult | undefined;
 	turnText: string;
-	/** Attributed provider/model error text when the turn died on a provider error. */
+	/** Short, attributed peer-visible error text (no stack) when the turn died on an error. */
 	error: string | undefined;
 	/** Whether the turn was aborted (runtime limit, cancellation, hard abort). */
 	aborted: boolean;
@@ -2496,13 +2496,20 @@ async function relayWakeTurnOutput(args: {
 	finalizeError: unknown;
 }): Promise<void> {
 	const bus = IrcBus.global();
-	const pending = wakeSources(args.records, args.id).filter(
-		source => !bus.sentSince(args.id, source.from, args.turnStartTime),
-	);
-	if (pending.length === 0) return;
-	const body = buildWakeRelayBody(args);
-	if (!body) return;
-	for (const source of pending) {
+	const sources = wakeSources(args.records, args.id);
+	if (sources.length === 0) return;
+	const failed = args.error !== undefined || args.aborted;
+	for (const source of sources) {
+		const alreadyMessaged = bus.sentSince(args.id, source.from, args.turnStartTime);
+		// A completed turn's answer would duplicate what the agent already sent
+		// this waker, so dedup stays. A failed/cancelled turn is a distinct
+		// lifecycle fact: `sentSince` cannot tell "already answered you" from
+		// "pinged you 'on it'", and suppressing the failure notice on a mere ping
+		// strands the waker exactly as before — one message later. So the failure
+		// lane always notifies, flavoured to acknowledge the earlier message.
+		if (alreadyMessaged && !failed) continue;
+		const body = buildWakeRelayBody({ ...args, alreadyMessaged });
+		if (!body) continue;
 		const receipt = await bus.send({
 			from: args.id,
 			to: source.from,
@@ -2521,11 +2528,15 @@ async function relayWakeTurnOutput(args: {
  * would otherwise see as the same generic "stopped without replying" note:
  * a real answer (yield summary or turn text), a provider failure carrying the
  * attributed `[provider/model] <error>`, a cancellation with its reason, a
- * finalization throw, or a turn that ran and produced nothing. Every
+ * finalization throw, or a turn that ran and produced nothing. A turn that
+ * yielded an artifact before failing is reported via that artifact's summary
+ * rather than contradicted with a "no output" claim; a partial-answer waker
+ * (`alreadyMessaged`) is told the earlier message was not the answer. Every
  * non-answer notice carries a `history://<id>` pointer so the peer can inspect
- * the transcript.
+ * the transcript. Exported for a focused contract test of the yielded-failure
+ * branch, which the observer seam cannot drive.
  */
-function buildWakeRelayBody(args: {
+export function buildWakeRelayBody(args: {
 	id: string;
 	yielded: boolean;
 	result: SingleResult | undefined;
@@ -2534,23 +2545,38 @@ function buildWakeRelayBody(args: {
 	aborted: boolean;
 	abortReason: string | undefined;
 	finalizeError: unknown;
+	alreadyMessaged: boolean;
 }): string {
 	const transcript = `See history://${args.id} for details.`;
-	if (args.error) {
-		return `Wake turn failed: ${args.error}. No answer was produced — ${transcript}`;
-	}
-	if (args.aborted) {
-		const reason = args.abortReason?.trim();
-		return `Wake turn was cancelled${reason ? `: ${reason}` : ""}. No answer was produced — ${transcript}`;
-	}
-	const answer =
+	// Computed once, above the completed/failed split: a turn that yielded an
+	// artifact before failing must be reported, never contradicted.
+	const summary =
 		args.yielded && args.result?.outputPath
 			? formatTaskResultSummary(args.result, { totalDurationMs: args.result.durationMs })
-			: args.turnText.trim();
+			: undefined;
+
+	const headline = args.error
+		? `Wake turn failed: ${args.error}.`
+		: args.aborted
+			? `Wake turn was cancelled${args.abortReason?.trim() ? `: ${args.abortReason.trim()}` : ""}.`
+			: undefined;
+	if (headline) {
+		if (summary) {
+			return `${headline} A result was recorded before the turn ended:\n\n${summary}\n\n${transcript}`;
+		}
+		const context = args.alreadyMessaged
+			? "You received a message earlier in this turn, but that was not the answer and nothing further was sent."
+			: "No answer was produced.";
+		return `${headline} ${context} ${transcript}`;
+	}
+
+	// Completed lane. `alreadyMessaged` completed turns were filtered upstream
+	// (their answer would duplicate what the agent already sent).
+	const answer = summary ?? args.turnText.trim();
 	if (answer) return answer;
 	if (args.finalizeError) {
 		const message = args.finalizeError instanceof Error ? args.finalizeError.message : String(args.finalizeError);
-		return `Wake turn failed to finalize: ${message}. No answer was produced — ${transcript}`;
+		return `Wake turn failed to finalize: ${message}. No answer was produced. ${transcript}`;
 	}
 	return `Wake turn produced no output. ${transcript}`;
 }
@@ -2644,14 +2670,25 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			const yielded = turnMonitor.yieldCalled();
 			const runtimeLimitExceeded = turnMonitor.runtimeLimitExceeded();
 			const aborted = runtimeLimitExceeded || (lastAssistant?.stopReason === "aborted" && !yielded);
-			const error =
+			// Two error lanes. `error` carries full diagnostics (a thrown turn
+			// error's stack) for `done.error`, logs, and lifecycle. `errorForPeer`
+			// carries only the short, attributed message: a stack trace injected
+			// into another agent's model context is noise, not signal.
+			const providerError =
 				lastAssistant?.stopReason === "error"
 					? attributeSubagentError(lastAssistant.errorMessage, lastAssistant)
-					: turnError !== undefined && !yielded
-						? turnError instanceof Error
-							? turnError.stack || turnError.message
-							: String(turnError)
-						: undefined;
+					: undefined;
+			const thrown = providerError === undefined && turnError !== undefined && !yielded ? turnError : undefined;
+			const error =
+				providerError ??
+				(thrown instanceof Error
+					? thrown.stack || thrown.message
+					: thrown === undefined
+						? undefined
+						: String(thrown));
+			const errorForPeer =
+				providerError ??
+				(thrown instanceof Error ? thrown.message : thrown === undefined ? undefined : String(thrown));
 			turnMonitor.finish();
 			// Read before finalization: a schema-bearing agent that answered in
 			// prose gets a missing-yield warning prepended to `result.output`.
@@ -2705,7 +2742,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 						yielded,
 						result,
 						turnText,
-						error,
+						error: errorForPeer,
 						aborted,
 						abortReason,
 						finalizeError,

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -14,6 +14,8 @@ import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createPersistedSubagentReviverFactory } from "@oh-my-pi/pi-coding-agent/task/persisted-revive";
+import { buildWakeRelayBody } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -762,5 +764,118 @@ describe("persisted subagent revival", () => {
 			AgentRegistry.resetGlobalForTests();
 			IrcBus.resetGlobalForTests();
 		});
+
+		it("reports the failure even after the agent sent a progress ping to the waker", async () => {
+			// `sentSince` cannot tell "already answered" from "pinged 'on it'".
+			// A progress ping is not an answer, so a failed wake turn must still
+			// tell the waker it died instead of being suppressed as a duplicate.
+			const cwd = makeTempDir("@pi-revive-relay-partial-");
+			const { ref, handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			const delivered: IrcMessage[] = [];
+			AgentRegistry.global().register({
+				id: "Main",
+				displayName: "Main",
+				kind: "main",
+				status: "idle",
+				session: {
+					deliverIrcMessage: async (msg: IrcMessage) => {
+						delivered.push(msg);
+						return "injected" as const;
+					},
+				} as unknown as AgentSession,
+			});
+			const bus = IrcBus.global();
+			const finish = observer?.([wakeRecord("Main")]);
+			await bus.send({ from: ref.id, to: "Main", body: "on it" });
+			handle.setLastAssistantStop({
+				stopReason: "error",
+				errorMessage: "402 usage balance exhausted",
+				provider: "some-provider",
+				model: "some-model",
+			});
+			await finish?.();
+			await handle.trackedReplies[0];
+
+			expect(delivered).toHaveLength(2);
+			expect(delivered[0]?.body).toBe("on it");
+			const notice = delivered[1];
+			expect(notice?.wakeRelay).toBe(true);
+			expect(notice?.body).toContain("402 usage balance exhausted");
+			expect(notice?.body.toLowerCase()).toContain("earlier in this turn");
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+
+		it("relays the error message without the stack trace when the wake turn throws", async () => {
+			// A thrown turn error's stack belongs in `done.error`/logs, not in the
+			// waking peer's model context.
+			const cwd = makeTempDir("@pi-revive-relay-thrown-");
+			const { ref, handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			const boom = new Error("boom while waking");
+			boom.stack = "boom while waking\n    at deepInternal (secret.ts:99:1)";
+			const finish = observer?.([wakeRecord("Main")]);
+			const reply = IrcBus.global().wait("Main", { from: ref.id }, 5000);
+			await finish?.(boom);
+			await handle.trackedReplies[0];
+
+			const msg = await reply;
+			expect(msg).not.toBeNull();
+			expect(msg?.body).toContain("boom while waking");
+			expect(msg?.body).not.toContain("secret.ts:99");
+			expect(msg?.body).not.toContain("at deepInternal");
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+	});
+});
+
+describe("buildWakeRelayBody", () => {
+	// A wake turn can yield an artifact and then fail on a later provider call
+	// (`finalizeRunResult` rewrites `<id>.md` on `hasYield`, and the error lane
+	// does not exclude a prior yield). The observer seam cannot drive a real
+	// yield, so pin the message contract here: the failure notice must report
+	// the recorded artifact, never claim nothing was produced.
+	it("reports the recorded artifact when a yielded turn then fails", () => {
+		const result = {
+			index: 0,
+			id: "SmokeKid",
+			agent: "scout",
+			agentSource: "bundled",
+			task: "follow up",
+			exitCode: 1,
+			output: "# Partial report\n\nrows written before the 402",
+			stderr: "",
+			truncated: false,
+			durationMs: 1200,
+			tokens: 0,
+			requests: 2,
+			error: "402 usage balance exhausted",
+			outputPath: "/tmp/SmokeKid.md",
+		} satisfies SingleResult;
+
+		const body = buildWakeRelayBody({
+			id: "SmokeKid",
+			yielded: true,
+			result,
+			turnText: "",
+			error: "[some-provider/some-model] 402 usage balance exhausted",
+			aborted: false,
+			abortReason: undefined,
+			finalizeError: undefined,
+			alreadyMessaged: false,
+		});
+
+		expect(body).toContain("Wake turn failed: [some-provider/some-model] 402 usage balance exhausted");
+		expect(body).not.toContain("No answer was produced");
+		expect(body).toContain("# Partial report");
+		expect(body).toContain("history://SmokeKid");
 	});
 });

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -47,13 +47,33 @@ interface RevivedSessionHandle {
 	observer: () => IrcWakeObserver | undefined;
 	/** Reply obligations the wake monitor registered via `trackIrcReply`. */
 	trackedReplies: Promise<void>[];
-	/** Text the stubbed session reports as its last assistant message. */
+	/** Text the stubbed session reports as its last assistant message (a `stop`ped turn). */
 	setLastAssistantText: (text: string) => void;
+	/** Report a terminal wake turn: provider error, abort, or empty completion. */
+	setLastAssistantStop: (stop: LastAssistantStop) => void;
+}
+
+/** Shape of a terminal assistant message the stub can report from a failed/cancelled wake turn. */
+interface LastAssistantStop {
+	stopReason: string;
+	errorMessage?: string;
+	provider?: string;
+	model?: string;
+	content?: Array<{ type: string; text?: string }>;
 }
 
 function createRevivedSession(activeToolNames: string[][], extensionRunner?: unknown): RevivedSessionHandle {
 	let observer: IrcWakeObserver | undefined;
-	let lastAssistantText: string | undefined;
+	let lastAssistant:
+		| {
+				role: "assistant";
+				content: Array<{ type: string; text?: string }>;
+				stopReason: string;
+				errorMessage?: string;
+				provider?: string;
+				model?: string;
+		  }
+		| undefined;
 	const trackedReplies: Promise<void>[] = [];
 	const session = {
 		getMountedXdevToolNames: () => [],
@@ -68,10 +88,7 @@ function createRevivedSession(activeToolNames: string[][], extensionRunner?: unk
 			trackedReplies.push(pending);
 		},
 		subscribeRunState: () => () => {},
-		getLastAssistantMessage: () =>
-			lastAssistantText === undefined
-				? undefined
-				: { role: "assistant", content: [{ type: "text", text: lastAssistantText }], stopReason: "stop" },
+		getLastAssistantMessage: () => lastAssistant,
 		extensionRunner,
 	} as unknown as AgentSession;
 	return {
@@ -79,7 +96,17 @@ function createRevivedSession(activeToolNames: string[][], extensionRunner?: unk
 		observer: () => observer,
 		trackedReplies,
 		setLastAssistantText: text => {
-			lastAssistantText = text;
+			lastAssistant = { role: "assistant", content: [{ type: "text", text }], stopReason: "stop" };
+		},
+		setLastAssistantStop: stop => {
+			lastAssistant = {
+				role: "assistant",
+				content: stop.content ?? [],
+				stopReason: stop.stopReason,
+				errorMessage: stop.errorMessage,
+				provider: stop.provider,
+				model: stop.model,
+			};
 		},
 	};
 }
@@ -595,6 +622,82 @@ describe("persisted subagent revival", () => {
 				replyTo: "irc-42",
 				body: "# Full table\n\n| tool | file |\n|---|---|\n| read | read.ts |",
 			});
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+
+		it("relays the attributed provider error when the wake turn fails", async () => {
+			// A failed wake turn (provider error / exhausted fallback chain) must not
+			// look like a healthy peer that chose not to answer: the waiter needs the
+			// attributed [provider/model] error, not a generic "stopped without replying".
+			const cwd = makeTempDir("@pi-revive-relay-failed-");
+			const { ref, handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			const finish = observer?.([wakeRecord("Main")]);
+			handle.setLastAssistantStop({
+				stopReason: "error",
+				errorMessage: "402 usage balance exhausted",
+				provider: "some-provider",
+				model: "some-model",
+			});
+			const reply = IrcBus.global().wait("Main", { from: ref.id }, 5000);
+			await finish?.();
+			await handle.trackedReplies[0];
+
+			const msg = await reply;
+			expect(msg).not.toBeNull();
+			expect(msg?.replyTo).toBe("irc-42");
+			expect(msg?.body).toContain("[some-provider/some-model]");
+			expect(msg?.body).toContain("402 usage balance exhausted");
+			expect(msg?.body).toContain(`history://${ref.id}`);
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+
+		it("relays a cancellation notice when the wake turn is aborted", async () => {
+			const cwd = makeTempDir("@pi-revive-relay-aborted-");
+			const { ref, handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			const finish = observer?.([wakeRecord("Main")]);
+			handle.setLastAssistantStop({ stopReason: "aborted" });
+			const reply = IrcBus.global().wait("Main", { from: ref.id }, 5000);
+			await finish?.();
+			await handle.trackedReplies[0];
+
+			const msg = await reply;
+			expect(msg).not.toBeNull();
+			expect(msg?.replyTo).toBe("irc-42");
+			expect(msg?.body.toLowerCase()).toContain("cancel");
+			expect(msg?.body).toContain(`history://${ref.id}`);
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+
+		it("relays a no-output notice when the wake turn completes without producing anything", async () => {
+			const cwd = makeTempDir("@pi-revive-relay-empty-");
+			const { ref, handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			// No setLastAssistant* call: the turn completes with zero output and never
+			// answers its waker. Previously the relay dropped the empty body silently.
+			const finish = observer?.([wakeRecord("Main")]);
+			const reply = IrcBus.global().wait("Main", { from: ref.id }, 5000);
+			await finish?.();
+			await handle.trackedReplies[0];
+
+			const msg = await reply;
+			expect(msg).not.toBeNull();
+			expect(msg?.replyTo).toBe("irc-42");
+			expect(msg?.body.toLowerCase()).toContain("no output");
+			expect(msg?.body).toContain(`history://${ref.id}`);
 			AgentLifecycleManager.resetGlobalForTests();
 			AgentRegistry.resetGlobalForTests();
 			IrcBus.resetGlobalForTests();


### PR DESCRIPTION
## Repro
A kept-alive subagent parks after a terminal yield, stays revivable, and is woken by a `hub send await:true`. When that wake turn fails (provider error / exhausted `retry.fallbackChains` / hard abort), is cancelled, or completes producing nothing, the waiter is told nothing distinguishable from a healthy peer that chose not to answer. Deterministic repro without a provider: `bun test test/task/persisted-revive.test.ts -t "wake-turn relay"` — the three new cases (failed / aborted / empty-completed) time out on `bus.wait` (relay never attempted) before the fix.

## Cause
`relayWakeTurnOutput` in `packages/coding-agent/src/task/executor.ts` was only invoked when `!aborted && !error`, and it returned early on an empty body. So a failed/cancelled/empty wake turn relayed no IRC message, and the `await:true` waiter fell back on the generic `stopped without replying` verdict from `executeSend` (`packages/coding-agent/src/tools/hub/messaging.ts`, via `IrcAwaitTargetStopped`) — the same text for a dead peer as for a silent-but-healthy one. This is the only channel a read-only scout (no `hub` tool) has; the structured `subagent_lifecycle status:"failed"` frame still fired, but nothing reached the peer.

## Fix
- `buildWakeRelayBody` classifies the settled turn once and returns a distinguishable body: real answer (yield summary or turn text) as before, otherwise an attributed `[provider/model] <error>` failure notice (from `attributeSubagentError`), a cancellation notice carrying `resolveAbortReasonText()`, a finalization-failure notice, or a `Wake turn produced no output` notice — each with a `history://<id>` pointer.
- `attachIrcWakeTurnMonitor` now computes `abortReason` once (reused for `finalizeRunResult`'s `done.abortReason` and the relay), holds `result`/`finalizeError`, and calls `relayWakeTurnOutput` unconditionally from the `finally` so a `finalizeRunResult` throw also notifies instead of stranding the waiter. The relay call is wrapped so a throw can never skip `relay.resolve()`.
- The `bus.sentSince` guard is unchanged, so an agent that already answered its waker is not doubled up on; nothing is fabricated (the run still finalizes `exitCode: 1` / aborted).
- Test harness gains `setLastAssistantStop` so the stubbed revived session can report a terminal turn; three regression cases added alongside the existing relay tests.

## Verification
`bun test test/task/persisted-revive.test.ts` → 20 pass (6 in `wake-turn relay`, including the 3 new cases that failed before the change). `bun check` clean (oxlint + oxfmt + types). Fixes #11290