### PR TITLE
fix(coding-agent): expand tabs in task descriptions before render

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Task descriptions containing tabs no longer misalign or overflow task rows; tabs are expanded before measuring and rendering.
 - GitHub Copilot model-policy 403s (plan, model policy, org restriction) no longer delete stored credentials, so the provider stays listed in `/model` after a per-model access denial instead of disappearing until the next `/login` ([#11280](https://github.com/can1357/oh-my-pi/pull/11280) by [@H4vC](https://github.com/H4vC)).
 
 ### Added

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -917,7 +917,7 @@ function renderAgentProgress(
 				: "accent";
 
 	// Reserve the name and required badges before optional model metadata and details.
-	const fullDescription = progress.description ? sanitizeText(progress.description).trim() : undefined;
+	const fullDescription = progress.description ? replaceTabs(sanitizeText(progress.description)).trim() : undefined;
 	const indent = prefix ? `${prefix} ` : "";
 	let statusBadge = "";
 	// Provider retry state takes precedence over the generic failure marker.
@@ -1283,7 +1283,7 @@ function renderAgentResult(
 					: "failed";
 
 	// Reserve the name and required badges before optional model metadata and details.
-	const fullDescription = result.description ? sanitizeText(result.description).trim() : undefined;
+	const fullDescription = result.description ? replaceTabs(sanitizeText(result.description)).trim() : undefined;
 	const indent = prefix ? `${prefix} ` : "";
 	const statusBadge = ` ${formatBadge(statusText, iconColor, theme)}`;
 	const displayId = truncateTaskRow(

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -703,6 +703,42 @@ describe("task progress rendering", () => {
 		expect(collapsed).toContain("5 succeeded");
 		expect(collapsed).toContain("1 failed");
 	});
+	it("expands tabs in task descriptions before measuring and rendering", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const description = "Inspect\trendering\tboundaries";
+		const snapshots: TaskToolDetails[] = [
+			detailsFor(runningProgress({ id: "TabWorker", description })),
+			{ projectAgentsDir: null, totalDurationMs: 0, results: [finishedResult({ id: "TabWorker", description })] },
+		];
+		for (const details of snapshots) {
+			const rows = taskToolRenderer
+				.renderResult({ content: [], details }, { expanded: false, isPartial: !!details.progress }, theme)
+				.render(120);
+			for (const row of rows) expect(Bun.stripANSI(row)).not.toContain("\t");
+			const text = rows.map(row => Bun.stripANSI(row)).join("\n");
+			expect(text).toContain("TabWorker");
+			expect(text).toContain("Inspect");
+			expect(text).toContain("rendering");
+		}
+		const longDescription = `First\tsection with a tab followed by enough detail to force the continuation line at narrow widths`;
+		const narrow: TaskToolDetails[] = [
+			detailsFor(runningProgress({ id: "TabNarrow", description: longDescription })),
+			{
+				projectAgentsDir: null,
+				totalDurationMs: 0,
+				results: [finishedResult({ id: "TabNarrow", description: longDescription })],
+			},
+		];
+		for (const details of narrow) {
+			const rows = taskToolRenderer
+				.renderResult({ content: [], details }, { expanded: false, isPartial: !!details.progress }, theme)
+				.render(40);
+			for (const row of rows) {
+				expect(Bun.stripANSI(row)).not.toContain("\t");
+				expect(visibleWidth(row)).toBeLessThanOrEqual(40);
+			}
+		}
+	});
 });
 
 describe("task result detail-less state", () => {


### PR DESCRIPTION
Followup to #11161 review 5144806063: normalize tabs in task descriptions via replaceTabs before measuring/rendering, with regression test.