### PR TITLE
feat(coding-agent): add RPC custom command for sendCustomMessage

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -113,6 +113,7 @@ Important edge behavior from runtime:
 - `{ id?, type: "prompt", message: string, images?: ImageContent[], streamingBehavior?: "steer" | "followUp" }`
 - `{ id?, type: "steer", message: string, images?: ImageContent[] }`
 - `{ id?, type: "follow_up", message: string, images?: ImageContent[] }`
+- `{ id?, type: "custom", customType: string, content: string, display?: boolean, deliverAs?: "steer" | "followUp" | "nextTurn" | "aside", triggerTurn?: boolean }`
 - `{ id?, type: "abort" }`
 - `{ id?, type: "abort_and_prompt", message: string, images?: ImageContent[] }`
 - `{ id?, type: "new_session", parentSession?: string }`
@@ -229,6 +230,22 @@ Data payloads are command-specific and defined in `rpc-types.ts`.
 ```
 
 Local-only slash commands may emit `command_output` frames before completing via `data.agentInvoked: false` or a later `prompt_result`. They do not emit `agent_end`.
+
+### `custom` payload
+
+`custom` injects a hidden or visible custom message through `AgentSession.sendCustomMessage`. The response includes whether the message synchronously started a new turn:
+
+```json
+{
+  "id": "req_1",
+  "type": "response",
+  "command": "custom",
+  "success": true,
+  "data": { "delivered": false }
+}
+```
+
+`data.delivered` mirrors the boolean return value of `sendCustomMessage`.
 
 ### `get_state` payload
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -113,7 +113,7 @@ Important edge behavior from runtime:
 - `{ id?, type: "prompt", message: string, images?: ImageContent[], streamingBehavior?: "steer" | "followUp" }`
 - `{ id?, type: "steer", message: string, images?: ImageContent[] }`
 - `{ id?, type: "follow_up", message: string, images?: ImageContent[] }`
-- `{ id?, type: "custom", customType: string, content: string, display?: boolean, deliverAs?: "steer" | "followUp" | "nextTurn" | "aside", triggerTurn?: boolean }`
+- `{ id?, type: "custom", customType: string, content: string, display?: boolean, deliverAs?: "steer" | "followUp" | "nextTurn" | "aside", triggerTurn?: boolean }` — `display` is optional and defaults to `false` when omitted
 - `{ id?, type: "abort" }`
 - `{ id?, type: "abort_and_prompt", message: string, images?: ImageContent[] }`
 - `{ id?, type: "new_session", parentSession?: string }`

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -614,6 +614,48 @@ function isSubagentSubscriptionLevel(value: unknown): value is RpcSubagentSubscr
 	return value === "off" || value === "progress" || value === "events";
 }
 
+function isRpcCustomDeliverAs(value: unknown): value is "steer" | "followUp" | "nextTurn" | "aside" {
+	return value === "steer" || value === "followUp" || value === "nextTurn" || value === "aside";
+}
+
+export type RpcCustomCommandSession = Pick<AgentSession, "sendCustomMessage">;
+
+export type RpcCustomCommand = Extract<RpcCommand, { type: "custom" }>;
+
+export type RpcCustomCommandResult = { delivered: boolean } | { error: string };
+
+export async function handleRpcCustomCommand(
+	session: RpcCustomCommandSession,
+	command: RpcCustomCommand,
+): Promise<RpcCustomCommandResult> {
+	const customType = typeof command.customType === "string" ? command.customType.trim() : "";
+	if (!customType) {
+		return { error: "customType must be a non-empty string" };
+	}
+	if (typeof command.content !== "string") {
+		return { error: "content must be a string" };
+	}
+	if (command.display !== undefined && typeof command.display !== "boolean") {
+		return { error: "display must be a boolean" };
+	}
+	if (command.deliverAs !== undefined && !isRpcCustomDeliverAs(command.deliverAs)) {
+		return { error: `Invalid deliverAs: ${String(command.deliverAs)}` };
+	}
+	if (command.triggerTurn !== undefined && typeof command.triggerTurn !== "boolean") {
+		return { error: "triggerTurn must be a boolean" };
+	}
+
+	const display = command.display ?? false;
+	const delivered = await session.sendCustomMessage(
+		{ customType, content: command.content, display, details: undefined, attribution: undefined },
+		{
+			...(command.deliverAs !== undefined ? { deliverAs: command.deliverAs } : {}),
+			...(command.triggerTurn !== undefined ? { triggerTurn: command.triggerTurn } : {}),
+		},
+	);
+	return { delivered };
+}
+
 /** Sends an RPC select request while retaining aligned option descriptions. */
 export function requestRpcSelect(
 	pendingRequests: Map<string, PendingExtensionRequest>,
@@ -1162,6 +1204,14 @@ export async function runRpcMode(
 			case "follow_up": {
 				await session.followUp(command.message, command.images);
 				return success(id, "follow_up");
+			}
+
+			case "custom": {
+				const result = await handleRpcCustomCommand(session, command);
+				if ("error" in result) {
+					return error(id, "custom", result.error);
+				}
+				return success(id, "custom", { delivered: result.delivered });
 			}
 
 			case "abort": {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -33,6 +33,15 @@ export type RpcCommand =
 	| { id?: string; type: "prompt"; message: string; images?: ImageContent[]; streamingBehavior?: "steer" | "followUp" }
 	| { id?: string; type: "steer"; message: string; images?: ImageContent[] }
 	| { id?: string; type: "follow_up"; message: string; images?: ImageContent[] }
+	| {
+			id?: string;
+			type: "custom";
+			customType: string;
+			content: string;
+			display?: boolean;
+			deliverAs?: "steer" | "followUp" | "nextTurn" | "aside";
+			triggerTurn?: boolean;
+	  }
 	| { id?: string; type: "abort" }
 	| { id?: string; type: "abort_and_prompt"; message: string; images?: ImageContent[] }
 	| { id?: string; type: "new_session"; parentSession?: string }
@@ -207,6 +216,7 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "prompt"; success: true; data?: { agentInvoked: boolean } }
 	| { id?: string; type: "response"; command: "steer"; success: true }
 	| { id?: string; type: "response"; command: "follow_up"; success: true }
+	| { id?: string; type: "response"; command: "custom"; success: true; data?: { delivered: boolean } }
 	| { id?: string; type: "response"; command: "abort"; success: true }
 	| { id?: string; type: "response"; command: "abort_and_prompt"; success: true }
 	| { id?: string; type: "response"; command: "new_session"; success: true; data: { cancelled: boolean } }

--- a/packages/coding-agent/test/rpc-custom-command.test.ts
+++ b/packages/coding-agent/test/rpc-custom-command.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { handleRpcCustomCommand } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import type { RpcCustomCommandSession } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+
+const makeSession = (delivered = false): RpcCustomCommandSession & {
+	calls: Array<{ message: unknown; options?: unknown }>;
+} => {
+	const calls: Array<{ message: unknown; options?: unknown }> = [];
+	return {
+		calls,
+		sendCustomMessage: async (message, options) => {
+			calls.push({ message, options });
+			return delivered;
+		},
+	};
+};
+
+describe("handleRpcCustomCommand", () => {
+	test("forwards a hidden custom message and returns delivered", async () => {
+		const session = makeSession(true);
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "host-context",
+			content: "background note",
+		});
+
+		expect(result).toEqual({ delivered: true });
+		expect(session.calls).toEqual([
+			{
+				message: {
+					customType: "host-context",
+					content: "background note",
+					display: false,
+					details: undefined,
+					attribution: undefined,
+				},
+				options: {},
+			},
+		]);
+	});
+
+	test("passes display, deliverAs, and triggerTurn when provided", async () => {
+		const session = makeSession(false);
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "visible-card",
+			content: "shown to user",
+			display: true,
+			deliverAs: "nextTurn",
+			triggerTurn: true,
+		});
+
+		expect(result).toEqual({ delivered: false });
+		expect(session.calls[0]?.message).toEqual({
+			customType: "visible-card",
+			content: "shown to user",
+			display: true,
+			details: undefined,
+			attribution: undefined,
+		});
+		expect(session.calls[0]?.options).toEqual({ deliverAs: "nextTurn", triggerTurn: true });
+	});
+
+	test("rejects missing customType", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "   ",
+			content: "note",
+		});
+
+		expect(result).toEqual({ error: "customType must be a non-empty string" });
+		expect(session.calls).toHaveLength(0);
+	});
+
+	test("rejects missing content", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "host-context",
+			content: undefined as unknown as string,
+		});
+
+		expect(result).toEqual({ error: "content must be a string" });
+		expect(session.calls).toHaveLength(0);
+	});
+
+	test("rejects invalid deliverAs", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "host-context",
+			content: "note",
+			deliverAs: "now" as "steer",
+		});
+
+		expect(result).toEqual({ error: "Invalid deliverAs: now" });
+		expect(session.calls).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/rpc-custom-command.test.ts
+++ b/packages/coding-agent/test/rpc-custom-command.test.ts
@@ -63,7 +63,7 @@ describe("handleRpcCustomCommand", () => {
 		expect(session.calls[0]?.options).toEqual({ deliverAs: "nextTurn", triggerTurn: true });
 	});
 
-	test("rejects missing customType", async () => {
+	test("rejects whitespace-only customType", async () => {
 		const session = makeSession();
 
 		const result = await handleRpcCustomCommand(session, {
@@ -71,6 +71,18 @@ describe("handleRpcCustomCommand", () => {
 			customType: "   ",
 			content: "note",
 		});
+
+		expect(result).toEqual({ error: "customType must be a non-empty string" });
+		expect(session.calls).toHaveLength(0);
+	});
+
+	test("rejects missing customType", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			content: "note",
+		} as Parameters<typeof handleRpcCustomCommand>[1]);
 
 		expect(result).toEqual({ error: "customType must be a non-empty string" });
 		expect(session.calls).toHaveLength(0);
@@ -100,6 +112,34 @@ describe("handleRpcCustomCommand", () => {
 		});
 
 		expect(result).toEqual({ error: "Invalid deliverAs: now" });
+		expect(session.calls).toHaveLength(0);
+	});
+
+	test("rejects non-boolean display", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "host-context",
+			content: "note",
+			display: "yes" as unknown as boolean,
+		});
+
+		expect(result).toEqual({ error: "display must be a boolean" });
+		expect(session.calls).toHaveLength(0);
+	});
+
+	test("rejects non-boolean triggerTurn", async () => {
+		const session = makeSession();
+
+		const result = await handleRpcCustomCommand(session, {
+			type: "custom",
+			customType: "host-context",
+			content: "note",
+			triggerTurn: 1 as unknown as boolean,
+		});
+
+		expect(result).toEqual({ error: "triggerTurn must be a boolean" });
 		expect(session.calls).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## The Issue:
RPC hosts (e.g. the 10x desktop app) need to inject hidden custom messages into a session — capability notices, mode cues — without a visible user prompt. This change was made to address the following:
- The RPC surface exposes `prompt`/`steer`/`follow_up`, all of which create visible user messages; there is no way to reach `AgentSession.sendCustomMessage` over RPC

## The Fix:
- Add a `custom` RPC command that forwards to `session.sendCustomMessage`, exposing `customType`, `content`, `display` (default false), `deliverAs` (`steer` | `followUp` | `nextTurn` | `aside`), and `triggerTurn`
- Response carries `{ delivered: boolean }` from `sendCustomMessage`

## Basic tests:
- `bun run check:types` (packages/coding-agent) — pass
- `bun test test/rpc-custom-command.test.ts` — 8/8 pass (hidden round-trip, option passthrough, validation and boolean-guard failures)

## Manual verification
- Not verified end-to-end over a live RPC session (needs a built CLI + API key)

## Notes
- First consumer: 10x's computer-use feature sends a hidden `computer-use` capability cue when the user invokes computer use (⇧⌘C), instead of injecting a visible prompt
- TS/Python RPC client helpers for `custom` intentionally not added — first consumer is a Swift client; helpers can follow when a TS/Python consumer exists
