### PR TITLE
feat(coding-agent): add persistent btw history and follow-ups

### DIFF
--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -214,6 +214,71 @@ conversation; `/new`, which creates a new session identity and transcript file;
 and `/drop`, which attempts to delete the old persisted session before starting
 a new one.
 
+## BTW history
+
+`/btw <question>` asks an independent side question using the current session
+context. Bare `/btw` opens this session's history, with the newest question selected.
+Saved side questions are not appended to the main transcript or sent as history
+to unrelated turns. Each new `/btw <question>` remains independent; explicit
+follow-ups include only the selected side conversation alongside the current
+main-session context.
+
+Previous questions and answers are replayed as separate `user` and `assistant`
+messages, followed by the new user question, rather than embedded in one prompt.
+The original question template stays in the same position across follow-ups.
+History is snapshotted before asynchronous conversion and uses the normal
+provider normalization and secret-obfuscation pipeline.
+
+The main prompt-cache key and static system/tool prefix are retained. Each BTW
+topic has its own stable provider-side conversation identity, separate from the
+main conversation and other topics. Successful serialized follow-ups reuse it;
+after a cancelled, failed, or interrupted turn the next request uses a new
+transport generation, so an unwinding request cannot share its state.
+Standalone ephemeral callers without a conversation key keep per-request IDs.
+Actual cache hits depend on the provider. The main-session context is still
+current, not frozen at the first question; advancing or compacting it can change
+the prefix.
+Saved BTW records contain visible answer text, not opaque provider reasoning or
+replay signatures, so restoration preserves the dialogue roles and text rather
+than a byte-for-byte native provider transcript.
+
+- `Esc` hides the inline answer or history without cancelling the request.
+- `x` explicitly cancels a running question; any partial answer is retained.
+- `c` copies the completed inline answer, or the selected topic's latest nonempty answer.
+- After an inline BTW answer completes, `f` opens that topic's follow-up input
+  directly, without requiring `/btw` first. The main editor must be empty and focused.
+- In history, `f` or `Enter` opens a native follow-up input for the selected topic.
+  Inside the input, `Enter` sends a nonempty question and `Esc` cancels the draft
+  and returns to history; `f`, `c`, and `x` are ordinary text.
+- Follow-ups append to the same topic, retain prior answers and cancelled partial
+  output, and survive resume. The original question remains the history-list title;
+  `Details` shows every question and answer in chronological order.
+- In history, `Up`/`Down` select topics; `Tab` switches between history and
+  details. `Right` focuses details, `Left` returns to history.
+- Focused details support scrolling, `Page Up`/`Page Down`, and `Home`/`End`.
+  Narrow terminals show one pane at a time.
+- New questions and follow-ups are refused while any BTW request is running,
+  even if its panel is hidden. There is no implicit cancellation or queue.
+- A refused follow-up submission keeps the draft for retry; repeated Enter while
+  submission is pending cannot create duplicate requests.
+
+History is saved as private per-topic files under the session artifact
+directory's `btw-history/` subdirectory. This changes `/btw` from transient-only
+display to local retention alongside the session. Even a session containing only
+side questions is made resumable. `--no-session` keeps history in memory only.
+Ordinary transcript export/share does not include these sidecar records.
+
+Starting a question saves its running state. Completion, error, and explicit
+cancellation save a final checkpoint; cancelled answers retain text already
+received. A crash can lose uncheckpointed streaming text, but a saved running
+record reopens as `Interrupted` and is never automatically resubmitted.
+History remains attached to the session artifacts and follows operations that
+copy or remove those artifacts; it does not move the conversation leaf.
+
+The existing inline `b` action still promotes a completed answer to a chat branch
+only when the original session/leaf is unchanged and the main session is idle.
+History browsing itself does not promote answers or relax these branch guards.
+
 ## Fork
 
 Interactive `/fork` creates a new session from the current one and switches the active session identity.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Added
 
+- Added session-local `/btw` history with persistent answers, copy and cancel controls; bare `/btw` reopens history, Esc hides without cancelling, and new questions no longer replace an in-progress answer.
+- Added `f follow up` in BTW history to continue a selected side conversation with an English input prompt, persistent multi-turn history, and no changes to the main conversation.
+- Completed inline BTW answers now support `f follow up` directly; history uses `Tab` for pane navigation and `Enter` or `f` to start a follow-up.
 - Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.
 - Headless browser tabs now freeze when a turn settles so idle animated/WebGL pages stop burning CPU/GPU, resuming automatically on next use; tabs idle past `browser.idleCloseSec` (default 30 minutes) are closed. `persist: true` on `browser.open` opts a tab out of both ([#8246](https://github.com/can1357/oh-my-pi/issues/8246) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed
 
+- BTW follow-ups now preserve separate user/assistant messages and reuse an isolated topic-specific provider session for prompt caching; cancellation or failure starts a fresh transport generation.
 - Bash results no longer replace a failing command's output with the shell minimizer's lossy summary when the original capture cannot be persisted as an artifact; the raw diagnostics are kept so a failure stays actionable ([#11081](https://github.com/can1357/oh-my-pi/issues/11081)).
 - Fixed worker subprocesses failing to declare themselves as worker hosts before dispatching selectors, which prevented nested thread worker spawns during `/usage` stats sync on multi-core systems.
 - Fixed `/usage` displaying a misleading generic database read failure when activity loading fails; the error detail is now sanitized, collapsed to a single line with shortened paths, and surfaced in the dashboard.

--- a/packages/coding-agent/src/modes/components/btw-history-panel.ts
+++ b/packages/coding-agent/src/modes/components/btw-history-panel.ts
@@ -1,0 +1,501 @@
+import {
+	type Component,
+	type Focusable,
+	Input,
+	Markdown,
+	matchesKey,
+	ScrollView,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@oh-my-pi/pi-tui";
+import { type BtwHistoryRecord, type BtwHistoryTurn, getBtwLatestTurn, getBtwTurns } from "../../session/btw-history";
+import { getMarkdownTheme, type ThemeColor, theme } from "../theme/theme";
+import {
+	matchesSelectCancel,
+	matchesSelectDown,
+	matchesSelectPageDown,
+	matchesSelectPageUp,
+	matchesSelectUp,
+} from "../utils/keybinding-matchers";
+import { sanitizeDisplayLine, sanitizeDisplayText } from "./extensions/display-text";
+import { editorKey, rawKeyHint } from "./keybinding-hints";
+import { bottomBorder, fit, row, splitBodyWidth, splitRow, topBorder } from "./overlay-box";
+import { clampSelection, contentRowWidth, padLinesToHeight, renderScrollableList } from "./selector-helpers";
+
+interface BtwHistoryPanelOptions {
+	records: readonly BtwHistoryRecord[];
+	onClose: () => void;
+	onCopy: (record: BtwHistoryRecord) => void;
+	onCancel: (record: BtwHistoryRecord) => void;
+	canFollowUp?: (record: BtwHistoryRecord) => boolean;
+	onFollowUp?: (record: BtwHistoryRecord, question: string) => Promise<boolean>;
+	requestRender: () => void;
+	getHeight: () => number;
+}
+
+interface FollowUpComposer {
+	recordId: string;
+	input: Input;
+	notice?: string;
+}
+
+interface RenderedTurn {
+	turn: BtwHistoryTurn;
+	question: Markdown;
+	answer: Markdown;
+	lines: readonly string[];
+	width: number;
+}
+
+const STATUS: Record<BtwHistoryRecord["status"], { label: string; color: ThemeColor }> = {
+	running: { label: "Running", color: "accent" },
+	complete: { label: "Complete", color: "success" },
+	cancelled: { label: "Cancelled", color: "warning" },
+	error: { label: "Error", color: "error" },
+	interrupted: { label: "Interrupted", color: "warning" },
+};
+
+/** Session-local side questions. Selecting or copying never promotes them into chat. */
+export class BtwHistoryPanel implements Component, Focusable {
+	readonly #options: BtwHistoryPanelOptions;
+	#records: readonly BtwHistoryRecord[] = [];
+	#selectedId: string | undefined;
+	#focus: "list" | "answer" = "list";
+	#listScroll = 0;
+	#listHeight = 1;
+	#focused = false;
+	#composer: FollowUpComposer | undefined;
+	#followUpPending = false;
+	#followLatest = false;
+	#turns: RenderedTurn[] = [];
+	#detailRecord: BtwHistoryRecord | undefined;
+	#detailWidth = 0;
+	#detailDirty = true;
+	readonly #detail = new ScrollView([], {
+		height: 1,
+		scrollbar: "auto",
+		theme: { track: text => theme.fg("muted", text), thumb: text => theme.fg("accent", text) },
+	});
+	readonly #timeFormat = new Intl.DateTimeFormat("en", { hour: "2-digit", minute: "2-digit", hourCycle: "h23" });
+	readonly #dateFormat = new Intl.DateTimeFormat("en", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		hourCycle: "h23",
+	});
+
+	constructor(options: BtwHistoryPanelOptions) {
+		this.#options = options;
+		this.#records = options.records;
+		this.#selectedId = options.records[0]?.id;
+	}
+
+	get focused(): boolean {
+		return this.#focused;
+	}
+
+	set focused(value: boolean) {
+		this.#focused = value;
+	}
+
+	update(records: readonly BtwHistoryRecord[]): void {
+		this.#records = records;
+		this.#detailDirty = true;
+		if (this.#composer && !records.some(record => record.id === this.#composer?.recordId)) {
+			this.#composer = undefined;
+		}
+		if (!records.some(record => record.id === this.#selectedId)) {
+			this.#selectedId = records[0]?.id;
+			this.#listScroll = 0;
+			this.#followLatest = false;
+			this.#detail.scrollToTop();
+		}
+		this.#options.requestRender();
+	}
+
+	invalidate(): void {
+		// Recreate Markdown with the current theme, retaining the viewport offset.
+		this.#detailRecord = undefined;
+		this.#turns = [];
+		this.#composer?.input.invalidate();
+		this.#detailDirty = true;
+	}
+
+	#selectedIndex(): number {
+		return Math.max(
+			0,
+			this.#records.findIndex(record => record.id === this.#selectedId),
+		);
+	}
+
+	#selected(): BtwHistoryRecord | undefined {
+		return this.#records[this.#selectedIndex()];
+	}
+
+	#select(index: number): void {
+		const record = this.#records[Math.max(0, Math.min(index, this.#records.length - 1))];
+		if (!record || record.id === this.#selectedId) return;
+		this.#selectedId = record.id;
+		this.#followLatest = false;
+		this.#detail.scrollToTop();
+	}
+
+	#canFollowUp(record: BtwHistoryRecord): boolean {
+		return !this.#followUpPending && !!this.#options.onFollowUp && !!this.#options.canFollowUp?.(record);
+	}
+
+	openFollowUp(recordId: string): boolean {
+		if (this.#composer) return false;
+		const index = this.#records.findIndex(record => record.id === recordId);
+		const record = this.#records[index];
+		if (!record || !this.#canFollowUp(record)) return false;
+		this.#select(index);
+		this.#openComposer(record);
+		return true;
+	}
+
+	#openComposer(record: BtwHistoryRecord): void {
+		const input = new Input();
+		input.prompt = theme.fg("accent", "Follow up: ");
+		const composer: FollowUpComposer = { recordId: record.id, input };
+		input.onEscape = () => {
+			this.#composer = undefined;
+		};
+		input.onSubmit = value => {
+			void this.#submitFollowUp(composer, value);
+		};
+		this.#composer = composer;
+		this.#focus = "answer";
+		this.#options.requestRender();
+	}
+
+	async #submitFollowUp(composer: FollowUpComposer, value: string): Promise<void> {
+		if (this.#followUpPending || this.#composer !== composer) return;
+		const question = value.trim();
+		if (!question) {
+			composer.notice = "Enter a follow-up question.";
+			return;
+		}
+		const record = this.#records.find(record => record.id === composer.recordId);
+		if (!record || !this.#canFollowUp(record)) {
+			composer.notice = "A BTW request is busy. Try again when it finishes.";
+			return;
+		}
+		this.#followUpPending = true;
+		composer.notice = "Starting follow-up…";
+		this.#options.requestRender();
+		try {
+			const accepted = await this.#options.onFollowUp!(record, question);
+			if (this.#composer !== composer) return;
+			if (accepted) {
+				this.#composer = undefined;
+				this.#selectedId = composer.recordId;
+				this.#focus = "answer";
+				this.#followLatest = true;
+			} else {
+				composer.notice = "Follow-up was not started. Your draft is kept; Enter to retry.";
+			}
+		} catch {
+			if (this.#composer === composer) {
+				composer.notice = "Could not start the follow-up. Your draft is kept; Enter to retry.";
+			}
+		} finally {
+			this.#followUpPending = false;
+			this.#options.requestRender();
+		}
+	}
+
+	/** Enhanced clipboard pastes belong only to the active composer. */
+	pasteText(text: string): void {
+		if (!this.#composer) return;
+		this.#composer.input.pasteText(text);
+		this.#options.requestRender();
+	}
+	handleInput(data: string): void {
+		if (this.#composer) {
+			// The input owns every key, including panel shortcuts and pasted text.
+			this.#composer.input.handleInput(data);
+			this.#options.requestRender();
+			return;
+		}
+		if (matchesSelectCancel(data) || matchesKey(data, "escape")) {
+			this.#options.onClose();
+			return;
+		}
+		const record = this.#selected();
+		if (matchesKey(data, "f") || matchesKey(data, "enter")) {
+			if (record) this.openFollowUp(record.id);
+			return;
+		}
+		if (matchesKey(data, "c")) {
+			if (record && getBtwLatestTurn(record).answer.trim()) this.#options.onCopy(record);
+			return;
+		}
+		if (matchesKey(data, "x")) {
+			if (record && getBtwLatestTurn(record).status === "running") this.#options.onCancel(record);
+			return;
+		}
+		if (matchesKey(data, "tab") || matchesKey(data, "shift+tab")) {
+			this.#focus = this.#focus === "list" ? "answer" : "list";
+		} else if (matchesKey(data, "right")) {
+			this.#focus = "answer";
+		} else if (matchesKey(data, "left")) {
+			this.#focus = "list";
+		} else if (this.#focus === "list") {
+			const index = this.#selectedIndex();
+			if (matchesSelectUp(data)) this.#select(index - 1);
+			else if (matchesSelectDown(data)) this.#select(index + 1);
+			else if (matchesSelectPageUp(data)) this.#select(index - this.#listHeight);
+			else if (matchesSelectPageDown(data)) this.#select(index + this.#listHeight);
+			else if (matchesKey(data, "home")) this.#select(0);
+			else if (matchesKey(data, "end")) this.#select(this.#records.length - 1);
+			else return;
+		} else {
+			if (matchesSelectUp(data)) this.#detail.scroll(-1);
+			else if (matchesSelectDown(data)) this.#detail.scroll(1);
+			else if (matchesSelectPageUp(data)) this.#detail.page(-1);
+			else if (matchesSelectPageDown(data)) this.#detail.page(1);
+			else if (!this.#detail.handleScrollKey(data)) return;
+			this.#followLatest = matchesKey(data, "end");
+		}
+		this.#options.requestRender();
+	}
+
+	#renderList(width: number, height: number): readonly string[] {
+		const rowSpan = width < 36 && height >= 2 ? 2 : 1;
+		this.#listHeight = Math.max(1, Math.floor(height / rowSpan));
+		if (this.#records.length === 0) {
+			return new Text(theme.fg("muted", "No side questions yet.\n\nUse /btw QUESTION to start one."), 0, 0)
+				.render(width)
+				.slice(0, height);
+		}
+		const selectedIndex = this.#selectedIndex();
+		const selection = clampSelection(selectedIndex, this.#listScroll, this.#records.length, this.#listHeight);
+		this.#listScroll = Math.min(selection.scrollOffset, Math.max(0, this.#records.length - this.#listHeight));
+		const contentWidth = contentRowWidth(width, this.#records.length * rowSpan, height);
+		const lines: string[] = [];
+		for (
+			let index = this.#listScroll;
+			index < Math.min(this.#records.length, this.#listScroll + this.#listHeight);
+			index++
+		) {
+			const record = this.#records[index]!;
+			const selected = index === selectedIndex;
+			const status = STATUS[getBtwLatestTurn(record).status];
+			const cursor = selected ? theme.fg(this.#focus === "list" ? "accent" : "muted", theme.nav.cursor) : " ";
+			const time = theme.fg("dim", this.#timeFormat.format(record.createdAt));
+			const badge = theme.fg(status.color, status.label);
+			const prefix = `${cursor} ${time} ${badge} `;
+			const question = sanitizeDisplayLine(record.question);
+			const snippet = truncateToWidth(
+				question,
+				Math.max(0, contentWidth - (rowSpan === 2 ? 2 : visibleWidth(prefix))),
+			);
+			const text = rowSpan === 2 ? prefix : `${prefix}${selected ? theme.bold(snippet) : snippet}`;
+			lines.push(selected ? theme.bg("selectedBg", fit(text, contentWidth)) : truncateToWidth(text, contentWidth));
+			if (rowSpan === 2) {
+				const questionLine = `  ${selected ? theme.bold(snippet) : snippet}`;
+				lines.push(selected ? theme.bg("selectedBg", fit(questionLine, contentWidth)) : questionLine);
+			}
+		}
+		return renderScrollableList(padLinesToHeight(lines, height), {
+			width,
+			totalRows: this.#records.length * rowSpan,
+			scrollOffset: this.#listScroll * rowSpan,
+		});
+	}
+
+	#renderTurn(turn: BtwHistoryTurn, cached: RenderedTurn | undefined, width: number): RenderedTurn {
+		const previous = cached?.turn;
+		if (
+			cached &&
+			cached.width === width &&
+			turn.question === previous?.question &&
+			turn.answer === previous?.answer &&
+			turn.status === previous?.status &&
+			turn.error === previous?.error &&
+			turn.createdAt === previous?.createdAt
+		) {
+			return cached;
+		}
+		const question = cached?.question ?? new Markdown("", 0, 0, getMarkdownTheme());
+		const answer = cached?.answer ?? new Markdown("", 0, 0, getMarkdownTheme());
+		if (turn.question !== previous?.question) question.setText(sanitizeDisplayText(turn.question));
+		if (turn.answer !== previous?.answer) answer.setText(sanitizeDisplayText(turn.answer));
+		const status = STATUS[turn.status];
+		const lines = [
+			...wrapTextWithAnsi(
+				theme.fg(status.color, `${status.label} · ${this.#dateFormat.format(turn.createdAt)}`),
+				width,
+			),
+			"",
+			theme.bold(theme.fg("accent", "Question")),
+			...question.render(width),
+			"",
+			theme.bold(theme.fg("accent", "Answer")),
+		];
+		if (turn.answer.trim()) lines.push(...answer.render(width));
+		else
+			lines.push(
+				...wrapTextWithAnsi(
+					theme.fg("dim", turn.status === "running" ? "Waiting for response…" : "No answer text."),
+					width,
+				),
+			);
+		if (turn.error) lines.push("", ...wrapTextWithAnsi(theme.fg("error", sanitizeDisplayText(turn.error)), width));
+		if (turn.status === "interrupted")
+			lines.push(
+				"",
+				...wrapTextWithAnsi(theme.fg("muted", "Interrupted when the session ended. Not restarted."), width),
+			);
+		return {
+			turn: {
+				question: turn.question,
+				answer: turn.answer,
+				status: turn.status,
+				error: turn.error,
+				createdAt: turn.createdAt,
+				updatedAt: turn.updatedAt,
+			},
+			question,
+			answer,
+			lines,
+			width,
+		};
+	}
+
+	#renderDetail(width: number, height: number): readonly string[] {
+		const record = this.#selected();
+		if (record?.id !== this.#detailRecord?.id) this.#turns = [];
+		if (this.#detailDirty || record !== this.#detailRecord || this.#detailWidth !== width) {
+			const inner = Math.max(1, width - 1);
+			const lines: string[] = [];
+			if (record) {
+				const turns = getBtwTurns(record);
+				for (let index = 0; index < turns.length; index++) {
+					const cached = this.#renderTurn(turns[index]!, this.#turns[index], inner);
+					this.#turns[index] = cached;
+					if (index > 0) lines.push("", theme.fg("dim", theme.boxRound.horizontal.repeat(inner)), "");
+					lines.push(...cached.lines);
+				}
+				this.#turns.length = turns.length;
+			} else {
+				lines.push(
+					...wrapTextWithAnsi(theme.fg("muted", "No side questions yet. Use /btw QUESTION to start one."), inner),
+				);
+			}
+			this.#detailRecord = record;
+			this.#detail.setLines(lines);
+			this.#detailWidth = width;
+			this.#detailDirty = false;
+		}
+		this.#detail.setHeight(height);
+		return this.#detail.render(width);
+	}
+
+	#focusLabel(focus: "list" | "answer"): string {
+		const label = focus === "list" ? `History (${this.#records.length})` : "Details";
+		return this.#focus === focus
+			? theme.bold(theme.fg("accent", `${theme.nav.cursor} ${label}`))
+			: theme.fg("muted", `  ${label}`);
+	}
+
+	render(width: number): readonly string[] {
+		const height = Math.max(0, Math.floor(this.#options.getHeight()));
+		width = Math.max(0, Math.floor(width));
+		if (width === 0 || height === 0) return [];
+		const framed = width >= 12 && height >= 8;
+		const inner = Math.max(1, width - (framed ? 4 : 0));
+		const wide = framed && width >= 96;
+		const listWidth = Math.min(46, Math.floor(width * 0.42));
+		const record = this.#selected();
+		const composer = this.#composer;
+		const latest = record ? getBtwLatestTurn(record) : undefined;
+		const actions = composer
+			? [rawKeyHint("Enter", this.#followUpPending ? "starting…" : "send"), rawKeyHint("Esc", "cancel")]
+			: [rawKeyHint("Esc", "close"), rawKeyHint("Tab", "switch pane")];
+		if (!composer) {
+			if (record && this.#canFollowUp(record)) actions.push(rawKeyHint("f/Enter", "follow up"));
+			if (latest?.answer.trim()) actions.push(rawKeyHint("c", inner < 40 ? "copy" : "copy answer"));
+			if (latest?.status === "running") actions.push(rawKeyHint("x", inner < 40 ? "cancel" : "cancel run"));
+		}
+		const actionLines = wrapTextWithAnsi(actions.join(" · "), inner).slice(0, framed ? 2 : 1);
+		const chrome = framed ? 3 + actionLines.length : height >= 3 ? 2 : 0;
+		const composerLines: string[] = [];
+		if (composer) {
+			const availableRows = Math.max(1, height - chrome - 1);
+			if (availableRows >= 2) {
+				composerLines.push(
+					theme.fg("dim", truncateToWidth(`Topic: ${sanitizeDisplayLine(record?.question ?? "")}`, inner)),
+				);
+			}
+			if (composer.notice && availableRows >= 3) {
+				composerLines.push(
+					theme.fg(this.#followUpPending ? "dim" : "warning", truncateToWidth(composer.notice, inner)),
+				);
+			}
+			composer.input.focused = this.#focused;
+			composerLines.push(...composer.input.render(inner));
+		}
+		let bodyHeight = Math.max(composer ? 0 : 1, height - chrome - composerLines.length);
+		const detailWidth = wide ? splitBodyWidth(width, listWidth) : inner;
+		const detailScroll = this.#detail.getScrollOffset();
+		let detail = wide || this.#focus === "answer" ? this.#renderDetail(detailWidth, bodyHeight) : undefined;
+		const showNavigation = framed && !composer && (this.#focus === "list" || this.#detail.getMaxScrollOffset() > 0);
+		if (showNavigation) {
+			bodyHeight = Math.max(1, bodyHeight - 1);
+			if (detail) {
+				// Measuring without a footer can clamp the last row off an End jump.
+				this.#detail.setHeight(bodyHeight);
+				this.#detail.setScrollOffset(detailScroll);
+				detail = this.#detail.render(detailWidth);
+			}
+		}
+		if (detail && this.#followLatest) {
+			this.#detail.scrollToBottom();
+			detail = this.#detail.render(detailWidth);
+		}
+		const lines: string[] = [];
+		if (framed) {
+			lines.push(topBorder(width, "BTW history"));
+			lines.push(
+				wide
+					? splitRow(this.#focusLabel("list"), this.#focusLabel("answer"), width, listWidth)
+					: row(this.#focusLabel(this.#focus), width),
+			);
+		} else if (height >= 3) {
+			lines.push(truncateToWidth(this.#focusLabel(this.#focus), width));
+		}
+		if (wide) {
+			const list = this.#renderList(listWidth, bodyHeight);
+			for (let index = 0; index < bodyHeight; index++)
+				lines.push(splitRow(list[index] ?? "", detail?.[index] ?? "", width, listWidth));
+		} else {
+			const body = this.#focus === "list" ? this.#renderList(inner, bodyHeight) : (detail ?? []);
+			for (const line of padLinesToHeight(body, bodyHeight)) lines.push(framed ? row(line, width) : line);
+		}
+		for (const line of composerLines) lines.push(framed ? row(line, width) : line);
+		if (framed) {
+			if (showNavigation) {
+				lines.push(
+					row(
+						rawKeyHint(
+							`${editorKey("tui.select.up")}/${editorKey("tui.select.down")}`,
+							this.#focus === "list" ? "select" : "scroll",
+						),
+						width,
+					),
+				);
+			}
+			for (const line of actionLines) lines.push(row(line, width));
+			lines.push(bottomBorder(width));
+		} else if (height >= 3) {
+			lines.push(actionLines[0] ?? "");
+		}
+		return lines.slice(0, height).map(line => truncateToWidth(line, width));
+	}
+}

--- a/packages/coding-agent/src/modes/components/btw-panel.ts
+++ b/packages/coding-agent/src/modes/components/btw-panel.ts
@@ -9,6 +9,7 @@ interface BtwPanelComponentOptions {
 	question: string;
 	tui: TUI;
 	canBranch?: () => boolean;
+	canFollowUp?: () => boolean;
 }
 
 class BtwFooter implements Component {
@@ -33,6 +34,7 @@ class BtwFooter implements Component {
 export class BtwPanelComponent extends OverlayPanel {
 	#tui: TUI;
 	#canBranch: (() => boolean) | undefined;
+	#canFollowUp: (() => boolean) | undefined;
 	#state: BtwPanelState = "running";
 	#answer = "";
 	#errorMessage: string | undefined;
@@ -43,6 +45,7 @@ export class BtwPanelComponent extends OverlayPanel {
 		super(`/btw ${replaceTabs(options.question)}`);
 		this.#tui = options.tui;
 		this.#canBranch = options.canBranch;
+		this.#canFollowUp = options.canFollowUp;
 		this.#rebuild();
 	}
 
@@ -122,20 +125,21 @@ export class BtwPanelComponent extends OverlayPanel {
 	#footerLine(): string {
 		switch (this.#state) {
 			case "running":
-				return theme.fg("muted", "Esc cancel /btw");
+				return theme.fg("muted", "x to cancel · Esc to close");
 			case "complete": {
-				if (!this.isCopyable()) return theme.fg("muted", "Esc dismiss");
-				const actions = ["c copy"];
-				if (this.#canBranch?.() ?? this.isBranchable()) actions.push("b branch to chat");
-				actions.push("Esc dismiss");
+				const actions: string[] = [];
+				if (this.isCopyable()) actions.push("c to copy");
+				if (this.#canFollowUp?.()) actions.push("f to follow up");
+				if (this.#canBranch?.() ?? this.isBranchable()) actions.push("b to branch");
+				actions.push("Esc to close");
 				return theme.fg("muted", actions.join(" · "));
 			}
 			case "branching":
 				return theme.fg("muted", `${theme.status.pending} Branching to chat…`);
 			case "aborted":
-				return theme.fg("warning", `${theme.status.warning} Cancelled · Esc dismiss`);
+				return theme.fg("warning", `${theme.status.warning} Cancelled · Esc to close`);
 			case "error":
-				return theme.fg("error", `${theme.status.error} Error · Esc dismiss`);
+				return theme.fg("error", `${theme.status.error} Error · Esc to close`);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/btw-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/btw-controller.ts
@@ -1,7 +1,16 @@
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import type { AssistantMessage, Message } from "@oh-my-pi/pi-ai";
+import { type OverlayHandle, replaceTabs } from "@oh-my-pi/pi-tui";
+import { logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import btwUserPrompt from "../../prompts/system/btw-user.md" with { type: "text" };
+import {
+	type BtwHistoryRecord,
+	type BtwHistoryTurn,
+	BtwHistoryStore,
+	getBtwLatestTurn,
+	getBtwTurns,
+} from "../../session/btw-history";
 import { copyToClipboard } from "../../utils/clipboard";
+import { BtwHistoryPanel } from "../components/btw-history-panel";
 import { BtwPanelComponent } from "../components/btw-panel";
 import type { InteractiveModeContext } from "../types";
 
@@ -11,6 +20,11 @@ interface BtwRequest {
 	question: string;
 	leafId: string | null;
 	sessionId: string;
+	session: InteractiveModeContext["session"];
+	store: BtwHistoryStore;
+	record: BtwHistoryRecord;
+	history?: readonly BtwHistoryTurn[];
+	conversationKey: string;
 }
 
 function assistantMessageWithReplyText(assistantMessage: AssistantMessage, replyText: string): AssistantMessage {
@@ -44,11 +58,22 @@ export class BtwController {
 	#branchInFlight = false;
 	#lastCopyText: string | undefined;
 	#copyInFlight = false;
+	#visible = false;
+	#starting = false;
+	#generation = 0;
+	#store: BtwHistoryStore | undefined;
+	#storePromise: Promise<BtwHistoryStore> | undefined;
+	#storeSessionId: string | undefined;
+	#storeArtifactsDir: string | undefined;
+	#historyPanel: BtwHistoryPanel | undefined;
+	#historyOverlay: OverlayHandle | undefined;
+	readonly #writes = new Set<Promise<void>>();
 
 	constructor(private readonly ctx: InteractiveModeContext) {}
 
+	/** Whether the inline panel owns Escape, not whether its hidden request is running. */
 	hasActiveRequest(): boolean {
-		return this.#activeRequest !== undefined;
+		return this.#visible;
 	}
 
 	canBranch(): boolean {
@@ -58,7 +83,7 @@ export class BtwController {
 	/** Whether plain `b` is currently reserved for a completed or pending branch action. */
 	handlesBranchKey(): boolean {
 		if (this.#branchInFlight) return true;
-		if (this.#activeRequest?.component.isBranchable() !== true) return false;
+		if (!this.#visible || this.#activeRequest?.component.isBranchable() !== true) return false;
 		return (
 			this.#lastQuestion !== undefined &&
 			this.#lastReplyText !== undefined &&
@@ -70,32 +95,33 @@ export class BtwController {
 
 	#branchUnavailableReason(): string | undefined {
 		if (this.#branchInFlight) return "a branch is already in progress";
-		if (this.#activeRequest?.component.isBranchable() !== true) return "the answer is not ready";
-		if (!this.#lastQuestion || !this.#lastReplyText || !this.#lastAssistantMessage) {
+		if (!this.#visible || this.#activeRequest?.component.isBranchable() !== true) return "the answer is not ready";
+		if (!this.#lastQuestion || !this.#lastReplyText || !this.#lastAssistantMessage)
 			return "the answer is unavailable";
-		}
 		if (!this.#lastLeafId) return "the session has no branch point";
 		if (
 			this.#lastSessionId !== this.ctx.sessionManager.getSessionId() ||
 			this.#lastLeafId !== this.ctx.sessionManager.getLeafId()
-		) {
+		)
 			return "the session changed since /btw started";
-		}
 		if (this.ctx.session.isStreaming) return "a turn is still running";
 		return undefined;
 	}
 
 	canCopy(): boolean {
 		return (
-			!this.#copyInFlight && this.#activeRequest?.component.isCopyable() === true && this.#lastCopyText !== undefined
+			this.#visible &&
+			!this.#copyInFlight &&
+			this.#activeRequest?.component.isCopyable() === true &&
+			this.#lastCopyText !== undefined
 		);
 	}
 
-	async handleCopy(): Promise<boolean> {
-		if (!this.canCopy() || this.#lastCopyText === undefined) return false;
+	async #copyAnswer(answer: string): Promise<boolean> {
+		if (this.#copyInFlight || !answer.trim()) return false;
 		this.#copyInFlight = true;
 		try {
-			await copyToClipboard(this.#lastCopyText);
+			await copyToClipboard(replaceTabs(answer).trim());
 			this.ctx.showStatus("Copied /btw answer to clipboard");
 			return true;
 		} catch (error) {
@@ -104,6 +130,11 @@ export class BtwController {
 		} finally {
 			this.#copyInFlight = false;
 		}
+	}
+
+	async handleCopy(): Promise<boolean> {
+		if (!this.canCopy() || this.#lastCopyText === undefined) return false;
+		return this.#copyAnswer(this.#lastCopyText);
 	}
 
 	async handleBranch(): Promise<boolean> {
@@ -118,10 +149,10 @@ export class BtwController {
 		const leafId = this.#lastLeafId;
 		const sessionId = this.#lastSessionId;
 		if (!request || !question || !assistantMessage || !leafId || !sessionId) return false;
-
 		this.#branchInFlight = true;
 		request.component.markBranching();
 		try {
+			await this.flush();
 			await this.ctx.handleBtwBranch(question, assistantMessage, leafId, sessionId);
 			return true;
 		} finally {
@@ -135,98 +166,366 @@ export class BtwController {
 			this.ctx.showStatus("/btw branch is in progress", { dim: true });
 			return true;
 		}
-		if (!this.#activeRequest) return false;
-		this.#closeActiveRequest({ abort: this.#activeRequest.abortController.signal.aborted === false });
+		if (!this.#visible) return false;
+		this.#hideInline();
 		return true;
 	}
 
-	dispose(): void {
-		this.#closeActiveRequest({ abort: true });
+	canFollowUp(): boolean {
+		const request = this.#activeRequest;
+		return (
+			this.#visible &&
+			!this.#starting &&
+			!this.#branchInFlight &&
+			request !== undefined &&
+			this.#isActiveRequest(request) &&
+			getBtwLatestTurn(request.record).status === "complete"
+		);
+	}
+
+	handleFollowUp(): boolean {
+		const request = this.#activeRequest;
+		if (!request || !this.canFollowUp()) return false;
+		return this.#showHistory(request.store).openFollowUp(request.record.id);
+	}
+
+	canCancel(): boolean {
+		return (
+			this.#visible &&
+			this.#activeRequest !== undefined &&
+			getBtwLatestTurn(this.#activeRequest.record).status === "running"
+		);
+	}
+
+	handleCancel(): boolean {
+		const request = this.#activeRequest;
+		if (!request || getBtwLatestTurn(request.record).status !== "running") return false;
+		this.#updateRequest(request, { status: "cancelled", updatedAt: Date.now() });
+		request.abortController.abort();
+		request.component.markAborted();
+		this.#persist(request);
+		this.#refreshHistory();
+		return true;
+	}
+
+	async dispose(): Promise<void> {
+		this.#generation++;
+		this.#starting = false;
+		this.handleCancel();
+		this.#closeHistory();
+		this.#hideInline();
+		this.#activeRequest?.component.close();
+		this.#activeRequest = undefined;
+		this.#clearCompletedState();
+		this.#store = undefined;
+		this.#storePromise = undefined;
+		this.#storeSessionId = undefined;
+		this.#storeArtifactsDir = undefined;
+		await this.flush();
+	}
+
+	async flush(): Promise<void> {
+		while (this.#writes.size > 0) await Promise.all(this.#writes);
+	}
+
+	async #loadHistory(): Promise<BtwHistoryStore> {
+		const sessionId = this.ctx.sessionManager.getSessionId();
+		const artifactsDir = this.ctx.sessionManager.getArtifactsDir() ?? undefined;
+		if (this.#storeSessionId !== sessionId || this.#storeArtifactsDir !== artifactsDir) {
+			const closing = this.dispose();
+			this.#starting = true;
+			this.#storeSessionId = sessionId;
+			this.#storeArtifactsDir = artifactsDir;
+			await closing;
+			if (this.#storeSessionId !== sessionId || this.#storeArtifactsDir !== artifactsDir) {
+				throw new Error("The session changed while opening BTW history.");
+			}
+		}
+		this.#storePromise ??= BtwHistoryStore.open(artifactsDir);
+		const pending = this.#storePromise;
+		try {
+			const store = await pending;
+			if (this.#storePromise === pending) this.#store = store;
+			return store;
+		} catch (error) {
+			if (this.#storePromise === pending) this.#storePromise = undefined;
+			throw error;
+		}
 	}
 
 	async start(question: string): Promise<void> {
+		await this.#start(question);
+	}
+
+	async startFollowUp(recordId: string, question: string): Promise<boolean> {
+		if (!question.trim()) return false;
+		return this.#start(question, recordId);
+	}
+
+	async #start(question: string, recordId?: string): Promise<boolean> {
 		const trimmedQuestion = question.trim();
-		if (!trimmedQuestion) {
-			this.ctx.showStatus("Usage: /btw <question>");
-			return;
+		if (this.#starting || this.#branchInFlight) {
+			this.ctx.showStatus("A /btw action is in progress. Please wait.", { dim: true });
+			return false;
 		}
-
-		const model = this.ctx.session.model;
-		if (!model) {
-			this.ctx.showError("No active model available for /btw.");
-			return;
+		if (
+			trimmedQuestion &&
+			this.#activeRequest &&
+			getBtwLatestTurn(this.#activeRequest.record).status === "running" &&
+			this.#activeRequest.sessionId === this.ctx.sessionManager.getSessionId()
+		) {
+			this.ctx.showStatus("A /btw question is still running. Open /btw to view it or cancel it first.", {
+				dim: true,
+			});
+			return false;
 		}
-
-		this.#closeActiveRequest({ abort: true });
-
-		const request: BtwRequest = {
-			component: new BtwPanelComponent({
+		const originalSessionId = this.ctx.sessionManager.getSessionId();
+		this.#starting = true;
+		try {
+			const store = await this.#loadHistory();
+			const generation = this.#generation;
+			const sessionId = this.ctx.sessionManager.getSessionId();
+			if (store !== this.#store || sessionId !== originalSessionId) return false;
+			if (!trimmedQuestion) {
+				this.#showHistory(store);
+				return true;
+			}
+			const previous = recordId ? store.getRecords().find(record => record.id === recordId) : undefined;
+			if (recordId && (!previous || getBtwLatestTurn(previous).status === "running")) {
+				this.ctx.showStatus("This side conversation is unavailable or still running.", { dim: true });
+				return false;
+			}
+			const session = this.ctx.session;
+			if (!session.model) {
+				this.ctx.showError("No active model available for /btw.");
+				return false;
+			}
+			await this.ctx.sessionManager.ensureOnDisk();
+			if (generation !== this.#generation || sessionId !== this.ctx.sessionManager.getSessionId()) return false;
+			if (!previous) this.#closeHistory();
+			this.#activeRequest?.component.close();
+			this.#clearCompletedState();
+			const now = Date.now();
+			const leafId = this.ctx.sessionManager.getLeafId();
+			const turn: BtwHistoryTurn = {
 				question: trimmedQuestion,
-				tui: this.ctx.ui,
-				canBranch: () => this.canBranch(),
-			}),
-			abortController: new AbortController(),
-			question: trimmedQuestion,
-			leafId: this.ctx.sessionManager.getLeafId(),
-			sessionId: this.ctx.sessionManager.getSessionId(),
-		};
-		this.ctx.btwContainer.clear();
-		this.ctx.btwContainer.addChild(request.component);
+				answer: "",
+				status: "running",
+				createdAt: now,
+				updatedAt: now,
+			};
+			const record: BtwHistoryRecord = previous
+				? { ...previous, followUps: [...(previous.followUps ?? []), turn] }
+				: { ...turn, id: Snowflake.next(), leafId };
+			const history = previous ? getBtwTurns(previous) : undefined;
+			// A cancelled/failed transport may still be unwinding. Start a fresh
+			// lineage after that boundary, while successful follow-ups share one.
+			const transportEpoch = (history?.findLastIndex(item => item.status !== "complete") ?? -1) + 1;
+			const request: BtwRequest = {
+				component: new BtwPanelComponent({
+					question: trimmedQuestion,
+					tui: this.ctx.ui,
+					canBranch: () => this.canBranch(),
+					canFollowUp: () => this.canFollowUp(),
+				}),
+				abortController: new AbortController(),
+				question: trimmedQuestion,
+				leafId,
+				sessionId,
+				session,
+				store,
+				record,
+				history,
+				conversationKey: `btw:${record.id}:${transportEpoch}`,
+			};
+			this.#activeRequest = request;
+			this.#visible = !previous;
+			this.ctx.btwContainer.clear();
+			if (this.#visible) this.ctx.btwContainer.addChild(request.component);
+			this.ctx.ui.requestRender();
+			this.#persist(request);
+			this.#refreshHistory();
+			void this.#runRequest(request);
+			return true;
+		} catch (error) {
+			this.ctx.showError(`Cannot open /btw history: ${error instanceof Error ? error.message : String(error)}`);
+			return false;
+		} finally {
+			this.#starting = false;
+		}
+	}
+
+	#showHistory(store: BtwHistoryStore): BtwHistoryPanel {
+		if (this.#historyOverlay && this.#historyPanel) {
+			this.#refreshHistory();
+			return this.#historyPanel;
+		}
+		this.#hideInline();
+		const panel = new BtwHistoryPanel({
+			records: this.#historyRecords(store),
+			onClose: () => this.#closeHistory(),
+			onCopy: record => {
+				void this.#copyAnswer(getBtwLatestTurn(record).answer);
+			},
+			onCancel: record => {
+				if (this.#activeRequest?.record.id === record.id) this.handleCancel();
+			},
+			canFollowUp: record =>
+				!this.#starting &&
+				!this.#branchInFlight &&
+				getBtwLatestTurn(record).status !== "running" &&
+				(!this.#activeRequest || getBtwLatestTurn(this.#activeRequest.record).status !== "running"),
+			onFollowUp: (record, question) => {
+				if (this.#store !== store || this.#storeSessionId !== this.ctx.sessionManager.getSessionId()) {
+					return Promise.resolve(false);
+				}
+				return this.startFollowUp(record.id, question);
+			},
+			requestRender: () => this.ctx.ui.requestRender(),
+			getHeight: () => this.ctx.ui.terminal.rows,
+		});
+		this.#historyPanel = panel;
+		this.#historyOverlay = this.ctx.ui.showOverlay(panel, {
+			anchor: "bottom-center",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+			fullscreen: true,
+		});
+		this.ctx.ui.setFocus(panel);
 		this.ctx.ui.requestRender();
-		this.#activeRequest = request;
-		void this.#runRequest(request);
+		return panel;
+	}
+
+	#historyRecords(store: BtwHistoryStore): readonly BtwHistoryRecord[] {
+		const records = store.getRecords();
+		const request = this.#activeRequest;
+		if (!request || request.store !== store) return records;
+		return records.map(record => (record.id === request.record.id ? request.record : record));
+	}
+
+	#refreshHistory(): void {
+		if (this.#historyPanel && this.#store) this.#historyPanel.update(this.#historyRecords(this.#store));
+	}
+
+	#closeHistory(): void {
+		const overlay = this.#historyOverlay;
+		this.#historyOverlay = undefined;
+		this.#historyPanel = undefined;
+		if (!overlay) return;
+		overlay.hide();
+		this.ctx.ui.requestRender();
+	}
+
+	#persist(request: BtwRequest): void {
+		const write = request.store.upsert(request.record).catch(error => {
+			logger.error("BTW history save failed", { error });
+			if (request.sessionId === this.ctx.sessionManager.getSessionId()) {
+				this.ctx.showError(
+					`Could not save /btw history: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		});
+		this.#writes.add(write);
+		void write.finally(() => this.#writes.delete(write));
+	}
+
+	#updateRequest(request: BtwRequest, patch: Partial<BtwHistoryTurn>): void {
+		const followUps = request.record.followUps;
+		if (followUps?.length) {
+			request.record = {
+				...request.record,
+				followUps: [...followUps.slice(0, -1), { ...followUps[followUps.length - 1]!, ...patch }],
+			};
+		} else {
+			request.record = { ...request.record, ...patch };
+		}
 	}
 
 	async #runRequest(request: BtwRequest): Promise<void> {
 		try {
 			const promptText = prompt.render(btwUserPrompt, { question: request.question });
-			const { replyText, assistantMessage } = await this.ctx.session.runEphemeralTurn({
+			const model = request.session.model;
+			if (!model) throw new Error("No active model available for /btw.");
+			const history: Message[] = [];
+			for (const turn of request.history ?? []) {
+				history.push({
+					role: "user",
+					content: [{ type: "text", text: prompt.render(btwUserPrompt, { question: turn.question }) }],
+					attribution: "agent",
+					timestamp: turn.createdAt,
+				});
+				if (!turn.answer) continue;
+				// Saved BTW history contains visible text, not provider-native reasoning
+				// or replay signatures. These are context messages, not new billed turns.
+				history.push({
+					role: "assistant",
+					content: [{ type: "text", text: turn.answer }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: turn.updatedAt,
+				});
+			}
+			const { replyText, assistantMessage } = await request.session.runEphemeralTurn({
 				promptText,
+				history,
+				conversationKey: request.conversationKey,
 				onTextDelta: delta => {
+					const latest = getBtwLatestTurn(request.record);
+					if (latest.status !== "running") return;
+					this.#updateRequest(request, { answer: latest.answer + delta, updatedAt: Date.now() });
 					if (this.#isActiveRequest(request)) {
-						request.component.appendText(delta);
+						if (this.#visible) request.component.appendText(delta);
+						this.#refreshHistory();
 					}
 				},
 				signal: request.abortController.signal,
 			});
-
-			if (!this.#isActiveRequest(request)) {
-				return;
-			}
-			request.component.setAnswer(replyText);
-			request.component.markComplete();
-			const copyText = request.component.getCopyText();
-			if (copyText !== undefined) {
-				this.#lastQuestion = request.question;
-				this.#lastReplyText = replyText;
-				this.#lastCopyText = copyText;
-				this.#lastAssistantMessage = assistantMessageWithReplyText(assistantMessage, replyText);
-				this.#lastLeafId = request.leafId;
-				this.#lastSessionId = request.sessionId;
-			} else {
-				this.#clearCompletedState();
+			if (getBtwLatestTurn(request.record).status !== "running") return;
+			this.#updateRequest(request, { answer: replyText, status: "complete", updatedAt: Date.now() });
+			if (this.#isActiveRequest(request)) {
+				request.component.setAnswer(replyText);
+				request.component.markComplete();
+				const copyText = request.component.getCopyText();
+				if (copyText !== undefined) {
+					this.#lastQuestion = request.question;
+					this.#lastReplyText = replyText;
+					this.#lastCopyText = copyText;
+					this.#lastAssistantMessage = assistantMessageWithReplyText(assistantMessage, replyText);
+					this.#lastLeafId = request.leafId;
+					this.#lastSessionId = request.sessionId;
+				} else this.#clearCompletedState();
 			}
 		} catch (error) {
-			if (!this.#isActiveRequest(request)) {
-				return;
+			if (getBtwLatestTurn(request.record).status !== "running") return;
+			const cancelled = request.abortController.signal.aborted;
+			const message = error instanceof Error ? error.message : String(error);
+			this.#updateRequest(request, {
+				status: cancelled ? "cancelled" : "error",
+				updatedAt: Date.now(),
+				...(cancelled ? {} : { error: message }),
+			});
+			if (this.#isActiveRequest(request)) {
+				if (cancelled) request.component.markAborted();
+				else request.component.markError(message);
 			}
-			if (request.abortController.signal.aborted) {
-				request.component.markAborted();
-				return;
-			}
-			request.component.markError(error instanceof Error ? error.message : String(error));
 		}
+		this.#persist(request);
+		if (this.#isActiveRequest(request)) this.#refreshHistory();
 	}
 
-	#closeActiveRequest(options: { abort: boolean }): void {
-		const request = this.#activeRequest;
-		if (!request) return;
-		this.#activeRequest = undefined;
-		this.#clearCompletedState();
-		if (options.abort) {
-			request.abortController.abort();
-		}
-		request.component.close();
+	#hideInline(): void {
+		this.#visible = false;
 		this.ctx.btwContainer.clear();
 		this.ctx.ui.requestRender();
 	}
@@ -241,6 +540,6 @@ export class BtwController {
 	}
 
 	#isActiveRequest(request: BtwRequest): boolean {
-		return this.#activeRequest === request;
+		return this.#activeRequest === request && request.sessionId === this.ctx.sessionManager.getSessionId();
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -290,10 +290,17 @@ export class InputController {
 		if (!this.#btwCopyListenerInstalled) {
 			this.#btwCopyListenerInstalled = true;
 			this.ctx.ui.addInputListener(data => {
-				if (!matchesKey(data, "c")) return undefined;
-				if (!this.ctx.canCopyBtw()) return undefined;
 				if (this.ctx.ui.getFocused() !== this.ctx.editor) return undefined;
 				if (this.ctx.editor.getText().trim()) return undefined;
+				if (matchesKey(data, "f") && this.ctx.canFollowUpBtw()) {
+					this.ctx.handleBtwFollowUpKey();
+					return { consume: true };
+				}
+				if (matchesKey(data, "x") && this.ctx.canCancelBtw()) {
+					this.ctx.handleBtwCancelKey();
+					return { consume: true };
+				}
+				if (!matchesKey(data, "c") || !this.ctx.canCopyBtw()) return undefined;
 				void this.ctx.handleBtwCopyKey();
 				return { consume: true };
 			});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1128,8 +1128,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			getDraftText: () => this.#inputController.getDraftText(),
 			beginDispose: () => this.session.beginDispose(),
 			saveDraft: text => this.sessionManager.saveDraft(text),
-			disposeSession: reason =>
-				this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS, reason }),
+			disposeSession: async reason => {
+				await this.#btwController.dispose();
+				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS, reason });
+			},
 		});
 		// Forward the postmortem reason (SIGTERM/SIGHUP/uncaughtException/…) so the
 		// persisted `session_exit` diagnostic carries the real trigger. Postmortem
@@ -4872,7 +4874,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #teardown(): Promise<void> {
 		await this.#liveCommandController.stop();
 
-		this.#btwController.dispose();
+		await this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#cleanseController.dispose();
 		this.#focusController.dispose();
@@ -5489,8 +5491,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		return true;
 	}
 
-	#prepareSessionSwitch(): void {
-		this.#btwController.dispose();
+	async #prepareSessionSwitch(): Promise<void> {
+		await this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#cleanseController.dispose();
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
@@ -5500,7 +5502,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleClearCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		await this.#prepareSessionSwitch();
 		await this.#commandController.handleClearCommand();
 	}
 
@@ -5514,13 +5516,13 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleDropCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		await this.#prepareSessionSwitch();
 		await this.#commandController.handleDropCommand();
 	}
 
 	async handleForkCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#btwController.dispose();
+		await this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#cleanseController.dispose();
 		await this.#commandController.handleForkCommand();
@@ -5528,11 +5530,13 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleMoveCommand(targetPath?: string): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
+		await this.#btwController.dispose();
 		await this.#commandController.handleMoveCommand(targetPath);
 	}
 
 	async handleWorktreeCommand(branch?: string): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
+		await this.#btwController.dispose();
 		await this.#commandController.handleWorktreeCommand(branch);
 	}
 
@@ -5763,7 +5767,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showError(`Failed to save pending settings: ${err instanceof Error ? err.message : String(err)}`);
 			return;
 		}
-		this.#btwController.dispose();
+		await this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#cleanseController.dispose();
 		this.resetObserverRegistry();
@@ -5878,6 +5882,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#btwController.handleCopy();
 	}
 
+	canCancelBtw(): boolean {
+		return this.#btwController.canCancel();
+	}
+
+	handleBtwCancelKey(): boolean {
+		return this.#btwController.handleCancel();
+	}
+
+	canFollowUpBtw(): boolean {
+		return this.#btwController.canFollowUp();
+	}
+
+	handleBtwFollowUpKey(): boolean {
+		return this.#btwController.handleFollowUp();
+	}
+
 	async handleBtwBranch(
 		question: string,
 		assistantMessage: AssistantMessage,
@@ -5890,7 +5910,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.showStatus("/btw branch cancelled", { dim: true });
 				return;
 			}
-			this.#btwController.dispose();
+			await this.#btwController.dispose();
 			this.#omfgController.dispose();
 			this.#cleanseController.dispose();
 			await this.renderInitialMessages({ clearTerminalHistory: true });

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -480,6 +480,10 @@ export interface InteractiveModeContext {
 	handlesBtwBranchKey(): boolean;
 	canCopyBtw(): boolean;
 	handleBtwCopyKey(): Promise<boolean>;
+	canCancelBtw(): boolean;
+	handleBtwCancelKey(): boolean;
+	canFollowUpBtw(): boolean;
+	handleBtwFollowUpKey(): boolean;
 	handleBtwBranch(
 		question: string,
 		assistantMessage: AssistantMessage,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8625,6 +8625,9 @@ export class AgentSession {
 	 */
 	async runEphemeralTurn(args: {
 		promptText: string;
+		history?: readonly Message[];
+		/** Session-local key for serialized side turns; rotate after cancellation or failure. */
+		conversationKey?: string;
 		onTextDelta?: (delta: string) => void;
 		signal?: AbortSignal;
 		dedupeReply?: boolean;
@@ -8634,7 +8637,7 @@ export class AgentSession {
 			throw new Error("No active model on session");
 		}
 		const cacheSessionId = this.sessionId;
-		const snapshot = this.#buildEphemeralSnapshot(args.promptText);
+		const snapshot = this.#buildEphemeralSnapshot(args.promptText, args.history);
 		const llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
 		const context = await this.agent.buildSideRequestContext(llmMessages);
 		const options = this.prepareSimpleStreamOptions(
@@ -8643,10 +8646,12 @@ export class AgentSession {
 				// Side-channel turns must not share OpenAI/Codex append-only
 				// conversation state with the main agent turn: IRC and /btw can run
 				// while the main turn is mid-tool-call. Keep the prompt-cache key
-				// stable, but give provider routing a unique request lineage. The
-				// shared provider state map is still required so Codex can allocate
-				// websocket state under that side-channel session id.
-				sessionId: `${cacheSessionId}:side:${Snowflake.next()}`,
+				// stable, but isolate provider routing from the main conversation.
+				// Serialized BTW follow-ups reuse a topic-specific lineage; standalone
+				// side requests retain their unique request lineage.
+				sessionId: args.conversationKey
+					? `${cacheSessionId}:side:conversation:${args.conversationKey}`
+					: `${cacheSessionId}:side:${Snowflake.next()}`,
 				promptCacheKey: this.agent.promptCacheKey ?? this.agent.sessionId,
 				preferWebsockets: this.#preferWebsockets,
 				providerSessionState: this.#providerSessionState,
@@ -8715,10 +8720,10 @@ export class AgentSession {
 	/**
 	 * Build a message snapshot for an ephemeral side-channel turn.  Includes
 	 * the in-flight streaming assistant message (if any) so the model sees
-	 * the partial response in context, then appends the prompt as a virtual
-	 * user message.
+	 * the partial response in context, then appends detached side-channel history
+	 * and the current prompt after the no-tools reminder.
 	 */
-	#buildEphemeralSnapshot(promptText: string): AgentMessage[] {
+	#buildEphemeralSnapshot(promptText: string, history?: readonly Message[]): AgentMessage[] {
 		const messages = [...this.messages];
 		const streaming = this.agent.state.streamMessage;
 		if (streaming && streaming.role === "assistant" && Array.isArray(streaming.content)) {
@@ -8755,6 +8760,10 @@ export class AgentSession {
 			attribution: "agent",
 			timestamp: Date.now(),
 		});
+		if (history?.length) {
+			// Detach before the conversion pipeline can await or mutate caller-owned messages.
+			messages.push(...structuredClone(history));
+		}
 		messages.push({
 			role: "user",
 			content: [{ type: "text", text: promptText }],

--- a/packages/coding-agent/src/session/btw-history.ts
+++ b/packages/coding-agent/src/session/btw-history.ts
@@ -1,0 +1,182 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { isEnoent, toError } from "@oh-my-pi/pi-utils";
+import { replaceFileAtomically } from "../utils/atomic-file";
+
+export interface BtwHistoryTurn {
+	question: string;
+	answer: string;
+	status: "running" | "complete" | "cancelled" | "error" | "interrupted";
+	createdAt: number;
+	updatedAt: number;
+	error?: string;
+}
+
+export interface BtwHistoryRecord extends BtwHistoryTurn {
+	id: string;
+	leafId: string | null;
+	followUps?: readonly BtwHistoryTurn[];
+}
+
+export function getBtwLatestTurn(record: BtwHistoryRecord): BtwHistoryTurn {
+	return record.followUps?.at(-1) ?? record;
+}
+
+export function getBtwTurns(record: BtwHistoryRecord): readonly BtwHistoryTurn[] {
+	return [record, ...(record.followUps ?? [])];
+}
+
+const turnFields = {
+	question: "string",
+	answer: "string",
+	status: "'running' | 'complete' | 'cancelled' | 'error' | 'interrupted'",
+	createdAt: "number >= 0",
+	updatedAt: "number >= 0",
+	"error?": "string",
+} as const;
+const turnSchema = type({ ...turnFields, "+": "reject" });
+const recordSchema = type({
+	...turnFields,
+	id: "string > 0",
+	leafId: "string | null",
+	"followUps?": turnSchema.array(),
+	"+": "reject",
+});
+
+function parseRecord(value: unknown): BtwHistoryRecord {
+	const result = recordSchema(value);
+	if (result instanceof type.errors) {
+		throw new Error(`Invalid BTW history record: ${result.summary}`);
+	}
+	if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/.test(result.id)) {
+		throw new Error("Invalid BTW history record id");
+	}
+	for (const turn of getBtwTurns(result)) {
+		if (!Number.isFinite(turn.createdAt) || !Number.isFinite(turn.updatedAt)) {
+			throw new Error("Invalid BTW history record timestamp");
+		}
+	}
+	return result;
+}
+
+function snapshotRecord(record: BtwHistoryRecord, recover = false): BtwHistoryRecord {
+	const snapshotTurn = (turn: BtwHistoryTurn): BtwHistoryTurn =>
+		Object.freeze({ ...turn, status: recover && turn.status === "running" ? "interrupted" : turn.status });
+	return Object.freeze({
+		...record,
+		status: recover && record.status === "running" ? "interrupted" : record.status,
+		...(record.followUps ? { followUps: Object.freeze(record.followUps.map(snapshotTurn)) } : {}),
+	});
+}
+
+function recordFileName(id: string): string {
+	// The prefix also prevents Windows device names (CON, NUL, etc.).
+	return `entry-${id}.json`;
+}
+
+async function readRecord(filePath: string): Promise<BtwHistoryRecord | undefined> {
+	try {
+		const stat = await fs.lstat(filePath);
+		if (!stat.isFile()) throw new Error("Expected a regular file");
+		const value: unknown = await Bun.file(filePath).json();
+		const record = parseRecord(value);
+		if (path.basename(filePath) !== recordFileName(record.id)) {
+			throw new Error("Record id does not match its filename");
+		}
+		return record;
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw new Error(`Failed to read BTW history ${filePath}: ${toError(error).message}`, { cause: error });
+	}
+}
+
+/** Session-local sidecar storage; never reads or writes the main session journal. */
+export class BtwHistoryStore {
+	readonly #directory: string | undefined;
+	readonly #records = new Map<string, BtwHistoryRecord>();
+	#snapshot: readonly BtwHistoryRecord[] = Object.freeze([]);
+	#pending: Promise<void> = Promise.resolve();
+	#writeError: Error | undefined;
+
+	constructor(directory: string | undefined) {
+		this.#directory = directory;
+	}
+
+	static async open(artifactsDir: string | undefined): Promise<BtwHistoryStore> {
+		const store = new BtwHistoryStore(
+			artifactsDir === undefined ? undefined : path.join(artifactsDir, "btw-history"),
+		);
+		if (store.#directory === undefined) return store;
+		let names: string[];
+		try {
+			names = await fs.readdir(store.#directory);
+		} catch (error) {
+			if (isEnoent(error)) return store;
+			throw error;
+		}
+		for (const name of names.sort()) {
+			if (!name.endsWith(".json")) continue;
+			const record = await readRecord(path.join(store.#directory, name));
+			if (!record) continue;
+			// Recovery is a view, not a write: another process may still own this
+			// record. Never overwrite its newer checkpoint or resubmit its question.
+			store.#records.set(record.id, snapshotRecord(record, true));
+		}
+		store.#refreshSnapshot();
+		return store;
+	}
+
+	getRecords(): readonly BtwHistoryRecord[] {
+		return this.#snapshot;
+	}
+
+	async upsert(record: BtwHistoryRecord): Promise<void> {
+		if (this.#writeError) throw this.#writeError;
+		// Capture before yielding: callers may keep mutating their streaming record.
+		const snapshot = snapshotRecord(parseRecord(record));
+		this.#records.set(snapshot.id, snapshot);
+		this.#refreshSnapshot();
+		if (this.#directory === undefined) return;
+		const directory = this.#directory;
+		const content = `${JSON.stringify(snapshot)}\n`;
+		const write = this.#pending.then(async () => {
+			if (this.#writeError) throw this.#writeError;
+			await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+			if (process.platform !== "win32") await fs.chmod(directory, 0o700);
+			const filePath = path.join(directory, recordFileName(snapshot.id));
+			// Refuse to destroy corruption introduced after open, too.
+			await readRecord(filePath);
+			const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+			try {
+				await fs.writeFile(temporaryPath, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+				await replaceFileAtomically(temporaryPath, filePath);
+			} finally {
+				await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+			}
+		});
+		// Keep the queue handled while retaining the original failure for callers
+		// and every later flush/upsert. A successful drain must not hide data loss.
+		this.#pending = write.catch(error => {
+			this.#writeError ??= toError(error);
+		});
+		await write;
+	}
+
+	async flush(): Promise<void> {
+		let pending: Promise<void>;
+		do {
+			pending = this.#pending;
+			await pending;
+		} while (pending !== this.#pending);
+		if (this.#writeError) throw this.#writeError;
+	}
+
+	#refreshSnapshot(): void {
+		this.#snapshot = Object.freeze(
+			[...this.#records.values()].sort(
+				(a, b) => b.createdAt - a.createdAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+			),
+		);
+	}
+}

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -447,8 +447,8 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 	{
 		name: "btw",
 		icon: "question",
-		description: "Ask an ephemeral side question using the current session context",
-		inlineHint: "<question>",
+		description: "Ask a side question, or browse this session's BTW history",
+		inlineHint: "[question]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			const question = command.text.slice(`/${command.name}`.length).trim();

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -463,7 +463,7 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.providerSessionState).toBe(session.providerSessionState);
 	});
 
-	it("runs ephemeral side-channel requests through the configured side stream function", async () => {
+	it("preserves the provider prefix when ephemeral followups append structured history", async () => {
 		const model = buildModel({
 			id: "side-stream-model",
 			name: "Side Stream Model",
@@ -476,11 +476,11 @@ describe("AgentSession message pipeline", () => {
 			contextWindow: 4096,
 			maxTokens: 1024,
 		} as ModelSpec<Api>) as Model<Api>;
-		let capturedOptions: SimpleStreamOptions | undefined;
-		let capturedContext: Context | undefined;
-		const sideStreamFn: StreamFn = (_model, context, options) => {
-			capturedContext = context;
-			capturedOptions = options;
+		const contexts: Context[] = [];
+		const options: SimpleStreamOptions[] = [];
+		const sideStreamFn: StreamFn = (_model, context, streamOptions) => {
+			contexts.push({ ...context, messages: structuredClone(context.messages) });
+			options.push(streamOptions ?? {});
 			const stream = new AssistantMessageEventStream();
 			queueMicrotask(() => {
 				const message = createAssistantMessage("Side answer");
@@ -489,27 +489,76 @@ describe("AgentSession message pipeline", () => {
 			});
 			return stream;
 		};
+		const tool: AgentTool = {
+			name: "side_tool",
+			label: "Side Tool",
+			description: "A tool in the main catalog",
+			parameters: { type: "object", properties: {} },
+			execute: async () => ({ content: [], details: {} }),
+		};
+		const agent = new Agent({
+			promptCacheKey: "parent-cache",
+			initialState: {
+				model,
+				systemPrompt: ["system prompt"],
+				messages: [{ role: "user", content: "Main question", timestamp: 1 }],
+				tools: [tool],
+			},
+		});
 		const session = new AgentSession({
-			agent: new Agent({
-				initialState: {
-					model,
-					systemPrompt: ["system prompt"],
-					messages: [],
-					tools: [],
-				},
-			}),
+			agent,
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: createModelRegistryStub() as never,
 			sideStreamFn,
 		});
 		sessions.push(session);
+		const mainMessages = agent.state.messages;
+		const mainSnapshot = structuredClone(mainMessages);
+		const journalSnapshot = structuredClone(session.sessionManager.getEntries());
 
-		const result = await session.runEphemeralTurn({ promptText: "Question?" });
+		const first = await session.runEphemeralTurn({ promptText: "Question?", conversationKey: "topic-a" });
+		const history: readonly Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "Question?" }],
+				attribution: "agent",
+				timestamp: 2,
+			},
+			first.assistantMessage,
+		];
+		const historySnapshot = structuredClone(history);
+		await session.runEphemeralTurn({ promptText: "Followup?", history, conversationKey: "topic-a" });
+		await session.runEphemeralTurn({ promptText: "Question?", history: [], conversationKey: "topic-b" });
 
-		expect(result.replyText).toBe("Side answer");
-		expect(capturedContext?.messages.at(-1)?.content).toEqual([{ type: "text", text: "Question?" }]);
-		expect(capturedOptions?.sessionId).toStartWith(`${session.sessionId}:side:`);
+		const [initial, followup, emptyHistory] = contexts;
+		expect(initial.messages.map(message => message.role)).toEqual(["user", "developer", "user"]);
+		expect(followup.messages.map(message => message.role)).toEqual([
+			"user",
+			"developer",
+			"user",
+			"assistant",
+			"user",
+		]);
+		// Compare prompt-bearing fields, not per-request timestamps or usage metadata.
+		const promptMessages = (context: Context) => context.messages.map(({ role, content }) => ({ role, content }));
+		expect(followup.systemPrompt).toEqual(initial.systemPrompt);
+		expect(followup.tools).toEqual(initial.tools);
+		expect(initial.tools?.map(tool => tool.name)).toEqual(["side_tool"]);
+		expect(promptMessages(followup).slice(0, initial.messages.length)).toEqual(promptMessages(initial));
+		expect(followup.messages.at(-2)?.content).toEqual([{ type: "text", text: "Side answer" }]);
+		expect(getConvertedUserText(followup.messages.at(-1))).toBe("Followup?");
+		expect(promptMessages(emptyHistory)).toEqual(promptMessages(initial));
+		expect(options.map(option => option.promptCacheKey)).toEqual(["parent-cache", "parent-cache", "parent-cache"]);
+		expect(options[1]?.sessionId).toBe(options[0]?.sessionId);
+		expect(options[2]?.sessionId).not.toBe(options[0]?.sessionId);
+		for (const option of options) {
+			expect(option.sessionId).toStartWith(`${session.sessionId}:side:`);
+		}
+		expect(history).toEqual(historySnapshot);
+		expect(agent.state.messages).toBe(mainMessages);
+		expect(agent.state.messages).toEqual(mainSnapshot);
+		expect(session.sessionManager.getEntries()).toEqual(journalSnapshot);
 	});
 
 	it("rotates ephemeral side-channel credentials on Google Resource exhausted", async () => {
@@ -633,9 +682,12 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.openrouterVariant).toBe("nitro");
 	});
 
-	it("obfuscates user messages on ephemeral side-channel requests", async () => {
+	it("snapshots and obfuscates ephemeral history before asynchronous context conversion", async () => {
 		const api = "test-ephemeral-secret-redaction";
 		const secret = "EPHEMERAL_SECRET_TOKEN_12345";
+		const conversionStarted = Promise.withResolvers<void>();
+		const continueConversion = Promise.withResolvers<void>();
+		const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 		let capturedContext: Context | undefined;
 		registerCustomApi(api, (_model, context, _options) => {
 			capturedContext = context;
@@ -672,16 +724,42 @@ describe("AgentSession message pipeline", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: createModelRegistryStub() as never,
-			obfuscator: new SecretObfuscator([{ type: "plain", content: secret }]),
+			obfuscator,
+			transformContext: async messages => {
+				conversionStarted.resolve();
+				await continueConversion.promise;
+				return messages;
+			},
 		});
 		sessions.push(session);
 
-		const result = await session.runEphemeralTurn({ promptText: `question about ${secret}` });
+		const questionBlock: TextContent = { type: "text", text: `previous question about ${secret}` };
+		const answerBlock: TextContent = { type: "text", text: `previous answer about ${secret}` };
+		const history: Message[] = [
+			{ role: "user", content: [questionBlock], timestamp: 1 },
+			{ ...createAssistantMessage(""), content: [answerBlock] },
+		];
+		const originalHistory = structuredClone(history);
+		const pendingTurn = session.runEphemeralTurn({ promptText: `question about ${secret}`, history });
+		await conversionStarted.promise;
+		expect(history).toEqual(originalHistory);
+		questionBlock.text = "caller replaced question";
+		answerBlock.text = "caller replaced answer";
+		history.push({ role: "user", content: "caller appended question", timestamp: 2 });
+		const mutatedHistory = structuredClone(history);
+		continueConversion.resolve();
+		const result = await pendingTurn;
 
 		expect(result.replyText).toBe("Answer");
-		expect(capturedContext).toBeDefined();
-		// The secret entered only via the user prompt, which the opt-in obfuscator redacts.
+		const messages = capturedContext!.messages;
+		expect(messages.map(message => message.role)).toEqual(["developer", "user", "assistant", "user"]);
+		expect(getConvertedUserText(messages[1])).toBe(obfuscator.obfuscate(`previous question about ${secret}`));
+		expect(messages[2].content).toEqual([
+			{ type: "text", text: obfuscator.obfuscate(`previous answer about ${secret}`) },
+		]);
+		expect(getConvertedUserText(messages[3])).toBe(obfuscator.obfuscate(`question about ${secret}`));
 		expect(JSON.stringify(capturedContext)).not.toContain(secret);
+		expect(history).toEqual(mutatedHistory);
 	});
 
 	it("keeps obfuscated side-channel stable prefix byte-identical to the main turn", async () => {

--- a/packages/coding-agent/test/btw-follow-up.test.ts
+++ b/packages/coding-agent/test/btw-follow-up.test.ts
@@ -1,0 +1,484 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AssistantMessage, Message, Usage } from "@oh-my-pi/pi-ai";
+import { BtwHistoryPanel } from "@oh-my-pi/pi-coding-agent/modes/components/btw-history-panel";
+import { BtwController } from "@oh-my-pi/pi-coding-agent/modes/controllers/btw-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { type BtwHistoryRecord, BtwHistoryStore, getBtwTurns } from "@oh-my-pi/pi-coding-agent/session/btw-history";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
+import { Container, type TUI } from "@oh-my-pi/pi-tui";
+
+interface TurnArgs {
+	promptText: string;
+	history?: readonly Message[];
+	conversationKey?: string;
+	onTextDelta?: (delta: string) => void;
+	signal?: AbortSignal;
+}
+
+interface TurnResult {
+	replyText: string;
+	assistantMessage: AssistantMessage;
+}
+
+interface PendingTurn {
+	args: TurnArgs;
+	resolve: (result: TurnResult) => void;
+	reject: (error: Error) => void;
+}
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function answer(text: string): TurnResult {
+	return {
+		replyText: text,
+		assistantMessage: {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage,
+			stopReason: "stop",
+			timestamp: Date.now(),
+		},
+	};
+}
+
+async function drain(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function records(manager: SessionManager): Promise<readonly BtwHistoryRecord[]> {
+	const artifacts = manager.getArtifactsDir();
+	if (!artifacts) throw new Error("Expected persisted session artifacts");
+	return (await BtwHistoryStore.open(artifacts)).getRecords();
+}
+
+async function harness() {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-btw-follow-up-"));
+	const manager = SessionManager.create(directory, directory);
+	const managers = [manager];
+	const requests: PendingTurn[] = [];
+	const runEphemeralTurn = vi.fn((args: TurnArgs) => {
+		const pending = Promise.withResolvers<TurnResult>();
+		requests.push({ args, resolve: pending.resolve, reject: pending.reject });
+		return pending.promise;
+	});
+	const session = {
+		model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+		isStreaming: false,
+		runEphemeralTurn,
+	} as unknown as InteractiveModeContext["session"];
+	const ctx = {
+		ui: {
+			requestRender: vi.fn(),
+			requestComponentRender: vi.fn(),
+			showOverlay: vi.fn(() => ({ hide: vi.fn() })),
+			setFocus: vi.fn(),
+			terminal: { rows: 30 },
+		} as unknown as TUI,
+		btwContainer: new Container(),
+		session,
+		sessionManager: manager,
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		handleBtwBranch: vi.fn(async () => {}),
+	} as unknown as InteractiveModeContext;
+	const controller = new BtwController(ctx);
+	cleanups.push(async () => {
+		await controller.dispose();
+		for (const item of managers) await item.flush();
+		await fs.rm(directory, { recursive: true, force: true });
+	});
+	manager.appendMessage({ role: "user", content: "Main task remains untouched", timestamp: Date.now() });
+	await manager.ensureOnDisk();
+
+	async function complete(text: string): Promise<void> {
+		const request = requests.at(-1);
+		if (!request) throw new Error("Expected a pending BTW turn");
+		request.resolve(answer(text));
+		await drain();
+		await controller.flush();
+	}
+
+	async function root(question: string, text: string): Promise<BtwHistoryRecord> {
+		await controller.start(question);
+		await complete(text);
+		const record = (await records(ctx.sessionManager)).find(item => item.question === question);
+		if (!record) throw new Error("Expected a persisted root question");
+		return record;
+	}
+
+	return { directory, manager, managers, ctx, controller, requests, runEphemeralTurn, complete, root };
+}
+
+describe("BTW follow-up lifecycle", () => {
+	it("opens the just-completed inline topic directly for follow-up without launching a request", async () => {
+		const h = await harness();
+		await h.root("Earlier topic", "Earlier answer");
+		await h.controller.start("Current topic");
+		expect(h.controller.canFollowUp()).toBe(false);
+		expect(h.controller.handleFollowUp()).toBe(false);
+		await h.complete("Current answer");
+		const overlay = vi.spyOn(h.ctx.ui, "showOverlay");
+		expect(h.controller.canFollowUp()).toBe(true);
+		expect(h.controller.handleFollowUp()).toBe(true);
+		expect(h.controller.hasActiveRequest()).toBe(false);
+		const panel = overlay.mock.calls.at(-1)?.[0];
+		if (!(panel instanceof BtwHistoryPanel)) throw new Error("Expected BTW follow-up composer");
+		expect(h.runEphemeralTurn).toHaveBeenCalledTimes(2);
+		const started = Promise.withResolvers<boolean>();
+		const start = h.controller.startFollowUp.bind(h.controller);
+		vi.spyOn(h.controller, "startFollowUp").mockImplementation(async (...args) => {
+			const accepted = await start(...args);
+			started.resolve(accepted);
+			return accepted;
+		});
+		panel.pasteText("Continue this topic");
+		panel.handleInput("\r");
+		expect(await started.promise).toBe(true);
+		expect(h.runEphemeralTurn).toHaveBeenCalledTimes(3);
+		const request = h.requests.at(-1)!.args;
+		expect(JSON.stringify(request.history)).toContain("Current answer");
+		expect(JSON.stringify(request.history)).not.toContain("Earlier answer");
+		await h.complete("Continued answer");
+		const topics = await records(h.manager);
+		expect(topics.find(topic => topic.question === "Current topic")?.followUps?.[0]?.answer).toBe("Continued answer");
+	});
+
+	it("resumes only the selected chronological conversation, including cancelled partial output, without promoting it into main chat", async () => {
+		const h = await harness();
+		const file = h.manager.getSessionFile()!;
+		const journal = await Bun.file(file).text();
+		const leaf = h.manager.getLeafId();
+		const context = JSON.stringify(h.manager.buildSessionContext());
+		const root = await h.root("Selected root question", "Selected root answer");
+		const originalPrompt = h.requests[0]!.args.promptText;
+		const originalConversationKey = h.requests[0]!.args.conversationKey;
+		await h.root("Unrelated private question", "Unrelated private answer");
+		expect(h.requests.at(-1)!.args.conversationKey).not.toBe(originalConversationKey);
+
+		expect(await h.controller.startFollowUp(root.id, "First follow-up question")).toBe(true);
+		expect(h.requests.at(-1)!.args.conversationKey).toBe(originalConversationKey);
+		await h.complete("First follow-up answer");
+		expect(await h.controller.startFollowUp(root.id, "Cancelled follow-up question")).toBe(true);
+		const cancelled = h.requests.at(-1)!;
+		cancelled.args.onTextDelta?.("Cancelled partial answer");
+		expect(h.controller.handleCancel()).toBe(true);
+		expect(cancelled.args.signal?.aborted).toBe(true);
+		cancelled.resolve(answer("Ignored cancellation result"));
+		await drain();
+		await h.controller.flush();
+		const beforeReopen = (await records(h.manager)).find(item => item.id === root.id)!;
+		expect(getBtwTurns(beforeReopen).map(turn => [turn.question, turn.answer, turn.status])).toEqual([
+			["Selected root question", "Selected root answer", "complete"],
+			["First follow-up question", "First follow-up answer", "complete"],
+			["Cancelled follow-up question", "Cancelled partial answer", "cancelled"],
+		]);
+
+		await h.controller.dispose();
+		const reopened = await SessionManager.open(file);
+		h.managers.push(reopened);
+		h.ctx.sessionManager = reopened;
+		expect(await h.controller.startFollowUp(root.id, "Continue after cancellation")).toBe(true);
+		const request = h.requests.at(-1)!.args;
+		expect(request.conversationKey).not.toBe(originalConversationKey);
+		expect(request.history?.map(message => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+		]);
+		const texts = request.history?.map(message =>
+			typeof message.content === "string"
+				? message.content
+				: message.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join(""),
+		);
+		expect(texts?.[0]).toBe(originalPrompt);
+		expect(texts?.[1]).toBe("Selected root answer");
+		expect(texts?.[2]).toContain("First follow-up question");
+		expect(texts?.[3]).toBe("First follow-up answer");
+		expect(texts?.[4]).toContain("Cancelled follow-up question");
+		expect(texts?.[5]).toBe("Cancelled partial answer");
+		expect(request.promptText).toContain("Continue after cancellation");
+		expect(request.promptText).not.toContain("Selected root question");
+		const combined = JSON.stringify(request);
+		expect(combined).not.toContain("Unrelated private question");
+		expect(combined).not.toContain("Unrelated private answer");
+		expect(combined).not.toContain("Ignored cancellation result");
+		await h.complete("Resumed follow-up answer");
+		await h.controller.dispose();
+		const saved = await records(reopened);
+		expect(saved).toHaveLength(2);
+		const selected = saved.find(item => item.id === root.id)!;
+		expect(selected.leafId).toBe(leaf);
+		expect(getBtwTurns(selected).map(turn => [turn.question, turn.answer, turn.status])).toEqual([
+			["Selected root question", "Selected root answer", "complete"],
+			["First follow-up question", "First follow-up answer", "complete"],
+			["Cancelled follow-up question", "Cancelled partial answer", "cancelled"],
+			["Continue after cancellation", "Resumed follow-up answer", "complete"],
+		]);
+		expect(await Bun.file(file).text()).toBe(journal);
+		expect(reopened.getLeafId()).toBe(leaf);
+		expect(JSON.stringify(reopened.buildSessionContext())).toBe(context);
+	});
+
+	it("keeps earlier answers after a streamed follow-up errors and copies the latest completed answer", async () => {
+		const h = await harness();
+		const root = await h.root("Original question", "Original answer");
+		expect(await h.controller.startFollowUp(root.id, "Successful continuation")).toBe(true);
+		const result = answer("Latest complete answer");
+		result.assistantMessage.providerPayload = {
+			type: "openaiResponsesHistory",
+			provider: "openai-codex",
+			dt: true,
+			items: [{ type: "reasoning", encrypted_content: "private-provider-payload" }],
+		};
+		h.requests.at(-1)!.resolve(result);
+		await drain();
+		await h.controller.flush();
+		const copy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+		const overlay = vi.spyOn(h.ctx.ui, "showOverlay");
+		await h.controller.start("");
+		const panel = overlay.mock.calls.at(-1)?.[0];
+		if (!(panel instanceof BtwHistoryPanel)) throw new Error("Expected BTW history panel");
+		panel.handleInput("c");
+		await drain();
+		expect(copy).toHaveBeenCalledWith("Latest complete answer");
+
+		expect(await h.controller.startFollowUp(root.id, "Failing continuation")).toBe(true);
+		h.requests.at(-1)!.args.onTextDelta?.("Partial failing answer");
+		h.requests.at(-1)!.reject(new Error("Provider disconnected"));
+		await drain();
+		await h.controller.flush();
+		const saved = (await records(h.manager))[0]!;
+		expect(getBtwTurns(saved).map(turn => [turn.answer, turn.status, turn.error])).toEqual([
+			["Original answer", "complete", undefined],
+			["Latest complete answer", "complete", undefined],
+			["Partial failing answer", "error", "Provider disconnected"],
+		]);
+		expect(JSON.stringify(saved)).not.toContain("private-provider-payload");
+	});
+
+	it("rejects blank questions and overlapping starts without adding turns or aborting the accepted request", async () => {
+		const h = await harness();
+		const root = await h.root("Root", "Answer");
+		const before = await records(h.manager);
+		expect(await h.controller.startFollowUp(root.id, " \n\t ")).toBe(false);
+		expect(await records(h.manager)).toEqual(before);
+		expect(h.runEphemeralTurn).toHaveBeenCalledTimes(1);
+
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		vi.spyOn(h.manager, "ensureOnDisk").mockImplementation(async () => {
+			entered.resolve();
+			await release.promise;
+		});
+		const starting = h.controller.startFollowUp(root.id, "Accepted continuation");
+		await entered.promise;
+		expect(await h.controller.startFollowUp(root.id, "Overlapping start")).toBe(false);
+		release.resolve();
+		expect(await starting).toBe(true);
+		await h.controller.start("Overlapping new root");
+		expect(await h.controller.startFollowUp(root.id, "Overlapping running turn")).toBe(false);
+		expect(h.runEphemeralTurn).toHaveBeenCalledTimes(2);
+		expect(h.requests.at(-1)!.args.signal?.aborted).toBe(false);
+		await h.complete("Accepted answer");
+		const saved = await records(h.manager);
+		expect(saved).toHaveLength(1);
+		expect(saved[0]!.followUps?.map(turn => turn.question)).toEqual(["Accepted continuation"]);
+	});
+
+	it("rotates a cancelled topic transport before a new follow-up while the old request unwinds", async () => {
+		const h = await harness();
+		const root = await h.root("Topic", "Original answer");
+		expect(await h.controller.startFollowUp(root.id, "Cancelled request")).toBe(true);
+		const cancelled = h.requests.at(-1)!;
+		cancelled.args.onTextDelta?.("Partial answer");
+		expect(h.controller.handleCancel()).toBe(true);
+		expect(await h.controller.startFollowUp(root.id, "New request")).toBe(true);
+		const current = h.requests.at(-1)!;
+		expect(current.args.conversationKey).not.toBe(cancelled.args.conversationKey);
+		cancelled.args.onTextDelta?.("Stale output");
+		cancelled.resolve(answer("Stale final answer"));
+		await h.complete("Current answer");
+		const saved = (await records(h.manager))[0]!;
+		expect(getBtwTurns(saved).map(turn => [turn.answer, turn.status])).toEqual([
+			["Original answer", "complete"],
+			["Partial answer", "cancelled"],
+			["Current answer", "complete"],
+		]);
+		expect(await h.controller.startFollowUp(root.id, "Continue successfully")).toBe(true);
+		expect(h.requests.at(-1)!.args.conversationKey).toBe(current.args.conversationKey);
+		await h.complete("Continued answer");
+	});
+
+	it("ignores late stream and result after disposal while a different session runs its own follow-up", async () => {
+		const h = await harness();
+		const oldRoot = await h.root("Old root", "Old answer");
+		expect(await h.controller.startFollowUp(oldRoot.id, "Old follow-up")).toBe(true);
+		const oldRequest = h.requests.at(-1)!;
+		oldRequest.args.onTextDelta?.("Old partial answer");
+		await h.controller.dispose();
+		expect(oldRequest.args.signal?.aborted).toBe(true);
+
+		const next = SessionManager.create(h.directory, h.directory);
+		h.managers.push(next);
+		h.ctx.sessionManager = next;
+		const newRoot = await h.root("New root", "New answer");
+		expect(await h.controller.startFollowUp(newRoot.id, "New follow-up")).toBe(true);
+		oldRequest.args.onTextDelta?.("Leaked late delta");
+		oldRequest.resolve(answer("Leaked late result"));
+		await drain();
+		await h.complete("New follow-up answer");
+		await h.controller.dispose();
+		const oldSaved = (await records(h.manager))[0]!;
+		expect(getBtwTurns(oldSaved).map(turn => [turn.answer, turn.status])).toEqual([
+			["Old answer", "complete"],
+			["Old partial answer", "cancelled"],
+		]);
+		const newSaved = await records(next);
+		expect(newSaved).toHaveLength(1);
+		expect(newSaved[0]!.id).toBe(newRoot.id);
+		expect(getBtwTurns(newSaved[0]!).map(turn => [turn.answer, turn.status])).toEqual([
+			["New answer", "complete"],
+			["New follow-up answer", "complete"],
+		]);
+	});
+
+	it("refuses a follow-up whose asynchronous start outlives disposal and a session switch", async () => {
+		const h = await harness();
+		const root = await h.root("Old root", "Original answer");
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		vi.spyOn(h.manager, "ensureOnDisk").mockImplementation(async () => {
+			entered.resolve();
+			await release.promise;
+		});
+		const starting = h.controller.startFollowUp(root.id, "Must not cross sessions");
+		await entered.promise;
+		await h.controller.dispose();
+		const next = SessionManager.create(h.directory, h.directory);
+		h.managers.push(next);
+		h.ctx.sessionManager = next;
+		release.resolve();
+		expect(await starting).toBe(false);
+		expect(h.runEphemeralTurn).toHaveBeenCalledTimes(1);
+		expect(await records(next)).toEqual([]);
+		expect((await records(h.manager))[0]!.followUps ?? []).toEqual([]);
+	});
+});
+
+function composer(onFollowUp: (record: BtwHistoryRecord, question: string) => Promise<boolean>) {
+	const record: BtwHistoryRecord = {
+		id: "composer-root",
+		leafId: "main-leaf",
+		question: "Original question",
+		answer: "Original answer",
+		status: "complete",
+		createdAt: 1,
+		updatedAt: 2,
+	};
+	const onClose = vi.fn();
+	const onCopy = vi.fn();
+	const onCancel = vi.fn();
+	const panel = new BtwHistoryPanel({
+		records: [record],
+		onClose,
+		onCopy,
+		onCancel,
+		canFollowUp: () => true,
+		onFollowUp,
+		requestRender: vi.fn(),
+		getHeight: () => 30,
+	});
+	panel.render(100);
+	return { panel, record, onClose, onCopy, onCancel };
+}
+
+describe("BTW follow-up composer", () => {
+	it("uses Tab for pane navigation and Enter to open, then submit, a follow-up", async () => {
+		const followUp = vi.fn(async () => true);
+		const h = composer(followUp);
+		h.panel.handleInput("\t");
+		h.panel.handleInput("c");
+		expect(h.onCopy).toHaveBeenCalledTimes(1);
+		expect(followUp).not.toHaveBeenCalled();
+
+		h.panel.handleInput("\r");
+		expect(followUp).not.toHaveBeenCalled();
+		h.panel.pasteText("A follow-up");
+		h.panel.handleInput("\r");
+		await drain();
+		expect(followUp).toHaveBeenCalledWith(h.record, "A follow-up");
+	});
+
+	it("treats f/c/x as draft text and lets Escape cancel only the composer", () => {
+		const followUp = vi.fn(async () => true);
+		const h = composer(followUp);
+		h.panel.handleInput("f");
+		h.panel.render(100);
+		for (const key of ["f", "c", "x"]) h.panel.handleInput(key);
+		expect(Bun.stripANSI(h.panel.render(100).join("\n"))).toContain("fcx");
+		h.panel.handleInput("\x1b");
+		h.panel.render(100);
+		expect(followUp).not.toHaveBeenCalled();
+		expect(h.onCopy).not.toHaveBeenCalled();
+		expect(h.onCancel).not.toHaveBeenCalled();
+		expect(h.onClose).not.toHaveBeenCalled();
+		h.panel.handleInput("\x1b");
+		expect(h.onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("submits once while pending and retains the rejected draft for a successful retry", async () => {
+		const pending = Promise.withResolvers<boolean>();
+		const followUp = vi.fn((_record: BtwHistoryRecord, _question: string) => pending.promise);
+		const h = composer(followUp);
+		h.panel.handleInput("f");
+		h.panel.render(100);
+		for (const key of ["f", "c", "x"]) h.panel.handleInput(key);
+		h.panel.handleInput("\r");
+		h.panel.render(100);
+		h.panel.handleInput("\r");
+		expect(followUp).toHaveBeenCalledTimes(1);
+		expect(followUp).toHaveBeenCalledWith(h.record, "fcx");
+		pending.resolve(false);
+		await drain();
+		expect(Bun.stripANSI(h.panel.render(100).join("\n"))).toContain("fcx");
+		followUp.mockResolvedValue(true);
+		h.panel.handleInput("\r");
+		await drain();
+		h.panel.render(100);
+		expect(followUp).toHaveBeenCalledTimes(2);
+		expect(followUp.mock.calls[1]).toEqual([h.record, "fcx"]);
+		h.panel.handleInput("c");
+		expect(h.onCopy).toHaveBeenCalledWith(h.record);
+		expect(h.onCancel).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/btw-history.test.ts
+++ b/packages/coding-agent/test/btw-history.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type BtwHistoryRecord, BtwHistoryStore } from "@oh-my-pi/pi-coding-agent/session/btw-history";
+
+describe("BtwHistoryStore", () => {
+	let directory: string;
+	let artifactsDir: string;
+
+	beforeEach(async () => {
+		directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-btw-history-"));
+		artifactsDir = path.join(directory, "session");
+	});
+
+	afterEach(async () => {
+		await fs.rm(directory, { recursive: true, force: true });
+	});
+
+	function record(id: string, overrides: Partial<BtwHistoryRecord> = {}): BtwHistoryRecord {
+		return {
+			id,
+			question: `Question ${id}`,
+			answer: `Answer ${id}`,
+			status: "complete",
+			createdAt: 1,
+			updatedAt: 2,
+			leafId: "main-leaf",
+			...overrides,
+		};
+	}
+
+	it("retains every entry after reopen without changing the main journal", async () => {
+		const journalPath = `${artifactsDir}.jsonl`;
+		const journal = '{"type":"session","id":"session"}\n';
+		await Bun.write(journalPath, journal);
+		const store = await BtwHistoryStore.open(artifactsDir);
+		const first = record("first");
+		const newerB = record("newer-b", { createdAt: 10, updatedAt: 11 });
+		const newerA = record("newer-a", { createdAt: 10, updatedAt: 12, status: "error", error: "Connection lost" });
+		await store.upsert(first);
+		await store.upsert(newerB);
+		await store.upsert(newerA);
+		await store.upsert({ ...first, answer: "Revised answer", updatedAt: 20 });
+		await store.flush();
+
+		const reopened = await BtwHistoryStore.open(artifactsDir);
+		expect(reopened.getRecords()).toEqual([newerA, newerB, { ...first, answer: "Revised answer", updatedAt: 20 }]);
+		expect(await Bun.file(journalPath).text()).toBe(journal);
+	});
+
+	it("recovers unfinished answers as interrupted without overwriting a live writer", async () => {
+		const writer = await BtwHistoryStore.open(artifactsDir);
+		const running = record("running", { status: "running", answer: "Partial answer" });
+		await writer.upsert(running);
+		const recovered = await BtwHistoryStore.open(artifactsDir);
+		expect(recovered.getRecords()).toEqual([{ ...running, status: "interrupted" }]);
+
+		const complete = { ...running, status: "complete" as const, answer: "Final answer", updatedAt: 3 };
+		await writer.upsert(complete);
+		await recovered.flush();
+		expect((await BtwHistoryStore.open(artifactsDir)).getRecords()).toEqual([complete]);
+	});
+
+	it("does not lose independent entries written by stores opened before either write", async () => {
+		const left = await BtwHistoryStore.open(artifactsDir);
+		const right = await BtwHistoryStore.open(artifactsDir);
+		const first = record("left");
+		const second = record("right", { status: "cancelled", answer: "Partial cancelled answer" });
+		await Promise.all([left.upsert(first), right.upsert(second)]);
+		await Promise.all([left.flush(), right.flush()]);
+		expect((await BtwHistoryStore.open(artifactsDir)).getRecords()).toEqual([first, second]);
+	});
+
+	it("captures streaming snapshots before queued writes and keeps old views stable", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		const streaming = record("streaming", { status: "running", answer: "Captured partial" });
+		const pending = store.upsert(streaming);
+		const oldView = store.getRecords();
+		streaming.answer = "Uncheckpointed text";
+		streaming.status = "complete";
+		await pending;
+		expect((await BtwHistoryStore.open(artifactsDir)).getRecords()[0]).toEqual({
+			...streaming,
+			answer: "Captured partial",
+			status: "interrupted",
+		});
+
+		await store.upsert(streaming);
+		expect(oldView[0]?.answer).toBe("Captured partial");
+		expect(oldView[0]?.status).toBe("running");
+		expect((await BtwHistoryStore.open(artifactsDir)).getRecords()).toEqual([streaming]);
+	});
+
+	it("snapshots nested follow-ups and recovers only unfinished turns", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		const followUp = {
+			question: "Continue this topic",
+			answer: "Partial",
+			status: "running" as const,
+			createdAt: 3,
+			updatedAt: 4,
+		};
+		const topic = record("topic", { followUps: [followUp] });
+		const writing = store.upsert(topic);
+		followUp.answer = "Uncheckpointed";
+		await writing;
+		expect(store.getRecords()[0]?.followUps?.[0]?.answer).toBe("Partial");
+		const recovered = (await BtwHistoryStore.open(artifactsDir)).getRecords()[0]!;
+		expect(recovered.status).toBe("complete");
+		expect(recovered.answer).toBe("Answer topic");
+		expect(recovered.followUps).toEqual([{ ...followUp, answer: "Partial", status: "interrupted" }]);
+		const raw = await Bun.file(path.join(artifactsDir, "btw-history", "entry-topic.json")).json();
+		expect(raw.followUps[0].status).toBe("running");
+	});
+
+	it("surfaces malformed JSON without replacing any saved bytes", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		await store.upsert(record("valid", { status: "running" }));
+		const corruptPath = path.join(artifactsDir, "btw-history", "entry-corrupt.json");
+		const invalid = '{"id":"corrupt",';
+		await Bun.write(corruptPath, invalid);
+		const validPath = path.join(artifactsDir, "btw-history", "entry-valid.json");
+		const validBefore = await Bun.file(validPath).text();
+
+		await expect(BtwHistoryStore.open(artifactsDir)).rejects.toThrow("Failed to read BTW history");
+		expect(await Bun.file(corruptPath).text()).toBe(invalid);
+		expect(await Bun.file(validPath).text()).toBe(validBefore);
+	});
+
+	it("rejects unknown fields, invalid status, nonfinite timestamps, and mismatched identities", async () => {
+		const historyDir = path.join(artifactsDir, "btw-history");
+		await fs.mkdir(historyDir, { recursive: true });
+		const filePath = path.join(historyDir, "entry-record.json");
+		const malformed = [
+			JSON.stringify({ ...record("record"), injectedContext: "must not persist" }),
+			JSON.stringify({ ...record("record"), status: "queued" }),
+			JSON.stringify(record("record")).replace('"createdAt":1', '"createdAt":1e999'),
+			JSON.stringify(record("different-id")),
+		];
+		for (const content of malformed) {
+			await Bun.write(filePath, content);
+			await expect(BtwHistoryStore.open(artifactsDir)).rejects.toThrow("Failed to read BTW history");
+			expect(await Bun.file(filePath).text()).toBe(content);
+		}
+	});
+
+	it("rejects traversal ids before creating files or accepting the record", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		await expect(store.upsert(record("../../outside"))).rejects.toThrow("Invalid BTW history record id");
+		expect(store.getRecords()).toEqual([]);
+		expect(await fs.readdir(directory)).toEqual([]);
+	});
+
+	it("retains write failures through flush and refuses to overwrite later corruption", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		const saved = record("saved");
+		await store.upsert(saved);
+		const filePath = path.join(artifactsDir, "btw-history", "entry-saved.json");
+		await Bun.write(filePath, "broken");
+		await expect(store.upsert({ ...saved, answer: "Replacement" })).rejects.toThrow("Failed to read BTW history");
+		await expect(store.flush()).rejects.toThrow("Failed to read BTW history");
+		await expect(store.upsert(record("later"))).rejects.toThrow("Failed to read BTW history");
+		await expect(store.flush()).rejects.toThrow("Failed to read BTW history");
+		expect(await Bun.file(filePath).text()).toBe("broken");
+		expect(await fs.readdir(path.dirname(filePath))).toEqual(["entry-saved.json"]);
+	});
+
+	it("publishes private records and removes staged files after queued writes drain", async () => {
+		const store = await BtwHistoryStore.open(artifactsDir);
+		const first = store.upsert(record("first"));
+		const second = store.upsert(record("second"));
+		await store.flush();
+		await Promise.all([first, second]);
+		const historyDir = path.join(artifactsDir, "btw-history");
+		expect((await fs.readdir(historyDir)).sort()).toEqual(["entry-first.json", "entry-second.json"]);
+		if (process.platform !== "win32") {
+			expect((await fs.stat(historyDir)).mode & 0o777).toBe(0o700);
+			expect((await fs.stat(path.join(historyDir, "entry-first.json"))).mode & 0o777).toBe(0o600);
+		}
+	});
+});

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -117,6 +117,8 @@ async function createContext() {
 	const handleBtwCopyKey = vi.fn(async () => true);
 	const canBranchBtw = vi.fn(() => false);
 	const canCopyBtw = vi.fn(() => false);
+	const canFollowUpBtw = vi.fn(() => false);
+	const handleBtwFollowUpKey = vi.fn(() => true);
 	const hasActiveBtw = vi.fn(() => false);
 	const handlesBtwBranchKey = vi.fn(() => false);
 	const editor: FakeEditor = {
@@ -233,6 +235,8 @@ async function createContext() {
 		canBranchBtw,
 		canCopyBtw,
 		handleBtwCopyKey,
+		canFollowUpBtw,
+		handleBtwFollowUpKey,
 		showError,
 		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
@@ -270,6 +274,8 @@ async function createContext() {
 			handlesBtwBranchKey,
 			handleBtwCopyKey,
 			canCopyBtw,
+			canFollowUpBtw,
+			handleBtwFollowUpKey,
 			showError,
 		},
 	};
@@ -528,6 +534,26 @@ describe("InputController keybinding setup", () => {
 		expect(focusedPasteText).not.toHaveBeenCalled();
 		expect(editor.pendingImages).toHaveLength(0);
 		expect(editor.getText()).toBe("");
+	});
+
+	it("opens inline follow-up only with an empty focused editor and a ready BTW answer", async () => {
+		const { InputController, ctx, editor, setFocused, spies } = await createContext();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+		const listeners = registeredInputListeners(spies.addInputListener);
+
+		expect(dispatchInput(listeners, "f")).toBeUndefined();
+		spies.canFollowUpBtw.mockReturnValue(true);
+		editor.setText("finish this draft");
+		expect(dispatchInput(listeners, "f")).toBeUndefined();
+		editor.setText("");
+		setFocused({ pasteText: vi.fn() });
+		expect(dispatchInput(listeners, "f")).toBeUndefined();
+		expect(spies.handleBtwFollowUpKey).not.toHaveBeenCalled();
+
+		setFocused(ctx.editor);
+		expect(dispatchInput(listeners, "f")).toEqual({ consume: true });
+		expect(spies.handleBtwFollowUpKey).toHaveBeenCalledTimes(1);
 	});
 
 	it("routes c to copy a copyable /btw panel when the editor is empty", async () => {

--- a/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BtwHistoryPanel } from "@oh-my-pi/pi-coding-agent/modes/components/btw-history-panel";
+import { BtwHistoryStore } from "@oh-my-pi/pi-coding-agent/session/btw-history";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { BtwPanelComponent } from "@oh-my-pi/pi-coding-agent/modes/components/btw-panel";
 import { BtwController } from "@oh-my-pi/pi-coding-agent/modes/controllers/btw-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -54,12 +60,20 @@ function makeCtx(session: InteractiveModeContext["session"], btwContainer = new 
 	let leafId: string | null = "leaf-1";
 	let sessionId = "session-1";
 	return {
-		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+		ui: {
+			requestRender: vi.fn(),
+			requestComponentRender: vi.fn(),
+			showOverlay: vi.fn(() => ({ hide: vi.fn() })),
+			setFocus: vi.fn(),
+			terminal: { rows: 30 },
+		} as unknown as TUI,
 		btwContainer,
 		session,
 		sessionManager: {
 			getLeafId: () => leafId,
 			getSessionId: () => sessionId,
+			getArtifactsDir: () => undefined,
+			ensureOnDisk: async () => {},
 		} as unknown as InteractiveModeContext["sessionManager"],
 		showStatus: vi.fn(),
 		showError: vi.fn(),
@@ -99,106 +113,26 @@ describe("BtwPanelComponent", () => {
 		panel.setAnswer("Answer");
 		expect(panel.isBranchable()).toBe(true);
 	});
-
-	it("advertises copy and branch actions after a complete non-empty answer", () => {
-		const ui = { requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI;
-		const panel = new BtwPanelComponent({ question: "Question?", tui: ui });
-
-		panel.setAnswer("Answer");
-		panel.markComplete();
-
-		const rendered = Bun.stripANSI(panel.render(120).join("\n"));
-		expect(rendered).toContain("c copy");
-		expect(rendered).toContain("b branch to chat");
-		expect(rendered).toContain("Esc dismiss");
-	});
-
-	it("hides the branch action when the controller rejects the current leaf", () => {
-		const ui = { requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI;
-		const panel = new BtwPanelComponent({ question: "Question?", tui: ui, canBranch: () => false });
-
-		panel.setAnswer("Answer");
-		panel.markComplete();
-
-		const rendered = Bun.stripANSI(panel.render(120).join("\n"));
-		expect(rendered).toContain("c copy");
-		expect(rendered).not.toContain("b branch to chat");
-	});
 });
 
 describe("BtwController", () => {
-	it("dispatches the question to runEphemeralTurn with the btw prompt wrapper and a fresh signal", async () => {
-		const runEphemeralTurn = vi.fn(async (_args: RunEphemeralTurnArgs) => ({
-			replyText: "Answer",
-			assistantMessage: createAssistantMessage("Answer"),
-		}));
+	it("refuses a second question without cancelling the running request, even when hidden", async () => {
+		const first = Promise.withResolvers<RunEphemeralTurnResult>();
+		const runEphemeralTurn = vi.fn((_args: RunEphemeralTurnArgs) => first.promise);
 		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
 		const controller = new BtwController(ctx);
 
-		await controller.start("What changed?");
-		// Drain microtasks so the inner promise can resolve.
-		await Promise.resolve();
-		await Promise.resolve();
+		await controller.start("First?");
+		controller.handleEscape();
+		await controller.start("Second?");
 
 		expect(runEphemeralTurn).toHaveBeenCalledTimes(1);
-		const callArg = runEphemeralTurn.mock.calls[0]?.[0];
-		expect(callArg).toBeDefined();
-		expect(callArg?.promptText).toContain("<btw>");
-		expect(callArg?.promptText).toContain("What changed?");
-		expect(callArg?.signal).toBeInstanceOf(AbortSignal);
-		expect(typeof callArg?.onTextDelta).toBe("function");
-		expect(controller.hasActiveRequest()).toBe(true);
-	});
-
-	it("renders completed /btw answers with copy and branch affordances", async () => {
-		const runEphemeralTurn = vi.fn(async () => ({
-			replyText: "Answer",
-			assistantMessage: createAssistantMessage("Answer"),
-		}));
-		const btwContainer = new Container();
-		const ctx = makeCtx(makeFakeSession(runEphemeralTurn), btwContainer);
-		const controller = new BtwController(ctx);
-
-		await controller.start("What changed?");
-		await drainBtwRequest();
-
-		const panel = btwContainer.children[0] as BtwPanelComponent | undefined;
-		expect(panel).toBeDefined();
-		const rendered = Bun.stripANSI(panel?.render(120).join("\n") ?? "");
-		expect(rendered).toContain("c copy");
-		expect(rendered).toContain("b branch to chat");
-	});
-
-	it("replaces a previous request by aborting it before issuing the next runEphemeralTurn", async () => {
-		const signals: AbortSignal[] = [];
-		const first = Promise.withResolvers<RunEphemeralTurnResult>();
-		const firstPromise = first.promise;
-		const runEphemeralTurn = vi
-			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
-			.mockImplementationOnce(async args => {
-				signals.push(args.signal as AbortSignal);
-				return firstPromise;
-			})
-			.mockImplementationOnce(async args => {
-				signals.push(args.signal as AbortSignal);
-				return { replyText: "second", assistantMessage: createAssistantMessage("second") };
-			});
-		const btwContainer = new Container();
-		const ctx = makeCtx(makeFakeSession(runEphemeralTurn), btwContainer);
-		const controller = new BtwController(ctx);
-
-		await controller.start("First?");
-		await controller.start("Second?");
-		// Allow the second call to settle.
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(runEphemeralTurn).toHaveBeenCalledTimes(2);
-		expect(signals[0]?.aborted).toBe(true);
-		expect(signals[1]?.aborted).toBe(false);
-		expect(btwContainer.children).toHaveLength(1);
-		// Allow the orphaned first request to finish to keep the test clean.
+		expect(runEphemeralTurn.mock.calls[0]?.[0].signal?.aborted).toBe(false);
 		first.resolve({ replyText: "first", assistantMessage: createAssistantMessage("first") });
+		await drainBtwRequest();
+		await controller.start("Third?");
+		expect(runEphemeralTurn).toHaveBeenCalledTimes(2);
+		await controller.dispose();
 	});
 
 	it("clears the panel when the active request is dismissed via Escape", async () => {
@@ -214,17 +148,18 @@ describe("BtwController", () => {
 		expect(controller.hasActiveRequest()).toBe(false);
 	});
 
-	it("rejects empty questions before issuing the side-channel call", async () => {
+	it("opens history without a model request when invoked without a question", async () => {
 		const runEphemeralTurn = vi.fn(async () => ({
 			replyText: "n/a",
 			assistantMessage: createAssistantMessage("n/a"),
 		}));
 		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
 		const controller = new BtwController(ctx);
-
 		await controller.start("   ");
 		expect(runEphemeralTurn).not.toHaveBeenCalled();
+		expect(ctx.ui.showOverlay).toHaveBeenCalledTimes(1);
 		expect(controller.hasActiveRequest()).toBe(false);
+		await controller.dispose();
 	});
 
 	it("shows an error message when no model is configured", async () => {
@@ -301,9 +236,6 @@ describe("BtwController", () => {
 		expect(controller.handlesBranchKey()).toBe(true);
 		expect(await controller.handleBranch()).toBe(false);
 		expect(ctx.handleBtwBranch).not.toHaveBeenCalled();
-		expect(ctx.showStatus).toHaveBeenCalledWith("/btw branch unavailable: the session changed since /btw started", {
-			dim: true,
-		});
 	});
 
 	it("refuses a completed branch while the main turn is streaming", async () => {
@@ -320,12 +252,7 @@ describe("BtwController", () => {
 
 		expect(controller.canBranch()).toBe(false);
 		expect(controller.handlesBranchKey()).toBe(true);
-		const panel = btwContainer.children[0];
-		expect(Bun.stripANSI(panel?.render(120).join("\n") ?? "")).not.toContain("b branch to chat");
 		expect(await controller.handleBranch()).toBe(false);
-		expect(ctx.showStatus).toHaveBeenCalledWith("/btw branch unavailable: a turn is still running", {
-			dim: true,
-		});
 	});
 
 	it("does not allow branch after a complete empty reply", async () => {
@@ -405,7 +332,6 @@ describe("BtwController", () => {
 		expect(Bun.stripANSI(panel?.render(120).join("\n") ?? "")).toContain("Branching to chat");
 		expect(controller.handleEscape()).toBe(true);
 		expect(btwContainer.children).toHaveLength(1);
-		expect(ctx.showStatus).toHaveBeenCalledWith("/btw branch is in progress", { dim: true });
 
 		branch.resolve();
 		await branchPromise;
@@ -466,7 +392,6 @@ describe("BtwController", () => {
 		expect(controller.canCopy()).toBe(true);
 		expect(await controller.handleCopy()).toBe(true);
 		expect(copySpy).toHaveBeenCalledWith(replaceTabs("Visible\tanswer\n\nfrom /btw"));
-		expect(ctx.showStatus).toHaveBeenCalledWith("Copied /btw answer to clipboard");
 	});
 
 	it("does not copy running, empty, or errored /btw answers", async () => {
@@ -602,5 +527,76 @@ describe("BtwController", () => {
 		expect(disposeController.canBranch()).toBe(true);
 		disposeController.dispose();
 		expect(disposeController.canBranch()).toBe(false);
+	});
+
+	it("keeps hidden answers across resume without changing the main journal or model context", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-btw-history-controller-"));
+		const manager = SessionManager.create(directory, directory);
+		const session = makeFakeSession(async () => ({
+			replyText: "Saved side answer",
+			assistantMessage: createAssistantMessage("Saved side answer"),
+		}));
+		const ctx = makeCtx(session);
+		const showOverlay = vi.spyOn(ctx.ui, "showOverlay");
+		ctx.sessionManager = manager;
+		const controller = new BtwController(ctx);
+		try {
+			manager.appendMessage({ role: "user", content: "Main task", timestamp: Date.now() });
+			await manager.ensureOnDisk();
+			const file = manager.getSessionFile()!;
+			const before = await Bun.file(file).text();
+			const leaf = manager.getLeafId();
+			await controller.start("Side question");
+			controller.handleEscape();
+			await drainBtwRequest();
+			await controller.flush();
+			expect(await Bun.file(file).text()).toBe(before);
+			expect(manager.getLeafId()).toBe(leaf);
+			expect(JSON.stringify(manager.buildSessionContext().messages)).not.toContain("Saved side answer");
+			await controller.dispose();
+
+			const restored = new BtwController(ctx);
+			await restored.start("");
+			const panel = showOverlay.mock.calls.at(-1)?.[0];
+			if (!(panel instanceof BtwHistoryPanel)) throw new Error("Expected BTW history");
+			const copy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+			panel.handleInput("c");
+			await drainBtwRequest();
+			expect(copy).toHaveBeenCalledWith("Saved side answer");
+			await restored.dispose();
+		} finally {
+			await controller.dispose();
+			await manager.flush();
+			await fs.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("persists cancellation and ignores late output after switching sessions", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-btw-cancel-"));
+		const pending = Promise.withResolvers<RunEphemeralTurnResult>();
+		const run = vi.fn((_args: RunEphemeralTurnArgs) => pending.promise);
+		const ctx = makeCtx(makeFakeSession(run));
+		const showOverlay = vi.spyOn(ctx.ui, "showOverlay");
+		ctx.sessionManager = SessionManager.create(directory, directory);
+		const controller = new BtwController(ctx);
+		try {
+			await controller.start("Cancel this");
+			const artifacts = ctx.sessionManager.getArtifactsDir()!;
+			run.mock.calls[0]?.[0].onTextDelta?.("Partial answer");
+			await controller.dispose();
+			ctx.sessionManager = SessionManager.inMemory();
+			pending.resolve({ replyText: "Late answer", assistantMessage: createAssistantMessage("Late answer") });
+			await drainBtwRequest();
+			await controller.flush();
+			const saved = (await BtwHistoryStore.open(artifacts)).getRecords();
+			expect(saved.map(record => [record.answer, record.status])).toEqual([["Partial answer", "cancelled"]]);
+			await controller.start("");
+			const panel = showOverlay.mock.calls.at(-1)?.[0];
+			if (!(panel instanceof BtwHistoryPanel)) throw new Error("Expected BTW history");
+			expect(Bun.stripANSI(panel.render(100).join("\n"))).not.toContain("Partial answer");
+		} finally {
+			await controller.dispose();
+			await fs.rm(directory, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
While using Oh My Pi, I often want to ask follow-up questions or revisit earlier `/btw` exchanges. Creating a full chat branch can be unnecessarily heavy for a quick follow-up and promotes an otherwise temporary side discussion into the new branch’s context.

Previously, dismissing the `/btw` panel with `Esc` discarded the exchange, and starting another `/btw` replaced the previous one. There was no way to keep multiple side conversations available for later reference.

This change adds persistent `/btw` history and lightweight follow-ups, making it easier to revisit and continue side conversations while keeping them separate from the main task’s context.

## What

Add persistent, session-local `/btw` history and follow-up conversations.

- Bare `/btw` opens a themed history/details panel with keyboard navigation, scrolling, copying, and cancellation.
- `/btw <question>` starts an independent side conversation without replacing a running request.
- Completed inline answers support `f` to follow up directly. In history, `Tab` switches panes and `Enter` or `f` opens the follow-up input.
- Questions, answers, and follow-ups persist alongside the session. Cancelled requests retain partial output; unfinished records reopen as interrupted without automatic replay.
- Follow-ups preserve separate user/assistant messages and reuse an isolated, topic-specific provider session for caching. Cancellation or failure starts a fresh transport generation.
- Side conversations remain outside the main transcript and model context. Existing inline branch-to-chat behavior and its guards are preserved.

## Why

Previously, `/btw` kept only one transient answer. Starting another question replaced the previous panel and cancelled any active request; dismissing the panel discarded the stored answer state.

Users should be able to revisit side questions and continue a selected topic without copying its history into a new prompt or interrupting the main task.

Flattening previous questions and answers into a single user message also changed the conversation structure. Structured replay preserves the message sequence, while stable, isolated topic routing enables cache reuse without sharing the main task’s provider conversation.

## Testing

- `bun run check` passed in `packages/coding-agent`, including lint, formatting, and TypeScript checks.
- **156 tests passed across 10 focused test files**, covering persistence, interrupted recovery, context isolation, structured replay, transport rotation, cancellation races, keyboard routing, and existing branch behavior.
- Exercised the actual TUI with GPT-6 Astra: new side questions, direct inline follow-up, history navigation, copying, cancellation, and recovery after restarting.
- Checked panel rendering and input behavior at wide and narrow terminal sizes.
- Measured three consecutive production-path requests with a stable main context:
  - Initial question: **25,384 uncached input tokens**, no cache read.
  - First follow-up: **25,216 cached + 253 uncached input tokens** — **99.01%** cached.
  - Second follow-up: **25,344 cached + 210 uncached input tokens** — **99.18%** cached.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)