### PR TITLE
feat(ai): add provider-native byte-pass gateway transport

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2076,6 +2076,7 @@ function recoverTransientErrorToolTurn(
 	availableTools: ReadonlyArray<Pick<AgentTool, "name" | "customWireName">>,
 ): AssistantMessage {
 	if (message.stopReason !== "error") return message;
+	if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return message;
 	const toolCalls = message.content.filter(block => block.type === "toolCall");
 	if (toolCalls.length === 0) return message;
 	const stopDetailType = message.stopDetails?.type;

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -19,6 +19,8 @@ import {
 
 export const Flag = {
 	Class: 0x1000,
+	/** The attempt must not be repeated by automatic retry or model fallback. */
+	NoRetry: 0x0000_0800,
 	ThinkingLoop: 0x0001_0000,
 	Transient: 0x0002_0000,
 	Timeout: 0x0004_0000,
@@ -48,6 +50,7 @@ export const Flag = {
 export type Flag = (typeof Flag)[keyof typeof Flag];
 
 const KIND_MASK =
+	Flag.NoRetry |
 	Flag.ThinkingLoop |
 	Flag.Transient |
 	Flag.Timeout |
@@ -285,6 +288,7 @@ export function isOAuthExpiry(errorMessage: string): boolean {
 }
 
 const ERROR_KIND_LABELS: readonly [Flag, string][] = [
+	[Flag.NoRetry, "no-retry"],
 	[Flag.ThinkingLoop, "thinking-loop"],
 	[Flag.Transient, "transient"],
 	[Flag.Timeout, "timeout"],
@@ -322,6 +326,7 @@ export function is(id: number | undefined, flag: Flag): boolean {
 }
 
 export function retriable(id: number | undefined, opts?: { replayUnsafe?: boolean }): boolean {
+	if (is(id, Flag.NoRetry)) return false;
 	if (is(id, Flag.ContentBlocked)) return false;
 	if (is(id, Flag.PayloadRejected)) return false;
 	if (opts?.replayUnsafe) return false;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1286,6 +1286,9 @@ function foundryTlsOptionsCacheKey(): string {
 }
 
 function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: string): string | undefined {
+	// The wire router owns the gateway destination; provider env overrides must
+	// not change the official URL produced by this codec.
+	if (model.transport === "provider-wire") return normalizeAnthropicBaseUrl(model.baseUrl);
 	if (model.provider === "github-copilot") {
 		return normalizeAnthropicBaseUrl(resolveGitHubCopilotBaseUrl(model.baseUrl, apiKey) ?? model.baseUrl);
 	}
@@ -2924,6 +2927,9 @@ const streamAnthropicOnce = (
 					break;
 				} catch (streamError) {
 					const streamFailure = activeAbortTracker.getLocalAbortReason() ?? streamError;
+					// Only the wire router may replay a pre-execution refusal. A codec
+					// fallback, parse failure, or transport loss cannot prove non-execution.
+					if (model.transport === "provider-wire") throw streamFailure;
 					if (
 						!disableStrictTools &&
 						firstTokenTime === undefined &&
@@ -3128,9 +3134,11 @@ const streamAnthropicOnce = (
  * loop. The inner attempt owns Anthropic provider-failure retries.
  */
 export const streamAnthropic: StreamFunction<"anthropic-messages"> = (model, context, options) =>
-	withReplaySafeStreamRetry(model, context, options, streamAnthropicOnce, {
-		retryEmptyCompletion: true,
-	});
+	model.transport === "provider-wire"
+		? streamAnthropicOnce(model, context, options)
+		: withReplaySafeStreamRetry(model, context, options, streamAnthropicOnce, {
+				retryEmptyCompletion: true,
+			});
 
 export type AnthropicSystemBlock = {
 	type: "text";

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -140,6 +140,8 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	reasoningContext?: CodexReasoningContext;
 	textVerbosity?: "low" | "medium" | "high";
 	codexMode?: boolean;
+	/** Explicit ChatGPT OAuth mode when a credential-holding relay injects the account identity. */
+	isOAuth?: boolean;
 	toolChoice?: ToolChoice;
 	preferWebsockets?: boolean;
 	serviceTier?: ServiceTier;
@@ -303,12 +305,15 @@ export function setCodexAttestationProvider(provider: CodexAttestationProvider |
 
 /**
  * Resolve the `x-oai-attestation` header value for one upstream request.
- * Gated on ChatGPT-OAuth credentials (a Codex JWT carries `chatgpt_account_id`;
- * codex-rs gates on `auth.is_chatgpt_auth()`). A throwing hook degrades to no
- * header rather than failing the request.
+ * Gated on ChatGPT OAuth mode, inferred from the account-bearing JWT for
+ * direct requests or supplied explicitly by a credential-holding relay.
+ * A throwing hook degrades to no header rather than failing the request.
  */
-export async function getCodexAttestationHeader(accountId: string | undefined): Promise<string | undefined> {
-	if (!accountId || !codexAttestationProvider) return undefined;
+export async function getCodexAttestationHeader(
+	accountId: string | undefined,
+	isOAuth = !!accountId,
+): Promise<string | undefined> {
+	if (!isOAuth || !codexAttestationProvider) return undefined;
 	try {
 		return await codexAttestationProvider();
 	} catch {
@@ -1837,7 +1842,7 @@ async function openCodexWebSocketTransport(
 		requestContext.turnState,
 		requestContext.responsesLite,
 		requestContext.requestMetadata,
-		await getCodexAttestationHeader(requestContext.accountId),
+		await getCodexAttestationHeader(requestContext.accountId, options?.isOAuth),
 		requestContext.transformedBody,
 	);
 	const requestBodyForState = structuredCloneJSON(requestContext.transformedBody);
@@ -1941,9 +1946,11 @@ async function openCodexSseTransport(
 				requestContext.requestMetadata,
 				requestSetup.requestSignal,
 				requestSetup.firstEventTimeoutMs,
-				options?.codexSseMaxAttempts,
+				model.transport === "provider-wire" ? 1 : options?.codexSseMaxAttempts,
 				event => options?.onSseEvent?.(event, model),
 				options?.fetch,
+				options?.isOAuth,
+				model.transport !== "provider-wire",
 			),
 		);
 	};
@@ -2572,6 +2579,9 @@ class CodexStreamProcessor {
 	}
 
 	async #recoverStreamError(error: unknown): Promise<boolean> {
+		// A received SSE stream proves the request started. The wire transport
+		// must not replay even a pre-content parse/timeout/provider failure.
+		if (this.model.transport === "provider-wire") return false;
 		if (await this.#tryRecoverWhitespaceToolCallLoop(error)) {
 			return true;
 		}
@@ -3091,7 +3101,14 @@ export async function prewarmOpenAICodexResponses(
 	model: Model<"openai-codex-responses">,
 	options?: Pick<
 		OpenAICodexResponsesOptions,
-		"apiKey" | "headers" | "sessionId" | "signal" | "preferWebsockets" | "providerSessionState" | "responsesLite"
+		| "apiKey"
+		| "headers"
+		| "sessionId"
+		| "signal"
+		| "preferWebsockets"
+		| "providerSessionState"
+		| "responsesLite"
+		| "isOAuth"
 	>,
 ): Promise<void> {
 	const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
@@ -3118,7 +3135,7 @@ export async function prewarmOpenAICodexResponses(
 	const turnState = getOrCreateCodexTurnState(metadataSession, sessionKey);
 	const codexClientVersion = CODEX_CLIENT_VERSION;
 	const requestIdentity = createCodexCompatibilityIdentity(metadataSession);
-	const attestation = await getCodexAttestationHeader(accountId);
+	const attestation = await getCodexAttestationHeader(accountId, options?.isOAuth);
 	const headers = logger.time(
 		"prewarmCodex:createHeaders",
 		createCodexHeaders,
@@ -3221,6 +3238,7 @@ function shouldUseCodexWebSocket(
 	state: CodexWebSocketSessionState | undefined,
 	preferWebsockets?: boolean,
 ): boolean {
+	if (model.transport === "provider-wire") return false;
 	// Explicitly disabled by the model or session state.
 	if (model.preferWebsockets === false) return false;
 	// Explicitly disabled by the session state.
@@ -4307,6 +4325,8 @@ async function openCodexSseEventStream(
 	codexSseMaxAttempts: number | undefined,
 	onSseEvent?: OpenAICodexResponsesOptions["onSseEvent"],
 	fetchOverride?: FetchImpl,
+	isOAuth?: boolean,
+	allowEncodingFallback = true,
 ): Promise<AsyncGenerator<Record<string, unknown>>> {
 	const headers = createCodexHeaders(
 		requestHeaders,
@@ -4319,7 +4339,7 @@ async function openCodexSseEventStream(
 		turnState,
 		responsesLite,
 		requestMetadata,
-		await getCodexAttestationHeader(accountId),
+		await getCodexAttestationHeader(accountId, isOAuth),
 		body,
 	);
 	// `wrapCodexSseStream` arms the iterator-level idle watchdog only after this
@@ -4369,7 +4389,11 @@ async function openCodexSseEventStream(
 	let response: Response;
 	try {
 		response = await send(compressedBody ?? bodyJson);
-		if (compressedBody !== undefined && (response.status === 400 || response.status === 415)) {
+		if (
+			allowEncodingFallback &&
+			compressedBody !== undefined &&
+			(response.status === 400 || response.status === 415)
+		) {
 			const rejectedStatus = response.status;
 			await response.body?.cancel();
 			headers.delete("content-encoding");

--- a/packages/ai/src/providers/provider-wire-client.ts
+++ b/packages/ai/src/providers/provider-wire-client.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import { CODEX_BASE_URL, OPENAI_HEADERS } from "@oh-my-pi/pi-catalog/wire/codex";
+import { resolveApiKeyOnce, type ApiKey } from "../auth-retry";
+import { AuthGatewayError, ConfigurationError, OpenAIHttpError } from "../error";
+import type { Api, Context, FetchImpl, Model, OptionsForApi, StreamOptions } from "../types";
+import { getHeaderCaseInsensitive } from "../utils";
+import { AssistantMessageEventStream } from "../utils/event-stream";
+import type { CapturedHttpErrorResponse } from "../utils/http-inspector";
+import { captureOpenAIHttpError } from "../utils/openai-http";
+import { transportFetch } from "../utils/transport-fetch";
+import type { AnthropicOptions } from "./anthropic";
+import type { OpenAICodexResponsesOptions } from "./openai-codex-responses";
+import { streamAnthropic, streamOpenAICodexResponses } from "./register-builtins";
+
+const MAX_ATTEMPTS = 3;
+const PRE_EXECUTION_REFUSALS = new Set([401, 403, 408, 409, 429]);
+const PROVIDER_URLS = {
+	anthropic: "https://api.anthropic.com/v1/messages?beta=true",
+	"openai-codex": `${CODEX_BASE_URL}/codex/responses`,
+} as const;
+
+// No arbitrary header prefix is trusted. In particular, authorization, API keys,
+// cookies, account/residency claims, destination and proxy headers are absent.
+const SAFE_HEADERS: Record<string, true> = {
+	accept: true,
+	"accept-encoding": true,
+	"content-type": true,
+	"content-encoding": true,
+	"user-agent": true,
+	"anthropic-version": true,
+	"anthropic-beta": true,
+	"anthropic-dangerous-direct-browser-access": true,
+	"x-app": true,
+	"x-claude-code-session-id": true,
+	"x-client-request-id": true,
+	"x-stainless-arch": true,
+	"x-stainless-lang": true,
+	"x-stainless-os": true,
+	"x-stainless-package-version": true,
+	"x-stainless-retry-count": true,
+	"x-stainless-runtime": true,
+	"x-stainless-runtime-version": true,
+	"x-stainless-timeout": true,
+	"x-codex-turn-state": true,
+	"x-models-etag": true,
+	[OPENAI_HEADERS.BETA.toLowerCase()]: true,
+	[OPENAI_HEADERS.CODEX_BETA_FEATURES]: true,
+	[OPENAI_HEADERS.ORIGINATOR]: true,
+	[OPENAI_HEADERS.VERSION]: true,
+	[OPENAI_HEADERS.SESSION_ID]: true,
+	[OPENAI_HEADERS.CONVERSATION_ID]: true,
+	[OPENAI_HEADERS.SCOPED_SESSION_ID]: true,
+	[OPENAI_HEADERS.THREAD_ID]: true,
+	[OPENAI_HEADERS.WINDOW_ID]: true,
+	[OPENAI_HEADERS.TURN_METADATA]: true,
+	[OPENAI_HEADERS.PARENT_THREAD_ID]: true,
+	[OPENAI_HEADERS.SUBAGENT]: true,
+	[OPENAI_HEADERS.RESPONSES_LITE]: true,
+	[OPENAI_HEADERS.ATTESTATION]: true,
+	[OPENAI_HEADERS.ROUTING_HINT]: true,
+};
+
+/** The complete gateway error envelope is retained, not flattened into an assistant error string. */
+export class ProviderWireError extends AuthGatewayError {
+	readonly captured: CapturedHttpErrorResponse;
+
+	constructor(captured: CapturedHttpErrorResponse) {
+		const { detail, code } = OpenAIHttpError.parseEnvelope(captured.bodyJson, captured.bodyText);
+		super(detail ?? `auth-gateway ${captured.status}`, captured.status, captured.headers, code);
+		this.name = "ProviderWireError";
+		this.captured = captured;
+	}
+}
+
+function safeHeaders(source: RequestInit["headers"]): Headers {
+	const safe = new Headers();
+	for (const [name, value] of new Headers(source)) {
+		if (SAFE_HEADERS[name] === true) safe.set(name, value);
+	}
+	return safe;
+}
+
+/**
+ * Route already-serialized provider requests to the byte-pass gateway. The
+ * allowlisted provider URL is a codec invariant, never a caller destination.
+ * Retries reuse the same client-owned bytes only after a known refusal.
+ */
+export function createProviderWireFetch(model: Model<Api>, options: StreamOptions): FetchImpl {
+	const provider = model.provider;
+	if (
+		!(
+			(provider === "anthropic" && model.api === "anthropic-messages") ||
+			(provider === "openai-codex" && model.api === "openai-codex-responses")
+		)
+	) {
+		throw new ConfigurationError("provider-wire requires the Anthropic or OpenAI Codex native API");
+	}
+	if (!model.baseUrl) throw new ConfigurationError("provider-wire requires a gateway baseUrl");
+	const gateway = new URL(model.baseUrl);
+	const gatewayHostname = gateway.hostname.replace(/\.$/, "");
+	if (
+		(gateway.protocol !== "https:" && gateway.protocol !== "http:") ||
+		gateway.username ||
+		gateway.password ||
+		gateway.search ||
+		gateway.hash ||
+		gatewayHostname === "api.anthropic.com" ||
+		gatewayHostname === "chatgpt.com"
+	) {
+		throw new ConfigurationError(
+			"provider-wire requires an HTTP(S) gateway URL, not a provider or credential-bearing URL",
+		);
+	}
+	const gatewayUrl = `${gateway.href.replace(/\/+$/, "")}/v1/provider-wire/${provider}`;
+	if (!/^[\x21-\x7e]{1,256}$/.test(model.id)) {
+		throw new ConfigurationError("provider-wire model id must contain 1-256 visible ASCII bytes");
+	}
+	const sessionId = options.sessionId || options.promptCacheKey;
+	if (sessionId !== undefined && Buffer.byteLength(sessionId, "utf8") > 1000) {
+		throw new ConfigurationError("provider-wire session id must not exceed 1000 bytes");
+	}
+	if (!options.apiKey) throw new ConfigurationError("provider-wire requires a gateway bearer");
+	const bearer = options.apiKey;
+	const expectedUrl = PROVIDER_URLS[provider];
+	// Explicitly avoid Anthropic's direct-provider cowork fetch default. Network
+	// policy/debug still comes from the shared transport, at the gateway URL.
+	const gatewayFetch = transportFetch(model, options.fetch ?? globalThis.fetch);
+
+	return async (input, init) => {
+		const url = input instanceof Request ? input.url : String(input);
+		const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+		if (url !== expectedUrl || method !== "POST") {
+			throw new ConfigurationError("provider-wire refused a non-canonical provider request URL or method");
+		}
+		// Both stock codecs serialize into a string or byte array. Do not buffer
+		// an arbitrary stream/Request, or reserialize a body to make it replayable.
+		const body = init?.body;
+		if (typeof body !== "string" && !(body instanceof Uint8Array)) {
+			throw new ConfigurationError("provider-wire requires a serialized provider request body");
+		}
+		const headers = safeHeaders(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+		headers.set("authorization", `Bearer ${bearer}`);
+		headers.set("x-omp-provider-wire-version", "1");
+		headers.set("x-omp-model-id", model.id);
+		if (sessionId !== undefined) headers.set("x-omp-session-id", sessionId);
+		for (const [name, value] of [
+			["x-omp-first-event-timeout-ms", options.streamFirstEventTimeoutMs],
+			["x-omp-idle-timeout-ms", options.streamIdleTimeoutMs],
+		] as const) {
+			if (value === undefined || value === 0) continue;
+			if (!Number.isSafeInteger(value) || value < 0) {
+				throw new ConfigurationError(`${name} must be a positive safe integer`);
+			}
+			headers.set(name, String(value));
+		}
+		const providerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+		const signal =
+			providerSignal && options.signal && providerSignal !== options.signal
+				? AbortSignal.any([providerSignal, options.signal])
+				: (providerSignal ?? options.signal);
+		// Bun's timeout:false keeps the codec's own first/idle watchdogs in charge.
+		const requestInit = {
+			method: "POST",
+			headers,
+			body,
+			signal,
+			redirect: "error",
+			credentials: "omit",
+			timeout: false,
+		} satisfies RequestInit & { timeout: false };
+		for (let attempt = 1; ; attempt++) {
+			signal?.throwIfAborted();
+			// Never follow a redirect with gateway authorization, or inherit a
+			// provider Request's cookies, TLS/proxy settings, Host, or destination.
+			const response = await gatewayFetch(gatewayUrl, requestInit);
+			if (response.ok) return response;
+			const refused =
+				(PRE_EXECUTION_REFUSALS.has(response.status) &&
+					(response.headers.get("x-s99-upstream") === "provider" ||
+						response.headers.get("x-s99-execution") === "none")) ||
+				(response.status === 503 && response.headers.get("x-s99-execution") === "none");
+			if (!refused || attempt >= MAX_ATTEMPTS) {
+				const error = await captureOpenAIHttpError(response);
+				signal?.throwIfAborted();
+				throw new ProviderWireError(error.captured);
+			}
+			await response.body?.cancel();
+			// No catch/retry around fetch: a timeout or connection loss cannot
+			// establish whether the provider executed this request.
+		}
+	};
+}
+
+/** Run the stock provider codecs locally; only auth injection and bytes cross the gateway. */
+export function streamProviderWire<TApi extends Api>(
+	model: Model<TApi>,
+	context: Context,
+	options?: OptionsForApi<TApi>,
+	gatewayKey: ApiKey | undefined = options?.apiKey,
+): AssistantMessageEventStream {
+	const outer = new AssistantMessageEventStream();
+	void (async () => {
+		try {
+			options?.signal?.throwIfAborted();
+			if (options && "client" in options && options.client !== undefined) {
+				throw new ConfigurationError("provider-wire requires the native provider client; customize fetch instead");
+			}
+			if (options?.anthropicCacheRefreshRequest) {
+				throw new ConfigurationError("provider-wire only supports streaming provider requests");
+			}
+			const resolvedKey = await resolveApiKeyOnce(gatewayKey, options?.signal);
+			const authorization =
+				getHeaderCaseInsensitive(options?.headers, "authorization") ??
+				getHeaderCaseInsensitive(model.headers, "authorization");
+			const apiKey = resolvedKey || (authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined);
+			const sessionId = options?.sessionId || options?.promptCacheKey || randomUUID();
+			const routingFetch = createProviderWireFetch(model, { ...options, apiKey, sessionId });
+			let requestFailure: unknown;
+			const fetch: FetchImpl = async (input, init) => {
+				try {
+					return await routingFetch(input, init);
+				} catch (error) {
+					requestFailure = error;
+					throw error;
+				}
+			};
+			const wireOptions = {
+				...options,
+				apiKey,
+				sessionId,
+				fetch,
+				headers: Object.fromEntries(safeHeaders(options?.headers)),
+				isOAuth: true,
+			};
+			const providerModel: Model<TApi> = {
+				...model,
+				transport: "provider-wire",
+				headers: Object.fromEntries(safeHeaders(model.headers)),
+			};
+			let inner: AssistantMessageEventStream;
+			if (model.api === "anthropic-messages") {
+				inner = streamAnthropic(
+					{ ...(providerModel as Model<"anthropic-messages">), baseUrl: "https://api.anthropic.com" },
+					context,
+					wireOptions as AnthropicOptions,
+				);
+			} else {
+				inner = streamOpenAICodexResponses(
+					{
+						...(providerModel as Model<"openai-codex-responses">),
+						baseUrl: CODEX_BASE_URL,
+						preferWebsockets: false,
+					},
+					context,
+					{ ...wireOptions, preferWebsockets: false } as OpenAICodexResponsesOptions,
+				);
+			}
+			for await (const event of inner) {
+				// Native codecs normalize exceptions into assistant error events.
+				// Preserve the gateway's complete error (including arbitrary fields)
+				// and original fetch/abort error instead, as pi-native does.
+				if (event.type === "error") {
+					options?.signal?.throwIfAborted();
+					if (requestFailure !== undefined) {
+						outer.fail(requestFailure);
+						return;
+					}
+				}
+				outer.push(event);
+			}
+			if (!outer.done) outer.end(await inner.result());
+		} catch (error) {
+			outer.fail(error);
+		}
+	})();
+	return outer;
+}

--- a/packages/ai/src/providers/provider-wire-client.ts
+++ b/packages/ai/src/providers/provider-wire-client.ts
@@ -1,7 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { CODEX_BASE_URL, OPENAI_HEADERS } from "@oh-my-pi/pi-catalog/wire/codex";
 import { resolveApiKeyOnce, type ApiKey } from "../auth-retry";
-import { AuthGatewayError, ConfigurationError, OpenAIHttpError } from "../error";
+import {
+	attach,
+	AuthGatewayError,
+	classify,
+	classifyMessage,
+	ConfigurationError,
+	create,
+	Flag,
+	OpenAIHttpError,
+} from "../error";
 import type { Api, Context, FetchImpl, Model, OptionsForApi, StreamOptions } from "../types";
 import { getHeaderCaseInsensitive } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -69,6 +78,7 @@ export class ProviderWireError extends AuthGatewayError {
 		super(detail ?? `auth-gateway ${captured.status}`, captured.status, captured.headers, code);
 		this.name = "ProviderWireError";
 		this.captured = captured;
+		attach(this, create(classify(this), Flag.NoRetry));
 	}
 }
 
@@ -78,6 +88,14 @@ function safeHeaders(source: RequestInit["headers"]): Headers {
 		if (SAFE_HEADERS[name] === true) safe.set(name, value);
 	}
 	return safe;
+}
+
+function forbidReplay(error: unknown): unknown {
+	const target =
+		error !== null && typeof error === "object" && Object.isExtensible(error)
+			? error
+			: new Error(error instanceof Error ? error.message : String(error), { cause: error });
+	return attach(target, create(classify(error), Flag.NoRetry));
 }
 
 /**
@@ -260,9 +278,12 @@ export function streamProviderWire<TApi extends Api>(
 				// Preserve the gateway's complete error (including arbitrary fields)
 				// and original fetch/abort error instead, as pi-native does.
 				if (event.type === "error") {
+					// No decoded output does not prove non-execution. The transport
+					// already owns its bounded known-refusal retries.
+					event.error.errorId = create(classifyMessage(event.error), Flag.NoRetry);
 					options?.signal?.throwIfAborted();
 					if (requestFailure !== undefined) {
-						outer.fail(requestFailure);
+						outer.fail(forbidReplay(requestFailure));
 						return;
 					}
 				}
@@ -270,7 +291,7 @@ export function streamProviderWire<TApi extends Api>(
 			}
 			if (!outer.done) outer.end(await inner.result());
 		} catch (error) {
-			outer.fail(error);
+			outer.fail(forbidReplay(error));
 		}
 	})();
 	return outer;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1049,6 +1049,7 @@ const THINKING_LOOP_RETRY_MAX_DELAY_MS = 8_000;
 function isRetryableThinkingLoop(message: AssistantMessage): boolean {
 	return (
 		message.stopReason === "error" &&
+		!AIError.is(message.errorId, AIError.Flag.NoRetry) &&
 		message.content.length === 0 &&
 		AIError.is(message.errorId, AIError.Flag.ThinkingLoop)
 	);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -36,6 +36,7 @@ import { isKimiModel, streamKimi } from "./providers/kimi";
 import type { OllamaChatOptions } from "./providers/ollama";
 import type { OpenAICompletionsOptions } from "./providers/openai-completions";
 import { streamPiNative } from "./providers/pi-native-client";
+import { streamProviderWire } from "./providers/provider-wire-client";
 // Heavy provider stream functions are imported lazily via register-builtins,
 // which wraps each provider module in a dynamic import. This keeps the
 // AWS SDK, google-auth-library, @google/genai, and
@@ -106,6 +107,11 @@ function isGoogleVertexAuthenticatedModel(model: Model<Api>): boolean {
  * that effective endpoint — exempt only when it resolves to the official host.
  */
 function isLeakedThinkingHealExempt(model: Model<Api>): boolean {
+	// The byte-pass transport has fixed official destinations and local native
+	// decoders, even though the configured baseUrl names a gateway.
+	if (model.transport === "provider-wire") {
+		return model.provider === "anthropic" || model.provider === "openai-codex";
+	}
 	switch (model.provider) {
 		case "anthropic": {
 			// Mirror resolveAnthropicBaseUrl's effective endpoint: Foundry redirects
@@ -897,6 +903,10 @@ function streamDispatch<TApi extends Api>(
 	context: Context,
 	options?: OptionsForApi<TApi>,
 ): AssistantMessageEventStream {
+	// Explicit gateway transport wins over extension and provider routing.
+	if (model.transport === "provider-wire") {
+		return streamProviderWire(model, context, options);
+	}
 	const requestOptions = withTransportFetch(model, (options || {}) as StreamOptions) as OptionsForApi<TApi>;
 	assertExplicitOpenAIResponsesPromptCacheSupport(model, requestOptions);
 
@@ -1085,6 +1095,7 @@ export async function complete<TApi extends Api>(
 	context: Context,
 	options?: OptionsForApi<TApi>,
 ): Promise<AssistantMessage> {
+	if (model.transport === "provider-wire") return stream(model, context, options).result();
 	return resolveWithThinkingLoopRetries(options?.signal, () => stream(model, context, options));
 }
 
@@ -1241,7 +1252,7 @@ function supportsAnthropicCacheRefresh<TApi extends Api>(model: Model<TApi>): bo
 	return (
 		model.api === "anthropic-messages" &&
 		model.provider === "anthropic" &&
-		model.transport !== "pi-native" &&
+		model.transport === undefined &&
 		isLeakedThinkingHealExempt(model)
 	);
 }
@@ -1442,7 +1453,8 @@ export function streamSimple<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
-	const sessionOptions = withInferenceSessionId(options);
+	// Wire routing resolves sessionId > promptCacheKey > a fresh identity itself.
+	const sessionOptions = model.transport === "provider-wire" ? (options ?? {}) : withInferenceSessionId(options);
 	if (!model.requiresGlyphTokenization) {
 		return streamSimpleWithAnthropicCacheRefresh(model, context, sessionOptions);
 	}
@@ -1485,6 +1497,15 @@ function streamSimpleRequest<TApi extends Api>(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
+	// Resolve a gateway bearer once, outside the provider credential-rotation
+	// wrapper. Only the wire fetch may replay a serialized refused request.
+	if (model.transport === "provider-wire") {
+		return withThinkingLoopGuard(model, options, opts =>
+			withProviderInFlightLimit(model, opts, () =>
+				streamProviderWire(model, context, mapOptionsForApi(model, opts), opts?.apiKey),
+			),
+		);
+	}
 	const requestOptions = withTransportFetch(model, (options || {}) as SimpleStreamOptions);
 
 	const apiKeyResolver = isApiKeyResolver(requestOptions?.apiKey) ? requestOptions.apiKey : undefined;
@@ -1739,6 +1760,11 @@ export async function completeSimple<TApi extends Api>(
 	},
 ): Promise<AssistantMessage> {
 	const { onAttempt, ...streamOptions } = options ?? {};
+	if (model.transport === "provider-wire") {
+		const message = await streamSimple(model, context, streamOptions).result();
+		onAttempt?.(message);
+		return message;
+	}
 	const sessionOptions = withInferenceSessionId(streamOptions);
 	return resolveWithThinkingLoopRetries(
 		options?.signal,

--- a/packages/ai/test/error-id.test.ts
+++ b/packages/ai/test/error-id.test.ts
@@ -24,6 +24,17 @@ function message(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
 }
 
 describe("error-id classification", () => {
+	it("preserves a no-retry decision through error causes and persisted diagnostics", () => {
+		const failure = AIError.attach(
+			new Error("stream ended before message_start"),
+			AIError.create(AIError.Flag.NoRetry),
+		);
+		const id = AIError.classify(new Error("503 upstream failure", { cause: failure }));
+		const restored = message({ errorId: id, errorStatus: 503, errorMessage: "timeout" });
+		expect(AIError.retriable(AIError.classifyMessage(restored))).toBe(false);
+		expect(AIError.is(restored.errorId, AIError.Flag.Timeout)).toBe(true);
+	});
+
 	it("composes timeout with transient", () => {
 		const id = AIError.classify(new Error("provider stream stall timeout"), "anthropic-messages");
 		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);

--- a/packages/ai/test/provider-wire-client.test.ts
+++ b/packages/ai/test/provider-wire-client.test.ts
@@ -1,0 +1,552 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import { ConfigurationError } from "@oh-my-pi/pi-ai/error";
+import { applyClaudeToolPrefix } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { setCodexAttestationProvider } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import { createProviderWireFetch, ProviderWireError } from "@oh-my-pi/pi-ai/providers/provider-wire-client";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type {
+	Api,
+	AssistantMessageEvent,
+	Context,
+	FetchImpl,
+	Model,
+	ProviderSessionState,
+} from "@oh-my-pi/pi-ai/types";
+import { __resetProxyCache } from "@oh-my-pi/pi-ai/utils/proxy";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { withEnv } from "./helpers";
+
+const GATEWAY_BEARER = "gateway-bearer-not-an-oauth-token-or-jwt";
+const context: Context = {
+	systemPrompt: ["Use the supplied inspection tool."],
+	messages: [{ role: "user", content: "Inspect the file and explain your reasoning.", timestamp: 1000 }],
+	tools: [{ name: "inspect", description: "Inspect a file", parameters: type({ path: "string" }) }],
+};
+const anthropicModel = buildModel({
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 },
+	contextWindow: 200000,
+	maxTokens: 8192,
+});
+const codexModel = buildModel({
+	id: "gpt-5.4",
+	name: "GPT 5.4",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	preferWebsockets: true,
+	cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 },
+	contextWindow: 200000,
+	maxTokens: 8192,
+});
+const servers: Bun.Server<undefined>[] = [];
+const states: Map<string, ProviderSessionState>[] = [];
+const originalWebSocket = globalThis.WebSocket;
+let websocketAttempts = 0;
+
+beforeEach(() => {
+	websocketAttempts = 0;
+	// A regression must fail locally, never attempt a real provider WebSocket.
+	globalThis.WebSocket = new Proxy(originalWebSocket, {
+		construct() {
+			websocketAttempts++;
+			throw new Error("Unexpected WebSocket transport");
+		},
+	});
+});
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+	for (const server of servers.splice(0)) server.stop(true);
+	for (const state of states.splice(0)) for (const entry of state.values()) entry.close();
+	setCodexAttestationProvider(undefined);
+	vi.restoreAllMocks();
+	__resetProxyCache();
+});
+
+function loopback(handler: (request: Request) => Response | Promise<Response>) {
+	const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: handler });
+	servers.push(server);
+	const baseUrl = server.url.origin;
+	const fetch: FetchImpl = (input, init) => {
+		const url = input instanceof Request ? input.url : String(input);
+		if (new URL(url).origin !== baseUrl) throw new Error(`Refused non-loopback request: ${url}`);
+		return globalThis.fetch(input, { ...init, proxy: undefined });
+	};
+	return { baseUrl, fetch };
+}
+
+function wireModel<TApi extends Api>(model: Model<TApi>, baseUrl: string): Model<TApi> {
+	return { ...model, transport: "provider-wire", baseUrl };
+}
+
+function sse(events: Record<string, unknown>[]): Response {
+	const bytes = new TextEncoder().encode(
+		events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""),
+	);
+	let offset = 0;
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (offset === bytes.length) {
+					controller.close();
+					return;
+				}
+				const end = Math.min(offset + 37, bytes.length);
+				controller.enqueue(bytes.subarray(offset, end));
+				offset = end;
+			},
+		}),
+		{ headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+function anthropicEvents(): Record<string, unknown>[] {
+	return [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_wire",
+				type: "message",
+				role: "assistant",
+				model: anthropicModel.id,
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 13, output_tokens: 0 },
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "First inspect the file." } },
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "signature_delta", signature: "opaque-thinking-signature" },
+		},
+		{ type: "content_block_stop", index: 0 },
+		{ type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Inspecting " } },
+		{ type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "the file." } },
+		{ type: "content_block_stop", index: 1 },
+		{
+			type: "content_block_start",
+			index: 2,
+			content_block: { type: "tool_use", id: "toolu_wire", name: applyClaudeToolPrefix("inspect"), input: {} },
+		},
+		{ type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"path":' } },
+		{ type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '"sample.ts"}' } },
+		{ type: "content_block_stop", index: 2 },
+		{ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 7 } },
+		{ type: "message_stop" },
+	];
+}
+
+function codexEvents(): Record<string, unknown>[] {
+	return [
+		{ type: "response.created", response: { id: "resp_wire", status: "in_progress" } },
+		{ type: "response.output_item.added", output_index: 0, item: { type: "reasoning", id: "rs_wire", summary: [] } },
+		{
+			type: "response.reasoning_summary_part.added",
+			output_index: 0,
+			item_id: "rs_wire",
+			summary_index: 0,
+			part: { type: "summary_text", text: "" },
+		},
+		{
+			type: "response.reasoning_summary_text.delta",
+			output_index: 0,
+			item_id: "rs_wire",
+			summary_index: 0,
+			delta: "First inspect the file.",
+		},
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "reasoning",
+				id: "rs_wire",
+				encrypted_content: "opaque-reasoning",
+				summary: [{ type: "summary_text", text: "First inspect the file." }],
+			},
+		},
+		{
+			type: "response.output_item.added",
+			output_index: 1,
+			item: { type: "message", id: "msg_wire", role: "assistant", status: "in_progress", content: [] },
+		},
+		{
+			type: "response.content_part.added",
+			output_index: 1,
+			item_id: "msg_wire",
+			part: { type: "output_text", text: "" },
+		},
+		{ type: "response.output_text.delta", output_index: 1, item_id: "msg_wire", delta: "Inspecting " },
+		{ type: "response.output_text.delta", output_index: 1, item_id: "msg_wire", delta: "the file." },
+		{
+			type: "response.output_item.done",
+			output_index: 1,
+			item: {
+				type: "message",
+				id: "msg_wire",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "Inspecting the file." }],
+			},
+		},
+		{
+			type: "response.output_item.added",
+			output_index: 2,
+			item: { type: "function_call", id: "fc_wire", call_id: "call_wire", name: "inspect", arguments: "" },
+		},
+		{ type: "response.function_call_arguments.delta", output_index: 2, item_id: "fc_wire", delta: '{"path":' },
+		{ type: "response.function_call_arguments.delta", output_index: 2, item_id: "fc_wire", delta: '"sample.ts"}' },
+		{
+			type: "response.output_item.done",
+			output_index: 2,
+			item: {
+				type: "function_call",
+				id: "fc_wire",
+				call_id: "call_wire",
+				name: "inspect",
+				arguments: '{"path":"sample.ts"}',
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_wire",
+				status: "completed",
+				usage: { input_tokens: 13, output_tokens: 7, total_tokens: 20 },
+			},
+		},
+	];
+}
+
+async function requestBody(request: Request): Promise<Record<string, unknown>> {
+	const bytes = new Uint8Array(await request.arrayBuffer());
+	const json = new TextDecoder().decode(
+		request.headers.get("content-encoding") === "zstd" ? Bun.zstdDecompressSync(bytes) : bytes,
+	);
+	return JSON.parse(json);
+}
+
+describe("provider-wire native codecs", () => {
+	it("builds OAuth Anthropic tools/thinking/attestation and decodes fragmented provider SSE", async () => {
+		let body: Record<string, unknown> | undefined;
+		let headers: Headers | undefined;
+		const endpoint = loopback(async request => {
+			expect(new URL(request.url).pathname).toBe("/v1/provider-wire/anthropic");
+			headers = request.headers;
+			body = await requestBody(request);
+			return sse(anthropicEvents());
+		});
+		const events: AssistantMessageEvent[] = [];
+		const response = streamSimple(wireModel(anthropicModel, endpoint.baseUrl), context, {
+			apiKey: GATEWAY_BEARER,
+			fetch: endpoint.fetch,
+			reasoning: Effort.High,
+			sessionId: "wire-session",
+			headers: { "x-api-key": "must-not-leak", Cookie: "must-not-leak", "Proxy-Authorization": "must-not-leak" },
+		});
+		for await (const event of response) events.push(event);
+		const result = await response.result();
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "thinking",
+					thinking: "First inspect the file.",
+					thinkingSignature: "opaque-thinking-signature",
+				}),
+				expect.objectContaining({ type: "text", text: "Inspecting the file." }),
+				expect.objectContaining({ type: "toolCall", name: "inspect", arguments: { path: "sample.ts" } }),
+			]),
+		);
+		expect(events.filter(event => event.type === "text_delta").map(event => event.delta)).toEqual([
+			"Inspecting ",
+			"the file.",
+		]);
+		expect(body).toMatchObject({
+			stream: true,
+			thinking: { type: "enabled" },
+			tools: [{ name: applyClaudeToolPrefix("inspect") }],
+		});
+		expect(JSON.stringify(body)).toMatch(/x-anthropic-billing-header:.*cch=[0-9a-f]{5}/);
+		expect(JSON.stringify(body)).not.toContain("cch=00000");
+		expect(JSON.stringify(body)).not.toContain(GATEWAY_BEARER);
+		expect(headers?.get("authorization")).toBe(`Bearer ${GATEWAY_BEARER}`);
+		expect(headers?.get("anthropic-beta")).toContain("oauth-2025-04-20");
+		expect(headers?.get("x-omp-model-id")).toBe(anthropicModel.id);
+		expect(headers?.get("x-omp-provider-wire-version")).toBe("1");
+		expect(headers?.get("x-omp-session-id")).toBe("wire-session");
+		for (const name of ["x-api-key", "cookie", "proxy-authorization"]) expect(headers?.has(name)).toBe(false);
+	});
+
+	it("runs Codex SSE with effort/tools, explicit OAuth attestation and no client account claims", async () => {
+		let body: Record<string, unknown> | undefined;
+		let headers: Headers | undefined;
+		const endpoint = loopback(async request => {
+			expect(new URL(request.url).pathname).toBe("/v1/provider-wire/openai-codex");
+			headers = request.headers;
+			body = await requestBody(request);
+			return sse(codexEvents());
+		});
+		setCodexAttestationProvider(async () => '{"v":1,"s":0,"t":"test-attestation"}');
+		const state = new Map<string, ProviderSessionState>();
+		states.push(state);
+		await withEnv({ PI_CODEX_WEBSOCKET_V2: "1" }, async () => {
+			const response = streamSimple(wireModel(codexModel, endpoint.baseUrl), context, {
+				apiKey: GATEWAY_BEARER,
+				fetch: endpoint.fetch,
+				reasoning: Effort.High,
+				promptCacheKey: "cache-session",
+				providerSessionState: state,
+				preferWebsockets: true,
+				headers: {
+					"chatgpt-account-id": "untrusted-account",
+					"x-openai-internal-codex-residency": "untrusted-region",
+					"x-api-key": "must-not-leak",
+				},
+			});
+			const result = await response.result();
+			expect(result.stopReason).toBe("toolUse");
+			expect(result.content).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ type: "thinking", thinking: "First inspect the file." }),
+					expect.objectContaining({ type: "text", text: "Inspecting the file." }),
+					expect.objectContaining({ type: "toolCall", name: "inspect", arguments: { path: "sample.ts" } }),
+				]),
+			);
+		});
+		expect(body).toMatchObject({
+			stream: true,
+			reasoning: { effort: "high" },
+			tools: [{ type: "function", name: "inspect" }],
+			prompt_cache_key: "cache-session",
+		});
+		expect(JSON.stringify(body)).not.toContain(GATEWAY_BEARER);
+		expect(headers?.get("x-oai-attestation")).toBe('{"v":1,"s":0,"t":"test-attestation"}');
+		expect(headers?.get("x-omp-session-id")).toBe("cache-session");
+		expect(headers?.get("session_id")).toBe("cache-session");
+		expect(headers?.get("authorization")).toBe(`Bearer ${GATEWAY_BEARER}`);
+		for (const name of ["chatgpt-account-id", "x-openai-internal-codex-residency", "x-api-key"])
+			expect(headers?.has(name)).toBe(false);
+		expect(websocketAttempts).toBe(0);
+	});
+
+	it("replays identical serialized bytes on safe refusals without re-running payload hooks or rotating gateway bearers", async () => {
+		const bodies: Uint8Array[] = [];
+		let resolutions = 0;
+		let payloads = 0;
+		const endpoint = loopback(async request => {
+			bodies.push(new Uint8Array(await request.arrayBuffer()));
+			if (bodies.length === 1)
+				return Response.json(
+					{ error: { message: "grant expired", type: "authentication_error" } },
+					{ status: 401, headers: { "X-S99-Upstream": "provider" } },
+				);
+			if (bodies.length === 2)
+				return Response.json(
+					{ error: { message: "no capacity", type: "capacity" } },
+					{ status: 503, headers: { "X-S99-Execution": "none" } },
+				);
+			return sse(anthropicEvents());
+		});
+		const result = await streamSimple(wireModel(anthropicModel, endpoint.baseUrl), context, {
+			apiKey: () => {
+				resolutions++;
+				return GATEWAY_BEARER;
+			},
+			fetch: endpoint.fetch,
+			onPayload: () => {
+				payloads++;
+			},
+		}).result();
+		expect(result.stopReason).toBe("toolUse");
+		expect(bodies).toHaveLength(3);
+		expect(bodies[1]).toEqual(bodies[0]);
+		expect(bodies[2]).toEqual(bodies[0]);
+		expect(resolutions).toBe(1);
+		expect(payloads).toBe(1);
+	});
+
+	it("keeps explicit session affinity and gives unrelated sessionless calls fresh identities", async () => {
+		const sessions: (string | null)[] = [];
+		const endpoint = loopback(request => {
+			sessions.push(request.headers.get("x-omp-session-id"));
+			return sse(anthropicEvents());
+		});
+		const model = wireModel(anthropicModel, endpoint.baseUrl);
+		await streamSimple(model, context, {
+			apiKey: GATEWAY_BEARER,
+			fetch: endpoint.fetch,
+			sessionId: "explicit-session",
+			promptCacheKey: "cache-session",
+		}).result();
+		await streamSimple(model, context, { apiKey: GATEWAY_BEARER, fetch: endpoint.fetch }).result();
+		await streamSimple(model, context, { apiKey: GATEWAY_BEARER, fetch: endpoint.fetch }).result();
+		expect(sessions[0]).toBe("explicit-session");
+		expect(sessions[1]).toMatch(/^[0-9a-f-]{36}$/);
+		expect(sessions[2]).toMatch(/^[0-9a-f-]{36}$/);
+		expect(sessions[1]).not.toBe(sessions[2]);
+	});
+
+	it("retains the terminal gateway error fields and stops at three auth refusals", async () => {
+		let attempts = 0;
+		const envelope = {
+			error: {
+				message: "all grants denied",
+				type: "authentication_error",
+				code: "grant_denied",
+				grant: "opaque-id",
+			},
+			request_id: "request-wire",
+			retryable: false,
+		};
+		const endpoint = loopback(() => {
+			attempts++;
+			return Response.json(envelope, {
+				status: 403,
+				headers: { "x-request-id": "request-wire", "X-S99-Execution": "none" },
+			});
+		});
+		let failure: unknown;
+		try {
+			await streamSimple(wireModel(codexModel, endpoint.baseUrl), context, {
+				apiKey: GATEWAY_BEARER,
+				fetch: endpoint.fetch,
+			}).result();
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).toBeInstanceOf(ProviderWireError);
+		if (!(failure instanceof ProviderWireError)) throw failure;
+		expect(failure.message).toBe(envelope.error.message);
+		expect(failure.status).toBe(403);
+		expect(failure.code).toBe("grant_denied");
+		expect(failure.captured.bodyJson).toEqual(envelope);
+		expect(failure.headers?.get("x-request-id")).toBe("request-wire");
+		expect(attempts).toBe(3);
+	});
+
+	for (const model of [anthropicModel, codexModel]) {
+		it(`${model.provider} never replays generic 5xx, connection loss, or started SSE failures`, async () => {
+			let requests = 0;
+			const endpoint = loopback(() => {
+				requests++;
+				return Response.json({ error: { message: "uncertain execution" } }, { status: 503 });
+			});
+			await expect(
+				streamSimple(wireModel(model, endpoint.baseUrl), context, {
+					apiKey: GATEWAY_BEARER,
+					fetch: endpoint.fetch,
+				}).result(),
+			).rejects.toMatchObject({ status: 503 });
+			expect(requests).toBe(1);
+			const lost = new Error("connection lost after upload");
+			let transportAttempts = 0;
+			await expect(
+				streamSimple(wireModel(model, endpoint.baseUrl), context, {
+					apiKey: GATEWAY_BEARER,
+					fetch: async () => {
+						transportAttempts++;
+						throw lost;
+					},
+				}).result(),
+			).rejects.toBe(lost);
+			expect(transportAttempts).toBe(1);
+			let truncatedAttempts = 0;
+			const truncated = await streamSimple(wireModel(model, endpoint.baseUrl), context, {
+				apiKey: GATEWAY_BEARER,
+				fetch: async () => {
+					truncatedAttempts++;
+					return sse(model.provider === "anthropic" ? anthropicEvents().slice(0, 1) : codexEvents().slice(0, 1));
+				},
+			}).result();
+			expect(truncated.stopReason).toBe("error");
+			expect(truncatedAttempts).toBe(1);
+			let streamErrorAttempts = 0;
+			const failed = await streamSimple(wireModel(model, endpoint.baseUrl), context, {
+				apiKey: GATEWAY_BEARER,
+				fetch: async () => {
+					streamErrorAttempts++;
+					return sse([
+						model.provider === "anthropic"
+							? { type: "error", error: { type: "overloaded_error", message: "Overloaded, retry your request" } }
+							: { type: "error", code: "server_error", message: "Internal server error, retry your request" },
+					]);
+				},
+			}).result();
+			expect(failed.stopReason).toBe("error");
+			expect(streamErrorAttempts).toBe(1);
+		});
+	}
+
+	it("cancels a pending wire fetch without retrying", async () => {
+		const controller = new AbortController();
+		const entered = Promise.withResolvers<void>();
+		const stopped = new Error("caller stopped");
+		let attempts = 0;
+		const response = streamSimple(wireModel(anthropicModel, "http://127.0.0.1:4000"), context, {
+			apiKey: GATEWAY_BEARER,
+			signal: controller.signal,
+			fetch: async (_input, init) => {
+				attempts++;
+				const pending = Promise.withResolvers<Response>();
+				init?.signal?.addEventListener("abort", () => pending.reject(init.signal?.reason), { once: true });
+				entered.resolve();
+				return pending.promise;
+			},
+		});
+		await entered.promise;
+		controller.abort(stopped);
+		await expect(response.result()).rejects.toBe(stopped);
+		expect(attempts).toBe(1);
+	});
+
+	it("refuses non-canonical provider destinations/methods before any network call", async () => {
+		const network = vi.fn(async () => new Response());
+		const route = createProviderWireFetch(wireModel(anthropicModel, "http://127.0.0.1:4000"), {
+			apiKey: GATEWAY_BEARER,
+			fetch: network,
+		});
+		for (const url of [
+			"https://api.anthropic.com.evil/v1/messages?beta=true",
+			"https://api.anthropic.com/v1/messages?beta=true&url=evil",
+			"https://api.anthropic.com/v1/oauth/token",
+		]) {
+			await expect(route(url, { method: "POST", body: "{}" })).rejects.toBeInstanceOf(ConfigurationError);
+		}
+		await expect(
+			route("https://api.anthropic.com/v1/messages?beta=true", { method: "GET", body: "{}" }),
+		).rejects.toBeInstanceOf(ConfigurationError);
+		expect(network).not.toHaveBeenCalled();
+	});
+
+	it("never follows gateway redirects to a provider with its bearer", async () => {
+		let attempts = 0;
+		const endpoint = loopback(() => {
+			attempts++;
+			return new Response(null, {
+				status: 307,
+				headers: { location: "https://api.anthropic.com/v1/messages?beta=true" },
+			});
+		});
+		await expect(
+			streamSimple(wireModel(anthropicModel, endpoint.baseUrl), context, {
+				apiKey: GATEWAY_BEARER,
+				fetch: endpoint.fetch,
+			}).result(),
+		).rejects.toBeDefined();
+		expect(attempts).toBe(1);
+	});
+});

--- a/packages/ai/test/provider-wire-client.test.ts
+++ b/packages/ai/test/provider-wire-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
-import { ConfigurationError } from "@oh-my-pi/pi-ai/error";
+import { classify, ConfigurationError, retriable } from "@oh-my-pi/pi-ai/error";
 import { applyClaudeToolPrefix } from "@oh-my-pi/pi-ai/providers/anthropic";
 import { setCodexAttestationProvider } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { createProviderWireFetch, ProviderWireError } from "@oh-my-pi/pi-ai/providers/provider-wire-client";
@@ -464,6 +464,7 @@ describe("provider-wire native codecs", () => {
 				}).result(),
 			).rejects.toBe(lost);
 			expect(transportAttempts).toBe(1);
+			expect(retriable(classify(lost))).toBe(false);
 			let truncatedAttempts = 0;
 			const truncated = await streamSimple(wireModel(model, endpoint.baseUrl), context, {
 				apiKey: GATEWAY_BEARER,
@@ -473,6 +474,7 @@ describe("provider-wire native codecs", () => {
 				},
 			}).result();
 			expect(truncated.stopReason).toBe("error");
+			expect(retriable(truncated.errorId)).toBe(false);
 			expect(truncatedAttempts).toBe(1);
 			let streamErrorAttempts = 0;
 			const failed = await streamSimple(wireModel(model, endpoint.baseUrl), context, {
@@ -487,6 +489,7 @@ describe("provider-wire native codecs", () => {
 				},
 			}).result();
 			expect(failed.stopReason).toBe("error");
+			expect(retriable(failed.errorId)).toBe(false);
 			expect(streamErrorAttempts).toBe(1);
 		});
 	}

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1150,8 +1150,12 @@ export interface Model<TApi extends Api = Api> {
 	 * credentials. The model's other metadata (pricing, context window,
 	 * thinking config, …) still resolves locally; only the streaming
 	 * dispatch is redirected.
+	 *
+	 * `"provider-wire"` instead runs the local Anthropic/Codex request builder
+	 * and SSE decoder, sending provider bytes to `/v1/provider-wire/:provider`.
+	 * Only the gateway holds provider credentials; `apiKey` is its bearer.
 	 */
-	transport?: "pi-native";
+	transport?: "pi-native" | "provider-wire";
 	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
 	preferWebsockets?: boolean;
 	/** Codex Responses Lite transport: send the lite marker and carry instructions/tools as input items (mirrors codex-rs `use_responses_lite`). */

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -324,13 +324,13 @@ export const getModelsConfigSchemaBundle = once(() => {
 		 */
 		"requestMetadata?": { "[string]": "string" },
 		/**
-		 * Streaming transport override. When set to `"pi-native"`, omp dispatches
-		 * every model under this provider via the auth-gateway's
-		 * `POST /v1/pi/stream` endpoint instead of the per-provider SDK. The
-		 * provider's `baseUrl` must point at a compatible `omp auth-gateway`
-		 * and `apiKey` must carry the gateway bearer.
+		 * Gateway transport for every model under this provider. `"pi-native"`
+		 * delegates provider codecs to `/v1/pi/stream`; `"provider-wire"` runs
+		 * Anthropic/Codex codecs locally over `/v1/provider-wire/:provider`.
+		 * `baseUrl` points at the gateway and `apiKey` carries its bearer,
+		 * never the provider credential.
 		 */
-		"transport?": '"pi-native"',
+		"transport?": '"pi-native" | "provider-wire"',
 	}).narrow((value, ctx) => {
 		if (value.baseUrl !== undefined && typeof value.baseUrl === "string" && value.baseUrl.length === 0) {
 			return ctx.mustBe("baseUrl a non-empty string");

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1199,6 +1199,7 @@ export class TurnRecovery {
 	 * their own marker, not the generic sentinel, so they never match here.
 	 */
 	isRetryableReasonlessAbort(message: AssistantMessage): boolean {
+		if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return false;
 		if (
 			(message.stopReason !== "aborted" && message.stopReason !== "error") ||
 			message.content.length !== 0 ||
@@ -1225,6 +1226,7 @@ export class TurnRecovery {
 	 * Context overflow is NOT retryable (handled by compaction instead).
 	 */
 	isRetryableError(message: AssistantMessage): boolean {
+		if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return false;
 		if (message.stopReason !== "error") return false;
 		if (this.#isUsagePreflightBlocked(message)) return false;
 		const model = this.#host.model();
@@ -1321,6 +1323,7 @@ export class TurnRecovery {
 	 * unexecuted call must be reissued.
 	 */
 	classifyResolvedInterruptedToolTurn(message: AssistantMessage): "reasonless-abort" | "stream-stall" | undefined {
+		if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return undefined;
 		const id = this.#classifyRetryMessage(message);
 		const genericAbort =
 			message.errorMessage === "Request was aborted" || message.errorMessage === "Request was aborted.";
@@ -1958,6 +1961,7 @@ export class TurnRecovery {
 	 * `pinFallback`), and turns that already emitted replay-unsafe output.
 	 */
 	isHardErrorFallbackEligible(message: AssistantMessage): boolean {
+		if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return false;
 		if (message.stopReason !== "error") return false;
 		if (this.#isUsagePreflightBlocked(message)) return false;
 		const model = this.#host.model();
@@ -2100,6 +2104,7 @@ export class TurnRecovery {
 			preserveFailedTurn?: boolean;
 		},
 	): Promise<boolean> {
+		if (AIError.is(message.errorId, AIError.Flag.NoRetry)) return false;
 		const retrySettings = this.#host.settings.getGroup("retry");
 		// The Fireworks Fast→base degrade is an intrinsic model-selection safety net,
 		// not a retry loop, so it runs even when the user disabled retries: it switches

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -493,6 +493,36 @@ describe("ModelRegistry", () => {
 			expect(getModelsForProvider(registry, "anthropic")[0].baseUrl).toBe("https://second-proxy.example.com/v1");
 		});
 
+		test("JSON provider-wire config survives offline refresh with the gateway bearer", async () => {
+			writeRawModelsJson({
+				anthropic: {
+					baseUrl: "http://127.0.0.1:4000",
+					apiKey: "gateway-bearer",
+					transport: "provider-wire",
+				},
+				"openai-codex": {
+					baseUrl: "http://127.0.0.1:4000",
+					apiKey: "gateway-bearer",
+					transport: "provider-wire",
+				},
+			});
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			for (const phase of ["loaded", "refreshed"]) {
+				if (phase === "refreshed") await registry.refresh("offline");
+				expect(registry.find("anthropic", "claude-sonnet-4-5")).toMatchObject({
+					api: "anthropic-messages",
+					baseUrl: "http://127.0.0.1:4000",
+					transport: "provider-wire",
+				});
+				expect(registry.find("openai-codex", "gpt-5.4")).toMatchObject({
+					api: "openai-codex-responses",
+					baseUrl: "http://127.0.0.1:4000",
+					transport: "provider-wire",
+				});
+				expect(await registry.getApiKey(registry.find("anthropic", "claude-sonnet-4-5")!)).toBe("gateway-bearer");
+			}
+		});
+
 		test("refresh keeps transport override on built-in provider (#2555 openrouter gateway)", async () => {
 			// Reporter ran `omp` with the auth-gateway broker proxying OpenRouter.
 			// Default model worked; switching via `/model` produced

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -264,6 +264,22 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(modelChanges).toEqual([`${fallback.provider}/${fallback.id}`]);
 	});
 
+	it("honors transport-owned terminal failure before retry, fallback, or abort recovery", async () => {
+		const recovery = new TurnRecovery(
+			createHost(model, modelRegistry, { fallbackChains: { default: ["anthropic/*", "openai/*"] } }),
+		);
+		const failed = makeMessage([], model);
+		failed.errorId = AIError.create(AIError.Flag.NoRetry, AIError.Flag.Transient);
+		expect(recovery.isRetryableError(failed)).toBe(false);
+		expect(recovery.isHardErrorFallbackEligible(failed)).toBe(false);
+		expect(await recovery.handleRetryableError(failed, { hardErrorFallback: true })).toBe(false);
+		failed.stopReason = "aborted";
+		failed.errorMessage = "Request was aborted";
+		failed.errorId = AIError.create(AIError.Flag.NoRetry, AIError.Flag.Abort);
+		expect(recovery.isRetryableReasonlessAbort(failed)).toBe(false);
+		expect(recovery.classifyResolvedInterruptedToolTurn(failed)).toBeUndefined();
+	});
+
 	it("treats a failed turn with partial non-whitespace text as NOT retriable", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
 		const message = makeMessage([{ type: "text", text: "Here is the first part of my answer" }], model);


### PR DESCRIPTION
## Change

Add opt-in `transport: provider-wire` for Anthropic Messages and OpenAI Codex Responses. Stock client codecs still shape OAuth tool/thinking requests and decode provider errors/SSE; the gateway forwards native bytes and owns grant selection/token injection. This moves answer accumulation and native decoding to the client instead of a per-grant gateway process.

- Existing model configuration, streaming API and provider/session semantics remain; other transports are unchanged.
- Literal provider routes only. Forward a bounded allowlist of protocol/model/session headers and the gateway bearer, never local provider credentials, account/residency claims or cookies.
- Reject redirects; force Codex SSE, not WebSockets. Preserve native first/idle watchdogs.
- Replay the same client-owned bytes only for explicit safe refusals; do not re-run payload hooks, refresh a provider token, or replay unknown execution.
- Provider errors retain bounded native response details. Registry accepts and preserves the new provider transport.
- Carry a typed `NoRetry` prohibition through assistant errors, agent-loop conversion and turn recovery. A failed native response cannot silently restart via an outer retry, model fallback or abort-recovery path.

Gateway contract: `POST /v1/provider-wire/{anthropic|openai-codex}` with `X-OMP-Provider-Wire-Version: 1`, `X-OMP-Model-Id`, `X-OMP-Session-Id`. Gateway injects exact OAuth identity at the provider boundary. The matching system-99 draft is https://github.com/99point/system-99/pull/171 . This is not a live rollout or a published client release.

## Proof

At commit `34c8687fe4`:
- AI and coding-agent `tsgo --noEmit` checks passed.
- Provider-wire, error-id and turn-recovery regression files: **87 tests, 244 assertions, 0 failures**. Earlier native/model-registry proof: 11 tests, 77 assertions.
- Genuine compiled CLI reconstructed both Anthropic and Codex SSE through the assembled system-99 ingress/worker stack, one provider request each. Codex exercised its real zstd-compressed request.
- A broken Anthropic stream caused **11 provider requests before the fix**. The same compiled-client scenario now exits with its real error after **one request**, without outer replay.
- The full native installer contract passed with both the real source CLI and the locally compiled client. System-99's separate runtime-only image passed installed module/assembly/peer/rollout plus nginx/njs console/lease/capped-spend smoke. It is not the default release image and does not substitute for published-binary/installer parity.
- Existing released OMP 18.1.10/18.1.14 are not native-capable; system-99 refuses unsupported installation before changing user files. Published-binary/architecture gates remain required.

## Review / release hold

**Draft. Independent Fable 5.1 review has not completed:** the shared review service refused startup at its warm-thread limit. No waiver or passing verdict is claimed. No live provider traffic, token changes or deployment occurred. A reviewed tagged binary plus coordinated gateway/client adoption is required before release; this PR alone does not upgrade a running system-99 fleet.
