### PR TITLE
fix(catalog): DSML-heal deepseek models behind LiteLLM / Nous gateways

### DIFF
--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -577,6 +577,11 @@ const DSML_HEALING_PROVIDERS: Record<string, true> = {
 	nanogpt: true,
 	"opencode-go": true,
 	openrouter: true,
+	// Transparent gateways / user-configured hosts forward the upstream model's
+	// native chat template unchanged, so a deepseek-classed model behind them
+	// still emits DSML tool-call envelopes and needs the DSML healer.
+	litellm: true,
+	nous: true,
 };
 
 /**

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4582,7 +4582,9 @@
 					"fireworks",
 					"nanogpt",
 					"opencode-go",
-					"openrouter"
+					"openrouter",
+					"litellm",
+					"nous"
 				],
 				"wire": {
 					"streamMarkupHealingPattern": "dsml"

--- a/packages/catalog/src/compat/rules/classes/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/classes/deepseek.kdl
@@ -73,7 +73,7 @@ class "deepseek" {
 	models token="vision" {
 		strip-image-input #false
 	}
-	on "ollama-cloud" "nvidia" "deepseek" "fireworks" "nanogpt" "opencode-go" "openrouter" {
+	on "ollama-cloud" "nvidia" "deepseek" "fireworks" "nanogpt" "opencode-go" "openrouter" "litellm" "nous" {
 		stream-markup-healing-pattern "dsml"
 	}
 	thinking-loop-guard "deepseek"

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -655,6 +655,28 @@ describe("openai-completions wire-quirk compat detection", () => {
 				completionsSpec({ provider: "moonshot", id: "kimi-k2", baseUrl: "https://api.moonshot.ai/v1" }),
 			).compat.streamMarkupHealingPattern,
 		).toBe("kimi");
+		// Transparent gateways / user-configured hosts forward the upstream chat
+		// template unchanged: a deepseek-classed model behind a LiteLLM proxy or
+		// the NousResearch inference API still emits DSML envelopes and needs the
+		// DSML grammar, not the generic thinking healer.
+		expect(
+			resolveModelPolicy(
+				completionsSpec({
+					provider: "litellm",
+					id: "deepseek/deepseek-chat",
+					baseUrl: "http://127.0.0.1:4000/v1",
+				}),
+			).compat.streamMarkupHealingPattern,
+		).toBe("dsml");
+		expect(
+			resolveModelPolicy(
+				completionsSpec({
+					provider: "nous",
+					id: "deepseek/deepseek-v4-flash-0731",
+					baseUrl: "https://inference-api.nousresearch.com/v1",
+				}),
+			).compat.streamMarkupHealingPattern,
+		).toBe("dsml");
 	});
 
 	it("derives Responses obfuscation opt-out and wire mode per surface", () => {

--- a/packages/catalog/test/compat-conformance.test.ts
+++ b/packages/catalog/test/compat-conformance.test.ts
@@ -19,6 +19,12 @@ const RUNTIME_ONLY_PROVIDERS = new Set([
 	"lm-studio",
 	"vllm",
 	"openai-codex-device",
+	// User-configured LiteLLM proxy (models.yml provider or litellm auth flow;
+	// PROXY_OPENAI_COMPAT_PROVIDERS) that forwards upstream chat templates.
+	"litellm",
+	// User-configured models.yml provider pointing at
+	// https://inference-api.nousresearch.com/v1 (NousResearch inference API).
+	"nous",
 ]);
 
 function collectReferencedProviders(): Map<string, string> {


### PR DESCRIPTION
## What

Adds `litellm` and `nous` to both places that decide whether a deepseek-classed model gets the DSML leaked-markup healer for OpenAI-compatible streams:

- `DSML_HEALING_PROVIDERS` in `packages/catalog/src/compat/resolve.ts` (resolve-time fallback, used when no cascade rule matches)
- the `stream-markup-healing-pattern "dsml"` selector in `packages/catalog/src/compat/rules/classes/deepseek.kdl` (cascade rule), with `rules.json` regenerated to match
- registers both providers in the conformance test's `RUNTIME_ONLY_PROVIDERS` (neither has bundled `models.json` rows) and adds unit coverage in `build.test.ts`

## Why

DeepSeek models served through a **LiteLLM proxy** (`http://<host>:4000/v1`, an established provider id upstream — auth flow, `PROXY_OPENAI_COMPAT_PROVIDERS`, discovery notes) or a user-configured models.yml provider pointing at the **NousResearch inference API** (`https://inference-api.nousresearch.com/v1`) pass the upstream chat template through unchanged, so a model classed `deepseek` (e.g. `deepseek/deepseek-chat`, `deepseek/deepseek-v4-flash-0731`) still emits DSML tool-call envelopes.

Neither provider was in the allowlist, so the generic `"thinking"` healer was selected and raw `<|DSML|tool_calls>` / `<|DSML|invoke>` tokens leaked into visible output (unparsed, they also defeat tool-call handling). This is the same class of issue the existing entries guard against; the two added providers are the transparent-gateway / user-hosted cases where template passthrough is guaranteed by the operator.

Verified live before this change: default model was a deepseek model behind such a gateway, and raw DSML tags repeatedly appeared in terminal output.

## Testing

- `bun test test/compat-compile.test.ts test/compat-conformance.test.ts` in `packages/catalog` — 19 pass (includes "committed rules.json matches a fresh compile of rules/", confirming the checked-in `rules.json` edit is byte-identical to a recompile, and the runtime-only provider conformance check)
- `resolveModelPolicy()` exercised directly for both new cases and the negative cases:

```
litellm deepseek/deepseek-chat                => streamMarkupHealingPattern: dsml
nous   deepseek/deepseek-v4-flash-0731        => streamMarkupHealingPattern: dsml
litellm deepseek/deepseek-chat (responses)    => streamMarkupHealingPattern: dsml
litellm qwen3 (non-deepseek)                  => thinking   (unchanged)
litellm entrim (opaque alias, not classed)    => thinking   (unchanged)
openai  gpt-5 (official endpoint)             => undefined  (unchanged)
```

- `oxlint` / `oxfmt --check` pass on the touched TS files
- `packages/catalog/test/build.test.ts` could not run end-to-end locally (requires the Rust `pi_natives` addon, which is only built in CI/release); the new assertions mirror the existing cases in that file and the underlying `resolveModelPolicy` behavior was verified directly as above.

Note: models whose *id* doesn't classify as deepseek behind these gateways (e.g. a LiteLLM proxy alias like `entrim`) still need a per-model `compat.streamMarkupHealingPattern: "dsml"` pin in models.yml — classification is id-based and opaque aliases are inherently user-local. This PR fixes the default path for actual deepseek ids behind the two providers.
