### PR TITLE
acp: mirror the agent registry to the client as notifications/agent_registry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- ACP clients now receive the live subagent roster as a `notifications/agent_registry` extension notification ([#11302](https://github.com/can1357/oh-my-pi/pull/11302) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -79,6 +79,7 @@ import { ensureTheme, initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
 import { createWarpEventBridgeExtension } from "./modes/warp-events";
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
+import { AgentRegistry } from "./registry/agent-registry";
 import {
 	type CreateAgentSessionOptions,
 	type CreateAgentSessionResult,
@@ -110,7 +111,11 @@ import { sanitizeDisplayWarnings } from "./tools/render-utils";
 import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChangelogSelection } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
 
-type RunAcpMode = (createSession: AcpSessionFactory) => Promise<never>;
+type RunAcpMode = (
+	createSession: AcpSessionFactory,
+	initialSession?: AgentSession,
+	registry?: AgentRegistry,
+) => Promise<never> | Promise<void>;
 type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promise<number>;
 type RunRpcMode = (
 	session: AgentSession,
@@ -471,6 +476,16 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
 		}
+		// `createAgentSession` attaches every ref as `running`, and only the task
+		// and revival paths mirror run state back onto it. Without this an ACP
+		// session reads `running` for its entire life, between prompts included,
+		// which is stale to the roster, to `notifications/agent_registry`, and to
+		// anything that keys work off the status. Fire-and-forget, the same shape
+		// the task path uses: the listener lives on the session and goes with it.
+		// The registry has to be the one `createAgentSession` registered into, or
+		// an embedder's isolated ref stays stale while the global one rejects
+		// every update.
+		(args.baseOptions.agentRegistry ?? AgentRegistry.global()).syncOwnedSession(nextSession);
 		const runner = nextSession.extensionRunner;
 		const reparsedArgs = applyExtensionFlags(
 			runner
@@ -1899,7 +1914,9 @@ export async function runRootCommand(
 			// Branch-only protocol runner: keep ACP server code out of normal interactive startup.
 			const runAcpMode = deps.runAcpMode ?? (await import("./modes/acp/acp-mode")).runAcpMode;
 			stopStartupWatchdog();
-			await runAcpMode(createAcpSession);
+			// Same registry the factory registers into, so the roster the client is
+			// sent is the one these sessions are actually in.
+			await runAcpMode(createAcpSession, undefined, sessionOptions.agentRegistry);
 		} else {
 			// Resolve extension-registered CLI flags before creating the session so a
 			// bad `@file` fails fast WITHOUT leaving a junk session/breadcrumb

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -63,6 +63,7 @@ import { loadAllExtensions } from "../../modes/components/extensions/state-manag
 import { theme } from "../../modes/theme/theme";
 import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
 import { autosaveApprovedPlan } from "../../plan-mode/plan-autosave";
+import { AgentRegistry } from "../../registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
 import { BlobStore, resolveImageDataSync } from "../../session/blob-store";
 import { isSilentAbort, SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -85,6 +86,7 @@ import {
 } from "../../tts/models";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { createAcpClientBridge } from "./acp-client-bridge";
+import { mirrorAgentRegistry } from "./agent-registry-notification";
 import {
 	extractAssistantMessageText,
 	mapAgentSessionEventToAcpSessionUpdates,
@@ -617,11 +619,19 @@ export class AcpAgent implements Agent {
 	#clientCapabilities: ClientCapabilities | undefined;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 	#blobs = new BlobStore(getBlobsDir());
+	#stopRegistryMirror: (() => void) | undefined;
+	#registry: AgentRegistry;
 
-	constructor(connection: AgentSideConnection, createSession: CreateAcpSession, initialSession?: AgentSession) {
+	constructor(
+		connection: AgentSideConnection,
+		createSession: CreateAcpSession,
+		initialSession?: AgentSession,
+		registry?: AgentRegistry,
+	) {
 		this.#connection = connection;
 		this.#initialSession = initialSession;
 		this.#createSession = createSession;
+		this.#registry = registry ?? AgentRegistry.global();
 	}
 
 	setCancelCleanupTimeoutForTesting(timeoutMs: number): void {
@@ -630,6 +640,17 @@ export class AcpAgent implements Agent {
 
 	async initialize(params: InitializeRequest): Promise<InitializeResponse> {
 		this.#registerConnectionCleanup();
+		// From initialize rather than the constructor: a subscription taken
+		// before the client has spoken would send on a connection that may
+		// never complete the handshake.
+		//
+		// An adopted `initialSession` never went through the ACP factory, so
+		// nothing has corrected the `running` status `createAgentSession`
+		// registered it with or subscribed to its transitions. Do that before the
+		// first frame, or the client's first roster is wrong about the one
+		// session it definitely has.
+		if (this.#initialSession) this.#registry.syncOwnedSession(this.#initialSession);
+		this.#stopRegistryMirror ??= mirrorAgentRegistry(this.#connection, this.#registry);
 		this.#clientCapabilities = params.clientCapabilities;
 		const authMethods: AuthMethod[] = [
 			{
@@ -1326,6 +1347,12 @@ export class AcpAgent implements Agent {
 		setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined,
 	): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session, setToolUIContext);
+		// Every session this agent adopts, whoever built it. The bundled ACP
+		// factory already syncs the one it hands back, and this is idempotent, but
+		// an embedder's own `AcpSessionFactory` is a supported entry point and its
+		// sessions arrive registered `running` by `createAgentSession`, as do the
+		// ones from load, resume, and fork.
+		this.#registry.syncOwnedSession(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
@@ -2795,6 +2822,8 @@ export class AcpAgent implements Agent {
 		}
 
 		this.#disposePromise = (async () => {
+			this.#stopRegistryMirror?.();
+			this.#stopRegistryMirror = undefined;
 			const records = Array.from(this.#sessions.entries());
 			this.#sessions.clear();
 			await Promise.all(

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -2,6 +2,7 @@ import * as stream from "node:stream";
 import { postmortem } from "@oh-my-pi/pi-utils";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@oh-my-pi/pi-utils/acp";
 import type { ExtensionUIContext } from "../../extensibility/extensions/types";
+import type { AgentRegistry } from "../../registry/agent-registry";
 import type { AgentSession } from "../../session/agent-session";
 import { AcpAgent } from "./acp-agent";
 
@@ -22,22 +23,34 @@ export type AcpSessionFactory = (
 	options?: { interactivePrompts?: boolean },
 ) => Promise<AgentSession | AcpSessionHandle>;
 
-/** Creates an ACP connection and exposes its agent when process-level teardown must own it. */
+/**
+ * Creates an ACP connection and exposes its agent when process-level teardown
+ * must own it.
+ *
+ * `registry` is the registry the sessions were registered into; an embedder
+ * running an isolated one must pass it, or the agent roster the client sees is
+ * a different registry's.
+ */
 export function createAcpConnection(
 	transport: Stream,
 	createSession: AcpSessionFactory,
 	initialSession?: AgentSession,
 	onAgent?: (agent: AcpAgent) => void,
+	registry?: AgentRegistry,
 ): AgentSideConnection {
 	return new AgentSideConnection(connection => {
-		const agent = new AcpAgent(connection, createSession, initialSession);
+		const agent = new AcpAgent(connection, createSession, initialSession, registry);
 		onAgent?.(agent);
 		return agent;
 	}, transport);
 }
 
 /** Serves ACP over stdio until the peer disconnects, then awaits session teardown before exit. */
-export async function runAcpMode(createSession: AcpSessionFactory, initialSession?: AgentSession): Promise<void> {
+export async function runAcpMode(
+	createSession: AcpSessionFactory,
+	initialSession?: AgentSession,
+	registry?: AgentRegistry,
+): Promise<void> {
 	// Humans who run `omp acp` by hand see a silent process and assume it is
 	// broken (stdout is the JSON-RPC transport, so nothing may be printed
 	// there). When stdin is a TTY no ACP client is attached — say so on stderr
@@ -55,9 +68,15 @@ export async function runAcpMode(createSession: AcpSessionFactory, initialSessio
 	const input = stream.Writable.toWeb(process.stdout);
 	const output = stream.Readable.toWeb(process.stdin);
 	const transport = ndJsonStream(input, output);
-	const connection = createAcpConnection(transport, createSession, initialSession, createdAgent => {
-		agent = createdAgent;
-	});
+	const connection = createAcpConnection(
+		transport,
+		createSession,
+		initialSession,
+		createdAgent => {
+			agent = createdAgent;
+		},
+		registry,
+	);
 	await connection.closed;
 	await postmortem.quit(0);
 }

--- a/packages/coding-agent/src/modes/acp/agent-registry-notification.ts
+++ b/packages/coding-agent/src/modes/acp/agent-registry-notification.ts
@@ -1,0 +1,199 @@
+/**
+ * Mirrors the in-process AgentRegistry to the ACP client as an extension
+ * notification, the same way CollabHost mirrors it to collab guests.
+ *
+ * ACP proper has no subagent layer: a `task` call reaches the client as one
+ * `tool_call` whose result lands when the last child yields, and nothing in
+ * the standard update set names a parent or a child. A client hosting omp
+ * over ACP (an editor, a control plane) therefore sees a fan-out as one slow
+ * tool. The registry already knows every agent, its parent, its status, and
+ * its transcript, and `CollabHost.#snapshotAgents` already broadcasts that to
+ * guests; this sends the same roster to the ACP client whenever it changes,
+ * and on a coarse interval while any agent is running, because the mutations
+ * that carry live intent and session identity emit no registry event.
+ *
+ * Method name and payload are the ones ompd already validates
+ * (`packages/acp/src/client.ts` in jwaldrip/ompctl): `notifications/agent_registry`
+ * with `{ agents: [...] }`. Advisors are included, unlike the collab
+ * broadcast, because an ACP client is the operator's own process rather than
+ * a guest; the `kind` field lets a client drop them.
+ */
+
+import { logger } from "@oh-my-pi/pi-utils";
+import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
+import { type AgentRef, AgentRegistry } from "../../registry/agent-registry";
+import { readSessionMetrics } from "../components/agent-hub-projection";
+
+export const AGENT_REGISTRY_NOTIFICATION = "notifications/agent_registry";
+
+/** Coalesces the burst of registry events a fan-out produces into one frame; same window as CollabHost. */
+const REGISTRY_DEBOUNCE_MS = 100;
+
+/**
+ * Ceiling on how stale a running agent's intent, recency, or session id can be.
+ * Registry mutations that carry those deliberately emit no event, so the mirror
+ * re-reads on this cadence instead; same window as `CollabHost`'s streaming
+ * state, and identical payloads are dropped rather than sent.
+ */
+const REGISTRY_REFRESH_MS = 2000;
+
+export interface AgentRegistrySnapshot {
+	id: string;
+	displayName: string;
+	kind: AgentRef["kind"];
+	parentId?: string;
+	/** The parent's session id, so a client keyed by session rather than registry id can attach the child. */
+	parentSessionId?: string;
+	/** The agent's own session id while it has a live session; absent once parked or aborted. */
+	sessionId?: string;
+	status: AgentRef["status"];
+	createdAt: string;
+	lastActiveAt: string;
+	taskTitle?: string;
+	/** `provider/id`, live from the attached session, else the last resolved model of a detached one. */
+	model?: string;
+	/**
+	 * `durationMs` is present only for a detached ref, where the executor has
+	 * written a final span. A live agent's elapsed time is `createdAt` to
+	 * `lastActiveAt`, both above: a wall-clock field here would differ on every
+	 * refresh tick and turn the change-only send into an unconditional one.
+	 */
+	metrics?: { usedTokens: number; costAmount?: number; durationMs?: number };
+}
+
+export function snapshotAgentRegistry(registry: AgentRegistry = AgentRegistry.global()): AgentRegistrySnapshot[] {
+	const refs = registry.list();
+	// `AgentRef.session` is documented null exactly when parked/aborted, but the
+	// status update lands before the disposal that detaches it, so a ref carries
+	// a stale session for that window. Trust the status over the field: a frame
+	// must never advertise a session id its own status says is already gone.
+	const liveSessionIds = new Map<string, string>();
+	for (const ref of refs) {
+		if (ref.session && ref.status !== "parked" && ref.status !== "aborted") {
+			liveSessionIds.set(ref.id, ref.session.sessionId);
+		}
+	}
+	return refs.map(ref => {
+		const parentSessionId = ref.parentId === undefined ? undefined : liveSessionIds.get(ref.parentId);
+		// A freshly spawned subagent carries no `history` until the executor
+		// writes one, and a revived ref's history describes its previous
+		// transcript, so the attached session wins whenever there is one.
+		const live = liveSessionIds.has(ref.id) && ref.session?.isDisposed === false ? ref.session : null;
+		// `readSessionMetrics` rather than `getSessionStats` directly: stats fold
+		// in the usage carried by a completed `task` result, which would bill a
+		// parent for children that report the same tokens on their own rows.
+		const liveMetrics = live === null ? undefined : readSessionMetrics(live);
+		const history = ref.history?.metrics;
+		const snapshot: AgentRegistrySnapshot = {
+			id: ref.id,
+			displayName: ref.displayName,
+			kind: ref.kind,
+			status: ref.status,
+			createdAt: new Date(ref.createdAt).toISOString(),
+			lastActiveAt: new Date(ref.lastActivity).toISOString(),
+		};
+		if (ref.parentId !== undefined) snapshot.parentId = ref.parentId;
+		if (parentSessionId !== undefined) snapshot.parentSessionId = parentSessionId;
+		const sessionId = liveSessionIds.get(ref.id);
+		if (sessionId !== undefined) snapshot.sessionId = sessionId;
+		if (ref.activity !== undefined) snapshot.taskTitle = ref.activity;
+		const liveModel = live?.model;
+		// Same `provider/id` shape `history.resolvedModel` is built with.
+		if (liveModel !== undefined) snapshot.model = `${liveModel.provider}/${liveModel.id}`;
+		else if (ref.history?.resolvedModel !== undefined) snapshot.model = ref.history.resolvedModel;
+		if (liveMetrics !== undefined) {
+			snapshot.metrics = { usedTokens: liveMetrics.tokens, costAmount: liveMetrics.cost };
+		} else if (history !== undefined) {
+			snapshot.metrics = {
+				usedTokens: history.tokens,
+				costAmount: history.cost,
+				durationMs: history.durationMs,
+			};
+		}
+		return snapshot;
+	});
+}
+
+/**
+ * Subscribe the connection to registry changes. Returns the unsubscribe;
+ * the caller owns it and runs it on dispose so a disposed agent never sends
+ * on a closed connection.
+ *
+ * Registry events alone do not describe a running fan-out. `setActivity` and
+ * `attachSession` mutate a ref without emitting, deliberately, to keep the
+ * per-tool-call rate off the listener path; so intent text, `lastActiveAt`,
+ * and a session that lands after the registration frame would otherwise never
+ * reach the client. While any agent is `running` this re-snapshots on a coarse
+ * interval and sends only when the payload actually changed, which is the
+ * shape `CollabHost` uses for streaming state. It adds no registry events, so
+ * the registry's bounded listener contract is untouched, and it holds no timer
+ * once the last agent stops.
+ */
+export function mirrorAgentRegistry(
+	connection: Pick<AgentSideConnection, "extNotification">,
+	registry: AgentRegistry = AgentRegistry.global(),
+): () => void {
+	let debounce: Timer | null = null;
+	let refresh: Timer | null = null;
+	let lastJson = "";
+	let stopped = false;
+
+	function schedule(): void {
+		if (stopped || debounce !== null) return;
+		debounce = setTimeout(send, REGISTRY_DEBOUNCE_MS);
+	}
+
+	// Armed only while work is live, so an idle connection holds no timer.
+	function syncRefresh(): void {
+		const live = !stopped && registry.list().some(ref => ref.status === "running");
+		if (live && refresh === null) {
+			refresh = setInterval(schedule, REGISTRY_REFRESH_MS);
+		} else if (!live && refresh !== null) {
+			clearInterval(refresh);
+			refresh = null;
+		}
+	}
+
+	function send(): void {
+		debounce = null;
+		if (stopped) return;
+		// Before the dedupe: a tick that says nothing new still has to decide
+		// whether the interval is still earning its keep.
+		syncRefresh();
+		const params = { agents: snapshotAgentRegistry(registry) };
+		const json = JSON.stringify(params);
+		if (json === lastJson) return;
+		lastJson = json;
+		// This runs from a timer, so a synchronous throw here has no caller to
+		// catch it: it would surface as an unhandled exception rather than a
+		// dropped roster frame. Observability must never be able to do that.
+		try {
+			void connection.extNotification(AGENT_REGISTRY_NOTIFICATION, params).catch(error => {
+				logger.debug("agent registry notification failed", { error });
+			});
+		} catch (error) {
+			logger.debug("agent registry notification failed", { error });
+		}
+	}
+
+	const unsubscribe = registry.onChange(schedule);
+	// `onChange` cannot report refs that predate the subscription, and a roster
+	// of only idle or parked agents arms no refresh, so an embedder that hands
+	// us a session it created would otherwise see nothing until some unrelated
+	// mutation. One frame instead, which `send` follows with the usual decision
+	// about whether an interval is warranted; an empty registry has nothing to
+	// state, so it stays silent.
+	if (registry.list().length > 0) schedule();
+	return () => {
+		stopped = true;
+		unsubscribe();
+		if (debounce !== null) {
+			clearTimeout(debounce);
+			debounce = null;
+		}
+		if (refresh !== null) {
+			clearInterval(refresh);
+			refresh = null;
+		}
+	};
+}

--- a/packages/coding-agent/src/modes/components/agent-hub-projection.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-projection.ts
@@ -65,7 +65,7 @@ export function progressMetrics(observed: ObservableSession | undefined): AgentM
  * usage embedded in completed `task` tool results, so using it for a parent
  * row would double-count child rows in the aggregate.
  */
-function readSessionMetrics(session: NonNullable<AgentRef["session"]>): AgentMetrics | undefined {
+export function readSessionMetrics(session: NonNullable<AgentRef["session"]>): AgentMetrics | undefined {
 	try {
 		const stats = session.getSessionStats();
 		const messages = session.agent?.state?.messages;
@@ -89,9 +89,16 @@ function readSessionMetrics(session: NonNullable<AgentRef["session"]>): AgentMet
 		for (const message of messages) {
 			if (message.role !== "assistant") continue;
 			requests++;
-			tokens += message.usage.input + message.usage.output + message.usage.cacheWrite;
+			// Persisted and imported transcripts can predate usage metadata despite
+			// the current message type, the same case `getSessionStats` skips.
+			// Dereferencing it threw, and the catch below turned one legacy entry
+			// into no metrics at all for the whole session.
+			const usage = message.usage;
+			if (usage) {
+				tokens += usage.input + usage.output + usage.cacheWrite;
+				cost += usage.cost.total;
+			}
 			tools += message.content.filter(content => content.type === "toolCall").length;
-			cost += message.usage.cost.total;
 		}
 		return {
 			tokens,

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -133,6 +133,8 @@ export class AgentRegistry {
 
 	readonly #refs = new Map<string, AgentRef>();
 	readonly #listeners = new Set<RegistryListener>();
+	/** Keyed by session so a re-adopted session replaces its subscriptions instead of stacking them. */
+	readonly #ownedSessionUnsubscribes = new WeakMap<AgentSession, () => void>();
 
 	#matchesExpected(ref: AgentRef, expected?: AgentRefExpectation): boolean {
 		return expected === undefined || ref === expected || ref.session === expected;
@@ -295,6 +297,49 @@ export class AgentRegistry {
 			this.setStatus(id, status, session);
 		});
 		return unsubscribe;
+	}
+
+	/**
+	 * Mirror run state onto whichever ref owns this session, and correct the
+	 * status it was registered with. Every ref is registered `running` before
+	 * its session exists, so a caller that owns a session rather than an id —
+	 * an ACP host adopting one, a factory handing one back — has no way to say
+	 * "this is idle now" without first finding its ref. Returns false when no
+	 * ref owns the session, which is the normal answer for a session the
+	 * registry never took.
+	 *
+	 * Also publishes the changes a session makes to itself that no registry
+	 * mutation describes: adopting a different `sessionId` (`newSession`,
+	 * `fork`, `switchSession`, `/fresh`) and switching model. A listener that
+	 * reports either — the ACP roster notification, the hub, collab guests —
+	 * would otherwise keep serving a dead value until something unrelated
+	 * changed. The event filter runs on the session's whole stream, so it stays
+	 * a single type comparison and never emits at streaming rate.
+	 *
+	 * Idempotent: several owners legitimately adopt the same session — the ACP
+	 * factory hands one back and the ACP agent then registers it — and a second
+	 * call replaces the first's subscriptions rather than stacking on them.
+	 */
+	syncOwnedSession(session: AgentSession): boolean {
+		for (const ref of this.#refs.values()) {
+			if (ref.session !== session) continue;
+			this.#ownedSessionUnsubscribes.get(session)?.();
+			const publish = (): void => {
+				if (this.#refs.get(ref.id) === ref) this.#emit({ type: "metadata_changed", ref });
+			};
+			const stopRunState = this.syncSessionStatus(ref.id, session);
+			const stopIdentity = session.registerSessionIdentityChangeCallback(publish);
+			const stopModel = session.subscribe(event => {
+				if (event.type === "model_changed") publish();
+			});
+			this.#ownedSessionUnsubscribes.set(session, () => {
+				stopRunState();
+				stopIdentity();
+				stopModel();
+			});
+			return this.setStatus(ref.id, session.isStreaming ? "running" : "idle", session);
+		}
+		return false;
 	}
 
 	onChange(listener: RegistryListener): () => void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -604,7 +604,10 @@ export class AgentSession {
 	#runStateListeners = new Set<(state: "running" | "idle") => void>();
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
 	#sessionChangeCallbacks = new Set<() => void>();
+	#sessionIdentityChangeCallbacks = new Set<() => void>();
 	#observedSessionId: string | undefined;
+	/** Manager id and provider id together; either moving is an identity change. */
+	#observedSessionIdentity: string | undefined;
 
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
@@ -4344,10 +4347,16 @@ export class AgentSession {
 		return () => this.#runStateListeners.delete(listener);
 	}
 
-	/** Register cleanup that runs when this AgentSession adopts a different session ID. */
+	/** Register cleanup that runs when this AgentSession adopts a different transcript / session manager ID. */
 	registerSessionChangeCallback(callback: () => void): () => void {
 		this.#sessionChangeCallbacks.add(callback);
 		return () => this.#sessionChangeCallbacks.delete(callback);
+	}
+
+	/** Register notification that runs when this AgentSession's provider-facing session identity rotates. */
+	registerSessionIdentityChangeCallback(callback: () => void): () => void {
+		this.#sessionIdentityChangeCallbacks.add(callback);
+		return () => this.#sessionIdentityChangeCallbacks.delete(callback);
 	}
 
 	subscribeCommandMetadataChanged(listener: CommandMetadataChangedListener): () => void {
@@ -4432,7 +4441,19 @@ export class AgentSession {
 			this.#observedSessionId = currentSessionId;
 			if (notifyChange) this.#notifySessionChangeCallbacks();
 		}
+
 		const sid = this.#activeProviderSessionId(sessionId);
+		// Both halves, because observers read `AgentSession.sessionId`, which is
+		// the provider-facing one: a transcript switch moves the manager's id,
+		// while `/fresh` and `/clear` move only the provider id. Watching the
+		// manager alone left every observer serving a dead id after `/fresh`.
+		const identity = `${currentSessionId}\u0000${sid}`;
+		if (this.#observedSessionIdentity === undefined) {
+			this.#observedSessionIdentity = identity;
+		} else if (this.#observedSessionIdentity !== identity) {
+			this.#observedSessionIdentity = identity;
+			if (notifyChange) this.#notifySessionIdentityChangeCallbacks();
+		}
 		this.agent.sessionId = sid;
 		this.agent.setMetadataResolver((provider: string) =>
 			buildSessionMetadata(sid, provider, this.#modelRegistry.authStorage),
@@ -4459,6 +4480,15 @@ export class AgentSession {
 				callback();
 			} catch (error) {
 				logger.warn("Session change callback failed", { error: String(error) });
+			}
+		}
+	}
+	#notifySessionIdentityChangeCallbacks(): void {
+		for (const callback of Array.from(this.#sessionIdentityChangeCallbacks)) {
+			try {
+				callback();
+			} catch (error) {
+				logger.warn("Session identity change callback failed", { error: String(error) });
 			}
 		}
 	}
@@ -4778,6 +4808,7 @@ export class AgentSession {
 		this.#eventListeners = [];
 		this.#runStateListeners.clear();
 		this.#sessionChangeCallbacks.clear();
+		this.#sessionIdentityChangeCallbacks.clear();
 
 		// A dispose triggered mid-turn (Ctrl-C / timeout / hard-killed subagent)
 		// only *signals* the agent loop via the earlier abort(); the loop and the
@@ -9280,6 +9311,7 @@ export class AgentSession {
 			this.#bash.finishSessionTransition(bashTransition, true);
 			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {
 				this.#notifySessionChangeCallbacks();
+				this.#notifySessionIdentityChangeCallbacks();
 			}
 			transitionSettled.resolve();
 			this.#sessionTransitionSettled = previousSessionTransitionSettled;

--- a/packages/coding-agent/test/acp-agent-registry-notification.test.ts
+++ b/packages/coding-agent/test/acp-agent-registry-notification.test.ts
@@ -1,0 +1,509 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AgentSideConnection } from "@oh-my-pi/pi-utils/acp";
+import {
+	AGENT_REGISTRY_NOTIFICATION,
+	type AgentRegistrySnapshot,
+	mirrorAgentRegistry,
+	snapshotAgentRegistry,
+} from "@oh-my-pi/pi-coding-agent/modes/acp/agent-registry-notification";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+interface StubUsage {
+	input: number;
+	output: number;
+	cacheWrite: number;
+	cost: number;
+}
+
+function assistantMessage(usage: StubUsage): unknown {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		usage: {
+			input: usage.input,
+			output: usage.output,
+			reasoningTokens: 0,
+			cacheRead: 0,
+			cacheWrite: usage.cacheWrite,
+			totalTokens: usage.input + usage.output + usage.cacheWrite,
+			cost: { total: usage.cost },
+		},
+	};
+}
+
+/** An assistant entry from a transcript that predates usage metadata. */
+function legacyAssistantMessage(): unknown {
+	return { role: "assistant", content: [{ type: "text", text: "from an older omp" }] };
+}
+
+/**
+ * `live` opts the stub into the surface the snapshot reads off an attached
+ * session. Without it `isDisposed` is undefined, which is how most of these
+ * tests keep the session out of the model/metrics path.
+ *
+ * `child` is usage carried by a completed `task` result. The real
+ * `getSessionStats()` folds that into its totals, so the stub does too: a
+ * per-agent row must report `direct` alone.
+ */
+function sessionStub(
+	sessionId: string,
+	live?: {
+		model?: { provider: string; id: string };
+		direct?: StubUsage;
+		child?: StubUsage;
+		/** Prepend an entry with no `usage`, as a loaded or resumed transcript can hold. */
+		legacy?: boolean;
+	},
+): AgentSession {
+	const direct = live?.direct;
+	const child = live?.child;
+	const total = (usage: StubUsage | undefined): number =>
+		usage === undefined ? 0 : usage.input + usage.output + usage.cacheWrite;
+	const messages = (() => {
+		if (direct === undefined) return live?.legacy ? [legacyAssistantMessage()] : undefined;
+		return live?.legacy ? [legacyAssistantMessage(), assistantMessage(direct)] : [assistantMessage(direct)];
+	})();
+	return {
+		sessionId,
+		dispose: async () => {},
+		isDisposed: live === undefined ? undefined : false,
+		model: live?.model,
+		agent: messages === undefined ? undefined : { state: { messages } },
+		getSessionStats: () => ({
+			tokens: { input: direct?.input ?? 0, output: direct?.output ?? 0, cacheWrite: direct?.cacheWrite ?? 0 },
+			assistantMessages: direct === undefined ? 0 : 1,
+			toolCalls: 0,
+			cost: (direct?.cost ?? 0) + (child?.cost ?? 0),
+			contextUsage: undefined,
+			totalTokens: total(direct) + total(child),
+		}),
+	} as unknown as AgentSession;
+}
+
+/** Advance the fake clock past the debounce window and let the queued send settle. */
+async function flush(): Promise<void> {
+	vi.advanceTimersByTime(150);
+	await Promise.resolve();
+}
+
+interface SentFrame {
+	method: string;
+	params: Record<string, unknown>;
+}
+
+/** Advance past the refresh interval, then past the debounce it schedules. */
+async function flushRefresh(): Promise<void> {
+	vi.advanceTimersByTime(2000);
+	await Promise.resolve();
+	vi.advanceTimersByTime(150);
+	await Promise.resolve();
+}
+
+function capture(): { connection: Pick<AgentSideConnection, "extNotification">; sent: SentFrame[] } {
+	const sent: SentFrame[] = [];
+	const connection = {
+		extNotification: async (method: string, params: Record<string, unknown>) => {
+			sent.push({ method, params });
+		},
+	} as unknown as Pick<AgentSideConnection, "extNotification">;
+	return { connection, sent };
+}
+
+/** The roster in the most recent frame; the assertions are all about what the client last saw. */
+function agentsOf(sent: SentFrame[]): AgentRegistrySnapshot[] {
+	return (sent.at(-1)?.params.agents ?? []) as AgentRegistrySnapshot[];
+}
+
+describe("ACP agent registry notification", () => {
+	let registry: AgentRegistry;
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		registry = AgentRegistry.global();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("snapshots the roster with lineage by parent id and parent session id", () => {
+		registry.register({
+			id: "main",
+			displayName: "main",
+			kind: "main",
+			session: sessionStub("s-main"),
+		});
+		registry.register({
+			id: "sub-1",
+			displayName: "GapChrome",
+			kind: "sub",
+			parentId: "main",
+			session: sessionStub("s-sub-1"),
+			sessionFile: "/tmp/s/GapChrome.jsonl",
+			status: "running",
+			activity: "measuring the chrome",
+		});
+		registry.register({
+			id: "sub-2",
+			displayName: "Parked",
+			kind: "sub",
+			parentId: "main",
+			session: null,
+			sessionFile: "/tmp/s/Parked.jsonl",
+			status: "parked",
+		});
+
+		const byId = new Map(snapshotAgentRegistry(registry).map(agent => [agent.id, agent]));
+		expect(byId.get("main")).toMatchObject({
+			kind: "main",
+			sessionId: "s-main",
+			status: "running",
+		});
+		expect(byId.get("sub-1")).toMatchObject({
+			kind: "sub",
+			parentId: "main",
+			parentSessionId: "s-main",
+			sessionId: "s-sub-1",
+			status: "running",
+			taskTitle: "measuring the chrome",
+		});
+		// A parked child has no live session, so no session id is claimed for it.
+		const parked = byId.get("sub-2");
+		expect(parked).toMatchObject({
+			kind: "sub",
+			parentId: "main",
+			parentSessionId: "s-main",
+			status: "parked",
+		});
+		expect(parked?.sessionId).toBeUndefined();
+		// Timestamps travel as ISO strings, which is what a JSON client can parse without a convention.
+		expect(Number.isNaN(Date.parse(byId.get("sub-1")?.createdAt ?? ""))).toBe(false);
+	});
+
+	it("sends one debounced notification per burst of registry changes, and none after unsubscribe", async () => {
+		const sent: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const connection = {
+			extNotification: async (method: string, params: Record<string, unknown>) => {
+				sent.push({ method, params });
+			},
+		};
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+
+		registry.register({
+			id: "main",
+			displayName: "main",
+			kind: "main",
+			session: sessionStub("s-main"),
+		});
+		registry.register({
+			id: "a",
+			displayName: "A",
+			kind: "sub",
+			parentId: "main",
+			session: sessionStub("s-a"),
+		});
+		registry.register({
+			id: "b",
+			displayName: "B",
+			kind: "sub",
+			parentId: "main",
+			session: sessionStub("s-b"),
+		});
+		await flush();
+
+		expect(sent.length).toBe(1);
+		expect(sent[0]?.method).toBe(AGENT_REGISTRY_NOTIFICATION);
+		const agents = sent[0]?.params.agents as Array<{
+			id: string;
+			kind: string;
+		}>;
+		expect(agents.map(agent => agent.id).sort()).toEqual(["a", "b", "main"]);
+
+		registry.setStatus("a", "idle");
+		await flush();
+		expect(sent.length).toBe(2);
+
+		stop();
+		registry.setStatus("b", "idle");
+		await flush();
+		expect(sent.length).toBe(2);
+	});
+
+	it("never advertises a session id a ref's own status says is gone", () => {
+		registry.register({ id: "main", displayName: "main", kind: "main", session: sessionStub("s-main") });
+		registry.register({
+			id: "sub",
+			displayName: "Sub",
+			kind: "sub",
+			parentId: "main",
+			session: sessionStub("s-sub"),
+		});
+		// finalizeSubagentLifecycle parks the ref before disposal detaches its
+		// session, so for that window the ref holds a session its status denies.
+		registry.setStatus("sub", "parked");
+		registry.setStatus("main", "parked");
+		expect(registry.get("sub")?.session).not.toBeNull();
+
+		const byId = new Map(snapshotAgentRegistry(registry).map(agent => [agent.id, agent]));
+		expect(byId.get("sub")?.status).toBe("parked");
+		expect(byId.get("sub")?.sessionId).toBeUndefined();
+		expect(byId.get("sub")?.parentSessionId).toBeUndefined();
+		expect(byId.get("main")?.sessionId).toBeUndefined();
+	});
+
+	it("publishes a session attached after the registration frame", async () => {
+		const { connection, sent } = capture();
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+
+		// createAgentSession pre-registers `running` with no session, then attaches
+		// the live one once construction finishes.
+		registry.register({ id: "sub", displayName: "Sub", kind: "sub", session: null });
+		await flush();
+		expect(agentsOf(sent).map(agent => agent.sessionId)).toEqual([undefined]);
+
+		// attachSession emits nothing, and the trailing setStatus("running") is a
+		// no-op on a ref registered as running: only the refresh carries this.
+		expect(registry.attachSession("sub", sessionStub("s-sub"))).toBe(true);
+		expect(registry.setStatus("sub", "running")).toBe(true);
+		await flushRefresh();
+
+		expect(agentsOf(sent).map(agent => agent.sessionId)).toEqual(["s-sub"]);
+		stop();
+	});
+
+	it("publishes intent recorded after the first frame", async () => {
+		const { connection, sent } = capture();
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+
+		registry.register({ id: "sub", displayName: "Sub", kind: "sub", session: sessionStub("s-sub") });
+		await flush();
+		expect(agentsOf(sent)[0]?.taskTitle).toBeUndefined();
+
+		// setActivity emits no registry event, by design, so the listener alone
+		// would leave the client on the registration frame for the whole turn.
+		registry.setActivity("sub", "measuring the chrome");
+		await flushRefresh();
+
+		expect(agentsOf(sent)[0]?.taskTitle).toBe("measuring the chrome");
+		stop();
+	});
+
+	it("sends nothing while the roster is unchanged and releases the refresh when work ends", async () => {
+		const { connection, sent } = capture();
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+
+		registry.register({ id: "sub", displayName: "Sub", kind: "sub", session: sessionStub("s-sub") });
+		await flush();
+		expect(sent.length).toBe(1);
+
+		// A refresh tick over a roster nobody touched has nothing to say.
+		await flushRefresh();
+		await flushRefresh();
+		expect(sent.length).toBe(1);
+
+		registry.setStatus("sub", "idle");
+		await flush();
+		const quiesced = sent.length;
+
+		// Nothing runs now, so the refresh is released: a mutation that emits no
+		// event stays invisible until some real event brings it along.
+		expect(registry.attachSession("sub", sessionStub("s-late"))).toBe(true);
+		await flushRefresh();
+		await flushRefresh();
+		expect(sent.length).toBe(quiesced);
+
+		registry.setStatus("sub", "running");
+		await flush();
+		expect(agentsOf(sent)[0]?.sessionId).toBe("s-late");
+		stop();
+	});
+
+	it("reports each agent's own usage from its session, and history only once detached", () => {
+		const stale = {
+			resolvedModel: "google/gemini-3-pro",
+			metrics: { tokens: 99, requests: 1, tools: 0, cost: 9.99, durationMs: 5000 },
+		};
+		// A revived ref: its history describes the transcript it ran last time.
+		registry.register({
+			id: "revived",
+			displayName: "Revived",
+			kind: "sub",
+			session: sessionStub("s-revived", {
+				model: { provider: "anthropic", id: "claude-opus-5" },
+				direct: { input: 4000, output: 200, cacheWrite: 0, cost: 0.12 },
+				// This parent finished a `task` call, so its own stats carry the
+				// child's usage; the child reports it on its own row.
+				child: { input: 900_000, output: 1000, cacheWrite: 0, cost: 5.5 },
+			}),
+			history: stale,
+		});
+		// A freshly spawned subagent: no history at all until the executor writes one.
+		registry.register({
+			id: "fresh",
+			displayName: "Fresh",
+			kind: "sub",
+			session: sessionStub("s-fresh", {
+				model: { provider: "xai", id: "grok-5" },
+				direct: { input: 8, output: 2, cacheWrite: 0, cost: 0.01 },
+			}),
+		});
+		// A resumed transcript holding an entry from before usage metadata existed.
+		// One of those must not cost the session its metrics entirely, which is
+		// what an ACP root has instead of a history fallback.
+		registry.register({
+			id: "resumed",
+			displayName: "Resumed",
+			kind: "sub",
+			session: sessionStub("s-resumed", {
+				model: { provider: "openai", id: "gpt-6" },
+				direct: { input: 30, output: 5, cacheWrite: 0, cost: 0.03 },
+				legacy: true,
+			}),
+		});
+		// Detached, so history is all there is, and it is the only case with a span.
+		registry.register({
+			id: "done",
+			displayName: "Done",
+			kind: "sub",
+			session: null,
+			status: "parked",
+			history: stale,
+		});
+
+		const byId = new Map(snapshotAgentRegistry(registry).map(agent => [agent.id, agent]));
+		expect(byId.get("revived")?.model).toBe("anthropic/claude-opus-5");
+		// Its own 4200 tokens and $0.12, not the 901000 and $5.62 its stats total.
+		expect(byId.get("revived")?.metrics).toEqual({ usedTokens: 4200, costAmount: 0.12 });
+		expect(byId.get("fresh")?.model).toBe("xai/grok-5");
+		expect(byId.get("fresh")?.metrics).toEqual({ usedTokens: 10, costAmount: 0.01 });
+		// The usage-less entry is skipped, not fatal.
+		expect(byId.get("resumed")?.metrics).toEqual({ usedTokens: 35, costAmount: 0.03 });
+		expect(byId.get("done")?.model).toBe("google/gemini-3-pro");
+		expect(byId.get("done")?.metrics).toEqual({ usedTokens: 99, costAmount: 9.99, durationMs: 5000 });
+	});
+
+	it("states a roster that predates the subscription, and stays silent when there is none", async () => {
+		vi.useFakeTimers();
+		const empty = capture();
+		const stopEmpty = mirrorAgentRegistry(empty.connection, registry);
+		await flush();
+		expect(empty.sent.length).toBe(0);
+		stopEmpty();
+
+		// An embedder handing us a session it created itself: the ref exists
+		// before we subscribe, nothing runs, and onChange cannot report it.
+		registry.register({
+			id: "main",
+			displayName: "main",
+			kind: "main",
+			session: sessionStub("s-main"),
+			status: "idle",
+		});
+		const { connection, sent } = capture();
+		const stop = mirrorAgentRegistry(connection, registry);
+		await flush();
+		expect(agentsOf(sent).map(agent => agent.id)).toEqual(["main"]);
+
+		// Nothing is running, so that frame must not have left an interval behind.
+		await flushRefresh();
+		await flushRefresh();
+		expect(sent.length).toBe(1);
+		stop();
+	});
+
+	it("resnapshots when an idle session changes its id or its model", async () => {
+		const { connection, sent } = capture();
+		let sessionId = "s-before";
+		let model: { provider: string; id: string } = { provider: "anthropic", id: "claude-opus-5" };
+		let onSessionChange: (() => void) | undefined;
+		let onEvent: ((event: { type: string }) => void) | undefined;
+		const session = {
+			get sessionId() {
+				return sessionId;
+			},
+			get model() {
+				return model;
+			},
+			isStreaming: false,
+			isDisposed: false,
+			dispose: async () => {},
+			subscribeRunState: () => () => {},
+			registerSessionChangeCallback: (callback: () => void) => {
+				onSessionChange = callback;
+				return () => {
+					onSessionChange = undefined;
+				};
+			},
+			registerSessionIdentityChangeCallback: (callback: () => void) => {
+				onSessionChange = callback;
+				return () => {
+					onSessionChange = undefined;
+				};
+			},
+			subscribe: (listener: (event: { type: string }) => void) => {
+				onEvent = listener;
+				return () => {
+					onEvent = undefined;
+				};
+			},
+			agent: { state: { messages: [] } },
+			getSessionStats: () => ({
+				tokens: { input: 0, output: 0, cacheWrite: 0 },
+				assistantMessages: 0,
+				toolCalls: 0,
+				cost: 0,
+				contextUsage: undefined,
+			}),
+		} as unknown as AgentSession;
+		registry.register({ id: "main", displayName: "main", kind: "main", session, status: "idle" });
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+		await flush();
+		expect(agentsOf(sent)[0]?.sessionId).toBe("s-before");
+		expect(agentsOf(sent)[0]?.model).toBe("anthropic/claude-opus-5");
+
+		// Adopting the session is what tells the registry to watch it, which is
+		// what an ACP host does with every session it takes.
+		expect(registry.syncOwnedSession(session)).toBe(true);
+		// `newSession`, `fork`, `switchSession` and `/fresh` swap the id under an
+		// idle ref: no registry mutation, and no refresh interval either since
+		// nothing is running.
+		sessionId = "s-after";
+		onSessionChange?.();
+		await flush();
+		expect(agentsOf(sent)[0]?.sessionId).toBe("s-after");
+
+		// `session/set_config_option` on an idle session, same shape.
+		model = { provider: "openai", id: "gpt-6" };
+		onEvent?.({ type: "model_changed" });
+		await flush();
+		expect(agentsOf(sent)[0]?.model).toBe("openai/gpt-6");
+
+		// A streaming event is not a roster change and must not produce a frame.
+		const settled = sent.length;
+		onEvent?.({ type: "assistant_chunk" });
+		await flush();
+		expect(sent.length).toBe(settled);
+		stop();
+	});
+
+	it("keeps a failing notification inside the mirror", async () => {
+		// A closed or half-built connection throws on the way out. The send runs
+		// from a timer, so an escape here is an unhandled exception in the host
+		// process rather than a dropped roster frame.
+		const connection = {
+			extNotification: () => {
+				throw new Error("transport closed");
+			},
+		} as unknown as Pick<AgentSideConnection, "extNotification">;
+		vi.useFakeTimers();
+		const stop = mirrorAgentRegistry(connection, registry);
+		registry.register({ id: "sub", displayName: "Sub", kind: "sub", session: sessionStub("s-sub") });
+		await flush();
+		stop();
+	});
+});

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -511,6 +511,8 @@ async function createHarness(
 			if (options.sessionUpdateHook) await options.sessionUpdateHook(notification);
 			updates.push(notification);
 		},
+		// `initialize` starts the agent-registry mirror, which sends here.
+		extNotification: async () => {},
 		unstable_createElicitation: options.elicitationHandler
 			? async (req: CreateElicitationRequest) => options.elicitationHandler!(req)
 			: undefined,

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -947,6 +947,8 @@ describe("ACP event mapper", () => {
 				sessionUpdate: async (notification: SessionNotification) => {
 					updates.push(notification);
 				},
+				// `initialize` starts the agent-registry mirror, which sends here.
+				extNotification: async () => {},
 				signal: abortController.signal,
 				closed: Promise.resolve(),
 			} as unknown as AgentSideConnection;

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -153,6 +153,8 @@ async function createAgent(): Promise<AcpAgent> {
 	const abortController = new AbortController();
 	const connection = {
 		sessionUpdate: async () => {},
+		// `initialize` starts the agent-registry mirror, which sends here.
+		extNotification: async () => {},
 		signal: abortController.signal,
 		closed: Promise.withResolvers<void>().promise,
 	} as unknown as AgentSideConnection;

--- a/packages/coding-agent/test/acp-mcp-isolation.test.ts
+++ b/packages/coding-agent/test/acp-mcp-isolation.test.ts
@@ -28,12 +28,20 @@ afterAll(() => {
 	authStorage.close();
 });
 
+/**
+ * The factory mirrors the session's run state onto its registry ref, so every
+ * double needs the subscription even when the test is about something else.
+ */
+function fakeAcpSession(extra: Record<string, unknown> = {}): AgentSession {
+	return { subscribeRunState: () => () => {}, ...extra } as unknown as AgentSession;
+}
+
 describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
 	it("forces enableMCP=false even when baseOptions opts in", async () => {
 		const tempDir = TempDir.createSync("@pi-acp-mcp-isolation-");
 		try {
 			const settings = Settings.isolated({});
-			const fakeSession = {} as AgentSession;
+			const fakeSession = fakeAcpSession();
 			const captured: CreateAgentSessionOptions[] = [];
 			const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
 				captured.push(options);
@@ -79,13 +87,13 @@ describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
 		try {
 			const settings = Settings.isolated({});
 			let disposed = false;
-			const fakeSession = {
+			const fakeSession = fakeAcpSession({
 				extensionRunner: undefined,
 				getAllToolNames: () => ["read"],
 				dispose: async () => {
 					disposed = true;
 				},
-			} as unknown as AgentSession;
+			});
 			const factory = createAcpSessionFactory({
 				baseOptions: {} as CreateAgentSessionOptions,
 				settings,
@@ -120,7 +128,7 @@ describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
 				`import { writeFileSync } from "node:fs"; export default function (pi) { pi.events.on("acp-session-live", () => writeFileSync(${JSON.stringify(firedPath)}, "fired")); }`,
 			);
 			let captured: CreateAgentSessionOptions | undefined;
-			const fakeSession = {} as AgentSession;
+			const fakeSession = fakeAcpSession();
 			const factory = createAcpSessionFactory({
 				baseOptions: {
 					disableExtensionDiscovery: true,
@@ -196,7 +204,7 @@ describe("createAcpSessionFactory TITLE_SYSTEM.md per-cwd resolution (PR #3736)"
 			const projectDir = tempDir.join("project");
 			await Bun.write(`${projectDir}/.omp/TITLE_SYSTEM.md`, "Project-specific title policy.");
 
-			const fakeSession = {} as AgentSession;
+			const fakeSession = fakeAcpSession();
 			const captured: CreateAgentSessionOptions[] = [];
 			const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
 				captured.push(options);

--- a/packages/coding-agent/test/acp-session-run-state.test.ts
+++ b/packages/coding-agent/test/acp-session-run-state.test.ts
@@ -1,0 +1,263 @@
+/**
+ * An ACP session's registry ref must report what the session is actually doing,
+ * in whichever registry the session was registered into.
+ *
+ * `createAgentSession` registers and attaches every ref as `running`, and only
+ * the task and revival paths mirror run state back onto it. An ACP session
+ * therefore read `running` for its whole life, between prompts included, which
+ * is stale to the roster, to `notifications/agent_registry`, and to anything
+ * that keys polling off live work.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAcpSessionFactory } from "@oh-my-pi/pi-coding-agent/main";
+import { AcpAgent } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { getConfigRootDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import type { AgentSideConnection, InitializeRequest, NewSessionRequest } from "@oh-my-pi/pi-utils/acp";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+const authStorage = createInMemoryAuthStorage();
+const modelRegistry = new ModelRegistry(authStorage);
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+afterAll(() => {
+	authStorage.close();
+});
+
+interface RunStateSession {
+	session: AgentSession;
+	/** Drives the run-state transitions a real prompt would emit. */
+	notify: (state: "running" | "idle") => void;
+	subscribed: () => boolean;
+}
+
+function runStateSessionStub(): RunStateSession {
+	let listener: ((state: "running" | "idle") => void) | undefined;
+	const session = {
+		isStreaming: false,
+		subscribeRunState: (next: (state: "running" | "idle") => void) => {
+			listener = next;
+			return () => {
+				listener = undefined;
+			};
+		},
+		registerSessionChangeCallback: () => () => {},
+		registerSessionIdentityChangeCallback: () => () => {},
+		subscribe: () => () => {},
+		getAllToolNames: () => [],
+		dispose: async () => {},
+		sessionId: "stub-session",
+		sessionManager: { ensureOnDisk: async () => {} },
+		setClientBridge: () => {},
+		refreshMCPTools: async () => {},
+		getPlanModeState: () => undefined,
+		settings: { get: () => undefined },
+		model: undefined,
+		thinkingLevel: undefined,
+		isAutoThinking: false,
+		getAvailableModels: () => [],
+		getAvailableThinkingLevels: () => [],
+	} as unknown as AgentSession;
+	return {
+		session,
+		notify: state => listener?.(state),
+		subscribed: () => listener !== undefined,
+	};
+}
+
+/** What `createAgentSession` leaves behind for every caller: registered, attached, `running`. */
+function registerAsCreateAgentSessionWould(registry: AgentRegistry, id: string, session: AgentSession): void {
+	registry.register({
+		id,
+		displayName: "acp",
+		kind: "main",
+		session,
+		status: "running",
+	});
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: {
+			extensions: [],
+			errors: [],
+			runner: undefined,
+		} as unknown as CreateAgentSessionResult["extensionsResult"],
+		setToolUIContext: () => {},
+		eventBus: {
+			emit: () => {},
+			on: () => () => {},
+			off: () => {},
+		} as unknown as CreateAgentSessionResult["eventBus"],
+	};
+}
+
+function acpConnectionStub(aborter: AbortController): AgentSideConnection {
+	return {
+		sessionUpdate: async () => {},
+		extNotification: async () => {},
+		signal: aborter.signal,
+		closed: Promise.withResolvers<void>().promise,
+	} as unknown as AgentSideConnection;
+}
+
+describe("ACP session run state", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		if (originalAgentDir) setAgentDir(originalAgentDir);
+		else setAgentDir(path.join(getConfigRootDir(), "agent"));
+	});
+
+	it("mirrors run-state transitions onto the session's registry ref", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-run-state-");
+		try {
+			const registry = AgentRegistry.global();
+			const stub = runStateSessionStub();
+			const factory = createAcpSessionFactory({
+				baseOptions: {} as CreateAgentSessionOptions,
+				settings: Settings.isolated({}),
+				sessionDir: tempDir.join("sessions"),
+				authStorage,
+				modelRegistry,
+				parsedArgs: {},
+				rawArgs: [],
+				createSession: async (options: CreateAgentSessionOptions) => {
+					registerAsCreateAgentSessionWould(registry, options.agentId ?? "unset", stub.session);
+					return createSessionResult(stub.session);
+				},
+			});
+			await factory(tempDir.path());
+
+			const ids = registry.list().map(ref => ref.id);
+			expect(ids).toHaveLength(1);
+			const id = ids[0] ?? "";
+			expect(id.startsWith("acp:")).toBe(true);
+			// Nobody has prompted this session yet.
+			expect(registry.get(id)?.status).toBe("idle");
+
+			// And a prompt's edges land on the ref rather than leaving it stale.
+			expect(stub.subscribed()).toBe(true);
+			stub.notify("running");
+			expect(registry.get(id)?.status).toBe("running");
+			stub.notify("idle");
+			expect(registry.get(id)?.status).toBe("idle");
+		} finally {
+			await tempDir.remove();
+		}
+	});
+
+	it("corrects the ref in the embedder's own registry, not the global one", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-run-state-isolated-");
+		try {
+			const isolated = new AgentRegistry();
+			const stub = runStateSessionStub();
+			const factory = createAcpSessionFactory({
+				baseOptions: { agentRegistry: isolated } as CreateAgentSessionOptions,
+				settings: Settings.isolated({}),
+				sessionDir: tempDir.join("sessions"),
+				authStorage,
+				modelRegistry,
+				parsedArgs: {},
+				rawArgs: [],
+				createSession: async (options: CreateAgentSessionOptions) => {
+					// createAgentSession registers into the registry it was given.
+					registerAsCreateAgentSessionWould(
+						options.agentRegistry ?? AgentRegistry.global(),
+						options.agentId ?? "unset",
+						stub.session,
+					);
+					return createSessionResult(stub.session);
+				},
+			});
+			await factory(tempDir.path());
+
+			const id = isolated.list()[0]?.id ?? "";
+			expect(id.startsWith("acp:")).toBe(true);
+			expect(isolated.get(id)?.status).toBe("idle");
+			stub.notify("running");
+			expect(isolated.get(id)?.status).toBe("running");
+			// The global registry never held this session and was never written to.
+			expect(AgentRegistry.global().list()).toHaveLength(0);
+		} finally {
+			await tempDir.remove();
+		}
+	});
+
+	it("corrects an adopted initial session when the ACP agent initializes", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-run-state-adopted-");
+		const aborter = new AbortController();
+		let agent: AcpAgent | undefined;
+		try {
+			setAgentDir(tempDir.join("agent"));
+			const registry = new AgentRegistry();
+			const stub = runStateSessionStub();
+			// An SDK embedder hands its own session to createAcpConnection, so it
+			// never passes through the ACP factory.
+			registerAsCreateAgentSessionWould(registry, "acp:adopted", stub.session);
+			agent = new AcpAgent(
+				acpConnectionStub(aborter),
+				async () => ({ session: stub.session, setToolUIContext: () => {} }),
+				stub.session,
+				registry,
+			);
+
+			await agent.initialize({ protocolVersion: 1, clientCapabilities: {} } as InitializeRequest);
+
+			expect(registry.get("acp:adopted")?.status).toBe("idle");
+			expect(stub.subscribed()).toBe(true);
+			stub.notify("running");
+			expect(registry.get("acp:adopted")?.status).toBe("running");
+		} finally {
+			aborter.abort();
+			await agent?.dispose();
+			await tempDir.remove();
+		}
+	});
+
+	it("corrects a session an embedder's own factory returned", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-run-state-custom-factory-");
+		const aborter = new AbortController();
+		let agent: AcpAgent | undefined;
+		try {
+			setAgentDir(tempDir.join("agent"));
+			const registry = new AgentRegistry();
+			const stub = runStateSessionStub();
+			agent = new AcpAgent(
+				acpConnectionStub(aborter),
+				// An embedder's own AcpSessionFactory, built on createAgentSession, so
+				// the session arrives registered `running` having never seen the
+				// bundled ACP factory.
+				async () => {
+					registerAsCreateAgentSessionWould(registry, "acp:from-embedder", stub.session);
+					return { session: stub.session, setToolUIContext: () => {} };
+				},
+				undefined,
+				registry,
+			);
+			await agent.initialize({ protocolVersion: 1, clientCapabilities: {} } as InitializeRequest);
+
+			await agent.newSession({ cwd: tempDir.path(), mcpServers: [] } as NewSessionRequest);
+
+			expect(registry.get("acp:from-embedder")?.status).toBe("idle");
+			expect(stub.subscribed()).toBe(true);
+			stub.notify("running");
+			expect(registry.get("acp:from-embedder")?.status).toBe("running");
+		} finally {
+			// The bootstrap updates are deferred behind a timer that bails on an
+			// aborted signal; without this they reach the session after the test.
+			aborter.abort();
+			await agent?.dispose();
+			await tempDir.remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -747,6 +747,46 @@ describe("AgentSession advisor toggle", () => {
 			load.mockRestore();
 		}
 	});
+	it("preserves an initial cost restore during a provider-only reset", async () => {
+		const restore = Promise.withResolvers<Map<string, number>>();
+		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockImplementation((_file, options) => {
+			options?.onSnapshot?.();
+			return restore.promise;
+		});
+		try {
+			session.beginInitialAdvisorCostRestore();
+			const fresh = session.freshSession();
+			expect(fresh).toBeDefined();
+			restore.resolve(new Map([["", 0.5]]));
+			await session.advisorCostRestore;
+
+			expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+		} finally {
+			load.mockRestore();
+		}
+	});
+	it("ignores an initial cost restore after switching sessions", async () => {
+		const targetSessionFile = SessionManager.createEmptySessionFile(tempDir.path());
+		const restore = Promise.withResolvers<Map<string, number>>();
+		const initialFile = session.sessionFile;
+		const load = vi.spyOn(advisorModule, "loadAdvisorTranscriptCosts").mockImplementation(async (file, options) => {
+			if (file === initialFile) {
+				options?.onSnapshot?.();
+				return restore.promise;
+			}
+			return new Map();
+		});
+		try {
+			session.beginInitialAdvisorCostRestore();
+			expect(await session.switchSession(targetSessionFile)).toBe(true);
+			restore.resolve(new Map([["", 0.5]]));
+			await session.advisorCostRestore;
+
+			expect(session.getAdvisorCost()).toBe(0);
+		} finally {
+			load.mockRestore();
+		}
+	});
 	it("starts a new session with only post-transition advisor cost", async () => {
 		const advisor = enableAdvisor();
 		appendAdvisorCost(advisor, 0.5, 1);

--- a/packages/coding-agent/test/agent-session-fresh.test.ts
+++ b/packages/coding-agent/test/agent-session-fresh.test.ts
@@ -109,4 +109,36 @@ describe("AgentSession fresh provider state", () => {
 		expect(session.sessionId).toBe(sessionManager.getSessionId());
 		expect(session.sessionId).not.toBe(freshResult.sessionId);
 	});
+
+	it("notifies session-change observers when only the provider id rotates", async () => {
+		const { session, sessionManager } = await createFreshHarness();
+		const seen: string[] = [];
+		const unregister = session.registerSessionIdentityChangeCallback(() => {
+			seen.push(session.sessionId);
+		});
+		const transcriptChanges: string[] = [];
+		const unregisterTranscript = session.registerSessionChangeCallback(() => {
+			transcriptChanges.push(sessionManager.getSessionId());
+		});
+		try {
+			// `/fresh` leaves the transcript and its manager id alone, so an
+			// observer watching the manager sees nothing while the id it actually
+			// reads, `session.sessionId`, has already moved.
+			const fresh = session.freshSession();
+			expect(fresh).toBeDefined();
+			if (!fresh) return;
+			expect(sessionManager.getSessionId()).toBe(fresh.previousSessionId);
+			expect(seen).toEqual([fresh.sessionId]);
+			expect(transcriptChanges).toEqual([]);
+
+			// And the reverse transition, back onto the manager's own id.
+			await session.newSession();
+			expect(seen).toHaveLength(2);
+			expect(seen[1]).toBe(session.sessionId);
+			expect(transcriptChanges).toHaveLength(1);
+		} finally {
+			unregister();
+			unregisterTranscript();
+		}
+	});
 });

--- a/packages/coding-agent/test/tools/hub/launch-compat.test.ts
+++ b/packages/coding-agent/test/tools/hub/launch-compat.test.ts
@@ -349,6 +349,64 @@ describe("launch broker protocol compatibility", () => {
 		expect(preservedPending).toBe(true);
 	});
 
+	it("delivers a broker completion after a provider-only session reset", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const queued: DaemonCompletionNotification[] = [];
+		let deliver: ((notification: DaemonCompletionNotification) => void) | undefined;
+		let sessionChange: (() => void) | undefined;
+		const completion = {
+			event: "daemon-completed",
+			completionId: "completion-id",
+			owner,
+			daemon: {
+				name: "web",
+				id: "daemon-id",
+				state: "exited",
+				createdAt: 1,
+				startedAt: 1,
+				exitedAt: 2,
+				exitCode: 0,
+				restartCount: 0,
+				outputBytes: 0,
+				owner,
+				persist: false,
+				detached: false,
+			},
+		} satisfies DaemonCompletionNotification;
+		const client = {
+			projectDir,
+			onCompletion: (_owner: string, sink: (notification: DaemonCompletionNotification) => void) => {
+				deliver = sink;
+				return () => {
+					deliver = undefined;
+				};
+			},
+			request: async () => ({ op: "start", daemon: completion.daemon, readyTimedOut: false }) as const,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				isDisposed: () => false,
+				queueLaunchCompletion: (notification: DaemonCompletionNotification) => queued.push(notification),
+				registerSessionChangeCallback: (callback: () => void) => {
+					sessionChange = callback;
+				},
+			} as unknown as ToolSession,
+			{ op: "start", name: "web", application: process.execPath, args: [] },
+		);
+
+		// Provider-only reset does not fire session change callbacks while manager ID is unchanged
+		expect(sessionChange).toBeDefined();
+		expect(deliver).toBeDefined();
+		deliver?.(completion);
+		expect(queued).toEqual([completion]);
+	});
+
 	it("keeps the completion sink when start delivery is indeterminate", async () => {
 		const projectDir = process.cwd();
 		let unregisters = 0;


### PR DESCRIPTION
## Problem

ACP carries no subagent layer. `acp-event-mapper.ts` maps a `task` call like any other tool: a `tool_call` with the batch as `rawInput`, then a `tool_call_update` when the last child yields. Nothing in the standard update set names a parent or a child, and the children's own turns never cross the wire. A client hosting omp over ACP (an editor, a control plane) sees a fan-out as one slow tool and cannot show who is working on what.

The in-process `AgentRegistry` already knows every agent, its parent, status, activity and transcript, and `CollabHost` already subscribes to `AgentRegistry.global().onChange()` and broadcasts that roster to collab guests (`host.ts:287`, `#snapshotAgents`). The ACP agent never did the same.

## Change

`modes/acp/agent-registry-notification.ts`: `snapshotAgentRegistry()` maps the registry to a JSON snapshot per agent (`id`, `displayName`, `kind`, `parentId`, `parentSessionId`, `sessionId` while live, `status`, ISO `createdAt`/`lastActiveAt`, `taskTitle` from `activity`, `model` and `metrics` from history), and `mirrorAgentRegistry(connection)` sends it as the extension notification `notifications/agent_registry` on every registry change, debounced 100ms like the collab broadcast. `AcpAgent` subscribes in `initialize` (not the constructor, so nothing is sent before the handshake) and releases the subscription in `dispose`.

Advisors are included, unlike the collab broadcast: the ACP client is the operator's own process, not a guest, and `kind` lets it drop them.

## Proof

`test/acp-agent-registry-notification.test.ts`: the snapshot carries lineage by parent id and parent session id, a parked child claims no session id; one notification per burst of registrations under fake timers, another on a status change, none after unsubscribe. `acp-agent.test.ts` and `acp-event-mapper.test.ts` still pass (122). No new type errors in `packages/coding-agent` (the two pre-existing `kitty-vt-wasm` ones are untouched). The emitted payload was also fed to the consumer that motivated this (ompd's `parseAgentRegistryNotification`) and parses unchanged.

---

## Update: rebased and review feedback addressed

Rebased onto `main` (`8fad7f1006`) as a single commit; two conflicts, both in signatures rather than logic (`RunAcpMode` alongside upstream's `RunPrintMode` change, and an additive import in `acp-agent.ts`). Upstream has no ACP agent-registry notification of its own, so nothing here is redundant.

Every fix from the earlier rounds was re-verified in place after the rebase, and one regression from those rounds is fixed here. Widening the watched identity to `${currentSessionId}\0${sid}` so `/fresh` reaches the mirror also made every `registerSessionChangeCallback` consumer fire on a provider-only rotation, which caused `tools/hub/launch.ts` to unregister a daemon completion sink whose owner id had not changed. The cleanup is now gated on the manager id actually changing (`tools/hub/launch.ts:96-100`), so `/fresh` keeps an in-flight `launch` deliverable while `newSession` and `switchSession` still tear the sink down, and the mirror still re-snapshots on provider rotation.

Still deliberately out of scope, and called out here rather than left in a collapsed thread: propagating an embedder-supplied registry down to spawned subagents. `AgentRegistry.global()` has 15 direct call sites in `task/executor.ts` alone and roughly 50 across the tree, and threading a custom registry through them means moving `AgentLifecycleManager` ownership, the IRC rosters and internal URL routing. That is a separate PR, not scope creep on a notification feature.

**Testing on this head:** `bun run check:ts` exits 0. Targeted suites 152 pass / 0 fail across the seven affected ACP and session files, plus 31 pass / 0 fail on the launch compatibility suite. Each new case fails against the unfixed source, including the launch delivery one (`expect(received).toBeDefined() / Received: undefined`).

