### PR TITLE
fix(acp): isolate JSON-RPC stdout from stray process.stdout writers

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,4 +1,5 @@
 import * as stream from "node:stream";
+import { inspect } from "node:util";
 import { postmortem } from "@oh-my-pi/pi-utils";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@oh-my-pi/pi-utils/acp";
 import type { ExtensionUIContext } from "../../extensibility/extensions/types";
@@ -36,6 +37,39 @@ export function createAcpConnection(
 	}, transport);
 }
 
+/**
+ * Redirects stray stdout traffic to stderr so it can never corrupt the JSON-RPC channel.
+ */
+function isolateProtocolStdout(): NodeJS.WriteStream {
+	// fd 1 is the JSON-RPC transport — the same invariant rpc-mode guards by
+	// suppressing notifications. Extensions, dependencies, and console.log all
+	// target process.stdout; a single OSC title or BEL spliced into the stream
+	// desyncs frame parsing and the client times out. Capture the real stdout
+	// for the transport, then detour every other writer to stderr.
+	const protocolStdout = process.stdout;
+	const stderrSink = new stream.Writable({
+		write(chunk, _encoding, callback) {
+			process.stderr.write(chunk, callback);
+		},
+	}) as unknown as NodeJS.WriteStream;
+	Object.defineProperty(process, "stdout", { value: stderrSink, configurable: true, writable: true });
+	// Node's bootstrap console bound to the original stdout object; rebind so
+	// extension console.log calls are detoured away from fd 1 as well.
+	(globalThis.console as unknown as { log: (...args: unknown[]) => void }).log = (...args) =>
+		process.stderr.write(`${formatConsoleArgs(args)}\n`);
+	return protocolStdout;
+}
+
+function formatConsoleArgs(args: unknown[]): string {
+	return args
+		.map(arg => {
+			if (typeof arg === "string") return arg;
+			if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+			return inspect(arg, { depth: 2, breakLength: 120 });
+		})
+		.join(" ");
+}
+
 /** Serves ACP over stdio until the peer disconnects, then awaits session teardown before exit. */
 export async function runAcpMode(createSession: AcpSessionFactory, initialSession?: AgentSession): Promise<void> {
 	// Humans who run `omp acp` by hand see a silent process and assume it is
@@ -52,7 +86,7 @@ export async function runAcpMode(createSession: AcpSessionFactory, initialSessio
 	let agent: AcpAgent | undefined;
 	postmortem.register("acp-session-teardown", reason => agent?.dispose(reason));
 	postmortem.registerStdioDisconnectHandling();
-	const input = stream.Writable.toWeb(process.stdout);
+	const input = stream.Writable.toWeb(isolateProtocolStdout());
 	const output = stream.Readable.toWeb(process.stdin);
 	const transport = ndJsonStream(input, output);
 	const connection = createAcpConnection(transport, createSession, initialSession, createdAgent => {


### PR DESCRIPTION
## Problem

Any extension or dependency that writes to `process.stdout` corrupts the ACP JSON-RPC stream. Node's bootstrap `console` is bound to fd 1, so even a stray `console.log` lands on the protocol channel. In `rpc-mode.ts` this invariant is documented and guarded:

> In RPC mode stdout is the JSON protocol channel — nothing else may write there.

ACP mode documents the same reality (`runAcpMode` warns humans that stdout is the transport) but never enforces it, and `PI_NO_TITLE=1` (set for ACP in `main.ts`) only covers writers that honor the flag. `ctx.hasUI === true` under ACP does not imply stdout is a terminal.

### Real-world failure

An OMP extension (notification adapter) writes an OSC tab-title escape sequence on `session_start` when it sees a remote UI. Under an ACP client (Buzz Desktop) those bytes spliced into the ndjson stream, the client discarded the `session/new` response, and **every managed agent timed out at 60s before reaching any model call** — startup was silently dead for all agents sharing that extension.

## Fix

In `runAcpMode`, before wiring the transport: capture the real `process.stdout` for the JSON-RPC side, then detour every other writer to stderr.

- `process.stdout` is replaced by a small Writable sink that forwards to `process.stderr` (captures OSC/BER sequences, raw writes, everything).
- `globalThis.console.log` is rebound to stderr (Node's bootstrap console object holds a direct reference to the original stdout stream object, so swapping `process.stdout` alone is not enough for `console.log`).
- The transport keeps writing to the original fd 1 — protocol framing untouched.

Extensions keep working; their output becomes log lines on stderr instead of protocol corruption. This makes the rpc-mode invariant structural for ACP rather than relying on every extension honoring `PI_NO_TITLE`.

## Verification

End-to-end over raw stdio (`initialize` + `session/new`) with a deliberately hostile probe extension (OSC title + `console.log` at module load, raw `process.stdout.write` + `console.log` on `session_start`), reading fd 1 and fd 2 into separate collectors:

| Run | fd-1 JSON frames | fd-1 corrupt lines | stderr noise | session/new |
|---|---|---|---|---|
| without patch | 4 | 3 (OSC + console text + raw write spliced into frame stream) | 0 | reply interleaved with garbage |
| with patch | 4 | 0 | 3 (all noise detoured) | clean reply |

Also verified: `tsgo --noEmit`, oxlint, and oxfmt clean on the touched file; hostile-extension turn completes normally with noise visible on stderr.