### PR TITLE
fix(coding-agent): sanitize tabs and CR in read error rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+
 ## [18.1.15] - 2026-09-08
 
 ### Added

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -30,7 +30,7 @@ import { applyListLimit } from "./list-limit";
 import { formatStyledArtifactReference, type OutputMeta } from "./output-meta";
 import { isReadableUrlPath, type LineRange, parseLineRanges, parseTailCount } from "./path-utils";
 import type { ParsedSelector } from "./read-selector";
-import { formatBytes, formatExpandHint, getDomain, replaceTabs } from "./render-utils";
+import { formatBytes, formatExpandHint, getDomain, sanitizeDisplayLines } from "./render-utils";
 import { listTables, looksLikeSqlite, openSqliteReadConnection, renderTableList } from "./sqlite-reader";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
@@ -1821,7 +1821,7 @@ export function renderReadUrlResult(
 		const urlText = details?.finalUrl ?? details?.url ?? "";
 		const description = urlText ? formatReadUrlDescription(urlText) : undefined;
 		const header = renderStatusLine({ icon: "error", title: "Read", description }, uiTheme);
-		const errorLines = errorText.split("\n").map(line => uiTheme.fg("error", replaceTabs(line)));
+		const errorLines = sanitizeDisplayLines(errorText).map(line => uiTheme.fg("error", line));
 		const outputBlock = new CachedOutputBlock();
 		return markFramedBlockComponent({
 			render: (width: number) =>
@@ -1884,7 +1884,9 @@ export function renderReadUrlResult(
 			if (contentPreviewLines === undefined || lastExpanded !== expanded) {
 				const previewLimit = expanded ? 12 : 3;
 				const previewList = applyListLimit(contentLines, { headLimit: previewLimit });
-				const previewLines = previewList.items.map(line => line.trimEnd());
+				const previewLines = previewList.items
+					.flatMap(line => sanitizeDisplayLines(line))
+					.map(line => line.trimEnd());
 				const remaining = Math.max(0, contentLines.length - previewList.items.length);
 				contentPreviewLines =
 					previewLines.length > 0

--- a/packages/coding-agent/src/tools/read-renderer.ts
+++ b/packages/coding-agent/src/tools/read-renderer.ts
@@ -10,7 +10,7 @@ import { formatFullOutputReference, formatStyledTruncationWarning, stripOutputNo
 import { isReadableUrlPath, splitInternalUrlSel, splitPathAndSel } from "./path-utils";
 import type { ReadToolDetails } from "./read";
 import { isRawSelector, parseSel } from "./read-selector";
-import { formatBytes, replaceTabs, shortenPath, wrapBrackets } from "./render-utils";
+import { formatBytes, sanitizeDisplayLines, shortenPath, wrapBrackets } from "./render-utils";
 
 // =============================================================================
 // TUI Renderer
@@ -138,7 +138,7 @@ export const readToolRenderer = {
 				title += `:${startLine}${endLine ? `-${endLine}` : ""}`;
 			}
 			const header = renderStatusLine({ icon: "error", title }, uiTheme);
-			const errorLines = errorText.split("\n").map(line => uiTheme.fg("error", replaceTabs(line)));
+			const errorLines = sanitizeDisplayLines(errorText).map(line => uiTheme.fg("error", line));
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
 				render: (width: number) =>
@@ -191,7 +191,9 @@ export const readToolRenderer = {
 				{ icon: suffix ? "warning" : "success", title: "Read", description: `${displayPath}${correction}` },
 				uiTheme,
 			);
-			const detailLines = contentText ? contentText.split("\n").map(line => uiTheme.fg("toolOutput", line)) : [];
+			const detailLines = contentText
+				? sanitizeDisplayLines(contentText).map(line => uiTheme.fg("toolOutput", line))
+				: [];
 			const lines = [...detailLines, ...warningLines];
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -318,6 +318,21 @@ function sanitizeErrorText(message: string | undefined): string {
 	return clean ? replaceTabs(truncateToWidth(clean, TRUNCATE_LENGTHS.LINE)) : "Unknown error";
 }
 
+/**
+ * Split multi-line tool text into TUI-safe display lines.
+ * Splits CRLF/LF, collapses stray `\r` progress overwrites to the final
+ * segment (mirroring terminal rendering), and expands tabs — so raw
+ * subprocess or fetched output (e.g. Windows ssh emitting CRLF, tab-indented
+ * web content) can't corrupt the framed block layout with cursor-moving
+ * control characters or tab-stop width mismatches.
+ */
+export function sanitizeDisplayLines(text: string): string[] {
+	return text.split(/\r?\n/).map(line => {
+		const idx = line.lastIndexOf("\r");
+		return replaceTabs(idx < 0 ? line : line.slice(idx + 1));
+	});
+}
+
 export function formatErrorMessage(message: string | undefined, theme: Theme): string {
 	return `${theme.styledSymbol("status.error", "error")} ${theme.fg("error", `Error: ${sanitizeErrorText(message)}`)}`;
 }

--- a/packages/coding-agent/test/tools/read-renderer.test.ts
+++ b/packages/coding-agent/test/tools/read-renderer.test.ts
@@ -222,3 +222,109 @@ describe("read ToolExecutionComponent framing", () => {
 		}
 	});
 });
+
+describe("readToolRenderer error sanitization", () => {
+	it("strips Windows CRLF and expands tabs in ssh failure output", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		// Windows ssh emits CRLF; a raw CR styled inside the color wrap rides
+		// past output-block trimming (it trims after wrapping) and moves the
+		// terminal cursor mid-row, tearing the framed block.
+		const component = readToolRenderer.renderResult(
+			{
+				content: [
+					{
+						type: "text",
+						text: "Failed to start SSH master for can.internal: The fingerprint for the ED25519 key sent by the remote host is\r\nSHA256:abc\tdef\r\nAdd correct host key in /root/.ssh/known_hosts to get rid of this message.\r\nHost key verification failed.",
+					},
+				],
+				isError: true,
+			},
+			{ expanded: false, isPartial: false },
+			theme!,
+			{ path: "ssh://can.internal/root/arc-smp-values.yaml" },
+		);
+
+		const raw = component.render(100).join("\n");
+		expect(raw).not.toContain("\t");
+		expect(raw).not.toContain("\r");
+		const stripped = Bun.stripANSI(raw);
+		expect(stripped).toContain("SHA256:abc");
+		expect(stripped).toContain("Host key verification failed.");
+	});
+
+	it("sanitizes URL read errors the same way", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "fetch failed:\tconn reset\r\nby peer" }],
+				isError: true,
+			},
+			{ expanded: false, isPartial: false },
+			theme!,
+			{ path: "http://example.com/file" },
+		);
+
+		const raw = component.render(100).join("\n");
+		expect(raw).not.toContain("\t");
+		expect(raw).not.toContain("\r");
+		expect(Bun.stripANSI(raw)).toContain("fetch failed:");
+	});
+});
+
+describe("readToolRenderer success-path sanitization", () => {
+	it("expands tabs in URL content previews", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "---\n\ncol1\tcol2\nrow2" }],
+				details: {
+					kind: "url",
+					url: "http://example.com/start",
+					finalUrl: "http://example.com/final",
+					contentType: "text/plain",
+					method: "fetch",
+					truncated: false,
+					notes: [],
+				},
+			} as never,
+			{ expanded: false, isPartial: false },
+			theme!,
+			{ path: "http://example.com/start" },
+		);
+
+		const raw = component.render(200).join("\n");
+		expect(raw).not.toContain("\t");
+		expect(raw).not.toContain("\r");
+		expect(Bun.stripANSI(raw)).toContain("col1");
+	});
+
+	it("expands tabs in image detail lines", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const component = readToolRenderer.renderResult(
+			{
+				content: [
+					{ type: "text", text: "a\tb" },
+					{ type: "image", data: "", mimeType: "image/png" },
+				],
+				details: { contentType: "image/png" },
+				isError: false,
+			} as never,
+			{ expanded: false, isPartial: false },
+			theme!,
+			{ path: "local://shot.png" },
+		);
+
+		const raw = component.render(100).join("\n");
+		expect(raw).not.toContain("\t");
+		expect(raw).not.toContain("\r");
+		expect(Bun.stripANSI(raw)).toContain("a");
+	});
+});

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -14,10 +14,16 @@ import {
 	formatParseErrors,
 	formatFeedModelBadge,
 	formatScreenshot,
+	sanitizeDisplayLines,
 	shortenPath,
 	truncateDiffByHunk,
 } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
-import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
+import {
+	DEFAULT_TAB_WIDTH,
+	getKeybindings,
+	setKeybindings,
+	type KeybindingsManager as TuiKeybindingsManager,
+} from "@oh-my-pi/pi-tui";
 
 describe("feed model badges", () => {
 	let uiTheme: Theme;
@@ -501,5 +507,22 @@ describe("formatExpandHint / expandKeyHint", () => {
 		setKeybindings(KeybindingsManager.inMemory());
 		expect(formatExpandHint(plainTheme, true, true)).toBe("");
 		expect(formatExpandHint(plainTheme, false, false)).toBe("");
+	});
+});
+
+describe("sanitizeDisplayLines", () => {
+	it("expands tabs so error lines never emit raw tab stops", () => {
+		expect(sanitizeDisplayLines("offending\tkey")).toEqual([`offending${" ".repeat(DEFAULT_TAB_WIDTH)}key`]);
+	});
+
+	it("splits Windows CRLF stderr without leaving carriage returns", () => {
+		const lines = sanitizeDisplayLines("SHA256:abc\r\nHost key verification failed.\r\n");
+		expect(lines.join("\n")).not.toContain("\r");
+		expect(lines).toContain("SHA256:abc");
+		expect(lines).toContain("Host key verification failed.");
+	});
+
+	it("collapses carriage-return progress overwrites to the final segment", () => {
+		expect(sanitizeDisplayLines("50%\r100%")).toEqual(["100%"]);
 	});
 });


### PR DESCRIPTION
Read error blocks split on LF and expanded tabs, but a trailing CR (e.g. Windows ssh emitting CRLF on host-key failures) survived inside the ANSI color wrap, moved the terminal cursor mid-row, and tore the framed block. Error lines in the read and URL-read renderers now go through a shared sanitizeDisplayLines helper (split CRLF/LF, collapse stray CR progress overwrites to the final segment, expand tabs). The same gap existed in two success-path previews rendering raw lines into the same framed blocks (URL content preview, image detail lines); both go through the helper too. Regression tests cover the helper, both error branches, and both preview branches; the error tests fail on the old code with the raw CR leaking into the frame.