### PR TITLE
fix(coding-agent): honor configured smol fallback for tiny

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Unset `tiny` model roles now honor the configured `@smol` fallback in direct execution and the `/models` Roles view ([#11311](https://github.com/can1357/oh-my-pi/issues/11311)).
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1151,6 +1151,10 @@ const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> =
 	tiny: "smol",
 };
 
+const ROLE_CONFIGURED_FALLBACK: Partial<Record<ModelRole, ModelRole>> = {
+	tiny: "smol",
+};
+
 /** Built-in priority patterns for a role, following {@link ROLE_PRIORITY_ALIAS}. */
 function rolePriorityDefaults(role: ModelRole): string[] {
 	const key = ROLE_PRIORITY_ALIAS[role] ?? (role as keyof typeof MODEL_PRIO);
@@ -1218,11 +1222,14 @@ function resolveConfiguredRolePattern(
 	const configured = settings?.getModelRole(role)?.trim();
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
+	const configuredFallback = isModelRole(role) ? ROLE_CONFIGURED_FALLBACK[role] : undefined;
 	const resolved = configured
 		? normalizeModelPatternList(configured)
-		: isModelRole(role)
-			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
-			: roleDefaults;
+		: configuredFallback
+			? (resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback), settings, new Set(visited)) ?? [])
+			: isModelRole(role)
+				? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
+				: roleDefaults;
 	if (resolved.length === 0) {
 		resolved.push(...roleDefaults);
 	}

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -13,7 +13,6 @@ import {
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";

--- a/packages/coding-agent/test/model-browser.test.ts
+++ b/packages/coding-agent/test/model-browser.test.ts
@@ -7,6 +7,7 @@ import {
 	buildBrowserItems,
 	ModelBrowser,
 	type RoleAssignments,
+	resolveRoleAssignments,
 	sortModelItems,
 } from "@oh-my-pi/pi-coding-agent/modes/components/model-browser";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -44,6 +45,25 @@ function makeBrowser(
 	browser.setItems(items);
 	return browser;
 }
+
+describe("resolveRoleAssignments", () => {
+	test("shows configured smol for an unconfigured tiny role", () => {
+		const smol = makeModel("demo", "custom-smol");
+		const priorityHead = makeModel("demo", "gemini-3.8-flash");
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "demo/default",
+				smol: "demo/custom-smol",
+			},
+		});
+
+		const roles = resolveRoleAssignments(settings, [smol, priorityHead], [smol, priorityHead]);
+
+		expect(roles.smol?.model).toBe(smol);
+		expect(roles.tiny?.model).toBe(smol);
+		expect(roles.tiny?.autoSelected).toBe(true);
+	});
+});
 
 describe("ModelBrowser search ranking", () => {
 	test("an exact query match outranks the MRU model", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1127,6 +1127,17 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@slow", settings })).toEqual(["local/llama"]);
 	});
 
+	test("uses configured smol for unconfigured tiny before priority defaults", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "local/default",
+				smol: "baseten/custom-smol:max",
+			},
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@tiny", settings })).toEqual(["baseten/custom-smol:max"]);
+	});
+
 	test("expands cross-role default aliases when inheriting for an unset role", () => {
 		const settings = Settings.isolated({
 			modelRoles: { default: "@slow", slow: "anthropic/claude-sonnet-4-5" },


### PR DESCRIPTION
## Repro
With `modelRoles.smol` set to `baseten/custom-smol:max` and `tiny` unset, run `bun -e 'import { resolveAgentModelPatterns } from \"@oh-my-pi/pi-coding-agent/config/model-resolver\"; import { Settings } from \"@oh-my-pi/pi-coding-agent/config/settings\"; const settings = Settings.isolated({ modelRoles: { default: \"local/default\", smol: \"baseten/custom-smol:max\" } }); console.log({ smol: resolveAgentModelPatterns({ agentModel: \"@smol\", settings }), tiny: resolveAgentModelPatterns({ agentModel: \"@tiny\", settings }) });'`. Before the fix, `@smol` returned the configured model while `@tiny` returned the built-in fast priority chain beginning with `google-antigravity/gemini-3.8-flash`.

## Cause
`resolveConfiguredRolePattern` in `packages/coding-agent/src/config/model-resolver.ts` only let `smol` and `slow` inherit the configured default role. Although `ROLE_PRIORITY_ALIAS` mapped `tiny` to the smol priority list, it did not consult the configured `modelRoles.smol` value, so direct `@tiny` resolution and `resolveRoleAssignments` entered the built-in chain immediately.

## Fix
- Resolve an unconfigured `tiny` role through the configured `smol` role before built-in priority defaults.
- Add regression coverage for direct role execution and the `/models` role assignment.
- Record the corrected user-visible fallback behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/model-browser.test.ts` passed: 184 tests, 0 failures. `bun run check:types` passed, and the publish gate's `bun check` passed. Re-running the minimal resolver command returns `baseten/custom-smol:max` for both `@smol` and `@tiny`. A headless source-mode `/models` visual check was blocked after launch by an unrelated existing `TypeError: editDescription is not a function`; the Roles-view resolver contract is covered by `model-browser.test.ts`.

Fixes #11311