### PR TITLE
feat(coding-agent): highlight selected agent row across full width in /agents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Highlight the full selected agent row in `/agents` so names and right-aligned model configurations are easier to match on wide terminals.
+
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -1249,7 +1249,11 @@ export class AgentsHubComponent implements Component {
 			const cursor = selected && listFocused ? theme.fg("accent", theme.nav.cursor) : " ";
 			if (rowDef.kind === "new") {
 				let line = ` ${cursor} ${theme.fg(selected ? "accent" : "dim", "+ New agent…")}`;
-				if (hovered) line = theme.bg("selectedBg", line);
+				if (selected || hovered) {
+					const w = visibleWidth(line);
+					if (w < width) line += " ".repeat(width - w);
+					line = theme.bg("selectedBg", line);
+				}
 				lines.push(truncateToWidth(line, width));
 				continue;
 			}
@@ -1278,7 +1282,7 @@ export class AgentsHubComponent implements Component {
 				line = `${line}${" ".repeat(width - lineWidth - rightWidth - 1)}${right}`;
 			}
 			line = truncateToWidth(line, width);
-			if (hovered) {
+			if (selected || hovered) {
 				const w = visibleWidth(line);
 				if (w < width) line += " ".repeat(width - w);
 				line = theme.bg("selectedBg", line);

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -106,6 +106,28 @@ describe("AgentsHub layout", () => {
 		expect(rendered).toContain("+ New agent");
 	});
 
+	test("highlights the full selected agent row and follows keyboard navigation", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5:high" });
+		const { hub } = await createHub(settings);
+		const lines = hub.render(200);
+		const selected = lines.find(line => line.includes("claude-sonnet-4-5:high") && line.includes("dev"))!;
+		const match = selected.match(/\x1b\[48;(?:2;\d+;\d+;\d+|5;\d+)m/);
+		expect(match).not.toBeNull();
+		const background = match![0];
+		expect(selected).toContain("\x1b[49m");
+		const painted = selected.slice(selected.indexOf(background) + background.length).split("\x1b[49m")[0];
+		expect(painted).toContain("dev");
+		expect(painted).toContain("anthropic/claude-sonnet-4-5:high");
+		expect(painted.replace(ANSI_PATTERN, "")).toMatch(/high $/);
+		expect(lines.find(line => line.includes("scout"))).not.toContain(background);
+		hub.handleInput("\x1b[B");
+		const moved = hub.render(200);
+		expect(moved.find(line => line.includes("dev"))).not.toContain(background);
+		expect(moved.find(line => line.includes("scout"))).toContain(background);
+	});
+
 	test("sidebar scope filters the rows to one source", async () => {
 		mockAgents();
 		const { hub, strip } = await createHub(Settings.isolated());


### PR DESCRIPTION
## What

Highlight the selected agent row across the full terminal width in the `/agents` hub with the theme's `selectedBg` background.

## Why

On wide monitors and high-resolution terminals, the `/agents` hub places agent names and status on the far left while model overrides and reasoning levels are aligned to the far right. Without a guiding line across the horizontal void, tracing which right-aligned model and reasoning configuration corresponds to which role on the left is difficult.

The selection row now draws the theme-configured `selectedBg` behind the entire active row, mirroring the selection pattern used across other selectors and preserving mode-aware 256-color terminal support without drowning out foreground colors.

## Testing

- Verified keyboard navigation (`up`/`down`) in the `/agents` hub updates the highlighted line smoothly.
- Verified appearance across dark and light themes (including `titanium`, `dark`, and `light`) to confirm text and status dots remain clear with no contrast loss.
- Added unit test in `packages/coding-agent/test/agents-hub.test.ts` verifying full-width background escape formatting on the selected row and following cursor movement.

## Screenshots

### Before
![Before](https://github.com/user-attachments/assets/2d18c5d9-511b-4212-92d3-2b2fff5b8a6a)

### After
![After](https://github.com/user-attachments/assets/63ce9d9a-ec6c-4a37-b08e-eab54fbab744)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
