### PR TITLE
fix(ai,catalog): align Cursor wire surface with decompiled CLI

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Cursor requests generate distinct run IDs, share them with the request header, and preserve conversation grouping.
 - Cursor requests preserve caller-supplied capability flags and session identifiers.
 - Cursor user messages use agent mode consistently with the native CLI.
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cursor requests preserve caller-supplied capability flags and session identifiers.
+- Cursor user messages use agent mode consistently with the native CLI.
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -339,6 +339,17 @@ const successfulRotatedConversationIds = new Set<string>();
 const freshRotatedConversationIds = new Set<string>();
 
 export interface CursorOptions extends StreamOptions {
+	/** Accept inline images in Cursor responses. */
+	cursorClientSupportsInlineImages?: boolean;
+	/** Accept routed-model updates from Cursor. */
+	cursorClientSupportsRoutedModelUpdate?: boolean;
+	/** Support Cursor prompt-context usage requests. */
+	cursorClientSupportsPromptContextUsageRpc?: boolean;
+	/** Caller-owned Cursor run identity. */
+	cursorRunId?: string;
+	/** Caller-owned Cursor agent session identity. */
+	cursorAgentSessionId?: string;
+
 	customSystemPrompt?: string;
 	conversationId?: string;
 	execHandlers?: CursorExecHandlers;
@@ -5203,6 +5214,7 @@ function createCursorUserMessage(
 	return create(UserMessageSchema, {
 		text,
 		messageId,
+		mode: 1,
 		...(images.length > 0
 			? {
 					selectedContext: create(SelectedContextSchema, {
@@ -5428,6 +5440,12 @@ async function buildGrpcRequestForWireMode(
 	if (options?.customSystemPrompt) {
 		runRequest.customSystemPrompt = options.customSystemPrompt;
 	}
+
+	runRequest.clientSupportsInlineImages = options?.cursorClientSupportsInlineImages === true;
+	runRequest.clientSupportsRoutedModelUpdate = options?.cursorClientSupportsRoutedModelUpdate === true;
+	runRequest.clientSupportsPromptContextUsageRpc = options?.cursorClientSupportsPromptContextUsageRpc === true;
+	runRequest.runId = options?.cursorRunId ?? "";
+	runRequest.agentSessionId = options?.cursorAgentSessionId ?? "";
 
 	// Tools are sent later via requestContext (exec handshake)
 	const replacementRequest = await options?.onPayload?.(runRequest, model);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -383,6 +383,8 @@ interface CursorGrpcRequest {
 interface CursorTransportRequest extends CursorGrpcRequest {
 	/** Exact discovery id eligible for a retry because the normalized effort payload was serialized unchanged. */
 	fallbackWireModelId?: string;
+	/** Final run id serialized on the request, also used for x-request-id. */
+	runId: string;
 }
 
 const CONNECT_END_STREAM_FLAG = 0b00000010;
@@ -713,7 +715,7 @@ function streamCursorWithWireMode(
 				},
 				wireMode,
 			);
-			const { requestBytes, conversationState } = builtRequest;
+			const { requestBytes, conversationState, runId: requestRunId } = builtRequest;
 			serializedFallbackWireModelId = builtRequest.fallbackWireModelId;
 			conversationStateCache.set(conversationId, conversationState);
 			const requestContextTools = buildMcpToolDefinitions(
@@ -749,7 +751,7 @@ function streamCursorWithWireMode(
 				"x-ghost-mode": "true",
 				"x-cursor-client-version": CURSOR_CLIENT_VERSION,
 				"x-cursor-client-type": "cli",
-				"x-request-id": crypto.randomUUID(),
+				"x-request-id": requestRunId,
 			};
 			const debugSession = isRequestDebugEnabled()
 				? await createRequestDebugSession({
@@ -5444,8 +5446,9 @@ async function buildGrpcRequestForWireMode(
 	runRequest.clientSupportsInlineImages = options?.cursorClientSupportsInlineImages === true;
 	runRequest.clientSupportsRoutedModelUpdate = options?.cursorClientSupportsRoutedModelUpdate === true;
 	runRequest.clientSupportsPromptContextUsageRpc = options?.cursorClientSupportsPromptContextUsageRpc === true;
-	runRequest.runId = options?.cursorRunId ?? "";
+	runRequest.runId = options?.cursorRunId ?? crypto.randomUUID();
 	runRequest.agentSessionId = options?.cursorAgentSessionId ?? "";
+	runRequest.conversationGroupId = state.conversationId;
 
 	// Tools are sent later via requestContext (exec handshake)
 	const replacementRequest = await options?.onPayload?.(runRequest, model);
@@ -5484,7 +5487,7 @@ async function buildGrpcRequestForWireMode(
 		detail: detail || undefined,
 	});
 
-	return { requestBytes, blobStore, conversationState, fallbackWireModelId };
+	return { requestBytes, blobStore, conversationState, fallbackWireModelId, runId: runRequest.runId };
 }
 
 /** Builds the normalized Cursor Run request used by transport callers and request inspection hooks. */

--- a/packages/ai/src/providers/cursor/proto/agent.proto
+++ b/packages/ai/src/providers/cursor/proto/agent.proto
@@ -764,6 +764,37 @@ message AgentRunRequest {
    optional SkillOptions skill_options = 7;
    // Custom system prompt override. Allowlisted for specific teams only.
    optional string custom_system_prompt = 8;
+   bool suggest_next_prompt = 10;
+   string subagent_type_name = 11;
+   bool exclude_workspace_context = 12;
+   string harness = 13;
+   repeated RequestedModel selected_subagent_models = 14;
+   repeated ModelDetails selected_subagent_model_details = 15;
+   string conversation_group_id = 16;
+   repeated PreFetchedBlob pre_fetched_blobs = 17;
+   string dev_raw_model_slug = 18;
+   bool client_supports_inline_images = 19;
+   repeated SubagentModelOverride subagent_model_overrides = 20;
+   bool can_create_cloud_subagents = 21;
+   bool suppress_subagent_progress_update_tool = 22;
+   bool client_supports_send_to_user = 23;
+   int32 computer_use_coordinate_mode = 24;
+   string run_id = 25;
+   string agent_session_id = 26;
+   bool client_supports_prompt_context_usage_rpc = 27;
+   bool client_supports_routed_model_update = 28;
+}
+
+message PreFetchedBlob {
+   string id = 1;
+   bytes data = 2;
+}
+
+message SubagentModelOverride {
+   string subagent_type = 1;
+   oneof selection {
+      RequestedModel requested_model = 2;
+   }
 }
 
 message TextDeltaUpdate {
@@ -871,7 +902,43 @@ message InteractionUpdate {
       TurnEndedUpdate turn_ended = 14;
       StepStartedUpdate step_started = 16;
       StepCompletedUpdate step_completed = 17;
+      PromptSuggestionUpdate prompt_suggestion = 18;
+      PostRequestPromptUpdate post_request_prompt = 19;
+      ActiveBranchChangeUpdate active_branch_change = 20;
+      FeedbackRequestUpdate feedback_request = 21;
+      ResponseComparisonUpdate response_comparison = 22;
+      ContextInjectionStateUpdate context_injection_state = 23;
+      RoutedModelUpdate routed_model = 24;
    }
+}
+
+message PromptSuggestionUpdate {
+   string suggestion = 1;
+}
+
+message PostRequestPromptUpdate {
+   string prompt = 1;
+}
+
+message ActiveBranchChangeUpdate {
+   string branch = 1;
+}
+
+message FeedbackRequestUpdate {
+   string question = 1;
+}
+
+message ResponseComparisonUpdate {
+   string comparison = 1;
+}
+
+message ContextInjectionStateUpdate {
+   string injection_id = 1;
+}
+
+message RoutedModelUpdate {
+   string model_id = 1;
+   string display_name = 2;
 }
 
 // Interaction query messages for bidirectional communication
@@ -979,7 +1046,16 @@ message AgentServerMessage {
       ConversationStateStructure conversation_checkpoint_update = 3;
       KvServerMessage kv_server_message = 4;
       InteractionQuery interaction_query = 7;
+      TtftBreakdown ttft_breakdown = 8;
    }
+}
+
+message TtftBreakdown {
+   int64 server_first_token_ms = 1;
+   int64 pre_stream_setup_ms = 2;
+   int64 wait_for_first_event_ms = 3;
+   optional int64 provider_ttft_ms = 4;
+   int64 slow_pool_wait_ms = 5;
 }
 
 // New unary API for naming an agent from a user message
@@ -1004,7 +1080,8 @@ message GetDefaultModelForCliRequest {
 }
 
 message GetDefaultModelForCliResponse {
-   ModelDetails model = 1;
+   string model_id = 1;
+   string display_name = 2;
 }
 
 // Internal endpoint: returns all allowed model intents for devs
@@ -1012,7 +1089,7 @@ message GetAllowedModelIntentsRequest {
 }
 
 message GetAllowedModelIntentsResponse {
-   repeated string model_intents = 1;
+   repeated string allowed_intents = 1;
 }
 
 // IDE state persistence for clients (CLI / VSCode integration) Mirrors a subset of aiserver.v1.ConversationMessage.IdeEditorsState, but only contains the recently viewed files and avoids any deprecated fields.
@@ -3628,13 +3705,36 @@ message BidiRequestId {
 // Agent Service with bidirectional streaming
 service AgentService {
    rpc Run(AgentClientMessage) returns (AgentServerMessage);
-   rpc RunSSE(BidiRequestId) returns (AgentServerMessage);
+   rpc RunSSE(RunSSERequest) returns (stream AgentServerMessage);
+   rpc RunPoll(RunPollRequest) returns (stream RunPollResponse);
    // Generate a very short, succinct agent name from the provided user message.
    rpc NameAgent(NameAgentRequest) returns (NameAgentResponse);
    rpc GetUsableModels(GetUsableModelsRequest) returns (GetUsableModelsResponse);
    rpc GetDefaultModelForCli(GetDefaultModelForCliRequest) returns (GetDefaultModelForCliResponse);
    // Internal endpoint: returns all allowed model intents for devs
    rpc GetAllowedModelIntents(GetAllowedModelIntentsRequest) returns (GetAllowedModelIntentsResponse);
+   rpc GetPromptContextUsage(GetPromptContextUsageRequest) returns (GetPromptContextUsageResponse);
+}
+
+message RunSSERequest {
+   AgentRunRequest run_request = 1;
+}
+
+message RunPollRequest {
+   AgentRunRequest run_request = 1;
+}
+
+message RunPollResponse {
+   repeated AgentServerMessage messages = 1;
+}
+
+message GetPromptContextUsageRequest {
+   string conversation_id = 1;
+}
+
+message GetPromptContextUsageResponse {
+   int64 total_tokens = 1;
+   int64 max_tokens = 2;
 }
 
 service ControlService {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2405,6 +2405,11 @@ function mapOptionsForApi<TApi extends Api>(
 				execHandlers,
 				onToolResult,
 				externalToolExecutor: options?.cursorExternalToolExecutor,
+				cursorClientSupportsInlineImages: options?.cursorClientSupportsInlineImages,
+				cursorClientSupportsRoutedModelUpdate: options?.cursorClientSupportsRoutedModelUpdate,
+				cursorClientSupportsPromptContextUsageRpc: options?.cursorClientSupportsPromptContextUsageRpc,
+				cursorRunId: options?.cursorRunId,
+				cursorAgentSessionId: options?.cursorAgentSessionId,
 				wireModelId: resolveWireModelId(cursorModel, effort),
 			});
 		}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -648,6 +648,17 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	cursorOnToolResult?: CursorToolResultHandler;
 	/** Cursor hands unhandled MCP calls to an external executor instead of reporting them as missing. */
 	cursorExternalToolExecutor?: boolean;
+	/** Accept inline images in Cursor responses. */
+	cursorClientSupportsInlineImages?: boolean;
+	/** Accept routed-model updates from Cursor. */
+	cursorClientSupportsRoutedModelUpdate?: boolean;
+	/** Support Cursor prompt-context usage requests. */
+	cursorClientSupportsPromptContextUsageRpc?: boolean;
+	/** Caller-owned Cursor run identity. */
+	cursorRunId?: string;
+	/** Caller-owned Cursor agent session identity. */
+	cursorAgentSessionId?: string;
+
 	/**
 	 * Amazon Bedrock Guardrail settings forwarded through transports that do not
 	 * dispatch directly to the Bedrock provider. Model-level values take

--- a/packages/ai/test/cursor-caller-headers.test.ts
+++ b/packages/ai/test/cursor-caller-headers.test.ts
@@ -129,6 +129,20 @@ afterEach(async () => {
 });
 
 describe("Cursor caller headers reach the wire", () => {
+	it("uses the final payload run ID for the transport request ID", async () => {
+		const baseUrl = await startServer();
+		const result = await streamCursor(makeModel(baseUrl), context, {
+			apiKey: "test-token",
+			cursorRunId: "initial-run",
+			onPayload: payload => {
+				if (!payload || typeof payload !== "object") throw new Error("Missing Cursor request payload");
+				return { ...payload, runId: "hook-replaced-run" };
+			},
+		}).result();
+		expect(result.stopReason).toBe("stop");
+		expect(received["x-request-id"]).toBe("hook-replaced-run");
+	});
+
 	it("delivers an ordinary caller header to the server", async () => {
 		const sent = await send({ "x-trace": "abc", "x-waygate-activity": "mode=plan" });
 		expect(sent["x-trace"]).toBe("abc");

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import { buildGrpcRequest, type CursorOptions } from "@oh-my-pi/pi-ai/providers/cursor";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import type { AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { type AgentRunRequest, AgentClientMessageSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { fromBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 
 function cursorModel(id: string): Model<"cursor-agent"> {
 	return buildModel({
@@ -19,20 +20,16 @@ function cursorModel(id: string): Model<"cursor-agent"> {
 	});
 }
 
-function capture(model: Model<"cursor-agent">): Promise<AgentRunRequest> {
-	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
-	streamCursor(model, { messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context, {
-		apiKey: "test-token",
-		onPayload: payload => {
-			if (payload && typeof payload === "object" && "$typeName" in payload) {
-				resolve(payload as AgentRunRequest);
-			} else {
-				reject(new Error("Cursor payload was not an AgentRunRequest"));
-			}
-			throw new Error("stop after capturing Cursor payload");
-		},
-	});
-	return promise;
+async function capture(model: Model<"cursor-agent">, options?: CursorOptions): Promise<AgentRunRequest> {
+	const { requestBytes } = await buildGrpcRequest(
+		model,
+		{ messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context,
+		options,
+		{ conversationId: "wire-test", blobStore: new Map() },
+	);
+	const message = fromBinary(AgentClientMessageSchema, requestBytes).message;
+	if (message.case !== "runRequest") throw new Error("Expected Cursor run request");
+	return message.value;
 }
 
 describe("Cursor requestedModel wire shape", () => {
@@ -96,5 +93,36 @@ describe("Cursor requestedModel wire shape", () => {
 		const payload = await capture(cursorModel("claude-fable-5-low"));
 		expect(payload.requestedModel?.modelId).toBe("claude-fable-5-low");
 		expect(payload.requestedModel?.parameters).toEqual([]);
+	});
+});
+
+describe("Cursor auto router wire id", () => {
+	function rosterAutoModel(): Model<"cursor-agent"> {
+		return buildModel({
+			id: "auto",
+			name: "auto",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 64000,
+			requestModelId: "auto",
+		});
+	}
+
+	it("echoes a roster-resolved requestModelId auto verbatim (what the CLI sends)", async () => {
+		const payload = await capture(rosterAutoModel());
+		expect(payload.requestedModel?.modelId).toBe("auto");
+		expect(payload.requestedModel?.parameters).toEqual([]);
+		expect(payload.modelDetails?.modelId).toBe("auto");
+	});
+
+	it("honors an explicit caller wireModelId auto override", async () => {
+		const payload = await capture(cursorModel("cursor-composer-2.5"), { wireModelId: "auto" });
+		expect(payload.requestedModel?.modelId).toBe("auto");
+		expect(payload.modelDetails?.modelId).toBe("auto");
 	});
 });

--- a/packages/ai/test/cursor-run-request-options.test.ts
+++ b/packages/ai/test/cursor-run-request-options.test.ts
@@ -1,10 +1,11 @@
 // Contract: SimpleStreamOptions / CursorOptions capability and session fields
 // must populate AgentRunRequest protobuf members (not just be allowlisted).
 import { describe, expect, it } from "bun:test";
-import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import { buildGrpcRequest } from "@oh-my-pi/pi-ai/providers/cursor";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import type { AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { AgentClientMessageSchema, type AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { fromBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 
 function cursorModel(): Model<"cursor-agent"> {
 	return buildModel({
@@ -21,7 +22,7 @@ function cursorModel(): Model<"cursor-agent"> {
 	});
 }
 
-function capture(options: {
+async function capture(options: {
 	cursorClientSupportsInlineImages?: boolean;
 	cursorClientSupportsRoutedModelUpdate?: boolean;
 	cursorClientSupportsPromptContextUsageRpc?: boolean;
@@ -29,20 +30,15 @@ function capture(options: {
 	cursorAgentSessionId?: string;
 	conversationId?: string;
 }): Promise<AgentRunRequest> {
-	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
-	streamCursor(cursorModel(), { messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context, {
-		apiKey: "test-token",
-		...options,
-		onPayload: payload => {
-			if (payload && typeof payload === "object" && "conversationState" in payload) {
-				resolve(payload as AgentRunRequest);
-			} else {
-				reject(new Error("Cursor payload was not an AgentRunRequest"));
-			}
-			throw new Error("stop after capturing Cursor payload");
-		},
-	});
-	return promise;
+	const { requestBytes } = await buildGrpcRequest(
+		cursorModel(),
+		{ messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context,
+		options,
+		{ conversationId: options.conversationId ?? "fixture-conversation", blobStore: new Map() },
+	);
+	const message = fromBinary(AgentClientMessageSchema, requestBytes).message;
+	if (message.case !== "runRequest") throw new Error("Expected serialized RunRequest");
+	return message.value;
 }
 
 describe("Cursor AgentRunRequest option wiring", () => {

--- a/packages/ai/test/cursor-run-request-options.test.ts
+++ b/packages/ai/test/cursor-run-request-options.test.ts
@@ -1,0 +1,89 @@
+// Contract: SimpleStreamOptions / CursorOptions capability and session fields
+// must populate AgentRunRequest protobuf members (not just be allowlisted).
+import { describe, expect, it } from "bun:test";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+
+function cursorModel(): Model<"cursor-agent"> {
+	return buildModel({
+		id: "cursor-composer-2.5",
+		name: "Cursor Composer 2.5",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 32_000,
+	});
+}
+
+function capture(options: {
+	cursorClientSupportsInlineImages?: boolean;
+	cursorClientSupportsRoutedModelUpdate?: boolean;
+	cursorClientSupportsPromptContextUsageRpc?: boolean;
+	cursorRunId?: string;
+	cursorAgentSessionId?: string;
+	conversationId?: string;
+}): Promise<AgentRunRequest> {
+	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
+	streamCursor(cursorModel(), { messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context, {
+		apiKey: "test-token",
+		...options,
+		onPayload: payload => {
+			if (payload && typeof payload === "object" && "conversationState" in payload) {
+				resolve(payload as AgentRunRequest);
+			} else {
+				reject(new Error("Cursor payload was not an AgentRunRequest"));
+			}
+			throw new Error("stop after capturing Cursor payload");
+		},
+	});
+	return promise;
+}
+
+describe("Cursor AgentRunRequest option wiring", () => {
+	it("serializes capability flags and session ids onto the run request", async () => {
+		const payload = await capture({
+			cursorClientSupportsInlineImages: true,
+			cursorClientSupportsRoutedModelUpdate: true,
+			cursorClientSupportsPromptContextUsageRpc: true,
+			cursorRunId: "run-abc",
+			cursorAgentSessionId: "sess-xyz",
+		});
+		expect(payload).toMatchObject({
+			clientSupportsInlineImages: true,
+			clientSupportsRoutedModelUpdate: true,
+			clientSupportsPromptContextUsageRpc: true,
+			runId: "run-abc",
+			agentSessionId: "sess-xyz",
+		});
+	});
+
+	it("leaves capability flags false and session ids empty when unset", async () => {
+		const payload = await capture({});
+		expect(payload).toMatchObject({
+			clientSupportsInlineImages: false,
+			clientSupportsRoutedModelUpdate: false,
+			clientSupportsPromptContextUsageRpc: false,
+			agentSessionId: "",
+		});
+	});
+
+	it("mints a fresh run id per request when cursorRunId is unset", async () => {
+		const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+		const first = await capture({});
+		const second = await capture({});
+		expect(first.runId).toMatch(uuidPattern);
+		expect(second.runId).toMatch(uuidPattern);
+		expect(second.runId).not.toBe(first.runId);
+	});
+
+	it("defaults conversationGroupId to the request conversation", async () => {
+		const payload = await capture({ conversationId: "conv-group-check" });
+		expect(payload.conversationGroupId).toBe("conv-group-check");
+	});
+});

--- a/packages/ai/test/cursor-user-message-mode.test.ts
+++ b/packages/ai/test/cursor-user-message-mode.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { buildGrpcRequest, type CursorOptions } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { type AgentRunRequest, AgentClientMessageSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { fromBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+
+function cursorModel(): Model<"cursor-agent"> {
+	return buildModel({
+		id: "auto",
+		name: "Cursor Auto",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	});
+}
+
+async function capture(options?: CursorOptions): Promise<AgentRunRequest> {
+	const { requestBytes } = await buildGrpcRequest(
+		cursorModel(),
+		{ messages: [{ role: "user", content: "pong", timestamp: 0 }] } satisfies Context,
+		options,
+		{ conversationId: "wire-test", blobStore: new Map() },
+	);
+	const message = fromBinary(AgentClientMessageSchema, requestBytes).message;
+	if (message.case !== "runRequest") throw new Error("Expected Cursor run request");
+	return message.value;
+}
+
+describe("Cursor user message wire shape", () => {
+	it("sends AgentMode.AGENT (1), never UNSPECIFIED (0)", async () => {
+		const payload = await capture();
+		const action = payload.action?.action;
+		expect(action?.case).toBe("userMessageAction");
+		if (action?.case !== "userMessageAction") return;
+		expect(action.value.userMessage?.text).toBe("pong");
+		expect(action.value.userMessage?.mode).toBe(1);
+	});
+});
+
+// Losing these fields during encoding silently disables negotiated capabilities
+// and disconnects a run from the caller's session.
+it("encodes negotiated capabilities and caller session identity on the wire", async () => {
+	const payload = await capture({
+		cursorClientSupportsInlineImages: true,
+		cursorClientSupportsRoutedModelUpdate: true,
+		cursorClientSupportsPromptContextUsageRpc: true,
+		cursorRunId: "run-123",
+		cursorAgentSessionId: "session-456",
+	});
+	expect(payload).toMatchObject({
+		clientSupportsInlineImages: true,
+		clientSupportsRoutedModelUpdate: true,
+		clientSupportsPromptContextUsageRpc: true,
+		runId: "run-123",
+		agentSessionId: "session-456",
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Cursor automatic routing retains the correct wire identity across live discovery and cached catalogs.
 - Cursor discovery preserves the roster model ID for automatic routing.
 - Updated Cursor protocol definitions for capability flags, session identifiers, and server updates.
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cursor discovery preserves the roster model ID for automatic routing.
+- Updated Cursor protocol definitions for capability flags, session identifiers, and server updates.
+
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -66,6 +66,10 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 	if (typeof contextPromotionTarget === "string" && model.contextPromotionTarget === undefined) {
 		model.contextPromotionTarget = contextPromotionTarget;
 	}
+	const requestModelId = catalog.requestModelId;
+	if (typeof requestModelId === "string" && requestModelId.trim() && model.requestModelId === undefined) {
+		model.requestModelId = requestModelId.trim();
+	}
 }
 
 /**

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -269,6 +269,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	},
 	"clamp-context-override": { key: "clampContextOverride", set: "catalog", shape: "scalar" },
 	"context-promotion-target": { key: "contextPromotionTarget", set: "catalog", shape: "scalar" },
+	"request-model-id": { key: "requestModelId", set: "catalog", shape: "scalar" },
 	"context-window-floor": { key: "contextWindowFloor", set: "catalog", shape: "scalar" },
 	"cost-patch": { key: "costPatch", set: "catalog", shape: "object" },
 	"delegation-bias": { key: "delegationBias", set: "catalog", shape: "scalar", values: DELEGATION_BIASES },

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7698,7 +7698,22 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:6",
+				"source": "providers/cursor.kdl:5",
+				"providers": [
+					"cursor"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "auto"
+					}
+				],
+				"catalog": {
+					"requestModelId": "default"
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:10",
 				"class": "anthropic",
 				"providers": [
 					"cursor"
@@ -7709,7 +7724,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:14",
+				"source": "providers/cursor.kdl:18",
 				"class": "kimi",
 				"providers": [
 					"cursor"
@@ -7724,7 +7739,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:19",
+				"source": "providers/cursor.kdl:23",
 				"providers": [
 					"cursor"
 				],
@@ -7747,7 +7762,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:25",
+				"source": "providers/cursor.kdl:29",
 				"providers": [
 					"cursor"
 				],
@@ -7781,7 +7796,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:28",
+				"source": "providers/cursor.kdl:32",
 				"providers": [
 					"cursor"
 				],
@@ -7815,7 +7830,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:32",
+				"source": "providers/cursor.kdl:36",
 				"providers": [
 					"cursor"
 				],
@@ -7833,7 +7848,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:36",
+				"source": "providers/cursor.kdl:40",
 				"providers": [
 					"cursor"
 				],
@@ -7866,7 +7881,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:40",
+				"source": "providers/cursor.kdl:44",
 				"providers": [
 					"cursor"
 				],
@@ -7906,7 +7921,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:45",
+				"source": "providers/cursor.kdl:49",
 				"providers": [
 					"cursor"
 				],
@@ -7925,7 +7940,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:49",
+				"source": "providers/cursor.kdl:53",
 				"providers": [
 					"cursor"
 				],

--- a/packages/catalog/src/compat/rules/providers/cursor.kdl
+++ b/packages/catalog/src/compat/rules/providers/cursor.kdl
@@ -1,6 +1,10 @@
 // Provider-wire compat for "cursor"; regenerated from the frozen census using deployment contract selectors.
 
 provider "cursor" {
+	// Synthetic auto uses default; authoritative discovery request ids take precedence.
+	models "auto" {
+		request-model-id "default"
+	}
 	thinking-mode "effort"
 	class "anthropic" {
 		family "fable" {

--- a/packages/catalog/src/discovery/cursor-proto.ts
+++ b/packages/catalog/src/discovery/cursor-proto.ts
@@ -96,6 +96,15 @@ export enum SubagentBackgroundReason {
 	QUEUED_FOLLOW_UP = 3,
 }
 
+/** Cursor agent message agent.v1.ActiveBranchChangeUpdate. */
+export interface ActiveBranchChangeUpdate extends ProtoMessage {
+	branch: string;
+}
+
+export const ActiveBranchChangeUpdateSchema: MessageCodec<ActiveBranchChangeUpdate> = pb<ActiveBranchChangeUpdate>("agent.v1.ActiveBranchChangeUpdate", [
+	{ no: 1, name: "branch", kind: "string" },
+]);
+
 /** Cursor agent message agent.v1.AfterAgentResponseRequestQuery. */
 export interface AfterAgentResponseRequestQuery extends ProtoMessage {
 }
@@ -179,6 +188,25 @@ export interface AgentRunRequest extends ProtoMessage {
 	mcpFileSystemOptions?: McpFileSystemOptions;
 	skillOptions?: SkillOptions;
 	customSystemPrompt?: string;
+	suggestNextPrompt: boolean;
+	subagentTypeName: string;
+	excludeWorkspaceContext: boolean;
+	harness: string;
+	selectedSubagentModels: RequestedModel[];
+	selectedSubagentModelDetails: ModelDetails[];
+	conversationGroupId: string;
+	preFetchedBlobs: PreFetchedBlob[];
+	devRawModelSlug: string;
+	clientSupportsInlineImages: boolean;
+	subagentModelOverrides: SubagentModelOverride[];
+	canCreateCloudSubagents: boolean;
+	suppressSubagentProgressUpdateTool: boolean;
+	clientSupportsSendToUser: boolean;
+	computerUseCoordinateMode: number;
+	runId: string;
+	agentSessionId: string;
+	clientSupportsPromptContextUsageRpc: boolean;
+	clientSupportsRoutedModelUpdate: boolean;
 }
 
 export const AgentRunRequestSchema: MessageCodec<AgentRunRequest> = pb<AgentRunRequest>("agent.v1.AgentRunRequest", [
@@ -191,6 +219,25 @@ export const AgentRunRequestSchema: MessageCodec<AgentRunRequest> = pb<AgentRunR
 	{ no: 6, name: "mcpFileSystemOptions", kind: "message", T: () => McpFileSystemOptionsSchema },
 	{ no: 7, name: "skillOptions", kind: "message", T: () => SkillOptionsSchema },
 	{ no: 8, name: "customSystemPrompt", kind: "string", optional: true },
+	{ no: 10, name: "suggestNextPrompt", kind: "bool" },
+	{ no: 11, name: "subagentTypeName", kind: "string" },
+	{ no: 12, name: "excludeWorkspaceContext", kind: "bool" },
+	{ no: 13, name: "harness", kind: "string" },
+	{ no: 14, name: "selectedSubagentModels", kind: "message", T: () => RequestedModelSchema, repeat: true },
+	{ no: 15, name: "selectedSubagentModelDetails", kind: "message", T: () => ModelDetailsSchema, repeat: true },
+	{ no: 16, name: "conversationGroupId", kind: "string" },
+	{ no: 17, name: "preFetchedBlobs", kind: "message", T: () => PreFetchedBlobSchema, repeat: true },
+	{ no: 18, name: "devRawModelSlug", kind: "string" },
+	{ no: 19, name: "clientSupportsInlineImages", kind: "bool" },
+	{ no: 20, name: "subagentModelOverrides", kind: "message", T: () => SubagentModelOverrideSchema, repeat: true },
+	{ no: 21, name: "canCreateCloudSubagents", kind: "bool" },
+	{ no: 22, name: "suppressSubagentProgressUpdateTool", kind: "bool" },
+	{ no: 23, name: "clientSupportsSendToUser", kind: "bool" },
+	{ no: 24, name: "computerUseCoordinateMode", kind: "int32" },
+	{ no: 25, name: "runId", kind: "string" },
+	{ no: 26, name: "agentSessionId", kind: "string" },
+	{ no: 27, name: "clientSupportsPromptContextUsageRpc", kind: "bool" },
+	{ no: 28, name: "clientSupportsRoutedModelUpdate", kind: "bool" },
 ]);
 
 /** Cursor agent message agent.v1.AgentServerMessage. */
@@ -202,7 +249,8 @@ export interface AgentServerMessage extends ProtoMessage {
 		| { case: "execServerControlMessage"; value: ExecServerControlMessage }
 		| { case: "conversationCheckpointUpdate"; value: ConversationStateStructure }
 		| { case: "kvServerMessage"; value: KvServerMessage }
-		| { case: "interactionQuery"; value: InteractionQuery };
+		| { case: "interactionQuery"; value: InteractionQuery }
+		| { case: "ttftBreakdown"; value: TtftBreakdown };
 }
 
 export const AgentServerMessageSchema: MessageCodec<AgentServerMessage> = pb<AgentServerMessage>("agent.v1.AgentServerMessage", [
@@ -216,6 +264,7 @@ export const AgentServerMessageSchema: MessageCodec<AgentServerMessage> = pb<Age
 			{ no: 3, name: "conversationCheckpointUpdate", kind: "message", T: () => ConversationStateStructureSchema },
 			{ no: 4, name: "kvServerMessage", kind: "message", T: () => KvServerMessageSchema },
 			{ no: 7, name: "interactionQuery", kind: "message", T: () => InteractionQuerySchema },
+			{ no: 8, name: "ttftBreakdown", kind: "message", T: () => TtftBreakdownSchema },
 		],
 	},
 ]);
@@ -1035,6 +1084,15 @@ export interface ConnectScmToolCall extends ProtoMessage {
 export const ConnectScmToolCallSchema: MessageCodec<ConnectScmToolCall> = pb<ConnectScmToolCall>("agent.v1.ConnectScmToolCall", [
 	{ no: 1, name: "args", kind: "message", T: () => ConnectScmArgsSchema },
 	{ no: 2, name: "result", kind: "message", T: () => ConnectScmResultSchema },
+]);
+
+/** Cursor agent message agent.v1.ContextInjectionStateUpdate. */
+export interface ContextInjectionStateUpdate extends ProtoMessage {
+	injectionId: string;
+}
+
+export const ContextInjectionStateUpdateSchema: MessageCodec<ContextInjectionStateUpdate> = pb<ContextInjectionStateUpdate>("agent.v1.ContextInjectionStateUpdate", [
+	{ no: 1, name: "injectionId", kind: "string" },
 ]);
 
 /** Cursor agent message agent.v1.ConversationAction. */
@@ -2547,6 +2605,15 @@ export const ExtraContextEntrySchema: MessageCodec<ExtraContextEntry> = pb<Extra
 	},
 ]);
 
+/** Cursor agent message agent.v1.FeedbackRequestUpdate. */
+export interface FeedbackRequestUpdate extends ProtoMessage {
+	question: string;
+}
+
+export const FeedbackRequestUpdateSchema: MessageCodec<FeedbackRequestUpdate> = pb<FeedbackRequestUpdate>("agent.v1.FeedbackRequestUpdate", [
+	{ no: 1, name: "question", kind: "string" },
+]);
+
 /** Cursor agent message agent.v1.FetchArgs. */
 export interface FetchArgs extends ProtoMessage {
 	url: string;
@@ -3284,7 +3351,14 @@ export interface InteractionUpdate extends ProtoMessage {
 		| { case: "heartbeat"; value: HeartbeatUpdate }
 		| { case: "turnEnded"; value: TurnEndedUpdate }
 		| { case: "stepStarted"; value: StepStartedUpdate }
-		| { case: "stepCompleted"; value: StepCompletedUpdate };
+		| { case: "stepCompleted"; value: StepCompletedUpdate }
+		| { case: "promptSuggestion"; value: PromptSuggestionUpdate }
+		| { case: "postRequestPrompt"; value: PostRequestPromptUpdate }
+		| { case: "activeBranchChange"; value: ActiveBranchChangeUpdate }
+		| { case: "feedbackRequest"; value: FeedbackRequestUpdate }
+		| { case: "responseComparison"; value: ResponseComparisonUpdate }
+		| { case: "contextInjectionState"; value: ContextInjectionStateUpdate }
+		| { case: "routedModel"; value: RoutedModelUpdate };
 }
 
 export const InteractionUpdateSchema: MessageCodec<InteractionUpdate> = pb<InteractionUpdate>("agent.v1.InteractionUpdate", [
@@ -3309,6 +3383,13 @@ export const InteractionUpdateSchema: MessageCodec<InteractionUpdate> = pb<Inter
 			{ no: 14, name: "turnEnded", kind: "message", T: () => TurnEndedUpdateSchema },
 			{ no: 16, name: "stepStarted", kind: "message", T: () => StepStartedUpdateSchema },
 			{ no: 17, name: "stepCompleted", kind: "message", T: () => StepCompletedUpdateSchema },
+			{ no: 18, name: "promptSuggestion", kind: "message", T: () => PromptSuggestionUpdateSchema },
+			{ no: 19, name: "postRequestPrompt", kind: "message", T: () => PostRequestPromptUpdateSchema },
+			{ no: 20, name: "activeBranchChange", kind: "message", T: () => ActiveBranchChangeUpdateSchema },
+			{ no: 21, name: "feedbackRequest", kind: "message", T: () => FeedbackRequestUpdateSchema },
+			{ no: 22, name: "responseComparison", kind: "message", T: () => ResponseComparisonUpdateSchema },
+			{ no: 23, name: "contextInjectionState", kind: "message", T: () => ContextInjectionStateUpdateSchema },
+			{ no: 24, name: "routedModel", kind: "message", T: () => RoutedModelUpdateSchema },
 		],
 	},
 ]);
@@ -4725,6 +4806,15 @@ export const PositionSchema: MessageCodec<Position> = pb<Position>("agent.v1.Pos
 	{ no: 2, name: "column", kind: "uint32" },
 ]);
 
+/** Cursor agent message agent.v1.PostRequestPromptUpdate. */
+export interface PostRequestPromptUpdate extends ProtoMessage {
+	prompt: string;
+}
+
+export const PostRequestPromptUpdateSchema: MessageCodec<PostRequestPromptUpdate> = pb<PostRequestPromptUpdate>("agent.v1.PostRequestPromptUpdate", [
+	{ no: 1, name: "prompt", kind: "string" },
+]);
+
 /** Cursor agent message agent.v1.PostToolUseFailureRequestQuery. */
 export interface PostToolUseFailureRequestQuery extends ProtoMessage {
 }
@@ -4771,6 +4861,17 @@ export interface PreCompactRequestResponse extends ProtoMessage {
 
 export const PreCompactRequestResponseSchema: MessageCodec<PreCompactRequestResponse> = pb<PreCompactRequestResponse>("agent.v1.PreCompactRequestResponse", [
 	{ no: 1, name: "userMessage", kind: "string", optional: true },
+]);
+
+/** Cursor agent message agent.v1.PreFetchedBlob. */
+export interface PreFetchedBlob extends ProtoMessage {
+	id: string;
+	data: Uint8Array;
+}
+
+export const PreFetchedBlobSchema: MessageCodec<PreFetchedBlob> = pb<PreFetchedBlob>("agent.v1.PreFetchedBlob", [
+	{ no: 1, name: "id", kind: "string" },
+	{ no: 2, name: "data", kind: "bytes" },
 ]);
 
 /** Cursor agent message agent.v1.PreToolUseRequestQuery. */
@@ -4820,6 +4921,15 @@ export const PrewarmRequestSchema: MessageCodec<PrewarmRequest> = pb<PrewarmRequ
 	{ no: 6, name: "bestOfNGroupId", kind: "string", optional: true },
 	{ no: 7, name: "tryUseBestOfNPromotion", kind: "bool", optional: true },
 	{ no: 8, name: "customSystemPrompt", kind: "string", optional: true },
+]);
+
+/** Cursor agent message agent.v1.PromptSuggestionUpdate. */
+export interface PromptSuggestionUpdate extends ProtoMessage {
+	suggestion: string;
+}
+
+export const PromptSuggestionUpdateSchema: MessageCodec<PromptSuggestionUpdate> = pb<PromptSuggestionUpdate>("agent.v1.PromptSuggestionUpdate", [
+	{ no: 1, name: "suggestion", kind: "string" },
 ]);
 
 /** Cursor agent message agent.v1.Range. */
@@ -5648,6 +5758,15 @@ export const RequestedModel_ModelParameterbytesSchema: MessageCodec<RequestedMod
 	{ no: 2, name: "value", kind: "string" },
 ]);
 
+/** Cursor agent message agent.v1.ResponseComparisonUpdate. */
+export interface ResponseComparisonUpdate extends ProtoMessage {
+	comparison: string;
+}
+
+export const ResponseComparisonUpdateSchema: MessageCodec<ResponseComparisonUpdate> = pb<ResponseComparisonUpdate>("agent.v1.ResponseComparisonUpdate", [
+	{ no: 1, name: "comparison", kind: "string" },
+]);
+
 /** Cursor agent message agent.v1.ResumeAction. */
 export interface ResumeAction extends ProtoMessage {
 	requestContext?: RequestContext;
@@ -5655,6 +5774,17 @@ export interface ResumeAction extends ProtoMessage {
 
 export const ResumeActionSchema: MessageCodec<ResumeAction> = pb<ResumeAction>("agent.v1.ResumeAction", [
 	{ no: 2, name: "requestContext", kind: "message", T: () => RequestContextSchema },
+]);
+
+/** Cursor agent message agent.v1.RoutedModelUpdate. */
+export interface RoutedModelUpdate extends ProtoMessage {
+	modelId: string;
+	displayName: string;
+}
+
+export const RoutedModelUpdateSchema: MessageCodec<RoutedModelUpdate> = pb<RoutedModelUpdate>("agent.v1.RoutedModelUpdate", [
+	{ no: 1, name: "modelId", kind: "string" },
+	{ no: 2, name: "displayName", kind: "string" },
 ]);
 
 /** Cursor agent message agent.v1.SandboxPolicy. */
@@ -7146,6 +7276,25 @@ export const SubagentErrorSchema: MessageCodec<SubagentError> = pb<SubagentError
 	{ no: 2, name: "error", kind: "string" },
 ]);
 
+/** Cursor agent message agent.v1.SubagentModelOverride. */
+export interface SubagentModelOverride extends ProtoMessage {
+	subagentType: string;
+	selection:
+		| { case: undefined; value?: undefined }
+		| { case: "requestedModel"; value: RequestedModel };
+}
+
+export const SubagentModelOverrideSchema: MessageCodec<SubagentModelOverride> = pb<SubagentModelOverride>("agent.v1.SubagentModelOverride", [
+	{ no: 1, name: "subagentType", kind: "string" },
+	{
+		kind: "oneof",
+		name: "selection",
+		variants: [
+			{ no: 2, name: "requestedModel", kind: "message", T: () => RequestedModelSchema },
+		],
+	},
+]);
+
 /** Cursor agent message agent.v1.SubagentPersistedState. */
 export interface SubagentPersistedState extends ProtoMessage {
 	conversationState?: ConversationStateStructure;
@@ -7833,6 +7982,23 @@ export interface TruncatedToolCallSuccess extends ProtoMessage {
 }
 
 export const TruncatedToolCallSuccessSchema: MessageCodec<TruncatedToolCallSuccess> = pb<TruncatedToolCallSuccess>("agent.v1.TruncatedToolCallSuccess", [
+]);
+
+/** Cursor agent message agent.v1.TtftBreakdown. */
+export interface TtftBreakdown extends ProtoMessage {
+	serverFirstTokenMs: bigint;
+	preStreamSetupMs: bigint;
+	waitForFirstEventMs: bigint;
+	providerTtftMs?: bigint;
+	slowPoolWaitMs: bigint;
+}
+
+export const TtftBreakdownSchema: MessageCodec<TtftBreakdown> = pb<TtftBreakdown>("agent.v1.TtftBreakdown", [
+	{ no: 1, name: "serverFirstTokenMs", kind: "int64" },
+	{ no: 2, name: "preStreamSetupMs", kind: "int64" },
+	{ no: 3, name: "waitForFirstEventMs", kind: "int64" },
+	{ no: 4, name: "providerTtftMs", kind: "int64", optional: true },
+	{ no: 5, name: "slowPoolWaitMs", kind: "int64" },
 ]);
 
 /** Cursor agent message agent.v1.TurnEndedUpdate. */

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -321,9 +321,7 @@ function normalizeCursorModel(
 		Boolean(details.thinkingDetails) ||
 		reference?.reasoning === true;
 
-	// Roster-echoed auto sentinel: record the verbatim roster id so the
-	// provider echoes it instead of the synthetic "default" wire id.
-	const rosterAutoRequestModelId = id === "auto" ? { requestModelId: id } : {};
+	// Discovery records the authoritative wire identity for every roster row.
 	if (reference) {
 		return {
 			...reference,
@@ -334,7 +332,7 @@ function normalizeCursorModel(
 			input: resolveCursorInput(id, reference.input),
 			contextWindow: resolveCursorContextWindow(details, id, reference.contextWindow),
 			cursorMaxMode: details.maxMode,
-			...rosterAutoRequestModelId,
+			requestModelId: id,
 		};
 	}
 	return {
@@ -349,7 +347,7 @@ function normalizeCursorModel(
 		contextWindow: resolveCursorContextWindow(details, id, DEFAULT_CONTEXT_WINDOW),
 		maxTokens: DEFAULT_MAX_TOKENS,
 		cursorMaxMode: details.maxMode,
-		...rosterAutoRequestModelId,
+		requestModelId: id,
 	};
 }
 

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -321,6 +321,9 @@ function normalizeCursorModel(
 		Boolean(details.thinkingDetails) ||
 		reference?.reasoning === true;
 
+	// Roster-echoed auto sentinel: record the verbatim roster id so the
+	// provider echoes it instead of the synthetic "default" wire id.
+	const rosterAutoRequestModelId = id === "auto" ? { requestModelId: id } : {};
 	if (reference) {
 		return {
 			...reference,
@@ -331,6 +334,7 @@ function normalizeCursorModel(
 			input: resolveCursorInput(id, reference.input),
 			contextWindow: resolveCursorContextWindow(details, id, reference.contextWindow),
 			cursorMaxMode: details.maxMode,
+			...rosterAutoRequestModelId,
 		};
 	}
 	return {
@@ -345,6 +349,7 @@ function normalizeCursorModel(
 		contextWindow: resolveCursorContextWindow(details, id, DEFAULT_CONTEXT_WINDOW),
 		maxTokens: DEFAULT_MAX_TOKENS,
 		cursorMaxMode: details.maxMode,
+		...rosterAutoRequestModelId,
 	};
 }
 

--- a/packages/catalog/test/cursor-auto-discovery.test.ts
+++ b/packages/catalog/test/cursor-auto-discovery.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import * as http2 from "node:http2";
 import { fetchCursorUsableModels } from "../src/discovery/cursor";
+import { buildModel } from "../src/build";
 import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "../src/discovery/cursor-proto";
 import { create, toBinary } from "../src/discovery/protobuf";
 import type { ModelSpec } from "../src/types";
@@ -56,8 +57,13 @@ describe("cursor discovery auto sentinel", () => {
 		expect(byId.get("auto")?.requestModelId).toBe("auto");
 	});
 
-	it("leaves requestModelId unset on concrete roster entries", async () => {
+	it("keeps live and cached roster wire identities ahead of the synthetic default policy", async () => {
 		const byId = await discover();
-		expect(byId.get("composer-2.5")?.requestModelId).toBeUndefined();
+		const auto = byId.get("auto")!;
+		const cached = JSON.parse(JSON.stringify(auto)) as ModelSpec<"cursor-agent">;
+		expect(buildModel(auto).requestModelId).toBe("auto");
+		expect(buildModel(cached).requestModelId).toBe("auto");
+		expect(buildModel({ ...auto, requestModelId: undefined }).requestModelId).toBe("default");
+		expect(buildModel(byId.get("composer-2.5")!).requestModelId).toBe("composer-2.5");
 	});
 });

--- a/packages/catalog/test/cursor-auto-discovery.test.ts
+++ b/packages/catalog/test/cursor-auto-discovery.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as http2 from "node:http2";
+import { fetchCursorUsableModels } from "../src/discovery/cursor";
+import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "../src/discovery/cursor-proto";
+import { create, toBinary } from "../src/discovery/protobuf";
+import type { ModelSpec } from "../src/types";
+
+let server: http2.Http2Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+	const response = create(GetUsableModelsResponseSchema, {
+		models: [
+			create(ModelDetailsSchema, { modelId: "auto", displayName: "auto" }),
+			create(ModelDetailsSchema, { modelId: "composer-2.5" }),
+		],
+	});
+	const payload = Buffer.from(toBinary(GetUsableModelsResponseSchema, response));
+
+	server = http2.createServer();
+	server.on("stream", (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+		stream.on("data", () => {});
+		stream.on("end", () => {
+			if (headers[":path"] !== "/agent.v1.AgentService/GetUsableModels") {
+				stream.respond({ ":status": 404 });
+				stream.end();
+				return;
+			}
+			stream.respond({ ":status": 200, "content-type": "application/proto" });
+			stream.end(payload);
+		});
+	});
+	const listening = Promise.withResolvers<void>();
+	server.listen(0, "127.0.0.1", listening.resolve);
+	await listening.promise;
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("expected http2 fixture server to bind a tcp port");
+	}
+	baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(() => {
+	server?.close();
+});
+
+async function discover(): Promise<Map<string, ModelSpec<"cursor-agent">>> {
+	const models = await fetchCursorUsableModels({ apiKey: "test-key", baseUrl });
+	expect(models).not.toBeNull();
+	return new Map((models ?? []).map(model => [model.id, model]));
+}
+
+describe("cursor discovery auto sentinel", () => {
+	it("records the verbatim roster id on the auto entry for wire echo", async () => {
+		const byId = await discover();
+		expect(byId.get("auto")?.requestModelId).toBe("auto");
+	});
+
+	it("leaves requestModelId unset on concrete roster entries", async () => {
+		const byId = await discover();
+		expect(byId.get("composer-2.5")?.requestModelId).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Aligns Cursor requests with the native CLI: forwards caller capability flags and session identifiers, uses agent mode for user messages, preserves the advertised Auto model ID, and updates the generated protocol surface.

Each request now receives a fresh run ID unless explicitly supplied. The final payload's run ID also becomes `x-request-id`, including when an `onPayload` hook replaces it, and conversation grouping defaults to the current conversation.

Validation for this update:

- 340 Cursor provider and discovery tests passed.
- `bun check` passed in `packages/ai`.
- Regression coverage verifies distinct generated IDs, explicit overrides, stable conversation grouping, and the final run ID received by a real local HTTP/2 server.

Live account testing is limited by the currently exhausted Cursor API-model allowance; no live access restoration is claimed.
