### PR TITLE
Show jj bookmark/change ID in colocated workspaces

### DIFF
--- a/crates/pi-natives/src/vcs.rs
+++ b/crates/pi-natives/src/vcs.rs
@@ -495,6 +495,15 @@ pub fn vcs_discover(env: Env, dir: String) -> Result<Option<VcsRepo>> {
 		.map_err(|err| rich_error(env, err))
 }
 
+/// Discover the repository presenting a directory: equal-root jj+git ties
+/// prefer Jujutsu. Git-safe automation must keep using [`vcs_discover`].
+#[napi]
+pub fn vcs_discover_for_display(env: Env, dir: String) -> Result<Option<VcsRepo>> {
+	pi_vcs::detect_for_display(Path::new(&dir))
+		.map(|repo| repo.map(|inner| VcsRepo { inner }))
+		.map_err(|err| rich_error(env, err))
+}
+
 #[napi]
 impl VcsRepo {
 	/// Backend kind (`"git"` or `"jj"`).

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -282,6 +282,28 @@ pub fn detect(dir: &Path) -> Result<Option<Repo>> {
 	}
 }
 
+/// Detect which VCS should present `dir` in human-facing surfaces.
+///
+/// Same as [`detect`], except equal-root jj+git ties prefer Jujutsu:
+/// colocated workspaces resolve to [`Repo::Jj`]. A strictly deeper nested
+/// git checkout still wins (it is the tree the user works in), and
+/// [`is_pure_jj`] keeps using [`detect`], so git-mutating automation policy
+/// is unchanged. Existing [`Repo`] dispatch serves both detectors without a
+/// colocated variant: presentation reads label/status through the returned
+/// backend, while automation keeps the [`detect`] result.
+pub fn detect_for_display(dir: &Path) -> Result<Option<Repo>> {
+	let jj = jj::JjWorkspace::discover(dir)?;
+	let Some(jj) = jj else {
+		return Ok(git::GitRepo::discover(dir)?.map(|repo| Repo::Git(Arc::new(repo))));
+	};
+	match git::GitRepo::discover(dir)? {
+		Some(repo) if is_strict_descendant(repo.root(), jj.root()) => {
+			Ok(Some(Repo::Git(Arc::new(repo))))
+		},
+		_ => Ok(Some(Repo::Jj(Arc::new(jj)))),
+	}
+}
+
 /// Detect a "pure" Jujutsu workspace — one where git-mutating automation has
 /// no safe target because jj is the nearest (or only) VCS ancestor.
 ///
@@ -376,7 +398,51 @@ mod tests {
 			.unwrap()
 			.uncommitted_diff(&[])
 			.unwrap();
+
 		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn display_prefers_jj_on_equal_root_ties() {
+		let temp = tempfile::tempdir().unwrap();
+		init_git(temp.path());
+		fs::create_dir_all(temp.path().join(".jj/repo")).unwrap();
+		assert!(matches!(detect(temp.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(temp.path()).unwrap(), Some(Repo::Jj(_))));
+	}
+
+	#[test]
+	fn display_matches_detect_for_pure_and_nested_roots() {
+		// Pure git.
+		let git_dir = tempfile::tempdir().unwrap();
+		init_git(git_dir.path());
+		assert!(matches!(detect(git_dir.path()).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(git_dir.path()).unwrap(), Some(Repo::Git(_))));
+
+		// Pure jj.
+		let jj_dir = tempfile::tempdir().unwrap();
+		fs::create_dir_all(jj_dir.path().join(".jj/repo")).unwrap();
+		assert!(matches!(detect(jj_dir.path()).unwrap(), Some(Repo::Jj(_))));
+		assert!(matches!(detect_for_display(jj_dir.path()).unwrap(), Some(Repo::Jj(_))));
+
+		// Nested git checkout under an outer jj workspace: the strictly
+		// deeper git root still wins in both detectors.
+		let outer = tempfile::tempdir().unwrap();
+		fs::create_dir_all(outer.path().join(".jj/repo")).unwrap();
+		let inner = outer.path().join("sub");
+		fs::create_dir_all(&inner).unwrap();
+		init_git(&inner);
+		assert!(matches!(detect(&inner).unwrap(), Some(Repo::Git(_))));
+		assert!(matches!(detect_for_display(&inner).unwrap(), Some(Repo::Git(_))));
+
+		// Jj nested inside an unrelated git checkout: the deeper root wins
+		// in both detectors.
+		let git_outer = tempfile::tempdir().unwrap();
+		init_git(git_outer.path());
+		let jj_inner = git_outer.path().join("sub");
+		fs::create_dir_all(jj_inner.join(".jj/repo")).unwrap();
+		assert!(matches!(detect(&jj_inner).unwrap(), Some(Repo::Jj(_))));
+		assert!(matches!(detect_for_display(&jj_inner).unwrap(), Some(Repo::Jj(_))));
 	}
 
 	#[test]

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -282,15 +282,16 @@ pub fn detect(dir: &Path) -> Result<Option<Repo>> {
 	}
 }
 
-/// Detect which VCS should present `dir` in human-facing surfaces.
+/// Detect which VCS should present `dir` in the status line and footer.
 ///
 /// Same as [`detect`], except equal-root jj+git ties prefer Jujutsu:
 /// colocated workspaces resolve to [`Repo::Jj`]. A strictly deeper nested
 /// git checkout still wins (it is the tree the user works in), and
 /// [`is_pure_jj`] keeps using [`detect`], so git-mutating automation policy
 /// is unchanged. Existing [`Repo`] dispatch serves both detectors without a
-/// colocated variant: presentation reads label/status through the returned
-/// backend, while automation keeps the [`detect`] result.
+/// colocated variant: presentation reads the label through the returned
+/// backend (status counts stay on the operational handle), while automation
+/// keeps the [`detect`] result.
 pub fn detect_for_display(dir: &Path) -> Result<Option<Repo>> {
 	let jj = jj::JjWorkspace::discover(dir)?;
 	let Some(jj) = jj else {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Custom `Other` answers are now applied before the Ask dialog becomes interactive again, so the next Enter is no longer discarded ([#11558](https://github.com/can1357/oh-my-pi/pull/11558) by [@schickling-assistant](https://github.com/schickling-assistant)).
 - Explicit per-model price overrides retain their configured flat rates instead of inheriting time-based pricing.
 - Fixed wrong-typed `compat.stripImageInput` in `models.yml` being silently accepted, so the documented vision opt-out is now validated like its neighbours ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
+- In colocated jj-git workspaces, the status line and footer now show the JJ label (bookmark or short change ID) instead of a detached git HEAD. Git-backed automation still resolves these directories to Git ([#11071](https://github.com/can1357/oh-my-pi/issues/11071), [#11325](https://github.com/can1357/oh-my-pi/pull/11325) by [@boazy](https://github.com/boazy)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,6 +8,7 @@ import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
+import { colocatedJjWorkspace } from "./status-line/git-utils";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
 /**
@@ -121,6 +122,33 @@ export class FooterComponent implements Component {
 				this.#branchResolve = request;
 				void repository
 					.label(request.signal)
+					.then(label => {
+						if (this.#disposed || this.#branchGeneration !== generation) return;
+						const changed = this.#cachedBranch !== label;
+						this.#cachedBranch = label;
+						if (changed) this.#onBranchChange?.();
+					})
+					.catch(() => {
+						if (this.#disposed || this.#branchGeneration !== generation) return;
+						this.#cachedBranch = null;
+					})
+					.finally(() => {
+						if (this.#branchResolve === request) this.#branchResolve = undefined;
+					});
+			}
+			return this.#cachedBranch ?? null;
+		}
+		// Colocated jj-git checkout: jj owns the working-copy label even though
+		// `detect()` resolves the directory to Git (same root-equality
+		// predicate as the status line, independent of git HEAD state).
+		const colocatedJj = colocatedJjWorkspace(getProjectDir(), repository);
+		if (colocatedJj) {
+			if (!this.#branchResolve) {
+				const request = new AbortController();
+				const generation = this.#branchGeneration;
+				this.#branchResolve = request;
+				void colocatedJj
+					.workingCopyLabel(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
 						const changed = this.#cachedBranch !== label;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,7 +8,6 @@ import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
 import { sanitizeStatusText } from "../shared";
-import { colocatedJjWorkspace } from "./status-line/git-utils";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
 
 /**
@@ -58,7 +57,7 @@ export class FooterComponent implements Component {
 		this.#gitUnwatch = null;
 
 		if (!settings.get("git.enabled")) return;
-		const repository = vcs.repo(getProjectDir());
+		const repository = vcs.repoForDisplay(getProjectDir());
 		if (!repository) return;
 
 		try {
@@ -104,7 +103,7 @@ export class FooterComponent implements Component {
 
 		const repository = (() => {
 			try {
-				return vcs.repo(getProjectDir());
+				return vcs.repoForDisplay(getProjectDir());
 			} catch {
 				return null;
 			}
@@ -122,33 +121,6 @@ export class FooterComponent implements Component {
 				this.#branchResolve = request;
 				void repository
 					.label(request.signal)
-					.then(label => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						const changed = this.#cachedBranch !== label;
-						this.#cachedBranch = label;
-						if (changed) this.#onBranchChange?.();
-					})
-					.catch(() => {
-						if (this.#disposed || this.#branchGeneration !== generation) return;
-						this.#cachedBranch = null;
-					})
-					.finally(() => {
-						if (this.#branchResolve === request) this.#branchResolve = undefined;
-					});
-			}
-			return this.#cachedBranch ?? null;
-		}
-		// Colocated jj-git checkout: jj owns the working-copy label even though
-		// `detect()` resolves the directory to Git (same root-equality
-		// predicate as the status line, independent of git HEAD state).
-		const colocatedJj = colocatedJjWorkspace(getProjectDir(), repository);
-		if (colocatedJj) {
-			if (!this.#branchResolve) {
-				const request = new AbortController();
-				const generation = this.#branchGeneration;
-				this.#branchResolve = request;
-				void colocatedJj
-					.workingCopyLabel(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
 						const changed = this.#cachedBranch !== label;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -123,8 +123,9 @@ export class FooterComponent implements Component {
 					.label(request.signal)
 					.then(label => {
 						if (this.#disposed || this.#branchGeneration !== generation) return;
-						const changed = this.#cachedBranch !== label;
-						this.#cachedBranch = label;
+						const clean = typeof label === "string" ? sanitizeStatusText(label) : label;
+						const changed = this.#cachedBranch !== clean;
+						this.#cachedBranch = clean;
 						if (changed) this.#onBranchChange?.();
 					})
 					.catch(() => {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -7,7 +7,7 @@ import {
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
 import { getNextTimeBasedPricingTransition } from "@oh-my-pi/pi-catalog/models";
 import type { ModelCost } from "@oh-my-pi/pi-catalog/types";
-import type { VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -35,7 +35,13 @@ import {
 	type CodexResetUsageSnapshot,
 	detectCodexResetFireworks,
 } from "../codex-reset-fireworks";
-import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
+import {
+	canReuseCachedPr,
+	colocatedJjWorkspace,
+	createPrCacheContext,
+	isSamePrCacheContext,
+	type PrCacheContext,
+} from "./git-utils";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -1083,6 +1089,13 @@ export class StatusLineComponent implements Component {
 			})();
 			return this.#cachedJjBranch;
 		}
+		// Colocated jj-git checkout: jj owns the working-copy label even though
+		// `detect()` resolves the directory to Git. The predicate is root
+		// equality (see colocatedJjWorkspace), independent of git HEAD state.
+		const colocatedJj = colocatedJjWorkspace(gitCwd, repository);
+		if (colocatedJj) {
+			return this.#colocatedJjBranchLabel(gitCwd, colocatedJj);
+		}
 
 		const fallbackCacheExpired =
 			this.#gitWatcherUnavailable &&
@@ -1163,6 +1176,52 @@ export class StatusLineComponent implements Component {
 		}
 		this.#cachedBranch = head.kind === "ref" ? (head.branch ?? head.refName ?? "HEAD") : "detached";
 		return this.#cachedBranch ?? null;
+	}
+
+	/**
+	 * Working-copy label for a colocated jj-git checkout.
+	 *
+	 * Mirrors the pure-jj fetch above (same throttle state, same invalidation
+	 * lifecycle): the render path never blocks, the first paint returns the
+	 * cached label, and the resolve requests a repaint on change. The result
+	 * is mirrored into the git-branch cache so PR and default-branch lookups
+	 * follow the displayed jj bookmark.
+	 */
+	#colocatedJjBranchLabel(gitCwd: string, jj: VcsJjWorkspace): string | null {
+		if (this.#jjBranchActive || Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS) {
+			return this.#cachedJjBranch;
+		}
+		const request: JjResolveRequest = {
+			id: ++this.#jjResolveSeq,
+			controller: new AbortController(),
+		};
+		this.#jjBranchActive = request;
+		const generation = this.#jjCacheGeneration;
+		(async () => {
+			let next: string | null = null;
+			try {
+				next =
+					(await jj.workingCopyLabel(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
+			} catch {
+				next = null;
+			} finally {
+				if (this.#jjBranchActive?.id === request.id) this.#jjBranchActive = undefined;
+				if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
+			}
+			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
+			const changed = next !== this.#cachedJjBranch;
+			this.#cachedJjBranch = next;
+			this.#cachedBranchCwd = gitCwd;
+			try {
+				this.#cachedBranchRepoId = vcs.gitInfo(gitCwd)?.headPath ?? null;
+			} catch {
+				this.#cachedBranchRepoId = null;
+			}
+			this.#cachedBranch = next;
+			this.#branchLastFetch = Date.now();
+			if (changed) this.#onBranchChange?.();
+		})();
+		return this.#cachedJjBranch;
 	}
 
 	#isDefaultBranch(branch: string, effectiveGitCwd: string): boolean {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -7,7 +7,7 @@ import {
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
 import { getNextTimeBasedPricingTransition } from "@oh-my-pi/pi-catalog/models";
 import type { ModelCost } from "@oh-my-pi/pi-catalog/types";
-import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -1234,7 +1234,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveDisplayRepository(activeRepoCache);
+		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) return null;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -35,13 +35,7 @@ import {
 	type CodexResetUsageSnapshot,
 	detectCodexResetFireworks,
 } from "../codex-reset-fireworks";
-import {
-	canReuseCachedPr,
-	colocatedJjWorkspace,
-	createPrCacheContext,
-	isSamePrCacheContext,
-	type PrCacheContext,
-} from "./git-utils";
+import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -248,6 +242,8 @@ interface ActiveRepoCache {
 	activeRepo: ActiveRepoContext | null;
 	effectiveGitCwd: string;
 	repository: VcsRepo | null;
+	displayRepository: VcsRepo | null;
+	displayRepositoryCheckedAt: number;
 	repositoryCheckedAt: number;
 	/** Project + worktree dir name when `projectDir` is a linked worktree, else null. */
 	worktree: WorktreeContext | null;
@@ -547,6 +543,18 @@ export class StatusLineComponent implements Component {
 		const activeRepo = projectRepository ? null : resolveActiveRepoContextSync(projectDir);
 		const effectiveGitCwd = activeRepo?.repoRoot ?? projectDir;
 		const repository = projectRepository ?? (activeRepo ? vcs.repo(effectiveGitCwd) : null);
+		// Presentation follows a second detector whose only policy difference
+		// is preferring jj on equal-root ties (see detect_for_display);
+		// automation keeps `repository` above. A failed display lookup (or a
+		// caller that only stubs the operational detector) degrades to the
+		// operational repository rather than hiding the segment.
+		let displayRepository: VcsRepo | null;
+		try {
+			displayRepository = vcs.repoForDisplay(effectiveGitCwd);
+		} catch {
+			displayRepository = null;
+		}
+		displayRepository ??= repository;
 		// Only collapse the bare-cwd case: a single-direct-child-repo context
 		// (activeRepo set) renders `<parent> ↳ <child>`, which we leave intact.
 		const worktree = activeRepo ? null : resolveWorktreeContext(effectiveGitCwd);
@@ -555,6 +563,8 @@ export class StatusLineComponent implements Component {
 			activeRepo,
 			effectiveGitCwd,
 			repository,
+			displayRepository,
+			displayRepositoryCheckedAt: Date.now(),
 			repositoryCheckedAt: Date.now(),
 			worktree,
 		};
@@ -568,6 +578,21 @@ export class StatusLineComponent implements Component {
 		cache.repository = vcs.repo(cache.effectiveGitCwd);
 		cache.repositoryCheckedAt = now;
 		return cache.repository;
+	}
+
+	#resolveDisplayRepository(cache: ActiveRepoCache): VcsRepo | null {
+		if (cache.displayRepository) return cache.displayRepository;
+		const now = Date.now();
+		if (now - cache.displayRepositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return null;
+		let display: VcsRepo | null;
+		try {
+			display = vcs.repoForDisplay(cache.effectiveGitCwd);
+		} catch {
+			display = null;
+		}
+		cache.displayRepository = display ?? cache.repository;
+		cache.displayRepositoryCheckedAt = now;
+		return cache.displayRepository;
 	}
 
 	/**
@@ -791,7 +816,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		const activeRepoCache = this.#resolveActiveRepoCache();
-		const repository = this.#resolveRepository(activeRepoCache);
+		const repository = this.#resolveDisplayRepository(activeRepoCache);
 		if (!repository) {
 			// There is no path to watch yet. Cache the negative result only for the
 			// fallback poll interval so a later `git init` becomes visible without
@@ -1054,11 +1079,15 @@ export class StatusLineComponent implements Component {
 		this.#jjStatusActive?.controller.abort();
 		this.#jjStatusActive = undefined;
 	}
-	#getBranchLabel(activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache()): string | null {
+	#getBranchLabel(
+		activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache(),
+		// Presentation defaults to the display detector; PR lookup passes the
+		// operational repository so a jj label never becomes a GitHub head.
+		repository: VcsRepo | null = this.#resolveDisplayRepository(activeRepoCache),
+	): string | null {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) return null;
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
@@ -1089,14 +1118,6 @@ export class StatusLineComponent implements Component {
 			})();
 			return this.#cachedJjBranch;
 		}
-		// Colocated jj-git checkout: jj owns the working-copy label even though
-		// `detect()` resolves the directory to Git. The predicate is root
-		// equality (see colocatedJjWorkspace), independent of git HEAD state.
-		const colocatedJj = colocatedJjWorkspace(gitCwd, repository);
-		if (colocatedJj) {
-			return this.#colocatedJjBranchLabel(gitCwd, colocatedJj);
-		}
-
 		const fallbackCacheExpired =
 			this.#gitWatcherUnavailable &&
 			(this.#branchLastFetch === undefined || Date.now() - this.#branchLastFetch >= WATCHER_FAILURE_POLL_TTL_MS);
@@ -1178,52 +1199,6 @@ export class StatusLineComponent implements Component {
 		return this.#cachedBranch ?? null;
 	}
 
-	/**
-	 * Working-copy label for a colocated jj-git checkout.
-	 *
-	 * Mirrors the pure-jj fetch above (same throttle state, same invalidation
-	 * lifecycle): the render path never blocks, the first paint returns the
-	 * cached label, and the resolve requests a repaint on change. The result
-	 * is mirrored into the git-branch cache so PR and default-branch lookups
-	 * follow the displayed jj bookmark.
-	 */
-	#colocatedJjBranchLabel(gitCwd: string, jj: VcsJjWorkspace): string | null {
-		if (this.#jjBranchActive || Date.now() - this.#jjBranchLastFetch < JJ_REFRESH_TTL_MS) {
-			return this.#cachedJjBranch;
-		}
-		const request: JjResolveRequest = {
-			id: ++this.#jjResolveSeq,
-			controller: new AbortController(),
-		};
-		this.#jjBranchActive = request;
-		const generation = this.#jjCacheGeneration;
-		(async () => {
-			let next: string | null = null;
-			try {
-				next =
-					(await jj.workingCopyLabel(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
-			} catch {
-				next = null;
-			} finally {
-				if (this.#jjBranchActive?.id === request.id) this.#jjBranchActive = undefined;
-				if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
-			}
-			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
-			const changed = next !== this.#cachedJjBranch;
-			this.#cachedJjBranch = next;
-			this.#cachedBranchCwd = gitCwd;
-			try {
-				this.#cachedBranchRepoId = vcs.gitInfo(gitCwd)?.headPath ?? null;
-			} catch {
-				this.#cachedBranchRepoId = null;
-			}
-			this.#cachedBranch = next;
-			this.#branchLastFetch = Date.now();
-			if (changed) this.#onBranchChange?.();
-		})();
-		return this.#cachedJjBranch;
-	}
-
 	#isDefaultBranch(branch: string, effectiveGitCwd: string): boolean {
 		if (this.#defaultBranchCwd !== effectiveGitCwd) {
 			this.#defaultBranch = undefined;
@@ -1255,7 +1230,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
-		const repository = this.#resolveRepository(activeRepoCache);
+		const repository = this.#resolveDisplayRepository(activeRepoCache);
 		if (!repository) return null;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
@@ -1327,7 +1302,7 @@ export class StatusLineComponent implements Component {
 
 		const gitCwd = activeRepoCache.effectiveGitCwd;
 		if (this.#resolveRepository(activeRepoCache)?.kind() !== "git") return null;
-		const branch = this.#getBranchLabel(activeRepoCache);
+		const branch = this.#getBranchLabel(activeRepoCache, this.#resolveRepository(activeRepoCache));
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 
 		if (canReuseCachedPr(this.#cachedPr, this.#cachedPrContext, currentContext)) {
@@ -1357,7 +1332,10 @@ export class StatusLineComponent implements Component {
 			const setCachedPr = (value: { number: number; url: string } | null) => {
 				const latestActiveRepoCache = this.#resolveActiveRepoCache();
 				if (latestActiveRepoCache.effectiveGitCwd !== lookupCwd) return;
-				const latestBranch = this.#getBranchLabel(latestActiveRepoCache);
+				const latestBranch = this.#getBranchLabel(
+					latestActiveRepoCache,
+					this.#resolveRepository(latestActiveRepoCache),
+				);
 				const latestContext = latestBranch
 					? createPrCacheContext(latestBranch, this.#cachedBranchRepoId ?? null)
 					: undefined;
@@ -1952,6 +1930,8 @@ export class StatusLineComponent implements Component {
 					activeRepo: null,
 					effectiveGitCwd: projectDir,
 					repository: null,
+					displayRepository: null,
+					displayRepositoryCheckedAt: Date.now(),
 					repositoryCheckedAt: Date.now(),
 					worktree: null,
 				};

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1103,8 +1103,12 @@ export class StatusLineComponent implements Component {
 			(async () => {
 				let next: string | null = null;
 				try {
-					next =
+					const raw =
 						(await repository.label(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))) ?? null;
+					// Repository-controlled jj metadata can carry control
+					// characters; sanitize at the cache boundary (the git segment
+					// renders the label verbatim).
+					next = raw === null ? null : sanitizeStatusText(raw);
 				} catch {
 					next = null;
 				} finally {

--- a/packages/coding-agent/src/modes/components/status-line/git-utils.ts
+++ b/packages/coding-agent/src/modes/components/status-line/git-utils.ts
@@ -1,32 +1,3 @@
-import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
-import * as vcs from "@oh-my-pi/pi-natives/vcs";
-
-/**
- * Jujutsu workspace colocated with the checkout `repository` was discovered
- * from (same root), or null.
- *
- * `detect()` still resolves colocated directories to Git (git automation is
- * safe there), so presentation code must ask jj directly through the
- * independent `vcs.jj()` discovery. The predicate is root equality — not git
- * HEAD state: detached is valid in ordinary Git, and a colocated checkout
- * can have an attached HEAD. A jj workspace at a *different* root (e.g. a
- * nested git checkout under an outer jj tree) is not colocation: the git
- * branch stays authoritative there.
- */
-export function colocatedJjWorkspace(dir: string, repository: VcsRepo): VcsJjWorkspace | null {
-	let jj: VcsJjWorkspace | null;
-	try {
-		jj = vcs.jj(dir);
-	} catch {
-		return null;
-	}
-	if (!jj) return null;
-	try {
-		return jj.root() === repository.root() ? jj : null;
-	} catch {
-		return null;
-	}
-}
 /**
  * Extract "owner/repo" from a GitHub remote URL.
  * Handles HTTPS, SSH (scp-style), and git:// protocols.

--- a/packages/coding-agent/src/modes/components/status-line/git-utils.ts
+++ b/packages/coding-agent/src/modes/components/status-line/git-utils.ts
@@ -1,3 +1,32 @@
+import type { VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+
+/**
+ * Jujutsu workspace colocated with the checkout `repository` was discovered
+ * from (same root), or null.
+ *
+ * `detect()` still resolves colocated directories to Git (git automation is
+ * safe there), so presentation code must ask jj directly through the
+ * independent `vcs.jj()` discovery. The predicate is root equality — not git
+ * HEAD state: detached is valid in ordinary Git, and a colocated checkout
+ * can have an attached HEAD. A jj workspace at a *different* root (e.g. a
+ * nested git checkout under an outer jj tree) is not colocation: the git
+ * branch stays authoritative there.
+ */
+export function colocatedJjWorkspace(dir: string, repository: VcsRepo): VcsJjWorkspace | null {
+	let jj: VcsJjWorkspace | null;
+	try {
+		jj = vcs.jj(dir);
+	} catch {
+		return null;
+	}
+	if (!jj) return null;
+	try {
+		return jj.root() === repository.root() ? jj : null;
+	} catch {
+		return null;
+	}
+}
 /**
  * Extract "owner/repo" from a GitHub remote URL.
  * Handles HTTPS, SSH (scp-style), and git:// protocols.

--- a/packages/coding-agent/test/footer-jj-label-sanitize.test.ts
+++ b/packages/coding-agent/test/footer-jj-label-sanitize.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The footer renders the jj label verbatim inside the working-directory
+ * segment, so repository-controlled control characters must be sanitized
+ * at the cache boundary, mirroring the status-line jj label path.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { FooterComponent } from "@oh-my-pi/pi-coding-agent/modes/components/footer";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getContextUsage: () => undefined,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "footer-sanitize test",
+			getEntries: () => [],
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof FooterComponent>[0];
+}
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("FooterComponent jj label sanitization", () => {
+	it("sanitizes control characters from the jj label", async () => {
+		const root = "/repo/footer-sanitize";
+		const jj = {
+			kind: () => "jj",
+			asGit: () => null,
+			asJj: () => ({}) as never,
+			root: () => root,
+			watchTarget: () => `${root}/.jj/repo/op_heads/heads`,
+			label: async () => `footer-${String.fromCharCode(7)}bookmark`,
+		} as unknown as VcsRepo;
+		vi.spyOn(vcs, "repoForDisplay").mockReturnValue(jj);
+		vi.spyOn(vcs, "watch").mockImplementation((() => () => {}) as unknown as typeof vcs.watch);
+
+		const component = new FooterComponent(makeSession());
+		component.watchBranch(() => {});
+		try {
+			component.render(80);
+			await flush();
+			const content = component.render(80).join("\n");
+			expect(content).toContain("(footer-");
+			expect(content).toContain("bookmark)");
+			expect(content).not.toContain(String.fromCharCode(7));
+		} finally {
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1,22 +1,23 @@
 /**
  * #11071: a colocated jj-git checkout resolved to Git in `detect()`, so the
- * status line showed the git HEAD ("detached" in practice, or a stale git
- * branch) instead of the active jj bookmark/change id.
+ * status line showed the git HEAD ("detached" in practice) instead of the
+ * active jj bookmark/change id.
  *
- * `detect()` intentionally still resolves colocated directories to Git (git
- * automation is safe there). Presentation instead consults the independent
- * `vcs.jj()` discovery and prefers the jj label when both discoveries share
- * the same root — regardless of git HEAD state. A jj workspace at a
- * different root (nested git under an outer jj tree) keeps the git branch,
- * and ordinary git without jj keeps "detached".
+ * Presentation now follows a second detector, `vcs.repoForDisplay()`, whose
+ * only policy difference is preferring jj on equal-root ties; automation
+ * keeps `vcs.repo()`. The component (and legacy footer) split accordingly:
+ * branch label, status counts, and the head watcher come from the display
+ * repository, while PR lookup keeps resolving the operational git branch —
+ * a jj bookmark/change id must never become a GitHub head.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 
 type GitStatus = { staged: number; unstaged: number; untracked: number };
@@ -55,7 +56,7 @@ function makeSession() {
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		modelRegistry: { isUsingOAuth: () => false },
 		sessionManager: {
-			getSessionName: () => "colocated-jj test",
+			getSessionName: () => "display-detector test",
 			getUsageStatistics: () => ({
 				input: 0,
 				output: 0,
@@ -68,20 +69,11 @@ function makeSession() {
 	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
 }
 
-const attachedHead: VcsHeadState = {
-	kind: "ref",
-	branch: "git-branch-name",
-	refName: "refs/heads/git-branch-name",
-	commit: undefined,
-};
+function headFor(branch: string): VcsHeadState {
+	return { kind: "ref", branch, refName: `refs/heads/${branch}`, commit: undefined };
+}
 const detachedHead: VcsHeadState = { kind: "detached" };
 
-function jjWorkspace(root: string, workingCopyLabel: () => Promise<string | null>): VcsJjWorkspace {
-	return {
-		root: () => root,
-		workingCopyLabel,
-	} as unknown as VcsJjWorkspace;
-}
 function repoInfoFor(root: string): VcsGitRepoInfo {
 	return {
 		commonDir: `${root}/.git`,
@@ -93,7 +85,7 @@ function repoInfoFor(root: string): VcsGitRepoInfo {
 	};
 }
 
-function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
+function gitHandle(head: VcsHeadState | null): VcsGitRepo {
 	return {
 		headSync: () => head,
 		linkedWorktree: () => null,
@@ -101,14 +93,31 @@ function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
 	} as unknown as VcsGitRepo;
 }
 
-function unifiedGit(repository: VcsGitRepo, root: string): VcsRepo {
+function gitWithDefaultBranch(branch: string): VcsGitRepo {
+	return { defaultBranch: async () => branch, linkedWorktree: () => null } as unknown as VcsGitRepo;
+}
+
+function operationalGit(root: string, head: VcsHeadState | null): VcsRepo {
+	const handle = gitHandle(head);
 	return {
 		kind: () => "git",
-		asGit: () => repository,
+		asGit: () => handle,
 		asJj: () => null,
 		root: () => root,
 		watchTarget: () => `${root}/.git/HEAD`,
-		statusSummary: (signal?: AbortSignal) => repository.statusSummary(signal),
+		statusSummary: (signal?: AbortSignal) => handle.statusSummary(signal),
+	} as unknown as VcsRepo;
+}
+
+function displayJj(root: string, label: () => Promise<string | null>, status: GitStatus): VcsRepo {
+	return {
+		kind: () => "jj",
+		asGit: () => null,
+		asJj: () => ({}) as never,
+		root: () => root,
+		watchTarget: () => `${root}/.jj/repo/op_heads/heads`,
+		label,
+		statusSummary: async () => status,
 	} as unknown as VcsRepo;
 }
 
@@ -120,22 +129,36 @@ const gitSegment: StatusLineSettings = {
 	sessionAccent: false,
 	transparent: false,
 };
+const gitPrSegments: StatusLineSettings = {
+	...gitSegment,
+	leftSegments: ["git", "pr"],
+};
 
 async function flush(): Promise<void> {
 	await Promise.resolve();
 	await Promise.resolve();
 	await Promise.resolve();
+	await Promise.resolve();
 }
 
-describe("StatusLineComponent colocated jj-git label", () => {
-	it("prefers the jj bookmark over an attached git HEAD when roots match", async () => {
+function mockRepos(operational: VcsRepo, display: VcsRepo, root: string): void {
+	vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+	vi.spyOn(vcs, "git").mockReturnValue(null);
+	vi.spyOn(vcs, "repo").mockReturnValue(operational);
+	vi.spyOn(vcs, "repoForDisplay").mockReturnValue(display);
+}
+
+describe("StatusLineComponent display detector", () => {
+	it("shows the jj bookmark and jj status with the jj watch target when colocated", async () => {
 		const root = "/repo/colocated";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
-		const label = Promise.withResolvers<string | null>();
-		const workingCopyLabel = vi.fn(() => label.promise);
-		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace(root, workingCopyLabel));
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => "my-bookmark", { staged: 1, unstaged: 2, untracked: 3 });
+		mockRepos(operational, display, root);
+		let watched: VcsRepo | null = null;
+		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
+			watched = repo;
+			return () => {};
+		}) as unknown as typeof vcs.watch);
 
 		const onBranchChange = vi.fn();
 		const component = new StatusLineComponent(makeSession());
@@ -143,47 +166,86 @@ describe("StatusLineComponent colocated jj-git label", () => {
 		component.watchBranch(onBranchChange);
 
 		component.getTopBorder(80);
-		expect(workingCopyLabel).toHaveBeenCalled();
-
-		label.resolve("my-bookmark");
 		await flush();
 
+		expect(vcs.repoForDisplay).toHaveBeenCalled();
 		expect(onBranchChange).toHaveBeenCalled();
 		expect(component.getTopBorder(80).content).toContain("my-bookmark");
+		expect((watched as VcsRepo | null)?.watchTarget()).toBe(`${root}/.jj/repo/op_heads/heads`);
 		component.dispose();
 	});
 
 	it("keeps the git branch for a nested git checkout under an outer jj workspace", async () => {
 		const root = "/repo/nested";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
-		const workingCopyLabel = vi.fn(async (): Promise<string | null> => "outer-bookmark");
-		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace("/outer", workingCopyLabel));
+		const operational = operationalGit(root, headFor("git-branch-name"));
+		mockRepos(operational, operationalGit(root, headFor("git-branch-name")), root);
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSegment);
 		component.watchBranch(() => {});
 
+		component.getTopBorder(80);
 		await flush();
-		expect(workingCopyLabel).not.toHaveBeenCalled();
 		expect(component.getTopBorder(80).content).toContain("git-branch-name");
 		component.dispose();
 	});
 
 	it("keeps detached for ordinary git with no jj workspace", async () => {
 		const root = "/repo/plain";
-		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
-		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(detachedHead, root));
-		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(detachedHead, root), root));
-		vi.spyOn(vcs, "jj").mockReturnValue(null);
+		const operational = operationalGit(root, detachedHead);
+		mockRepos(operational, operationalGit(root, detachedHead), root);
 
 		const component = new StatusLineComponent(makeSession());
 		component.updateSettings(gitSegment);
 		component.watchBranch(() => {});
 
+		component.getTopBorder(80);
 		await flush();
 		expect(component.getTopBorder(80).content).toContain("detached");
+		component.dispose();
+	});
+
+	it("does not send the jj bookmark to PR lookup when the git branch is default", async () => {
+		const root = "/repo/colocated-pr";
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => "feature-x", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		const run = vi.spyOn(github, "run").mockResolvedValue({ exitCode: 0, stdout: "{}", stderr: "" });
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+
+		expect(component.getTopBorder(80).content).toContain("feature-x");
+		expect(run).not.toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("still looks up PRs by the operational git branch when it is not default", async () => {
+		const root = "/repo/colocated-pr-live";
+		const operational = operationalGit(root, headFor("git-branch-name"));
+		const display = displayJj(root, async () => "feature-x", { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+		vi.spyOn(vcs, "git").mockReturnValue(gitWithDefaultBranch("main"));
+		const run = vi
+			.spyOn(github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: '{"number":7,"url":"https://example.test/x/7"}', stderr: "" });
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitPrSegments);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0]?.[1]).toEqual(["pr", "view", "--json", "number,url"]);
+		expect(component.getTopBorder(80).content).toContain("feature-x");
+		expect(component.getTopBorder(80).content).toContain("#7");
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -5,10 +5,11 @@
  *
  * Presentation now follows a second detector, `vcs.repoForDisplay()`, whose
  * only policy difference is preferring jj on equal-root ties; automation
- * keeps `vcs.repo()`. The component (and legacy footer) split accordingly:
- * branch label, status counts, and the head watcher come from the display
- * repository, while PR lookup keeps resolving the operational git branch —
- * a jj bookmark/change id must never become a GitHub head.
+ * keeps `vcs.repo()`. The component (and footer) split accordingly:
+ * branch label and the head watcher come from the display
+ * repository (status counts stay on the operational repository), while PR
+ * lookup keeps resolving the operational git branch — a jj bookmark/change
+ * id must never become a GitHub head.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -149,10 +150,10 @@ function mockRepos(operational: VcsRepo, display: VcsRepo, root: string): void {
 }
 
 describe("StatusLineComponent display detector", () => {
-	it("shows the jj bookmark and jj status with the jj watch target when colocated", async () => {
+	it("shows the jj bookmark with the jj watch target when colocated", async () => {
 		const root = "/repo/colocated";
 		const operational = operationalGit(root, headFor("main"));
-		const display = displayJj(root, async () => "my-bookmark", { staged: 1, unstaged: 2, untracked: 3 });
+		const display = displayJj(root, async () => "my-bookmark", { staged: 0, unstaged: 0, untracked: 0 });
 		mockRepos(operational, display, root);
 		let watched: VcsRepo | null = null;
 		vi.spyOn(vcs, "watch").mockImplementation(((repo: VcsRepo) => {
@@ -170,7 +171,8 @@ describe("StatusLineComponent display detector", () => {
 
 		expect(vcs.repoForDisplay).toHaveBeenCalled();
 		expect(onBranchChange).toHaveBeenCalled();
-		expect(component.getTopBorder(80).content).toContain("my-bookmark");
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("my-bookmark");
 		expect((watched as VcsRepo | null)?.watchTarget()).toBe(`${root}/.jj/repo/op_heads/heads`);
 		component.dispose();
 	});
@@ -251,7 +253,11 @@ describe("StatusLineComponent display detector", () => {
 	it("sanitizes control characters from the jj label", async () => {
 		const root = "/repo/sanitize";
 		const operational = operationalGit(root, headFor("main"));
-		const display = displayJj(root, async () => `evil-${String.fromCharCode(27)}[2J-bookmark`, { staged: 0, unstaged: 0, untracked: 0 });
+		const display = displayJj(root, async () => `evil-${String.fromCharCode(27)}[2J-bookmark`, {
+			staged: 0,
+			unstaged: 0,
+			untracked: 0,
+		});
 		mockRepos(operational, display, root);
 
 		const component = new StatusLineComponent(makeSession());

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #11071: a colocated jj-git checkout resolved to Git in `detect()`, so the
+ * status line showed the git HEAD ("detached" in practice, or a stale git
+ * branch) instead of the active jj bookmark/change id.
+ *
+ * `detect()` intentionally still resolves colocated directories to Git (git
+ * automation is safe there). Presentation instead consults the independent
+ * `vcs.jj()` discovery and prefers the jj label when both discoveries share
+ * the same root — regardless of git HEAD state. A jj workspace at a
+ * different root (nested git under an outer jj tree) keeps the git branch,
+ * and ordinary git without jj keeps "detached".
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsJjWorkspace, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+type GitStatus = { staged: number; unstaged: number; untracked: number };
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "colocated-jj test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+const attachedHead: VcsHeadState = {
+	kind: "ref",
+	branch: "git-branch-name",
+	refName: "refs/heads/git-branch-name",
+	commit: undefined,
+};
+const detachedHead: VcsHeadState = { kind: "detached" };
+
+function jjWorkspace(root: string, workingCopyLabel: () => Promise<string | null>): VcsJjWorkspace {
+	return {
+		root: () => root,
+		workingCopyLabel,
+	} as unknown as VcsJjWorkspace;
+}
+function repoInfoFor(root: string): VcsGitRepoInfo {
+	return {
+		commonDir: `${root}/.git`,
+		gitDir: `${root}/.git`,
+		gitEntryPath: `${root}/.git`,
+		headPath: `${root}/.git/HEAD`,
+		repoRoot: root,
+		isReftable: false,
+	};
+}
+
+function gitRepo(head: VcsHeadState | null, _root: string): VcsGitRepo {
+	return {
+		headSync: () => head,
+		linkedWorktree: () => null,
+		statusSummary: async (): Promise<GitStatus | null> => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	} as unknown as VcsGitRepo;
+}
+
+function unifiedGit(repository: VcsGitRepo, root: string): VcsRepo {
+	return {
+		kind: () => "git",
+		asGit: () => repository,
+		asJj: () => null,
+		root: () => root,
+		watchTarget: () => `${root}/.git/HEAD`,
+		statusSummary: (signal?: AbortSignal) => repository.statusSummary(signal),
+	} as unknown as VcsRepo;
+}
+
+const gitSegment: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["git"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("StatusLineComponent colocated jj-git label", () => {
+	it("prefers the jj bookmark over an attached git HEAD when roots match", async () => {
+		const root = "/repo/colocated";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
+		const label = Promise.withResolvers<string | null>();
+		const workingCopyLabel = vi.fn(() => label.promise);
+		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace(root, workingCopyLabel));
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80);
+		expect(workingCopyLabel).toHaveBeenCalled();
+
+		label.resolve("my-bookmark");
+		await flush();
+
+		expect(onBranchChange).toHaveBeenCalled();
+		expect(component.getTopBorder(80).content).toContain("my-bookmark");
+		component.dispose();
+	});
+
+	it("keeps the git branch for a nested git checkout under an outer jj workspace", async () => {
+		const root = "/repo/nested";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(attachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(attachedHead, root), root));
+		const workingCopyLabel = vi.fn(async (): Promise<string | null> => "outer-bookmark");
+		vi.spyOn(vcs, "jj").mockReturnValue(jjWorkspace("/outer", workingCopyLabel));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		await flush();
+		expect(workingCopyLabel).not.toHaveBeenCalled();
+		expect(component.getTopBorder(80).content).toContain("git-branch-name");
+		component.dispose();
+	});
+
+	it("keeps detached for ordinary git with no jj workspace", async () => {
+		const root = "/repo/plain";
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(repoInfoFor(root));
+		vi.spyOn(vcs, "git").mockReturnValue(gitRepo(detachedHead, root));
+		vi.spyOn(vcs, "repo").mockReturnValue(unifiedGit(gitRepo(detachedHead, root), root));
+		vi.spyOn(vcs, "jj").mockReturnValue(null);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		await flush();
+		expect(component.getTopBorder(80).content).toContain("detached");
+		component.dispose();
+	});
+});

--- a/packages/coding-agent/test/status-line-colocated-jj.test.ts
+++ b/packages/coding-agent/test/status-line-colocated-jj.test.ts
@@ -248,4 +248,24 @@ describe("StatusLineComponent display detector", () => {
 		expect(component.getTopBorder(80).content).toContain("#7");
 		component.dispose();
 	});
+	it("sanitizes control characters from the jj label", async () => {
+		const root = "/repo/sanitize";
+		const operational = operationalGit(root, headFor("main"));
+		const display = displayJj(root, async () => `evil-${String.fromCharCode(27)}[2J-bookmark`, { staged: 0, unstaged: 0, untracked: 0 });
+		mockRepos(operational, display, root);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(() => {});
+
+		component.getTopBorder(80);
+		await flush();
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("evil-");
+		expect(content).toContain("bookmark");
+		// The raw erase-display payload is gone (theme ANSI aside, which is
+		// emitted by the renderer itself, not the label).
+		expect(content).not.toContain("[2J");
+		component.dispose();
+	});
 });

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -149,6 +149,16 @@ beforeEach(() => {
 	vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
 	vi.spyOn(vcs, "git").mockReturnValue(fakeRepository);
 	vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepository);
+	// Presentation now resolves a second handle: forward to the operational
+	// double's current implementation without recording an extra `repo` call,
+	// so these scenarios keep display == operational (pure git / pure jj)
+	// while call-count assertions on the operational detector keep meaning.
+	const operational = vi.spyOn(vcs, "repo") as unknown as {
+		getMockImplementation(): ((dir: string) => VcsRepo | null) | undefined;
+	};
+	vi.spyOn(vcs, "repoForDisplay").mockImplementation(
+		(dir: string) => operational.getMockImplementation()?.(dir) ?? null,
+	);
 });
 
 function useReftable(info: Partial<VcsGitRepoInfo> = {}): void {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Fixed Wayland computer-use clicks landing in the wrong place on scaled monitors by mapping captures through the portal's logical monitor geometry ([#11540](https://github.com/can1357/oh-my-pi/issues/11540)).
 
+### Added
+
+- Added `vcsDiscoverForDisplay` (`repoForDisplay`): like repository discovery, but equal-root jj+git ties prefer Jujutsu for the status line and footer. Git-safe automation must keep using `vcsDiscover` ([#11071](https://github.com/can1357/oh-my-pi/issues/11071), [#11325](https://github.com/can1357/oh-my-pi/pull/11325) by [@boazy](https://github.com/boazy)).
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -2778,6 +2778,12 @@ export interface VcsDiffOptions {
 /** Discover the repository owning a directory. */
 export declare function vcsDiscover(dir: string): VcsRepo | null
 
+/**
+ * Discover the repository presenting a directory: equal-root jj+git ties
+ * prefer Jujutsu. Git-safe automation must keep using [`vcs_discover`].
+ */
+export declare function vcsDiscoverForDisplay(dir: string): VcsRepo | null
+
 /** Clone a Git repository. */
 export declare function vcsGitClone(url: string, target: string, options: VcsCloneOptions, signal?: unknown | undefined | null): Promise<void>
 

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -113,6 +113,7 @@ export const supportsLanguage = nativeBindings.supportsLanguage;
 export const truncateToWidth = nativeBindings.truncateToWidth;
 export const vcsDetachGitDir = nativeBindings.vcsDetachGitDir;
 export const vcsDiscover = nativeBindings.vcsDiscover;
+export const vcsDiscoverForDisplay = nativeBindings.vcsDiscoverForDisplay;
 export const vcsGitClone = nativeBindings.vcsGitClone;
 export const vcsGitDiscover = nativeBindings.vcsGitDiscover;
 export const vcsGitRepoInfo = nativeBindings.vcsGitRepoInfo;

--- a/packages/natives/native/vcs.d.ts
+++ b/packages/natives/native/vcs.d.ts
@@ -47,6 +47,8 @@ export declare function isEmptyCherryPick(error: unknown): error is VcsError & {
 export declare function git(dir: string): VcsGitRepo | null;
 /** Discover the repository owning `dir`; `null` outside any repository. */
 export declare function repo(dir: string): VcsRepo | null;
+/** Like {@link repo}, but equal-root jj+git ties prefer Jujutsu for display. Git-safe automation must keep using {@link repo}. */
+export declare function repoForDisplay(dir: string): VcsRepo | null;
 
 /** Like {@link repo}, asserting any requested backend capabilities. */
 export declare function require(dir: string, ...features: VcsFeature[]): VcsRepo;

--- a/packages/natives/native/vcs.js
+++ b/packages/natives/native/vcs.js
@@ -41,6 +41,11 @@ export function repo(dir) {
 	return api().vcsDiscover(dir);
 }
 
+/** Like {@link repo}, but equal-root jj+git ties prefer Jujutsu for display. Git-safe automation must keep using {@link repo}. */
+export function repoForDisplay(dir) {
+	return api().vcsDiscoverForDisplay(dir);
+}
+
 /** Like {@link repo}, asserting any requested backend capabilities. */
 export function require(dir, ...features) {
 	const discovered = repo(dir);


### PR DESCRIPTION
Fixes #11071.

In a colocated jj-git workspace (one directory that is both a jj workspace and a git checkout), repository detection resolves to Git, so the status line and footer read detached HEAD instead of the active jj label (a bookmark when one is present, otherwise the short change ID).

This PR adds a display detector that prefers jj when both tools claim the same directory, shows the jj label in the status line and footer, and sanitizes control characters from jj labels before rendering.

## Out of scope

- Git fallback for unloadable stores: a corrupt store shows an empty branch label until that follow-up lands. Kept whole there with its repaint, ordering, recovery, and cancellation handling, since shipping it partial would leave known defects.
- Repository-target-change handling (stale branch, PR, and default-branch caches; watcher rebinds): pre-existing shared-cache behavior that also covers pure-git flows, not jj-specific. Follows separately.
- Mid-session nesting, removal handling, and operational revalidation under stable displays: rare edge cases, each reviewable alone.
- Watcher and lifecycle hardening: pre-existing behavior independent of this feature.
- `CancelToken` pre-abort handling: shared native infrastructure bug, separate PR.
- Showing the correct git or PR status for broken colocated repositories (e.g. git HEAD was modified outside of jj)

## Verification (branch `fix/colocated-jj-status-label-v2`)

- `bun test test/status-line-*.test.ts test/footer-*.test.ts` (packages/coding-agent): 193 pass, 0 fail.
- `bunx tsgo -p tsconfig.json --noEmit`, `oxlint`, `oxfmt --check`: clean.
- `cargo test -p pi-vcs --lib`: 43 pass, 13 fail — all 13 are CLI-oracle mismatches in untouched areas (git diff/patch text fixtures, jj CLI fixture, unborn-diff cases); both new detector tests (`display_prefers_jj_on_equal_root_ties`, `display_matches_detect_for_pure_and_nested_roots`) pass.
- `cargo check -p pi-natives` (pinned nightly): clean.
- `bun test test/vcs.test.ts` (packages/natives, binding rebuilt from this branch): 5 pass, 2 fail — identical 2 failures on clean `origin/main` with a main-built binding (system-git diff-text skew in portable-Git oracle assertions); unrelated to this change.