### PR TITLE
fix(ai): treat Cloudflare AI Gateway 2009 as a rate limit

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cloudflare AI Gateway request-rate rejections, which arrive as `401` with `AiGatewayError` code 2009, now back off instead of rotating gateway credentials: rotating cannot clear a rate window, and a plain `401` still counts as an auth failure.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Cloudflare AI Gateway request-rate rejections, which arrive as `401` with `AiGatewayError` code 2009, now back off instead of rotating gateway credentials: rotating cannot clear a rate window, and a plain `401` still counts as an auth failure ([#11327](https://github.com/can1357/oh-my-pi/pull/11327) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- Cloudflare AI Gateway request-rate rejections, which arrive as `401` with `AiGatewayError` code 2009, now back off instead of rotating gateway credentials: rotating cannot clear a rate window, and a plain `401` still counts as an auth failure. The auth gateway reports the same response as `429 rate_limit_error`, so its clients back off instead of discarding a working credential ([#11327](https://github.com/can1357/oh-my-pi/pull/11327) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Cloudflare AI Gateway request-rate rejections, which arrive as `401` with `AiGatewayError` code 2009, now back off instead of rotating gateway credentials: rotating cannot clear a rate window, and a plain `401` still counts as an auth failure.
+- Cloudflare AI Gateway request-rate rejections, which arrive as `401` with `AiGatewayError` code 2009, now back off instead of rotating gateway credentials: rotating cannot clear a rate window, and a plain `401` still counts as an auth failure ([#11327](https://github.com/can1357/oh-my-pi/pull/11327) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/src/error/auth-classify.ts
+++ b/packages/ai/src/error/auth-classify.ts
@@ -1,7 +1,7 @@
 import { extractHttpStatusFromError } from "@oh-my-pi/pi-utils";
 import { isAccountPolicyError, isClinePassSurfaceGateMessage, isOAuthExpiry, isUsageLimit } from "./flags";
 import { OAuthError } from "./oauth";
-import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./rate-limit";
+import { isCloudflareAiGatewayThrottleText, isConcurrencyCapExclusion, isUsageLimitOutcome } from "./rate-limit";
 
 /**
  * Whether an OAuth refresh failure is definitive (the credential must be
@@ -49,6 +49,10 @@ export function isAuthRetryableError(error: unknown): boolean {
 	// A Cline surface-gate 403 is per-model client policy, not a credential
 	// problem: sibling keys fail identically, so rotation only burns them.
 	if (isClinePassSurfaceGateMessage(message)) return false;
+	// Cloudflare AI Gateway answers an over-rate request with 401 and its own
+	// `AiGatewayError` 2009: rotating credentials cannot clear a rate window, so
+	// this stays in the upstream-backoff lane like any other rate limit.
+	if (isCloudflareAiGatewayThrottleText(message)) return false;
 	if (status === 401 || status === 403) return true;
 	return isUsageLimitOutcome(status, message);
 }

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -570,11 +570,16 @@ export function classify(error: unknown, api?: Api): number {
 			) {
 				linkKinds |= Flag.UsageLimit;
 			}
-			if (code === "overloaded_error" || code === "rate_limit_error") {
+			// A Cloudflare AI Gateway 2009 is a rate rejection wearing a 401, so it
+			// belongs in the transient lane rather than the auth lane whatever
+			// shape the transport gave the error.
+			const cloudflareGatewayThrottle = isCloudflareAiGatewayThrottleText(link.message);
+			if (code === "overloaded_error" || code === "rate_limit_error" || cloudflareGatewayThrottle) {
 				linkKinds |= Flag.Transient;
 			}
 			if (
 				(codeStatus === 401 || codeStatus === 403) &&
+				!cloudflareGatewayThrottle &&
 				!(codeStatus === 403 && parseRateLimitReason(link.message) === "CONCURRENT_LIMIT")
 			) {
 				linkKinds |= Flag.AuthFailed;

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -10,6 +10,7 @@ import {
 import {
 	is402BillingCapBody,
 	isAccountScopedCapText,
+	isCloudflareAiGatewayThrottleText,
 	isDashScopeTokenLimitText,
 	isOpaqueStatusBody,
 	isUsageLimitStatus,
@@ -455,7 +456,12 @@ function classifyText(
 		) {
 			kinds |= Flag.AccountPolicy | Flag.ContentBlocked;
 		}
-		if (isAuthFailureText(errorMessage)) kinds |= Flag.AuthFailed;
+		// Cloudflare AI Gateway's rate rejection arrives as 401 + AiGatewayError
+		// 2009, whose "Unauthorized" wording would otherwise read as a hard auth
+		// failure and rotate gateway keys that cannot clear a rate window.
+		const cloudflareGatewayThrottle = isCloudflareAiGatewayThrottleText(errorMessage);
+		if (cloudflareGatewayThrottle) kinds |= Flag.Transient;
+		if (isAuthFailureText(errorMessage) && !cloudflareGatewayThrottle) kinds |= Flag.AuthFailed;
 
 		const statusClean = errorStatus ? errorStatus : (status({ message: errorMessage }) ?? undefined);
 		const cleanMessage = errorMessage;

--- a/packages/ai/src/error/gateway.ts
+++ b/packages/ai/src/error/gateway.ts
@@ -1,4 +1,5 @@
 import { isUsageLimit } from "./flags";
+import { isCloudflareAiGatewayThrottleText } from "./rate-limit";
 
 /** A gateway-facing classification of an arbitrary upstream/internal error. */
 export interface GatewayErrorClassification {
@@ -57,7 +58,10 @@ export function classifyGatewayError(err: unknown): GatewayErrorClassification {
 		// this branch the classifier falls through to the default
 		// 502/upstream_error, which is what callers saw when their account
 		// hit its cap.
-		isUsageLimit(message)
+		isUsageLimit(message) ||
+		// Cloudflare AI Gateway words its rate rejection as `Unauthorized`, so it
+		// must be recognized before the auth branch below claims it.
+		isCloudflareAiGatewayThrottleText(message)
 	) {
 		return { status: 429, type: "rate_limit_error", message };
 	}
@@ -71,6 +75,12 @@ export function classifyGatewayError(err: unknown): GatewayErrorClassification {
 }
 
 function bucketStatus(status: number, message: string): GatewayErrorClassification {
+	// Cloudflare AI Gateway serves an over-rate request as 401 with its own
+	// `AiGatewayError` 2009. Reporting that to a gateway client as an auth
+	// failure invites it to discard a working credential instead of backing off.
+	if ((status === 401 || status === 403) && isCloudflareAiGatewayThrottleText(message)) {
+		return { status: 429, type: "rate_limit_error", message };
+	}
 	if (status === 401 || status === 403) return { status, type: "authentication_error", message };
 	if (status === 429) return { status, type: "rate_limit_error", message };
 	if (status >= 400 && status < 500) return { status, type: "invalid_request_error", message };

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -100,6 +100,22 @@ export function isDashScopeTokenLimitText(errorMessage: string): boolean {
 	);
 }
 
+/**
+ * Cloudflare AI Gateway rejects over-rate requests with HTTP 401 and its own
+ * `AiGatewayError` code 2009 ("Unauthorized") instead of a 429, so the wire
+ * shape is indistinguishable from a bad token by status alone. Measured on
+ * `workers-ai/@cf/zai-org/glm-5.3` with one credential against one account:
+ * 3/3 success at 40s request spacing, 1/3 at ~4s spacing, and the same
+ * credential serves `glm-5.3-flash` throughout. Rotating gateway keys cannot
+ * clear a rate window, so this is a shed-and-backoff throttle: retry the same
+ * credential instead of burning siblings and falling through the model chain.
+ */
+export function isCloudflareAiGatewayThrottleText(errorMessage: string | undefined): boolean {
+	if (!errorMessage) return false;
+	if (!/AiGatewayError/.test(errorMessage)) return false;
+	return /"(?:internalCode|code)"\s*:\s*2009\b/.test(errorMessage);
+}
+
 const GOOGLE_RPC_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
 const ANTIGRAVITY_MODEL_QUOTA_PATTERN = /\bexhausted your capacity on this model\b/i;
 const LONG_RATE_LIMIT_DELAY_MS = 5 * 60 * 1000;
@@ -179,6 +195,7 @@ function isQuotaExhaustedReason(reason: RateLimitReason): boolean {
 export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	const structuredReason = parseGoogleRpcRateLimitReason(errorMessage);
 	if (structuredReason !== undefined) return structuredReason;
+	if (isCloudflareAiGatewayThrottleText(errorMessage)) return "RATE_LIMIT_EXCEEDED";
 	const lowerWithStatus = errorMessage.toLowerCase();
 	const lower = lowerWithStatus.replace(RESOURCE_EXHAUSTED_PATTERN, "");
 	const hasResourceExhaustedStatus = lower !== lowerWithStatus;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -20,7 +20,7 @@ import { getCustomApi } from "./api-registry";
 import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } from "./auth-retry";
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
-import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
+import { isCloudflareAiGatewayThrottleText, isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { MessageCreateParamsStreaming } from "./providers/anthropic-wire";
@@ -1123,6 +1123,10 @@ function isRetryableUpstreamError(
 	// classify as RATE_LIMIT_EXCEEDED in `parseRateLimitReason` and stay in the
 	// provider's own backoff layer instead of burning siblings.
 	if (AIError.isCodexChatGPTAccountPolicyError(error, model.provider, model.id)) return true;
+	// Cloudflare AI Gateway serves its rate rejection as 401 + AiGatewayError
+	// 2009; rotating gateway credentials cannot clear a rate window, so keep it
+	// in the provider backoff layer instead of burning every sibling key.
+	if (isCloudflareAiGatewayThrottleText(message)) return false;
 	if (status === 401 || (status === 403 && !isConcurrencyCapExclusion(status, message))) return true;
 	return isUsageLimitOutcome(status, message);
 }

--- a/packages/ai/test/auth-gateway-classify-error.test.ts
+++ b/packages/ai/test/auth-gateway-classify-error.test.ts
@@ -18,6 +18,27 @@ describe("auth-gateway classifyGatewayError", () => {
 		expect(classifyGatewayError(Object.assign(new Error(""), { status: 429 })).type).toBe("rate_limit_error");
 	});
 
+	// Cloudflare AI Gateway serves an over-rate request as 401 + `AiGatewayError`
+	// 2009. A gateway client told "authentication_error" may discard a working
+	// credential, so the public response must read as a rate limit. Both the
+	// status property and the status embedded in the body reach this path.
+	it("maps a Cloudflare AI Gateway 2009 to rate_limit_error", () => {
+		const body =
+			'{"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009}';
+		const viaStatus = classifyGatewayError(Object.assign(new Error(body), { status: 401 }));
+		expect(viaStatus.status).toBe(429);
+		expect(viaStatus.type).toBe("rate_limit_error");
+
+		const viaEmbedded = classifyGatewayError(new Error(`401 ${body}`));
+		expect(viaEmbedded.status).toBe(429);
+		expect(viaEmbedded.type).toBe("rate_limit_error");
+
+		// A plain 401 still authenticates-fails.
+		expect(classifyGatewayError(Object.assign(new Error("Unauthorized"), { status: 401 })).type).toBe(
+			"authentication_error",
+		);
+	});
+
 	it("does NOT misclassify `GenerateContentRequest` 400 as rate-limited (the original bug)", () => {
 		// Verbatim shape Google emits when functionResponse.name is missing.
 		const msg =

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -88,6 +88,19 @@ describe("isAuthRetryableError", () => {
 		// A generic (non-account) 429 rate limit is NOT rotatable — switching
 		// credentials won't help an org/global limit.
 		expect(isAuthRetryableError(Object.assign(new Error("429 too many requests"), { status: 429 }))).toBe(false);
+		// Cloudflare AI Gateway serves an over-rate request as 401 + `AiGatewayError`
+		// 2009. Rotating gateway credentials cannot clear a rate window, so this
+		// must stay in the backoff lane despite the 401.
+		expect(
+			isAuthRetryableError(
+				Object.assign(
+					new Error(
+						'401 {"success":false,"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009}',
+					),
+					{ status: 401 },
+				),
+			),
+		).toBe(false);
 		expect(isAuthRetryableError("Error: 401 unauthorized")).toBe(true);
 		expect(isAuthRetryableError("Encountered invalidated oauth token for user, failing request")).toBe(true);
 		// xAI SuperGrok surfaces account exhaustion as 403 + "run out of credits" /

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -679,6 +679,32 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(false);
 		expect(isUsageLimit(Object.assign(new Error(message), { status: 429 }))).toBe(false);
 	});
+
+	it("treats Cloudflare AI Gateway 2009 as a transient throttle, not an auth failure", () => {
+		const body =
+			'401 {"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009,"message":"Unauthorized","description":"Unauthorized"}';
+		expect(parseRateLimitReason(body)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimitOutcome(401, body)).toBe(false);
+		const id = classify(Object.assign(new Error(body), { status: 401 }));
+		expect(is(id, Flag.Transient)).toBe(true);
+		expect(is(id, Flag.AuthFailed)).toBe(false);
+		expect(retriable(id)).toBe(true);
+		// The OpenAI-compatible transport wraps the same response in a typed
+		// error, whose own 401 arm must make the same call.
+		const typed = classify(new ProviderHttpError(body, 401));
+		expect(is(typed, Flag.Transient)).toBe(true);
+		expect(is(typed, Flag.AuthFailed)).toBe(false);
+		expect(retriable(typed)).toBe(true);
+	});
+
+	it("keeps a plain 401 an auth failure", () => {
+		const body = '401 {"error":"Unauthorized","message":"Invalid API key"}';
+		const id = classify(Object.assign(new Error(body), { status: 401 }));
+		expect(is(id, Flag.AuthFailed)).toBe(true);
+		expect(retriable(id)).toBe(false);
+		const typed = classify(new ProviderHttpError(body, 401));
+		expect(is(typed, Flag.AuthFailed)).toBe(true);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {
@@ -718,23 +744,5 @@ describe("is402BillingCapBody", () => {
 	it("returns false for non-quota informative bodies", () => {
 		expect(is402BillingCapBody("A subscription is required for this endpoint")).toBe(false);
 		expect(is402BillingCapBody("Rate limit exceeded, too many requests")).toBe(false);
-	});
-
-	it("treats Cloudflare AI Gateway 2009 as a transient throttle, not an auth failure", () => {
-		const body =
-			'401 {"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009,"message":"Unauthorized","description":"Unauthorized"}';
-		expect(parseRateLimitReason(body)).toBe("RATE_LIMIT_EXCEEDED");
-		expect(isUsageLimitOutcome(401, body)).toBe(false);
-		const id = classify(Object.assign(new Error(body), { status: 401 }));
-		expect(is(id, Flag.Transient)).toBe(true);
-		expect(is(id, Flag.AuthFailed)).toBe(false);
-		expect(retriable(id)).toBe(true);
-	});
-
-	it("keeps a plain 401 an auth failure", () => {
-		const body = '401 {"error":"Unauthorized","message":"Invalid API key"}';
-		const id = classify(Object.assign(new Error(body), { status: 401 }));
-		expect(is(id, Flag.AuthFailed)).toBe(true);
-		expect(retriable(id)).toBe(false);
 	});
 });

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -719,4 +719,22 @@ describe("is402BillingCapBody", () => {
 		expect(is402BillingCapBody("A subscription is required for this endpoint")).toBe(false);
 		expect(is402BillingCapBody("Rate limit exceeded, too many requests")).toBe(false);
 	});
+
+	it("treats Cloudflare AI Gateway 2009 as a transient throttle, not an auth failure", () => {
+		const body =
+			'401 {"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009,"message":"Unauthorized","description":"Unauthorized"}';
+		expect(parseRateLimitReason(body)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimitOutcome(401, body)).toBe(false);
+		const id = classify(Object.assign(new Error(body), { status: 401 }));
+		expect(is(id, Flag.Transient)).toBe(true);
+		expect(is(id, Flag.AuthFailed)).toBe(false);
+		expect(retriable(id)).toBe(true);
+	});
+
+	it("keeps a plain 401 an auth failure", () => {
+		const body = '401 {"error":"Unauthorized","message":"Invalid API key"}';
+		const id = classify(Object.assign(new Error(body), { status: 401 }));
+		expect(is(id, Flag.AuthFailed)).toBe(true);
+		expect(retriable(id)).toBe(false);
+	});
 });

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -300,6 +300,83 @@ describe("streamSimple resolver auth retry", () => {
 		]);
 	});
 
+	// Cloudflare AI Gateway rejects an over-rate request with 401 and its own
+	// `AiGatewayError` 2009. Rotating gateway credentials cannot clear a rate
+	// window, so neither the thrown path nor the error-event path may resolve a
+	// replacement key.
+	const gatewayThrottleBody =
+		'401 {"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009,"message":"Unauthorized"}';
+
+	it("surfaces a thrown Cloudflare gateway throttle without rotating credentials", async () => {
+		const keys: unknown[] = [];
+		const contexts: ApiKeyResolveContext[] = [];
+		const throttle = Object.assign(new Error(gatewayThrottleBody), { status: 401 });
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => stream.fail(throttle));
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => {
+				contexts.push(ctx);
+				return ctx.error === undefined ? "old-key" : ctx.lastChance ? "sibling-key" : "refresh-key";
+			},
+		});
+		await expect(
+			(async () => {
+				for await (const _event of stream) {
+					// drain
+				}
+			})(),
+		).rejects.toBe(throttle);
+
+		expect(keys).toEqual(["old-key"]);
+		expect(contexts.map(ctx => ({ lastChance: ctx.lastChance, hasError: ctx.error !== undefined }))).toEqual([
+			{ lastChance: false, hasError: false },
+		]);
+	});
+
+	it("surfaces a Cloudflare gateway throttle error event without rotating credentials", async () => {
+		const keys: unknown[] = [];
+		const contexts: ApiKeyResolveContext[] = [];
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: assistant() });
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: assistantError(gatewayThrottleBody, 401),
+					});
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => {
+				contexts.push(ctx);
+				return ctx.error === undefined ? "old-key" : "new-key";
+			},
+		});
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(keys).toEqual(["old-key"]);
+		expect(contexts.map(ctx => ctx.error !== undefined)).toEqual([false]);
+	});
+
 	it("buffers the start event and retries on a 401 error event before content", async () => {
 		const keys: unknown[] = [];
 		const eventTypes: string[] = [];


### PR DESCRIPTION
## What

Adds `isCloudflareAiGatewayThrottleText` and uses it in three places: the reason parser returns `RATE_LIMIT_EXCEEDED`, the error classifier marks the error transient instead of `AuthFailed`, and `isRetryableUpstreamError` stops treating it as a credential failure. A plain `401` without that body still classifies as an auth failure.

## Why

Cloudflare AI Gateway answers an over-rate request with HTTP 401 and its own error body:

```text
401 {"success":false,"result":[],"messages":[],"error":[{"code":2009,"message":"Unauthorized"}],"name":"AiGatewayError","httpCode":401,"internalCode":2009}
```

The status and the wording look like a bad token, so OMP rotated gateway credentials and, with a fallback chain configured for that model, walked to the next entry. Rotating credentials cannot clear a rate window, so this burned the whole gateway pool on a condition that resolves by waiting.

It is rate-based, not credential-based. Same credential, same model (`workers-ai/@cf/zai-org/glm-5.3`):

- three requests about 4 seconds apart: 1 success, 2 failures with the body above;
- the same three requests 40 seconds apart: 3 successes;
- six concurrent requests on a later day: 6 successes;
- `@cf/zai-org/glm-5.3-flash` on that same credential never failed.

Across two days of logs, plain `glm-5.3` produced 19 of these 401s alongside 4 ordinary 429s and 2 stream closures, and the latter two only happen after authorization succeeds.

## Testing

- `packages/ai/test/rate-limit-utils.test.ts` gained two cases: the gateway body classifies as a transient rate limit and is not a usage-limit outcome, and a plain `401` stays an auth failure. With the source changes reverted the first fails (72 pass, 1 fail); with them, 73 pass, 0 fail.
- Exercised live against the gateway: after the change, repeated `glm-5.3` requests on one credential wrote no credential block (`auth_credential_blocks` has 0 cloudflare rows) and no request fell through to the next chain entry.
- `bun test packages/ai/test/`: 4477 pass, 1 fail — the pre-existing `Bedrock cross-region inference-profile geo routing` case, which fails the same way on `main`.
- `bun run check:types` in `packages/ai`: clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
