### PR TITLE
fix(ai): adopt externally added credentials before selection

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A running session now picks up credentials another process committed: adding an account in a second terminal is visible to credential selection and rotation without restarting the session ([#11329](https://github.com/can1357/oh-my-pi/pull/11329) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- A running session now picks up credentials another process committed: adding an account in a second terminal is visible to credential selection and rotation without restarting the session, and a session's pinned account is re-resolved by row id so a row another process deleted cannot hand its slot to a sibling ([#11329](https://github.com/can1357/oh-my-pi/pull/11329) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A running session now picks up credentials another process committed: adding an account in a second terminal is visible to credential selection and rotation without restarting the session.
+- A running session now picks up credentials another process committed: adding an account in a second terminal is visible to credential selection and rotation without restarting the session ([#11329](https://github.com/can1357/oh-my-pi/pull/11329) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A running session now picks up credentials another process committed: adding an account in a second terminal is visible to credential selection and rotation without restarting the session.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1488,6 +1488,33 @@ export class AuthStorage {
 		return true;
 	}
 
+	/**
+	 * Adopt credentials another process committed before selecting or rotating.
+	 *
+	 * The store is shared across every omp process, but the pool is an
+	 * in-process cache refreshed only by this process's own writes. Without
+	 * this a long-running session ranks a stale pool for its whole lifetime:
+	 * `omp auth` in another terminal is invisible, rotation reports no usable
+	 * sibling while a freshly added account sits unblocked in SQLite, and the
+	 * turn degrades to the fallback chain. The auth-broker path already polls;
+	 * direct-store sessions had no equivalent.
+	 *
+	 * A poll is two cheap reads (`PRAGMA data_version` plus the auth revision)
+	 * and re-lists credentials only when another connection committed, so it
+	 * runs on every resolution rather than on a timer that would make recovery
+	 * depend on wall-clock spacing.
+	 */
+	async #adoptExternalCredentialChanges(): Promise<void> {
+		if (this.#closed || this.#store.pollExternalChanges === undefined) return;
+		try {
+			await this.pollExternalChanges();
+		} catch (error) {
+			// A failed poll must not fail credential resolution: the in-memory
+			// pool is still serviceable, just possibly stale.
+			logger.debug("External credential poll failed", { error: String(error) });
+		}
+	}
+
 	onGenerationChanged(listener: (generation: number) => void): () => void {
 		this.#generationListeners.add(listener);
 		return () => {
@@ -5955,6 +5982,7 @@ export class AuthStorage {
 
 		// Precedence: a deliberate OAuth/login credential wins, then an explicit env var,
 		// then a stored static api_key (which may be a stale broker-migrated copy) as a last resort.
+		await this.#adoptExternalCredentialChanges();
 		const oauthResolved = await this.#resolveOAuthSelection(provider, sessionId, options);
 		if (oauthResolved) {
 			return oauthResolved.apiKey;
@@ -6859,6 +6887,7 @@ export class AuthStorage {
 			signal?: AbortSignal;
 		},
 	): Promise<boolean> {
+		await this.#adoptExternalCredentialChanges();
 		const error = options?.error;
 		const status = AIError.status(error);
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1351,7 +1351,7 @@ export class AuthStorage {
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
 	#sessionLastCredential: Map<
 		string,
-		Map<string, { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number }>
+		Map<string, { type: AuthCredential["type"]; index: number; credentialId?: number; lastUsedAtMs?: number }>
 	> = new Map();
 	/** Recent bearer fingerprints resolved for each durable OAuth row; used only for delayed usage-limit attribution. */
 	#oauthBearerFingerprints: Map<string, Map<number, string[]>> = new Map();
@@ -2112,12 +2112,12 @@ export class AuthStorage {
 	): void {
 		if (!sessionId) return;
 		const nowMs = lastUsedAtMs ?? Date.now();
+		const credentialId = this.#getStoredCredentials(provider)[index]?.id;
 		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map();
-		sessionMap.set(sessionId, { type, index, lastUsedAtMs: nowMs });
+		sessionMap.set(sessionId, { type, index, credentialId, lastUsedAtMs: nowMs });
 		this.#sessionLastCredential.set(provider, sessionMap);
 
 		try {
-			const credentialId = this.#getStoredCredentials(provider)[index]?.id;
 			if (credentialId !== undefined) {
 				const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
 				const cacheValue = JSON.stringify({
@@ -2139,11 +2139,24 @@ export class AuthStorage {
 	#getSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-	): { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number } | undefined {
+	): { type: AuthCredential["type"]; index: number; credentialId?: number; lastUsedAtMs?: number } | undefined {
 		if (!sessionId) return undefined;
 		let sessionMap = this.#sessionLastCredential.get(provider);
-		if (sessionMap?.has(sessionId)) {
-			return sessionMap.get(sessionId);
+		const live = sessionMap?.get(sessionId);
+		if (live) {
+			// Another process can add or drop rows mid-session and the pool is an
+			// index-ordered snapshot, so re-resolve the pin through its durable row
+			// id: a compacted array must not point the session at a different
+			// account, and a deleted account must not hand its slot to a sibling.
+			if (live.credentialId === undefined) return live;
+			const stored = this.#getStoredCredentials(provider);
+			const actualIndex = stored.findIndex(entry => entry.id === live.credentialId);
+			if (actualIndex === -1 || stored[actualIndex]?.credential.type !== live.type) {
+				sessionMap?.delete(sessionId);
+				return undefined;
+			}
+			live.index = actualIndex;
+			return live;
 		}
 		try {
 			const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
@@ -2177,6 +2190,7 @@ export class AuthStorage {
 				const sessionVal = {
 					type: val.type,
 					index: val.index,
+					credentialId: val.credentialId,
 					lastUsedAtMs: val.lastUsedAtMs,
 				};
 				sessionMap.set(sessionId, sessionVal);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1502,7 +1502,10 @@ export class AuthStorage {
 	 * A poll is two cheap reads (`PRAGMA data_version` plus the auth revision)
 	 * and re-lists credentials only when another connection committed, so it
 	 * runs on every resolution rather than on a timer that would make recovery
-	 * depend on wall-clock spacing.
+	 * depend on wall-clock spacing. It sits on the paths that read the pool —
+	 * OAuth selection, and the two public usage-limit entry points — and is
+	 * idempotent, so a rotation reached through `markUsageLimitReached` costs
+	 * one extra `data_version` read and no second reload.
 	 */
 	async #adoptExternalCredentialChanges(): Promise<void> {
 		if (this.#closed || this.#store.pollExternalChanges === undefined) return;
@@ -4820,6 +4823,7 @@ export class AuthStorage {
 			signal?: AbortSignal;
 		},
 	): Promise<UsageLimitMarkResult> {
+		await this.#adoptExternalCredentialChanges();
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
 			credentialId: options?.credentialId,
 			apiKey: options?.apiKey,
@@ -5161,6 +5165,7 @@ export class AuthStorage {
 		sessionId?: string,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthResolutionResult | undefined> {
+		await this.#adoptExternalCredentialChanges();
 		const credentials = this.#getCredentialsForProvider(provider)
 			.map((credential, index) => ({ credential, index }))
 			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
@@ -5982,7 +5987,6 @@ export class AuthStorage {
 
 		// Precedence: a deliberate OAuth/login credential wins, then an explicit env var,
 		// then a stored static api_key (which may be a stale broker-migrated copy) as a last resort.
-		await this.#adoptExternalCredentialChanges();
 		const oauthResolved = await this.#resolveOAuthSelection(provider, sessionId, options);
 		if (oauthResolved) {
 			return oauthResolved.apiKey;

--- a/packages/ai/test/credential-external-reload.test.ts
+++ b/packages/ai/test/credential-external-reload.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	type AuthCredential,
+	type AuthCredentialStore,
+	AuthStorage,
+	type StoredAuthCredential,
+} from "@oh-my-pi/pi-ai/auth-storage";
+
+/**
+ * A session that is already running must see credentials another process
+ * committed. `omp auth` in a second terminal writes to the shared SQLite store;
+ * without a reload the running session ranks a stale in-memory pool for its
+ * whole lifetime, so rotation reports "no usable sibling" while a freshly added
+ * account sits unblocked in the database and the turn degrades to the fallback
+ * chain instead of switching accounts.
+ */
+function oauthRow(id: number): StoredAuthCredential {
+	const credential: AuthCredential = {
+		type: "oauth",
+		access: `access-${id}`,
+		refresh: `refresh-${id}`,
+		expires: Date.now() + 60 * 60_000,
+		accountId: `account-${id}`,
+	};
+	return { id, provider: "anthropic", credential, disabledCause: null };
+}
+
+interface ExternalStore {
+	store: AuthCredentialStore;
+	/** Simulates another process committing a credential row. */
+	commitExternally: (row: StoredAuthCredential) => void;
+}
+
+function makeExternallyMutableStore(rows: StoredAuthCredential[]): ExternalStore {
+	const cache = new Map<string, { value: string; expiresAtSec: number }>();
+	const blocks = new Map<string, number>();
+	let externalCommitPending = false;
+	const store: AuthCredentialStore = {
+		close() {},
+		listAuthCredentials: provider => rows.filter(row => provider === undefined || row.provider === provider),
+		updateAuthCredential() {},
+		deleteAuthCredential() {},
+		tryDisableAuthCredentialIfMatches: () => false,
+		replaceAuthCredentialsForProvider: () => rows,
+		upsertAuthCredentialForProvider: () => rows,
+		deleteAuthCredentialsForProvider() {},
+		getCredentialBlock: (credentialId: number, _providerKey: string, blockScope: string) =>
+			blocks.get(`${credentialId}:${blockScope}`),
+		upsertCredentialBlock: block => {
+			blocks.set(`${block.credentialId}:${block.blockScope}`, block.blockedUntilMs);
+		},
+		getCache(key) {
+			const entry = cache.get(key);
+			return entry && entry.expiresAtSec * 1000 > Date.now() ? entry.value : null;
+		},
+		setCache(key, value, expiresAtSec) {
+			cache.set(key, { value, expiresAtSec });
+		},
+		cleanExpiredCache() {},
+		// Mirrors SqliteAuthCredentialStore: true exactly once per external commit.
+		pollExternalChanges: () => {
+			if (!externalCommitPending) return false;
+			externalCommitPending = false;
+			return true;
+		},
+		acknowledgeLocalChanges() {},
+	};
+	return {
+		store,
+		commitExternally: row => {
+			rows.push(row);
+			externalCommitPending = true;
+		},
+	};
+}
+
+describe("credential pool visibility across processes", () => {
+	const storages: AuthStorage[] = [];
+	afterEach(() => {
+		for (const storage of storages) storage.close();
+		storages.length = 0;
+	});
+
+	it("rotates onto an account another process added mid-session", async () => {
+		const rows = [oauthRow(1)];
+		const { store, commitExternally } = makeExternallyMutableStore(rows);
+		const storage = new AuthStorage(store, { configValueResolver: async value => value });
+		storages.push(storage);
+		await storage.reload();
+
+		// Rotation attributes the failure to the session's pinned credential, so
+		// establish the pin the way a real turn does.
+		expect(await storage.getApiKey("anthropic", "session-1")).toBe("access-1");
+
+		const usageLimitError = Object.assign(new Error("429 usage limit reached"), { status: 429 });
+
+		// Sole account is spent: nothing to rotate onto.
+		expect(await storage.rotateSessionCredential("anthropic", "session-1", { error: usageLimitError })).toBe(false);
+
+		commitExternally(oauthRow(2));
+
+		// The new account is usable, so the same session must switch to it rather
+		// than report the provider exhausted.
+		expect(await storage.rotateSessionCredential("anthropic", "session-1", { error: usageLimitError })).toBe(true);
+		expect(await storage.getApiKey("anthropic", "session-1")).toBe("access-2");
+	});
+
+	it("does not reload when no other process committed", async () => {
+		const rows = [oauthRow(1), oauthRow(2)];
+		const { store } = makeExternallyMutableStore(rows);
+		let listCalls = 0;
+		const listAuthCredentials = store.listAuthCredentials;
+		store.listAuthCredentials = provider => {
+			listCalls += 1;
+			return listAuthCredentials(provider);
+		};
+		const storage = new AuthStorage(store, { configValueResolver: async value => value });
+		storages.push(storage);
+		await storage.reload();
+		const afterInitialLoad = listCalls;
+
+		const usageLimitError = Object.assign(new Error("429 usage limit reached"), { status: 429 });
+		await storage.rotateSessionCredential("anthropic", "session-1", { error: usageLimitError });
+
+		// An unchanged store is a `PRAGMA data_version` read, never a re-list.
+		expect(listCalls).toBe(afterInitialLoad);
+	});
+});

--- a/packages/ai/test/credential-external-reload.test.ts
+++ b/packages/ai/test/credential-external-reload.test.ts
@@ -29,6 +29,10 @@ interface ExternalStore {
 	store: AuthCredentialStore;
 	/** Simulates another process committing a credential row. */
 	commitExternally: (row: StoredAuthCredential) => void;
+	/** Simulates another process deleting a credential row. */
+	removeExternally: (id: number) => void;
+	/** Blocks written through the store, keyed `credentialId:blockScope`. */
+	blocks: Map<string, number>;
 }
 
 function makeExternallyMutableStore(rows: StoredAuthCredential[]): ExternalStore {
@@ -67,8 +71,14 @@ function makeExternallyMutableStore(rows: StoredAuthCredential[]): ExternalStore
 	};
 	return {
 		store,
+		blocks,
 		commitExternally: row => {
 			rows.push(row);
+			externalCommitPending = true;
+		},
+		removeExternally: id => {
+			const at = rows.findIndex(row => row.id === id);
+			if (at >= 0) rows.splice(at, 1);
 			externalCommitPending = true;
 		},
 	};
@@ -156,5 +166,28 @@ describe("credential pool visibility across processes", () => {
 
 		// An unchanged store is a `PRAGMA data_version` read, never a re-list.
 		expect(listCalls).toBe(afterInitialLoad);
+	});
+
+	it("does not blame a sibling when another process deletes the pinned account", async () => {
+		const rows = [oauthRow(1), oauthRow(2)];
+		const { store, removeExternally, blocks } = makeExternallyMutableStore(rows);
+		const storage = new AuthStorage(store, { configValueResolver: async value => value });
+		storages.push(storage);
+		await storage.reload();
+
+		// Pin the session to the first row, the way a real turn does.
+		expect(await storage.getApiKey("anthropic", "session-1")).toBe("access-1");
+
+		// The pool is an index-ordered snapshot, so deleting the pinned row moves
+		// the sibling into its slot.
+		removeExternally(1);
+
+		const usageLimitError = Object.assign(new Error("429 usage limit reached"), { status: 429 });
+		const switched = await storage.rotateSessionCredential("anthropic", "session-1", { error: usageLimitError });
+
+		// The failure belongs to an account that is gone; the sibling that took
+		// index 0 must not be blocked for it.
+		expect(switched).toBe(false);
+		expect([...blocks.keys()].filter(key => key.startsWith("2:"))).toEqual([]);
 	});
 });

--- a/packages/ai/test/credential-external-reload.test.ts
+++ b/packages/ai/test/credential-external-reload.test.ts
@@ -105,6 +105,38 @@ describe("credential pool visibility across processes", () => {
 		expect(await storage.getApiKey("anthropic", "session-1")).toBe("access-2");
 	});
 
+	it("selects an account another process added, with no rotation in between", async () => {
+		const rows: StoredAuthCredential[] = [];
+		const { store, commitExternally } = makeExternallyMutableStore(rows);
+		const storage = new AuthStorage(store, { configValueResolver: async value => value });
+		storages.push(storage);
+		await storage.reload();
+
+		// A session that started before any account existed.
+		expect(await storage.getApiKey("anthropic", "session-1")).toBeUndefined();
+
+		commitExternally(oauthRow(1));
+
+		// Selection alone must see the new row: no usage-limit error, no rotation.
+		expect(await storage.getApiKey("anthropic", "session-1")).toBe("access-1");
+	});
+
+	it("resolves OAuth access for an account another process added", async () => {
+		const rows: StoredAuthCredential[] = [];
+		const { store, commitExternally } = makeExternallyMutableStore(rows);
+		const storage = new AuthStorage(store, { configValueResolver: async value => value });
+		storages.push(storage);
+		await storage.reload();
+
+		// `withOAuthAccess` consumers start here rather than at `getApiKey`.
+		expect(await storage.getOAuthAccess("anthropic", "session-1")).toBeUndefined();
+
+		commitExternally(oauthRow(1));
+
+		const resolved = await storage.getOAuthAccess("anthropic", "session-1");
+		expect(resolved?.accessToken).toBe("access-1");
+	});
+
 	it("does not reload when no other process committed", async () => {
 		const rows = [oauthRow(1), oauthRow(2)];
 		const { store } = makeExternallyMutableStore(rows);


### PR DESCRIPTION
## What

`getApiKey` and `markUsageLimitReached` now poll the backing store for external commits before they select or rotate a credential, through a small guard that logs and swallows poll failures so resolution never fails because of a stale-check error.

## Why

The credential store is shared by every omp process, but the in-memory pool is refreshed only by this process's own writes. A long-running session therefore ranks a stale pool for its whole lifetime: logging in from another terminal is invisible, and rotation reports no usable sibling while a freshly added account sits unblocked in SQLite, so the turn degrades to the fallback chain until the session restarts. The auth-broker path already polls; direct-store sessions had no equivalent.

A poll is two cheap reads, `PRAGMA data_version` plus the auth revision, and re-lists credentials only when another connection committed. That is why it runs per resolution instead of on a timer, which would make recovery depend on wall-clock spacing.

## Testing

- New `packages/ai/test/credential-external-reload.test.ts`: a credential added to the store after the session's first resolution is selectable on the next one, and rotation finds the new sibling. With the source change reverted, 1 pass and 1 fail; with it, 2 pass, 0 fail.
- `bun test packages/ai/test/`: 4477 pass, 1 fail — the pre-existing `Bedrock cross-region inference-profile geo routing` case, which fails the same way on `main`.
- `bun run check:types` in `packages/ai`: clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
