### PR TITLE
TUI: single delta marker for turn elapsed time in usage rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
+- Transcript usage row now shows the prompt-to-yield time as a bare delta, keeping the clock icon for time to first token only.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/usage-row.ts
+++ b/packages/coding-agent/src/modes/components/usage-row.ts
@@ -45,13 +45,13 @@ export function formatUsageRow(
 	if (timestamp !== undefined && Number.isFinite(timestamp) && timestamp > 0) {
 		parts.push(formatUsageTimestamp(timestamp));
 	}
-	// The delta the operator actually waited, clock-suffixed so it reads apart
-	// from the TTFT figure below (which reuses the same clock icon).
+	// The delta the operator actually waited, bare with a space so it scans
+	// apart from the TTFT figure below (which keeps the clock icon).
 	// `message.duration` comes from performance.now(), so the combined value is
 	// fractional; round before formatDuration so the label never prints a raw
 	// float (e.g. `347.28381699998863ms`).
 	if (turnElapsedMs !== undefined && turnElapsedMs > 0) {
-		parts.push(`${theme.icon.time}Δ${formatDuration(Math.round(turnElapsedMs))}`);
+		parts.push(`Δ ${formatDuration(Math.round(turnElapsedMs))}`);
 	}
 	parts.push(`${theme.icon.input} ${formatNumber(totalInput)}`);
 	parts.push(`${theme.icon.output} ${formatNumber(usage.output)}`);

--- a/packages/coding-agent/test/usage-row-turn-time.test.ts
+++ b/packages/coding-agent/test/usage-row-turn-time.test.ts
@@ -1,5 +1,5 @@
 /**
- * Coverage for the per-turn prompt→yield time (Δ + clock) in transcript usage
+ * Coverage for the per-turn prompt→yield time (bare Δ marker) in transcript usage
  * rows, gated by `display.showTurnTime` — the delta sits right after the turn's
  * timestamp and counts hooks, tool calls, and the final generation.
  */
@@ -37,7 +37,7 @@ const PROMPT_AT = new Date(2026, 0, 2, 3, 4, 5).getTime();
 const RESPONSE_CREATED_AT = PROMPT_AT + 30_000;
 const REQUEST_DURATION_MS = 30_000;
 const USAGE_LABEL = "4.2K";
-const TURN_ELAPSED_LABEL = "Δ1m";
+const TURN_ELAPSED_LABEL = "Δ 1m";
 
 type AssistantFixture = Extract<AgentMessage, { role: "assistant" }>;
 
@@ -89,7 +89,7 @@ describe("formatUsageRow turn elapsed", () => {
 		await initTheme();
 	});
 
-	it("renders the clock-and-delta prompt→yield time right after the timestamp", () => {
+	it("renders the bare-delta prompt→yield time right after the timestamp", () => {
 		const row = formatUsageRow(assistantMessage().usage as Usage, REQUEST_DURATION_MS, undefined, PROMPT_AT, 60_000);
 		expect(row.indexOf("2026-01-02 03:04:05")).toBeLessThan(row.indexOf(TURN_ELAPSED_LABEL));
 		expect(row).toContain(TURN_ELAPSED_LABEL);
@@ -109,7 +109,7 @@ describe("formatUsageRow turn elapsed", () => {
 			undefined,
 			347.28381699998863,
 		);
-		expect(row).toContain("Δ347ms");
+		expect(row).toContain("Δ 347ms");
 		expect(row).not.toContain("347.28381699998863");
 	});
 });
@@ -159,7 +159,7 @@ describe("ChatTranscriptBuilder turn elapsed", () => {
 		// gitlab-duo-style: `timestamp` stamped at request start, no provider
 		// `duration` — the session's `completedAt` stamp still yields the full span.
 		transcript.rebuild(toEntries([userMessage(), assistantMessage({ duration: undefined })]));
-		expect(renderedText(transcript.container)).toContain("Δ1m");
+		expect(renderedText(transcript.container)).toContain("Δ 1m");
 	});
 
 	it("shows no delta for a legacy message without the local completion stamp", () => {
@@ -180,7 +180,7 @@ describe("ChatTranscriptBuilder turn elapsed", () => {
 		transcript.rebuild(toEntries([userMessage(), assistantMessage(), developer, assistantMessage()]));
 		// Only the user turn's row carries the delta; the auto-continuation run
 		// (developer message, no user prompt) must not inherit the user anchor.
-		const occurrences = renderedText(transcript.container).match(/Δ1m/g)?.length ?? 0;
+		const occurrences = renderedText(transcript.container).match(/Δ 1m/g)?.length ?? 0;
 		expect(occurrences).toBe(1);
 	});
 	it("keeps the prompt anchor across a persisted same-turn continuation reminder", () => {
@@ -195,7 +195,7 @@ describe("ChatTranscriptBuilder turn elapsed", () => {
 			timestamp: RESPONSE_CREATED_AT + 5_000,
 		} as unknown as AgentMessage;
 		transcript.rebuild(toEntries([userMessage(), assistantMessage(), reminder, assistantMessage()]));
-		const occurrences = renderedText(transcript.container).match(/Δ1m/g)?.length ?? 0;
+		const occurrences = renderedText(transcript.container).match(/Δ 1m/g)?.length ?? 0;
 		expect(occurrences).toBe(2);
 	});
 	it("anchors a user-initiated continue shortcut to its own submission time", () => {
@@ -212,7 +212,7 @@ describe("ChatTranscriptBuilder turn elapsed", () => {
 			timestamp: PROMPT_AT,
 		} as unknown as AgentMessage;
 		transcript.rebuild(toEntries([continuePrompt, assistantMessage()]));
-		expect(renderedText(transcript.container)).toContain("Δ1m");
+		expect(renderedText(transcript.container)).toContain("Δ 1m");
 	});
 
 	it("seeds the prompt→yield delta from a user-invoked skill custom message", () => {
@@ -258,7 +258,7 @@ describe("ChatTranscriptBuilder turn elapsed", () => {
 		transcript.rebuild(toEntries([userMessage(), assistantMessage(), redirect, assistantMessage()]));
 		// The real user prompt anchors both turns; the redirect adds no reset, so
 		// the second assistant row still measures from the initiating prompt.
-		const occurrences = renderedText(transcript.container).match(/Δ1m/g)?.length ?? 0;
+		const occurrences = renderedText(transcript.container).match(/Δ 1m/g)?.length ?? 0;
 		expect(occurrences).toBe(2);
 	});
 });
@@ -398,7 +398,7 @@ describe("focus-attach mid-turn keeps the prompt→yield delta", () => {
 		await driveAssistantTurn(controller, assistantMessage());
 
 		// Turn 1 keeps its row's delta; the synthetic run must not add another.
-		const occurrences = renderedText(chatContainer).match(/Δ1m/g)?.length ?? 0;
+		const occurrences = renderedText(chatContainer).match(/Δ 1m/g)?.length ?? 0;
 		expect(occurrences).toBe(1);
 	});
 	it("seeds the delta from a user-invoked skill prompt in the live path", async () => {
@@ -445,7 +445,7 @@ describe("focus-attach mid-turn keeps the prompt→yield delta", () => {
 		>);
 		await driveAssistantTurn(controller, assistantMessage());
 
-		const occurrences = renderedText(chatContainer).match(/Δ1m/g)?.length ?? 0;
+		const occurrences = renderedText(chatContainer).match(/Δ 1m/g)?.length ?? 0;
 		expect(occurrences).toBe(1); // the synthetic run's row adds no delta
 	});
 });

--- a/packages/coding-agent/test/usage-row-turn-time.test.ts
+++ b/packages/coding-agent/test/usage-row-turn-time.test.ts
@@ -18,7 +18,7 @@ import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/ex
 import { ChatTranscriptBuilder } from "@oh-my-pi/pi-coding-agent/modes/components/chat-transcript-builder";
 import { formatUsageRow } from "@oh-my-pi/pi-coding-agent/modes/components/usage-row";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -90,9 +90,11 @@ describe("formatUsageRow turn elapsed", () => {
 	});
 
 	it("renders the bare-delta prompt→yield time right after the timestamp", () => {
-		const row = formatUsageRow(assistantMessage().usage as Usage, REQUEST_DURATION_MS, undefined, PROMPT_AT, 60_000);
+		const row = formatUsageRow(assistantMessage().usage as Usage, REQUEST_DURATION_MS, 6_700, PROMPT_AT, 60_000);
 		expect(row.indexOf("2026-01-02 03:04:05")).toBeLessThan(row.indexOf(TURN_ELAPSED_LABEL));
 		expect(row).toContain(TURN_ELAPSED_LABEL);
+		expect(row).not.toContain(`${theme.icon.time}Δ`);
+		expect(row).toContain(`${theme.icon.time} 6.7s`);
 	});
 
 	it("omits the delta when no elapsed is supplied", () => {


### PR DESCRIPTION
# TUI: single delta marker for turn elapsed time in usage rows

I kept misreading the elapsed-time prefix at normal terminal text sizes: with
the unicode symbol preset the adjacent `⏱Δ9m1s` characters crowd together, and
the clock glyph duplicates the one already used for TTFT later in the same row.
This drops the shared clock from the elapsed-time prefix so the row reads
`Δ 9m1s … ⏱ 6.7s` — one delta marker plus a space for total prompt-to-response
elapsed time, with the clock icon kept for time to first token only.

Behavior verified by running the focused test file
`packages/coding-agent/test/usage-row-turn-time.test.ts` in the unit worktree
(bun test, 23 pass / 0 fail), which now asserts the bare `Δ 1m` label ordering
after the timestamp, its absence when no elapsed is supplied, and the rounded
`Δ 347ms` fractional case.

Fixes #11181
