### PR TITLE
fix(ai): rotate accounts when Anthropic reports credits_required

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Anthropic `credits_required` responses now rotate to another account instead of retrying the same one: the entitlement wall is a quota outcome, so a session no longer repeats the request against an account that cannot serve the model ([#11326](https://github.com/can1357/oh-my-pi/pull/11326) by [@AshishKumar4](https://github.com/AshishKumar4)).
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Anthropic `credits_required` responses now rotate to another account instead of retrying the same one: the entitlement wall is a quota outcome, so a session no longer repeats the request against an account that cannot serve the model ([#11326](https://github.com/can1357/oh-my-pi/pull/11333) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- Anthropic `credits_required` responses now rotate to another account instead of retrying the same one: the entitlement wall is a quota outcome, so a session no longer repeats the request against an account that cannot serve the model ([#11333](https://github.com/can1357/oh-my-pi/pull/11333) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Anthropic `credits_required` responses now rotate to another account instead of retrying the same one: the entitlement wall is a quota outcome, so a session no longer repeats the request against an account that cannot serve the model ([#11326](https://github.com/can1357/oh-my-pi/pull/11326) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- Anthropic `credits_required` responses now rotate to another account instead of retrying the same one: the entitlement wall is a quota outcome, so a session no longer repeats the request against an account that cannot serve the model ([#11326](https://github.com/can1357/oh-my-pi/pull/11333) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -32,8 +32,11 @@ const CREDITS_EXHAUSTED_PATTERN =
 	/\b(?:exceed\w*|insufficient|not enough)\b[^\n]{0,40}\bcredits?\b|\bcredits?\b[^\n]{0,40}\b(?:exhausted|depleted)\b/i;
 // Anthropic subscription entitlement wall: "Usage credits are required for this
 // model" with `error_code: credits_required`. The account cannot serve the model
-// at all, so rotate to a sibling rather than backing off on this one.
-const ANTHROPIC_CREDITS_REQUIRED_PATTERN = /usage.?credits|credits_required/i;
+// at all, so rotate to a sibling rather than backing off on this one. Bounded to
+// the documented sentence and the exact code: bare "usage credits" also appears
+// in unrelated diagnostics ("Failed to fetch usage credits from billing
+// service"), which must not rotate a healthy credential.
+const ANTHROPIC_CREDITS_REQUIRED_PATTERN = /\busage credits are required\b|\bcredits_required\b/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const SUBSCRIPTION_CAP_PATTERN =
 	/\b(?:subscription|plan|membership)\b[^\n]{0,80}\b(?:rate.?limits?|quota|cap)\b|\b(?:rate.?limits?|quota|cap)\b[^\n]{0,80}\b(?:subscription|plan|membership)\b/i;

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -30,6 +30,10 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 // "credits exhausted". Account-local, so rotate to a sibling credential.
 const CREDITS_EXHAUSTED_PATTERN =
 	/\b(?:exceed\w*|insufficient|not enough)\b[^\n]{0,40}\bcredits?\b|\bcredits?\b[^\n]{0,40}\b(?:exhausted|depleted)\b/i;
+// Anthropic subscription entitlement wall: "Usage credits are required for this
+// model" with `error_code: credits_required`. The account cannot serve the model
+// at all, so rotate to a sibling rather than backing off on this one.
+const ANTHROPIC_CREDITS_REQUIRED_PATTERN = /usage.?credits|credits_required/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const SUBSCRIPTION_CAP_PATTERN =
 	/\b(?:subscription|plan|membership)\b[^\n]{0,80}\b(?:rate.?limits?|quota|cap)\b|\b(?:rate.?limits?|quota|cap)\b[^\n]{0,80}\b(?:subscription|plan|membership)\b/i;
@@ -234,6 +238,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "QUOTA_EXHAUSTED";
 	}
 
+	if (ANTHROPIC_CREDITS_REQUIRED_PATTERN.test(errorMessage)) {
+		return "QUOTA_EXHAUSTED";
+	}
+
 	if (
 		lower.includes("per minute") ||
 		lower.includes("rate limit") ||
@@ -397,6 +405,7 @@ export function matchesUsageLimitText(errorMessage: string): boolean {
 	if (isDashScopeTokenLimitText(errorMessage)) return false;
 	return (
 		USAGE_LIMIT_PATTERN.test(errorMessage) ||
+		ANTHROPIC_CREDITS_REQUIRED_PATTERN.test(errorMessage) ||
 		CREDITS_EXHAUSTED_PATTERN.test(errorMessage) ||
 		(CN_QUOTA_EXHAUSTED_PATTERN.test(errorMessage) && !CN_TRANSIENT_CAP_PATTERN.test(errorMessage)) ||
 		SPEND_LIMIT_PATTERN.test(errorMessage) ||

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -679,6 +679,13 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(false);
 		expect(isUsageLimit(Object.assign(new Error(message), { status: 429 }))).toBe(false);
 	});
+
+	it("rotates Anthropic credits-required walls", () => {
+		const body =
+			'429 {"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5"}}}';
+		expect(parseRateLimitReason(body)).toBe("QUOTA_EXHAUSTED");
+		expect(isUsageLimitOutcome(429, body)).toBe(true);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -8,6 +8,7 @@ import {
 	isOpaqueStatusBody,
 	isUsageLimitOutcome,
 	isUsageLimitStatus,
+	matchesUsageLimitText,
 	parseRateLimitReason,
 } from "@oh-my-pi/pi-ai/error/rate-limit";
 
@@ -685,6 +686,20 @@ describe("isUsageLimitOutcome", () => {
 			'429 {"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5"}}}';
 		expect(parseRateLimitReason(body)).toBe("QUOTA_EXHAUSTED");
 		expect(isUsageLimitOutcome(429, body)).toBe(true);
+	});
+
+	// The entitlement wall rotates, but "usage credits" also appears in
+	// unrelated diagnostics. Those must stay in their own lane: rotating on a
+	// 500 from a billing service blocks a credential that never hit a cap.
+	it("leaves non-entitlement usage-credits wording alone", () => {
+		const diagnostic = "500 Failed to fetch usage credits from billing service";
+		expect(parseRateLimitReason(diagnostic)).not.toBe("QUOTA_EXHAUSTED");
+		expect(isUsageLimitOutcome(500, diagnostic)).toBe(false);
+		expect(matchesUsageLimitText(diagnostic)).toBe(false);
+
+		const perMinute = "429 Usage credits are limited per minute for this workspace";
+		expect(parseRateLimitReason(perMinute)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimitOutcome(429, perMinute)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

`parseRateLimitReason` now classifies Anthropic's `credits_required` response as `QUOTA_EXHAUSTED`, and `matchesUsageLimitText` matches the same wording, so the response counts as a usage-limit outcome and rotates the credential. One named pattern, `ANTHROPIC_CREDITS_REQUIRED_PATTERN`, holds the rule for both.

## Why

On a Claude subscription, asking for a model the plan is not entitled to returns:

```text
429 {"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5"}}}
```

The reason parser returned `UNKNOWN` and `isUsageLimitOutcome` returned `false`, so nothing rotated and no block was written. With several accounts logged in, the session kept retrying the same account until the retry budget ran out and the turn fell back to a lower-tier model, while a sibling account could have served it. In my logs this repeated 46 times in one day, the same session failing 1-2 seconds apart on the same account.

Since `blockScope` already maps Fable and Mythos to `tier:<kind>`, the block this now writes stays scoped to that tier, so the account keeps serving Opus and Sonnet.

## Testing

- `packages/ai/test/rate-limit-utils.test.ts` gained a case built from the captured response body, under `describe("isUsageLimitOutcome")` since it asserts the rotation decision. With the source change reverted it fails (71 pass, 1 fail); with it, 72 pass, 0 fail.
- `bun test packages/ai/test/`: 4476 pass, 1 fail. The failure is `Bedrock cross-region inference-profile geo routing > leaves region-agnostic global. profiles on the ambient region`, which fails the same way on `main` without this change.
- `bun run check:ts` (oxlint, oxfmt, workspace type checks): clean.

Replaces #11326, which GitHub closed when I force-pushed the branch from a shallow clone. The review feedback there is addressed here: the matcher is named once and reused, the changelog carries the attribution, and the regression moved to the contract it exercises.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
