### PR TITLE
fix(ai): heal stale Claude tier blocks from a fresh usage report

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A stale Anthropic tier block (`tier:fable`, `tier:mythos`) is now cleared once a live usage report shows headroom on both the tier row and the shared windows, instead of idling a usable account until the reported reset ([#11328](https://github.com/can1357/oh-my-pi/pull/11328) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- A stale Anthropic tier block (`tier:fable`, `tier:mythos`) is now cleared once a live usage report shows headroom on both the tier row and the shared windows, instead of idling a usable account until the reported reset. Healing requires a live report, and a credential held by an unscoped block spends no usage request on a probe that cannot lift it ([#11328](https://github.com/can1357/oh-my-pi/pull/11334) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A stale Anthropic tier block (`tier:fable`, `tier:mythos`) is now cleared once a live usage report shows headroom on both the tier row and the shared windows, instead of idling a usable account until the reported reset. Healing requires a live report, and a credential held by an unscoped block spends no usage request on a probe that cannot lift it ([#11328](https://github.com/can1357/oh-my-pi/pull/11334) by [@AshishKumar4](https://github.com/AshishKumar4)).
+- A stale Anthropic tier block (`tier:fable`, `tier:mythos`) is now cleared once a live usage report shows headroom on both the tier row and the shared windows, instead of idling a usable account until the reported reset. Healing requires a live report, and a credential held by an unscoped block spends no usage request on a probe that cannot lift it ([#11334](https://github.com/can1357/oh-my-pi/pull/11334) by [@AshishKumar4](https://github.com/AshishKumar4)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A stale Anthropic tier block (`tier:fable`, `tier:mythos`) is now cleared once a live usage report shows headroom on both the tier row and the shared windows, instead of idling a usable account until the reported reset ([#11328](https://github.com/can1357/oh-my-pi/pull/11328) by [@AshishKumar4](https://github.com/AshishKumar4)).
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6629,11 +6629,12 @@ export class AuthStorage {
 	 * Whether a fresh report could lift what currently blocks this credential.
 	 *
 	 * A strategy that names healable scopes can only vouch for those scopes, so
-	 * clearing one frees the credential exactly when the deadline it sets is
-	 * the one holding it. An unscoped block — an Opus/Sonnet usage limit, a
-	 * refresh failure — outlasts the scope, so a probe cannot change the
-	 * outcome and must not be spent. Codex heals through its meter metadata
-	 * rather than named scopes, so its blocks always qualify.
+	 * a live unscoped block — an Opus/Sonnet usage limit, a refresh failure —
+	 * keeps the credential unusable whatever the report says about a tier. A
+	 * probe then cannot change the outcome and must not be spent; the tier scope
+	 * heals on a later pass, once the block that actually holds the credential
+	 * has lifted. Codex heals through its meter metadata rather than named
+	 * scopes, so its blocks always qualify.
 	 */
 	#blockedCredentialCanHeal(
 		provider: Provider,
@@ -6643,10 +6644,8 @@ export class AuthStorage {
 	): boolean {
 		if (!this.#supportsUsageBlockHealing(provider)) return false;
 		if (this.#rankingStrategyResolver?.(provider)?.healableBlockScopes === undefined) return true;
-		const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScopeOrScopes);
-		if (blockedUntil === undefined) return false;
-		const unscopedBlockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex);
-		return unscopedBlockedUntil === undefined || blockedUntil > unscopedBlockedUntil;
+		if (this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex) !== undefined) return false;
+		return this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScopeOrScopes) !== undefined;
 	}
 
 	/**
@@ -6663,6 +6662,10 @@ export class AuthStorage {
 		if (credentialIndex < 0) return;
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		if (provider !== "openai-codex") {
+			// Only a live report proves recovery. A broker can serve its retained
+			// last-good report for hours after `/usage` starts failing, and those
+			// healthy limits describe the account before the 429 that blocked it.
+			if (!Number.isFinite(report.fetchedAt) || Date.now() - report.fetchedAt > USAGE_REPORT_TTL_MS) return;
 			for (const { blockScope, limits } of strategy?.healableBlockScopes?.(report) ?? []) {
 				if (limits.length === 0 || this.#isUsageLimitReached(limits)) continue;
 				this.#clearHealedBlockScope(provider, providerKey, credentialId, credentialIndex, blockScope);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4202,7 +4202,14 @@ export class AuthStorage {
 				const credentialType = entry.credential.type;
 				const providerKey = this.#getProviderTypeKey(provider, credentialType);
 				let blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
-				if (blockedUntil !== undefined && provider !== "openai-codex") {
+				// A block under a scope the strategy can vouch for must still fetch
+				// a probe report, or it outlives the recovery that report would
+				// prove: no report means no reconciliation, so the credential idles
+				// until the clock runs out even after quota is restored.
+				if (
+					blockedUntil !== undefined &&
+					!this.#blockedCredentialCanHeal(provider, providerKey, index, blockScopes)
+				) {
 					return {
 						credentialId: entry.id,
 						credentialType,
@@ -4229,7 +4236,7 @@ export class AuthStorage {
 					planEligibilityByCredential.set(entry.id, getOpenAICodexPlanEligibility(report, planRequirement));
 				}
 
-				if (provider === "openai-codex") {
+				if (this.#supportsUsageBlockHealing(provider)) {
 					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				}
 				if (blockedUntil !== undefined) {
@@ -5009,7 +5016,15 @@ export class AuthStorage {
 				);
 				let usage: UsageReport | null = null;
 				let usageChecked = false;
-				if (blockedUntil !== undefined && args.provider === "openai-codex") {
+				if (
+					blockedUntil !== undefined &&
+					this.#blockedCredentialCanHeal(
+						args.provider,
+						args.providerKey,
+						selection.index,
+						args.blockScopes ?? args.blockScope,
+					)
+				) {
 					usage = await this.#getUsageReport(args.provider, selection.credential, {
 						...args.options,
 						timeoutMs: this.#usageRequestTimeoutMs,
@@ -6608,6 +6623,30 @@ export class AuthStorage {
 		return (
 			provider === "openai-codex" || this.#rankingStrategyResolver?.(provider)?.healableBlockScopes !== undefined
 		);
+	}
+
+	/**
+	 * Whether a fresh report could lift what currently blocks this credential.
+	 *
+	 * A strategy that names healable scopes can only vouch for those scopes, so
+	 * clearing one frees the credential exactly when the deadline it sets is
+	 * the one holding it. An unscoped block — an Opus/Sonnet usage limit, a
+	 * refresh failure — outlasts the scope, so a probe cannot change the
+	 * outcome and must not be spent. Codex heals through its meter metadata
+	 * rather than named scopes, so its blocks always qualify.
+	 */
+	#blockedCredentialCanHeal(
+		provider: Provider,
+		providerKey: string,
+		credentialIndex: number,
+		blockScopeOrScopes: string | readonly string[] | undefined,
+	): boolean {
+		if (!this.#supportsUsageBlockHealing(provider)) return false;
+		if (this.#rankingStrategyResolver?.(provider)?.healableBlockScopes === undefined) return true;
+		const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScopeOrScopes);
+		if (blockedUntil === undefined) return false;
+		const unscopedBlockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex);
+		return unscopedBlockedUntil === undefined || blockedUntil > unscopedBlockedUntil;
 	}
 
 	/**

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -22,6 +22,8 @@ import { HOUR_MS, parseIsoTimestamp, WEEK_MS } from "./shared";
 const DEFAULT_ENDPOINT = "https://api.anthropic.com/api/oauth";
 const MAX_ATTEMPTS = 3;
 const BASE_RETRY_DELAY_MS = 500;
+/** Shared windows that gate every Claude request, whatever the model. */
+const CLAUDE_SHARED_GATE_WINDOW_IDS = ["5h", "7d"] as const;
 
 const CLAUDE_HEADERS = {
 	accept: "application/json, text/plain, */*",
@@ -826,6 +828,37 @@ export const claudeRankingStrategy: CredentialRankingStrategy = {
 	blockScope(context) {
 		const kind = getClaudeModelKind(context);
 		return kind === "fable" || kind === "mythos" ? `tier:${kind}` : undefined;
+	},
+	/**
+	 * A reactive Fable/Mythos block carries the reset the 429 reported, but
+	 * Anthropic can restore the tier earlier (plan change, corrected counter),
+	 * and the block then idles a usable account for days. Judge each tier scope
+	 * against the limits that actually gate a request of that kind — its own
+	 * weekly row plus the shared umbrella windows — so a healthy report lifts
+	 * the block while a spent shared 5-hour wall keeps it.
+	 *
+	 * Only Fable/Mythos appear: {@link blockScope} scopes reactive blocks for
+	 * those tiers alone, so no other scope can exist to heal.
+	 */
+	healableBlockScopes(report) {
+		const sharedLimits = report.limits.filter(limit => limit.scope.shared === true);
+		// The endpoint returns a report as soon as one window parses, and a tier
+		// 429 can be caused by a shared wall. A payload missing a shared gate
+		// leaves the block's cause unknown, so vouch for nothing rather than
+		// clear a block that still holds.
+		const everySharedGateReported = CLAUDE_SHARED_GATE_WINDOW_IDS.every(windowId =>
+			sharedLimits.some(limit => limit.scope.windowId === windowId || limit.window?.id === windowId),
+		);
+		if (!everySharedGateReported) return [];
+		const tiers = new Set<string>();
+		for (const limit of report.limits) {
+			const tier = limit.scope.tier;
+			if (tier === "fable" || tier === "mythos") tiers.add(tier);
+		}
+		return [...tiers].map(tier => ({
+			blockScope: `tier:${tier}`,
+			limits: [...sharedLimits, ...report.limits.filter(limit => limit.scope.tier === tier)],
+		}));
 	},
 	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 7 * 24 * 60 * 60 * 1000 },
 };

--- a/packages/ai/test/claude-block-healing.test.ts
+++ b/packages/ai/test/claude-block-healing.test.ts
@@ -39,12 +39,26 @@ function tierLimit(tier: string, usedFraction: number): UsageLimit {
 	};
 }
 
-function claudeReport(limits: UsageLimit[]): UsageReport {
+function claudeReport(limits: UsageLimit[], fetchedAt = Date.now()): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt,
+		limits,
+		metadata: { accountId: "account-1" },
+	};
+}
+
+/**
+ * A sibling that can serve but has nearly nothing left, so credential ranking
+ * prefers the blocked-then-healed account whenever the block actually lifts.
+ * That makes `getApiKey` a direct read of the healing outcome.
+ */
+function nearlySpentSiblingReport(): UsageReport {
 	return {
 		provider: "anthropic",
 		fetchedAt: Date.now(),
-		limits,
-		metadata: { accountId: "account-1" },
+		limits: [sharedLimit("5h", "5h", 0.8), sharedLimit("7d", "7d", 0.97), tierLimit("fable", 0.97)],
+		metadata: { accountId: "account-2" },
 	};
 }
 
@@ -64,10 +78,12 @@ interface HealHarness {
 	clearedScopes: string[];
 	/** Usage requests the selection path spent while the credential was blocked. */
 	probeCount: () => number;
+	/** Persisted blocks, keyed `credentialId:blockScope`, so a test can add one. */
+	blocks: Map<string, number>;
 }
 
 function makeHarness(report: UsageReport, blockScope = "tier:fable"): HealHarness {
-	const rows = [oauthRow(1)];
+	const rows = [oauthRow(1), oauthRow(2)];
 	const cache = new Map<string, { value: string; expiresAtSec: number }>();
 	const blocks = new Map<string, number>();
 	blocks.set(`1:${blockScope}`, Date.now() + 3 * 24 * 60 * 60_000);
@@ -102,7 +118,9 @@ function makeHarness(report: UsageReport, blockScope = "tier:fable"): HealHarnes
 	};
 	const usageProvider: UsageProvider = {
 		id: "anthropic",
-		fetchUsage: async () => {
+		fetchUsage: async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (access === "access-2") return nearlySpentSiblingReport();
 			probes += 1;
 			return report;
 		},
@@ -112,7 +130,7 @@ function makeHarness(report: UsageReport, blockScope = "tier:fable"): HealHarnes
 		rankingStrategyResolver: provider => (provider === "anthropic" ? claudeRankingStrategy : undefined),
 		configValueResolver: async value => value,
 	});
-	return { storage, clearedScopes, probeCount: () => probes };
+	return { storage, clearedScopes, probeCount: () => probes, blocks };
 }
 
 describe("claude usage-block healing", () => {
@@ -153,6 +171,9 @@ describe("claude usage-block healing", () => {
 		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
 
 		expect(clearedScopes).toContain("tier:fable");
+		// The user-visible contract: the recovered account is selectable again,
+		// not merely reported healthy.
+		expect(await storage.getApiKey("anthropic", "s-heal", { modelId: "claude-fable-5-1" })).toBe("access-1");
 	});
 
 	it("keeps the block while the shared 5-hour window is spent", async () => {
@@ -165,6 +186,7 @@ describe("claude usage-block healing", () => {
 		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
 
 		expect(clearedScopes).not.toContain("tier:fable");
+		expect(await storage.getApiKey("anthropic", "s-5h", { modelId: "claude-fable-5-1" })).toBe("access-2");
 	});
 
 	it("keeps the block when the report omits a shared gate", async () => {
@@ -179,6 +201,7 @@ describe("claude usage-block healing", () => {
 		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
 
 		expect(clearedScopes).not.toContain("tier:fable");
+		expect(await storage.getApiKey("anthropic", "s-partial", { modelId: "claude-fable-5-1" })).toBe("access-2");
 	});
 
 	it("spends no usage request on a block its scopes cannot heal", async () => {
@@ -199,5 +222,43 @@ describe("claude usage-block healing", () => {
 		expect(probeCount()).toBe(0);
 		expect(clearedScopes).toEqual([]);
 		expect(health.accounts[0]?.state).toBe("depleted");
+	});
+
+	it("keeps the block when the report predates it", async () => {
+		// A broker serves its retained last-good report for hours after `/usage`
+		// starts failing; those healthy limits describe the account before the
+		// 429 that blocked it.
+		const stale = claudeReport(
+			[sharedLimit("5h", "5h", 0.1), sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)],
+			Date.now() - 60 * 60_000,
+		);
+		const { storage, clearedScopes } = makeHarness(stale);
+		storages.push(storage);
+		await storage.reload();
+
+		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
+
+		expect(clearedScopes).not.toContain("tier:fable");
+		expect(await storage.getApiKey("anthropic", "s-stale", { modelId: "claude-fable-5-1" })).toBe("access-2");
+	});
+
+	it("spends no probe while an unscoped block also holds the credential", async () => {
+		// A tier block written after a global one carries the later deadline, but
+		// the global block still makes the credential unusable, so clearing the
+		// tier early buys nothing and the request must not be spent.
+		const { storage, probeCount, blocks } = makeHarness(
+			claudeReport([sharedLimit("5h", "5h", 0.1), sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)]),
+		);
+		storages.push(storage);
+		blocks.set("1:", Date.now() + 60 * 60_000);
+		await storage.reload();
+
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5-1",
+			reserveFraction: 0.1,
+		});
+
+		expect(probeCount()).toBe(0);
+		expect(health.accounts.find(account => account.credentialId === 1)?.state).toBe("depleted");
 	});
 });

--- a/packages/ai/test/claude-block-healing.test.ts
+++ b/packages/ai/test/claude-block-healing.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	type AuthCredential,
+	type AuthCredentialStore,
+	AuthStorage,
+	type StoredAuthCredential,
+} from "@oh-my-pi/pi-ai/auth-storage";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { claudeRankingStrategy } from "@oh-my-pi/pi-ai/usage/claude";
+
+/**
+ * A reactive Fable 429 blocks the credential until the reset that error
+ * reported. Anthropic can restore the tier earlier (a plan change or a
+ * corrected counter), and the block then idles a usable account for days —
+ * observed as `tier:fable` blocks persisting three days past a quota reset
+ * while the live report read 0% used. A healthy live report must lift it, but
+ * only when every limit gating that scope has headroom: the shared 5-hour wall
+ * blocks Fable too, so a spent 5h window must keep the block alive.
+ */
+function sharedLimit(id: string, windowId: string, usedFraction: number): UsageLimit {
+	return {
+		id: `anthropic:${id}`,
+		label: id,
+		scope: { provider: "anthropic", shared: true, windowId },
+		window: { id: windowId, label: windowId, resetsAt: Date.now() + 60 * 60_000 },
+		amount: { usedFraction, unit: "percent" },
+		status: usedFraction >= 1 ? "exhausted" : "ok",
+	};
+}
+
+function tierLimit(tier: string, usedFraction: number): UsageLimit {
+	return {
+		id: `anthropic:7d:${tier}`,
+		label: `7d ${tier}`,
+		scope: { provider: "anthropic", tier, windowId: "7d" },
+		window: { id: "7d", label: "7d", resetsAt: Date.now() + 24 * 60 * 60_000 },
+		amount: { usedFraction, unit: "percent" },
+		status: usedFraction >= 1 ? "exhausted" : "ok",
+	};
+}
+
+function claudeReport(limits: UsageLimit[]): UsageReport {
+	return {
+		provider: "anthropic",
+		fetchedAt: Date.now(),
+		limits,
+		metadata: { accountId: "account-1" },
+	};
+}
+
+function oauthRow(id: number): StoredAuthCredential {
+	const credential: AuthCredential = {
+		type: "oauth",
+		access: `access-${id}`,
+		refresh: `refresh-${id}`,
+		expires: Date.now() + 60 * 60_000,
+		accountId: `account-${id}`,
+	};
+	return { id, provider: "anthropic", credential, disabledCause: null };
+}
+
+interface HealHarness {
+	storage: AuthStorage;
+	clearedScopes: string[];
+	/** Usage requests the selection path spent while the credential was blocked. */
+	probeCount: () => number;
+}
+
+function makeHarness(report: UsageReport, blockScope = "tier:fable"): HealHarness {
+	const rows = [oauthRow(1)];
+	const cache = new Map<string, { value: string; expiresAtSec: number }>();
+	const blocks = new Map<string, number>();
+	blocks.set(`1:${blockScope}`, Date.now() + 3 * 24 * 60 * 60_000);
+	const clearedScopes: string[] = [];
+	let probes = 0;
+	const store: AuthCredentialStore = {
+		close() {},
+		listAuthCredentials: provider => rows.filter(row => provider === undefined || row.provider === provider),
+		updateAuthCredential() {},
+		deleteAuthCredential() {},
+		tryDisableAuthCredentialIfMatches: () => false,
+		replaceAuthCredentialsForProvider: () => rows,
+		upsertAuthCredentialForProvider: () => rows,
+		deleteAuthCredentialsForProvider() {},
+		getCredentialBlock: (credentialId: number, _providerKey: string, scope: string) =>
+			blocks.get(`${credentialId}:${scope}`),
+		upsertCredentialBlock: block => {
+			blocks.set(`${block.credentialId}:${block.blockScope}`, block.blockedUntilMs);
+		},
+		deleteCredentialBlock: (credentialId: number, _providerKey: string, scope: string) => {
+			clearedScopes.push(scope);
+			blocks.delete(`${credentialId}:${scope}`);
+		},
+		getCache(key) {
+			const entry = cache.get(key);
+			return entry && entry.expiresAtSec * 1000 > Date.now() ? entry.value : null;
+		},
+		setCache(key, value, expiresAtSec) {
+			cache.set(key, { value, expiresAtSec });
+		},
+		cleanExpiredCache() {},
+	};
+	const usageProvider: UsageProvider = {
+		id: "anthropic",
+		fetchUsage: async () => {
+			probes += 1;
+			return report;
+		},
+	};
+	const storage = new AuthStorage(store, {
+		usageProviderResolver: provider => (provider === "anthropic" ? usageProvider : undefined),
+		rankingStrategyResolver: provider => (provider === "anthropic" ? claudeRankingStrategy : undefined),
+		configValueResolver: async value => value,
+	});
+	return { storage, clearedScopes, probeCount: () => probes };
+}
+
+describe("claude usage-block healing", () => {
+	const storages: AuthStorage[] = [];
+	afterEach(() => {
+		for (const storage of storages) storage.close();
+		storages.length = 0;
+	});
+
+	it("pairs each tier scope with the shared windows that also gate it", () => {
+		const report = claudeReport([
+			sharedLimit("5h", "5h", 0.2),
+			sharedLimit("7d", "7d", 0.3),
+			tierLimit("fable", 0.4),
+			tierLimit("opus", 0.5),
+		]);
+		const scopes = claudeRankingStrategy.healableBlockScopes?.(report) ?? [];
+		const fable = scopes.find(scope => scope.blockScope === "tier:fable");
+
+		expect(fable).toBeDefined();
+		const ids = (fable?.limits ?? []).map(entry => entry.id);
+		expect(ids).toContain("anthropic:7d:fable");
+		// Shared walls must judge the scope too, else a spent 5h window heals.
+		expect(ids).toContain("anthropic:5h");
+		expect(ids).toContain("anthropic:7d");
+		// Opus/Sonnet requests never take a scoped block, so nothing to heal.
+		expect(ids).not.toContain("anthropic:7d:opus");
+		expect(scopes.some(scope => scope.blockScope === "tier:opus")).toBe(false);
+	});
+
+	it("lifts a stale tier:fable block when the live report has headroom", async () => {
+		const { storage, clearedScopes } = makeHarness(
+			claudeReport([sharedLimit("5h", "5h", 0.1), sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)]),
+		);
+		storages.push(storage);
+		await storage.reload();
+
+		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
+
+		expect(clearedScopes).toContain("tier:fable");
+	});
+
+	it("keeps the block while the shared 5-hour window is spent", async () => {
+		const { storage, clearedScopes } = makeHarness(
+			claudeReport([sharedLimit("5h", "5h", 1), sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)]),
+		);
+		storages.push(storage);
+		await storage.reload();
+
+		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
+
+		expect(clearedScopes).not.toContain("tier:fable");
+	});
+
+	it("keeps the block when the report omits a shared gate", async () => {
+		// The endpoint answers with whatever parsed, so a healthy tier row can
+		// arrive without the 5-hour window that may be what blocked the request.
+		const { storage, clearedScopes } = makeHarness(
+			claudeReport([sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)]),
+		);
+		storages.push(storage);
+		await storage.reload();
+
+		await storage.getModelUsageHealth("anthropic", { modelId: "claude-fable-5-1", reserveFraction: 0.1 });
+
+		expect(clearedScopes).not.toContain("tier:fable");
+	});
+
+	it("spends no usage request on a block its scopes cannot heal", async () => {
+		// An unscoped block (Opus/Sonnet usage limit, refresh failure) is outside
+		// every scope the strategy vouches for, so probing cannot change it.
+		const { storage, clearedScopes, probeCount } = makeHarness(
+			claudeReport([sharedLimit("5h", "5h", 0.1), sharedLimit("7d", "7d", 0.2), tierLimit("fable", 0)]),
+			"",
+		);
+		storages.push(storage);
+		await storage.reload();
+
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5-1",
+			reserveFraction: 0.1,
+		});
+
+		expect(probeCount()).toBe(0);
+		expect(clearedScopes).toEqual([]);
+		expect(health.accounts[0]?.state).toBe("depleted");
+	});
+});


### PR DESCRIPTION
## What

Implements `healableBlockScopes` for the Anthropic ranking strategy, pairing each `tier:fable` / `tier:mythos` scope with its own weekly row plus the shared windows. Two probe gates that hardcoded `provider === "openai-codex"` now ask whether the blocking deadline comes from a scope the strategy can clear, so healing runs for Anthropic and a block nothing can vouch for spends no usage request.

## Why

A Fable 429 blocks the credential until the reset that error reported. Anthropic can restore the tier earlier, through a plan change or a corrected counter, and the block then idles a usable account for days. I had four accounts sitting under `tier:fable` blocks for two to five days while the live usage report read 0% used on every window, and deleting the rows by hand was the only way to reach that quota.

The healing path already existed; it never ran for Anthropic. The strategy declared no healable scopes, and the blocked-credential probe that produces the fresh report was skipped for every provider except `openai-codex`, so no report meant no reconciliation.

Two guards keep the recovery honest:

- `fetchClaudeUsage` returns a report as soon as any single window parses, so a payload missing the shared 5-hour or 7-day row could clear a tier block that row still justified. A scope is only offered when both shared gates are present.
- Clearing a scope frees the credential exactly when the deadline it sets is the one holding it, so a global block from Opus/Sonnet or a refresh failure skips the probe instead of paying for a request that cannot change the outcome.

## Testing

- New `packages/ai/test/claude-block-healing.test.ts`: a healthy live report lifts a stale `tier:fable` block, a spent shared 5-hour window keeps it, a report missing a shared gate keeps it, an unscoped block spends zero usage requests and stays `depleted`, and each tier scope is paired with the shared windows. Every guard was checked in isolation: removing any one of the three fails exactly its own case, and against `main` the two healing cases fail.
- The stale-block scenario comes from the field state above. Anthropic restoring a tier early is not reproducible on demand, so the recovery itself is exercised by replaying that report rather than by waiting for the provider.
- `bun test packages/ai/test/`: 4478 pass, 1 fail — the pre-existing `Bedrock cross-region inference-profile geo routing` case, which fails the same way on `main`.
- `bun run check:ts` (oxlint, oxfmt, workspace type checks): clean.

Replaces #11328, which GitHub closed when I force-pushed the branch from a shallow clone. The review feedback there is addressed here, including the narrower probe gate: `google-antigravity` now fetches a probe only when one of its own counter scopes holds the credential, not for global blocks.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
