### PR TITLE
fix(extensions): classify symlinks by their target in configured-directory scans

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Configured extension-directory scans no longer abort startup when they encounter symlinks to regular files or cyclic targets ([#11337](https://github.com/can1357/oh-my-pi/pull/11337) by [@srobroek](https://github.com/srobroek)).
+
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -593,12 +593,29 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 	for (const entry of entries) {
 		const entryPath = path.join(dir, entry.name);
 
-		if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionFile(entry.name)) {
+		// A symlink is whatever its target is. Treating every link as a directory
+		// candidate made stat("<link-to-file>/index.ts") answer ENOTDIR, which is not
+		// an ignorable code and aborted the whole load; marketplace checkouts carry
+		// `CLAUDE.md -> AGENTS.md`.
+		let isFile = entry.isFile();
+		let isDirectory = entry.isDirectory();
+		if (entry.isSymbolicLink()) {
+			try {
+				const target = await fs.stat(entryPath);
+				isFile = target.isFile();
+				isDirectory = target.isDirectory();
+			} catch (err) {
+				if (isEnoent(err) || isEacces(err) || hasFsCode(err, "ENOTDIR") || hasFsCode(err, "EPERM")) continue;
+				throw err;
+			}
+		}
+
+		if (isFile && isExtensionFile(entry.name)) {
 			discovered.push(entryPath);
 			continue;
 		}
 
-		if (entry.isDirectory() || entry.isSymbolicLink()) {
+		if (isDirectory) {
 			const resolved = await resolveExtensionEntries(entryPath);
 			if (resolved) {
 				discovered.push(...resolved);

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -605,7 +605,14 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 				isFile = target.isFile();
 				isDirectory = target.isDirectory();
 			} catch (err) {
-				if (isEnoent(err) || isEacces(err) || hasFsCode(err, "ENOTDIR") || hasFsCode(err, "EPERM")) continue;
+				if (
+					isEnoent(err) ||
+					isEacces(err) ||
+					hasFsCode(err, "ENOTDIR") ||
+					hasFsCode(err, "ELOOP") ||
+					hasFsCode(err, "EPERM")
+				)
+					continue;
 				throw err;
 			}
 		}

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -540,6 +540,19 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("gate.ts");
 	});
 
+	it("skips cyclic symlinks while scanning a configured directory", async () => {
+		const packageDir = path.join(tempDir.path(), "extensions-package");
+		fs.mkdirSync(packageDir, { recursive: true });
+		fs.symlinkSync("loop.ts", path.join(packageDir, "loop.ts"), "file");
+		fs.writeFileSync(path.join(packageDir, "gate.ts"), extensionCode);
+
+		const result = await discoverForTest([packageDir]);
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].path).toContain("gate.ts");
+	});
+
 	it("resolves 3rd party npm dependencies (chalk)", async () => {
 		// Load the real chalk-logger extension from examples
 		const chalkLoggerPath = path.resolve(import.meta.dirname, "..", "examples", "extensions", "chalk-logger.ts");

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -523,6 +523,23 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("my-ext.ts");
 	});
 
+	it("scans a configured directory that holds a symlink to a regular file", async () => {
+		// Marketplace checkouts carry `CLAUDE.md -> AGENTS.md`. The one-level scan takes
+		// every symlink as a directory candidate, and stat("CLAUDE.md/index.ts") answers
+		// ENOTDIR rather than ENOENT, which used to abort the whole load.
+		const packageDir = path.join(tempDir.path(), "skills-package");
+		fs.mkdirSync(packageDir, { recursive: true });
+		fs.writeFileSync(path.join(packageDir, "AGENTS.md"), "# agents\n");
+		fs.symlinkSync(path.join(packageDir, "AGENTS.md"), path.join(packageDir, "CLAUDE.md"), "file");
+		fs.writeFileSync(path.join(packageDir, "gate.ts"), extensionCode);
+
+		const result = await discoverForTest([packageDir]);
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].path).toContain("gate.ts");
+	});
+
 	it("resolves 3rd party npm dependencies (chalk)", async () => {
 		// Load the real chalk-logger extension from examples
 		const chalkLoggerPath = path.resolve(import.meta.dirname, "..", "examples", "extensions", "chalk-logger.ts");


### PR DESCRIPTION
This PR fixes the issue where symlinks are automatically treated as a directory, causing failures for a common scenario where AGENTS.md is symlinked to CLAUDE.md.

## What

`discoverExtensionsInDir` (configured-directory scan, `loader.ts`) treated every symlink as a directory candidate. For a symlink to a regular file, `fs.stat("<link>/index.ts")` fails with `ENOTDIR`, which none of the ignore lists in `resolveExtensionEntries` accept, so the exception escaped `discoverAndLoadExtensions` and omp failed to start.

This change classifies a symlink by its `stat` target: a link to a file is a file, a link to a directory is a directory, a dangling or unreadable link is skipped like a missing entry.

## Reproduction (omp 18.1.14)

Marketplace checkouts under `~/.omp/plugins/node_modules/` carry `CLAUDE.md -> AGENTS.md` (created by the installer for e.g. `mattpocock-skills` and `project-scaffold`). With such a root listed under `extensions:` in `~/.omp/agent/config.yml`:

```
ENOTDIR: not a directory, stat '/Users/…/.omp/plugins/node_modules/project-scaffold/CLAUDE.md/index.ts'
    at async nDt (…/pi-coding-agent/dist/cli.js:18833:30038)
```

and the session never starts.

## Verification

- New test `scans a configured directory that holds a symlink to a regular file` in `test/extensions-discovery.test.ts`: fails on `main` with the `ENOTDIR` above, passes with this change. `test/extensions-discovery.test.ts` 43/43 pass; `bun run check:tools` clean.
- Ran the patched CLI from source with the two offending roots explicitly configured: `bun --cwd=packages/coding-agent src/cli.ts -e ~/.omp/plugins/node_modules/project-scaffold -e ~/.omp/plugins/node_modules/mattpocock-skills -p 'ok'` starts and reaches the model call (the released 18.1.14 binary aborts on the same input with the trace above).

