### PR TITLE
fix(ai): project Gemini schemas for OpenAI compatibility

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Gemini models routed through OpenAI-compatible providers now project tool schemas onto Google's typed function-declaration subset, preventing `task.outputSchema` unions from rejecting the whole request ([#11336](https://github.com/can1357/oh-my-pi/issues/11336)).
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -46,6 +46,7 @@ import {
 	findStrictToolSchemaViolation,
 	flattenExclusiveRequiredRootUnion,
 	NO_STRICT,
+	normalizeSchemaForCCA,
 	normalizeSchemaForMoonshot,
 	sanitizeSchemaForGrammar,
 	toolWireSchema,
@@ -2466,6 +2467,9 @@ function convertTools(
 		const includeExplicitFalse =
 			!includeStrict && tool.strict === false && toolStrictMode === "mixed" && compat.supportsStrictMode !== false;
 		const wireParameters = includeStrict ? parameters : baseParameters;
+		// Gemini/Vertex-backed OpenAI-compatible hosts translate tools into the
+		// typed legacy functionDeclaration subset and reject composition-only
+		// nodes such as task.outputSchema (issue #11336).
 		// Moonshot/Kimi native hosts validate against the stricter MFJS subset
 		// (const→enum, typed enums, no validators) and 400 otherwise.
 		// Grammar-constrained local backends (llama.cpp, LM Studio, vLLM)
@@ -2473,11 +2477,13 @@ function convertTools(
 		// `Unrecognized schema: true` on the bare boolean subschema
 		// `toolWireSchema` emits for open fields (issue #5914).
 		const emittedParameters =
-			compat.toolSchemaFlavor === "moonshot-mfjs"
-				? (normalizeSchemaForMoonshot(wireParameters) as Record<string, unknown>)
-				: compat.toolSchemaFlavor === "grammar"
-					? sanitizeSchemaForGrammar(wireParameters)
-					: wireParameters;
+			compat.toolSchemaFlavor === "google-function"
+				? (normalizeSchemaForCCA(wireParameters) as Record<string, unknown>)
+				: compat.toolSchemaFlavor === "moonshot-mfjs"
+					? (normalizeSchemaForMoonshot(wireParameters) as Record<string, unknown>)
+					: compat.toolSchemaFlavor === "grammar"
+						? sanitizeSchemaForGrammar(wireParameters)
+						: wireParameters;
 		const violation = findStrictToolSchemaViolation(emittedParameters, "#", { rejectRootObjectUnion });
 		if (violation) {
 			logger.warn(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -38,6 +38,7 @@ import {
 	findStrictToolSchemaViolation,
 	flattenExclusiveRequiredRootUnion,
 	NO_STRICT,
+	normalizeSchemaForCCA,
 	normalizeSchemaForMoonshot,
 	sanitizeSchemaForOpenAIResponses,
 	toolWireSchema,
@@ -1445,7 +1446,13 @@ export function convertTools(
 			model.compat.toolSchemaFlavor === "moonshot-mfjs"
 				? (normalizeSchemaForMoonshot(providerParameters) as Record<string, unknown>)
 				: providerParameters;
-		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(responseParameters, strict);
+		const { schema: adaptedParameters, strict: effectiveStrict } = adaptSchemaForStrict(responseParameters, strict);
+		// Gemini/Vertex's legacy functionDeclaration validator requires a type
+		// on every node, including unions introduced by strict adaptation.
+		const parameters =
+			model.compat.toolSchemaFlavor === "google-function"
+				? (normalizeSchemaForCCA(adaptedParameters) as Record<string, unknown>)
+				: adaptedParameters;
 		// Quarantine a tool whose emitted schema carries a provider-rejecting
 		// enum/const-vs-type contradiction: dropping just that tool keeps the rest
 		// of the request valid instead of letting one bad MCP schema 400 the whole

--- a/packages/ai/src/utils/schema/CONSTRAINTS.md
+++ b/packages/ai/src/utils/schema/CONSTRAINTS.md
@@ -85,14 +85,15 @@ Schemas sent on the Google JSON Schema path MUST follow:
    - `{ "type": "object" }` becomes `{ "type": "object", "properties": {} }`.
 ---
 
-## 3) Claude via Cloud Code Assist (`normalizeSchemaForCCA`)
+## 3) Typed Google function declarations (`normalizeSchemaForCCA`)
 
-For Cloud Code Assist Claude tool declarations, schema MUST satisfy stricter constraints than generic Google path.
+Cloud Code Assist Claude declarations and Gemini models routed through OpenAI-compatible adapters use a legacy function-declaration schema that is stricter than the generic Google JSON Schema path.
 
 ### 3.1 Transport contract
 
-1. **Use legacy `parameters` field** (not `parametersJsonSchema`) for CCA Claude.
-2. CCA path uses the full `normalizeSchemaForCCA` pipeline.
+1. Cloud Code Assist Claude uses the legacy `parameters` field (not `parametersJsonSchema`).
+2. Gemini models on `openai-completions` and `openai-responses` select the `google-function` tool-schema flavor.
+3. Both paths use the full `normalizeSchemaForCCA` pipeline.
 
 ### 3.2 Sanitization contract
 
@@ -105,7 +106,7 @@ For Cloud Code Assist Claude tool declarations, schema MUST satisfy stricter con
 
 1. Object-only `anyOf`/`oneOf` variants SHOULD be merged into a single object shape where safe.
 2. Same-type combiner variants SHOULD be collapsed to one schema.
-3. Mixed-type combiner variants MAY be lossy-collapsed to first non-null scalar type when required for CCA acceptance.
+3. Mixed-type combiner variants MAY be lossy-collapsed to the first non-null scalar type when typed function-declaration acceptance requires it.
 4. Residual combiners are recursively stripped where collapsible (`stripResidualCombiners`).
 
 ### 3.4 Nullable property normalization contract
@@ -152,6 +153,9 @@ If any remain, schema is incompatible.
 
 - **Cloud Code Assist Claude models (`model.id` starts with `claude-`)**:
   - Use `normalizeSchemaForCCA` and send sanitized normalized schema in `parameters`.
+
+- **Gemini models through OpenAI-compatible adapters**:
+  - Use `normalizeSchemaForCCA` after strict-schema adaptation so composition-only nodes are projected onto a representable top-level type.
 
 ---
 

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -128,6 +128,19 @@ async function captureOpenAICompletionsPayload(
 	});
 	return promise;
 }
+function toolParameters(payload: unknown, toolName: string): Record<string, unknown> {
+	const tools = toObject(payload)?.tools;
+	if (!Array.isArray(tools)) throw new Error("payload tools missing");
+	for (const entry of tools) {
+		const fn = getNestedObject(entry, "function");
+		if (fn?.name === toolName) {
+			const params = toObject(fn.parameters);
+			if (!params) throw new Error(`tool ${toolName} has no parameters`);
+			return params;
+		}
+	}
+	throw new Error(`tool ${toolName} not in payload`);
+}
 
 function getPayloadMessages(payload: unknown): Record<string, unknown>[] {
 	const payloadObject = toObject(payload);
@@ -2552,20 +2565,6 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		},
 	];
 
-	function toolParameters(payload: unknown, toolName: string): Record<string, unknown> {
-		const tools = toObject(payload)?.tools;
-		if (!Array.isArray(tools)) throw new Error("payload tools missing");
-		for (const entry of tools) {
-			const fn = getNestedObject(entry, "function");
-			if (fn?.name === toolName) {
-				const params = toObject(fn.parameters);
-				if (!params) throw new Error(`tool ${toolName} has no parameters`);
-				return params;
-			}
-		}
-		throw new Error(`tool ${toolName} not in payload`);
-	}
-
 	function probeProperty(payload: unknown, toolName: string, prop: string): Record<string, unknown> {
 		const properties = toObject(toolParameters(payload, toolName).properties);
 		const node = toObject(properties?.[prop]);
@@ -2623,6 +2622,46 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		expect(taskProperties?.outputSchema).toBe(true);
 	});
 });
+describe("Google function-declaration tool normalization (issue #11336)", () => {
+	const taskTool: Tool = {
+		name: "task",
+		description: "spawn task",
+		strict: false,
+		parameters: {
+			type: "object",
+			properties: {
+				tasks: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {
+							outputSchema: {
+								anyOf: [{ type: "object" }, { type: "boolean" }, { type: "string" }, { type: "null" }],
+							},
+						},
+					},
+				},
+			},
+		},
+	};
+
+	it("gives the task outputSchema node an explicit type for Gemini models behind OpenAI-compatible hosts", async () => {
+		const model = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://api.example.com/v1",
+			id: "gemini-3.8-flash",
+		} as ModelSpec<"openai-completions">);
+		expect(model.compat.toolSchemaFlavor).toBe("google-function");
+
+		const payload = await captureOpenAICompletionsPayload(model, { ...baseContext(), tools: [taskTool] });
+		const tasks = getNestedObject(toObject(toolParameters(payload, "task").properties), "tasks");
+		const items = getNestedObject(tasks, "items");
+		const outputSchema = getNestedObject(toObject(items?.properties), "outputSchema");
+		expect(outputSchema).toEqual({ type: "object", properties: {} });
+	});
+});
 
 describe("grammar tool-schema normalization (issue #5914)", () => {
 	const primitiveUnion = {
@@ -2657,20 +2696,6 @@ describe("grammar tool-schema normalization (issue #5914)", () => {
 			additionalProperties: false,
 		},
 	};
-
-	function toolParameters(payload: unknown, toolName: string): Record<string, unknown> {
-		const tools = toObject(payload)?.tools;
-		if (!Array.isArray(tools)) throw new Error("payload tools missing");
-		for (const entry of tools) {
-			const fn = getNestedObject(entry, "function");
-			if (fn?.name === toolName) {
-				const params = toObject(fn.parameters);
-				if (!params) throw new Error(`tool ${toolName} has no parameters`);
-				return params;
-			}
-		}
-		throw new Error(`tool ${toolName} not in payload`);
-	}
 
 	function localLlamaModel(): Model<"openai-completions"> {
 		return buildModel({

--- a/packages/ai/test/openai-responses-tool-quarantine.test.ts
+++ b/packages/ai/test/openai-responses-tool-quarantine.test.ts
@@ -19,6 +19,20 @@ function makeModel(provider: "openai" | "xai-oauth" = "openai"): Model<"openai-r
 		maxTokens: 128000,
 	} as ModelSpec<"openai-responses">);
 }
+function makeGeminiModel(): Model<"openai-responses"> {
+	return buildModel({
+		id: "gemini-3.8-flash",
+		name: "Gemini 3.8 Flash",
+		api: "openai-responses",
+		provider: "custom",
+		baseUrl: "https://api.example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	} satisfies ModelSpec<"openai-responses">);
+}
 
 const leftoverRootUnion = {
 	type: "object",
@@ -121,6 +135,28 @@ const computerTool: Tool = {
 	native: { type: "computer" },
 };
 
+const taskTool: Tool = {
+	name: "task",
+	description: "spawn task",
+	strict: false,
+	parameters: {
+		type: "object",
+		properties: {
+			tasks: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						outputSchema: {
+							anyOf: [{ type: "object" }, { type: "boolean" }, { type: "string" }, { type: "null" }],
+						},
+					},
+				},
+			},
+		},
+	},
+};
+
 describe("convertTools quarantine (#2652)", () => {
 	test("drops only the tool with the provider-rejecting schema, keeping the rest", () => {
 		const out = convertTools([goodTool, badTool], true, makeModel()) as Array<{ name: string }>;
@@ -193,6 +229,30 @@ describe("convertTools quarantine (#2652)", () => {
 		const dropped: Array<{ name: string; path: string }> = [];
 		convertTools([badTool], true, makeModel(), (name, path) => dropped.push({ name, path }));
 		expect(dropped).toEqual([{ name: "mcp__server__bad", path: "#/properties/choice/enum" }]);
+	});
+});
+
+describe("Gemini function-declaration schema projection (#11336)", () => {
+	test("types task outputSchema after Responses schema adaptation", () => {
+		const model = makeGeminiModel();
+		expect(model.compat.toolSchemaFlavor).toBe("google-function");
+
+		const out = convertTools([taskTool], false, model);
+		expect(out[0]).toMatchObject({
+			type: "function",
+			name: "task",
+			parameters: {
+				properties: {
+					tasks: {
+						items: {
+							properties: {
+								outputSchema: { type: "object", properties: {} },
+							},
+						},
+					},
+				},
+			},
+		});
 	});
 });
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Gemini models on OpenAI-compatible transports now select the typed Google function-declaration schema flavor, including custom gateways ([#11336](https://github.com/can1357/oh-my-pi/issues/11336)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -174,7 +174,12 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 		"chat-template",
 	]),
 	"thinking-keep": wire("thinkingKeep", ["openai"]),
-	"tool-schema-flavor": wire("toolSchemaFlavor", OAI, "scalar", ["moonshot-mfjs", "grammar", "none"]),
+	"tool-schema-flavor": wire("toolSchemaFlavor", OAI, "scalar", [
+		"google-function",
+		"moonshot-mfjs",
+		"grammar",
+		"none",
+	]),
 	"tool-strict-mode": wire("toolStrictMode", ["openai"], "scalar", ["all_strict", "none", "mixed"]),
 	"uses-openai-tool-call-id-limit": wire("usesOpenAIToolCallIdLimit", OAI),
 	"when-thinking": wire("whenThinking", ["openai"], "object"),

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4843,7 +4843,8 @@
 				"class": "gemini",
 				"apis": [
 					"openai-completions",
-					"openai-responses"
+					"openai-responses",
+					"openrouter"
 				],
 				"wire": {
 					"toolSchemaFlavor": "google-function"

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4839,7 +4839,18 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:102",
+				"source": "classes/gemini.kdl:103",
+				"class": "gemini",
+				"apis": [
+					"openai-completions",
+					"openai-responses"
+				],
+				"wire": {
+					"toolSchemaFlavor": "google-function"
+				}
+			},
+			{
+				"source": "classes/gemini.kdl:108",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity",

--- a/packages/catalog/src/compat/rules/classes/gemini.kdl
+++ b/packages/catalog/src/compat/rules/classes/gemini.kdl
@@ -98,6 +98,12 @@ class "gemini" {
 			supports-function-part-id #true
 		}
 	}
+	// OpenAI-compatible gateways translate tool parameters back into Google's
+	// legacy functionDeclaration schema, which requires a type on every node.
+	on-api "openai-completions" "openai-responses" {
+		tool-schema-flavor "google-function"
+	}
+
 	on "google-antigravity" "google-gemini-cli" {
 		family "flash" {
 			stream-first-event-timeout-ms 60000

--- a/packages/catalog/src/compat/rules/classes/gemini.kdl
+++ b/packages/catalog/src/compat/rules/classes/gemini.kdl
@@ -100,7 +100,7 @@ class "gemini" {
 	}
 	// OpenAI-compatible gateways translate tool parameters back into Google's
 	// legacy functionDeclaration schema, which requires a type on every node.
-	on-api "openai-completions" "openai-responses" {
+	on-api "openai-completions" "openai-responses" "openrouter" {
 		tool-schema-flavor "google-function"
 	}
 

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -46224,7 +46224,7 @@
 		},
 		"cline-free/muse-spark-1.3-contributor": {
 			"id": "cline-free/muse-spark-1.3-contributor",
-			"name": "Muse Spark 1.3 (C) (free)",
+			"name": "Muse Spark 1.3 Contributor (free)",
 			"api": "openai-completions",
 			"provider": "cline-pass",
 			"baseUrl": "https://api.cline.bot/api/v1",
@@ -46240,7 +46240,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 943718,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -80096,8 +80096,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -80187,8 +80187,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -80460,8 +80460,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -80671,8 +80671,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -80793,8 +80793,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -264623,6 +264623,8 @@
 				"priority": 2.5
 			},
 			"applyPatchToolType": "freeform",
+			"int": 52.8,
+			"tps": 54.3,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -264678,8 +264680,6 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 52.8,
-			"tps": 54.3,
 			"supportsComputerUse": false
 		},
 		"gpt-daybreak-blue-latest": {
@@ -280094,6 +280094,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -280196,6 +280197,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289443,6 +289445,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289536,6 +289539,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289640,6 +289644,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289744,6 +289749,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289846,6 +289852,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -289948,6 +289955,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290050,6 +290058,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290152,6 +290161,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290257,6 +290267,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290360,6 +290371,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290463,6 +290475,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290566,6 +290579,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290670,6 +290684,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290774,6 +290789,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290875,6 +290891,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -290976,6 +290993,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291080,6 +291098,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291175,6 +291194,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291279,6 +291299,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291384,6 +291405,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291487,6 +291509,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291590,6 +291613,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291696,6 +291720,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291802,6 +291827,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -291906,6 +291932,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292010,6 +292037,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292116,6 +292144,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292220,6 +292249,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292325,6 +292355,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292428,6 +292459,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292532,6 +292564,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -292634,6 +292667,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -297252,6 +297286,7 @@
 			},
 			"requiresGlyphTokenization": false,
 			"int": 62.1,
+			"tps": 229.5,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -297316,7 +297351,6 @@
 				"requiresReasoningOffJuiceInstruction": false,
 				"supportsReasoningSummary": true
 			},
-			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -312242,6 +312276,8 @@
 				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
+			"int": 52.8,
+			"tps": 54.3,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -312306,8 +312342,6 @@
 				"requiresReasoningOffJuiceInstruction": true,
 				"supportsReasoningSummary": true
 			},
-			"int": 52.8,
-			"tps": 54.3,
 			"supportsComputerUse": false
 		},
 		"openai/gpt-6-astra-pro": {
@@ -339132,7 +339166,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1310720,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"identity": {
 				"class": "unknown"
@@ -339213,7 +339247,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
+			"contextWindow": 1000000,
 			"maxTokens": null,
 			"identity": {
 				"class": "unknown"
@@ -339541,7 +339575,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
+			"contextWindow": 1000000,
 			"maxTokens": null,
 			"identity": {
 				"class": "unknown"
@@ -340108,7 +340142,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 262144,
 			"maxTokens": 32768,
 			"identity": {
 				"class": "unknown"
@@ -356653,6 +356687,7 @@
 				]
 			},
 			"int": 62.1,
+			"tps": 229.5,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -356677,7 +356712,6 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
 			},
-			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -362186,6 +362220,8 @@
 					"max"
 				]
 			},
+			"int": 52.8,
+			"tps": 54.3,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -362210,8 +362246,6 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
 			},
-			"int": 52.8,
-			"tps": 54.3,
 			"supportsComputerUse": false
 		},
 		"openai/gpt-6-astra-fast": {
@@ -384093,6 +384127,7 @@
 				]
 			},
 			"int": 62.1,
+			"tps": 229.5,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -384147,7 +384182,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -389322,6 +389356,8 @@
 					"max"
 				]
 			},
+			"int": 52.8,
+			"tps": 54.3,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -389376,8 +389412,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"int": 52.8,
-			"tps": 54.3,
 			"supportsComputerUse": false
 		},
 		"openai/gpt-image-1.5": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -77,6 +77,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -171,6 +172,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270,6 +272,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -301,7 +304,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -311,14 +314,15 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
+			"int": 34.5,
+			"tps": 120.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
 			},
-			"int": 51.8,
-			"tps": 140,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -373,8 +377,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -392,7 +395,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -402,14 +405,15 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
+			"int": 36.3,
+			"tps": 74,
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
 			},
-			"int": 53.2,
-			"tps": 60.2,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -464,8 +468,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -485,7 +488,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -496,10 +499,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gemma"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -553,12 +557,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
-		"moonshotai/kimi-k2.7-code": {
-			"id": "moonshotai/kimi-k2.7-code",
-			"name": "Kimi K2.7 Code",
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -568,7 +571,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
+				"input": 0.85,
 				"output": 3.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -585,14 +588,15 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
+			"int": 31.3,
+			"tps": 55.8,
 			"identity": {
 				"class": "kimi",
-				"family": "k2.7-code"
+				"family": "k2.6"
 			},
-			"int": 43,
-			"tps": 39,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -647,8 +651,101 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"int": 26.3,
+			"tps": 57.6,
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -866,13 +963,14 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
+			"int": 12.3,
+			"tps": 202.7,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
-			"int": 24.1,
-			"tps": 153,
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -926,8 +1024,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -941,13 +1038,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -957,14 +1054,15 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
+			"int": 21.9,
+			"tps": 55.9,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
 			},
-			"int": 37.7,
-			"tps": 52.5,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -1018,8 +1116,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -1113,9 +1210,9 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/glm-5.2": {
-			"id": "zai-org/glm-5.2",
-			"name": "GLM 5.2",
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -1124,12 +1221,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 4,
+				"input": 1.4,
+				"output": 4.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 202752,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -1138,15 +1235,16 @@
 					"low",
 					"medium",
 					"high",
-					"max"
+					"xhigh"
 				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -1200,8 +1298,97 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"zai-org/glm-5.2": {
+			"id": "zai-org/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"zai-org/glm-5.3": {
 			"id": "zai-org/glm-5.3",
@@ -11729,6 +11916,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -11748,7 +11936,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -11822,6 +12010,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -11914,6 +12103,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12008,6 +12198,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12100,6 +12291,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12192,6 +12384,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12286,6 +12479,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12378,6 +12572,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -12472,6 +12667,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -29551,8 +29747,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 16384,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29645,8 +29841,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 16384,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29741,7 +29937,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 36,
+			"int": 23.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29836,8 +30032,8 @@
 			},
 			"contextWindow": 196608,
 			"maxTokens": 24576,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29930,8 +30126,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 117.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30372,8 +30568,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30467,8 +30663,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30563,8 +30759,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -31879,6 +32075,101 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"apac.amazon.nova-lite-v1:0": {
+			"id": "apac.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.063,
+				"output": 0.252,
+				"cacheRead": 0.01575,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"apac.amazon.nova-micro-v1:0": {
+			"id": "apac.amazon.nova-micro-v1:0",
+			"name": "Nova Micro (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.037,
+				"output": 0.148,
+				"cacheRead": 0.00925,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"apac.amazon.nova-pro-v1:0": {
+			"id": "apac.amazon.nova-pro-v1:0",
+			"name": "Nova Pro (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.84,
+				"output": 3.36,
+				"cacheRead": 0.21,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Claude Haiku 4.5 (AU)",
@@ -31965,6 +32256,51 @@
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"au.anthropic.claude-opus-4-7": {
+			"id": "au.anthropic.claude-opus-4-7",
+			"name": "Claude Opus 4.7 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "opus",
+				"revision": "4.7.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v47",
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": true,
+				"promptCacheMinimumTokens": 4096,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 900000
 			}
 		},
 		"au.anthropic.claude-opus-4-8": {
@@ -32190,6 +32526,38 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"ca.amazon.nova-lite-v1:0": {
+			"id": "ca.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (CA)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.064,
+				"output": 0.256,
+				"cacheRead": 0.016,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
 		"cohere.command-r-plus-v1:0": {
 			"id": "cohere.command-r-plus-v1:0",
 			"name": "Command R+",
@@ -32309,7 +32677,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 81920,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -32373,6 +32741,143 @@
 				"streamIdleTimeoutMs": 600000
 			},
 			"supportsComputerUse": false
+		},
+		"eu.amazon.nova-2-lite-v1:0": {
+			"id": "eu.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.374,
+				"output": 3.157,
+				"cacheRead": 0.0935,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"eu.amazon.nova-lite-v1:0": {
+			"id": "eu.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.069,
+				"output": 0.276,
+				"cacheRead": 0.01725,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"eu.amazon.nova-micro-v1:0": {
+			"id": "eu.amazon.nova-micro-v1:0",
+			"name": "Nova Micro (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.16,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"eu.amazon.nova-pro-v1:0": {
+			"id": "eu.amazon.nova-pro-v1:0",
+			"name": "Nova Pro (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.92,
+				"output": 3.68,
+				"cacheRead": 0.23,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
 		},
 		"eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
 			"id": "eu.anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -33235,6 +33740,37 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"eu.mistral.pixtral-large-2502-v1:0": {
+			"id": "eu.mistral.pixtral-large-2502-v1:0",
+			"name": "Pixtral Large (25.02) (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
 		"global.amazon.nova-2-lite-v1:0": {
 			"id": "global.amazon.nova-2-lite-v1:0",
 			"name": "Nova 2 Lite",
@@ -33941,6 +34477,90 @@
 				"streamIdleTimeoutMs": 600000
 			}
 		},
+		"global.openai.gpt-6-astra": {
+			"id": "global.openai.gpt-6-astra",
+			"name": "GPT-6 Astra (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"global.xai.grok-4.6": {
+			"id": "global.xai.grok-4.6",
+			"name": "Grok 4.6 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
 		"google.gemma-3-27b-it": {
 			"id": "google.gemma-3-27b-it",
 			"name": "Google Gemma 3 27B Instruct",
@@ -34001,6 +34621,48 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"jp.amazon.nova-2-lite-v1:0": {
+			"id": "jp.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.396,
+				"output": 3.311,
+				"cacheRead": 0.099,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
 			}
 		},
 		"jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -34983,8 +35645,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.2,
-			"tps": 159.9,
+			"int": 6.8,
+			"tps": 145.3,
 			"identity": {
 				"class": "unknown"
 			},
@@ -35026,6 +35688,49 @@
 			},
 			"identity": {
 				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"openai.gpt-6-astra": {
+			"id": "openai.gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -36039,6 +36744,48 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"us.amazon.nova-2-lite-v1:0": {
+			"id": "us.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.33,
+				"output": 2.75,
+				"cacheRead": 0.0825,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
 		"us.amazon.nova-lite-v1:0": {
 			"id": "us.amazon.nova-lite-v1:0",
 			"name": "Nova Lite",
@@ -36874,6 +37621,66 @@
 				"streamIdleTimeoutMs": 600000
 			}
 		},
+		"us.meta.llama3-1-70b-instruct-v1:0": {
+			"id": "us.meta.llama3-1-70b-instruct-v1:0",
+			"name": "Llama 3.1 70B Instruct (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.72,
+				"output": 0.72,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.meta.llama3-1-8b-instruct-v1:0": {
+			"id": "us.meta.llama3-1-8b-instruct-v1:0",
+			"name": "Llama 3.1 8B Instruct (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.22,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
 		"us.meta.llama3-2-11b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-11b-instruct-v1:0",
 			"name": "Llama 3.2 11B Instruct",
@@ -37086,6 +37893,330 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.mistral.pixtral-large-2502-v1:0": {
+			"id": "us.mistral.pixtral-large-2502-v1:0",
+			"name": "Pixtral Large (25.02) (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.openai.gpt-5.6-luna": {
+			"id": "us.openai.gpt-5.6-luna",
+			"name": "GPT-5.6 Luna (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 1.32,
+				"cacheRead": 0.022,
+				"cacheWrite": 0.275
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-5.6-sol": {
+			"id": "us.openai.gpt-5.6-sol",
+			"name": "GPT-5.6 Sol (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.4,
+				"output": 22,
+				"cacheRead": 0.44,
+				"cacheWrite": 5.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-5.6-terra": {
+			"id": "us.openai.gpt-5.6-terra",
+			"name": "GPT-5.6 Terra (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 13.2,
+				"cacheRead": 0.22,
+				"cacheWrite": 2.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-6-astra": {
+			"id": "us.openai.gpt-6-astra",
+			"name": "GPT-6 Astra (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.writer.palmyra-x4-v1:0": {
+			"id": "us.writer.palmyra-x4-v1:0",
+			"name": "Palmyra X4 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 10,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 122880,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.writer.palmyra-x5-v1:0": {
+			"id": "us.writer.palmyra-x5-v1:0",
+			"name": "Palmyra X5 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1040000,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.xai.grok-4.6": {
+			"id": "us.xai.grok-4.6",
+			"name": "Grok 4.6 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 6.6,
+				"cacheRead": 0.55,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
 			}
 		},
 		"writer.palmyra-x4-v1:0": {
@@ -37550,8 +38681,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -37615,8 +38746,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -37816,13 +38947,14 @@
 				],
 				"supportsDisplay": true
 			},
-			"requiresGlyphTokenization": true,
-			"tokenizer": "claude-v5-sonnet",
 			"identity": {
 				"class": "anthropic",
 				"family": "mythos",
 				"revision": "5.0.0"
 			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37846,8 +38978,7 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-opus-4-0": {
 			"id": "claude-opus-4-0",
@@ -38100,8 +39231,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -38226,8 +39357,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38289,8 +39420,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38354,8 +39485,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38419,8 +39550,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38724,8 +39855,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38786,8 +39917,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38911,6 +40042,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -38991,6 +40123,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39071,6 +40204,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39103,8 +40237,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 32.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39155,6 +40289,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39236,6 +40371,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39267,8 +40403,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 154,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39319,6 +40455,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39350,8 +40487,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 113.6,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39402,6 +40539,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39433,8 +40571,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 123.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39485,6 +40623,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39516,8 +40655,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 150.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -39567,6 +40706,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39599,7 +40739,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 147.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -39649,6 +40789,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39680,8 +40821,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39741,6 +40882,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39772,7 +40914,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39832,6 +40974,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39863,8 +41006,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39924,6 +41067,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39955,8 +41099,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 182.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40016,6 +41160,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40106,6 +41251,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40137,8 +41283,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40198,6 +41344,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40287,6 +41434,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40319,7 +41467,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40379,6 +41527,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40471,6 +41620,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40502,7 +41652,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40560,6 +41710,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40591,8 +41742,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40652,6 +41803,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40741,6 +41893,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40773,7 +41926,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40833,6 +41986,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40922,6 +42076,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40954,8 +42109,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41015,6 +42170,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41046,8 +42202,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41107,6 +42263,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41138,8 +42295,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41199,6 +42356,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41230,8 +42388,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41291,6 +42449,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41381,6 +42540,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41412,8 +42572,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41474,6 +42634,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41505,8 +42666,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41567,6 +42728,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41598,8 +42760,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41660,6 +42822,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41691,8 +42854,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41753,6 +42916,101 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": true,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": true,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41843,6 +43101,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41874,7 +43133,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41935,6 +43194,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42025,6 +43285,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42057,8 +43318,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 164.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42119,6 +43380,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42149,8 +43411,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42212,6 +43474,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42243,8 +43506,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42306,6 +43569,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43815,6 +45079,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43905,6 +45170,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43995,6 +45261,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44085,6 +45352,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44175,6 +45443,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44224,7 +45493,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44278,7 +45546,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -44298,8 +45567,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 40960,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -44611,28 +45880,39 @@
 		},
 		"qwen-3.8-27b": {
 			"id": "qwen-3.8-27b",
-			"name": "qwen-3.8-27b",
+			"name": "Qwen3.8 27B",
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"baseUrl": "https://api.cerebras.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.99,
+				"output": 1.49,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 65536,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44686,8 +45966,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"zai-glm-4.6": {
 			"id": "zai-glm-4.6",
@@ -44879,6 +46158,173 @@
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 262144,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "cline-enabled-false",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false,
+				"wireModelIdMode": "raw"
+			}
+		},
+		"cline-free/muse-spark-1.3-contributor": {
+			"id": "cline-free/muse-spark-1.3-contributor",
+			"name": "Muse Spark 1.3 (C) (free)",
+			"api": "openai-completions",
+			"provider": "cline-pass",
+			"baseUrl": "https://api.cline.bot/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "meta",
+				"family": "muse-spark",
+				"revision": "1.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "cline-enabled-false",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false,
+				"wireModelIdMode": "raw"
+			}
+		},
+		"cline-free/solar-pro4": {
+			"id": "cline-free/solar-pro4",
+			"name": "Solar Pro 4 (free)",
+			"api": "openai-completions",
+			"provider": "cline-pass",
+			"baseUrl": "https://api.cline.bot/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 131072,
 			"identity": {
 				"class": "unknown"
 			},
@@ -45395,7 +46841,7 @@
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
-			"name": "GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
 			"api": "openai-completions",
 			"provider": "cline-pass",
 			"baseUrl": "https://api.cline.bot/api/v1",
@@ -46478,8 +47924,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 49.8,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -46530,8 +47976,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46592,8 +48038,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46655,8 +48101,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46718,8 +48164,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 39.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -47094,8 +48540,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47130,6 +48576,72 @@
 				"supportsMidConversationToolChanges": true,
 				"supportsPerMessageEffort": false,
 				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": false,
+				"supportsSamplingParams": false,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			}
+		},
+		"anthropic/claude-fable-5.1": {
+			"id": "anthropic/claude-fable-5.1",
+			"name": "Claude Fable 5.1",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 0.25,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"int": 53.4,
+			"tps": 67.8,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true,
+				"prefixBinding": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": true,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": true,
+				"supportsTurnScopedSystem": true,
+				"supportsMidConversationToolChanges": true,
+				"supportsPerMessageEffort": true,
+				"supportsThinkingBindingControls": true,
 				"supportsForcedToolChoice": false,
 				"supportsSamplingParams": false,
 				"requiresToolResultId": false,
@@ -47656,8 +49168,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -47720,8 +49232,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47783,8 +49295,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47848,8 +49360,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47913,8 +49425,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48224,8 +49736,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48286,8 +49798,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48412,8 +49924,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48476,8 +49988,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48643,8 +50155,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 154,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48696,8 +50208,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 113.6,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48749,8 +50261,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 123.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48802,8 +50314,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 150.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -48855,7 +50367,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 147.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -48906,8 +50418,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48968,8 +50480,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49030,8 +50542,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 182.7,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49152,8 +50664,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49692,8 +51204,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49754,8 +51266,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49816,8 +51328,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49938,8 +51450,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50123,8 +51635,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50186,8 +51698,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50249,8 +51761,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50436,8 +51948,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 164.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50498,8 +52010,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50625,8 +52137,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -51333,8 +52845,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51428,8 +52940,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51609,8 +53121,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51698,8 +53210,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51876,8 +53388,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51967,8 +53479,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52059,8 +53571,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52151,8 +53663,8 @@
 			},
 			"contextWindow": 1310720,
 			"maxTokens": 1310720,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52244,8 +53756,8 @@
 			},
 			"contextWindow": 1310720,
 			"maxTokens": 1048576,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52338,7 +53850,7 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"identity": {
 				"class": "xai",
 				"family": "grok",
@@ -52391,7 +53903,7 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52455,8 +53967,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52519,8 +54031,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52583,8 +54095,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52648,7 +54160,7 @@
 			},
 			"contextWindow": 161000,
 			"maxTokens": 161000,
-			"int": 21.4,
+			"int": 13.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -52730,8 +54242,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52910,8 +54422,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53179,8 +54691,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 6.4,
-			"tps": 104,
+			"int": 6.6,
+			"tps": 73.1,
 			"identity": {
 				"class": "unknown"
 			},
@@ -53259,8 +54771,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 19.6,
-			"tps": 144,
+			"int": 12.4,
+			"tps": 120,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53913,8 +55425,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54098,8 +55610,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54193,8 +55705,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54476,8 +55988,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 38.3,
-			"tps": 158.6,
+			"int": 23.4,
+			"tps": 160.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54654,8 +56166,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54743,8 +56255,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54832,8 +56344,8 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 32768,
-			"int": 6.8,
-			"tps": 62.3,
+			"int": 6.7,
+			"tps": 57.6,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -55337,8 +56849,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 144.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55429,8 +56941,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55521,8 +57033,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 22.3,
+			"tps": 122.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55613,8 +57125,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55876,8 +57388,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -55891,6 +57403,100 @@
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"zai-org/GLM-5.3-Flash": {
+			"id": "zai-org/GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
+			"api": "openai-completions",
+			"provider": "coreweave",
+			"baseUrl": "https://api.inference.wandb.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"int": 41.9,
+			"tps": 71.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash",
+				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
@@ -60643,7 +62249,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -62375,9 +63981,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
+				"input": 0.060000000000000005,
 				"output": 0.18,
-				"cacheRead": 0.016,
+				"cacheRead": 0.015000000000000001,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -62799,6 +64405,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -62893,6 +64500,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -62985,6 +64593,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -63075,6 +64684,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -63169,6 +64779,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -63263,6 +64874,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -64481,6 +66093,95 @@
 			},
 			"supportsComputerUse": false
 		},
+		"inclusionAI/Ling-3.0-flash-VL": {
+			"id": "inclusionAI/Ling-3.0-flash-VL",
+			"name": "inclusionAI/Ling-3.0-flash-VL",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.060000000000000005,
+				"output": 0.18,
+				"cacheRead": 0.012000000000000002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 			"name": "Llama 3.3 70B",
@@ -65112,96 +66813,6 @@
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
-		"MiniMaxAI/MiniMax-M2.7": {
-			"id": "MiniMaxAI/MiniMax-M2.7",
-			"name": "MiniMax-M2.7",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.05,
-				"cacheWrite": 0
-			},
-			"contextWindow": 196608,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"int": 38.9,
-			"tps": 76.8,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": true,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false,
 				"dropThinkingWhenReasoningEffort": false,
@@ -69600,190 +71211,6 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/GLM-4.7-Flash": {
-			"id": "zai-org/GLM-4.7-Flash",
-			"name": "GLM-4.7-Flash",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.060000000000000005,
-				"output": 0.4,
-				"cacheRead": 0.0100000002,
-				"cacheWrite": 0
-			},
-			"contextWindow": 202752,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "glm",
-				"family": "flash",
-				"revision": "4.7.0"
-			},
-			"int": 23.3,
-			"tps": 82.9,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
-		"zai-org/GLM-5": {
-			"id": "zai-org/GLM-5",
-			"name": "GLM-5",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.6,
-				"output": 2.08,
-				"cacheRead": 0.12,
-				"cacheWrite": 0
-			},
-			"contextWindow": 202752,
-			"maxTokens": 131072,
-			"tokenizer": "glm5",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "glm",
-				"revision": "5.0.0"
-			},
-			"int": 40.6,
-			"tps": 66.5,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
 			"name": "GLM-5.1",
@@ -70062,7 +71489,7 @@
 		},
 		"zai-org/GLM-5.3-Flash": {
 			"id": "zai-org/GLM-5.3-Flash",
-			"name": "GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
 			"api": "openai-completions",
 			"provider": "deepinfra",
 			"baseUrl": "https://api.deepinfra.com/v1/openai",
@@ -70174,8 +71601,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -70507,8 +71934,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -71603,6 +73030,8 @@
 				"class": "glm",
 				"revision": "5.1.0"
 			},
+			"int": 41,
+			"tps": 50.5,
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -71792,6 +73221,8 @@
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"int": 52.6,
+			"tps": 69.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -71942,7 +73373,7 @@
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
-			"name": "GLM-5.3-Flash",
+			"name": "cline-pass/glm-5.3-flash",
 			"api": "openai-completions",
 			"provider": "fireworks",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
@@ -72300,7 +73731,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "fireworks",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
@@ -72534,11 +73965,13 @@
 				"class": "kimi",
 				"family": "k2.6"
 			},
+			"int": 45.1,
+			"tps": 40.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -72557,7 +73990,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -72590,7 +74023,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -72730,11 +74166,13 @@
 				"class": "kimi",
 				"family": "k2.7-code"
 			},
+			"int": 43,
+			"tps": 39,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -72753,7 +74191,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -72785,7 +74223,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -74038,8 +75479,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74063,6 +75504,80 @@
 				"class": "anthropic",
 				"family": "fable",
 				"revision": "5.0.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": true,
+				"supportsContextManagement": false,
+				"supportsOutputEffort": true,
+				"disableStrictTools": true,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": false,
+				"supportsSamplingParams": false,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			}
+		},
+		"claude-fable-5.1": {
+			"id": "claude-fable-5.1",
+			"name": "Claude Fable 5.1",
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 0.25,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"int": 53.4,
+			"tps": 67.8,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
+			},
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true,
+				"prefixBinding": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
@@ -74209,7 +75724,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -74233,7 +75747,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.6": {
 			"id": "claude-opus-4.6",
@@ -74281,7 +75796,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -74305,7 +75819,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.7": {
 			"id": "claude-opus-4.7",
@@ -74326,8 +75841,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74399,8 +75914,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74472,8 +75987,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74570,7 +76085,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -74594,7 +76108,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
@@ -74640,7 +76155,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -74664,7 +76178,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.6": {
 			"id": "claude-sonnet-4.6",
@@ -74685,8 +76200,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74755,8 +76270,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -74894,6 +76409,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -74994,6 +76510,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75092,6 +76609,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75138,6 +76656,20 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "pro",
+				"revision": "3.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -75178,6 +76710,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75193,20 +76726,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "pro",
-				"revision": "3.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -75233,8 +76752,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -75283,6 +76802,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75340,8 +76860,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -75390,6 +76910,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75447,8 +76968,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -75497,6 +77018,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75535,6 +77057,114 @@
 				"supportsReasoningEffort": false
 			}
 		},
+		"gemini-3.8-flash": {
+			"id": "gemini-3.8-flash",
+			"name": "Gemini 3.8 Flash",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"int": 41.2,
+			"tps": 273,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": false,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "gemini",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			}
+		},
 		"gpt-4.1": {
 			"id": "gpt-4.1",
 			"name": "GPT-4.1",
@@ -75564,6 +77194,12 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "4.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -75618,12 +77254,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "4.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -75809,6 +77439,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -75841,8 +77472,8 @@
 			},
 			"contextWindow": 264000,
 			"maxTokens": 64000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -75910,6 +77541,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76009,6 +77641,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76108,6 +77741,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76208,6 +77842,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76305,6 +77940,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76362,7 +77998,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -76406,6 +78041,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76416,7 +78052,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -76461,7 +78098,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -76505,6 +78141,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76515,7 +78152,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -76536,8 +78174,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -76605,6 +78243,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76636,8 +78275,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -76705,6 +78344,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76736,8 +78376,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -76806,6 +78446,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76837,8 +78478,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -76906,6 +78547,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -76937,8 +78579,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77007,6 +78649,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77038,8 +78681,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77108,6 +78751,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77132,15 +78776,15 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 4,
+				"output": 20,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77209,6 +78853,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77240,8 +78885,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77310,6 +78955,109 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": true,
+				"supportsImageDetailOriginal": false,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77341,8 +79089,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 128000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77412,6 +79160,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77443,8 +79192,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77514,6 +79263,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -77645,8 +79395,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32000,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77751,8 +79501,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -77931,6 +79681,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -78028,6 +79779,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -78584,6 +80336,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -78674,6 +80427,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -79160,6 +80914,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -79250,6 +81005,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -79340,6 +81096,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -79410,8 +81167,8 @@
 					"max"
 				]
 			},
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
@@ -79836,8 +81593,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 202.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -79896,7 +81653,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 296.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -80241,8 +81998,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 123.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -80615,8 +82372,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 303.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -80717,8 +82474,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -80815,8 +82572,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -80867,8 +82624,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -80919,8 +82676,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -80971,8 +82728,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -81022,8 +82779,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -81773,7 +83530,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -81786,7 +83542,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
@@ -81883,7 +83640,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -81896,7 +83652,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -81941,7 +83698,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -81955,11 +83711,12 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
 			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
@@ -81993,7 +83750,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82006,7 +83762,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -82112,7 +83869,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82126,7 +83882,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -82207,7 +83964,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82221,7 +83977,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite": {
 			"id": "gemini-3.1-flash-lite",
@@ -82258,7 +84015,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82271,7 +84027,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro": {
 			"id": "gemini-3.1-pro",
@@ -82317,7 +84074,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82330,7 +84086,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -82384,7 +84141,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82398,7 +84154,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -82444,7 +84201,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82458,7 +84214,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -82504,7 +84261,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82518,7 +84274,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.8-flash": {
 			"id": "gemini-3.8-flash",
@@ -82564,7 +84321,6 @@
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82578,7 +84334,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -82615,7 +84372,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82627,7 +84383,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_flash_lite_preview": {
 			"id": "tab_flash_lite_preview",
@@ -82651,7 +84408,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82663,7 +84419,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_jump_flash_lite_preview": {
 			"id": "tab_jump_flash_lite_preview",
@@ -82687,7 +84444,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -82699,7 +84455,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"google-gemini-cli": {
@@ -83763,8 +85520,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 202.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -83823,7 +85580,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 296.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -83881,8 +85638,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 123.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -84041,8 +85798,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -84139,8 +85896,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -84191,8 +85948,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -84243,8 +86000,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -84295,8 +86052,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -84346,8 +86103,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -85721,8 +87478,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 65536,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85810,8 +87567,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 65536,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86153,8 +87910,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 16384,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86245,8 +88002,8 @@
 			},
 			"contextWindow": 131042,
 			"maxTokens": 16384,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86338,7 +88095,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 32768,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86515,7 +88272,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 8192,
-			"int": 14.2,
+			"int": 8.5,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -86597,7 +88354,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 163840,
-			"int": 15.2,
+			"int": 9.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -86679,7 +88436,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"int": 21.4,
+			"int": 13.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86768,7 +88525,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86857,8 +88614,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87127,8 +88884,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87722,8 +89479,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87812,8 +89569,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87902,8 +89659,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87992,8 +89749,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88083,8 +89840,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88336,8 +90093,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 33.5,
-			"tps": 116.4,
+			"int": 22,
+			"tps": 118.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88433,7 +90190,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88526,8 +90283,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88621,8 +90378,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88715,8 +90472,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88816,8 +90573,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88905,8 +90662,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88994,7 +90751,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"int": 6.9,
+			"int": 6.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "2.5.0"
@@ -89162,8 +90919,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 18.4,
-			"tps": 57.1,
+			"int": 12,
+			"tps": 58.4,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -89508,8 +91265,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 87.2,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -89590,8 +91347,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 18.2,
-			"tps": 65,
+			"int": 11.9,
+			"tps": 53.9,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -89672,8 +91429,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 117.1,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -89754,8 +91511,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 13.8,
-			"tps": 170.2,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -89919,8 +91676,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 14.4,
-			"tps": 51.2,
+			"int": 9.9,
+			"tps": 49.2,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -90095,8 +91852,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 129.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90187,8 +91944,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90279,8 +92036,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 144.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90371,8 +92128,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90463,8 +92220,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 82.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90555,8 +92312,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90647,8 +92404,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 22.3,
+			"tps": 122.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90738,8 +92495,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 57.7,
-			"tps": 40,
+			"int": 40,
+			"tps": 40.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90830,8 +92587,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -90921,8 +92678,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 213.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91013,8 +92770,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 81.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91104,8 +92861,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91195,8 +92952,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91286,8 +93043,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 1048576,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 132.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91376,7 +93133,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 4096,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91557,8 +93314,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91649,7 +93406,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91739,8 +93496,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 61.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91832,8 +93589,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91923,8 +93680,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92105,8 +93862,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92196,8 +93953,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92288,8 +94045,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92380,8 +94137,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92472,8 +94229,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92564,8 +94321,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92657,8 +94414,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93262,6 +95019,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -93353,6 +95111,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -93381,9 +95140,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 14,
-				"cacheRead": 0.29,
+				"input": 2.4,
+				"output": 12,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -93743,13 +95502,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07125,
-				"output": 0.2375,
-				"cacheRead": 0.01425,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93832,13 +95591,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.148,
-				"output": 3.608,
-				"cacheRead": 0.1886,
+				"input": 1.113,
+				"output": 3.498,
+				"cacheRead": 0.2067,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 943718,
+			"contextWindow": 1024000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -95784,7 +97543,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 4096,
-			"int": 3.5,
+			"int": 5.6,
 			"identity": {
 				"class": "anthropic",
 				"family": "haiku",
@@ -96208,8 +97967,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96302,8 +98061,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96673,8 +98432,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96767,8 +98526,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96954,8 +98713,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97140,8 +98899,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97326,8 +99085,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97696,8 +99455,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97790,8 +99549,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98278,8 +100037,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 80000,
-			"int": 18.7,
-			"tps": 313.7,
+			"int": 10.9,
+			"tps": 320.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -100597,9 +102356,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0,
+				"input": 0.29,
+				"output": 1.14,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -100682,8 +102441,8 @@
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 161000,
-			"maxTokens": 144900,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -100771,7 +102530,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 16000,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101108,7 +102867,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 21.7,
+			"int": 13.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101279,7 +103038,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101538,8 +103297,8 @@
 			},
 			"contextWindow": 1024000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101718,7 +103477,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101979,8 +103738,8 @@
 			},
 			"contextWindow": 1024000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102065,11 +103824,11 @@
 			"cost": {
 				"input": 1.32,
 				"output": 3.96,
-				"cacheRead": 0.132,
+				"cacheRead": 0.044,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1024000,
-			"maxTokens": 384000,
+			"contextWindow": 1048576,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102640,6 +104399,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -102723,6 +104483,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -102759,8 +104520,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 202.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102817,6 +104578,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -102897,6 +104659,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -102934,7 +104697,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 296.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102991,6 +104754,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103082,6 +104846,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103118,8 +104883,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 123.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -103177,6 +104942,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103269,6 +105035,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103361,6 +105128,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103453,6 +105221,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103543,6 +105312,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103632,6 +105402,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103723,6 +105494,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103804,6 +105576,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103885,6 +105658,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -103978,6 +105752,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104058,6 +105833,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104094,8 +105870,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 303.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104153,6 +105929,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104188,8 +105965,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104245,6 +106022,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104335,6 +106113,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104370,8 +106149,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104429,6 +106208,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104464,8 +106244,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104523,6 +106303,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104558,8 +106339,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104617,6 +106398,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104652,8 +106434,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104711,6 +106493,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -104746,8 +106529,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104805,6 +106588,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -105808,7 +107592,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -105862,7 +107645,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -105882,8 +107666,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 19.6,
-			"tps": 144,
+			"int": 12.4,
+			"tps": 120,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -106051,8 +107835,96 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 732.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 0.75,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -106155,7 +108027,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -106209,7 +108080,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-coder": {
 			"id": "inception/mercury-coder",
@@ -106606,7 +108478,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -106622,8 +108494,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 37.8,
-			"tps": 346.2,
+			"int": 24.9,
+			"tps": 292.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -106785,6 +108657,94 @@
 		"inclusionai/ling-3.0-flash-fin:free": {
 			"id": "inclusionai/ling-3.0-flash-fin:free",
 			"name": "Ling 3.0 Flash Fin (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inclusionai/ling-3.0-flash-sante:free": {
+			"id": "inclusionai/ling-3.0-flash-sante:free",
+			"name": "Ling 3.0 Flash Sante (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -108221,7 +110181,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 144000,
-			"int": 33.7,
+			"int": 21.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -108860,8 +110820,8 @@
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 262144,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 48.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -109421,7 +111381,7 @@
 		},
 		"meta-llama/llama-3.1-70b-instruct": {
 			"id": "meta-llama/llama-3.1-70b-instruct",
-			"name": "Llama 3.1 70B Instruct",
+			"name": "Llama-3.1-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -109913,8 +111873,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 115200,
-			"int": 14.5,
-			"tps": 86.3,
+			"int": 9.3,
+			"tps": 95.1,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -109995,8 +111955,8 @@
 			},
 			"contextWindow": 327680,
 			"maxTokens": 16384,
-			"int": 10.3,
-			"tps": 93.8,
+			"int": 6.5,
+			"tps": 85.7,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -110485,8 +112445,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 53.2,
-			"tps": 178.6,
+			"int": 34.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110578,8 +112537,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 219.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110762,7 +112721,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 62.1,
+			"int": 48.2,
+			"tps": 229.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111346,8 +113306,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111515,8 +113475,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111605,8 +113565,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111775,8 +113735,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111879,7 +113839,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111933,7 +113892,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
@@ -111954,8 +113914,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -112141,7 +114101,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112195,7 +114154,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
@@ -113086,7 +115046,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 102400,
-			"int": 4.1,
+			"int": 5.8,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -113166,7 +115126,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 7,
+			"int": 6.8,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -113407,8 +115367,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 12.5,
-			"tps": 132.1,
+			"int": 9,
+			"tps": 139.8,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -113489,8 +115449,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 209715,
-			"int": 30.4,
-			"tps": 131.9,
+			"int": 14.9,
+			"tps": 148.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -113581,8 +115541,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 14.7,
-			"tps": 133.3,
+			"int": 9.9,
+			"tps": 137.2,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -113741,7 +115701,7 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 26214,
-			"int": 6.2,
+			"int": 6.5,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -114547,8 +116507,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 100352,
-			"int": 19.7,
-			"tps": 39.9,
+			"int": 12.7,
+			"tps": 40.3,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -114630,8 +116590,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 100352,
-			"int": 24,
-			"tps": 40.4,
+			"int": 15.3,
+			"tps": 40,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -114794,9 +116754,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 100352,
-			"int": 33.5,
-			"tps": 116.4,
+			"maxTokens": 235929,
+			"int": 22,
+			"tps": 118.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -114890,7 +116850,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -115065,8 +117025,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -115242,8 +117202,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -115336,8 +117296,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -115928,7 +117888,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -115982,7 +117941,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -116019,7 +117979,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -116073,7 +118032,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -116153,6 +118113,183 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"nex-agi/nex-n2.5-mini:free": {
+			"id": "nex-agi/nex-n2.5-mini:free",
+			"name": "Nex-N2.5-Mini (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"nex-agi/nex-n2.5-pro:free": {
+			"id": "nex-agi/nex-n2.5-pro:free",
+			"name": "Nex-N2.5-Pro (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -117177,8 +119314,8 @@
 				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202800,
-			"maxTokens": 182520,
+			"contextWindow": 256000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117337,6 +119474,84 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"nvidia/nemotron-3.5-content-safety": {
+			"id": "nvidia/nemotron-3.5-content-safety",
+			"name": "Nemotron 3.5 Content Safety",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"nvidia/nemotron-3.5-content-safety:free": {
 			"id": "nvidia/nemotron-3.5-content-safety:free",
 			"name": "Nemotron 3.5 Content Safety (free)",
@@ -117433,8 +119648,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 23.6,
-			"tps": 285.8,
+			"int": 13.6,
+			"tps": 283.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -118110,7 +120325,7 @@
 			},
 			"contextWindow": 8191,
 			"maxTokens": 4096,
-			"int": 6.8,
+			"int": 6.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -118354,8 +120569,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 32.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -118517,8 +120732,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 154,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -118600,8 +120815,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 113.6,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -118683,8 +120898,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 123.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -118766,8 +120981,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 150.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -118848,8 +121063,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 8.4,
-			"tps": 80.4,
+			"int": 7.3,
+			"tps": 110.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -118930,8 +121145,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 111.1,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -119173,7 +121388,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 147.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -119574,8 +121789,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120019,8 +122234,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120111,8 +122326,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 182.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120293,8 +122508,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120467,7 +122682,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120650,7 +122865,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120739,8 +122954,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120912,7 +123127,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121174,8 +123389,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121266,8 +123481,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121438,8 +123653,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121530,8 +123745,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121712,8 +123927,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121896,8 +124111,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -122080,8 +124295,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -122166,10 +124381,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -122355,8 +124570,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -122462,6 +124677,190 @@
 				"class": "openai",
 				"family": "gpt",
 				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -122776,8 +125175,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -122945,8 +125344,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123121,7 +125520,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123305,8 +125704,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 164.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123490,8 +125889,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123583,8 +125982,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 15.7,
-			"tps": 236.6,
+			"int": 11,
+			"tps": 194.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123679,7 +126078,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 33.3,
+			"int": 21.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123772,8 +126171,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123959,8 +126358,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127268,8 +129667,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
-			"maxTokens": 16384,
+			"contextWindow": 131072,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127445,7 +129844,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -128126,8 +130525,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 87.2,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -128288,8 +130687,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 117.1,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -128531,8 +130930,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 49.8,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -128612,7 +131011,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.5,
+			"int": 21.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128703,9 +131102,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 13.8,
-			"tps": 170.2,
+			"maxTokens": 16384,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -128784,8 +131183,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128879,8 +131278,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 14.4,
-			"tps": 51.2,
+			"int": 9.9,
+			"tps": 49.2,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -129055,8 +131454,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 9.9,
-			"tps": 112,
+			"int": 7.9,
+			"tps": 107.8,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -129231,8 +131630,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 11,
-			"tps": 59.4,
+			"int": 8.4,
+			"tps": 65.8,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -129314,8 +131713,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 8.2,
-			"tps": 112.4,
+			"int": 7.3,
+			"tps": 114.8,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -129490,8 +131889,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 81920,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 129.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129582,8 +131981,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129672,10 +132071,10 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 29.9,
-			"tps": 151.7,
+			"contextWindow": 256000,
+			"maxTokens": 16384,
+			"int": 19.3,
+			"tps": 144.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129766,8 +132165,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129858,8 +132257,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 82.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -130219,9 +132618,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 37.7,
-			"tps": 52.5,
+			"maxTokens": 65536,
+			"int": 21.9,
+			"tps": 55.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -130312,8 +132711,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 22.3,
+			"tps": 122.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -130583,8 +132982,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -130926,8 +133325,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -131018,8 +133417,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -131189,9 +133588,9 @@
 				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 262144,
-			"int": 57.7,
-			"tps": 40,
+			"maxTokens": 131072,
+			"int": 40,
+			"tps": 40.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -131282,8 +133681,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -131466,6 +133865,96 @@
 			"maxTokens": 131072,
 			"int": 58.1,
 			"tps": 38.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen3.8-max-0902": {
+			"id": "qwen/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -132677,8 +135166,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -132771,8 +135260,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -132865,8 +135354,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -132959,8 +135448,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -133234,8 +135723,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -133325,8 +135814,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 213.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -133497,8 +135986,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 230400,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 81.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134062,15 +136551,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0825,
-				"output": 0.33,
-				"cacheRead": 0.020625,
+				"input": 0.132,
+				"output": 0.528,
+				"cacheRead": 0.033,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134159,7 +136648,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 34.4,
+			"int": 22.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134735,8 +137224,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 26214,
+			"contextWindow": 1024000,
+			"maxTokens": 819200,
 			"identity": {
 				"class": "unknown"
 			},
@@ -134816,8 +137305,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 471859,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134907,8 +137396,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 262144,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 132.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135335,8 +137824,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 14.5,
-			"tps": 143.9,
+			"int": 7.8,
+			"tps": 147.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135425,8 +137914,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 41.6,
-			"tps": 78.2,
+			"int": 28.2,
+			"tps": 75.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136201,8 +138690,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 1800000,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 104.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136551,8 +139040,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 900000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136645,8 +139134,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 450000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136739,8 +139228,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 450000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137632,8 +140121,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137804,7 +140293,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137894,8 +140383,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 61.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137987,8 +140476,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138071,15 +140560,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
-				"cacheRead": 0.11,
+				"input": 0.43,
+				"output": 1.75,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"contextWindow": 198000,
+			"maxTokens": 16384,
+			"int": 14.9,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138250,8 +140739,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 45.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138341,8 +140830,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138425,15 +140914,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.0605,
 				"output": 0.4,
-				"cacheRead": 0.01,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
-			"maxTokens": 16384,
-			"int": 23.3,
-			"tps": 82.9,
+			"contextWindow": 131072,
+			"maxTokens": 117964,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138524,8 +141013,8 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138616,7 +141105,7 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138708,8 +141197,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138800,8 +141289,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138972,9 +141461,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
-			"int": 59.5,
-			"tps": 69.2,
+			"maxTokens": 943718,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139066,8 +141555,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139160,7 +141649,7 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139796,7 +142285,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "kimi-code",
 			"baseUrl": "https://api.kimi.com/coding/v1",
@@ -140395,8 +142884,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140460,8 +142949,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140525,8 +143014,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140716,8 +143205,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140845,8 +143334,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140911,8 +143400,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -140976,8 +143465,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -141041,8 +143530,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -141232,8 +143721,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -141361,8 +143850,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -141427,8 +143916,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141523,8 +144012,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141713,8 +144202,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -141997,8 +144486,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142188,8 +144677,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142286,8 +144775,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142382,8 +144871,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142572,8 +145061,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -142856,8 +145345,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143047,8 +145536,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -143535,7 +146024,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 11.8,
+			"int": 8.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -143859,7 +146348,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 10.6,
+			"int": 8.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -145668,7 +148157,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145723,7 +148211,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-0905-preview": {
 			"id": "kimi-k2-0905-preview",
@@ -145749,7 +148238,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145804,7 +148292,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking": {
 			"id": "kimi-k2-thinking",
@@ -145844,7 +148333,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145899,7 +148387,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking-turbo": {
 			"id": "kimi-k2-thinking-turbo",
@@ -145935,7 +148424,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -145990,7 +148478,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-turbo-preview": {
 			"id": "kimi-k2-turbo-preview",
@@ -146016,7 +148505,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -146071,11 +148559,12 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "moonshot",
 			"baseUrl": "https://api.moonshot.ai/v1",
@@ -146108,7 +148597,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -146163,7 +148651,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.6": {
 			"id": "kimi-k2.6",
@@ -146184,8 +148673,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -146279,8 +148768,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -146465,8 +148954,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -147295,8 +149784,8 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 46.8,
-			"tps": 260,
+			"int": 39.8,
+			"tps": 219.4,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -147492,8 +149981,8 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 53,
-			"tps": 190.1,
+			"int": 48.2,
+			"tps": 229.5,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -148762,8 +151251,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.9,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
@@ -150003,8 +152492,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -150097,8 +152586,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -150374,8 +152863,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -150836,8 +153325,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -151022,8 +153511,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -151208,8 +153697,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -151393,8 +153882,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -151579,8 +154068,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"identity": {
 				"class": "anthropic",
 				"family": "sonnet",
@@ -153310,7 +155799,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -153365,7 +155853,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"brave": {
 			"id": "brave",
@@ -153622,7 +156111,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -155856,7 +158345,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -155948,7 +158437,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -158374,8 +160863,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 163840,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -158464,7 +160953,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 21.4,
+			"int": 13.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -158546,7 +161035,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 21.7,
+			"int": 13.9,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -159128,7 +161617,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -159463,7 +161952,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 15.2,
+			"int": 9.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -159713,7 +162202,7 @@
 			},
 			"contextWindow": 163000,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -159965,8 +162454,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -160592,8 +163081,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -161112,6 +163601,96 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1562,
+				"output": 0.3124,
+				"cacheRead": 0.03124,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"dmind/dmind-1": {
 			"id": "dmind/dmind-1",
 			"name": "dmind/dmind-1",
@@ -161382,7 +163961,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -161436,7 +164014,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"dots-studio/dots-3-note-preview:free": {
 			"id": "dots-studio/dots-3-note-preview:free",
@@ -164410,6 +166989,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164493,6 +167073,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164575,6 +167156,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164657,6 +167239,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164739,6 +167322,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164821,6 +167405,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164855,10 +167440,10 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 202.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -164915,6 +167500,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -164948,10 +167534,10 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 296.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -165008,6 +167594,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165099,6 +167686,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165133,9 +167721,9 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 13.1,
+			"int": 9.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -165199,6 +167787,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165280,6 +167869,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165372,6 +167962,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165464,6 +168055,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165498,9 +168090,9 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 19.1,
+			"int": 12.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -165564,6 +168156,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165597,10 +168190,10 @@
 				"cacheRead": 0.125,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 123.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -165658,6 +168251,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165739,6 +168333,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165821,6 +168416,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -165914,6 +168510,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -166007,6 +168604,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -166103,6 +168701,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -166183,6 +168782,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173303,7 +175903,6 @@
 				"revision": "1.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -173357,7 +175956,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-z1-airx": {
 			"id": "glm-z1-airx",
@@ -173535,7 +176135,7 @@
 				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -173594,6 +176194,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173686,6 +176287,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173770,6 +176372,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173804,10 +176407,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -173863,6 +176466,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173896,7 +176500,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -173953,6 +176557,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -173986,10 +176591,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174047,6 +176652,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174080,10 +176686,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174141,6 +176747,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174176,8 +176783,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174235,6 +176842,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174270,8 +176878,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174329,6 +176937,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174364,8 +176973,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174423,6 +177032,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174454,12 +177064,12 @@
 				"input": 0.75,
 				"output": 3.75,
 				"cacheRead": 0.075,
-				"cacheWrite": 0.075
+				"cacheWrite": 0.041667
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174517,6 +177127,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174548,12 +177159,12 @@
 				"input": 0.75,
 				"output": 3.75,
 				"cacheRead": 0.075,
-				"cacheWrite": 0.075
+				"cacheWrite": 0.041667
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -174611,6 +177222,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174692,6 +177304,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174784,6 +177397,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174875,6 +177489,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -174908,7 +177523,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -174966,6 +177581,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -177437,7 +180053,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 65536,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -177526,7 +180142,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 65536,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -178180,7 +180796,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -178234,7 +180849,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -178254,8 +180870,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 19.6,
-			"tps": 144,
+			"int": 12.4,
+			"tps": 120,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -178588,8 +181204,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 37.8,
-			"tps": 346.2,
+			"int": 24.9,
+			"tps": 292.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -180053,7 +182669,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -180108,7 +182723,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-thinking-preview": {
 			"id": "kimi-thinking-preview",
@@ -184613,8 +187229,8 @@
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 262144,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 48.5,
 			"identity": {
 				"class": "unknown"
 			},
@@ -185334,8 +187950,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 732.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -185822,8 +188438,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.5,
-			"tps": 86.3,
+			"int": 9.3,
+			"tps": 95.1,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -185904,8 +188520,8 @@
 			},
 			"contextWindow": 328000,
 			"maxTokens": 65536,
-			"int": 10.3,
-			"tps": 93.8,
+			"int": 6.5,
+			"tps": 85.7,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -185985,7 +188601,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 117964,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -186169,8 +188785,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 219.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -186353,7 +188969,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 62.1,
+			"int": 48.2,
+			"tps": 229.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -187112,8 +189729,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -187202,8 +189819,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -187292,8 +189909,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -187471,8 +190088,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 80000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"identity": {
 				"class": "minimax",
 				"family": "m3"
@@ -188278,8 +190895,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 30.4,
-			"tps": 131.9,
+			"int": 14.9,
+			"tps": 148.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -190495,8 +193112,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
+			"contextWindow": 262144,
+			"maxTokens": 100352,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -190578,8 +193195,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 98304,
-			"int": 33.5,
-			"tps": 116.4,
+			"int": 22,
+			"tps": 118.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -190839,7 +193456,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.5"
@@ -191014,8 +193631,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.6"
@@ -191191,8 +193808,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -191376,9 +193993,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 59.7,
-			"tps": 38,
+			"maxTokens": 943718,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -191478,7 +194095,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -192344,7 +194961,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192398,7 +195014,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -192435,7 +195052,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -192489,7 +195105,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -192746,8 +195363,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 8192,
-			"int": 4.8,
-			"tps": 35.1,
+			"int": 6,
+			"tps": 28.8,
 			"identity": {
 				"class": "unknown"
 			},
@@ -193397,7 +196014,7 @@
 		},
 		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
 			"id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-			"name": "Nvidia Nemotron 3 Nano Omni",
+			"name": "Nemotron 3 Nano Omni",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -193431,7 +196048,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -193485,7 +196101,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
@@ -193859,8 +196476,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 23.6,
-			"tps": 285.8,
+			"int": 13.6,
+			"tps": 283.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -194534,8 +197151,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 154,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -194785,8 +197402,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 150.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -194867,8 +197484,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 111.1,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -195272,8 +197889,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -195813,8 +198430,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -195902,8 +198519,8 @@
 				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 32768,
+			"contextWindow": 400000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196431,8 +199048,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196605,7 +199222,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196868,8 +199485,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196958,10 +199575,10 @@
 				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": 922000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197052,8 +199669,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197144,8 +199761,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197325,10 +199942,10 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197420,8 +200037,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197604,8 +200221,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197788,8 +200405,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197953,6 +200570,190 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT 6 Astra",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT 6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
 			"name": "GPT Chat Latest",
@@ -198055,10 +200856,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -198151,8 +200952,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -198240,8 +201041,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -198870,8 +201671,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -198963,8 +201764,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 15.7,
-			"tps": 236.6,
+			"int": 11,
+			"tps": 194.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -199058,8 +201859,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -199244,8 +202045,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -199430,8 +202231,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -201858,8 +204659,8 @@
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 41000,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 16384,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -202026,10 +204827,10 @@
 				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
-			"int": 18.4,
-			"tps": 57.1,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"int": 12,
+			"tps": 58.4,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -202349,8 +205150,8 @@
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
+			"contextWindow": 131072,
+			"maxTokens": 117964,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -202929,8 +205730,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 117.1,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -203172,10 +205973,10 @@
 				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
-			"int": 13.8,
-			"tps": 170.2,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -203517,8 +206318,8 @@
 			},
 			"contextWindow": 258048,
 			"maxTokens": 65536,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203616,8 +206417,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 82.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203806,8 +206607,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 22.3,
+			"tps": 122.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
@@ -204252,8 +207053,8 @@
 			},
 			"contextWindow": 991000,
 			"maxTokens": 65536,
-			"int": 57.7,
-			"tps": 40,
+			"int": 40,
+			"tps": 40.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.2"
@@ -205105,8 +207906,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 87.2,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -205432,7 +208233,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 5.2,
+			"int": 6.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205522,8 +208323,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 129.1,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -205694,8 +208495,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -209532,7 +212333,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 7.4,
+			"int": 6.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -209623,8 +212424,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 144.5,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -209796,8 +212597,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 20.4,
-			"tps": 23.5,
+			"int": 13.1,
+			"tps": 27.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -210400,8 +213201,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -210581,8 +213382,8 @@
 			},
 			"contextWindow": 991808,
 			"maxTokens": 65536,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -210763,8 +213564,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -210945,8 +213746,8 @@
 			},
 			"contextWindow": 991000,
 			"maxTokens": 65536,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 39.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
@@ -212169,14 +214970,14 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.045,
-				"output": 0.177,
-				"cacheRead": 0.028,
+				"input": 0.054,
+				"output": 0.2124,
+				"cacheRead": 0.0336,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
 			"maxTokens": 4096,
-			"int": 11.9,
+			"int": 8.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -214712,9 +217513,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 51.8,
-			"tps": 140,
+			"maxTokens": 393216,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -215998,8 +218799,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 65535,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216092,14 +218893,14 @@
 			],
 			"cost": {
 				"input": 1.4,
-				"output": 4.6,
-				"cacheRead": 0.5,
+				"output": 4.4,
+				"cacheRead": 0.7,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216184,8 +218985,8 @@
 			],
 			"cost": {
 				"input": 1.4,
-				"output": 4.6,
-				"cacheRead": 0.5,
+				"output": 4.4,
+				"cacheRead": 0.7,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -216280,8 +219081,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216373,8 +219174,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216811,8 +219612,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.6"
@@ -216895,8 +219696,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216988,9 +219789,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 59.7,
-			"tps": 38,
+			"maxTokens": 65535,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -217652,6 +220453,94 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"TEE/qwen3-8b": {
+			"id": "TEE/qwen3-8b",
+			"name": "Qwen3 8B TEE",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.11,
+				"output": 0.45,
+				"cacheRead": 0.11,
+				"cacheWrite": 0
+			},
+			"contextWindow": 40960,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"TEE/qwen3-coder": {
 			"id": "TEE/qwen3-coder",
@@ -218337,8 +221226,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -218506,9 +221395,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"int": 42.2,
-			"tps": 94.4,
+			"maxTokens": 128000,
+			"int": 25.8,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -218914,6 +221803,95 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"TheDrummer/Artemis-v1.1": {
+			"id": "TheDrummer/Artemis-v1.1",
+			"name": "TheDrummer/Artemis v1.1",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.45,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"TheDrummer/Cydonia-24B-v2": {
 			"id": "TheDrummer/Cydonia-24B-v2",
@@ -219645,8 +222623,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 32768,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"identity": {
 				"class": "unknown"
 			},
@@ -219726,8 +222704,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 32768,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 132.1,
 			"identity": {
 				"class": "unknown"
 			},
@@ -221279,8 +224257,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 41.6,
-			"tps": 78.2,
+			"int": 28.2,
+			"tps": 75.4,
 			"identity": {
 				"class": "unknown"
 			},
@@ -222198,8 +225176,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 131072,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 104.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222629,9 +225607,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 1000000,
-			"int": 37.9,
-			"tps": 134.9,
+			"maxTokens": 900000,
+			"int": 25.4,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222723,9 +225701,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"maxTokens": 450000,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222817,9 +225795,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"maxTokens": 450000,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222911,7 +225889,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"maxTokens": 230400,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -223095,7 +226073,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
+			"maxTokens": 450000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -223661,8 +226639,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -224524,8 +227502,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 61.3,
 			"identity": {
 				"class": "glm",
 				"family": "air",
@@ -224789,8 +227767,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 65535,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -225399,8 +228377,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 65535,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -225490,8 +228468,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -226119,8 +229097,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -226391,7 +229369,7 @@
 			},
 			"contextWindow": 202800,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"identity": {
 				"class": "glm",
 				"family": "turbo",
@@ -226563,8 +229541,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -226745,8 +229723,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -226927,8 +229905,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -227020,8 +229998,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -227296,7 +230274,7 @@
 			},
 			"contextWindow": 202800,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"identity": {
 				"class": "glm",
 				"family": "vision"
@@ -231948,7 +234926,7 @@
 			"cost": {
 				"input": 1.32,
 				"output": 3.96,
-				"cacheRead": 0.132,
+				"cacheRead": 0.044,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -232025,6 +235003,97 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"deepseek/deepseek-v4.1-flash-expires-on-0910": {
+			"id": "deepseek/deepseek-v4.1-flash-expires-on-0910",
+			"name": "DeepSeek V4.1 Flash Expires Exp",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 393216,
+			"supportsTools": true,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"dev/glm46": {
 			"id": "dev/glm46",
@@ -232613,7 +235682,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -236303,7 +239372,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next 80B-A3B Instruct",
+			"name": "Qwen3-Next-80B-A3B-Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -238467,7 +241536,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -240018,9 +243087,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -240837,8 +243906,8 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 262000,
-			"int": 18.5,
-			"tps": 34.8,
+			"int": 12.1,
+			"tps": 27.9,
 			"identity": {
 				"class": "unknown"
 			},
@@ -241427,8 +244496,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -241607,8 +244676,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -245535,8 +248604,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -245626,8 +248695,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 16384,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -246855,7 +249924,7 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 16384,
-			"int": 2,
+			"int": 5.1,
 			"identity": {
 				"class": "mistral",
 				"family": "mixtral"
@@ -247366,8 +250435,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -247461,8 +250530,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -248794,8 +251863,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 8.9,
-			"tps": 52.3,
+			"int": 7.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -249782,8 +252850,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 15,
-			"tps": 328.2,
+			"int": 10.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251318,8 +254385,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 7.2,
-			"tps": 159.9,
+			"int": 6.8,
+			"tps": 145.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251642,8 +254709,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251731,8 +254798,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251908,7 +254975,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 6.9,
+			"int": 6.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "2.5.0"
@@ -252051,11 +255118,11 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B-A22B",
+			"name": "Qwen 3 235b A22B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -252067,15 +255134,6 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -252155,8 +255213,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 18.2,
-			"tps": 65,
+			"int": 11.9,
+			"tps": 53.9,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -252237,8 +255295,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 13.8,
-			"tps": 170.2,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -252412,8 +255470,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 129.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -252504,8 +255562,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 8192,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -252595,7 +255653,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 2.6,
+			"int": 5.3,
 			"identity": {
 				"class": "unknown"
 			},
@@ -252752,8 +255810,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 213.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -252844,8 +255902,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 81.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -253014,8 +256072,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 16384,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -253664,8 +256722,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -254118,8 +257176,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254225,8 +257283,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254655,8 +257713,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254693,8 +257751,8 @@
 			},
 			"contextWindow": 976000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254729,8 +257787,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254769,8 +257827,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254948,7 +258006,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -254986,8 +258044,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255025,8 +258083,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255064,8 +258122,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255177,8 +258235,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255215,8 +258273,8 @@
 			},
 			"contextWindow": 196608,
 			"maxTokens": 196608,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255254,8 +258312,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 131072,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -255786,6 +258844,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -255884,6 +258943,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -255975,6 +259035,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256005,7 +259066,7 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 8192,
-			"int": 6.8,
+			"int": 6.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -256056,6 +259117,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256086,8 +259148,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 32.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -256138,6 +259200,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256168,8 +259231,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 154,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -256220,6 +259283,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256250,8 +259314,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 113.6,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -256302,6 +259366,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256332,8 +259397,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 123.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -256384,6 +259449,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256414,8 +259480,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 150.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -256465,6 +259531,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256495,8 +259562,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 8.4,
-			"tps": 80.4,
+			"int": 7.3,
+			"tps": 110.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -256546,6 +259613,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256576,8 +259644,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 111.1,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -256627,6 +259695,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256706,6 +259775,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256737,7 +259807,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 147.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -256787,6 +259857,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256817,8 +259888,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -256878,6 +259949,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -256959,6 +260031,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257050,6 +260123,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257081,8 +260155,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 106.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257142,6 +260216,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257173,8 +260248,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 182.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257234,6 +260309,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257324,6 +260400,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257355,8 +260432,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257416,6 +260493,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257506,6 +260584,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257597,6 +260676,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257689,6 +260769,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257778,6 +260859,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257809,8 +260891,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257870,6 +260952,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -257960,6 +261043,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258051,6 +261135,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258141,6 +261226,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258222,6 +261308,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258253,8 +261340,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258314,6 +261401,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258405,6 +261493,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258436,8 +261525,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258497,6 +261586,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258528,8 +261618,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258589,6 +261679,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258620,8 +261711,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258681,6 +261772,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258771,6 +261863,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258802,8 +261895,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258864,6 +261957,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -258955,6 +262049,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259054,6 +262149,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259146,6 +262242,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259184,8 +262281,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259247,6 +262344,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259285,8 +262383,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"requestModelId": "gpt-5.6-luna",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -259350,6 +262448,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259388,8 +262487,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259451,6 +262550,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259489,8 +262589,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"requestModelId": "gpt-5.6-sol",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -259554,6 +262654,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259592,8 +262693,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259655,6 +262756,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259693,8 +262795,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"requestModelId": "gpt-5.6-terra",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -259758,6 +262860,109 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": true,
+				"officialEndpoint": true,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": true
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "https://api.openai.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5,
+				"longContext": {
+					"inputThreshold": 272000,
+					"input": 20,
+					"output": 75,
+					"cacheRead": 2,
+					"cacheWrite": 25
+				}
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": true,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": true,
+				"supportsPromptCacheBreakpoints": true,
+				"promptCacheBreakpointTtl": "30m",
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259849,6 +263054,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259879,7 +263085,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259940,6 +263146,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -259970,7 +263177,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.1,
+			"int": 12.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260032,6 +263239,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260062,8 +263270,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 164.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260124,6 +263332,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260214,6 +263423,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260244,8 +263454,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 204,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260307,6 +263517,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260337,7 +263548,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 33.3,
+			"int": 21.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260399,6 +263610,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260429,8 +263641,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 151.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260492,6 +263704,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260582,6 +263795,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -260637,7 +263851,11 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -260681,6 +263899,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -260692,11 +263911,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -260741,7 +263956,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -260785,6 +264004,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -260796,11 +264016,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -260845,7 +264061,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -260889,6 +264109,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -260900,11 +264121,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -260950,7 +264167,11 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2.5
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -260994,6 +264215,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261005,11 +264227,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2.5
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -261064,7 +264282,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -261108,6 +264330,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261119,11 +264342,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -261178,7 +264397,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -261222,6 +264445,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261233,11 +264457,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -261292,7 +264512,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -261336,6 +264560,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261347,15 +264572,11 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-6-astra": {
 			"id": "gpt-6-astra",
-			"name": "GPT-6-Astra",
+			"name": "GPT-6 Astra",
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"baseUrl": "https://chatgpt.com/backend-api",
@@ -261397,7 +264618,11 @@
 				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2.5
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -261441,6 +264666,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261452,11 +264678,9 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2.5
-			},
-			"applyPatchToolType": "freeform"
+			"int": 52.8,
+			"tps": 54.3,
+			"supportsComputerUse": false
 		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",
@@ -261502,7 +264726,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -261546,6 +264774,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -261557,11 +264786,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		}
 	},
 	"opencode-go": {
@@ -261583,8 +264808,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -261644,6 +264869,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -261819,8 +265045,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262113,8 +265339,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 32768,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262261,8 +265487,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262409,8 +265635,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262558,8 +265784,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262708,8 +265934,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262770,6 +265996,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -262863,6 +266090,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -262895,8 +266123,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262958,6 +266186,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -262988,8 +266217,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263258,7 +266487,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -263423,8 +266652,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263574,8 +266803,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263723,8 +266952,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263884,8 +267113,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 48.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264479,8 +267708,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 128000,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264693,8 +267922,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264838,8 +268067,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265044,6 +268273,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -265135,6 +268365,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -265145,6 +268376,149 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"omen-alpha": {
+			"id": "omen-alpha",
+			"name": "Omen Alpha",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 0.66,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": false,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": false,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": false,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
 			}
 		},
 		"ox-alpha-free": {
@@ -265452,8 +268826,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265597,8 +268971,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265743,8 +269117,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265950,8 +269324,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 39.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266291,8 +269665,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266356,8 +269730,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266546,8 +269920,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -266610,8 +269984,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266673,8 +270047,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266738,8 +270112,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266803,8 +270177,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -266992,8 +270366,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -267054,8 +270428,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -267118,8 +270492,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267390,6 +270764,151 @@
 			},
 			"supportsComputerUse": false
 		},
+		"deepseek-v4-flash-vision-exp": {
+			"id": "deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": true,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": true,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": false,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": true,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"thinkingLoopGuard": "deepseek",
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -267408,8 +270927,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267555,8 +271074,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 27.9,
-			"tps": 186.6,
+			"int": 17.9,
+			"tps": 202.2,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -267703,8 +271222,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -267755,8 +271274,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -267807,8 +271326,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -267859,8 +271378,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -267910,8 +271429,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -268251,8 +271770,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268399,8 +271918,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268547,8 +272066,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268562,6 +272081,304 @@
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 600000,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": false,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": false,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": false,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 600000,
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"int": 44.9,
+			"tps": 62,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 600000,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": false,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": false,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": false,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 600000,
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
+		"glm-5.3-flash": {
+			"id": "glm-5.3-flash",
+			"name": "GLM-5.3-Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"int": 41.9,
+			"tps": 71.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash",
+				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
@@ -268696,8 +272513,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268757,6 +272574,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268788,7 +272606,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268848,6 +272666,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268879,8 +272698,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 182.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268940,6 +272759,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268971,8 +272791,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269032,6 +272852,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269063,7 +272884,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269123,6 +272944,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269215,6 +273037,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269246,7 +273069,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269304,6 +273127,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269335,8 +273159,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269396,6 +273220,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269427,7 +273252,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269487,6 +273312,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269518,8 +273344,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269579,6 +273405,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269669,6 +273496,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269700,8 +273528,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269761,6 +273589,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269792,8 +273621,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269853,6 +273682,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -269884,8 +273714,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269945,6 +273775,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270035,6 +273866,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270066,8 +273898,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270128,6 +273960,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270219,6 +274052,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270250,8 +274084,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270312,6 +274146,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270343,8 +274178,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270405,6 +274240,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270436,8 +274272,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270498,6 +274334,101 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsStrictMode": false,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270529,8 +274460,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270592,6 +274523,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270623,8 +274555,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270686,6 +274618,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270778,6 +274711,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -271247,7 +275181,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271395,8 +275329,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271546,8 +275480,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271695,8 +275629,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -273376,8 +277310,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -273583,8 +277517,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -273728,8 +277662,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274018,8 +277952,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 219.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274080,6 +278014,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274171,6 +278106,102 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"muse-spark-1.3": {
+			"id": "muse-spark-1.3",
+			"name": "Muse Spark 1.3",
+			"api": "openai-responses",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"int": 48.2,
+			"tps": 229.5,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "meta",
+				"family": "muse-spark",
+				"revision": "1.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsStrictMode": false,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274262,6 +278293,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274922,8 +278954,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -276203,9 +280235,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 14,
-				"cacheRead": 0.29,
+				"input": 2.4,
+				"output": 12,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -276607,13 +280639,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07125000000000001,
-				"output": 0.2375,
-				"cacheRead": 0.01425,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 131072,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276706,13 +280738,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.1480000000000001,
-				"output": 3.608,
-				"cacheRead": 0.18860000000000002,
+				"input": 1.113,
+				"output": 3.4979999999999998,
+				"cacheRead": 0.2067,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 943718,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -282715,7 +286747,7 @@
 		},
 		"bytedance-seed/seed-2-1-turbo": {
 			"id": "bytedance-seed/seed-2-1-turbo",
-			"name": "ByteDance Seed 2.1 Turbo",
+			"name": "Seed 2.1 Turbo",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -283489,9 +287521,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.135,
+				"input": 0.29,
+				"output": 1.1400000000000001,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -283580,13 +287612,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 1.6500000000000001,
-				"cacheRead": 0.55,
+				"input": 0.25,
+				"output": 0.95,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 144900,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -284268,9 +288300,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07784,
-				"output": 0.15568,
-				"cacheRead": 0.015568,
+				"input": 0.088606,
+				"output": 0.177212,
+				"cacheRead": 0.017721200000000003,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -284470,9 +288502,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.03,
+				"input": 0.11,
+				"output": 0.33,
+				"cacheRead": 0.0035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -284576,7 +288608,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -284591,6 +288623,106 @@
 				"class": "deepseek",
 				"family": "flash"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"deepseek/deepseek-v4-flash-vision-exp:batch": {
+			"id": "deepseek/deepseek-v4-flash-vision-exp:batch",
+			"name": "DeepSeek V4 Flash Vision Exp (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.11,
+				"output": 0.33,
+				"cacheRead": 0.0035,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -284769,9 +288901,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.0274699999999999,
-				"output": 2.0549399999999998,
-				"cacheRead": 0.0856225,
+				"input": 0.9552599999999999,
+				"output": 1.9105199999999998,
+				"cacheRead": 0.07960500000000001,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -284869,13 +289001,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.66,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.022,
+				"input": 0.57948,
+				"output": 1.73844,
+				"cacheRead": 0.018438,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -284969,9 +289101,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.32,
-				"output": 3.9600000000000004,
-				"cacheRead": 0.13,
+				"input": 0.66,
+				"output": 1.9800000000000002,
+				"cacheRead": 0.022,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -286463,7 +290595,7 @@
 		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
-			"name": "Gemini 3 Flash (Preview)",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -287176,7 +291308,7 @@
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
-			"name": "Gemini 3.1 Pro (Preview)",
+			"name": "Gemini 3.1 Pro Preview",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -287281,7 +291413,7 @@
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
 			"id": "google/gemini-3.1-pro-preview-customtools",
-			"name": "Gemini 3.1 Pro (Preview Custom Tools)",
+			"name": "Gemini 3.1 Pro Preview Custom Tools",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -289395,9 +293527,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.15,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.06,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -289671,6 +293803,103 @@
 				"supportsReasoningSummary": true
 			},
 			"supportsComputerUseConfig": false
+		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0.004,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-2.5-preview": {
 			"id": "inception/mercury-2.5-preview",
@@ -290216,7 +294445,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -290441,6 +294670,103 @@
 			},
 			"identity": {
 				"class": "unknown"
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"inclusionai/ling-3.0-flash-sante:free": {
+			"id": "inclusionai/ling-3.0-flash-sante:free",
+			"name": "Ling 3.0 Flash Sante (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			},
 			"compat": {
 				"supportsStore": true,
@@ -291827,7 +296153,7 @@
 		},
 		"meta-llama/llama-3.1-70b-instruct": {
 			"id": "meta-llama/llama-3.1-70b-instruct",
-			"name": "Llama 3.1 70B Instruct",
+			"name": "Llama-3.1-70B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -292484,9 +296810,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.35,
-				"output": 1.5,
-				"cacheRead": 0.04,
+				"input": 0.175,
+				"output": 0.75,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -292913,7 +297239,8 @@
 					"low",
 					"medium",
 					"high",
-					"xhigh"
+					"xhigh",
+					"max"
 				],
 				"defaultLevel": "medium",
 				"requiresEffort": true
@@ -292989,6 +297316,7 @@
 				"requiresReasoningOffJuiceInstruction": false,
 				"supportsReasoningSummary": true
 			},
+			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -293017,7 +297345,8 @@
 					"low",
 					"medium",
 					"high",
-					"xhigh"
+					"xhigh",
+					"max"
 				],
 				"defaultLevel": "medium",
 				"requiresEffort": true
@@ -297320,7 +301649,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 100352,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -297730,9 +302059,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
-				"output": 3.4,
-				"cacheRead": 0.18,
+				"input": 0.71,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -298538,6 +302867,201 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"nex-agi/nex-n2.5-mini:free": {
+			"id": "nex-agi/nex-n2.5-mini:free",
+			"name": "Nex-N2.5-Mini (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"nex-agi/nex-n2.5-pro:free": {
+			"id": "nex-agi/nex-n2.5-pro:free",
+			"name": "Nex-N2.5-Pro (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"nousresearch/deephermes-3-mistral-24b-preview": {
 			"id": "nousresearch/deephermes-3-mistral-24b-preview",
 			"name": "DeepHermes 3 Mistral 24B Preview",
@@ -299235,7 +303759,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 262144,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -299426,13 +303950,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 2.4,
-				"cacheRead": 0.12,
+				"input": 0.625,
+				"output": 3.125,
+				"cacheRead": 0.1875,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 182520,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -307681,6 +312205,420 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"int": 52.8,
+			"tps": 54.3,
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-pro:batch": {
+			"id": "openai/gpt-6-astra-pro:batch",
+			"name": "GPT-6 Astra Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra:batch": {
+			"id": "openai/gpt-6-astra:batch",
+			"name": "GPT-6 Astra (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
 			"name": "GPT Audio",
@@ -312683,107 +317621,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.24,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 16384,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "qwen",
-				"revision": "3.0.0"
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openrouter",
-				"reasoningDisableMode": "openrouter-enabled-false",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": true,
-				"wireModelIdMode": "openrouter",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": true,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false,
-				"supportsLongPromptCacheRetention": false,
-				"strictResponsesPairing": false,
-				"supportsImageDetailOriginal": true,
-				"supportsObfuscationOptOut": false,
-				"supportsAllTurnsReasoningContext": false,
-				"supportsConfigurationUpdate": false,
-				"officialEndpoint": false,
-				"harmonyLeakMitigation": false,
-				"requiresReasoningOffJuiceInstruction": false,
-				"supportsReasoningSummary": true
-			},
-			"supportsComputerUseConfig": false
-		},
-		"qwen/qwen3-235b-a22b": {
-			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B-A22B",
-			"api": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"provider": "openrouter",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.45499999999999996,
-				"output": 1.8199999999999998,
+				"input": 0.22749999999999998,
+				"output": 0.9099999999999999,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -312870,6 +317709,96 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3-235b-a22b": {
+			"id": "qwen/qwen3-235b-a22b",
+			"name": "Qwen 3 235b A22B",
+			"api": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"provider": "openrouter",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.45499999999999996,
+				"output": 1.8199999999999998,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"requiresGlyphTokenization": false,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUseConfig": false
+		},
 		"qwen/qwen3-235b-a22b-2507": {
 			"id": "qwen/qwen3-235b-a22b-2507",
 			"name": "Qwen3 235B A22B Instruct 2507",
@@ -312881,13 +317810,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0875,
-				"output": 0.35,
+				"input": 0.22,
+				"output": 0.88,
 				"cacheRead": 0.0175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -314574,7 +319503,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next 80B-A3B Instruct",
+			"name": "Qwen3-Next-80B-A3B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -314583,13 +319512,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.09,
 				"output": 1.1,
 				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -314773,7 +319702,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -315765,13 +320694,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
+				"input": 0.3125,
 				"output": 1.25,
-				"cacheRead": 0.25,
+				"cacheRead": 0.15625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -316477,13 +321406,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.5999999999999996,
-				"cacheRead": 0.12,
+				"input": 0.3,
+				"output": 2,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -317499,7 +322428,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"tokenizer": "qwen3",
 			"requiresGlyphTokenization": false,
 			"identity": {
@@ -317993,6 +322922,109 @@
 				"supportsReasoningSummary": true
 			},
 			"supportsComputerUseConfig": false
+		},
+		"qwen/qwen3.8-max-0902": {
+			"id": "qwen/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"defaultLevel": "xhigh",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -319143,7 +324175,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -319152,9 +324184,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0825,
-				"output": 0.33,
-				"cacheRead": 0.020625,
+				"input": 0.13199999999999998,
+				"output": 0.5279999999999999,
+				"cacheRead": 0.032999999999999995,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -319739,7 +324771,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1024000,
-			"maxTokens": 26214,
+			"maxTokens": 819200,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
@@ -321908,6 +326940,107 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"x-ai/grok-4.3:batch": {
+			"id": "x-ai/grok-4.3:batch",
+			"name": "Grok 4.3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 900000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"x-ai/grok-4.5": {
 			"id": "x-ai/grok-4.5",
 			"name": "Grok 4.5",
@@ -323330,7 +328463,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM-4.6",
+			"name": "GLM 4.6",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -323339,13 +328472,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
-				"cacheRead": 0.11,
+				"input": 0.43,
+				"output": 1.75,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -323733,7 +328866,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM-4.7-Flash",
+			"name": "GLM 4.7 Flash",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -323742,13 +328875,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.060500000000000005,
 				"output": 0.39999999999999997,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 16384,
+			"maxTokens": 117964,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -324244,13 +329377,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048575,
-			"maxTokens": 131072,
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -324448,11 +329581,11 @@
 			"cost": {
 				"input": 1.4,
 				"output": 4.4,
-				"cacheRead": 0.14,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 262144,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -324654,13 +329787,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.5,
-				"cacheRead": 0.03,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048575,
-			"maxTokens": 943717,
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -324678,6 +329811,106 @@
 				"family": "flash",
 				"revision": "5.3.0"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"z-ai/glm-5.3:batch": {
+			"id": "z-ai/glm-5.3:batch",
+			"name": "GLM 5.3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325157,6 +330390,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -325247,6 +330481,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -325337,6 +330572,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -325361,9 +330597,195 @@
 		}
 	},
 	"synthetic": {
+		"hf:MiniMaxAI/MiniMax-M3": {
+			"id": "hf:MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 1.2,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"int": 29.6,
+			"tps": 100.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m3"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:moonshotai/Kimi-K2.7-Code": {
+			"id": "hf:moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"int": 26.3,
+			"tps": 57.6,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"hf:moonshotai/Kimi-K3": {
 			"id": "hf:moonshotai/Kimi-K3",
-			"name": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325380,6 +330802,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -325393,12 +330817,13 @@
 				},
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"identity": {
 				"class": "kimi",
 				"family": "k3"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325458,12 +330883,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325474,7 +330898,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1,
-				"cacheRead": 0.06,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -325489,10 +330913,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325546,12 +330971,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325562,11 +330986,13 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -325575,11 +331001,12 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325633,8 +331060,99 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:Qwen/Qwen3.6-27B": {
+			"id": "hf:Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.45,
+				"output": 3.6,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"int": 21.9,
+			"tps": 55.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"hf:Qwen/Qwen3.8-27B": {
 			"id": "hf:Qwen/Qwen3.8-27B",
@@ -325728,7 +331246,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325739,11 +331257,13 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.5,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
 			"maxTokens": 65536,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -325754,12 +331274,13 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "4.7.0"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325813,12 +331334,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325827,13 +331347,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.16,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 1.4,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -325844,12 +331366,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325903,12 +331426,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.3-Flash": {
 			"id": "hf:zai-org/GLM-5.3-Flash",
-			"name": "zai-org/GLM-5.3-Flash",
+			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -325925,6 +331447,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -325935,13 +331459,14 @@
 				"defaultLevel": "max",
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "5.3.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -325995,8 +331520,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"syn:large:text": {
 			"id": "syn:large:text",
@@ -326466,7 +331990,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 14.2,
+			"int": 8.5,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -326548,7 +332072,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 21.4,
+			"int": 13.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -326808,8 +332332,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327394,8 +332918,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327484,8 +333008,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327575,8 +333099,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 250000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327650,7 +333174,7 @@
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
 			"id": "moonshotai/Kimi-K2-Instruct-0905",
-			"name": "Kimi-K2-Instruct-0905",
+			"name": "Kimi K2 0905",
 			"api": "openai-completions",
 			"provider": "together",
 			"baseUrl": "https://api.together.xyz/v1",
@@ -327748,7 +333272,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327841,8 +333365,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131000,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327935,8 +333459,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328029,8 +333553,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328218,8 +333742,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 202.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328307,8 +333831,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 199.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328715,8 +334239,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 130000,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328807,8 +334331,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 82.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328898,8 +334422,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 500000,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -328989,8 +334513,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 500000,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.7.0"
@@ -329072,8 +334596,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329253,8 +334777,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329345,8 +334869,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329437,8 +334961,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 164000,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329529,8 +335053,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 262144,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329622,8 +335146,8 @@
 			},
 			"contextWindow": 1048575,
 			"maxTokens": 400000,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330843,8 +336367,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330937,8 +336461,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331032,8 +336556,8 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 32768,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331126,8 +336650,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331313,8 +336837,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331500,8 +337024,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331779,8 +337303,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 52,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332057,8 +337581,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332244,8 +337768,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332337,7 +337861,7 @@
 			},
 			"contextWindow": 160000,
 			"maxTokens": 32768,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332426,8 +337950,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332695,8 +338219,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333592,6 +339116,168 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-glm-5-3-flash": {
+			"id": "e2ee-glm-5-3-flash",
+			"name": "e2ee-glm-5-3-flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1310720,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-glm-5-3-p": {
+			"id": "e2ee-glm-5-3-p",
+			"name": "e2ee-glm-5-3-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-gpt-oss-120b-p": {
 			"id": "e2ee-gpt-oss-120b-p",
 			"name": "e2ee-gpt-oss-120b-p",
@@ -333754,6 +339440,168 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-kimi-k2-6": {
+			"id": "e2ee-kimi-k2-6",
+			"name": "e2ee-kimi-k2-6",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-kimi-k3-p": {
+			"id": "e2ee-kimi-k3-p",
+			"name": "e2ee-kimi-k3-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsUsageInStreaming": false
 			}
@@ -334244,6 +340092,87 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-qwen3-8-27b": {
+			"id": "e2ee-qwen3-8-27b",
+			"name": "e2ee-qwen3-8-27b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-qwen3-vl-30b-a3b-p": {
 			"id": "e2ee-qwen3-vl-30b-a3b-p",
 			"name": "e2ee-qwen3-vl-30b-a3b-p",
@@ -334425,8 +340354,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334484,6 +340413,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -334519,8 +340449,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334578,6 +340508,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -334613,8 +340544,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 356,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334672,6 +340603,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -334707,8 +340639,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 195.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334766,6 +340698,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -334801,8 +340734,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 297.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334860,6 +340793,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -334895,8 +340829,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 273,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334954,6 +340888,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -335046,6 +340981,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -335136,6 +341072,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": false,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -335666,8 +341603,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 128000,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 104.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336009,8 +341946,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336103,8 +342040,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 32000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336197,8 +342134,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 200000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336650,8 +342587,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 75.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336741,7 +342678,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336834,8 +342771,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336928,8 +342865,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337119,8 +343056,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337478,8 +343415,96 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 732.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"mercury-2-5": {
+			"id": "mercury-2-5",
+			"name": "Mercury 2.5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04999999999999999,
+				"output": 0.18749999999999994,
+				"cacheRead": 0.004999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338354,8 +344379,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 7.2,
-			"tps": 202.8,
+			"int": 6.8,
+			"tps": 209.8,
 			"identity": {
 				"class": "unknown"
 			},
@@ -338434,8 +344459,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 38.3,
-			"tps": 158.6,
+			"int": 23.4,
+			"tps": 160.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -339574,10 +345599,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26666667,
-				"output": 1.6,
-				"cacheRead": 0.02666667,
-				"cacheWrite": 0.33333334
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -339664,10 +345689,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 7.5,
-				"cacheRead": 0.125,
-				"cacheWrite": 1.5625
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -339754,10 +345779,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 6.25,
-				"output": 37.5,
-				"cacheRead": 0.625,
-				"cacheWrite": 7.8125
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -339844,10 +345869,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 6.25,
-				"output": 37.5,
-				"cacheRead": 0.625,
-				"cacheWrite": 7.8125
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -339934,10 +345959,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.125,
-				"output": 18.75,
-				"cacheRead": 0.3125,
-				"cacheWrite": 3.90625
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -340024,10 +346049,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.125,
-				"output": 18.75,
-				"cacheRead": 0.3125,
-				"cacheWrite": 3.90625
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -340044,6 +346069,186 @@
 			"identity": {
 				"class": "openai",
 				"revision": "56.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai-gpt-6-astra": {
+			"id": "openai-gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai-gpt-6-astra-pro": {
+			"id": "openai-gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 12.5,
+				"output": 62.5,
+				"cacheRead": 1.25,
+				"cacheWrite": 15.625
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -340748,8 +346953,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 18.4,
-			"tps": 57.1,
+			"int": 12,
+			"tps": 58.4,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -341008,8 +347213,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 144.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341100,8 +347305,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 82.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341192,8 +347397,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 82.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341284,8 +347489,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341376,8 +347581,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 22.3,
+			"tps": 122.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341709,8 +347914,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 20.9,
-			"tps": 54.1,
+			"int": 13.4,
+			"tps": 55.7,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -347585,6 +353790,68 @@
 			},
 			"supportsComputerUse": false
 		},
+		"deepseek/deepseek-v4.1-flash-beta": {
+			"id": "deepseek/deepseek-v4.1-flash-beta",
+			"name": "DeepSeek V4.1 Flash Beta",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek"
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-2.0-flash": {
 			"id": "google/gemini-2.0-flash",
 			"requiresGlyphTokenization": false,
@@ -348248,7 +354515,7 @@
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
 			"requiresGlyphTokenization": false,
-			"name": "Gemini 3.1 Pro (Preview)",
+			"name": "Gemini 3.1 Pro Preview",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -348805,6 +355072,64 @@
 			},
 			"supportsComputerUse": false
 		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0.004,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
 		"inception/mercury-coder-small": {
 			"id": "inception/mercury-coder-small",
 			"requiresGlyphTokenization": false,
@@ -348856,7 +355181,7 @@
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
 			"requiresGlyphTokenization": false,
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -349087,6 +355412,122 @@
 				"stripImageInput": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-flash-sante": {
+			"id": "inclusionai/ling-3.0-flash-sante",
+			"name": "Ling 3.0 Flash Sante",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"inclusionai/ling-3.0-flash-sante-free": {
+			"id": "inclusionai/ling-3.0-flash-sante-free",
+			"name": "Ling 3.0 Flash Sante (Free)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-tiny-free": {
 			"id": "inclusionai/ling-3.0-tiny-free",
@@ -350236,6 +356677,7 @@
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
 			},
+			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -355416,7 +361858,7 @@
 				"input": 0.39999999999999997,
 				"output": 2.4,
 				"cacheRead": 0.04,
-				"cacheWrite": 0.25
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -355540,7 +361982,7 @@
 				"input": 4,
 				"output": 20,
 				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -355664,7 +362106,7 @@
 				"input": 4,
 				"output": 24,
 				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -355682,6 +362124,130 @@
 				"class": "openai",
 				"family": "gpt",
 				"revision": "5.6.0"
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"int": 52.8,
+			"tps": 54.3,
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-fast": {
+			"id": "openai/gpt-6-astra-fast",
+			"name": "GPT-6 Astra (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 20,
+				"output": 100,
+				"cacheRead": 2,
+				"cacheWrite": 25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
 			},
 			"compat": {
 				"officialEndpoint": false,
@@ -357684,7 +364250,7 @@
 		"tencent/hy3": {
 			"id": "tencent/hy3",
 			"requiresGlyphTokenization": false,
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -360403,9 +366969,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7,
-				"output": 2.2,
-				"cacheRead": 0.13,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -362459,6 +369025,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -362549,6 +369116,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -362639,6 +369207,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -362730,6 +369299,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -362821,6 +369391,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -362912,6 +369483,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363002,6 +369574,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363092,6 +369665,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363182,6 +369756,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363272,6 +369847,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363374,6 +369950,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363481,6 +370058,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363588,6 +370166,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363695,6 +370274,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363790,6 +370370,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363881,6 +370462,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -363972,6 +370554,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364063,6 +370646,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364154,6 +370738,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364199,7 +370784,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -364248,6 +370833,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364299,7 +370885,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -364348,6 +370934,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364453,6 +371040,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364552,6 +371140,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364662,6 +371251,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364710,8 +371300,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 120.7,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -364760,6 +371350,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364828,8 +371419,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -364878,6 +371469,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -364946,8 +371538,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.8,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -364994,6 +371586,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365105,6 +371698,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365198,6 +371792,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365294,6 +371889,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365384,6 +371980,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365431,13 +372028,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -365486,6 +372076,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365498,6 +372089,13 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"int": 25.2,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -365534,13 +372132,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -365589,6 +372180,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365601,6 +372193,13 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"int": 25.2,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -365636,25 +372235,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -365701,6 +372281,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365713,6 +372294,25 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -365752,26 +372352,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 37.9,
-			"tps": 134.9,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -365820,6 +372400,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365832,6 +372413,26 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"int": 25.4,
+			"tps": 120.7,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -365873,26 +372474,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 55.8,
-			"tps": 56.3,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -365941,6 +372522,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -365953,6 +372535,26 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"int": 39.1,
+			"tps": 55.7,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -365994,27 +372596,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
-			"int": 60.9,
-			"tps": 61.3,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -366061,6 +372642,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -366073,6 +372655,27 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"int": 44.4,
+			"tps": 55.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.6.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -366097,27 +372700,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 512000,
 			"maxTokens": 512000,
-			"identity": {
-				"class": "xai",
-				"family": "grok"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -366166,6 +372755,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -366178,6 +372768,11 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -366214,12 +372809,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "0.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -366268,6 +372857,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -366280,6 +372870,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "0.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -366300,28 +372896,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
 			"maxTokens": 200000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "2.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 37.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -366370,6 +372951,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -366382,6 +372964,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -366411,7 +372999,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -366509,7 +373097,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 35.9,
+			"int": 23.9,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -366606,7 +373194,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -366800,8 +373388,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -367087,7 +373675,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -367267,8 +373855,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -367451,7 +374039,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -367631,8 +374219,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -367815,7 +374403,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -367995,8 +374583,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -368196,7 +374784,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368256,8 +374844,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 61.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368379,8 +374967,8 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 46.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368440,8 +375028,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368502,8 +375090,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 45.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368563,8 +375151,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368624,8 +375212,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 99.7,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368746,8 +375334,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368808,7 +375396,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368870,8 +375458,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -368932,8 +375520,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -368991,8 +375579,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -369054,8 +375642,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -369149,7 +375737,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -369193,6 +375781,164 @@
 		}
 	},
 	"zenmux": {
+		"alibaba/wan3.0-video": {
+			"id": "alibaba/wan3.0-video",
+			"name": "Wan3.0-Video",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"alibaba/wan3.0-video-prime": {
+			"id": "alibaba/wan3.0-video-prime",
+			"name": "Wan3.0-Video-Prime",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-3.5-haiku": {
 			"id": "anthropic/claude-3.5-haiku",
 			"requiresGlyphTokenization": true,
@@ -369381,8 +376127,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 62.9,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -369752,8 +376498,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 46,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -369816,8 +376562,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 38,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -369879,8 +376625,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 45.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -369944,8 +376690,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -370198,8 +376944,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -370260,8 +377006,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 79.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -370388,7 +377134,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 22.3,
+			"int": 14.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -370582,6 +377328,95 @@
 			"identity": {
 				"class": "baidu",
 				"family": "ernie"
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bfl/flux-3-video": {
+			"id": "bfl/flux-3-video",
+			"name": "FLUX.3 Video",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			},
 			"compat": {
 				"supportsStore": true,
@@ -371269,6 +378104,85 @@
 			},
 			"supportsComputerUse": false
 		},
+		"bytedance/doubao-seed-asr-2.0": {
+			"id": "bytedance/doubao-seed-asr-2.0",
+			"name": "Doubao-Seed-ASR-2.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1024,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"bytedance/doubao-seed-character": {
 			"id": "bytedance/doubao-seed-character",
 			"name": "Doubao-Seed-Character",
@@ -371483,6 +378397,166 @@
 				"class": "bytedance",
 				"family": "doubao"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bytedance/doubao-seedance-2.0": {
+			"id": "bytedance/doubao-seedance-2.0",
+			"name": "Doubao-Seedance-2.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bytedance/doubao-seedance-2.5": {
+			"id": "bytedance/doubao-seedance-2.5",
+			"name": "Doubao-Seedance-2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -371903,7 +378977,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -372080,8 +379154,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -372441,8 +379515,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 74,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -372759,6 +379833,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -372842,6 +379917,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -372878,8 +379954,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 202.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -372936,6 +380012,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -372972,7 +380049,7 @@
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 296.4,
 			"identity": {
 				"class": "gemini",
 				"family": "lite",
@@ -373020,6 +380097,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373055,8 +380133,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 123.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373114,6 +380192,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373206,6 +380285,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373296,6 +380376,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373387,6 +380468,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373480,6 +380562,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373515,8 +380598,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 65530,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 303.3,
 			"identity": {
 				"class": "gemini",
 				"family": "lite",
@@ -373564,6 +380647,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373579,6 +380663,88 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			}
+		},
+		"google/gemini-3.1-flash-tts-preview": {
+			"id": "google/gemini-3.1-flash-tts-preview",
+			"name": "Gemini 3.1 Flash TTS Preview",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": null,
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.1.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "gemini",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
@@ -373599,8 +380765,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373656,6 +380822,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373691,8 +380858,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 210.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373750,6 +380917,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373842,6 +381010,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -373936,6 +381105,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -374030,6 +381200,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -374124,6 +381295,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -374218,6 +381390,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -374243,7 +381416,8 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.2,
@@ -374298,6 +381472,7 @@
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
 				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "google-function",
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
@@ -374810,7 +381985,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -375488,8 +382663,8 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 65000,
-			"int": 31.7,
-			"tps": 128.3,
+			"int": 17.3,
+			"tps": 118.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -375737,6 +382912,243 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"klingai/kling-3.0": {
+			"id": "klingai/kling-3.0",
+			"name": "Kling-3.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"klingai/kling-3.0-omni": {
+			"id": "klingai/kling-3.0-omni",
+			"name": "Kling-3.0-Omni",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"klingai/kling-3.0-turbo": {
+			"id": "klingai/kling-3.0-turbo",
+			"name": "Kling-3.0-Turbo",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"kuaishou/kat-coder-air-v2.5": {
 			"id": "kuaishou/kat-coder-air-v2.5",
@@ -375992,7 +383404,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"int": 33.7,
+			"int": 21.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -376735,6 +384147,7 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
+			"tps": 229.5,
 			"supportsComputerUse": false
 		},
 		"meta/muse-spark-1.3-contributor": {
@@ -377004,6 +384417,166 @@
 			},
 			"supportsComputerUse": false
 		},
+		"minimax/minimax-h3": {
+			"id": "minimax/minimax-h3",
+			"name": "MiniMax H3",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "minimax"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"minimax/minimax-h3-max": {
+			"id": "minimax/minimax-h3-max",
+			"name": "MiniMax H3 Max",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "minimax",
+				"effort": "max",
+				"logicalId": "minimax/minimax-h3"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
 			"name": "MiniMax M2",
@@ -377022,8 +384595,8 @@
 			},
 			"contextWindow": 204000,
 			"maxTokens": 64000,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 88.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -377191,8 +384764,8 @@
 			},
 			"contextWindow": 204000,
 			"maxTokens": 64000,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 85.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -377281,8 +384854,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 93.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -377459,8 +385032,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131070,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 67.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -377638,8 +385211,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 100.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378166,7 +385739,7 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 64000,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378259,8 +385832,8 @@
 			},
 			"contextWindow": 262140,
 			"maxTokens": 262140,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 55.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378354,8 +385927,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378632,8 +386205,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 37.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378817,7 +386390,7 @@
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
-			"name": "Nex N2 Pro",
+			"name": "Nex-N2-Pro",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -379417,8 +386990,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 86.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -379590,7 +387163,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -379955,8 +387528,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 115.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380128,7 +387701,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380219,7 +387792,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380308,8 +387881,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 77,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380481,7 +388054,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380741,8 +388314,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 132.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380833,8 +388406,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 139.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380924,8 +388497,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 221.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -381006,8 +388579,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 171.4,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -381179,8 +388752,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 87.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -381454,8 +389027,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 112.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -381547,8 +389120,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 67.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -381640,8 +389213,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 101.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -381713,6 +389286,99 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			}
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"int": 52.8,
+			"tps": 54.3,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-image-1.5": {
 			"id": "openai/gpt-image-1.5",
@@ -381820,6 +389486,247 @@
 				"family": "gpt",
 				"revision": "2.0.0"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-image-2.5-flare": {
+			"id": "openai/gpt-image-2.5-flare",
+			"name": "GPT-Image-2.5-Flare",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 0,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-image-2.5-sunburst": {
+			"id": "openai/gpt-image-2.5-sunburst",
+			"name": "GPT-Image-2.5-Sunburst",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 0,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-transcribe": {
+			"id": "openai/gpt-transcribe",
+			"name": "GPT Transcribe",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -382093,6 +390000,243 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"pixverse/c1": {
+			"id": "pixverse/c1",
+			"name": "C1",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"pixverse/v6": {
+			"id": "pixverse/v6",
+			"name": "V6",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen-audio-3.0-tts-plus": {
+			"id": "qwen/qwen-audio-3.0-tts-plus",
+			"name": "Qwen-Audio-3.0-TTS-Plus",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 20,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
 				"omitReasoningEffort": false,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
@@ -382648,8 +390792,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 49.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -382809,6 +390953,85 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3-rerank": {
+			"id": "qwen/qwen3-rerank",
+			"name": "Qwen3 Rerank",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"qwen/qwen3-vl-embedding": {
 			"id": "qwen/qwen3-vl-embedding",
 			"name": "Qwen3 VL Embedding",
@@ -382817,7 +391040,8 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.1,
@@ -382923,6 +391147,87 @@
 				"family": "vl",
 				"revision": "3.0.0"
 			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen3-vl-rerank": {
+			"id": "qwen/qwen3-vl-rerank",
+			"name": "Qwen3 VL Rerank",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"family": "vl",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -383347,8 +391652,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383528,8 +391833,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 200.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383620,8 +391925,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383968,7 +392273,7 @@
 		},
 		"qwen/qwen3.8-max": {
 			"id": "qwen/qwen3.8-max",
-			"name": "Qwen3.8 Max",
+			"name": "Qwen3.8-Max",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -384060,7 +392365,7 @@
 		},
 		"qwen/qwen3.8-max-0902": {
 			"id": "qwen/qwen3.8-max-0902",
-			"name": "Qwen3.8-Max-0902",
+			"name": "Qwen3.8 Max 0902",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -384076,7 +392381,7 @@
 				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 131072,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
@@ -384496,7 +392801,7 @@
 		},
 		"sapiens-ai/agnes-2.5-flash": {
 			"id": "sapiens-ai/agnes-2.5-flash",
-			"name": "Agnes-2.5-Flash",
+			"name": "Agnes 2.5 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -384585,7 +392890,7 @@
 		},
 		"sapiens-ai/agnes-2.5-pro": {
 			"id": "sapiens-ai/agnes-2.5-pro",
-			"name": "Agnes-2.5-Pro",
+			"name": "Agnes 2.5 Pro",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -384781,8 +393086,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 213.7,
 			"identity": {
 				"class": "stepfun",
 				"family": "step"
@@ -384953,8 +393258,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 81.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -385210,7 +393515,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -385316,7 +393621,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 34.4,
+			"int": 22.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386646,8 +394951,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 120.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386740,8 +395045,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387268,6 +395573,168 @@
 			},
 			"supportsComputerUse": false
 		},
+		"x-ai/grok-voice-stt-1.0": {
+			"id": "x-ai/grok-voice-stt-1.0",
+			"name": "Grok Voice STT 1.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "1.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"x-ai/grok-voice-tts-1.0": {
+			"id": "x-ai/grok-voice-tts-1.0",
+			"name": "Grok Voice TTS 1.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 15,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "1.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"xiaomi/mimo-v2-flash": {
 			"id": "xiaomi/mimo-v2-flash",
 			"name": "MiMo-V2-Flash",
@@ -387286,7 +395753,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387469,7 +395936,7 @@
 			},
 			"contextWindow": 265000,
 			"maxTokens": 265000,
-			"int": 35.9,
+			"int": 23.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387560,7 +396027,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 256000,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387724,6 +396191,88 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"xiaomi/mimo-v2.5-asr": {
+			"id": "xiaomi/mimo-v2.5-asr",
+			"name": "MiMo-V2.5-ASR",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1024,
+			"maxTokens": null,
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {
+					"minimal": "low",
+					"xhigh": "high"
+				},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
 			"name": "MiMo-V2.5-Pro",
@@ -387742,8 +396291,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 35.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387834,7 +396383,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387924,8 +396473,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 61.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388016,8 +396565,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 67.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388108,8 +396657,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 45.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388381,8 +396930,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388652,8 +397201,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 69,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388744,7 +397293,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388836,8 +397385,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388928,8 +397477,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -389387,7 +397936,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -389750,8 +398299,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 45.9,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -389845,8 +398394,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 95,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390032,7 +398581,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390129,8 +398678,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 27.4,
+			"tps": 59,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390226,8 +398775,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 62.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390502,8 +399051,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 62,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390601,8 +399150,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 71.4,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -390797,7 +399346,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -363,6 +363,9 @@ export interface OpenAICompat {
 	 * (collapse `const`→`enum`, infer `type` on bare enums, strip unsupported
 	 * validators/`prefixItems`) because Moonshot/Kimi native hosts reject
 	 * standard JSON Schema constructs with HTTP 400.
+	 * `"google-function"` triggers the typed function-declaration projection
+	 * used by Gemini/Vertex-backed OpenAI-compatible hosts, whose legacy schema
+	 * validator rejects composition-only nodes without a top-level `type`.
 	 *
 	 * `"grammar"` triggers grammar-sampler normalization (widen bare boolean
 	 * `true`/`{}` subschemas in genuine subschema slots into a value-accepting
@@ -373,13 +376,14 @@ export interface OpenAICompat {
 	 * grammar converter reads them as closed/open-object semantics, and
 	 * `additionalProperties: false` pins the strict object shape.
 	 *
-	 * Default: auto-detected — `"moonshot-mfjs"` on Moonshot native hosts
+	 * Default: auto-detected — `"google-function"` for Gemini-family models on
+	 * OpenAI-compatible adapters; `"moonshot-mfjs"` on Moonshot native hosts
 	 * (api.moonshot.ai / api.kimi.com) and Kimi-family model ids on any host,
 	 * since proxies (OpenRouter, custom gateways) forward schemas to Moonshot
 	 * verbatim; `"grammar"` on local OpenAI-compatible backends. Set `"none"`
 	 * to opt a host out.
 	 */
-	toolSchemaFlavor?: "moonshot-mfjs" | "grammar" | "none";
+	toolSchemaFlavor?: "google-function" | "moonshot-mfjs" | "grammar" | "none";
 	/**
 	 * Stream-watchdog first-event timeout in ms.
 	 * Set to `0` to allow unbounded prompt processing. Default: auto-detected

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -178,16 +178,15 @@ describe("buildModel", () => {
 		expect(model.compat?.supportsStrictMode).toBe(true);
 	});
 
-	it("loads bundled OpenAI-compatible Gemini models with typed function schemas", () => {
-		expect(getBundledModel<"openai-completions">("github-copilot", "gemini-3.8-flash").compat.toolSchemaFlavor).toBe(
-			"google-function",
-		);
-		expect(getBundledModel<"openai-completions">("zenmux", "google/gemini-3.8-flash").compat.toolSchemaFlavor).toBe(
-			"google-function",
-		);
-		expect(getBundledModel<"openrouter">("openrouter", "google/gemini-2.5-flash").compat.toolSchemaFlavor).toBe(
-			"google-function",
-		);
+	it("selects the typed Google function schema flavor for Gemini across OpenAI-compatible adapters", () => {
+		expect(buildModel(completionsSpec({ id: "gemini-3.8-flash" })).compat.toolSchemaFlavor).toBe("google-function");
+		expect(buildModel(responsesSpec({ id: "gemini-3.8-flash" })).compat.toolSchemaFlavor).toBe("google-function");
+		expect(
+			buildModel(openrouterSpec({ id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" })).compat
+				.toolSchemaFlavor,
+		).toBe("google-function");
+		// Non-Gemini models on the same adapters keep the host default.
+		expect(buildModel(completionsSpec()).compat.toolSchemaFlavor).toBeUndefined();
 	});
 
 	it("strips gateway author prefixes and extrinsic tags from display names", () => {

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -185,6 +185,9 @@ describe("buildModel", () => {
 		expect(getBundledModel<"openai-completions">("zenmux", "google/gemini-3.8-flash").compat.toolSchemaFlavor).toBe(
 			"google-function",
 		);
+		expect(getBundledModel<"openrouter">("openrouter", "google/gemini-2.5-flash").compat.toolSchemaFlavor).toBe(
+			"google-function",
+		);
 	});
 
 	it("strips gateway author prefixes and extrinsic tags from display names", () => {

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -178,6 +178,15 @@ describe("buildModel", () => {
 		expect(model.compat?.supportsStrictMode).toBe(true);
 	});
 
+	it("loads bundled OpenAI-compatible Gemini models with typed function schemas", () => {
+		expect(getBundledModel<"openai-completions">("github-copilot", "gemini-3.8-flash").compat.toolSchemaFlavor).toBe(
+			"google-function",
+		);
+		expect(getBundledModel<"openai-completions">("zenmux", "google/gemini-3.8-flash").compat.toolSchemaFlavor).toBe(
+			"google-function",
+		);
+	});
+
 	it("strips gateway author prefixes and extrinsic tags from display names", () => {
 		const cases: [string, string][] = [
 			["Anthropic: Claude Opus 4.6 (Fast) ($$$$)", "Claude Opus 4.6 (Fast)"],

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -13,7 +13,6 @@ import {
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";

--- a/packages/coding-agent/test/tools/provider-schema-compatibility.test.ts
+++ b/packages/coding-agent/test/tools/provider-schema-compatibility.test.ts
@@ -101,6 +101,21 @@ describe("builtin tool schemas provider compatibility", () => {
 		expect(adaptSchemaForStrict(toolWireSchema(todo), todo.strict !== false).strict).toBe(true);
 	});
 
+	it("types task outputSchema for Gemini function declarations", async () => {
+		const tools = await builtinToolsPromise;
+		const task = tools.find(tool => tool.name === "task");
+		expect(task).toBeDefined();
+		if (!task) return;
+
+		const normalized = asSchemaObject(normalizeSchemaForCCA(toolWireSchema(task)));
+		const properties = asSchemaObject(normalized?.properties);
+		const tasks = asSchemaObject(properties?.tasks);
+		const items = asSchemaObject(tasks?.items);
+		const itemProperties = asSchemaObject(items?.properties);
+
+		expect(itemProperties?.outputSchema).toEqual({ type: "object", properties: {} });
+	});
+
 	it("keeps all builtin and hidden tool schemas valid after provider enforcement", async () => {
 		const toolSchemas = await toolSchemasPromise;
 		const failures: string[] = [];


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'import { getTaskSchema } from "./packages/coding-agent/src/task/types.ts"; const schema = getTaskSchema({ isolationEnabled: false, batchEnabled: true }).toJsonSchema(); const properties = schema.properties as Record<string, unknown>; const tasks = properties.tasks as { items: { properties: Record<string, unknown> } }; console.log(JSON.stringify(tasks.items.properties.outputSchema));'` emits a typeless `anyOf` with object, boolean, string, and null branches, matching the Gemini/Vertex-backed HTTP 400 payload.

## Cause
`outputSchemaInputSchema` in `packages/coding-agent/src/task/types.ts` deliberately preserves the canonical mixed schema input, but `convertTools` in `packages/ai/src/providers/openai-completions.ts` and `packages/ai/src/providers/openai-responses.ts` had no Gemini-specific provider projection. OpenAI-compatible gateways therefore forwarded the composition-only node into Google's legacy `functionDeclaration` validator, which requires a top-level type.

## Fix
- Add the `google-function` tool-schema flavor and select it through Gemini class policy for OpenAI-compatible adapters.
- Apply the existing typed Google function-declaration projection after strict adaptation on Chat Completions and Responses payloads while retaining the canonical local task schema.
- Cover both wire paths and the actual built-in task schema; document the compatibility contract and release notes.

## Verification
`bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/openai-responses-tool-quarantine.test.ts` passed 93 tests; `bun test packages/coding-agent/test/tools/provider-schema-compatibility.test.ts` passed 4 tests; `bun check` passed.

Fixes #11336