### PR TITLE
fix(cli): wire model registry into omp read image questions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- `omp read <image>?q=<question>` no longer fails with "Model registry is unavailable for image questions."; the read CLI now wires a model registry so image questions resolve `modelRoles.vision`/`@default` like the agent ([#11338](https://github.com/can1357/oh-my-pi/issues/11338)).
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/cli/read-cli.ts
+++ b/packages/coding-agent/src/cli/read-cli.ts
@@ -7,17 +7,19 @@
  */
 import { getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
 import { extractUriScheme } from "../internal-urls/parse";
 import { InternalUrlRouter } from "../internal-urls/router";
 import { closeDaemonClients } from "../launch/client";
 import { discoverAndLoadMCPTools } from "../mcp/loader";
 import { MCPManager } from "../mcp/manager";
+import { loadCliExtensionProviders } from "../sdk";
 import { discoverAuthStorage } from "../session/auth-broker-config";
 import type { AuthStorage } from "../session/auth-storage";
 import type { ToolSession } from "../tools";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
-import { ReadTool } from "../tools/read";
+import { ReadTool, splitImageQuestionTarget } from "../tools/read";
 import { renderError } from "../tools/tool-errors";
 
 export interface ReadCommandArgs {
@@ -70,6 +72,20 @@ export async function runReadCommand(cmd: ReadCommandArgs): Promise<void> {
 			mcpManager = result.manager;
 			session.mcpManager = mcpManager;
 			MCPManager.setInstance(mcpManager);
+		}
+
+		// `read <image>?q=<question>` delegates to a vision model, which needs a
+		// model registry to resolve modelRoles.vision / @default and fetch its
+		// credentials. The lightweight session above omits it (plain reads never
+		// touch a model), so build one on demand — otherwise the tool aborts with
+		// "Model registry is unavailable for image questions." before resolving
+		// anything (issue #11338).
+		if (splitImageQuestionTarget(cmd.path).question) {
+			authStorage ??= await discoverAuthStorage();
+			const modelRegistry = new ModelRegistry(authStorage);
+			await modelRegistry.hydrateCredentialScopedModelCaches();
+			await loadCliExtensionProviders(modelRegistry, settings, cwd);
+			session.modelRegistry = modelRegistry;
 		}
 
 		const tool = wrapToolWithMetaNotice(new ReadTool(session));

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -603,7 +603,7 @@ const IMAGE_ATTACHMENT_URI_REGEX = /^attachment:\/\/[1-9]\d*$/;
 const IMAGE_QUESTION_SELECTOR_ERROR =
 	"The ?q= selector only supports images (raster files, .svg:img, attachment://N, local:// images, PDF page screenshots).";
 
-function splitImageQuestionTarget(readPath: string): { path: string; question?: string } {
+export function splitImageQuestionTarget(readPath: string): { path: string; question?: string } {
 	const supportsQuestion =
 		!readPath.includes("://") || readPath.startsWith("attachment://") || readPath.startsWith("local://");
 	if (!supportsQuestion || parseSqlitePathCandidates(readPath).length > 0) return { path: readPath };

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -13,7 +13,6 @@ import {
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";

--- a/packages/coding-agent/test/read-cli-image-question.test.ts
+++ b/packages/coding-agent/test/read-cli-image-question.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `omp read <image>?q=<question>` delegates to a vision model, which requires a
+ * model registry to resolve modelRoles.vision / @default and fetch credentials.
+ * The read CLI built a lightweight session with no registry, so the read tool
+ * aborted with "Model registry is unavailable for image questions." before any
+ * resolution (issue #11338). This drives the real `omp read` command in an
+ * isolated agent dir carrying a custom vision provider and asserts it reaches
+ * the completion attempt instead of the registry guard.
+ */
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+// 1x1 PNG so the read tool's image loader accepts the file.
+const PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+// Custom vision provider with a real (dummy) inline key so it counts as
+// available; its baseUrl points at a dead local port, so the completion attempt
+// fails fast with a connection error — never the registry guard, and never a
+// real network call.
+const MODELS_YML = `providers:
+  testvision:
+    api: openai-completions
+    baseUrl: http://127.0.0.1:1/v1
+    apiKey: "test-key"
+    models:
+      - id: vmodel
+        name: Vision Test
+        input:
+          - text
+          - image
+        contextWindow: 128000
+        maxTokens: 4096
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+`;
+
+const RUNNER = `import { runReadCommand } from "../src/cli/read-cli";
+await runReadCommand({ path: process.argv[2] });
+`;
+
+describe("omp read <image>?q=", () => {
+	it("resolves a vision model instead of failing with the registry guard", async () => {
+		const tempDir = TempDir.createSync("@pi-read-cli-imgq-");
+		try {
+			const agentDir = tempDir.join("agent");
+			const home = tempDir.join("home");
+			const project = tempDir.join("project");
+			fs.mkdirSync(agentDir, { recursive: true });
+			fs.mkdirSync(home, { recursive: true });
+			fs.mkdirSync(path.join(project, ".omp"), { recursive: true });
+			// Bound the completion attempt so a dead endpoint aborts quickly instead
+			// of running the provider SDK's full connection backoff.
+			fs.writeFileSync(path.join(project, ".omp", "config.yml"), "images:\n  questionTimeoutMs: 3000\n");
+			fs.writeFileSync(path.join(agentDir, "models.yml"), MODELS_YML);
+			const pngPath = path.join(project, "test.png");
+			fs.writeFileSync(pngPath, Buffer.from(PNG_1X1, "base64"));
+
+			// The runner lives inside the package so its imports resolve against the
+			// repo node_modules; cwd is the isolated project so getProjectDir() never
+			// picks up repo settings.
+			const runnerPath = path.join(import.meta.dir, `.read-cli-runner-${process.pid}.ts`);
+			fs.writeFileSync(runnerPath, RUNNER);
+			try {
+				const child = Bun.spawn(["bun", runnerPath, `${pngPath}?q=describe this image`], {
+					cwd: project,
+					env: {
+						...process.env,
+						HOME: home,
+						PI_CODING_AGENT_DIR: agentDir,
+						PI_TEST_RUNTIME: "1",
+					},
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(child.stdout).text(),
+					new Response(child.stderr).text(),
+					child.exited,
+				]);
+				const output = `${stdout}\n${stderr}`;
+				// The command fails (dead endpoint) but must get past the registry
+				// guard AND model resolution to an actual completion attempt.
+				expect(exitCode).not.toBe(0);
+				expect(output).not.toContain("Model registry is unavailable for image questions.");
+				expect(output).not.toContain("No models available for image questions.");
+			} finally {
+				fs.rmSync(runnerPath, { force: true });
+			}
+		} finally {
+			tempDir.removeSync();
+		}
+	}, 60_000);
+});


### PR DESCRIPTION
## Repro
`omp read <image>?q=<question>` fails immediately with `Model registry is unavailable for image questions.` (exit 1). Confirmed by driving `runReadCommand({ path: "/tmp/test.png?q=describe this image" })` from `packages/coding-agent/src/cli/read-cli.ts`. Note: the report attributes this to the agent (`omp -p` / interactive), but the agent path is fine — `createAgentSession` in `sdk.ts` wires `modelRegistry` onto the tool session, and `read <image>?q=` there resolves the vision model and reaches the provider (verified: returns a provider `401`/`404`, never the guard). Only the `omp read` CLI reproduces the reported error.

## Cause
`resolveImageQuestionModel` (`packages/coding-agent/src/utils/image-question.ts:32-35`) throws that error when `session.modelRegistry` is undefined. The `omp read` CLI builds its `ToolSession` in `read-cli.ts` (`runReadCommand`, lines 47-53) with only `cwd`/`settings`/spawn accessors and no `modelRegistry`, so the guard trips before any model resolution or network call. (The line cited in the issue, `session-tools.ts:1636`, is the MCP `CustomToolContext`, not the session the `read` tool receives.)

## Fix
- `read-cli.ts`: when the requested path is an image question, discover auth storage, build a `ModelRegistry`, hydrate credential-scoped caches, load CLI extension providers, and attach it to the session — mirroring the bench/dry-balance CLI registry setup and the agent's `createAgentSession`. Built on demand only for `?q=` paths so plain reads pay no registry cost; `authStorage` is closed in the existing `finally`.
- `read.ts`: export `splitImageQuestionTarget` so the CLI reuses the tool's own image-question detection instead of duplicating the parse.
- `CHANGELOG.md`: user-facing Fixed entry.

## Verification
`bun test packages/coding-agent/test/read-cli-image-question.test.ts` — new regression test drives the real `omp read` command in an isolated agent dir with a custom vision provider; asserts it gets past the registry guard to a completion attempt (previously the guard error). `bun check` passes. Fixes #11338