### PR TITLE
fix(tui): place recalled history at end

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Recalled prompt history now places the cursor at the end of the entry, so Up restores multiline prompts ready to edit; continue pressing Up to walk through the recalled lines before reaching older history.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -465,7 +465,6 @@ export interface EditorTextAssistProvider {
 	): EditorWordReplacements | null | Promise<EditorWordReplacements | null>;
 }
 
-type HistoryCursorAnchor = "start" | "end";
 type AutocompleteRequest = { kind: "regular"; explicitTab: boolean } | { kind: "force" };
 
 /** What the paste transport knew about the input burst before the editor inserts the payload. */
@@ -816,24 +815,18 @@ export class Editor implements Component, Focusable {
 		this.#historyIndex = newIndex;
 		if (this.#historyIndex === -1) {
 			// Returned to "current" state - clear editor
-			this.#setTextInternal("", "end");
+			this.#setTextInternal("");
 		} else {
-			const cursorAnchor: HistoryCursorAnchor = direction === -1 ? "start" : "end";
-			this.#setTextInternal(this.#history[this.#historyIndex] || "", cursorAnchor);
+			this.#setTextInternal(this.#history[this.#historyIndex] || "");
 		}
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
-	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
+	#setTextInternal(text: string): void {
 		this.#undoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
-		if (cursorAnchor === "start") {
-			this.#state.cursorLine = 0;
-			this.#setCursorCol(0);
-		} else {
-			this.#state.cursorLine = this.#state.lines.length - 1;
-			this.#setCursorCol(this.#state.lines[this.#state.cursorLine]?.length || 0);
-		}
+		this.#state.cursorLine = this.#state.lines.length - 1;
+		this.#setCursorCol(this.#state.lines[this.#state.cursorLine]?.length || 0);
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -194,12 +194,12 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("second");
 		});
 
-		it("exits history mode at the history edit anchor before public insertText", () => {
+		it("keeps the history entry at its end before public insertText", () => {
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.addToHistory("line1\nline2");
-			editor.handleInput("\x1b[A"); // Up - recalls at the top edit anchor
-			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+			editor.handleInput("\x1b[A"); // Up - recalls at the end edit anchor
+			expect(editor.getCursor()).toEqual({ line: 1, col: 5 });
 
 			editor.insertText("[Image #1] ");
 
@@ -305,14 +305,13 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("prompt 5");
 		});
 
-		it("anchors history entry at top when navigating with Up", () => {
+		it("anchors history entry at bottom when navigating with Up", () => {
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.addToHistory("line1\nline2\nline3");
 			editor.handleInput("\x1b[A");
-
 			expect(editor.getText()).toBe("line1\nline2\nline3");
-			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+			expect(editor.getCursor()).toEqual({ line: 2, col: 5 });
 		});
 
 		it("anchors history entry at bottom when navigating with Down", () => {
@@ -320,10 +319,9 @@ describe("Editor component", () => {
 
 			editor.addToHistory("older");
 			editor.addToHistory("line1\nline2\nline3");
-
-			editor.handleInput("\x1b[A"); // latest, anchored at top
-			editor.handleInput("\x1b[A"); // older, anchored at top
-			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+			editor.handleInput("\x1b[A"); // latest, anchored at bottom
+			editor.handleInput("\x1b[A"); // older, anchored at bottom
+			expect(editor.getCursor()).toEqual({ line: 2, col: 5 });
 
 			editor.handleInput("\x1b[B"); // newer, anchored at bottom
 			expect(editor.getText()).toBe("line1\nline2\nline3");
@@ -334,12 +332,12 @@ describe("Editor component", () => {
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.addToHistory("line1\nline2\nline3");
-			editor.handleInput("\x1b[A"); // top anchor
+			editor.handleInput("\x1b[A"); // end anchor
 
-			editor.handleInput("\x1b[B"); // move within entry
-			expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+			editor.handleInput("\x1b[A"); // move within entry
+			expect(editor.getCursor()).toEqual({ line: 1, col: 5 });
 
-			editor.handleInput("\x1b[B");
+			editor.handleInput("\x1b[B"); // move back to the end
 			editor.handleInput("\x1b[B"); // at bottom, exit history
 			expect(editor.getText()).toBe("");
 		});

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -314,14 +314,17 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 2, col: 5 });
 		});
 
-		it("anchors history entry at bottom when navigating with Down", () => {
+		it("anchors older history at the bottom when navigating with Down", () => {
 			const editor = new Editor(defaultEditorTheme);
 
 			editor.addToHistory("older");
 			editor.addToHistory("line1\nline2\nline3");
 			editor.handleInput("\x1b[A"); // latest, anchored at bottom
+			editor.handleInput("\x1b[A"); // move within latest entry
+			editor.handleInput("\x1b[A"); // first visual line of latest entry
 			editor.handleInput("\x1b[A"); // older, anchored at bottom
-			expect(editor.getCursor()).toEqual({ line: 2, col: 5 });
+			expect(editor.getText()).toBe("older");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 5 });
 
 			editor.handleInput("\x1b[B"); // newer, anchored at bottom
 			expect(editor.getText()).toBe("line1\nline2\nline3");


### PR DESCRIPTION
## Summary
- place recalled prompt history at the end of the editor
- remove the start-anchor path that made Up-arrow recall begin at column zero
- update multiline history navigation coverage for end anchoring and in-entry movement

## Verification
- `npx --yes bun --cwd=packages/tui run check` — passed
- `npx --yes bun test packages/tui/test/editor.test.ts` — blocked by the missing Windows native addon
- `npx --yes bun --cwd=packages/natives run build` — timed out after 300 seconds while building the native addon