### PR TITLE
feat(coding-agent): expose subagent observability

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -210,6 +210,7 @@ Handlers and tool `execute` receive `ctx` with:
 - `localProtocolOptions` (optional calling-session `local://` root mapping for external tool bridges)
 - `getContextUsage()`
 - `getAsyncJobSnapshot()` returns the current session's read-only async-job snapshot, or `null` when no session owns the context
+- `subagents` (optional versioned, read-only root-agent-tree observability; see below)
 - `compact(...)`
 - `isIdle()`, `hasPendingMessages()`, `abort()`
 - `shutdown()`
@@ -239,6 +240,24 @@ pi.on("session_start", async (_event, ctx) => {
 ```
 
 If you use raw `setInterval`/`setTimeout` or detached promises instead, you own the isolation: wrap the callback body in your own `try/catch` (an unhandled throw will take down the session) and clear the timer on `session_shutdown`.
+
+### Subagent observability (`ctx.subagents`)
+
+Feature-detect `ctx.subagents?.version === 1`, subscribe before taking the initial snapshot, and discard queued events whose `revision` is not newer than the snapshot. Revisions are monotonic within that root observer, so a revision gap can be recovered with another snapshot.
+
+```ts
+if (ctx.subagents?.version === 1) {
+  const unsubscribe = ctx.subagents.subscribe((event) => {
+    // Update a read-only dashboard from registered/lifecycle/progress/removed.
+  });
+  const initial = ctx.subagents.getSnapshot();
+  // Ignore queued events with event.revision <= initial.revision.
+
+  pi.on("session_shutdown", unsubscribe);
+}
+```
+
+The snapshot contains at most 512 records and retains the root record for stable correlation. Agent, parent, root, and parent-tool-call IDs are opaque. Progress exposes only allowlisted counts, current tool, actual resolved model/thinking metadata, and timestamps. Prompts, assignments, tool arguments/output, free-form intent/errors, transcripts, environment values, and absolute session paths never cross this API. `subscribe()` returns an idempotent unsubscribe function; session teardown also releases the observer's internal registry and event-bus listeners.
 
 ### Model selection (`ctx.models`)
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
+### Added
+
+- Extensions can observe the current root agent tree through the read-only `ctx.subagents` v1 snapshot and subscription API, with stable nested identities, lifecycle/progress events, bounded records, and sanitized executor metadata.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -12,6 +12,7 @@ export {
 	loadExtensions,
 } from "./loader";
 export * from "./runner";
+export * from "./subagent-observability";
 // Type guards
 export * from "./types";
 export * from "./wrapper";

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -23,6 +23,7 @@ import { addFileDeleteFallback, addFileWriteFallback } from "../../tools/file-wr
 import type { BranchHandler, NavigateTreeHandler, NewSessionHandler } from "../session-handler-types";
 import { ManagedTimers } from "./managed-timers";
 import { createExtensionModelQuery } from "./model-api";
+import type { SubagentObservabilityController } from "./subagent-observability";
 import type {
 	AfterProviderResponseEvent,
 	AssistantThinkingRenderer,
@@ -395,6 +396,7 @@ export async function emitSessionShutdownEvent(extensionRunner: ExtensionRunner 
 	} finally {
 		extensionRunner.disposeFileFallbacks();
 		extensionRunner.clearManagedTimers();
+		extensionRunner.disposeSubagentObservability();
 	}
 }
 
@@ -607,6 +609,7 @@ export class ExtensionRunner {
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
 		getAsyncJobSnapshot?: () => AsyncJobSnapshot | null,
+		private readonly subagents?: SubagentObservabilityController,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
@@ -1173,6 +1176,7 @@ export class ExtensionRunner {
 			getContextUsage: () => this.#getContextUsageFn(),
 			compact: instructionsOrOptions => this.#compactFn(instructionsOrOptions),
 			getAsyncJobSnapshot: () => this.#getAsyncJobSnapshotFn(),
+			subagents: this.subagents,
 			hasUI: this.hasUI(),
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
@@ -1222,6 +1226,11 @@ export class ExtensionRunner {
 	 */
 	clearManagedTimers(): void {
 		this.#managedTimers.clearAll();
+	}
+
+	/** Release the registry and root-bus listeners owned by the public observer. */
+	disposeSubagentObservability(): void {
+		this.subagents?.dispose();
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/subagent-observability.ts
+++ b/packages/coding-agent/src/extensibility/extensions/subagent-observability.ts
@@ -1,0 +1,325 @@
+import type { AgentRef, AgentStatus, RegistryEvent } from "../../registry/agent-registry";
+import { AgentRegistry } from "../../registry/agent-registry";
+import {
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+} from "../../task/types";
+import type { ConfiguredThinkingLevel } from "../../thinking";
+import type { EventBus } from "../../utils/event-bus";
+
+const SUBAGENT_SNAPSHOT_LIMIT = 512;
+const OBSERVABILITY_LABEL_LIMIT = 256;
+
+export type SubagentId = string;
+export type SubagentStatus =
+	| "registered"
+	| "running"
+	| "idle"
+	| "parked"
+	| "completed"
+	| "failed"
+	| "aborted"
+	| "removed";
+export type SubagentKind = "root" | "task" | "eval" | "other";
+
+export interface SubagentProgress {
+	readonly updatedAt: number;
+	readonly phase?: string;
+	readonly currentTool?: string;
+	readonly toolCount?: number;
+	readonly tokens?: number;
+	readonly contextTokens?: number;
+	readonly costUsd?: number;
+	readonly resolvedModel?: string;
+	readonly effort?: ConfiguredThinkingLevel;
+}
+
+export interface SubagentRecord {
+	readonly agentId: SubagentId;
+	readonly rootAgentId: SubagentId;
+	readonly parentAgentId?: SubagentId;
+	readonly parentToolCallId?: string;
+	readonly kind: SubagentKind;
+	readonly status: SubagentStatus;
+	readonly detached: boolean;
+	readonly sessionId?: string;
+	readonly startedAt: number;
+	readonly lastActivityAt: number;
+	readonly progress?: SubagentProgress;
+}
+
+export interface SubagentSnapshot {
+	readonly version: 1;
+	readonly rootAgentId: SubagentId;
+	readonly revision: number;
+	readonly capturedAt: number;
+	readonly agents: readonly SubagentRecord[];
+}
+
+export interface SubagentEventBase {
+	readonly version: 1;
+	readonly revision: number;
+	readonly observedAt: number;
+	readonly rootAgentId: SubagentId;
+	readonly agentId: SubagentId;
+}
+
+export type SubagentEvent =
+	| (SubagentEventBase & { readonly type: "registered"; readonly agent: SubagentRecord })
+	| (SubagentEventBase & {
+			readonly type: "lifecycle";
+			readonly from: SubagentStatus;
+			readonly to: SubagentStatus;
+			readonly agent: SubagentRecord;
+	  })
+	| (SubagentEventBase & {
+			readonly type: "progress";
+			readonly progress: SubagentProgress;
+			readonly agent: SubagentRecord;
+	  })
+	| (SubagentEventBase & { readonly type: "removed"; readonly finalStatus: SubagentStatus });
+
+type SubagentEventInput = SubagentEvent extends infer Event
+	? Event extends SubagentEvent
+		? Omit<Event, "version" | "revision" | "observedAt" | "rootAgentId">
+		: never
+	: never;
+
+/** Read-only, sanitized view of the current root session's agent tree. */
+export interface SubagentObservability {
+	readonly version: 1;
+	getSnapshot(): SubagentSnapshot;
+	subscribe(listener: (event: SubagentEvent) => void): () => void;
+}
+
+export interface CreateSubagentObservabilityOptions {
+	registry?: AgentRegistry;
+	eventBus: EventBus;
+	rootAgentId: string;
+	now?: () => number;
+}
+
+export interface SubagentObservabilityController extends SubagentObservability {
+	dispose(): void;
+}
+
+/** Resolve an agent's root from stable registry parent links. */
+export function resolveRootAgentId(registry: AgentRegistry, agentId: string): string {
+	let current = registry.get(agentId);
+	const visited = new Set<string>();
+	while (current?.parentId && !visited.has(current.id)) {
+		visited.add(current.id);
+		const parent = registry.get(current.parentId);
+		if (!parent) return current.parentId;
+		current = parent;
+	}
+	return current?.id ?? agentId;
+}
+
+function registryStatus(status: AgentStatus): SubagentStatus {
+	return status;
+}
+
+function lifecycleStatus(status: SubagentLifecyclePayload["status"]): SubagentStatus {
+	return status === "started" ? "running" : status;
+}
+
+function copyProgress(progress: SubagentProgress): SubagentProgress {
+	return { ...progress };
+}
+
+function copyRecord(record: SubagentRecord): SubagentRecord {
+	return { ...record, ...(record.progress ? { progress: copyProgress(record.progress) } : {}) };
+}
+
+function copyEvent(event: SubagentEvent): SubagentEvent {
+	if (event.type === "removed") return { ...event };
+	if (event.type === "progress") {
+		return { ...event, progress: copyProgress(event.progress), agent: copyRecord(event.agent) };
+	}
+	return { ...event, agent: copyRecord(event.agent) };
+}
+
+function sanitizedLabel(value: string): string {
+	return Array.from(value)
+		.filter(character => {
+			const code = character.codePointAt(0) ?? 0;
+			return code >= 32 && code !== 127;
+		})
+		.join("")
+		.slice(0, OBSERVABILITY_LABEL_LIMIT);
+}
+
+export function createSubagentObservability(
+	options: CreateSubagentObservabilityOptions,
+): SubagentObservabilityController {
+	const registry = options.registry ?? AgentRegistry.global();
+	const now = options.now ?? Date.now;
+	const listeners = new Set<(event: SubagentEvent) => void>();
+	const statuses = new Map<string, SubagentStatus>();
+	const metadata = new Map<string, { parentToolCallId?: string; detached?: boolean; progress?: SubagentProgress }>();
+	let revision = 0;
+	let disposed = false;
+
+	const rootOf = (ref: AgentRef): string => {
+		let current = ref;
+		const visited = new Set<string>();
+		while (current.parentId && !visited.has(current.id)) {
+			visited.add(current.id);
+			const parent = registry.get(current.parentId);
+			if (!parent) return current.parentId;
+			current = parent;
+		}
+		return current.id;
+	};
+	const belongs = (ref: AgentRef): boolean => rootOf(ref) === options.rootAgentId;
+	const getRef = (agentId: string): AgentRef | undefined => {
+		const ref = registry.get(agentId);
+		return ref && belongs(ref) ? ref : undefined;
+	};
+	const makeProgress = (payload: SubagentProgressPayload): SubagentProgress => ({
+		updatedAt: now(),
+		...(payload.progress.currentTool ? { currentTool: sanitizedLabel(payload.progress.currentTool) } : {}),
+		toolCount: payload.progress.toolCount,
+		tokens: payload.progress.tokens,
+		...(payload.progress.contextTokens === undefined ? {} : { contextTokens: payload.progress.contextTokens }),
+		costUsd: payload.progress.cost,
+		...(payload.progress.resolvedModelIdentity
+			? { resolvedModel: sanitizedLabel(payload.progress.resolvedModelIdentity) }
+			: {}),
+		...(payload.progress.resolvedThinkingLevel ? { effort: payload.progress.resolvedThinkingLevel } : {}),
+	});
+	const makeRecord = (ref: AgentRef): SubagentRecord => {
+		const extra = metadata.get(ref.id);
+		const sessionId = ref.session?.sessionId;
+		return {
+			agentId: ref.id,
+			rootAgentId: options.rootAgentId,
+			...(ref.parentId ? { parentAgentId: ref.parentId } : {}),
+			...(extra?.parentToolCallId ? { parentToolCallId: extra.parentToolCallId } : {}),
+			kind: ref.id === options.rootAgentId ? "root" : ref.kind === "sub" ? "task" : "other",
+			status: statuses.get(ref.id) ?? registryStatus(ref.status),
+			detached: extra?.detached ?? false,
+			...(sessionId ? { sessionId } : {}),
+			startedAt: ref.createdAt,
+			lastActivityAt: ref.lastActivity,
+			...(extra?.progress ? { progress: copyProgress(extra.progress) } : {}),
+		};
+	};
+	const publish = (event: SubagentEventInput): void => {
+		if (disposed) return;
+		const full = {
+			...event,
+			version: 1 as const,
+			revision: ++revision,
+			observedAt: now(),
+			rootAgentId: options.rootAgentId,
+		} as SubagentEvent;
+		for (const listener of listeners) {
+			try {
+				listener(copyEvent(full));
+			} catch {
+				// Public observers are isolated from execution and from one another.
+			}
+		}
+	};
+
+	for (const ref of registry.list()) {
+		if (belongs(ref)) statuses.set(ref.id, registryStatus(ref.status));
+	}
+
+	const handleRegistry = (event: RegistryEvent): void => {
+		if (!belongs(event.ref)) return;
+		if (event.type === "registered") {
+			statuses.set(event.ref.id, registryStatus(event.ref.status));
+			publish({ type: "registered", agentId: event.ref.id, agent: makeRecord(event.ref) });
+			return;
+		}
+		if (event.type === "status_changed") {
+			const from = statuses.get(event.ref.id) ?? "registered";
+			const to = registryStatus(event.ref.status);
+			statuses.set(event.ref.id, to);
+			if (from !== to) {
+				publish({ type: "lifecycle", agentId: event.ref.id, from, to, agent: makeRecord(event.ref) });
+			}
+			return;
+		}
+		if (event.type === "removed") {
+			const finalStatus = statuses.get(event.ref.id) ?? registryStatus(event.ref.status);
+			publish({ type: "removed", agentId: event.ref.id, finalStatus });
+			statuses.delete(event.ref.id);
+			metadata.delete(event.ref.id);
+		}
+	};
+	const registryUnsubscribe = registry.onChange(handleRegistry);
+	const lifecycleUnsubscribe = options.eventBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, data => {
+		const payload = data as SubagentLifecyclePayload;
+		const ref = getRef(payload.id);
+		if (!ref) return;
+		const prior = metadata.get(payload.id) ?? {};
+		metadata.set(payload.id, {
+			...prior,
+			...(payload.parentToolCallId ? { parentToolCallId: payload.parentToolCallId } : {}),
+			...(payload.detached === undefined ? {} : { detached: payload.detached }),
+		});
+		const from = statuses.get(payload.id) ?? registryStatus(ref.status);
+		const to = lifecycleStatus(payload.status);
+		statuses.set(payload.id, to);
+		publish({ type: "lifecycle", agentId: payload.id, from, to, agent: makeRecord(ref) });
+	});
+	const progressUnsubscribe = options.eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, data => {
+		const payload = data as SubagentProgressPayload;
+		const ref = getRef(payload.progress.id);
+		if (!ref) return;
+		const progress = makeProgress(payload);
+		const prior = metadata.get(ref.id) ?? {};
+		metadata.set(ref.id, {
+			...prior,
+			progress,
+			...(payload.parentToolCallId ? { parentToolCallId: payload.parentToolCallId } : {}),
+			...(payload.detached === undefined ? {} : { detached: payload.detached }),
+		});
+		publish({ type: "progress", agentId: ref.id, progress: copyProgress(progress), agent: makeRecord(ref) });
+	});
+
+	return {
+		version: 1,
+		getSnapshot: () => {
+			const sorted = registry
+				.list()
+				.filter(belongs)
+				.sort((left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id));
+			const root = sorted.find(ref => ref.id === options.rootAgentId);
+			const retained = sorted.filter(ref => ref !== root).slice(-(SUBAGENT_SNAPSHOT_LIMIT - (root ? 1 : 0)));
+			return {
+				version: 1,
+				rootAgentId: options.rootAgentId,
+				revision,
+				capturedAt: now(),
+				agents: [...(root ? [root] : []), ...retained].map(ref => copyRecord(makeRecord(ref))),
+			};
+		},
+		subscribe: listener => {
+			if (disposed) return () => {};
+			listeners.add(listener);
+			let subscribed = true;
+			return () => {
+				if (!subscribed) return;
+				subscribed = false;
+				listeners.delete(listener);
+			};
+		},
+		dispose: () => {
+			if (disposed) return;
+			disposed = true;
+			registryUnsubscribe();
+			lifecycleUnsubscribe();
+			progressUnsubscribe();
+			listeners.clear();
+			statuses.clear();
+			metadata.clear();
+		},
+	};
+}

--- a/packages/coding-agent/src/extensibility/extensions/subagent-observability.ts
+++ b/packages/coding-agent/src/extensibility/extensions/subagent-observability.ts
@@ -199,7 +199,7 @@ export function createSubagentObservability(
 			rootAgentId: options.rootAgentId,
 			...(ref.parentId ? { parentAgentId: ref.parentId } : {}),
 			...(extra?.parentToolCallId ? { parentToolCallId: extra.parentToolCallId } : {}),
-			kind: ref.id === options.rootAgentId ? "root" : ref.kind === "sub" ? "task" : "other",
+			kind: ref.id === options.rootAgentId ? "root" : ref.kind === "sub" ? (ref.invocationKind ?? "task") : "other",
 			status: statuses.get(ref.id) ?? registryStatus(ref.status),
 			detached: extra?.detached ?? false,
 			...(sessionId ? { sessionId } : {}),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -78,6 +78,7 @@ import type {
 	WriteToolInput,
 } from "../../tools";
 import type { ApprovalMode } from "../../tools/approval";
+import type { SubagentObservability } from "./subagent-observability";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
 import type { EventBus } from "../../utils/event-bus";
 import type {
@@ -461,6 +462,8 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Get a read-only snapshot of async jobs owned by this session. */
 	getAsyncJobSnapshot(): AsyncJobSnapshot | null;
+	/** Optional read-only, sanitized view of this session's root subagent tree. */
+	subagents?: SubagentObservability;
 	/** Compact the session context (interactive mode shows UI). */
 	compact(instructionsOrOptions?: string | CompactOptions): Promise<void>;
 	/** Whether UI is available (false in print/RPC mode) */

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -73,6 +73,8 @@ export interface AgentRef {
 	id: string;
 	displayName: string;
 	kind: AgentKind;
+	/** Structural launch surface for subagents; independent of labels and agent definitions. */
+	invocationKind?: "task" | "eval";
 	parentId?: string;
 	status: AgentStatus;
 	/** Null exactly when parked/aborted. */
@@ -100,6 +102,8 @@ export interface RegisterInput {
 	id: string;
 	displayName: string;
 	kind: AgentKind;
+	/** Structural launch surface for subagents; independent of labels and agent definitions. */
+	invocationKind?: "task" | "eval";
 	parentId?: string;
 	session: AgentSession | null;
 	sessionFile?: string | null;
@@ -147,6 +151,7 @@ export class AgentRegistry {
 			id: input.id,
 			displayName: input.displayName,
 			kind: input.kind,
+			invocationKind: input.invocationKind,
 			parentId: input.parentId,
 			status: input.status ?? "running",
 			session: input.session,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -115,6 +115,9 @@ import {
 	loadExtensions,
 	type PreparedExtension,
 	type RegisteredTool,
+	createSubagentObservability,
+	resolveRootAgentId,
+	type SubagentObservabilityController,
 	type ToolDefinition,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
@@ -1359,6 +1362,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// buffer — so we can't rely on it to catch startup events for the extension runner.
 	const startupCredentialDisabledEvents: CredentialDisabledEvent[] = [];
 	let credentialDisabledTarget: ExtensionRunner | undefined;
+	let subagentObservability: SubagentObservabilityController | undefined;
 	const unsubscribeCredentialDisabled: (() => void) | undefined = authStorage.onCredentialDisabled(event => {
 		if (credentialDisabledTarget) {
 			// Discard return: any handler error is routed through runner.onError listeners.
@@ -2799,6 +2803,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// (The builtin autoresearch extension is unconditionally loaded above, so this scenario
 		// is unreachable; unconditional runner construction keeps that invariant explicit and
 		// prevents future optional extensions from silently re-opening the hole.)
+		const rootAgentId = resolveRootAgentId(agentRegistry, options.parentAgentId ?? resolvedAgentId);
+		subagentObservability = createSubagentObservability({
+			registry: agentRegistry,
+			eventBus: subagentEventBus,
+			rootAgentId,
+		});
 		const extensionRunner: ExtensionRunner = new ExtensionRunner(
 			extensionsResult.extensions,
 			extensionsResult.runtime,
@@ -2809,6 +2819,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			settings,
 			localProtocolOptions,
 			() => (hasSession ? session.getAsyncJobSnapshot() : null),
+			subagentObservability,
 		);
 
 		credentialDisabledTarget = extensionRunner;
@@ -4316,6 +4327,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// dispose-wrap took ownership. Idempotent with dispose() — Set.delete is a no-op
 		// for already-removed listeners.
 		unsubscribeCredentialDisabled?.();
+		subagentObservability?.dispose();
 		try {
 			if (hasSession) {
 				await session.dispose();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -605,6 +605,8 @@ export interface CreateAgentSessionOptions {
 	 * top-level "Main" session, which has no parent.
 	 */
 	parentAgentId?: string;
+	/** Structural launch surface for registry observability of subagent sessions. */
+	invocationKind?: "task" | "eval";
 	/** Inherited eval executor session id for subagents sharing parent eval state. */
 	parentEvalSessionId?: string;
 
@@ -3322,6 +3324,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			id: resolvedAgentId,
 			displayName: resolvedAgentDisplayName,
 			kind: agentKind,
+			invocationKind: options.invocationKind,
 			parentId: options.parentAgentId,
 			session: null,
 			sessionFile: sessionManager.getSessionFile() ?? null,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -409,6 +409,8 @@ export interface ExecutorOptions {
 	index: number;
 	id: string;
 	parentToolCallId?: string;
+	/** Structural launch surface propagated to the registry for public observability. */
+	invocationKind?: "task" | "eval";
 	/**
 	 * Spawn runs as a detached background job (parent turn not blocked on it).
 	 * Rides the subagent lifecycle/progress payloads so HUD-style surfaces can
@@ -3509,6 +3511,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				agentId: id,
 				agentDisplayName: agent.name,
 				agentName: agent.name,
+				invocationKind: options.invocationKind,
 				expectedAgentRef,
 				enableLsp: lspEnabled,
 				enableIrc: options.enableIrc,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -418,6 +418,7 @@ function buildExecutorOptions(
 		parentToolCallId: request.parentToolCallId,
 		detached: request.detached,
 		id,
+		invocationKind: request.invocationKind,
 		taskDepth: session.taskDepth ?? 0,
 		invokedAt: request.invokedAt,
 		acquiredAt: request.acquiredAt,

--- a/packages/coding-agent/test/eval/agent-bridge.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge.test.ts
@@ -129,6 +129,7 @@ describe("runEvalAgent", () => {
 		expect(options?.mcpManager).toBe(mcpManager);
 		expect(options?.localProtocolOptions).toBe(localProtocolOptions);
 		expect(options?.parentAgentId).toBe("BridgeParent");
+		expect((options as { invocationKind?: string } | undefined)?.invocationKind).toBe("eval");
 	});
 
 	it("returns executor-parsed structured data through the public eval bridge", async () => {

--- a/packages/coding-agent/test/extension-context-async-jobs.test.ts
+++ b/packages/coding-agent/test/extension-context-async-jobs.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { SubagentObservabilityController } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/subagent-observability";
 
-function createRunner(getAsyncJobSnapshot?: () => AsyncJobSnapshot | null): ExtensionRunner {
+function createRunner(
+	getAsyncJobSnapshot?: () => AsyncJobSnapshot | null,
+	subagents?: SubagentObservabilityController,
+): ExtensionRunner {
 	const runtime = {
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
@@ -18,6 +22,7 @@ function createRunner(getAsyncJobSnapshot?: () => AsyncJobSnapshot | null): Exte
 		undefined,
 		undefined,
 		getAsyncJobSnapshot,
+		subagents,
 	);
 }
 
@@ -37,5 +42,15 @@ describe("ExtensionRunner async job context", () => {
 				.createContext()
 				.getAsyncJobSnapshot(),
 		).toBe(snapshot);
+	});
+
+	it("exposes the root-scoped subagent capability", () => {
+		const subagents: SubagentObservabilityController = {
+			version: 1,
+			getSnapshot: () => ({ version: 1, rootAgentId: "Root", revision: 0, capturedAt: 1, agents: [] }),
+			subscribe: () => () => {},
+			dispose: () => {},
+		};
+		expect(createRunner(undefined, subagents).createContext().subagents).toBe(subagents);
 	});
 });

--- a/packages/coding-agent/test/subagent-observability.test.ts
+++ b/packages/coding-agent/test/subagent-observability.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { AgentRegistry } from "../src/registry/agent-registry";
+import {
+	createSubagentObservability,
+	type SubagentEvent,
+} from "../src/extensibility/extensions/subagent-observability";
+import {
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+} from "../src/task/types";
+import { EventBus } from "../src/utils/event-bus";
+
+function lifecycle(
+	id: string,
+	status: SubagentLifecyclePayload["status"],
+	parentToolCallId: string,
+	detached = false,
+): SubagentLifecyclePayload {
+	return {
+		id,
+		agent: "task",
+		agentSource: "bundled",
+		status,
+		parentToolCallId,
+		index: 0,
+		detached,
+	};
+}
+
+function createHarness() {
+	let now = 1_000;
+	const registry = new AgentRegistry();
+	const bus = new EventBus();
+	registry.register({ id: "Root", displayName: "root", kind: "main", session: null, createdAt: 10, lastActivity: 20 });
+	const observer = createSubagentObservability({ registry, eventBus: bus, rootAgentId: "Root", now: () => ++now });
+	return { registry, bus, observer };
+}
+
+describe("public subagent observability", () => {
+	test("discovers v1 and snapshots stable nested identities in deterministic order", () => {
+		const { registry, observer } = createHarness();
+		registry.register({
+			id: "Child",
+			displayName: "child secret prompt",
+			kind: "sub",
+			parentId: "Root",
+			session: null,
+			createdAt: 30,
+			lastActivity: 40,
+		});
+		registry.register({
+			id: "Grandchild",
+			displayName: "nested secret prompt",
+			kind: "sub",
+			parentId: "Child",
+			session: null,
+			createdAt: 50,
+			lastActivity: 60,
+		});
+		registry.register({ id: "OtherRoot", displayName: "other", kind: "main", session: null });
+
+		const snapshot = observer.getSnapshot();
+		expect(observer.version).toBe(1);
+		expect(snapshot.agents.map(agent => agent.agentId)).toEqual(["Root", "Child", "Grandchild"]);
+		expect(snapshot.agents[2]).toMatchObject({
+			agentId: "Grandchild",
+			rootAgentId: "Root",
+			parentAgentId: "Child",
+			kind: "task",
+		});
+		expect(JSON.stringify(snapshot)).not.toContain("secret prompt");
+	});
+
+	test("correlates direct and eval launches and projects only allowlisted progress", () => {
+		const { registry, bus, observer } = createHarness();
+		registry.register({ id: "Direct", displayName: "direct", kind: "sub", parentId: "Root", session: null });
+		registry.register({ id: "Eval", displayName: "eval", kind: "sub", parentId: "Root", session: null });
+		const events: SubagentEvent[] = [];
+		observer.subscribe(event => events.push(event));
+		bus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, lifecycle("Direct", "started", "task-call-1", true));
+		bus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, lifecycle("Eval", "started", "eval-call-2"));
+		const progress: SubagentProgressPayload = {
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			task: "TOP SECRET prompt",
+			assignment: "SECRET assignment",
+			parentToolCallId: "eval-call-2",
+			sessionFile: "/Users/person/.omp/secret.jsonl",
+			progress: {
+				index: 0,
+				id: "Eval",
+				agent: "task",
+				agentSource: "bundled",
+				status: "running",
+				task: "TOP SECRET prompt",
+				lastIntent: "exfiltrate SECRET",
+				currentTool: "read",
+				currentToolArgs: "PASSWORD=SECRET",
+				recentTools: [{ tool: "bash", args: "token=SECRET", endMs: 1 }],
+				recentOutput: ["SECRET output"],
+				toolCount: 3,
+				requests: 2,
+				tokens: 99,
+				contextTokens: 44,
+				cost: 0.25,
+				durationMs: 10,
+				resolvedModelIdentity: "openai/gpt-5.6",
+				resolvedThinkingLevel: ThinkingLevel.High,
+			},
+		};
+		bus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, progress);
+
+		const snapshot = observer.getSnapshot();
+		expect(snapshot.agents.find(agent => agent.agentId === "Direct")).toMatchObject({
+			parentToolCallId: "task-call-1",
+			detached: true,
+		});
+		expect(snapshot.agents.find(agent => agent.agentId === "Eval")).toMatchObject({
+			parentToolCallId: "eval-call-2",
+			progress: {
+				currentTool: "read",
+				toolCount: 3,
+				tokens: 99,
+				contextTokens: 44,
+				costUsd: 0.25,
+				resolvedModel: "openai/gpt-5.6",
+				effort: "high",
+			},
+		});
+		const serialized = JSON.stringify({ events, snapshot });
+		for (const forbidden of ["TOP SECRET", "SECRET assignment", "PASSWORD", "SECRET output", "/Users/person"]) {
+			expect(serialized).not.toContain(forbidden);
+		}
+	});
+
+	test("emits ordered register, park, revive, cancel, terminal, and remove events", () => {
+		const { registry, bus, observer } = createHarness();
+		const events: SubagentEvent[] = [];
+		observer.subscribe(event => events.push(event));
+		registry.register({ id: "Worker", displayName: "worker", kind: "sub", parentId: "Root", session: null });
+		registry.setStatus("Worker", "parked");
+		registry.setStatus("Worker", "running");
+		bus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, lifecycle("Worker", "aborted", "task-call"));
+		registry.setStatus("Worker", "aborted");
+		registry.unregister("Worker");
+
+		expect(events.map(event => event.type)).toEqual(["registered", "lifecycle", "lifecycle", "lifecycle", "removed"]);
+		expect(events.map(event => event.revision)).toEqual([1, 2, 3, 4, 5]);
+		expect(events.filter(event => event.type === "lifecycle").map(event => event.to)).toEqual([
+			"parked",
+			"running",
+			"aborted",
+		]);
+	});
+
+	test("subscribe then snapshot closes races and unsubscribe is idempotent", () => {
+		const { registry, observer } = createHarness();
+		const events: SubagentEvent[] = [];
+		const unsubscribe = observer.subscribe(event => events.push(event));
+		registry.register({ id: "BeforeSnapshot", displayName: "one", kind: "sub", parentId: "Root", session: null });
+		const snapshot = observer.getSnapshot();
+		registry.register({ id: "AfterSnapshot", displayName: "two", kind: "sub", parentId: "Root", session: null });
+		const after = events.filter(event => event.revision > snapshot.revision);
+		expect(after.map(event => event.agentId)).toEqual(["AfterSnapshot"]);
+		unsubscribe();
+		unsubscribe();
+		registry.register({ id: "Ignored", displayName: "ignored", kind: "sub", parentId: "Root", session: null });
+		expect(events.at(-1)?.agentId).toBe("AfterSnapshot");
+	});
+
+	test("bounds snapshots while retaining the root correlation record", () => {
+		const { registry, observer } = createHarness();
+		for (let index = 0; index < 520; index++) {
+			registry.register({
+				id: `Worker-${index.toString().padStart(3, "0")}`,
+				displayName: "worker",
+				kind: "sub",
+				parentId: "Root",
+				session: null,
+				createdAt: 100 + index,
+			});
+		}
+		const snapshot = observer.getSnapshot();
+		expect(snapshot.agents).toHaveLength(512);
+		expect(snapshot.agents[0]?.agentId).toBe("Root");
+		expect(snapshot.agents.at(-1)?.agentId).toBe("Worker-519");
+	});
+
+	test("isolates throwing listeners, returns immutable copies, and disposes upstream subscriptions", () => {
+		const { registry, observer } = createHarness();
+		let calls = 0;
+		let secondListenerAgentId: string | undefined;
+		observer.subscribe(() => {
+			throw new Error("listener failure");
+		});
+		observer.subscribe(event => {
+			if (event.type === "registered") {
+				(event.agent as { agentId: string }).agentId = "listener mutation";
+			}
+		});
+		observer.subscribe(event => {
+			calls++;
+			secondListenerAgentId = event.type === "removed" ? event.agentId : event.agent.agentId;
+		});
+		registry.register({ id: "Worker", displayName: "worker", kind: "sub", parentId: "Root", session: null });
+		expect(calls).toBe(1);
+		expect(secondListenerAgentId).toBe("Worker");
+
+		const snapshot = observer.getSnapshot();
+		(snapshot.agents as unknown as Array<{ agentId: string }>)[0]!.agentId = "mutated";
+		expect(observer.getSnapshot().agents[0]?.agentId).toBe("Root");
+
+		observer.dispose();
+		registry.register({ id: "AfterDispose", displayName: "ignored", kind: "sub", parentId: "Root", session: null });
+		expect(calls).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/subagent-observability.test.ts
+++ b/packages/coding-agent/test/subagent-observability.test.ts
@@ -137,6 +137,25 @@ describe("public subagent observability", () => {
 		}
 	});
 
+	test("reports an explicitly registered eval invocation as eval in its event and snapshot", () => {
+		const { registry, observer } = createHarness();
+		const events: SubagentEvent[] = [];
+		observer.subscribe(event => events.push(event));
+
+		registry.register({
+			id: "Eval",
+			displayName: "eval",
+			kind: "sub",
+			parentId: "Root",
+			session: null,
+			invocationKind: "eval",
+		});
+
+		const registered = events.find(event => event.type === "registered");
+		expect(registered?.type === "registered" ? registered.agent.kind : undefined).toBe("eval");
+		expect(observer.getSnapshot().agents.find(agent => agent.agentId === "Eval")?.kind).toBe("eval");
+	});
+
 	test("emits ordered register, park, revive, cancel, terminal, and remove events", () => {
 		const { registry, bus, observer } = createHarness();
 		const events: SubagentEvent[] = [];


### PR DESCRIPTION
## What

- Adds the versioned, read-only `ctx.subagents` extension capability with root-scoped snapshots and subscriptions.
- Projects stable registry identity and nested parent correlation, lifecycle, bounded progress, and actual resolved model/thinking metadata.
- Keeps the surface sanitized and bounded: no prompts, assignments, tool arguments/output, free-form errors/intent, transcripts, environment values, or absolute session paths.
- Documents race-safe subscribe-then-snapshot consumption and idempotent teardown.

## Why

Extensions can currently see per-tool updates but cannot reliably correlate nested task/eval agents or dormant lifecycle state. This exposes the existing registry and root observability signals without adding execution or scheduling authority. Related proposal: #205.

Public API read-only bounded sanitized no raw prompt/output/secrets by default; correctly unsubscribe lifecycle.

## Testing

- `bun run check` in `packages/coding-agent`: passed (lint, format, typecheck; two unrelated pre-existing unused-variable warnings).
- Focused direct/eval/nested/registry/RPC suite: **58 passed, 0 failed**.
- Manual API smoke: instantiated the real registry, event bus, and public facade; observed one nested progress event and a two-agent snapshot; verified parent `Root`, actual resolved model `openai/gpt`, and that the sentinel prompt/output text was absent.
- Full coding-agent suite was also attempted: the new observability tests passed in its chunk, but 8 of 166 unrelated environment/global-state chunks failed (including MCP, skill discovery, ACP startup, and existing timeout-sensitive tests).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
