### PR TITLE
fix(tui): let /extensions search accept j and k

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -8,7 +8,7 @@
  *
  * Navigation:
  * - Tab/Shift+Tab or ←/→: switch provider tab
- * - Up/Down/j/k or wheel: move list selection
+ * - Up/Down or wheel: move list selection
  * - Space/Enter or click: toggle selected item (or provider master switch)
  * - Wheel over the inspector, or PageUp/PageDown when the inspector overflows: scroll the detail pane
  * - Esc: clear search (if active) then close

--- a/packages/coding-agent/src/modes/components/extensions/extension-list.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-list.ts
@@ -548,13 +548,15 @@ export class ExtensionList implements Component {
 	}
 
 	handleInput(data: string): void {
-		// Navigation
-		if (matchesSelectUp(data) || matchesKey(data, "k")) {
+		// Navigation (arrow keys / configurable tui.select.up/down). Bare j/k are
+		// intentionally NOT navigation here: the search filter is always active, so
+		// those letters must reach the query (e.g. searching for "jira"/"json").
+		if (matchesSelectUp(data)) {
 			this.#moveSelectionUp();
 			return;
 		}
 
-		if (matchesSelectDown(data) || matchesKey(data, "j")) {
+		if (matchesSelectDown(data)) {
 			this.#moveSelectionDown();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/selector-helpers.ts
+++ b/packages/coding-agent/src/modes/components/selector-helpers.ts
@@ -81,17 +81,13 @@ export function clampSelection(
 /**
  * Classify a key event for search-query text entry. Returns the single
  * printable character to append to the query, or `null` when the key is not a
- * searchable character: non-printable, multi-byte, or a reserved `j`/`k`
- * navigation key.
+ * searchable character: non-printable or multi-byte.
  */
 export function searchableChar(data: string): string | null {
 	const printableText = extractPrintableText(data);
 	if (printableText && printableText.length === 1) {
 		const printableCharCode = printableText.charCodeAt(0);
 		if (printableCharCode > 32 && printableCharCode < 127) {
-			if (printableText === "j" || printableText === "k") {
-				return null;
-			}
 			return printableText;
 		}
 	}

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -13,7 +13,6 @@ import {
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -345,6 +345,19 @@ describe("selector navigation keybindings", () => {
 		expect(list.getSelectedExtension()?.id).toBe("tool-a");
 	});
 
+	it("appends bare j/k to the extension search filter instead of navigating", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const list = new ExtensionList([
+			createExtension("jira", "Jira"),
+			createExtension("json", "JSON"),
+			createExtension("apple", "Apple"),
+		]);
+
+		for (const ch of "jira") list.handleInput(ch);
+
+		expect(list.getSearchQuery()).toBe("jira");
+	});
+
 	it("uses tui.select.down in history search", async () => {
 		setKeybindings(TEST_KEYBINDINGS);
 		const selected: string[] = [];


### PR DESCRIPTION
## Repro
In the Extension Control Center (`/extensions`) the search filter is always active, yet typing `j` or `k` moves the list selection instead of appending to the query, so extensions whose names contain those letters (`jira`, `json`, …) cannot be searched. Driving `ExtensionList.handleInput()` with the real key events:

```
typed 'jira'  -> searchQuery = "ira"
typed 'kayak' -> searchQuery = "aya"
searchableChar('j') = null   searchableChar('k') = null   searchableChar('a') = "a"
```

## Cause
Two layers swallowed the letters. `ExtensionList.handleInput()` (`packages/coding-agent/src/modes/components/extensions/extension-list.ts`) matched bare `matchesKey(data, "k")` / `matchesKey(data, "j")` as navigation and early-returned before the printable-character → search path. The shared `searchableChar()` helper (`packages/coding-agent/src/modes/components/selector-helpers.ts`) then hard-excluded `j`/`k`, so even removing the navigation hijack alone would not let the query receive them. Neither key is documented as navigation — the dashboard footer advertises only `↑/↓: navigate`, and sibling searchable selectors (`history-search.ts`, `tree-selector.ts`) never intercept bare letters; `hook-selector.ts` already gates its `j`/`k` nav on `!isSearchEnabled()`.

## Fix
- `extension-list.ts`: drop the bare `j`/`k` navigation branches; selection now moves only on arrow keys / the configurable `tui.select.up`/`down`.
- `selector-helpers.ts`: remove the `j`/`k` exclusion in `searchableChar()` (only consumed by `ExtensionList`) and update its doc comment.
- `extension-dashboard.ts`: correct the module doc comment that still listed `j/k` as navigation.
- Regression test in `test/keybindings-selector-navigation.test.ts`: typing `jira` into the extension list yields search query `"jira"`.

## Verification
`bun test test/keybindings-selector-navigation.test.ts` → 11 pass (incl. the new case); `bun test test/extension-inspector.test.ts test/extension-list-mouse.test.ts test/extension-mcp-inspector.test.ts` → 47 pass, no regressions. Fixes #11350