### PR TITLE
fix(catalog): honor LiteLLM reasoning effort metadata

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM discovery ignoring deployment-advertised reasoning effort levels and defaults for gateway aliases ([#11353](https://github.com/can1357/oh-my-pi/issues/11353)).
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -69,10 +69,9 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 		}
 		case "litellm": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
-			// rich-v8 invalidates rows whose `compatConfig` retained a colliding
-			// bundled model's provider-specific transport (e.g. Fireworks
-			// `wireModelIdMode`) before that leak was fixed (issue #9938).
-			return `litellm:rich-v8:${Bun.hash(baseUrl).toString(36)}`;
+			// rich-v9 invalidates rows discovered before LiteLLM's authoritative
+			// reasoning effort metadata was mapped (issue #11353).
+			return `litellm:rich-v9:${Bun.hash(baseUrl).toString(36)}`;
 		}
 		case "opencode-go":
 		case "opencode-zen": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4063,7 +4063,7 @@ function toSyntheticStringList(value: unknown): readonly string[] {
  */
 function resolveWireEffortThinking(
 	wireEfforts: readonly string[],
-	defaultWireEffort?: string,
+	defaultWireEffort?: string | null,
 ): ThinkingConfig | undefined {
 	const efforts = THINKING_EFFORTS.filter(effort => wireEfforts.includes(effort));
 	const wireHasNone = wireEfforts.includes(WIRE_EFFORT_NONE);
@@ -4083,6 +4083,10 @@ function resolveWireEffortThinking(
 			efforts: [Effort.Minimal, ...efforts],
 			effortMap: { [Effort.Minimal]: WIRE_EFFORT_NONE },
 		};
+	}
+	if (defaultWireEffort === null) {
+		thinking.defaultLevel = null;
+		return thinking;
 	}
 	const defaultLevel =
 		defaultWireEffort === WIRE_EFFORT_NONE && wireHasNone
@@ -5556,12 +5560,12 @@ function mapLiteLLMThinking(entry: LiteLLMRichModelEntry): ThinkingConfig | null
 		return null;
 	}
 	const wireEfforts = value.flatMap(item => (typeof item === "string" ? [item] : []));
-	return (
-		resolveWireEffortThinking(
-			wireEfforts,
-			toNonEmptyString(getLiteLLMMetadataValue(entry, "default_reasoning_effort")),
-		) ?? null
-	);
+	const rawDefaultEffort =
+		entry.default_reasoning_effort !== undefined
+			? entry.default_reasoning_effort
+			: getLiteLLMModelInfo(entry)?.default_reasoning_effort;
+	const defaultWireEffort = rawDefaultEffort === null ? null : toNonEmptyString(rawDefaultEffort);
+	return resolveWireEffortThinking(wireEfforts, defaultWireEffort) ?? null;
 }
 
 function getLiteLLMProviders(entry: LiteLLMRichModelEntry): string[] | undefined {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4047,8 +4047,8 @@ interface SyntheticModelRecord extends OpenAICompatibleModelRecord {
 	pricing?: unknown;
 }
 
-/** Synthetic's thinking-off wire tier — a router state, not a user effort. */
-const SYNTHETIC_WIRE_EFFORT_NONE = "none";
+/** OpenAI-compatible thinking-off wire tier, represented by OMP's minimal effort. */
+const WIRE_EFFORT_NONE = "none";
 /** Output cap for routes that advertise no `max_output_length`. */
 const SYNTHETIC_FALLBACK_MAX_TOKENS = 8192;
 
@@ -4057,32 +4057,41 @@ function toSyntheticStringList(value: unknown): readonly string[] {
 }
 
 /**
- * Translate Synthetic's per-model `reasoning_effort` vocabulary into an effort
- * ladder. Every advertised value that names an OMP tier maps verbatim; `none`
- * is the thinking-off state rather than a tier of its own, so it backs the
- * `minimal` selector through the wire map (same shape as the Fireworks
- * `minimal → none` map) and gives these routes a real no-thinking tier.
- * A route that advertises only `none` (or tiers this client doesn't know)
- * still gets the minimal-off mapping: falling through to identity inference
- * would fabricate an unadvertised ladder, and leaving thinking unset would
- * leak any stale reference ladder past the wire vocabulary.
+ * Translate an OpenAI-compatible wire effort vocabulary into OMP's effort
+ * ladder. `none` is exposed as `minimal` with an explicit wire map because it
+ * is a selectable upstream effort rather than OMP's omitted-thinking state.
  */
-function resolveSyntheticThinking(wireEfforts: readonly string[]): ThinkingConfig | undefined {
+function resolveWireEffortThinking(
+	wireEfforts: readonly string[],
+	defaultWireEffort?: string,
+): ThinkingConfig | undefined {
 	const efforts = THINKING_EFFORTS.filter(effort => wireEfforts.includes(effort));
-	const wireHasNone = wireEfforts.includes(SYNTHETIC_WIRE_EFFORT_NONE);
+	const wireHasNone = wireEfforts.includes(WIRE_EFFORT_NONE);
+	let thinking: ThinkingConfig;
 	if (efforts.length === 0) {
-		return wireHasNone
-			? { mode: "effort", efforts: [Effort.Minimal], effortMap: { [Effort.Minimal]: SYNTHETIC_WIRE_EFFORT_NONE } }
-			: undefined;
+		if (!wireHasNone) return undefined;
+		thinking = {
+			mode: "effort",
+			efforts: [Effort.Minimal],
+			effortMap: { [Effort.Minimal]: WIRE_EFFORT_NONE },
+		};
+	} else if (!wireHasNone || efforts.includes(Effort.Minimal)) {
+		thinking = { mode: "effort", efforts };
+	} else {
+		thinking = {
+			mode: "effort",
+			efforts: [Effort.Minimal, ...efforts],
+			effortMap: { [Effort.Minimal]: WIRE_EFFORT_NONE },
+		};
 	}
-	if (!wireHasNone || efforts.includes(Effort.Minimal)) {
-		return { mode: "effort", efforts };
+	const defaultLevel =
+		defaultWireEffort === WIRE_EFFORT_NONE && wireHasNone
+			? Effort.Minimal
+			: THINKING_EFFORTS.find(effort => effort === defaultWireEffort);
+	if (defaultLevel !== undefined && thinking.efforts.includes(defaultLevel)) {
+		thinking.defaultLevel = defaultLevel;
 	}
-	return {
-		mode: "effort",
-		efforts: [Effort.Minimal, ...efforts],
-		effortMap: { [Effort.Minimal]: SYNTHETIC_WIRE_EFFORT_NONE },
-	};
+	return thinking;
 }
 
 /** Synthetic quotes per-token USD as `"$0.000001"`; catalog cost is per-million. */
@@ -4148,7 +4157,7 @@ export function syntheticModelManagerOptions(
 							? toSyntheticStringList(record.reasoning_parameters.efforts)
 							: [];
 						const wireReasoning = features.includes("reasoning") || wireEfforts.length > 0;
-						const thinking = resolveSyntheticThinking(wireEfforts);
+						const thinking = resolveWireEffortThinking(wireEfforts);
 						// An advertised effort vocabulary is authoritative over the bundled
 						// reference: when the wire names tiers (even only `none`), the
 						// reference's reasoning flag must not re-add a dial the route
@@ -4159,7 +4168,7 @@ export function syntheticModelManagerOptions(
 						// effort dial for a dial with one stop. When the wire is silent on
 						// reasoning entirely, the reference gets a vote.
 						const namedTierCount =
-							(thinking?.efforts.length ?? 0) - (wireEfforts.includes(SYNTHETIC_WIRE_EFFORT_NONE) ? 1 : 0);
+							(thinking?.efforts.length ?? 0) - (wireEfforts.includes(WIRE_EFFORT_NONE) ? 1 : 0);
 						const reasoning =
 							wireReasoning && namedTierCount > 0
 								? true
@@ -5364,6 +5373,7 @@ type LiteLLMRichEndpointModel<TApi extends Api> = {
 	hasMaxTokens: boolean;
 	hasToolMetadata: boolean;
 	hasSupportedOpenAIParams: boolean;
+	hasThinkingMetadata: boolean;
 	hasCost: boolean;
 	reportedCost: Partial<ModelSpec<Api>["cost"]>;
 };
@@ -5540,6 +5550,20 @@ function getSupportedOpenAIParams(entry: LiteLLMRichModelEntry): string[] | unde
 	return value.flatMap(item => (typeof item === "string" ? [item] : []));
 }
 
+function mapLiteLLMThinking(entry: LiteLLMRichModelEntry): ThinkingConfig | null {
+	const value = getLiteLLMMetadataValue(entry, "reasoning_effort_levels");
+	if (!Array.isArray(value)) {
+		return null;
+	}
+	const wireEfforts = value.flatMap(item => (typeof item === "string" ? [item] : []));
+	return (
+		resolveWireEffortThinking(
+			wireEfforts,
+			toNonEmptyString(getLiteLLMMetadataValue(entry, "default_reasoning_effort")),
+		) ?? null
+	);
+}
+
 function getLiteLLMProviders(entry: LiteLLMRichModelEntry): string[] | undefined {
 	if (!Array.isArray(entry.providers)) {
 		return undefined;
@@ -5638,6 +5662,7 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 	entry: LiteLLMRichModelEntry,
 	options: FetchLiteLLMRichModelsOptions<TApi>,
 	runtimeBaseUrl: string,
+	richThinking: ThinkingConfig | null,
 ): ModelSpec<TApi> | null {
 	if (isLiteLLMUnusableSentinelPlaceholder(entry)) {
 		return null;
@@ -5687,11 +5712,15 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 		supportsDeveloperRole: false,
 		...(supportedOpenAIParams !== undefined
 			? { supportsReasoningEffort: supportedOpenAIParams.includes("reasoning_effort") }
-			: referenceCompat?.supportsReasoningEffort !== undefined
-				? { supportsReasoningEffort: referenceCompat.supportsReasoningEffort }
-				: {}),
-		...(referenceCompat?.reasoningEffortMap ? { reasoningEffortMap: referenceCompat.reasoningEffortMap } : {}),
-		...(referenceCompat?.omitReasoningEffort !== undefined
+			: richThinking !== null
+				? { supportsReasoningEffort: true }
+				: referenceCompat?.supportsReasoningEffort !== undefined
+					? { supportsReasoningEffort: referenceCompat.supportsReasoningEffort }
+					: {}),
+		...(richThinking === null && referenceCompat?.reasoningEffortMap
+			? { reasoningEffortMap: referenceCompat.reasoningEffortMap }
+			: {}),
+		...(richThinking === null && referenceCompat?.omitReasoningEffort !== undefined
 			? { omitReasoningEffort: referenceCompat.omitReasoningEffort }
 			: {}),
 	};
@@ -5710,7 +5739,7 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 					? ["text"]
 					: (reference?.input ?? ["text"]),
 		reasoning: typeof supportsReasoning === "boolean" ? supportsReasoning : (reference?.reasoning ?? false),
-		thinking: reference?.thinking,
+		thinking: richThinking ?? reference?.thinking,
 		cost: getLiteLLMCost(entry) ?? reference?.cost ?? UNKNOWN_PROXY_COST,
 		...(supportsTools !== undefined ? { supportsTools } : {}),
 		compat: compat as ModelSpec<TApi>["compat"],
@@ -5736,8 +5765,9 @@ function mergeLiteLLMRichEndpointModels<TApi extends Api>(
 		maxTokens: next.hasMaxTokens ? next.model.maxTokens : existing.model.maxTokens,
 		input: next.supportsVision === true || next.supportsVision === false ? next.model.input : existing.model.input,
 		reasoning: typeof next.supportsReasoning === "boolean" ? next.model.reasoning : existing.model.reasoning,
+		thinking: next.hasThinkingMetadata ? next.model.thinking : existing.model.thinking,
 		cost: { ...existing.model.cost, ...existing.reportedCost, ...next.reportedCost },
-		compat: next.hasSupportedOpenAIParams ? next.model.compat : existing.model.compat,
+		compat: next.hasSupportedOpenAIParams || next.hasThinkingMetadata ? next.model.compat : existing.model.compat,
 	};
 	if (next.hasToolMetadata) {
 		model.supportsTools = next.model.supportsTools;
@@ -5751,6 +5781,7 @@ function mergeLiteLLMRichEndpointModels<TApi extends Api>(
 		hasMaxTokens: existing.hasMaxTokens || next.hasMaxTokens,
 		hasToolMetadata: existing.hasToolMetadata || next.hasToolMetadata,
 		hasSupportedOpenAIParams: existing.hasSupportedOpenAIParams || next.hasSupportedOpenAIParams,
+		hasThinkingMetadata: existing.hasThinkingMetadata || next.hasThinkingMetadata,
 		hasCost: existing.hasCost || next.hasCost,
 	};
 }
@@ -5795,7 +5826,8 @@ async function fetchLiteLLMRichEndpoint<TApi extends Api>(
 	}
 	const deduped = new Map<string, LiteLLMRichEndpointModel<TApi>>();
 	for (const entry of entries) {
-		const model = mapLiteLLMRichEntry(entry, options, runtimeBaseUrl);
+		const richThinking = mapLiteLLMThinking(entry);
+		const model = mapLiteLLMRichEntry(entry, options, runtimeBaseUrl, richThinking);
 		if (model) {
 			const supportsVision = getLiteLLMMetadataValue(entry, "supports_vision");
 			const supportsReasoning = getLiteLLMMetadataValue(entry, "supports_reasoning");
@@ -5813,6 +5845,7 @@ async function fetchLiteLLMRichEndpoint<TApi extends Api>(
 					supportsFunctionCalling === false ||
 					supportedOpenAIParams !== undefined,
 				hasSupportedOpenAIParams: supportedOpenAIParams !== undefined,
+				hasThinkingMetadata: richThinking !== null,
 				hasCost: getLiteLLMCost(entry) !== undefined,
 				reportedCost: getLiteLLMReportedCost(entry),
 			};
@@ -5876,6 +5909,7 @@ async function fetchLiteLLMRichModelsInternal<TApi extends Api>(
 			for (const entry of deduped.values()) {
 				if (
 					(entry.supportsVision !== true && entry.supportsVision !== false) ||
+					(entry.model.reasoning && !entry.hasThinkingMetadata) ||
 					(options.resolveApi !== undefined && entry.apiRoute === "unknown") ||
 					(Object.keys(entry.reportedCost).length > 0 &&
 						(entry.reportedCost.input === undefined ||
@@ -5918,14 +5952,13 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
 	return {
 		providerId: "litellm",
-		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
-		// bundled model's provider-specific transport (e.g. Fireworks
-		// `wireModelIdMode`) before that leak was fixed. Earlier versions added
-		// bundled reference fallback, moved OpenAI models to Responses, continued
-		// past incomplete vision/API metadata and endpoints omitting cache
-		// pricing, stripped reseller usage suffixes, filtered placeholder rows,
-		// and mapped rich pricing. Bump the version whenever these mappers change,
-		// or warm authoritative caches keep serving pre-change rows for the full TTL.
+		// rich-v9 invalidates rows discovered before LiteLLM's authoritative
+		// reasoning effort metadata was mapped. Earlier versions added bundled
+		// reference fallback, moved OpenAI models to Responses, continued past
+		// incomplete vision/API metadata and endpoints omitting cache pricing,
+		// stripped reseller usage suffixes, filtered placeholder rows, mapped
+		// rich pricing, and isolated reference transport. Bump whenever these
+		// mappers change or warm caches serve pre-change rows for the full TTL.
 		cacheProviderId: resolveModelCacheProviderId("litellm", { baseUrl }),
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5714,10 +5714,10 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 	const compat: OpenAICompat = {
 		supportsStore: false,
 		supportsDeveloperRole: false,
-		...(supportedOpenAIParams !== undefined
-			? { supportsReasoningEffort: supportedOpenAIParams.includes("reasoning_effort") }
-			: richThinking !== null
-				? { supportsReasoningEffort: true }
+		...(richThinking !== null
+			? { supportsReasoningEffort: true }
+			: supportedOpenAIParams !== undefined
+				? { supportsReasoningEffort: supportedOpenAIParams.includes("reasoning_effort") }
 				: referenceCompat?.supportsReasoningEffort !== undefined
 					? { supportsReasoningEffort: referenceCompat.supportsReasoningEffort }
 					: {}),

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -41,8 +41,11 @@ export interface ThinkingConfig {
 	 * `thinking: undefined` instead of an empty list.
 	 */
 	efforts: readonly Effort[];
-	/** Optional default effort applied when this model is selected. Falls back to global default if absent. */
-	defaultLevel?: Effort;
+	/**
+	 * Model-specific default effort. `null` explicitly delegates to the user's
+	 * global default instead of allowing identity policy to fill a model default.
+	 */
+	defaultLevel?: Effort | null;
 	/**
 	 * Effort → provider wire-value remap, baked at build time. Identity for
 	 * efforts the map omits. Used by Anthropic adaptive thinking, OpenAI-

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -299,18 +299,18 @@ describe("LiteLLM provider discovery", () => {
 		expect(buildModel(spec).compat.supportsReasoningEffort).toBe(true);
 	});
 
-	test("uses model_info effort vocabulary and nullable defaults over alias and reference inference", async () => {
+	test("advertised effort vocabulary overrides incomplete params and reference inference", async () => {
 		const calls: string[] = [];
 		const groupModelInfo = {
 			supports_vision: false,
 			supports_reasoning: true,
-			supported_openai_params: ["reasoning_effort"],
+			supported_openai_params: ["tools", "temperature"],
 		};
 		const richModelInfo = {
 			supports_vision: false,
 			supports_reasoning: true,
 			reasoning_effort_levels: ["none", "low", "high", "max"],
-			supported_openai_params: ["reasoning_effort"],
+			supported_openai_params: ["tools", "temperature"],
 		};
 		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request) => {
 			const url = inputUrl(input);
@@ -387,6 +387,10 @@ describe("LiteLLM provider discovery", () => {
 			defaultLevel: Effort.High,
 		});
 		expect(direct.thinking).toEqual({ ...expectedThinking, defaultLevel: null });
+		// The incomplete `supported_openai_params` (no `reasoning_effort`) must not
+		// suppress the wire dial: advertised effort levels are authoritative.
+		expect(buildModel(aliased).compat.supportsReasoningEffort).toBe(true);
+		expect(buildModel(direct).compat.supportsReasoningEffort).toBe(true);
 		expect(buildModel(direct).thinking?.defaultLevel).toBeNull();
 	});
 

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -379,11 +379,15 @@ describe("LiteLLM provider discovery", () => {
 			efforts: [Effort.Minimal, Effort.Low, Effort.High, Effort.Max],
 			effortMap: { [Effort.Minimal]: "none" },
 		};
-		expect(specs?.find(model => model.id === "my-gateway/coding-pro")?.thinking).toEqual({
+		const aliased = specs?.find(model => model.id === "my-gateway/coding-pro");
+		const direct = specs?.find(model => model.id === "zai-org/GLM-5.3");
+		if (!aliased || !direct) throw new Error("expected both LiteLLM models");
+		expect(aliased.thinking).toEqual({
 			...expectedThinking,
 			defaultLevel: Effort.High,
 		});
-		expect(specs?.find(model => model.id === "zai-org/GLM-5.3")?.thinking).toEqual(expectedThinking);
+		expect(direct.thinking).toEqual({ ...expectedThinking, defaultLevel: null });
+		expect(buildModel(direct).thinking?.defaultLevel).toBeNull();
 	});
 
 	test("routes only OpenAI-backed rich models through Responses", async () => {

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import {
 	fetchLiteLLMRichModels,
 	litellmModelManagerOptions,
 	resolveLiteLLMApi,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { Api, FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import type { Api, FetchImpl, ModelSpec, ThinkingConfig } from "@oh-my-pi/pi-catalog/types";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 
 const ORIGINAL_LITELLM_BASE_URL = Bun.env.LITELLM_BASE_URL;
@@ -131,7 +132,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v8:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
+			`litellm:rich-v9:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -155,7 +156,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v8:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
+			`litellm:rich-v9:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -296,6 +297,93 @@ describe("LiteLLM provider discovery", () => {
 		if (!spec) throw new Error("expected exactly one discovered model");
 		expect(spec.compat).not.toHaveProperty("supportsReasoningEffort");
 		expect(buildModel(spec).compat.supportsReasoningEffort).toBe(true);
+	});
+
+	test("uses model_info effort vocabulary and nullable defaults over alias and reference inference", async () => {
+		const calls: string[] = [];
+		const groupModelInfo = {
+			supports_vision: false,
+			supports_reasoning: true,
+			supported_openai_params: ["reasoning_effort"],
+		};
+		const richModelInfo = {
+			supports_vision: false,
+			supports_reasoning: true,
+			reasoning_effort_levels: ["none", "low", "high", "max"],
+			supported_openai_params: ["reasoning_effort"],
+		};
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			calls.push(url);
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{ model_group: "my-gateway/coding-pro", ...groupModelInfo },
+						{ model_group: "zai-org/GLM-5.3", ...groupModelInfo },
+					],
+				});
+			}
+			if (url === "http://primary:4000/v2/model/info") {
+				return new Response("{}", { status: 404 });
+			}
+			if (url === "http://primary:4000/model/info") {
+				return Response.json({
+					data: [
+						{
+							model_name: "my-gateway/coding-pro",
+							model_info: { ...richModelInfo, default_reasoning_effort: "high" },
+						},
+						{
+							model_name: "zai-org/GLM-5.3",
+							model_info: { ...richModelInfo, default_reasoning_effort: null },
+						},
+					],
+				});
+			}
+			return new Response("{}", { status: 404 });
+		});
+		const reference: ModelSpec<"openai-completions"> = {
+			id: "zai-org/GLM-5.3",
+			name: "GLM 5.3",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.Max],
+				defaultLevel: Effort.Max,
+			},
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 131_072,
+			maxTokens: 32_768,
+			compat: { supportsReasoningEffort: true },
+		};
+
+		const specs = await fetchLiteLLMRichModels<"openai-completions">({
+			api: "openai-completions",
+			provider: "private-litellm",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+			referenceResolver: id => (id === reference.id ? reference : undefined),
+		});
+
+		expect(calls).toEqual([
+			"http://primary:4000/model_group/info",
+			"http://primary:4000/v2/model/info",
+			"http://primary:4000/model/info",
+		]);
+		const expectedThinking: ThinkingConfig = {
+			mode: "effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.High, Effort.Max],
+			effortMap: { [Effort.Minimal]: "none" },
+		};
+		expect(specs?.find(model => model.id === "my-gateway/coding-pro")?.thinking).toEqual({
+			...expectedThinking,
+			defaultLevel: Effort.High,
+		});
+		expect(specs?.find(model => model.id === "zai-org/GLM-5.3")?.thinking).toEqual(expectedThinking);
 	});
 
 	test("routes only OpenAI-backed rich models through Responses", async () => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1563,12 +1563,13 @@ export class ModelRegistry {
 				: `${providerConfig.provider}:openai-models-list-context-v3`;
 		}
 		if (providerConfig.discovery.type === "litellm") {
-			// rich-v4 invalidates rows whose `compatConfig` retained a colliding
-			// bundled model's provider-specific transport (e.g. Fireworks
-			// `wireModelIdMode`) before that leak was fixed (issue #9938); keep in
-			// lockstep with the catalog package's `litellm:rich-vN` namespace
-			// whenever LiteLLM mapping behavior changes.
-			return `${providerConfig.provider}:litellm-rich-v4`;
+			// rich-v5 invalidates rows discovered before LiteLLM's authoritative
+			// reasoning effort metadata was mapped (issue #11353); earlier bumps
+			// covered the colliding-transport leak (issue #9938). Provider-scoped
+			// here because configured gateways carry arbitrary provider names;
+			// keep the version in lockstep with the catalog package's
+			// `litellm:rich-vN` namespace whenever LiteLLM mapping behavior changes.
+			return `${providerConfig.provider}:litellm-rich-v5`;
 		}
 		return providerConfig.provider;
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1612,7 +1612,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
 			level = defaultRoleSpec.thinkingLevel;
 		}
-		if (level === undefined && selectedModel?.thinking?.defaultLevel !== undefined) {
+		if (
+			level === undefined &&
+			selectedModel?.thinking?.defaultLevel !== undefined &&
+			selectedModel.thinking.defaultLevel !== null
+		) {
 			level = selectedModel.thinking.defaultLevel;
 		}
 		if (level === undefined) {

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -249,7 +249,7 @@ export class ModelControls {
 
 		// Re-apply thinking for the newly selected model. Prefer the model's
 		// configured defaultLevel; otherwise preserve the current level (or auto).
-		this.#reapplyThinkingLevel(targetModel.thinking?.defaultLevel);
+		this.#reapplyThinkingLevel(targetModel.thinking?.defaultLevel ?? undefined);
 		await this.#host.syncAfterModelChange(previousEditMode);
 		return { switched: true };
 	}
@@ -287,7 +287,7 @@ export class ModelControls {
 		if (thinkingLevel !== undefined) {
 			this.setThinkingLevel(thinkingLevel);
 		} else {
-			this.#reapplyThinkingLevel(targetModel.thinking?.defaultLevel);
+			this.#reapplyThinkingLevel(targetModel.thinking?.defaultLevel ?? undefined);
 		}
 		await this.#host.syncAfterModelChange(previousEditMode);
 	}

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -13,7 +13,6 @@ import {
 	convertToLlm,
 	SKILL_PROMPT_MESSAGE_TYPE,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2554,12 +2554,12 @@ describe("ModelRegistry", () => {
 					maxTokens: 16_384,
 				});
 			litellmStaleNamespaceCache = readonlyRegistry(litellmProxyConfig(), {
-				// Rows cached under the retired namespace whose `compatConfig`
-				// retained a colliding bundled model's provider-specific transport
-				// (issue #9938) must be orphaned instead of served.
+				// Rows cached under the retired rich-v4 namespace predate LiteLLM's
+				// authoritative reasoning-effort mapping (issue #11353): they carry
+				// inferred/reference effort metadata and must be orphaned, not served.
 				seedCache: dbPath =>
 					writeModelCache(
-						"litellm-proxy:litellm-rich-v3",
+						"litellm-proxy:litellm-rich-v4",
 						Date.now(),
 						[litellmCachedModel("MiniMax-M3 (3x usage)")],
 						true,
@@ -2570,7 +2570,7 @@ describe("ModelRegistry", () => {
 			litellmCurrentNamespaceCache = readonlyRegistry(litellmProxyConfig(), {
 				seedCache: dbPath =>
 					writeModelCache(
-						"litellm-proxy:litellm-rich-v4",
+						"litellm-proxy:litellm-rich-v5",
 						Date.now(),
 						[litellmCachedModel("MiniMax-M3")],
 						true,
@@ -2656,13 +2656,13 @@ describe("ModelRegistry", () => {
 			});
 		});
 
-		test("ignores litellm discovery rows cached under the retired rich-v3 namespace", () => {
-			// Warm rich-v3 rows carry the leaked provider-specific compat and must not load.
+		test("ignores litellm discovery rows cached under the retired rich-v4 namespace", () => {
+			// Warm rich-v4 rows carry inferred effort metadata and must not load.
 			expect(litellmStaleNamespaceCache.find("litellm-proxy", "minimax/minimax-m3")).toBeUndefined();
 			expect(getModelsForProvider(litellmStaleNamespaceCache, "litellm-proxy")).toHaveLength(0);
 		});
 
-		test("loads litellm discovery rows cached under the rich-v4 namespace", () => {
+		test("loads litellm discovery rows cached under the rich-v5 namespace", () => {
 			const model = litellmCurrentNamespaceCache.find("litellm-proxy", "minimax/minimax-m3");
 			expect(model?.name).toBe("MiniMax-M3");
 			expect(model?.provider).toBe("litellm-proxy");


### PR DESCRIPTION
## Repro
A LiteLLM mock returns reasoning-capable, vision-complete aliases from `/model_group/info` and `reasoning_effort_levels` plus `default_reasoning_effort` from `/model/info`. `bun test packages/catalog/test/litellm-provider.test.ts --test-name-pattern "uses model_info effort vocabulary"` failed before the fix because discovery made only the first request and retained inferred/reference thinking metadata.

## Cause
`fetchLiteLLMRichModelsInternal` in `packages/catalog/src/provider-models/openai-compat.ts` stopped once vision/API/cost metadata looked complete, without treating reasoning effort metadata as incomplete. `mapLiteLLMRichEntry` also ignored LiteLLM’s advertised effort vocabulary and default, always falling back to a bundled reference or later generic inference.

## Fix
- Map `reasoning_effort_levels` into the canonical OMP ladder, including `none` as the `minimal` wire value, and honor nullable `default_reasoning_effort`.
- Keep querying rich endpoints for reasoning models until deployment effort metadata is found, then give it precedence during endpoint merges.
- Bump the LiteLLM discovery cache namespace and document the user-visible fix.

## Verification
`bun test packages/catalog/test/litellm-provider.test.ts` — 30 passed, 0 failed. `bun check` — passed; two pre-existing unused-variable warnings remain in coding-agent tests.

Fixes #11353