### PR TITLE
fix(catalog): require reasoning for Codex Astra

### DIFF
--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -6496,3 +6496,35 @@ describe("openai-codex SSE statelessness", () => {
 		expect(stats).toMatchObject({ fullContextRequests: 2, deltaRequests: 0 });
 	});
 });
+
+it("clamps disabled Astra reasoning to low before sending a Codex request", async () => {
+	using tempDir = TempDir.createSync("@pi-codex-astra-");
+	setAgentDir(tempDir.path());
+	const model = buildModel({
+		id: "gpt-6-astra",
+		name: "GPT-6 Astra",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text"],
+		preferWebsockets: false,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272000,
+		maxTokens: 128000,
+	});
+	let requestBody: { reasoning?: { effort?: string } } | undefined;
+	const fetchMock: FetchImpl = async (_input, init) => {
+		requestBody = JSON.parse(decodeCodexRequestBody(init?.body));
+		return new Response(createCompletedCodexSse("Hello"), {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	};
+	await streamSimple(
+		model,
+		{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+		{ apiKey: createCodexTestToken(), forceReasoningOff: true, fetch: fetchMock },
+	).result();
+	expect(requestBody?.reasoning?.effort).toBe("low");
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Astra on Codex clamps disabled thinking to its lowest supported effort instead of sending unsupported `none`.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10905,6 +10905,21 @@
 				}
 			},
 			{
+				"source": "providers/openai-codex.kdl:152",
+				"providers": [
+					"openai-codex"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "gpt-6-astra"
+					}
+				],
+				"thinking": {
+					"requiresEffort": true
+				}
+			},
+			{
 				"source": "providers/openai-codex.kdl:3",
 				"providers": [
 					"openai-codex"

--- a/packages/catalog/src/compat/rules/providers/openai-codex.kdl
+++ b/packages/catalog/src/compat/rules/providers/openai-codex.kdl
@@ -148,4 +148,8 @@ provider "openai-codex" {
 	models "gpt-5.6-luna" "gpt-5.6-sol" "gpt-5.6-terra" {
 		context-window-floor 1000000
 	}
+	// Codex Astra rejects reasoning.effort "none"; clamp thinking-off to low.
+	models "gpt-6-astra" {
+		thinking-requires-effort #true
+	}
 }


### PR DESCRIPTION
## Summary

Mark `openai-codex/gpt-6-astra` as requiring reasoning in the provider's canonical KDL policy, and regenerate the compiled catalog rules.

Codex rejects explicit thinking-off requests because `none` is unsupported for Astra; accepted values are `low`, `medium`, `high`, `xhigh`, and `max`. Astra already has this effort ladder, but lacks `thinking.requiresEffort`. Consequently, public stream normalization preserves `forceReasoningOff`, and the Codex request sends `reasoning.effort: "none"`. The existing mandatory-reasoning normalization supplies the fix by clamping to the lowest supported effort, `low`.

## Scope

- Provider-scoped metadata for Codex Astra; no model-wide override affecting Azure or other providers.
- No transport retry logic, new dependencies, or changes to models that support reasoning-off.
- Outgoing-request regression uses `streamSimple` and captures the Codex payload with thinking explicitly disabled.
- Includes generated `rules.json` and catalog changelog. No fork-only patch machinery.

## Verification

- Regression fails on the upstream base: expected `low`, received `none`.
- Regression passes after compiling the policy.
- `bun test packages/ai/test/openai-codex-stream.test.ts packages/ai/test/requires-effort.test.ts packages/catalog/test/model-thinking.test.ts packages/catalog/test/codex-discovery.test.ts packages/catalog/test/compat-compile.test.ts`: 186 passed, 0 failed.
- `bun run check:ts`: passed.