### PR TITLE
fix(coding-agent): break tiny/smol fallback cycle on default alias

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1178,8 +1178,10 @@ function resolveDefaultInheritedPatterns(
 			MAX_THINKING_SUFFIX_OPTIONS,
 		);
 		const aliasRole = getModelRoleAlias(aliasCandidate, settings);
-		if (aliasRole === role) {
-			// Self-alias (e.g. modelRoles.default = "@smol") would loop back to the
+		if (aliasRole && visited.has(aliasRole)) {
+			// Cycle (self-alias like modelRoles.default = "@smol", or tiny → smol
+			// → default = "@tiny") would loop back to a visited role: fall back
+			// to the built-in chain instead of leaking the unresolved alias.
 			resolved.push(
 				...(thinkingLevel
 					? roleDefaults.map(defaultPattern => `${defaultPattern}:${thinkingLevel}`)
@@ -1187,7 +1189,7 @@ function resolveDefaultInheritedPatterns(
 			);
 			continue;
 		}
-		if (aliasRole && !visited.has(aliasRole)) {
+		if (aliasRole) {
 			// Cross-role alias (e.g. modelRoles.default = "@slow"): resolve the
 			// concrete model patterns instead of another role alias.
 			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
@@ -1223,10 +1225,24 @@ function resolveConfiguredRolePattern(
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
 	const configuredFallback = isModelRole(role) ? ROLE_CONFIGURED_FALLBACK[role] : undefined;
+	const fallbackPatterns =
+		configured || !configuredFallback
+			? undefined
+			: (
+					resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback), settings, new Set(visited)) ?? []
+				).filter(pattern => {
+					const { base } = splitThinkingSuffix(
+						pattern,
+						modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
+						MAX_THINKING_SUFFIX_OPTIONS,
+					);
+					const patternRole = getModelRoleAlias(base, settings);
+					return !patternRole || !visited.has(patternRole);
+				});
 	const resolved = configured
 		? normalizeModelPatternList(configured)
-		: configuredFallback
-			? (resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback), settings, new Set(visited)) ?? [])
+		: fallbackPatterns
+			? fallbackPatterns
 			: isModelRole(role)
 				? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
 				: roleDefaults;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1230,14 +1230,18 @@ function resolveConfiguredRolePattern(
 			? undefined
 			: (
 					resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback), settings, new Set(visited)) ?? []
-				).filter(pattern => {
-					const { base } = splitThinkingSuffix(
+				).flatMap(pattern => {
+					const { base, level } = splitThinkingSuffix(
 						pattern,
 						modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
 						MAX_THINKING_SUFFIX_OPTIONS,
 					);
 					const patternRole = getModelRoleAlias(base, settings);
-					return !patternRole || !visited.has(patternRole);
+					if (!patternRole || !visited.has(patternRole)) return [pattern];
+					// Cyclic fallback alias (e.g. smol = "@tiny:high" while resolving
+					// @tiny): expand to the built-in chain, preserving the requested
+					// thinking level instead of dropping the suffix.
+					return level ? roleDefaults.map(defaultPattern => `${defaultPattern}:${level}`) : [];
 				});
 	const resolved = configured
 		? normalizeModelPatternList(configured)

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1140,14 +1140,25 @@ describe("resolveAgentModelPatterns", () => {
 
 	test("breaks the tiny/smol fallback cycle via a default alias", () => {
 		const settings = Settings.isolated({ modelRoles: { default: "@tiny" } });
+		const baseline = resolveAgentModelPatterns({ agentModel: "@smol", settings: Settings.isolated() });
 
 		const tiny = resolveAgentModelPatterns({ agentModel: "@tiny", settings });
 		const smol = resolveAgentModelPatterns({ agentModel: "@smol", settings });
 
+		expect(baseline.length).toBeGreaterThan(0);
 		expect(tiny).not.toContain("@tiny");
 		expect(smol).not.toContain("@tiny");
-		expect(tiny[0]).toBe("google-antigravity/gemini-3.8-flash");
+		expect(tiny).toEqual(baseline);
 		expect(smol).toEqual(tiny);
+	});
+
+	test("preserves thinking suffix when breaking the smol fallback cycle", () => {
+		const settings = Settings.isolated({ modelRoles: { smol: "@tiny:high" } });
+		const baseline = resolveAgentModelPatterns({ agentModel: "@smol", settings: Settings.isolated() });
+
+		const tiny = resolveAgentModelPatterns({ agentModel: "@tiny", settings });
+
+		expect(tiny).toEqual(baseline.map(pattern => `${pattern}:high`));
 	});
 
 	test("expands cross-role default aliases when inheriting for an unset role", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1138,6 +1138,18 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@tiny", settings })).toEqual(["baseten/custom-smol:max"]);
 	});
 
+	test("breaks the tiny/smol fallback cycle via a default alias", () => {
+		const settings = Settings.isolated({ modelRoles: { default: "@tiny" } });
+
+		const tiny = resolveAgentModelPatterns({ agentModel: "@tiny", settings });
+		const smol = resolveAgentModelPatterns({ agentModel: "@smol", settings });
+
+		expect(tiny).not.toContain("@tiny");
+		expect(smol).not.toContain("@tiny");
+		expect(tiny[0]).toBe("google-antigravity/gemini-3.8-flash");
+		expect(smol).toEqual(tiny);
+	});
+
 	test("expands cross-role default aliases when inheriting for an unset role", () => {
 		const settings = Settings.isolated({
 			modelRoles: { default: "@slow", slow: "anthropic/claude-sonnet-4-5" },


### PR DESCRIPTION
Followup to #11312 addressing the P2 nit (r3967379483).

When modelRoles.default is @tiny with tiny/smol unset, resolving @tiny followed tiny -> smol -> configured default -> tiny. resolveDefaultInheritedPatterns retained the literal @tiny, so the new configured-fallback branch returned ["@tiny"] instead of the built-in smol chain.

- Generalize the self-alias guard in resolveDefaultInheritedPatterns to any visited role, falling back to the built-in chain (preserves thinking suffix).
- Filter visited role aliases out of the tiny->smol configured-fallback result so an explicit smol=@tiny cycle also falls back to roleDefaults via the existing empty->defaults path.
- Regression test: default=@tiny resolves @tiny/@smol to the smol priority head, never @tiny.

Verification: bun test model-resolver + model-browser (185 pass), orig repro still returns baseten/custom-smol:max for both roles, cycle repro returns smol chain head for both, @tiny:high maps chain with :high.