### PR TITLE
fix(coding-agent): recheck vibe guard after loop condition gate

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 - Codex turns interrupted before terminal completion now auto-continue after resolved tool calls instead of stopping ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
 - `/handoff` no longer leaves the TUI in a running state when completion races with delayed session events ([#11263](https://github.com/can1357/oh-my-pi/issues/11263)).
+- Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1861,6 +1861,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		// /vibe can be enabled while the gate was awaiting: the pre-gate guard
+		// above is stale, and handleClearCommand would only warn and then let
+		// the iteration submit without resetting.
+		if (action === "reset" && this.vibeModeEnabled) {
+			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
+			return;
+		}
+
 		if (!consumeLoopLimitIteration(this.loopLimit)) {
 			this.disableLoopMode("Loop limit reached. Loop mode disabled.");
 			return;

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -360,5 +360,33 @@ describe("InteractiveMode loop auto-submit", () => {
 			mode.setLoopPrompt("keep going");
 			expect(captured?.aborted).toBe(true);
 		});
+
+		// /vibe enabled while the gate is awaiting must kill a reset loop: the
+		// pre-gate guard is stale by then, and handleClearCommand would only
+		// warn while the iteration still submitted without resetting.
+		it("disables a reset loop when vibe is enabled while the condition is in flight", async () => {
+			vi.useFakeTimers();
+			settings.set("loop.mode", "reset");
+			idleSession();
+			const pending = Promise.withResolvers<LoopConditionVerdict>();
+			vi.spyOn(loopCondition, "evaluateLoopCondition").mockImplementation(async () => await pending.promise);
+			const clear = vi.spyOn(mode, "handleClearCommand");
+			const showStatus = vi.spyOn(mode, "showStatus");
+			mode.loopCondition = { command: "sleep 30", until: false };
+
+			const resolved = armLoop("reset me");
+			vi.advanceTimersByTime(800);
+			await flushMicrotasks();
+
+			mode.vibeModeEnabled = true;
+			pending.resolve({ kind: "continue" });
+			await flushMicrotasks();
+
+			expect(clear).not.toHaveBeenCalled();
+			expect(resolved).toHaveLength(0);
+			expect(mode.loopModeEnabled).toBe(false);
+			expect(mode.loopPrompt).toBeUndefined();
+			expect(showStatus).toHaveBeenCalledWith("Exit vibe mode before using reset loops. Loop mode disabled.");
+		});
 	});
 });


### PR DESCRIPTION
Follow-up to #10858 addressing the post-merge nit (codex P2 on `interactive-mode.ts:1857`).

## Problem
In `#runLoopIteration`, the `reset` + vibe-mode guard ran only before the `--while`/`--until` condition await. If the user enabled `/vibe` while a slow condition command was in flight, the stale pre-await guard was bypassed: execution reached `handleClearCommand()`, which only warns (`Exit vibe mode first.`) and refuses the reset, but `#submitLoopPromptWhenReady()` still submitted the next iteration — leaving a reset loop running without resets while warning on every iteration.

## Fix
Re-apply the `reset` + vibe guard after the condition gate resolves (alongside the existing post-await `#isAutoSubmitBlocked()` recheck), so a mid-gate `/vibe` disables the loop instead of looping without resets.

## Testing
- New regression test: `disables a reset loop when vibe is enabled while the condition is in flight` — verified it fails pre-fix (1 fail) and passes post-fix.
- `interactive-mode-loop.test.ts`: 12 pass; related suites (`loop-condition`, `loop-limit`, `interactive-mode-loop-teardown`, `status-line-loop`, `shell-tokenize`): 54 pass.
- `bun check` passes.
- CHANGELOG under Unreleased/Fixed.