### PR TITLE
fix(coding-agent): guard reset loops against in-flight vibe activation

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -785,6 +785,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	// Loop reset guards treat a pending entry as active, and a concurrent /vibe
 	// command awaits it instead of dispatching its prompt on the stale toolset.
 	#vibeModeEntry: Promise<void> | undefined;
+	// Live skill-prompt reservation: set synchronously when a /vibe skill prompt
+	// starts dispatching (its file read yields before the turn reserves), so a
+	// concurrent prompt cannot take the idle waiter and start its turn first.
+	// Cleared when the skill dispatch settles.
+	#vibeSkillReservation: object | undefined;
 	#vibeScopeSuspendedForSwitch = false;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
 	#goalTurnHadToolCalls = false;
@@ -4199,13 +4204,26 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#enterVibeMode();
 		if (!initialPrompt) return false;
 		if (isKnownSkillCommand(this, initialPrompt)) {
-			await invokeSkillCommandFromText(this, initialPrompt, "steer", {
-				images: input?.images,
-				propagateErrors: true,
-			});
-			return true;
+			// Claim synchronously: the skill file read below yields before the
+			// turn reserves, so a concurrent plain prompt must see this
+			// reservation before it can take the idle waiter.
+			const reservation = {};
+			this.#vibeSkillReservation = reservation;
+			try {
+				await this.#waitForInFlightSubmission(reservation);
+				await invokeSkillCommandFromText(this, initialPrompt, "steer", {
+					images: input?.images,
+					propagateErrors: true,
+				});
+				return true;
+			} finally {
+				if (this.#vibeSkillReservation === reservation) this.#vibeSkillReservation = undefined;
+			}
 		}
 		if (this.session.isStreaming) {
+			// Same ordering covenant as below: a skill prompt may be reserving
+			// ahead of us even though the session looks continuously busy.
+			await this.#waitForInFlightSubmission();
 			const images = input?.images?.length ? input.images : undefined;
 			await this.withLocalSubmission(
 				initialPrompt,
@@ -4214,10 +4232,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			);
 			return true;
 		}
-		// Fresh CFA scope per call (a repeat read of the property would stay
-		// narrowed). Invoked synchronously so the first resumer always wins the
-		// one-shot waiter.
 		const dispatchViaWaiter = (): boolean => {
+			// A skill prompt reserving ahead of us owns the next turn: leave the
+			// waiter armed until it reserves, so the main loop submits in order.
+			if (this.#vibeSkillReservation) return false;
 			const onInput = this.onInputCallback;
 			if (!onInput) return false;
 			onInput(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
@@ -4243,26 +4261,28 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	/**
-	 * Yield until a waiter-delivered submission reserves its turn (streaming,
-	 * queued, or dropped) or a fresh waiter arms. Without this, a prompt
-	 * dispatched right after a concurrent submit resolved the one-shot input
-	 * waiter would reach {@link session.prompt} before the main loop submits
-	 * the earlier input, reversing their order. No-op when nothing is in
-	 * flight; bounded so a stalled loop degrades to immediate dispatch.
+	 * Yield until prior dispatches reserve their turn (streaming, queued, or
+	 * dropped) or a fresh waiter arms. Without this, a prompt dispatched right
+	 * after a concurrent submit resolved the one-shot input waiter — or while a
+	 * skill prompt is still reading its file — would reach
+	 * {@link session.prompt} before the main loop submits the earlier input,
+	 * reversing their order. No-op when nothing is in flight; bounded so a
+	 * stalled loop degrades to immediate dispatch. `ignoreSkillReservation`
+	 * lets a skill dispatch wait for earlier submissions without hanging on
+	 * its own reservation.
 	 */
-	async #waitForInFlightSubmission(): Promise<void> {
-		const awaited = this.#pendingSubmittedInput;
-		if (!awaited || awaited.cancelled) return;
+	async #waitForInFlightSubmission(ignoreSkillReservation?: object): Promise<void> {
 		for (let index = 0; index < 200; index++) {
-			if (
-				this.#pendingSubmittedInput !== awaited ||
-				awaited.cancelled ||
-				this.session.isStreaming ||
-				this.session.queuedMessageCount > 0 ||
-				this.onInputCallback
-			) {
-				return;
-			}
+			const skillBlocked =
+				this.#vibeSkillReservation !== undefined && this.#vibeSkillReservation !== ignoreSkillReservation;
+			const awaited = this.#pendingSubmittedInput;
+			const pendingBlocked =
+				awaited !== undefined &&
+				!awaited.cancelled &&
+				!this.session.isStreaming &&
+				this.session.queuedMessageCount === 0 &&
+				!this.onInputCallback;
+			if (!skillBlocked && !pendingBlocked) return;
 			await Bun.sleep(10);
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -785,11 +785,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	// Loop reset guards treat a pending entry as active, and a concurrent /vibe
 	// command awaits it instead of dispatching its prompt on the stale toolset.
 	#vibeModeEntry: Promise<void> | undefined;
-	// Live skill-prompt reservation: set synchronously when a /vibe skill prompt
-	// starts dispatching (its file read yields before the turn reserves), so a
-	// concurrent prompt cannot take the idle waiter and start its turn first.
-	// Cleared when the skill dispatch settles.
-	#vibeSkillReservation: object | undefined;
+	// FIFO tail + live count for concurrent /vibe skill dispatches. A skill
+	// prompt yields on its file read before the turn reserves, so each skill
+	// links behind its predecessor (arrival order) while the count — visible
+	// synchronously, unlike a single shared slot — stops later prompts from
+	// overtaking any of them. Both settle when the dispatch settles, so a
+	// failure unblocks every waiter instead of hanging it.
+	#vibeSkillTail: Promise<void> = Promise.resolve();
+	#vibeSkillInFlight = 0;
 	#vibeScopeSuspendedForSwitch = false;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
 	#goalTurnHadToolCalls = false;
@@ -4204,21 +4207,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#enterVibeMode();
 		if (!initialPrompt) return false;
 		if (isKnownSkillCommand(this, initialPrompt)) {
-			// Claim synchronously: the skill file read below yields before the
-			// turn reserves, so a concurrent plain prompt must see this
-			// reservation before it can take the idle waiter.
-			const reservation = {};
-			this.#vibeSkillReservation = reservation;
-			try {
-				await this.#waitForInFlightSubmission(reservation);
-				await invokeSkillCommandFromText(this, initialPrompt, "steer", {
-					images: input?.images,
-					propagateErrors: true,
-				});
-				return true;
-			} finally {
-				if (this.#vibeSkillReservation === reservation) this.#vibeSkillReservation = undefined;
-			}
+			// Append synchronously: the skill file read below yields before the
+			// turn reserves, so a concurrent plain prompt must see this claim
+			// before it can take the idle waiter — and a later skill must queue
+			// behind this one rather than overwrite a shared slot.
+			const prev = this.#vibeSkillTail;
+			this.#vibeSkillInFlight++;
+			const mine = (async () => {
+				try {
+					await prev;
+					await this.#waitForInFlightSubmission(true);
+					await invokeSkillCommandFromText(this, initialPrompt, "steer", {
+						images: input?.images,
+						propagateErrors: true,
+					});
+				} finally {
+					this.#vibeSkillInFlight--;
+				}
+			})();
+			// Never reject: a failed skill must not break the chain for later ones.
+			this.#vibeSkillTail = mine.catch(() => {});
+			await mine;
+			return true;
 		}
 		if (this.session.isStreaming) {
 			// Same ordering covenant as below: a skill prompt may be reserving
@@ -4235,7 +4245,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const dispatchViaWaiter = (): boolean => {
 			// A skill prompt reserving ahead of us owns the next turn: leave the
 			// waiter armed until it reserves, so the main loop submits in order.
-			if (this.#vibeSkillReservation) return false;
+			if (this.#vibeSkillInFlight > 0) return false;
 			const onInput = this.onInputCallback;
 			if (!onInput) return false;
 			onInput(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
@@ -4267,14 +4277,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * skill prompt is still reading its file — would reach
 	 * {@link session.prompt} before the main loop submits the earlier input,
 	 * reversing their order. No-op when nothing is in flight; bounded so a
-	 * stalled loop degrades to immediate dispatch. `ignoreSkillReservation`
-	 * lets a skill dispatch wait for earlier submissions without hanging on
-	 * its own reservation.
+	 * stalled loop degrades to immediate dispatch. `excludeOwnSkill` lets a
+	 * skill dispatch wait for earlier submissions without hanging on the unit
+	 * it just appended (concurrent skills order themselves through the tail
+	 * chain instead).
 	 */
-	async #waitForInFlightSubmission(ignoreSkillReservation?: object): Promise<void> {
+	async #waitForInFlightSubmission(excludeOwnSkill = false): Promise<void> {
 		for (let index = 0; index < 200; index++) {
-			const skillBlocked =
-				this.#vibeSkillReservation !== undefined && this.#vibeSkillReservation !== ignoreSkillReservation;
+			const skillBlocked = this.#vibeSkillInFlight - (excludeOwnSkill ? 1 : 0) > 0;
 			const awaited = this.#pendingSubmittedInput;
 			const pendingBlocked =
 				awaited !== undefined &&

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4277,14 +4277,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * skill prompt is still reading its file — would reach
 	 * {@link session.prompt} before the main loop submits the earlier input,
 	 * reversing their order. No-op when nothing is in flight; bounded so a
-	 * stalled loop degrades to immediate dispatch. `excludeOwnSkill` lets a
-	 * skill dispatch wait for earlier submissions without hanging on the unit
-	 * it just appended (concurrent skills order themselves through the tail
-	 * chain instead).
+	 * stalled loop degrades to immediate dispatch. `ignoreSkills` lets a skill
+	 * dispatch wait for earlier plain submissions only: concurrent skills order
+	 * themselves through the tail chain, and counting the live total here would
+	 * stall an earlier skill behind a later one it must precede.
 	 */
-	async #waitForInFlightSubmission(excludeOwnSkill = false): Promise<void> {
+	async #waitForInFlightSubmission(ignoreSkills = false): Promise<void> {
 		for (let index = 0; index < 200; index++) {
-			const skillBlocked = this.#vibeSkillInFlight - (excludeOwnSkill ? 1 : 0) > 0;
+			const skillBlocked = !ignoreSkills && this.#vibeSkillInFlight > 0;
 			const awaited = this.#pendingSubmittedInput;
 			const pendingBlocked =
 				awaited !== undefined &&

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4218,7 +4218,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
 			return true;
 		}
-		return false;
+		// No input waiter: a concurrent /vibe consumed the one-shot waiter, or
+		// the main loop is between turns. Steer directly instead of silently
+		// swallowing the prompt — the same fallback the normal submit path uses
+		// when its waiter is gone.
+		const images = input?.images?.length ? input.images : undefined;
+		await this.withLocalSubmission(
+			initialPrompt,
+			() => this.session.prompt(initialPrompt, { streamingBehavior: "steer", images }),
+			{ imageCount: images?.length ?? 0 },
+		);
+		return true;
 	}
 
 	async #enterVibeMode(options?: { persistModeChange?: boolean; previousTools?: string[] }): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -780,6 +780,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	#goalModePreviousTools: string[] | undefined;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
+	// True while #enterVibeMode awaits activateVibeTools: vibeModeEnabled is
+	// still false, but a reset iteration must already treat vibe as active so
+	// it cannot slip in concurrently with the toolset switch.
+	#vibeModeEntering = false;
 	#vibeScopeSuspendedForSwitch = false;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
 	#goalTurnHadToolCalls = false;
@@ -1834,7 +1838,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		if (action === "reset" && this.vibeModeEnabled) {
+		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntering)) {
 			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
 			return;
 		}
@@ -1863,8 +1867,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// /vibe can be enabled while the gate was awaiting: the pre-gate guard
 		// above is stale, and handleClearCommand would only warn and then let
-		// the iteration submit without resetting.
-		if (action === "reset" && this.vibeModeEnabled) {
+		// the iteration submit without resetting. Check the entering transition
+		// too: vibeModeEnabled is still false while activateVibeTools is in
+		// flight, but the reset must not run concurrently with the toolset switch.
+		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntering)) {
 			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
 			return;
 		}
@@ -4215,7 +4221,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async #enterVibeMode(options?: { persistModeChange?: boolean; previousTools?: string[] }): Promise<void> {
-		if (this.vibeModeEnabled) {
+		if (this.vibeModeEnabled || this.#vibeModeEntering) {
 			return;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
@@ -4238,10 +4244,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		const previousTools = options?.previousTools ?? this.session.getEnabledToolNames();
 		const vibeBaseTools = ["read"];
 		if (this.session.hasBuiltInTool("todo")) vibeBaseTools.push("todo");
-		await this.session.activateVibeTools(vibeBaseTools);
+		this.#vibeModeEntering = true;
+		try {
+			await this.session.activateVibeTools(vibeBaseTools);
+		} catch (error) {
+			this.#vibeModeEntering = false;
+			throw error;
+		}
 		this.#vibeModePreviousTools = previousTools;
 		this.#vibeModeOwnerScope = ownerScope;
 		this.vibeModeEnabled = true;
+		this.#vibeModeEntering = false;
 		// Suppress cache-miss marker on the next turn: vibe mode changes the
 		// injected context, which predictably invalidates the cache.
 		this.lastAssistantUsage = undefined;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4214,14 +4214,25 @@ export class InteractiveMode implements InteractiveModeContext {
 			);
 			return true;
 		}
-		if (this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
+		// Fresh CFA scope per call (a repeat read of the property would stay
+		// narrowed). Invoked synchronously so the first resumer always wins the
+		// one-shot waiter.
+		const dispatchViaWaiter = (): boolean => {
+			const onInput = this.onInputCallback;
+			if (!onInput) return false;
+			onInput(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
 			return true;
-		}
-		// No input waiter: a concurrent /vibe consumed the one-shot waiter, or
-		// the main loop is between turns. Steer directly instead of silently
-		// swallowing the prompt — the same fallback the normal submit path uses
-		// when its waiter is gone.
+		};
+		if (dispatchViaWaiter()) return true;
+		// No input waiter: a concurrent dispatch may have just taken the one-shot
+		// waiter — its submission exists but the main loop hasn't handed it to the
+		// session yet. Steering now would overtake it and reverse prompt order, so
+		// yield until it reserves its turn, then re-check for a fresh waiter.
+		await this.#waitForInFlightSubmission();
+		if (dispatchViaWaiter()) return true;
+		// Still no waiter (the main loop is between turns): steer directly instead
+		// of silently swallowing the prompt — the same fallback the normal submit
+		// path uses when its waiter is gone.
 		const images = input?.images?.length ? input.images : undefined;
 		await this.withLocalSubmission(
 			initialPrompt,
@@ -4229,6 +4240,31 @@ export class InteractiveMode implements InteractiveModeContext {
 			{ imageCount: images?.length ?? 0 },
 		);
 		return true;
+	}
+
+	/**
+	 * Yield until a waiter-delivered submission reserves its turn (streaming,
+	 * queued, or dropped) or a fresh waiter arms. Without this, a prompt
+	 * dispatched right after a concurrent submit resolved the one-shot input
+	 * waiter would reach {@link session.prompt} before the main loop submits
+	 * the earlier input, reversing their order. No-op when nothing is in
+	 * flight; bounded so a stalled loop degrades to immediate dispatch.
+	 */
+	async #waitForInFlightSubmission(): Promise<void> {
+		const awaited = this.#pendingSubmittedInput;
+		if (!awaited || awaited.cancelled) return;
+		for (let index = 0; index < 200; index++) {
+			if (
+				this.#pendingSubmittedInput !== awaited ||
+				awaited.cancelled ||
+				this.session.isStreaming ||
+				this.session.queuedMessageCount > 0 ||
+				this.onInputCallback
+			) {
+				return;
+			}
+			await Bun.sleep(10);
+		}
 	}
 
 	async #enterVibeMode(options?: { persistModeChange?: boolean; previousTools?: string[] }): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -780,10 +780,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	#goalModePreviousTools: string[] | undefined;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
-	// True while #enterVibeMode awaits activateVibeTools: vibeModeEnabled is
-	// still false, but a reset iteration must already treat vibe as active so
-	// it cannot slip in concurrently with the toolset switch.
-	#vibeModeEntering = false;
+	// In-flight #enterVibeMode promise: set before the activateVibeTools await
+	// (while vibeModeEnabled is still false) and cleared when entry settles.
+	// Loop reset guards treat a pending entry as active, and a concurrent /vibe
+	// command awaits it instead of dispatching its prompt on the stale toolset.
+	#vibeModeEntry: Promise<void> | undefined;
 	#vibeScopeSuspendedForSwitch = false;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
 	#goalTurnHadToolCalls = false;
@@ -1838,7 +1839,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntering)) {
+		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntry !== undefined)) {
 			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
 			return;
 		}
@@ -1870,7 +1871,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// the iteration submit without resetting. Check the entering transition
 		// too: vibeModeEnabled is still false while activateVibeTools is in
 		// flight, but the reset must not run concurrently with the toolset switch.
-		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntering)) {
+		if (action === "reset" && (this.vibeModeEnabled || this.#vibeModeEntry !== undefined)) {
 			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
 			return;
 		}
@@ -4221,7 +4222,17 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async #enterVibeMode(options?: { persistModeChange?: boolean; previousTools?: string[] }): Promise<void> {
-		if (this.vibeModeEnabled || this.#vibeModeEntering) {
+		if (this.vibeModeEnabled) {
+			return;
+		}
+		const inFlight = this.#vibeModeEntry;
+		if (inFlight) {
+			// A second /vibe (possibly with a prompt) submitted while activation
+			// is still in flight must not dispatch on the stale toolset: wait for
+			// the first entry, then return with vibe active. A failed entry
+			// rejects here too, so the prompt is dropped instead of running
+			// outside vibe mode.
+			await inFlight;
 			return;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
@@ -4244,29 +4255,34 @@ export class InteractiveMode implements InteractiveModeContext {
 		const previousTools = options?.previousTools ?? this.session.getEnabledToolNames();
 		const vibeBaseTools = ["read"];
 		if (this.session.hasBuiltInTool("todo")) vibeBaseTools.push("todo");
-		this.#vibeModeEntering = true;
-		try {
+		// The entry runs as a stored promise so a concurrent /vibe joins it
+		// above instead of dispatching on the stale toolset. The first caller
+		// awaits it below, so a failure is always observed (no unhandled
+		// rejection) and propagates to every joiner, dropping their prompts.
+		const entry = (async () => {
 			await this.session.activateVibeTools(vibeBaseTools);
-		} catch (error) {
-			this.#vibeModeEntering = false;
-			throw error;
+			this.#vibeModePreviousTools = previousTools;
+			this.#vibeModeOwnerScope = ownerScope;
+			this.vibeModeEnabled = true;
+			// Suppress cache-miss marker on the next turn: vibe mode changes the
+			// injected context, which predictably invalidates the cache.
+			this.lastAssistantUsage = undefined;
+			this.session.setVibeModeState({ enabled: true });
+			if (this.session.isStreaming) {
+				await this.session.sendVibeModeContext({ deliverAs: "steer" });
+			}
+			this.#updateVibeModeStatus();
+			if (options?.persistModeChange !== false) this.sessionManager.appendModeChange("vibe", { previousTools });
+			this.showStatus(
+				"Vibe mode enabled. You direct fast/good worker sessions; toolset is read + optional parent Todo + vibe tools.",
+			);
+		})();
+		this.#vibeModeEntry = entry;
+		try {
+			await entry;
+		} finally {
+			if (this.#vibeModeEntry === entry) this.#vibeModeEntry = undefined;
 		}
-		this.#vibeModePreviousTools = previousTools;
-		this.#vibeModeOwnerScope = ownerScope;
-		this.vibeModeEnabled = true;
-		this.#vibeModeEntering = false;
-		// Suppress cache-miss marker on the next turn: vibe mode changes the
-		// injected context, which predictably invalidates the cache.
-		this.lastAssistantUsage = undefined;
-		this.session.setVibeModeState({ enabled: true });
-		if (this.session.isStreaming) {
-			await this.session.sendVibeModeContext({ deliverAs: "steer" });
-		}
-		this.#updateVibeModeStatus();
-		if (options?.persistModeChange !== false) this.sessionManager.appendModeChange("vibe", { previousTools });
-		this.showStatus(
-			"Vibe mode enabled. You direct fast/good worker sessions; toolset is read + optional parent Todo + vibe tools.",
-		);
 	}
 
 	async #exitVibeMode(): Promise<void> {

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -363,7 +363,9 @@ describe("InteractiveMode loop auto-submit", () => {
 
 		// /vibe enabled while the gate is awaiting must kill a reset loop: the
 		// pre-gate guard is stale by then, and handleClearCommand would only
-		// warn while the iteration still submitted without resetting.
+		// warn while the iteration still submitted without resetting. Goes
+		// through the real /vibe command so the vibeModeEnabled transition is
+		// exercised instead of assigned directly.
 		it("disables a reset loop when vibe is enabled while the condition is in flight", async () => {
 			vi.useFakeTimers();
 			settings.set("loop.mode", "reset");
@@ -372,13 +374,15 @@ describe("InteractiveMode loop auto-submit", () => {
 			vi.spyOn(loopCondition, "evaluateLoopCondition").mockImplementation(async () => await pending.promise);
 			const clear = vi.spyOn(mode, "handleClearCommand");
 			const showStatus = vi.spyOn(mode, "showStatus");
+			vi.spyOn(session, "activateVibeTools").mockResolvedValue();
 			mode.loopCondition = { command: "sleep 30", until: false };
 
 			const resolved = armLoop("reset me");
 			vi.advanceTimersByTime(800);
 			await flushMicrotasks();
 
-			mode.vibeModeEnabled = true;
+			await mode.handleVibeModeCommand();
+			expect(mode.vibeModeEnabled).toBe(true);
 			pending.resolve({ kind: "continue" });
 			await flushMicrotasks();
 
@@ -387,6 +391,44 @@ describe("InteractiveMode loop auto-submit", () => {
 			expect(mode.loopModeEnabled).toBe(false);
 			expect(mode.loopPrompt).toBeUndefined();
 			expect(showStatus).toHaveBeenCalledWith("Exit vibe mode before using reset loops. Loop mode disabled.");
+		});
+
+		// The condition can resolve while /vibe tool activation is still in
+		// flight: vibeModeEnabled is still false, but the reset must not run
+		// concurrently with the toolset switch. The loop must disable on the
+		// entering transition, not just the settled flag.
+		it("disables a reset loop when the condition resolves during vibe activation", async () => {
+			vi.useFakeTimers();
+			settings.set("loop.mode", "reset");
+			idleSession();
+			const pending = Promise.withResolvers<LoopConditionVerdict>();
+			vi.spyOn(loopCondition, "evaluateLoopCondition").mockImplementation(async () => await pending.promise);
+			const clear = vi.spyOn(mode, "handleClearCommand");
+			const showStatus = vi.spyOn(mode, "showStatus");
+			const vibeGate = Promise.withResolvers<void>();
+			vi.spyOn(session, "activateVibeTools").mockImplementation(() => vibeGate.promise);
+			mode.loopCondition = { command: "sleep 30", until: false };
+
+			const resolved = armLoop("reset me");
+			vi.advanceTimersByTime(800);
+			await flushMicrotasks();
+
+			const vibeEnter = mode.handleVibeModeCommand();
+			await flushMicrotasks();
+			expect(mode.vibeModeEnabled).toBe(false);
+
+			pending.resolve({ kind: "continue" });
+			await flushMicrotasks();
+
+			expect(clear).not.toHaveBeenCalled();
+			expect(resolved).toHaveLength(0);
+			expect(mode.loopModeEnabled).toBe(false);
+			expect(mode.loopPrompt).toBeUndefined();
+			expect(showStatus).toHaveBeenCalledWith("Exit vibe mode before using reset loops. Loop mode disabled.");
+
+			vibeGate.resolve();
+			await vibeEnter;
+			expect(mode.vibeModeEnabled).toBe(true);
 		});
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -789,14 +789,30 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(session.getVibeModeState()).toBeUndefined();
 	});
 
-	it("preserves every prompt when a concurrent /vibe joins activation", async () => {
+	it("preserves submission order when a concurrent /vibe joins activation", async () => {
 		const gate = Promise.withResolvers<void>();
 		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
-		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(true);
-		// Real one-shot waiter, like the main loop installs while idle: the
-		// first dispatch consumes it, so a reusable stub would hide the loss.
-		const received: string[] = [];
-		void mode.getUserInput().then(input => received.push(input.text));
+		const promptCalls: string[] = [];
+		vi.spyOn(session, "prompt").mockImplementation(async text => {
+			promptCalls.push(text);
+			return true;
+		});
+		// Faithful main-loop dispatch: the waiter-delivered prompt travels the
+		// real getUserInput → submit path (mark + session.prompt + finish), so
+		// merely recording the waiter result cannot hide an order reversal.
+		void (async () => {
+			const input = await mode.getUserInput();
+			if (mode.markPendingSubmissionStarted(input)) {
+				try {
+					await session.prompt(input.text, {
+						images: input.images,
+						streamingBehavior: input.streamingBehavior ?? "followUp",
+					});
+				} finally {
+					mode.finishPendingSubmission(input);
+				}
+			}
+		})();
 		for (let index = 0; index < 5; index++) await Promise.resolve();
 
 		// First /vibe <prompt> parks on tool activation with vibe not yet enabled.
@@ -806,19 +822,16 @@ describe("InteractiveMode vibe mode toggle", () => {
 
 		// A second submit while activation is in flight (the editor fires
 		// onSubmit without awaiting the first handler) must wait for vibe
-		// instead of dispatching on the stale toolset — and must not lose its
-		// prompt to the consumed waiter.
+		// instead of dispatching on the stale toolset — and must not overtake
+		// the first prompt, which is still on its way through the main loop.
 		const second = mode.handleVibeModeCommand("second prompt");
 		for (let index = 0; index < 5; index++) await Promise.resolve();
-		expect(received).toHaveLength(0);
-		expect(promptSpy).not.toHaveBeenCalled();
+		expect(promptCalls).toHaveLength(0);
 
 		gate.resolve();
 		expect(await first).toBe(true);
 		expect(await second).toBe(true);
 		expect(mode.vibeModeEnabled).toBe(true);
-		expect(received).toEqual(["first prompt"]);
-		expect(promptSpy).toHaveBeenCalledTimes(1);
-		expect(promptSpy).toHaveBeenCalledWith("second prompt", { streamingBehavior: "steer", images: undefined });
+		expect(promptCalls).toEqual(["first prompt", "second prompt"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -788,4 +788,31 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(mode.vibeModeEnabled).toBe(false);
 		expect(session.getVibeModeState()).toBeUndefined();
 	});
+
+	it("holds a concurrent /vibe prompt until activation finishes", async () => {
+		const gate = Promise.withResolvers<void>();
+		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
+		const dispatched: string[] = [];
+		mode.onInputCallback = input => {
+			dispatched.push(input.text);
+		};
+
+		// First /vibe <prompt> parks on tool activation with vibe not yet enabled.
+		const first = mode.handleVibeModeCommand("first prompt");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(mode.vibeModeEnabled).toBe(false);
+
+		// A second submit while activation is in flight (the editor fires
+		// onSubmit without awaiting the first handler) must wait for vibe
+		// instead of dispatching its prompt on the stale toolset.
+		const second = mode.handleVibeModeCommand("second prompt");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(dispatched).toHaveLength(0);
+
+		gate.resolve();
+		expect(await first).toBe(true);
+		expect(await second).toBe(true);
+		expect(mode.vibeModeEnabled).toBe(true);
+		expect(dispatched).toEqual(["first prompt", "second prompt"]);
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -789,13 +789,15 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(session.getVibeModeState()).toBeUndefined();
 	});
 
-	it("holds a concurrent /vibe prompt until activation finishes", async () => {
+	it("preserves every prompt when a concurrent /vibe joins activation", async () => {
 		const gate = Promise.withResolvers<void>();
 		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
-		const dispatched: string[] = [];
-		mode.onInputCallback = input => {
-			dispatched.push(input.text);
-		};
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(true);
+		// Real one-shot waiter, like the main loop installs while idle: the
+		// first dispatch consumes it, so a reusable stub would hide the loss.
+		const received: string[] = [];
+		void mode.getUserInput().then(input => received.push(input.text));
+		for (let index = 0; index < 5; index++) await Promise.resolve();
 
 		// First /vibe <prompt> parks on tool activation with vibe not yet enabled.
 		const first = mode.handleVibeModeCommand("first prompt");
@@ -804,15 +806,19 @@ describe("InteractiveMode vibe mode toggle", () => {
 
 		// A second submit while activation is in flight (the editor fires
 		// onSubmit without awaiting the first handler) must wait for vibe
-		// instead of dispatching its prompt on the stale toolset.
+		// instead of dispatching on the stale toolset — and must not lose its
+		// prompt to the consumed waiter.
 		const second = mode.handleVibeModeCommand("second prompt");
 		for (let index = 0; index < 5; index++) await Promise.resolve();
-		expect(dispatched).toHaveLength(0);
+		expect(received).toHaveLength(0);
+		expect(promptSpy).not.toHaveBeenCalled();
 
 		gate.resolve();
 		expect(await first).toBe(true);
 		expect(await second).toBe(true);
 		expect(mode.vibeModeEnabled).toBe(true);
-		expect(dispatched).toEqual(["first prompt", "second prompt"]);
+		expect(received).toEqual(["first prompt"]);
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy).toHaveBeenCalledWith("second prompt", { streamingBehavior: "steer", images: undefined });
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -46,17 +46,22 @@ function vibeModeEntryCount(manager: SessionManager): number {
 	return manager.getEntries().filter(entry => entry.type === "mode_change" && entry.mode === "vibe").length;
 }
 
-async function registerOrderSkill(tempDir: TempDir, mode: InteractiveMode): Promise<void> {
-	const filePath = path.join(tempDir.path(), "order-skill.md");
-	await Bun.write(filePath, "---\nname: order-skill\n---\nDo it in order.\n");
+async function registerOrderSkill(
+	tempDir: TempDir,
+	mode: InteractiveMode,
+	name = "order-skill",
+	body = "Do it in order.",
+): Promise<void> {
+	const filePath = path.join(tempDir.path(), `${name}.md`);
+	await Bun.write(filePath, `---\nname: ${name}\n---\n${body}\n`);
 	const skill: Skill = {
-		name: "order-skill",
+		name,
 		description: "",
 		filePath,
 		baseDir: tempDir.path(),
 		source: "test",
 	};
-	mode.skillCommands.set("skill:order-skill", skill);
+	mode.skillCommands.set(`skill:${name}`, skill);
 }
 
 function armOrderLoop(mode: InteractiveMode, session: AgentSession): { done: Promise<void>; order: string[] } {
@@ -65,8 +70,11 @@ function armOrderLoop(mode: InteractiveMode, session: AgentSession): { done: Pro
 		order.push(`plain:${text}`);
 		return true;
 	});
-	vi.spyOn(session, "promptCustomMessage").mockImplementation(async () => {
-		order.push("skill");
+	vi.spyOn(session, "promptCustomMessage").mockImplementation(async message => {
+		const text = typeof message.content === "string" ? message.content : "";
+		if (text.includes("Skill A body")) order.push("skill-a");
+		else if (text.includes("Skill B body")) order.push("skill-b");
+		else order.push("skill");
 		return true;
 	});
 	// Faithful main-loop dispatch: the waiter-delivered prompt travels the real
@@ -926,5 +934,35 @@ describe("InteractiveMode vibe mode toggle", () => {
 		await loop.done;
 		expect(mode.vibeModeEnabled).toBe(true);
 		expect(loop.order).toEqual(["plain:plain first", "skill"]);
+	});
+
+	it("orders two skill vibe prompts behind a plain prompt in arrival order", async () => {
+		const gate = Promise.withResolvers<void>();
+		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
+		await registerOrderSkill(tempDir, mode, "order-skill-a", "Skill A body.");
+		await registerOrderSkill(tempDir, mode, "order-skill-b", "Skill B body.");
+		const loop = armOrderLoop(mode, session);
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+
+		const first = mode.handleVibeModeCommand("plain first");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(mode.vibeModeEnabled).toBe(false);
+
+		// Each skill links behind its predecessor instead of overwriting a
+		// shared slot, so the second skill cannot dispatch ahead of the first
+		// once the plain prompt reserves.
+		const second = mode.handleVibeModeCommand("/skill:order-skill-a go a");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		const third = mode.handleVibeModeCommand("/skill:order-skill-b go b");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(loop.order).toHaveLength(0);
+
+		gate.resolve();
+		expect(await first).toBe(true);
+		expect(await second).toBe(true);
+		expect(await third).toBe(true);
+		await loop.done;
+		expect(mode.vibeModeEnabled).toBe(true);
+		expect(loop.order).toEqual(["plain:plain first", "skill-a", "skill-b"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -14,6 +14,7 @@ import { Agent, type AgentTool, type StreamFn } from "@oh-my-pi/pi-agent-core";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
@@ -43,6 +44,47 @@ function stubTool(name: string): AgentTool {
 
 function vibeModeEntryCount(manager: SessionManager): number {
 	return manager.getEntries().filter(entry => entry.type === "mode_change" && entry.mode === "vibe").length;
+}
+
+async function registerOrderSkill(tempDir: TempDir, mode: InteractiveMode): Promise<void> {
+	const filePath = path.join(tempDir.path(), "order-skill.md");
+	await Bun.write(filePath, "---\nname: order-skill\n---\nDo it in order.\n");
+	const skill: Skill = {
+		name: "order-skill",
+		description: "",
+		filePath,
+		baseDir: tempDir.path(),
+		source: "test",
+	};
+	mode.skillCommands.set("skill:order-skill", skill);
+}
+
+function armOrderLoop(mode: InteractiveMode, session: AgentSession): { done: Promise<void>; order: string[] } {
+	const order: string[] = [];
+	vi.spyOn(session, "prompt").mockImplementation(async text => {
+		order.push(`plain:${text}`);
+		return true;
+	});
+	vi.spyOn(session, "promptCustomMessage").mockImplementation(async () => {
+		order.push("skill");
+		return true;
+	});
+	// Faithful main-loop dispatch: the waiter-delivered prompt travels the real
+	// getUserInput → submit path, so waiter-vs-steer order is agent-visible.
+	const done = (async () => {
+		const input = await mode.getUserInput();
+		if (mode.markPendingSubmissionStarted(input)) {
+			try {
+				await session.prompt(input.text, {
+					images: input.images,
+					streamingBehavior: input.streamingBehavior ?? "followUp",
+				});
+			} finally {
+				mode.finishPendingSubmission(input);
+			}
+		}
+	})();
+	return { done, order };
 }
 
 class ExitFaultStorage extends FileSessionStorage {
@@ -833,5 +875,56 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(await second).toBe(true);
 		expect(mode.vibeModeEnabled).toBe(true);
 		expect(promptCalls).toEqual(["first prompt", "second prompt"]);
+	});
+
+	it("orders a skill vibe prompt before a concurrent plain prompt", async () => {
+		const gate = Promise.withResolvers<void>();
+		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
+		await registerOrderSkill(tempDir, mode);
+		const loop = armOrderLoop(mode, session);
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+
+		// Skill first: its file read yields before the turn reserves.
+		const first = mode.handleVibeModeCommand("/skill:order-skill do it");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(mode.vibeModeEnabled).toBe(false);
+
+		// Plain second must not take the still-armed waiter and start its turn
+		// first: the skill reservation owns the next turn.
+		const second = mode.handleVibeModeCommand("plain follow-up");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(loop.order).toHaveLength(0);
+
+		gate.resolve();
+		expect(await first).toBe(true);
+		expect(await second).toBe(true);
+		await loop.done;
+		expect(mode.vibeModeEnabled).toBe(true);
+		expect(loop.order).toEqual(["skill", "plain:plain follow-up"]);
+	});
+
+	it("orders a plain vibe prompt before a concurrent skill prompt", async () => {
+		const gate = Promise.withResolvers<void>();
+		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
+		await registerOrderSkill(tempDir, mode);
+		const loop = armOrderLoop(mode, session);
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+
+		const first = mode.handleVibeModeCommand("plain first");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(mode.vibeModeEnabled).toBe(false);
+
+		// Skill second must wait for the waiter-delivered prompt to reserve
+		// before reading its file and steering behind it.
+		const second = mode.handleVibeModeCommand("/skill:order-skill do it");
+		for (let index = 0; index < 5; index++) await Promise.resolve();
+		expect(loop.order).toHaveLength(0);
+
+		gate.resolve();
+		expect(await first).toBe(true);
+		expect(await second).toBe(true);
+		await loop.done;
+		expect(mode.vibeModeEnabled).toBe(true);
+		expect(loop.order).toEqual(["plain:plain first", "skill"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -64,7 +64,11 @@ async function registerOrderSkill(
 	mode.skillCommands.set(`skill:${name}`, skill);
 }
 
-function armOrderLoop(mode: InteractiveMode, session: AgentSession): { done: Promise<void>; order: string[] } {
+function armOrderLoop(
+	mode: InteractiveMode,
+	session: AgentSession,
+	onDispatch?: (label: string) => void,
+): { done: Promise<void>; order: string[] } {
 	const order: string[] = [];
 	vi.spyOn(session, "prompt").mockImplementation(async text => {
 		order.push(`plain:${text}`);
@@ -72,9 +76,11 @@ function armOrderLoop(mode: InteractiveMode, session: AgentSession): { done: Pro
 	});
 	vi.spyOn(session, "promptCustomMessage").mockImplementation(async message => {
 		const text = typeof message.content === "string" ? message.content : "";
-		if (text.includes("Skill A body")) order.push("skill-a");
-		else if (text.includes("Skill B body")) order.push("skill-b");
-		else order.push("skill");
+		let label = "skill";
+		if (text.includes("Skill A body")) label = "skill-a";
+		else if (text.includes("Skill B body")) label = "skill-b";
+		order.push(label);
+		onDispatch?.(label);
 		return true;
 	});
 	// Faithful main-loop dispatch: the waiter-delivered prompt travels the real
@@ -941,7 +947,14 @@ describe("InteractiveMode vibe mode toggle", () => {
 		vi.spyOn(session, "activateVibeTools").mockImplementation(() => gate.promise);
 		await registerOrderSkill(tempDir, mode, "order-skill-a", "Skill A body.");
 		await registerOrderSkill(tempDir, mode, "order-skill-b", "Skill B body.");
-		const loop = armOrderLoop(mode, session);
+		// Signal, not a timer: the first skill must dispatch without stalling
+		// behind the second (parked on the first's own link). A
+		// successor-inclusive count leaves this unsettled until the ~2s bound
+		// expires instead, so this hangs to the test timeout pre-fix.
+		const aDispatched = Promise.withResolvers<void>();
+		const loop = armOrderLoop(mode, session, label => {
+			if (label === "skill-a") aDispatched.resolve();
+		});
 		for (let index = 0; index < 5; index++) await Promise.resolve();
 
 		const first = mode.handleVibeModeCommand("plain first");
@@ -958,11 +971,23 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(loop.order).toHaveLength(0);
 
 		gate.resolve();
+		// Wall-clock bound, not a guessed duration: the first skill must dispatch
+		// without stalling behind the second (parked on the first's own link). A
+		// successor-inclusive count burns 200 sequential 10ms sleeps (provably
+		// >=2000ms — timers never fire early), while the fixed path does
+		// millisecond-scale I/O with no wall waits; fake timers cannot drive the
+		// real file reads, so assert absence of the stall instead of exact order
+		// timing. Awaiting the dispatch signal above would merely pass slowly.
+		const startedAt = performance.now();
+		await aDispatched.promise;
+		expect(loop.order[0]).toBe("plain:plain first");
+		expect(loop.order).toContain("skill-a");
 		expect(await first).toBe(true);
 		expect(await second).toBe(true);
 		expect(await third).toBe(true);
 		await loop.done;
 		expect(mode.vibeModeEnabled).toBe(true);
 		expect(loop.order).toEqual(["plain:plain first", "skill-a", "skill-b"]);
+		expect(performance.now() - startedAt).toBeLessThan(1500);
 	});
 });


### PR DESCRIPTION
Follow-up to #11367 stacking six ordered race fixes for `/vibe` + reset `--while`/`--until` loops and concurrent `/vibe <prompt>` submissions (reviews 5153412489, r3967645584, r3967736944, r3967932137, r3967999698, r3968121821, r3968256130, r3968404879).

**Fixes:**
- Re-check the reset+vibe guard after the condition gate resolves (mid-gate `/vibe` disables the loop instead of looping without resets).
- Track the vibe entering transition: `#enterVibeMode` exposes the in-flight activation as `#vibeModeEntry`; loop reset guards treat a pending entry as active, and concurrent `/vibe` commands await it instead of dispatching on the stale toolset (failure rejects every joiner, dropping prompts rather than running them outside vibe mode).
- Joined prompts missing the one-shot input waiter steer via `session.prompt` instead of being silently dropped (same fallback as the normal submit path).
- Order preservation: the first waiter check stays await-free so the first resumer wins the one-shot waiter; waiterless dispatch waits (bounded ~2s) for the in-flight submission to reserve its turn, then re-checks for a fresh waiter. Skill prompts append to a FIFO tail chain (arrival order) while a live count keeps the reservation synchronously visible, so plain prompts leave the waiter armed until every outstanding skill reserves and skill/plain pairs submit in arrival order either way round — including plain+skill+skill triples, where a shared slot deterministically reversed the skills.
- Predecessor-scoped blocking: skill waits ignore the live skill count (concurrent skills order solely through the tail chain), so an earlier skill can no longer stall behind a later one parked on its own link — previously a wait cycle that burned the full bound and let the plain prompt overtake both skills. Plains keep watching the count, which for them always means other parties.
- Regression tests drive the real `/vibe` command through a real `getUserInput`-plus-submit mini main loop (plus deferred activation/real skill files): mid-gate vibe, in-flight activation, concurrent-prompt preservation, plain/plain order, skill/plain order both ways round, and plain+skill+skill arrival order with a dispatch-signal await plus a sub-1500ms completion bound (the buggy path provably burns >=2000ms of sequential real sleeps, so the bound cannot flake on the fail side). Each new test was verified to fail pre-fix and pass post-fix.
- Related suites (loop-condition, loop-limit, loop-teardown, status-line-loop, shell-tokenize, vibe-toggle, goal-integration): 114 pass; `bun check` passes.

No CHANGELOG change: the Unreleased entry from #11367 already describes this user-visible behavior.