### PR TITLE
[omp2] Compare canonical executable paths in sandbox tests

### DIFF
--- a/crates/sandbox/src/backends/landlock.rs
+++ b/crates/sandbox/src/backends/landlock.rs
@@ -150,10 +150,7 @@ pub fn compile(
 	Ok(plan)
 }
 
-pub const fn prepare(
-	spec: &SandboxSpec,
-	prepared: &mut PreparedSandbox,
-) -> Result<(), SandboxError> {
+pub fn prepare(spec: &SandboxSpec, prepared: &mut PreparedSandbox) -> Result<(), SandboxError> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		let _ = (spec, prepared);
@@ -293,7 +290,7 @@ fn write_paths(writer: &mut impl Write, paths: &[PathBuf]) -> io::Result<()> {
 
 /// Returns the running kernel's Landlock ABI, or `None` when unavailable.
 #[must_use]
-pub const fn abi() -> Option<u32> {
+pub fn abi() -> Option<u32> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		None
@@ -345,7 +342,7 @@ pub fn probe() -> BackendStatus {
 /// The caller must dispatch this before launching untrusted work. The helper
 /// reads an owned BPF artifact, optionally applies an owned Landlock manifest,
 /// and then `execve(2)`s the command following the required `--` separator.
-pub const fn run_child_entry() -> Result<(), SandboxError> {
+pub fn run_child_entry() -> Result<(), SandboxError> {
 	#[cfg(not(target_os = "linux"))]
 	{
 		Err(SandboxError::UnsupportedHost { os: std::env::consts::OS })
@@ -838,6 +835,8 @@ fn proxy_relay(socket: &Path, listener: TcpListener) -> io::Result<()> {
 	loop {
 		match listener.accept() {
 			Ok((client, _)) if live.fetch_add(1, Ordering::AcqRel) >= MAX_CONNECTIONS => {
+				// Over the connection ceiling: close the accepted socket instead of serving it.
+				drop(client);
 				live.fetch_sub(1, Ordering::AcqRel);
 			},
 			Ok((client, _)) => {

--- a/crates/sandbox/tests/bubblewrap.rs
+++ b/crates/sandbox/tests/bubblewrap.rs
@@ -49,7 +49,12 @@ fn disabled_network_uses_hidden_seccomp_child_contract() {
 		.expect("hidden sandbox child");
 	assert_eq!(argv[child + 1], "@omp-sandbox-bpf@");
 	assert_eq!(argv[child + 2], "--");
-	assert_eq!(Path::new(&argv[child + 3]), target);
+	// The plan carries the resolved program, so compare against the canonical form
+	// of the input rather than the literal path the spec was built from.
+	assert_eq!(
+		Path::new(&argv[child + 3]),
+		fs::canonicalize(target).expect("canonical target program"),
+	);
 	assert!(has_mount(
 		argv,
 		"--ro-bind",

--- a/crates/sandbox/tests/landlock.rs
+++ b/crates/sandbox/tests/landlock.rs
@@ -1,6 +1,6 @@
 //! Landlock fallback plan and honest-degradation contracts.
 
-use std::path::Path;
+use std::{fs, path::Path};
 
 use omp_sandbox::{
 	Backend, Capability, DegradationPolicy, NetworkMode, Runner, SandboxError, SandboxSpec,
@@ -22,7 +22,9 @@ fn helper_argv_contract_carries_owned_policy_artifacts() {
 	assert_eq!(argv[3], "--landlock");
 	assert_eq!(argv[4], "@omp-sandbox-landlock-policy@");
 	assert_eq!(argv[5], "--");
-	assert_eq!(Path::new(&argv[6]), target);
+	// The plan carries the resolved program, so compare against the canonical form
+	// of the input rather than the literal path the spec was built from.
+	assert_eq!(Path::new(&argv[6]), fs::canonicalize(target).expect("canonical target program"),);
 	assert!(plan.enforced().contains(Capability::NetDisable));
 	assert!(plan.enforced().contains(Capability::FsWriteDeny));
 	assert!(!plan.enforced().contains(Capability::IpcRestrict));


### PR DESCRIPTION
The runner resolves executable symlinks before it builds helper argv. Compare each exact executable slot with the canonical test input rather than a host-specific /bin spelling. Keep the policy and argument checks. Two files: crates/sandbox/tests/bubblewrap.rs, crates/sandbox/tests/landlock.rs (10+/3-).

Depends on #11369 (landlock compile fix): this head is stacked as c28 + 85 onto omp2 so the tree compiles on Linux.

Verification on the stacked tree (c28 + this): rustfmt clean, just check-pkg omp-sandbox green, release nextest 106 passed with the Docker async-lock follow-up applied (full-stack proof); this prerequisite pair alone restores the 2 host-path assertions that failed before the repair. Mechanical test-only unit, no linked issue.