### PR TITLE
fix(ai): fall back to the canonical Anthropic usage endpoint when a custom baseUrl does not serve it

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Codex SSE streams that end without a terminal completion event now retry when replay-safe and remain transient errors when partial output prevents replay ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
+- Anthropic subscription usage now falls back to the canonical `api.anthropic.com` OAuth usage endpoint when a custom provider `baseUrl` does not serve it, instead of leaving the report to rate-limit headers — those carry the model-scoped weekly window only on responses for that model family, so `/usage` could report a scoped window far below its real utilization.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -57,10 +57,15 @@ function normalizeClaudeBaseUrl(baseUrl?: string): string {
  * Subscription usage is served by Anthropic's OAuth API, which a custom
  * `baseUrl` pointed at a Messages-only endpoint does not expose. Probe the
  * configured host first so a full mirror keeps answering (including its own
- * `/profile` identity), then fall back to the canonical endpoint: without it
- * the report degrades to rate-limit headers, and those carry the model-scoped
- * weekly row only on responses for that model family, so a scoped window can
- * read far below its real utilization until a request hits the family again.
+ * `/profile` identity), then fall back to the canonical endpoint — but only
+ * when the configured host answered that it has no usage endpoint there (see
+ * {@link ClaudeUsagePayloadResult.endpointAbsent}), so a host that refuses the
+ * credential or fails transiently keeps the request.
+ *
+ * Without the fallback the report degrades to rate-limit headers, and those
+ * carry the model-scoped weekly row only on responses for that model family,
+ * so a scoped window can read far below its real utilization until a request
+ * hits the family again.
  */
 function claudeUsageBaseUrls(baseUrl?: string): readonly string[] {
 	const configured = normalizeClaudeBaseUrl(baseUrl);
@@ -288,15 +293,41 @@ async function waitBeforeRetry(
 	}
 }
 
+/** Statuses that answer "this host does not implement the endpoint". */
+const ENDPOINT_ABSENT_STATUSES = new Set([404, 405, 410, 501]);
+
+interface ClaudeUsagePayloadResult {
+	/** Best payload seen; may lack usage data when the retries gave up. */
+	payload: ClaudeUsageResponse | null;
+	/** The host answered, but does not serve subscription usage at this path. */
+	endpointAbsent: boolean;
+}
+
+/**
+ * A body with none of the usage keys is a host answering something else at this
+ * path (an error document, an index page), not an account whose windows are all
+ * empty — the latter still carries the keys.
+ */
+function looksLikeUsagePayload(payload: ClaudeUsageResponse): boolean {
+	return (
+		"five_hour" in payload ||
+		"seven_day" in payload ||
+		"limits" in payload ||
+		"extra_usage" in payload ||
+		"spend" in payload
+	);
+}
+
 async function fetchUsagePayload(
 	url: string,
 	headers: Record<string, string>,
 	ctx: UsageFetchContext,
 	signal?: AbortSignal,
-): Promise<ClaudeUsageResponse | null> {
-	if (signal?.aborted) return null;
+): Promise<ClaudeUsagePayloadResult> {
+	if (signal?.aborted) return { payload: null, endpointAbsent: false };
 
 	let lastPayload: ClaudeUsageResponse | null = null;
+	let endpointAbsent = false;
 	for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 		try {
 			const response = await ctx.fetch(url, { headers, signal });
@@ -309,7 +340,7 @@ async function fetchUsagePayload(
 					attempt,
 					willRetry: retryable && attempt < MAX_ATTEMPTS - 1,
 				});
-				if (!retryable) return null;
+				if (!retryable) return { payload: null, endpointAbsent: ENDPOINT_ABSENT_STATUSES.has(response.status) };
 				const retryAfter = response.headers.get("retry-after");
 				if (!(await waitBeforeRetry(attempt, retryAfter, signal, ctx.retryWait))) break;
 				continue;
@@ -319,7 +350,10 @@ async function fetchUsagePayload(
 			if (isRecord(parsed)) {
 				const payload = parsed as ClaudeUsageResponse;
 				lastPayload = payload;
-				if (hasUsageData(payload)) return payload;
+				if (hasUsageData(payload)) return { payload, endpointAbsent: false };
+				endpointAbsent = !looksLikeUsagePayload(payload);
+			} else {
+				endpointAbsent = true;
 			}
 
 			ctx.logger?.warn("Claude usage response missing usage data", {
@@ -328,7 +362,7 @@ async function fetchUsagePayload(
 			});
 			if (!(await waitBeforeRetry(attempt, null, signal, ctx.retryWait))) break;
 		} catch (error) {
-			if (isAbortError(error, signal)) return null;
+			if (isAbortError(error, signal)) return { payload: null, endpointAbsent: false };
 			ctx.logger?.warn("Claude usage fetch error", {
 				error: String(error),
 				attempt,
@@ -338,7 +372,7 @@ async function fetchUsagePayload(
 		}
 	}
 
-	return lastPayload;
+	return { payload: lastPayload, endpointAbsent };
 }
 
 interface ClaudeProfile {
@@ -630,19 +664,24 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 	let baseUrl: string | undefined;
 	let payload: ClaudeUsageResponse | null = null;
 	for (const candidate of claudeUsageBaseUrls(params.baseUrl)) {
-		const candidatePayload = await fetchUsagePayload(`${candidate}/usage`, headers, ctx, params.signal);
-		if (candidatePayload && hasUsageData(candidatePayload)) {
+		const result = await fetchUsagePayload(`${candidate}/usage`, headers, ctx, params.signal);
+		if (result.payload && hasUsageData(result.payload)) {
 			baseUrl = candidate;
-			payload = candidatePayload;
+			payload = result.payload;
 			break;
 		}
-		// Recognized shape without usage data: retries already gave up on fresher
+		// Usage-shaped body without numbers: retries already gave up on fresher
 		// numbers here, so hold it while the remaining candidate is probed.
-		if (candidatePayload && !payload) {
+		if (result.payload && !payload) {
 			baseUrl = candidate;
-			payload = candidatePayload;
+			payload = result.payload;
 		}
 		if (params.signal?.aborted) break;
+		// Only a host that answered "no usage endpoint here" justifies moving the
+		// request off the configured one. A refused credential (401/403) or a
+		// transient failure is that host's answer about this account, so it stands
+		// and the next poll retries it.
+		if (!result.endpointAbsent) break;
 	}
 	if (!payload || baseUrl === undefined) return null;
 	const url = `${baseUrl}/usage`;

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -333,14 +333,17 @@ async function fetchUsagePayload(
 			const response = await ctx.fetch(url, { headers, signal });
 
 			if (!response.ok) {
-				const retryable = isRetryableStatus(response.status);
+				// Absence outranks the generic transient classification: 501 is a 5xx,
+				// but "not implemented" does not become implemented on replay.
+				const absent = ENDPOINT_ABSENT_STATUSES.has(response.status);
+				const retryable = !absent && isRetryableStatus(response.status);
 				ctx.logger?.warn("Claude usage fetch failed", {
 					status: response.status,
 					statusText: response.statusText,
 					attempt,
 					willRetry: retryable && attempt < MAX_ATTEMPTS - 1,
 				});
-				if (!retryable) return { payload: null, endpointAbsent: ENDPOINT_ABSENT_STATUSES.has(response.status) };
+				if (!retryable) return { payload: null, endpointAbsent: absent };
 				const retryAfter = response.headers.get("retry-after");
 				if (!(await waitBeforeRetry(attempt, retryAfter, signal, ctx.retryWait))) break;
 				continue;

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -346,7 +346,30 @@ async function fetchUsagePayload(
 				continue;
 			}
 
-			const parsed = (await response.json()) as unknown;
+			const body = await response.text();
+			if (body.trim().length === 0) {
+				// An empty 2xx serves nothing here; a gateway answering unknown paths
+				// this way has no usage endpoint to poll.
+				return { payload: lastPayload, endpointAbsent: true };
+			}
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(body) as unknown;
+			} catch {
+				// A non-JSON 2xx is this host answering something else at this path
+				// (an index page, a plain-text notice). A body that claims JSON and
+				// fails to parse is truncated or garbled instead, so keep retrying it
+				// against this host rather than moving the request.
+				const claimsJson = /json/i.test(response.headers.get("content-type") ?? "");
+				ctx.logger?.warn("Claude usage response was not JSON", {
+					contentType: response.headers.get("content-type") ?? undefined,
+					attempt,
+					willRetry: claimsJson && attempt < MAX_ATTEMPTS - 1,
+				});
+				if (!claimsJson) return { payload: lastPayload, endpointAbsent: true };
+				if (!(await waitBeforeRetry(attempt, null, signal, ctx.retryWait))) break;
+				continue;
+			}
 			if (isRecord(parsed)) {
 				const payload = parsed as ClaudeUsageResponse;
 				lastPayload = payload;

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -53,6 +53,20 @@ function normalizeClaudeBaseUrl(baseUrl?: string): string {
 	return `${url.origin}${path}/api/oauth`;
 }
 
+/**
+ * Subscription usage is served by Anthropic's OAuth API, which a custom
+ * `baseUrl` pointed at a Messages-only endpoint does not expose. Probe the
+ * configured host first so a full mirror keeps answering (including its own
+ * `/profile` identity), then fall back to the canonical endpoint: without it
+ * the report degrades to rate-limit headers, and those carry the model-scoped
+ * weekly row only on responses for that model family, so a scoped window can
+ * read far below its real utilization until a request hits the family again.
+ */
+function claudeUsageBaseUrls(baseUrl?: string): readonly string[] {
+	const configured = normalizeClaudeBaseUrl(baseUrl);
+	return configured === DEFAULT_ENDPOINT ? [DEFAULT_ENDPOINT] : [configured, DEFAULT_ENDPOINT];
+}
+
 interface ClaudeUsageBucket {
 	utilization?: number;
 	resets_at?: string;
@@ -608,15 +622,30 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 	const credential = params.credential;
 	if (credential.type !== "oauth" || !credential.accessToken) return null;
 
-	const baseUrl = normalizeClaudeBaseUrl(params.baseUrl);
-	const url = `${baseUrl}/usage`;
 	const headers: Record<string, string> = {
 		...CLAUDE_HEADERS,
 		authorization: `Bearer ${credential.accessToken}`,
 	};
 
-	const payload = await fetchUsagePayload(url, headers, ctx, params.signal);
-	if (!payload || !isRecord(payload)) return null;
+	let baseUrl: string | undefined;
+	let payload: ClaudeUsageResponse | null = null;
+	for (const candidate of claudeUsageBaseUrls(params.baseUrl)) {
+		const candidatePayload = await fetchUsagePayload(`${candidate}/usage`, headers, ctx, params.signal);
+		if (candidatePayload && hasUsageData(candidatePayload)) {
+			baseUrl = candidate;
+			payload = candidatePayload;
+			break;
+		}
+		// Recognized shape without usage data: retries already gave up on fresher
+		// numbers here, so hold it while the remaining candidate is probed.
+		if (candidatePayload && !payload) {
+			baseUrl = candidate;
+			payload = candidatePayload;
+		}
+		if (params.signal?.aborted) break;
+	}
+	if (!payload || baseUrl === undefined) return null;
+	const url = `${baseUrl}/usage`;
 
 	const apiLimitEntries = parseApiLimitEntries(payload.limits);
 	const fiveHour = parseBucket(payload.five_hour) ?? apiLimitEntries.find(entry => entry.kind === "session")?.bucket;

--- a/packages/ai/test/claude-usage-endpoint.test.ts
+++ b/packages/ai/test/claude-usage-endpoint.test.ts
@@ -86,4 +86,39 @@ describe("claudeUsageProvider usage endpoint resolution", () => {
 		expect(report).toBeNull();
 		expect(urls).toEqual([CANONICAL_USAGE_URL]);
 	});
+
+	it("keeps the request on a custom baseUrl that refuses the credential", async () => {
+		const { fetch, urls } = recordingFetch(() => jsonResponse(401, { error: "unauthorized" }));
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		// A 401 is the configured host's answer about this account, not a missing
+		// endpoint: moving the token to another destination is not ours to decide.
+		expect(report).toBeNull();
+		expect(urls).toEqual(["https://gateway.example.com/api/oauth/usage"]);
+	});
+
+	it("keeps the request on a custom baseUrl that fails transiently", async () => {
+		const { fetch, urls } = recordingFetch(() => jsonResponse(503, { error: "unavailable" }));
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		expect(report).toBeNull();
+		// Retried on the configured host only; the next poll tries it again.
+		expect(urls).toEqual(Array.from({ length: 3 }, () => "https://gateway.example.com/api/oauth/usage"));
+	});
+
+	it("falls back when a custom baseUrl answers 200 with an unrelated body", async () => {
+		const { fetch, urls } = recordingFetch(url =>
+			url === CANONICAL_USAGE_URL ? jsonResponse(200, USAGE_PAYLOAD) : jsonResponse(200, { hello: "world" }),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		expect(urls).toEqual([
+			...Array.from({ length: 3 }, () => "https://gateway.example.com/api/oauth/usage"),
+			CANONICAL_USAGE_URL,
+		]);
+		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
+	});
 });

--- a/packages/ai/test/claude-usage-endpoint.test.ts
+++ b/packages/ai/test/claude-usage-endpoint.test.ts
@@ -163,4 +163,19 @@ describe("claudeUsageProvider usage endpoint resolution", () => {
 		expect(report).toBeNull();
 		expect(urls).toEqual(Array.from({ length: 3 }, () => "https://mirror.example.com/api/oauth/usage"));
 	});
+
+	it("falls back on 501 without spending retries on it", async () => {
+		const { fetch, urls } = recordingFetch(url =>
+			url === CANONICAL_USAGE_URL
+				? jsonResponse(200, USAGE_PAYLOAD)
+				: jsonResponse(501, { error: "not_implemented" }),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		// 501 is a 5xx, but "not implemented" is permanent: absence must outrank
+		// the generic transient classification.
+		expect(urls).toEqual(["https://gateway.example.com/api/oauth/usage", CANONICAL_USAGE_URL]);
+		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
+	});
 });

--- a/packages/ai/test/claude-usage-endpoint.test.ts
+++ b/packages/ai/test/claude-usage-endpoint.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import type { UsageFetchContext } from "@oh-my-pi/pi-ai/usage";
+import { claudeUsageProvider } from "@oh-my-pi/pi-ai/usage/claude";
+
+const CANONICAL_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+
+const USAGE_PAYLOAD = {
+	five_hour: { utilization: 17, resets_at: new Date(Date.now() + 60 * 60_000).toISOString() },
+	seven_day: { utilization: 75, resets_at: new Date(Date.now() + 3 * 24 * 60 * 60_000).toISOString() },
+	limits: [
+		{
+			kind: "weekly_scoped",
+			percent: 100,
+			resets_at: new Date(Date.now() + 3 * 24 * 60 * 60_000).toISOString(),
+			scope: { model: { display_name: "Fable" } },
+		},
+	],
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function recordingFetch(handler: (url: string) => Response): { fetch: FetchImpl; urls: string[] } {
+	const urls: string[] = [];
+	const fetch = (async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		urls.push(url);
+		return handler(url);
+	}) as FetchImpl;
+	return { fetch, urls };
+}
+
+function params(baseUrl?: string) {
+	return {
+		provider: "anthropic" as const,
+		credential: {
+			type: "oauth" as const,
+			accessToken: "oat-test",
+			accountId: "account_test",
+			email: "user@example.com",
+			expiresAt: Date.now() + 60_000,
+		},
+		...(baseUrl === undefined ? {} : { baseUrl }),
+	};
+}
+
+function context(fetch: FetchImpl): UsageFetchContext {
+	return { fetch, retryWait: async () => {} };
+}
+
+describe("claudeUsageProvider usage endpoint resolution", () => {
+	it("falls back to the canonical endpoint when a custom baseUrl does not serve usage", async () => {
+		const { fetch, urls } = recordingFetch(url =>
+			url === CANONICAL_USAGE_URL ? jsonResponse(200, USAGE_PAYLOAD) : jsonResponse(404, { error: "not_found" }),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(
+			params("https://gateway.example.com/claude/v1"),
+			context(fetch),
+		);
+
+		expect(urls).toEqual(["https://gateway.example.com/claude/api/oauth/usage", CANONICAL_USAGE_URL]);
+		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
+		// The model-scoped weekly row is what rate-limit headers cannot refresh
+		// unless the request itself hit that family — it must survive the fallback.
+		expect(report?.limits.find(limit => limit.scope.tier === "fable")?.amount.usedFraction).toBe(1);
+		expect(report?.limits.find(limit => limit.id === "anthropic:7d")?.amount.usedFraction).toBe(0.75);
+	});
+
+	it("keeps a custom baseUrl that does serve usage and never probes the canonical endpoint", async () => {
+		const { fetch, urls } = recordingFetch(() => jsonResponse(200, USAGE_PAYLOAD));
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://mirror.example.com/v1"), context(fetch));
+
+		expect(urls).toEqual(["https://mirror.example.com/api/oauth/usage"]);
+		expect(report?.metadata?.endpoint).toBe("https://mirror.example.com/api/oauth/usage");
+	});
+
+	it("does not double-request when the configured baseUrl already resolves to the canonical endpoint", async () => {
+		const { fetch, urls } = recordingFetch(() => jsonResponse(404, { error: "not_found" }));
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://api.anthropic.com/v1"), context(fetch));
+
+		expect(report).toBeNull();
+		expect(urls).toEqual([CANONICAL_USAGE_URL]);
+	});
+});

--- a/packages/ai/test/claude-usage-endpoint.test.ts
+++ b/packages/ai/test/claude-usage-endpoint.test.ts
@@ -121,4 +121,46 @@ describe("claudeUsageProvider usage endpoint resolution", () => {
 		]);
 		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
 	});
+
+	it("falls back when a custom baseUrl answers 200 with an SPA index page", async () => {
+		const { fetch, urls } = recordingFetch(url =>
+			url === CANONICAL_USAGE_URL
+				? jsonResponse(200, USAGE_PAYLOAD)
+				: new Response("<!doctype html><title>gateway</title>", {
+						status: 200,
+						headers: { "Content-Type": "text/html" },
+					}),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		// A single probe is enough: an HTML 200 is not a usage endpoint having a
+		// bad moment, so retrying it only delays the canonical fallback.
+		expect(urls).toEqual(["https://gateway.example.com/api/oauth/usage", CANONICAL_USAGE_URL]);
+		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
+	});
+
+	it("falls back when a custom baseUrl answers 200 with an empty body", async () => {
+		const { fetch, urls } = recordingFetch(url =>
+			url === CANONICAL_USAGE_URL ? jsonResponse(200, USAGE_PAYLOAD) : new Response("", { status: 200 }),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://gateway.example.com/v1"), context(fetch));
+
+		expect(urls).toEqual(["https://gateway.example.com/api/oauth/usage", CANONICAL_USAGE_URL]);
+		expect(report?.metadata?.endpoint).toBe(CANONICAL_USAGE_URL);
+	});
+
+	it("keeps retrying a truncated JSON body on the configured host", async () => {
+		const { fetch, urls } = recordingFetch(
+			() => new Response('{"five_hour":{"utiliz', { status: 200, headers: { "Content-Type": "application/json" } }),
+		);
+
+		const report = await claudeUsageProvider.fetchUsage(params("https://mirror.example.com/v1"), context(fetch));
+
+		// A JSON content type that fails to parse is a damaged response from a host
+		// that does serve usage — the request must not move.
+		expect(report).toBeNull();
+		expect(urls).toEqual(Array.from({ length: 3 }, () => "https://mirror.example.com/api/oauth/usage"));
+	});
 });


### PR DESCRIPTION
I hit this with an `anthropic` provider whose `baseUrl` only speaks the Messages API: `/usage` kept showing my weekly Fable window at 79% while the account was actually capped at 100%, and this change makes the usage poll ask Anthropic directly when the configured host has no usage endpoint.

## What

`fetchClaudeUsage` derived the OAuth usage endpoint from `params.baseUrl` and used only that one URL. It now probes the configured host first and falls back to `https://api.anthropic.com/api/oauth` when the configured one returns nothing usable, and `metadata.endpoint` reports whichever host answered.

A full mirror keeps its previous behaviour (including its own `/profile` identity lookup), and a `baseUrl` that already resolves to the canonical endpoint still issues exactly one request.

## Why

With a `baseUrl` pointed at a Messages-only endpoint, `GET <baseUrl>/api/oauth/usage` 404s, `fetchUsage` returns `null` on every poll, and the report permanently degrades to `metadata.source: "ratelimit-headers"`.

That fallback is not equivalent for model-scoped windows. Anthropic emits `anthropic-ratelimit-unified-7d_oi-*` only on responses for that model family — a Sonnet/Opus response carries `5h` and `7d` and no scoped row at all. `AuthStorage.ingestUsageHeaders` keeps previously known limits that the incoming headers omit and restamps `fetchedAt`/`headersUpdatedAt` to now, so the scoped row freezes at whatever it was when a request last hit that family, while presenting as freshly checked. Mine sat at 79% for days; the real value was 100%.

The usage endpoint returns all windows in one response (`five_hour`, `seven_day`, `limits[]` with `weekly_scoped`), so reaching it is what keeps a scoped window honest — and it also restores extra-usage/spend rows, which headers never carry.

## Testing

- `packages/ai/test/claude-usage-endpoint.test.ts` (new): fallback on a non-serving custom `baseUrl` (asserts request order, `metadata.endpoint`, and that the 100% scoped weekly row survives), no fallback when the custom host does serve usage, and no duplicate request when `baseUrl` already resolves to the canonical endpoint. The first case fails on `main`.
- `bun test` on `packages/ai/test/claude-usage-{endpoint,retry,headers}.test.ts`, `claude-ratelimit-headers.test.ts`, `auth-storage-usage-cache.test.ts`, `auth-storage-claude-fable-fallback.test.ts`, `auth-storage-model-usage-health.test.ts` — 133 pass.
- `bun run check` in `packages/ai` — clean.
- End to end, with `providers.anthropic.baseUrl` pointed at a local host that forwards only `/v1/*` to Anthropic:
  - before: `omp usage --json` → `metadata.source: "ratelimit-headers"`, `Claude 7 Day (Fable)` at 79% `ok`, while a Fable request returned `429` with `anthropic-ratelimit-unified-7d_oi-utilization: 1.0`;
  - after: `metadata.endpoint: "https://api.anthropic.com/api/oauth/usage"`, `Claude 7 Day (Fable)` at 100% `exhausted`, `5h`/`7d` matching what the response headers report.

---

- [x] `bun check` passes (`packages/ai`)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)