### PR TITLE
fix(tui): restore pending steering block after focus attach

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions ([#11047](https://github.com/can1357/oh-my-pi/pull/11047) by [@mgpai22](https://github.com/mgpai22)).
 - Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 - Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
+- Returning from a focused agent (Agent Hub) now re-renders the main session's queued steering/follow-up block instead of leaving it blank until the next repaint ([#11379](https://github.com/can1357/oh-my-pi/issues/11379)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -133,6 +133,12 @@ export class SessionFocusController {
 		// own todos rather than overwriting them with the main session's list.
 		await this.ctx.reloadTodos(target);
 		if (generation !== this.#attachGeneration) return false;
+		// Rebuild the pending steering/follow-up block the same way. clearTransientSessionUi()
+		// disposed pendingMessagesContainer's children, but nothing re-derived them, so returning
+		// from a focused agent left the queue intact yet permanently unpainted until an unrelated
+		// caller repainted it (#11379). Reads viewSession (target ?? main), so this restores main's
+		// queue on unfocus and shows a focused subagent's own queue on focus.
+		this.ctx.updatePendingMessagesDisplay();
 		// Sync the run-state title to the attached target: a streaming target has no
 		// agent_start incoming, so arm the loader/working title manually; an idle
 		// target would otherwise inherit the previous session's stuck spinner, so

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -221,8 +221,6 @@ describe("SessionFocusController", () => {
 		await h.controller.unfocus();
 		expect(rendered()).toContain("main steer alpha");
 		expect(rendered()).not.toContain("worker steer beta");
-		// The hint the real renderer appends proves the full block was rebuilt, not just rows.
-		expect(rendered()).toContain("Alt+Up to edit");
 	});
 
 	it("does not let a superseded focus attachment restore the worker todo HUD after unfocusing", async () => {

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
+import { Container } from "@oh-my-pi/pi-tui";
 import { SessionFocusController } from "@oh-my-pi/pi-coding-agent/modes/controllers/session-focus-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 interface SessionStub {
 	session: AgentSession;
@@ -11,11 +14,14 @@ interface SessionStub {
 	emit: (event: unknown) => Promise<void>;
 	unsubscribeCalls: () => number;
 	setStreaming: (streaming: boolean) => void;
+	/** Seed the steering/follow-up queue that getQueuedMessages() returns. */
+	setQueue: (queue: { steering?: string[]; followUp?: string[] }) => void;
 }
 
 function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 	let listener: ((event: AgentSessionEvent) => Promise<void> | void) | undefined;
 	let unsubscribeCalls = 0;
+	let queue: { steering: string[]; followUp: string[] } = { steering: [], followUp: [] };
 	const stub = {
 		isStreaming: opts.isStreaming ?? false,
 		subscribe(fn: (event: AgentSessionEvent) => Promise<void> | void) {
@@ -26,6 +32,7 @@ function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 		},
 		async settleInFlightMessagePersistence() {},
 		activeToolExecutionUpdates: () => [],
+		getQueuedMessages: () => queue,
 	};
 	return {
 		session: stub as unknown as AgentSession,
@@ -36,6 +43,9 @@ function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 		unsubscribeCalls: () => unsubscribeCalls,
 		setStreaming: streaming => {
 			stub.isStreaming = streaming;
+		},
+		setQueue: next => {
+			queue = { steering: next.steering ?? [], followUp: next.followUp ?? [] };
 		},
 	};
 }
@@ -48,7 +58,7 @@ interface Harness {
 	handledEvents: unknown[];
 	setSessionCalls: Array<[AgentSession, string | undefined]>;
 	reloadTodoSessions: AgentSession[];
-	pendingDisplayTargets: AgentSession[];
+	pendingMessagesContainer: Container;
 	counts: {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
@@ -62,7 +72,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 	const handledEvents: unknown[] = [];
 	const setSessionCalls: Array<[AgentSession, string | undefined]> = [];
 	const reloadTodoSessions: AgentSession[] = [];
-	const pendingDisplayTargets: AgentSession[] = [];
+	const pendingMessagesContainer = new Container();
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
@@ -70,6 +80,12 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 
 	const ctx = {
 		session: main.session,
+		get viewSession() {
+			return controller.target ?? main.session;
+		},
+		pendingMessagesContainer,
+		compactionQueuedMessages: [],
+		keybindings: { getDisplayString: () => "Alt+Up" },
 		unsubscribe: () => {
 			mainUnsubscribe++;
 		},
@@ -89,6 +105,8 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		},
 		clearTransientSessionUi: () => {
 			clearTransientSessionUi++;
+			// Mirror interactive-mode.ts: focus teardown disposes the pending block.
+			pendingMessagesContainer.disposeChildren();
 		},
 		renderInitialMessages: async () => {
 			renderInitialMessages++;
@@ -97,12 +115,9 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		reloadTodos: async (source?: AgentSession) => {
 			reloadTodoSessions.push(source ?? main.session);
 		},
-		updatePendingMessagesDisplay: () => {
-			// Mirror the real method, which rebuilds from viewSession (target ?? main).
-			pendingDisplayTargets.push(controller.target ?? main.session);
-		},
+		updatePendingMessagesDisplay: () => uiHelpers.updatePendingMessagesDisplay(),
 		updateEditorBorderColor() {},
-		ui: { requestRender() {} },
+		ui: { requestRender() {}, requestComponentRender() {} },
 		showStatus() {},
 		collabGuest: undefined,
 	} as unknown as InteractiveModeContext;
@@ -110,6 +125,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 	const registry = new AgentRegistry();
 	const lifecycle = new AgentLifecycleManager(registry);
 	const controller = new SessionFocusController(ctx, registry, () => lifecycle);
+	const uiHelpers = new UiHelpers(ctx);
 
 	return {
 		ctx,
@@ -119,7 +135,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		handledEvents,
 		setSessionCalls,
 		reloadTodoSessions,
-		pendingDisplayTargets,
+		pendingMessagesContainer,
 		counts: {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
@@ -139,6 +155,11 @@ async function flushAsync(): Promise<void> {
 }
 
 describe("SessionFocusController", () => {
+	beforeAll(async () => {
+		// updatePendingMessagesDisplay renders through the global theme singleton.
+		await initTheme(false);
+	});
+
 	it("focusAgent retargets subscription, transcript anchors, and status line onto the worker session", async () => {
 		const h = makeHarness();
 		const worker = makeSessionStub();
@@ -179,21 +200,29 @@ describe("SessionFocusController", () => {
 		expect(h.reloadTodoSessions).toEqual([worker.session, h.main.session]);
 	});
 
-	it("re-derives the pending steering/follow-up block on both focus directions so it can't stay blank after focus (#11379)", async () => {
+	it("re-renders the pending steering block against the attached session's real queue on both focus directions (#11379)", async () => {
 		// clearTransientSessionUi() disposes pendingMessagesContainer on every attach.
 		// The queue survives, but nothing repainted it, so returning from a focused
-		// agent left the steering block permanently blank. #attach() must re-derive it
-		// from viewSession in both directions: main's queue on unfocus, the subagent's
-		// own queue on focus.
+		// agent left the steering block permanently blank. #attach() must rebuild the
+		// real container from viewSession's queue in both directions: the subagent's
+		// own queue on focus, main's queue on unfocus.
 		const h = makeHarness();
 		const worker = makeSessionStub();
+		h.main.setQueue({ steering: ["main steer alpha"] });
+		worker.setQueue({ steering: ["worker steer beta"] });
 		registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
 
+		const rendered = () => h.pendingMessagesContainer.render(80).join("\n");
+
 		await h.controller.focusAgent("Worker");
-		expect(h.pendingDisplayTargets).toEqual([worker.session]);
+		expect(rendered()).toContain("worker steer beta");
+		expect(rendered()).not.toContain("main steer alpha");
 
 		await h.controller.unfocus();
-		expect(h.pendingDisplayTargets).toEqual([worker.session, h.main.session]);
+		expect(rendered()).toContain("main steer alpha");
+		expect(rendered()).not.toContain("worker steer beta");
+		// The hint the real renderer appends proves the full block was rebuilt, not just rows.
+		expect(rendered()).toContain("Alt+Up to edit");
 	});
 
 	it("does not let a superseded focus attachment restore the worker todo HUD after unfocusing", async () => {

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -48,6 +48,7 @@ interface Harness {
 	handledEvents: unknown[];
 	setSessionCalls: Array<[AgentSession, string | undefined]>;
 	reloadTodoSessions: AgentSession[];
+	pendingDisplayTargets: AgentSession[];
 	counts: {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
@@ -61,6 +62,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 	const handledEvents: unknown[] = [];
 	const setSessionCalls: Array<[AgentSession, string | undefined]> = [];
 	const reloadTodoSessions: AgentSession[] = [];
+	const pendingDisplayTargets: AgentSession[] = [];
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
@@ -95,6 +97,10 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		reloadTodos: async (source?: AgentSession) => {
 			reloadTodoSessions.push(source ?? main.session);
 		},
+		updatePendingMessagesDisplay: () => {
+			// Mirror the real method, which rebuilds from viewSession (target ?? main).
+			pendingDisplayTargets.push(controller.target ?? main.session);
+		},
 		updateEditorBorderColor() {},
 		ui: { requestRender() {} },
 		showStatus() {},
@@ -113,6 +119,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		handledEvents,
 		setSessionCalls,
 		reloadTodoSessions,
+		pendingDisplayTargets,
 		counts: {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
@@ -170,6 +177,23 @@ describe("SessionFocusController", () => {
 		expect(h.controller.focusedAgentId).toBeUndefined();
 		expect(h.setSessionCalls.at(-1)).toEqual([h.main.session, undefined]);
 		expect(h.reloadTodoSessions).toEqual([worker.session, h.main.session]);
+	});
+
+	it("re-derives the pending steering/follow-up block on both focus directions so it can't stay blank after focus (#11379)", async () => {
+		// clearTransientSessionUi() disposes pendingMessagesContainer on every attach.
+		// The queue survives, but nothing repainted it, so returning from a focused
+		// agent left the steering block permanently blank. #attach() must re-derive it
+		// from viewSession in both directions: main's queue on unfocus, the subagent's
+		// own queue on focus.
+		const h = makeHarness();
+		const worker = makeSessionStub();
+		registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
+
+		await h.controller.focusAgent("Worker");
+		expect(h.pendingDisplayTargets).toEqual([worker.session]);
+
+		await h.controller.unfocus();
+		expect(h.pendingDisplayTargets).toEqual([worker.session, h.main.session]);
 	});
 
 	it("does not let a superseded focus attachment restore the worker todo HUD after unfocusing", async () => {


### PR DESCRIPTION
## Repro
Queue a steering message while the main agent streams (the `Steering·N` block appears above the composer), open the Agent Hub, focus any agent with Enter, then return to main with Esc. The pending block is gone and `Alt+L` (`app.display.reset`) does not bring it back, even though the queue is intact and the message still sends. Captured with a `SessionFocusController` unit test: with the fix removed, focusing a worker never repaints the pending container.

```
(fail) re-derives the pending steering/follow-up block on both focus directions (#11379)
expect(received).toEqual(expected)
- [ worker.session ]
+ []
```

## Cause
`SessionFocusController.#attach()` (`packages/coding-agent/src/modes/controllers/session-focus-controller.ts`) runs on every focus attach and detach and calls `clearTransientSessionUi()` (`interactive-mode.ts`), which disposes `pendingMessagesContainer`'s children. `#attach()` then rebuilds the transcript, status line, live tool cards, and the Todo HUD (`reloadTodos`), but never called `updatePendingMessagesDisplay()` — the only code that reads `viewSession.getQueuedMessages()` and re-adds the rows and the `Alt+Up to edit` hint (`ui-helpers.ts`). The container stayed empty until an unrelated caller (`event-controller.ts`, or queueing another message) repainted it. Same teardown path as #9816.

## Fix
- Call `this.ctx.updatePendingMessagesDisplay()` in `#attach()`, right after the Todo HUD reload and its generation guard. It reads `viewSession` (`target ?? main`), so it restores main's queue on unfocus and renders a focused subagent's own queue on focus — covering both directions, exactly like the adjacent `reloadTodos(target)`.
- Added a `SessionFocusController` regression test asserting the pending block is re-derived against the worker on focus and against main on unfocus.

## Verification
`bun test test/session-focus-controller.test.ts` — 7 pass. With the fix line removed the new test fails (queue intact, display blank), confirming it guards the regression. Full related suite `bun test test/session-focus-controller.test.ts test/issue-9816-hub-inflight-focus-rebuild.test.ts test/input-controller-focused-submit-restore.test.ts` — 14 pass. Fixes #11379