### PR TITLE
feat(tui): mark the live session in the /resume picker

### DIFF
--- a/docs/session-switching-and-recent-listing.md
+++ b/docs/session-switching-and-recent-listing.md
@@ -60,7 +60,7 @@ For `SessionInfo` list entries:
 
 - `title` is the fixed title-slot value when present, otherwise `header.title`, otherwise the last compaction `shortSummary` seen in the prefix
 - `firstMessage` is first user message text discoverable from the prefix or `"(no messages)"`
-- the picker also shows modified time, file size, lifecycle status (except `unknown`), fork marker, and cwd in all-projects scope
+- the picker also shows modified time, file size, a `current` marker on the live session, lifecycle status (except `unknown`), fork marker, and cwd in all-projects scope
 
 ## `--continue` resolution and terminal breadcrumb preference
 
@@ -134,7 +134,7 @@ Uses `SessionManager.continueRecent(...)` directly (breadcrumb-first behavior ab
 Flow:
 
 1. fetch current-folder sessions via `SessionManager.list(currentCwd, currentSessionDir)`; the all-projects list remains lazy even when folder scope is empty
-2. present `SessionSelectorComponent` as a fullscreen alternate-screen overlay via `ctx.ui.showOverlay` (anchored top-left at full size; the transcript underneath is untouched), wired with lazy all-project loading (`loadAllSessions`), a `history.db` prompt matcher, deletion, and pinned-session markers
+2. present `SessionSelectorComponent` as a fullscreen alternate-screen overlay via `ctx.ui.showOverlay` (anchored top-left at full size; the transcript underneath is untouched), wired with lazy all-project loading (`loadAllSessions`), a `history.db` prompt matcher, deletion, pinned-session markers, and a current-session marker
 3. callbacks:
    - select -> lock picker input and call `handleResumeSession(sessionPath)`; on success hide the overlay and restore editor focus, a recoverable pre-switch failure unlocks the picker and keeps it open
    - cancel -> hide overlay, restore editor focus, rerender
@@ -153,6 +153,7 @@ Flow:
 - Tab to toggle current-folder / all-projects scope
 - mouse wheel/click in the fullscreen picker
 - multi-token search across id/title/cwd/first message/prefix message text/path: literal matches lead by recency, then sufficiently strong fuzzy matches; prompt-history matches from `history.db` may be promoted after typing pauses
+- the live session (when `currentSessionPath` is supplied) is labeled `current` on its metadata line and focused on open and after a Tab scope toggle
 
 Empty-list render behavior:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
-- The `/resume` picker (Ctrl+L when bound to `app.session.resume`) marks the live session with a `current` label on its metadata line and focuses that row on open.
+- The `/resume` picker (Ctrl+L when bound to `app.session.resume`) marks the live session with a `current` label on its metadata line and focuses that row on open. ([#11381](https://github.com/can1357/oh-my-pi/pull/11381) by [@tkossak](https://github.com/tkossak))
 - `/loop` accepts `--until '<cmd>'` / `--while '<cmd>'` to gate each iteration on a shell command's exit status, so a loop can stop on real project state instead of only a count or duration. ([#10858](https://github.com/can1357/oh-my-pi/pull/10858) by [@andyhite](https://github.com/andyhite))
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added opt-in experimental notes-backed context windows with persistent branch-local notes, searchable original session history, retained latest user requests, and a model-callable rollover tool, including in Code Mode.
+- The `/resume` picker (Ctrl+L when bound to `app.session.resume`) marks the live session with a `current` label on its metadata line and focuses that row on open.
 - `/loop` accepts `--until '<cmd>'` / `--while '<cmd>'` to gate each iteration on a shell command's exit status, so a loop can stop on real project state instead of only a count or duration. ([#10858](https://github.com/can1357/oh-my-pi/pull/10858) by [@andyhite](https://github.com/andyhite))
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -390,6 +390,7 @@ class SessionList implements Component {
 		if (tokens.length === 0) {
 			this.#filteredSessions = this.#allSessions;
 			this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, this.#filteredSessions.length - 1));
+			this.#selectCurrentSession();
 			this.#scheduleHistoryMerge(query);
 			return;
 		}
@@ -415,6 +416,11 @@ class SessionList implements Component {
 		// and spill the remainder into async chunks.
 		this.#scanFuzzySlice(this.#scanGeneration, tokens, rest, 0, FUZZY_SCAN_INLINE_COUNT);
 		this.#composeFiltered();
+		// Query change rebuilds ranking; keep the numeric index only for async
+		// compose (fuzzy chunks / history merge) so an arrow selection survives
+		// those. A live-session index > 0 would otherwise clamp onto a lower
+		// match instead of the top-ranked hit.
+		this.#selectedIndex = 0;
 		this.#scheduleHistoryMerge(query);
 	}
 

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -309,6 +309,8 @@ class SessionList implements Component {
 	#selectionMoved = false;
 	/** True after a nonempty query; empty refilter restores current only then. */
 	#hadFilterQuery = false;
+	/** Last query passed to {@link #filterSessions}; same-query refilter keeps the index. */
+	#lastFilterQuery = "";
 
 	constructor(
 		sessions: SessionInfo[],
@@ -392,7 +394,9 @@ class SessionList implements Component {
 
 		const tokens = tokenizeSessionQuery(query);
 		const hadQuery = this.#hadFilterQuery;
+		const queryChanged = query !== this.#lastFilterQuery;
 		this.#hadFilterQuery = tokens.length > 0;
+		this.#lastFilterQuery = query;
 		if (tokens.length === 0) {
 			this.#filteredSessions = this.#allSessions;
 			this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, this.#filteredSessions.length - 1));
@@ -422,11 +426,11 @@ class SessionList implements Component {
 		// and spill the remainder into async chunks.
 		this.#scanFuzzySlice(this.#scanGeneration, tokens, rest, 0, FUZZY_SCAN_INLINE_COUNT);
 		this.#composeFiltered();
-		// Query change rebuilds ranking; keep the numeric index only for async
-		// compose (fuzzy chunks / history merge) so an arrow selection survives
-		// those. A live-session index > 0 would otherwise clamp onto a lower
-		// match instead of the top-ranked hit.
-		this.#selectedIndex = 0;
+		// New query rebuilds ranking from scratch. Same-query refilter (delete)
+		// and async compose (fuzzy chunks / history merge) only clamp so an
+		// arrow selection survives. A live-session index > 0 would otherwise
+		// land on a lower-ranked match after the first keystroke.
+		if (queryChanged) this.#selectedIndex = 0;
 		this.#scheduleHistoryMerge(query);
 	}
 

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -282,7 +282,7 @@ class SessionList implements Component {
 	#allSessions: SessionInfo[];
 	#showCwd: boolean;
 	#pinnedIds: ReadonlySet<string>;
-	#currentSessionPath: string | undefined;
+	readonly #getCurrentSessionPath: () => string | undefined;
 	readonly #historyMatcher?: SessionHistoryMatcher;
 	#historyMergeTimer: NodeJS.Timeout | undefined;
 	/** Re-render hook for async list updates (fuzzy scan chunks, history merge). */
@@ -316,13 +316,14 @@ class SessionList implements Component {
 		historyMatcher?: SessionHistoryMatcher,
 		getTerminalRows: () => number = () => 24,
 		pinnedIds: ReadonlySet<string> = new Set(),
-		currentSessionPath?: string,
+		currentSessionPath?: string | (() => string | undefined),
 	) {
 		this.#getTerminalRows = getTerminalRows;
 		this.#allSessions = sessions;
 		this.#showCwd = showCwd;
 		this.#pinnedIds = pinnedIds;
-		this.#currentSessionPath = currentSessionPath;
+		this.#getCurrentSessionPath =
+			typeof currentSessionPath === "function" ? currentSessionPath : () => currentSessionPath;
 		this.#historyMatcher = historyMatcher;
 		this.#filteredSessions = sessions;
 		this.#selectCurrentSession();
@@ -362,8 +363,9 @@ class SessionList implements Component {
 
 	/** Focus the live session when it is in the visible list. */
 	#selectCurrentSession(): void {
-		if (!this.#currentSessionPath) return;
-		const index = this.#filteredSessions.findIndex(s => s.path === this.#currentSessionPath);
+		const currentPath = this.#getCurrentSessionPath();
+		if (!currentPath) return;
+		const index = this.#filteredSessions.findIndex(s => s.path === currentPath);
 		if (index >= 0) this.#selectedIndex = index;
 	}
 
@@ -616,6 +618,7 @@ class SessionList implements Component {
 		const sessionRowIndex: number[] = [];
 		const overflow = startIndex > 0 || endIndex < filtered.length;
 		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
+		const currentPath = this.#getCurrentSessionPath();
 		for (let i = startIndex; i < endIndex; i++) {
 			const blockStart = sessionLines.length;
 			const session = this.#filteredSessions[i];
@@ -659,7 +662,7 @@ class SessionList implements Component {
 			const dot = dim(theme.sep.dot);
 			const modified = formatDate(session.modified);
 			let metadata = `  ${dim(modified)} ${dot} ${dim(formatBytes(session.size))}`;
-			if (this.#currentSessionPath !== undefined && session.path === this.#currentSessionPath) {
+			if (currentPath !== undefined && session.path === currentPath) {
 				metadata += ` ${dot} ${theme.fg("accent", "current")}`;
 			}
 			const status = formatSessionStatus(session.status);
@@ -808,8 +811,8 @@ export interface SessionSelectorOptions {
 	fillHeight?: boolean;
 	/** Set of pinned session ids to display with a pin indicator. */
 	pinnedIds?: ReadonlySet<string>;
-	/** Path of the live session; marked `current` and focused on open. */
-	currentSessionPath?: string;
+	/** Path of the live session, or a getter so detach/newSession stays accurate. */
+	currentSessionPath?: string | (() => string | undefined);
 }
 
 /**
@@ -1006,6 +1009,10 @@ export class SessionSelectorComponent extends OverlayPanel {
 						const deleted = await this.#onDelete(session);
 						if (deleted) {
 							this.#sessionList.removeSession(session.path);
+							this.#folderSessions = this.#folderSessions.filter(s => s.path !== session.path);
+							if (this.#globalSessions) {
+								this.#globalSessions = this.#globalSessions.filter(s => s.path !== session.path);
+							}
 						}
 					} catch (err) {
 						this.#showError(err instanceof Error ? err.message : String(err));

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -282,6 +282,7 @@ class SessionList implements Component {
 	#allSessions: SessionInfo[];
 	#showCwd: boolean;
 	#pinnedIds: ReadonlySet<string>;
+	#currentSessionPath: string | undefined;
 	readonly #historyMatcher?: SessionHistoryMatcher;
 	#historyMergeTimer: NodeJS.Timeout | undefined;
 	/** Re-render hook for async list updates (fuzzy scan chunks, history merge). */
@@ -313,13 +314,16 @@ class SessionList implements Component {
 		historyMatcher?: SessionHistoryMatcher,
 		getTerminalRows: () => number = () => 24,
 		pinnedIds: ReadonlySet<string> = new Set(),
+		currentSessionPath?: string,
 	) {
 		this.#getTerminalRows = getTerminalRows;
 		this.#allSessions = sessions;
 		this.#showCwd = showCwd;
 		this.#pinnedIds = pinnedIds;
+		this.#currentSessionPath = currentSessionPath;
 		this.#historyMatcher = historyMatcher;
 		this.#filteredSessions = sessions;
+		this.#selectCurrentSession();
 		this.#searchInput = new Input();
 
 		// Handle Enter in search input - select current item
@@ -354,6 +358,13 @@ class SessionList implements Component {
 		return Math.max(2, Math.floor(this.#lineBudget() / 4));
 	}
 
+	/** Focus the live session when it is in the visible list. */
+	#selectCurrentSession(): void {
+		if (!this.#currentSessionPath) return;
+		const index = this.#filteredSessions.findIndex(s => s.path === this.#currentSessionPath);
+		if (index >= 0) this.#selectedIndex = index;
+	}
+
 	/** Replace the visible dataset, e.g. when toggling folder/all-projects scope. */
 	setSessions(sessions: SessionInfo[], showCwd: boolean, pinnedIds?: ReadonlySet<string>): void {
 		this.#allSessions = sessions;
@@ -361,6 +372,7 @@ class SessionList implements Component {
 		if (pinnedIds !== undefined) this.#pinnedIds = pinnedIds;
 		this.#selectedIndex = 0;
 		this.#filterSessions(this.#searchInput.getValue());
+		this.#selectCurrentSession();
 	}
 
 	#filterSessions(query: string): void {
@@ -629,13 +641,17 @@ class SessionList implements Component {
 				sessionLines.push(messageLine);
 			}
 
-			// Metadata line: date + file size + lifecycle status (+ project dir in
-			// all-projects scope). The status segment carries its own color, so each
-			// segment is dimmed individually rather than wrapping the whole line.
+			// Metadata line: date + file size + current marker + lifecycle status
+			// (+ project dir in all-projects scope). The status segment carries
+			// its own color, so each segment is dimmed individually rather than
+			// wrapping the whole line.
 			const dim = (s: string) => theme.fg("dim", s);
 			const dot = dim(theme.sep.dot);
 			const modified = formatDate(session.modified);
 			let metadata = `  ${dim(modified)} ${dot} ${dim(formatBytes(session.size))}`;
+			if (this.#currentSessionPath !== undefined && session.path === this.#currentSessionPath) {
+				metadata += ` ${dot} ${theme.fg("accent", "current")}`;
+			}
 			const status = formatSessionStatus(session.status);
 			if (status) {
 				metadata += ` ${dot} ${status}`;
@@ -782,6 +798,8 @@ export interface SessionSelectorOptions {
 	fillHeight?: boolean;
 	/** Set of pinned session ids to display with a pin indicator. */
 	pinnedIds?: ReadonlySet<string>;
+	/** Path of the live session; marked `current` and focused on open. */
+	currentSessionPath?: string;
 }
 
 /**
@@ -852,6 +870,7 @@ export class SessionSelectorComponent extends OverlayPanel {
 			options.historyMatcher,
 			options.getTerminalRows,
 			options.pinnedIds,
+			options.currentSessionPath,
 		);
 		// Every exit path cancels the list's pending history merge, so a stale
 		// debounce timer can never run its SQLite lookup after the picker closed.

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -307,6 +307,8 @@ class SessionList implements Component {
 	 * only append below the literal group, which never shifts existing rows.)
 	 */
 	#selectionMoved = false;
+	/** True after a nonempty query; empty refilter restores current only then. */
+	#hadFilterQuery = false;
 
 	constructor(
 		sessions: SessionInfo[],
@@ -387,10 +389,12 @@ class SessionList implements Component {
 		this.#fuzzyRanked = [];
 
 		const tokens = tokenizeSessionQuery(query);
+		const hadQuery = this.#hadFilterQuery;
+		this.#hadFilterQuery = tokens.length > 0;
 		if (tokens.length === 0) {
 			this.#filteredSessions = this.#allSessions;
 			this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, this.#filteredSessions.length - 1));
-			this.#selectCurrentSession();
+			if (hadQuery) this.#selectCurrentSession();
 			this.#scheduleHistoryMerge(query);
 			return;
 		}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1819,7 +1819,9 @@ export class SelectorController {
 				historyMatcher,
 				loadAllSessions: () => SessionManager.listAll(),
 				pinnedIds,
-				currentSessionPath: () => this.ctx.sessionManager.getSessionFile(),
+				// Live getter so detach/newSession stays accurate; tolerant of partial
+				// contexts and in-memory sessions (undefined file means no marker).
+				currentSessionPath: () => this.ctx.sessionManager.getSessionFile?.() ?? undefined,
 			};
 		}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1819,6 +1819,7 @@ export class SelectorController {
 				historyMatcher,
 				loadAllSessions: () => SessionManager.listAll(),
 				pinnedIds,
+				currentSessionPath: this.ctx.sessionManager.getSessionFile(),
 			};
 		}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1819,7 +1819,7 @@ export class SelectorController {
 				historyMatcher,
 				loadAllSessions: () => SessionManager.listAll(),
 				pinnedIds,
-				currentSessionPath: this.ctx.sessionManager.getSessionFile(),
+				currentSessionPath: () => this.ctx.sessionManager.getSessionFile(),
 			};
 		}
 

--- a/packages/coding-agent/test/modes/components/session-selector-current.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-current.test.ts
@@ -94,4 +94,46 @@ describe("SessionSelectorComponent current session marker", () => {
 		expect(sessionSection(rendered, "Alpha work")).toContain(`${cursor} Alpha work`);
 		expect(sessionSection(rendered, "Alpha other")).not.toContain(`${cursor} Alpha other`);
 	});
+
+	it("keeps the neighboring row focused after deleting with an empty query", () => {
+		const alpha = createSession("alpha", "Alpha", "2024-01-03T00:00:00Z");
+		const bravo = createSession("bravo", "Bravo", "2024-01-02T00:00:00Z");
+		const live = createSession("live", "Charlie live", "2024-01-01T00:00:00Z");
+		const selector = new SessionSelectorComponent(
+			[alpha, bravo, live],
+			() => {},
+			() => {},
+			() => {},
+			{
+				getTerminalRows: () => 100,
+				currentSessionPath: live.path,
+			},
+		);
+		selector.handleInput("\x1b[A");
+		selector.handleInput("\x1b[A");
+		selector.getSessionList().removeSession(alpha.path);
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		const cursor = theme.nav.cursor;
+		expect(sessionSection(rendered, "Bravo")).toContain(`${cursor} Bravo`);
+		expect(sessionSection(rendered, "Charlie live")).not.toContain(`${cursor} Charlie live`);
+	});
+
+	it("restores live-session focus when the search query is cleared", () => {
+		const selector = new SessionSelectorComponent(
+			[newer, older],
+			() => {},
+			() => {},
+			() => {},
+			{
+				getTerminalRows: () => 100,
+				currentSessionPath: older.path,
+			},
+		);
+		selector.handleInput("x");
+		selector.handleInput("\x7f");
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		const cursor = theme.nav.cursor;
+		expect(sessionSection(rendered, "Older session")).toContain(`${cursor} Older session`);
+		expect(sessionSection(rendered, "Newer session")).not.toContain(`${cursor} Newer session`);
+	});
 });

--- a/packages/coding-agent/test/modes/components/session-selector-current.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-current.test.ts
@@ -118,6 +118,30 @@ describe("SessionSelectorComponent current session marker", () => {
 		expect(sessionSection(rendered, "Charlie live")).not.toContain(`${cursor} Charlie live`);
 	});
 
+	it("keeps the neighboring row focused after deleting a filtered result", () => {
+		const alpha = createSession("alpha", "Alpha work", "2024-01-03T00:00:00Z");
+		const bravo = createSession("bravo", "Alpha bravo", "2024-01-02T00:00:00Z");
+		const charlie = createSession("charlie", "Alpha charlie", "2024-01-01T00:00:00Z");
+		const live = createSession("live", "Beta live", "2023-12-31T00:00:00Z");
+		const selector = new SessionSelectorComponent(
+			[alpha, bravo, charlie, live],
+			() => {},
+			() => {},
+			() => {},
+			{
+				getTerminalRows: () => 100,
+				currentSessionPath: live.path,
+			},
+		);
+		for (const ch of "alpha") selector.handleInput(ch);
+		selector.handleInput("\x1b[B");
+		selector.getSessionList().removeSession(bravo.path);
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		const cursor = theme.nav.cursor;
+		expect(sessionSection(rendered, "Alpha charlie")).toContain(`${cursor} Alpha charlie`);
+		expect(sessionSection(rendered, "Alpha work")).not.toContain(`${cursor} Alpha work`);
+	});
+
 	it("restores live-session focus when the search query is cleared", () => {
 		const selector = new SessionSelectorComponent(
 			[newer, older],

--- a/packages/coding-agent/test/modes/components/session-selector-current.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-current.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { SessionSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/session-selector";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterAll(async () => {
+	await initTheme();
+});
+
+function createSession(id: string, title: string, modified: string): SessionInfo {
+	return {
+		path: `/work/${id}.jsonl`,
+		id,
+		cwd: "/work",
+		title,
+		created: new Date("2024-01-01T00:00:00Z"),
+		modified: new Date(modified),
+		messageCount: 1,
+		size: 2048,
+		firstMessage: `first message ${id}`,
+		allMessagesText: `first message ${id}`,
+	};
+}
+
+function renderPlain(sessions: SessionInfo[], currentSessionPath?: string): string {
+	const selector = new SessionSelectorComponent(sessions, () => {}, () => {}, () => {}, {
+		getTerminalRows: () => 100,
+		currentSessionPath,
+	});
+	return selector
+		.render(120)
+		.join("\n")
+		.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function sessionSection(rendered: string, title: string): string {
+	const lines = rendered.split("\n");
+	const idx = lines.findIndex(line => line.includes(title));
+	expect(idx).toBeGreaterThan(-1);
+	return lines.slice(idx, idx + 4).join("\n");
+}
+
+describe("SessionSelectorComponent current session marker", () => {
+	const newer = createSession("newer", "Newer session", "2024-01-03T00:00:00Z");
+	const older = createSession("older", "Older session", "2024-01-02T00:00:00Z");
+
+	it("renders no current marker when the live session path is not provided", () => {
+		const rendered = renderPlain([newer, older]);
+		expect(sessionSection(rendered, "Newer session")).not.toContain("current");
+		expect(sessionSection(rendered, "Older session")).not.toContain("current");
+	});
+
+	it("labels only the live session current on the metadata line", () => {
+		const rendered = renderPlain([newer, older], older.path);
+		expect(sessionSection(rendered, "Older session")).toContain("current");
+		expect(sessionSection(rendered, "Newer session")).not.toContain("current");
+	});
+
+	it("focuses the live session even when it is not the most recent row", () => {
+		const rendered = renderPlain([newer, older], older.path);
+		const cursor = theme.nav.cursor;
+		expect(sessionSection(rendered, "Older session")).toContain(`${cursor} Older session`);
+		expect(sessionSection(rendered, "Newer session")).not.toContain(`${cursor} Newer session`);
+	});
+});

--- a/packages/coding-agent/test/modes/components/session-selector-current.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-current.test.ts
@@ -136,4 +136,36 @@ describe("SessionSelectorComponent current session marker", () => {
 		expect(sessionSection(rendered, "Older session")).toContain(`${cursor} Older session`);
 		expect(sessionSection(rendered, "Newer session")).not.toContain(`${cursor} Newer session`);
 	});
+
+	it("drops a deleted live session from the cached all-projects list", async () => {
+		const alpha = createSession("alpha", "Alpha", "2024-01-03T00:00:00Z");
+		const live = createSession("live", "Charlie live", "2024-01-02T00:00:00Z");
+		const other = createSession("other", "Other project", "2024-01-01T00:00:00Z");
+		let currentPath: string | undefined = live.path;
+		const selector = new SessionSelectorComponent(
+			[alpha, live],
+			() => {},
+			() => {},
+			() => {},
+			{
+				getTerminalRows: () => 100,
+				currentSessionPath: () => currentPath,
+				allSessions: [alpha, live, other],
+				onDelete: async () => {
+					currentPath = "/work/fresh.jsonl";
+					return true;
+				},
+			},
+		);
+		selector.handleInput("\x1b[3~");
+		selector.handleInput("\n");
+		await Promise.resolve();
+		selector.handleInput("\t");
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(rendered).toContain("(all projects)");
+		expect(rendered).toContain("Other project");
+		expect(rendered).not.toContain("Charlie live");
+		expect(sessionSection(rendered, "Alpha")).not.toContain("current");
+		expect(sessionSection(rendered, "Other project")).not.toContain("current");
+	});
 });

--- a/packages/coding-agent/test/modes/components/session-selector-current.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-current.test.ts
@@ -27,14 +27,21 @@ function createSession(id: string, title: string, modified: string): SessionInfo
 }
 
 function renderPlain(sessions: SessionInfo[], currentSessionPath?: string): string {
-	const selector = new SessionSelectorComponent(sessions, () => {}, () => {}, () => {}, {
-		getTerminalRows: () => 100,
-		currentSessionPath,
-	});
-	return selector
-		.render(120)
-		.join("\n")
-		.replace(/\x1b\[[0-9;]*m/g, "");
+	const selector = new SessionSelectorComponent(
+		sessions,
+		() => {},
+		() => {},
+		() => {},
+		{
+			getTerminalRows: () => 100,
+			currentSessionPath,
+		},
+	);
+	return stripAnsi(selector.render(120).join("\n"));
+}
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 function sessionSection(rendered: string, title: string): string {
@@ -65,5 +72,26 @@ describe("SessionSelectorComponent current session marker", () => {
 		const cursor = theme.nav.cursor;
 		expect(sessionSection(rendered, "Older session")).toContain(`${cursor} Older session`);
 		expect(sessionSection(rendered, "Newer session")).not.toContain(`${cursor} Newer session`);
+	});
+
+	it("resets focus to the top search match when the live session is excluded", () => {
+		const work = createSession("work", "Alpha work", "2024-01-03T00:00:00Z");
+		const live = createSession("live", "Beta live", "2024-01-02T00:00:00Z");
+		const other = createSession("other", "Alpha other", "2024-01-01T00:00:00Z");
+		const selector = new SessionSelectorComponent(
+			[work, live, other],
+			() => {},
+			() => {},
+			() => {},
+			{
+				getTerminalRows: () => 100,
+				currentSessionPath: live.path,
+			},
+		);
+		for (const ch of "alpha") selector.handleInput(ch);
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		const cursor = theme.nav.cursor;
+		expect(sessionSection(rendered, "Alpha work")).toContain(`${cursor} Alpha work`);
+		expect(sessionSection(rendered, "Alpha other")).not.toContain(`${cursor} Alpha other`);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
@@ -118,6 +118,9 @@ describe("SelectorController session replacement overlay", () => {
 			sessionManager: {
 				getCwd: () => "/tmp",
 				getSessionDir: () => "/tmp",
+				// Live-session path: keeps the picker's current-marker/focus code live
+				// during the overlay assertions (single-row list stays deterministic).
+				getSessionFile: () => session.path,
 			},
 			ui: {
 				showOverlay: vi.fn(component => {


### PR DESCRIPTION
## What

The `/resume` picker now marks the live session with a `current` label on its metadata line and focuses that row on open and after a Tab scope toggle.

## Why

The picker already showed pin glyphs, but `showSessionSelector` never passed the active session path, so Ctrl+L / `/resume` had no indicator of which row you were already in.

## Testing

- `bun test` on the session-selector suite (including new `session-selector-current.test.ts`): 33 pass, 0 fail.
- Local TUI: run from source with `bun packages/coding-agent/src/cli.ts` and open the resume picker.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
