### PR TITLE
feat(browser): SSRF url-guard + output redaction for browser tool

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4577,6 +4577,30 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"browser.allowPrivateUrls": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Grep & Browser",
+			label: "Allow Private Network URLs",
+			description:
+				"Allow the browser tool to navigate to private/loopback/link-local addresses. Cloud metadata endpoints stay blocked. Set PI_BROWSER_ALLOW_PRIVATE_URLS=0|1 to override.",
+		},
+	},
+
+	"browser.privateUrlAllowlist": {
+		type: "array",
+		default: EMPTY_STRING_ARRAY,
+		ui: {
+			tab: "tools",
+			group: "Grep & Browser",
+			label: "Browser URL Allowlist",
+			description:
+				"Hostnames the browser tool may navigate to even though they resolve privately: exact hosts, *.suffix wildcards, IPs or CIDRs. Configured relay/CDP endpoints are allowed implicitly.",
+		},
+	},
+
 	"browser.headless": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -11,6 +11,7 @@ import browserDeclarations from "./browser/declarations.d.ts" with { type: "text
 import browserJavascript from "./browser/prelude.js" with { type: "text" };
 import browserPython from "./browser/prelude.py" with { type: "text" };
 import { resolveCmuxKind } from "./browser/cmux/rpc";
+import { redactBrowserOutput } from "./browser/output-redact";
 import {
 	acquireBrowser,
 	type BrowserHandle,
@@ -28,6 +29,7 @@ import {
 	cancelIdleCloseForOwner,
 	dropHeadlessTabs,
 	getTab,
+	navigationSettingsForSession,
 	releaseAllTabs,
 	releaseIdleTabsForOwner,
 	releaseTab,
@@ -289,6 +291,7 @@ async function openBrowser(
 					timeoutMs,
 					deadlineStartMs: deadlineStart,
 					dialogs: params.dialogs,
+					navigation: navigationSettingsForSession(session, kind),
 					signal: openSignal,
 					ownerSessionId: session.getSessionId?.() ?? undefined,
 					// Omitted stays undefined: creation defaults it to false
@@ -387,7 +390,10 @@ async function runBrowser(
 
 	if (screenshots.length) details.screenshots = screenshots;
 
-	if (returnValue !== undefined) details.value = returnValue;
+	// Final egress net: worker/cmux already redact, but the run's return
+	// value crosses one more seam here — `details.value` is handed back to
+	// the prelude sandbox (`tab.run()` result) before reaching the model.
+	if (returnValue !== undefined) details.value = redactBrowserOutput(returnValue);
 	const content = [...displays];
 	const textOnly = content
 		.filter((part): part is { type: "text"; text: string } => part.type === "text")

--- a/packages/coding-agent/src/tools/browser/NOTICE
+++ b/packages/coding-agent/src/tools/browser/NOTICE
@@ -1,0 +1,51 @@
+Portions of the omp browser tool's security layer are adapted from
+hermes-agent (https://github.com/NousResearch/hermes-agent), used under the
+MIT License. This attribution covers the URL/SSRF navigation guard and the
+browser-output redaction pass.
+
+  Copyright (c) 2025 Nous Research
+
+Adapted from hermes-agent:
+- `tools/url_safety.py` — IP classification, private/metadata/link-local
+  blocking, metadata floor, DNS-rebind posture → `url-guard.ts`.
+- `tools/browser_tool.py` (SSRF guard, `_url_is_private`) → `url-guard.ts`.
+- `agent/redact.py` — secret-shape masking → `output-redact.ts`.
+
+TypeScript deltas vs hermes (recorded in detail in the port receipt):
+- Guard resolves hostnames through Node `node:dns` instead of Python
+  socket/httpx; fail-closed on DNS failure (hermes fails open behind a proxy).
+- No connection pinning over CDP: TOCTOU/DNS-rebind checked at pre-navigation
+  (resolved IPs) and post-commit (DNS-free literal fast path), documented.
+- Config-driven allowlist (settings + env + configured relay endpoint
+  hostnames); `127.0.0.1:9224` relay preserves its loopback exemption.
+- Userinfo (`user:pass@`) masked unconditionally; added `Cookie:`/`Set-Cookie:`
+  and AWS STS (`ASIA…`) passes; redaction is force-on with no opt-out.
+
+Not ported (omp already masks at egress, or out of scope):
+- sensitive-query-param navigation *block* (omp masks secret-shaped values at
+  final output instead); `_auto_local_for_private_urls` sidecar routing;
+  `check_website_access`; QQ `_TRUSTED_PRIVATE_IP_HOSTS`; E.164 phone masking;
+  `_redact_http_request_target_query_params`; `file_read` sentinel; `code_file`
+  toggle; redaction opt-out toggle (force-on per contract); supervisor
+  `_redact_cdp_error_text`; `_JS_URL_LITERAL_RE` / `_RISKY_BROWSER_EVAL_PATTERNS`
+  eval pre-screen; `document.cookie` eval denylist; httpx IP pinning.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -21,9 +21,23 @@ import {
 import { ToolAbortError, ToolError, throwIfAborted } from "../../tool-errors";
 import { type AriaSnapshotOptions, assertSelectorString, buildAriaSnapshotScript } from "../aria/aria-snapshot";
 import { DEFAULT_VIEWPORT } from "../launch";
+import { redactBrowserOutput, redactBrowserText } from "../output-redact";
 import { extractReadableFromHtml, type ReadableFormat } from "../readable";
 import { cloneSafe, RunOutput } from "../run-output";
-import type { Observation, ReadyInfo, RunResultOk, ScreenshotResult, SessionSnapshot } from "../tab-protocol";
+import type {
+	NavigationGuardSettings,
+	Observation,
+	ReadyInfo,
+	RunResultOk,
+	ScreenshotResult,
+	SessionSnapshot,
+} from "../tab-protocol";
+import {
+	checkNavigationTarget,
+	isBlockedCommittedNavigation,
+	navigationBlockedMessage,
+	policyFromSettings,
+} from "../url-guard";
 import {
 	type CmuxEvalResult,
 	type CmuxGeometry,
@@ -333,8 +347,23 @@ export class CmuxTab {
 	readonly #elementRefs = new Map<number, CachedElementRef>();
 	#pageFacade: CmuxPageFacade | undefined;
 	#browserFacade: CmuxBrowserFacade | undefined;
-	constructor(opts: { client: CmuxSocketClient; surfaceId: string; url?: string; title?: string }) {
+	/** SSRF navigation-guard policy recorded at acquisition (config-resolved). */
+	#navigation: NavigationGuardSettings | undefined;
+	/**
+	 * Landed URL of a committed navigation that the guard forbids. cmux has no
+	 * frame-navigation event, so this is set by `goto`'s post-commit recheck
+	 * after the navigate request; the run's reply is failed by `runCmuxCode`.
+	 */
+	#navViolation: string | undefined;
+	constructor(opts: {
+		client: CmuxSocketClient;
+		surfaceId: string;
+		url?: string;
+		title?: string;
+		navigation?: NavigationGuardSettings;
+	}) {
 		this.#client = opts.client;
+		this.#navigation = opts.navigation;
 		this.#surfaceId = opts.surfaceId;
 		if (opts.url) this.#lastUrl = opts.url;
 		this.#lastTitle = opts.title;
@@ -387,8 +416,8 @@ export class CmuxTab {
 			: viewport;
 		await this.title().catch(() => "");
 		return {
-			url: this.#lastUrl,
-			title: this.#lastTitle,
+			url: redactBrowserText(this.#lastUrl),
+			title: this.#lastTitle === undefined ? undefined : redactBrowserText(this.#lastTitle),
 			viewport: this.#lastViewport,
 			targetId: this.#surfaceId,
 		};
@@ -402,11 +431,32 @@ export class CmuxTab {
 		this.#runContext = undefined;
 	}
 
+	/** Clear the per-run committed-navigation violation flag (run start). */
+	beginNavigationRun(): void {
+		this.#navViolation = undefined;
+	}
+
+	/** Consume the committed-navigation violation recorded during the run. */
+	takeNavigationViolation(): string | undefined {
+		const violation = this.#navViolation;
+		this.#navViolation = undefined;
+		return violation;
+	}
+
 	async goto(url: string, opts?: { waitUntil?: WaitUntil; timeoutMs?: number }): Promise<void> {
 		const timeoutMs = opts?.timeoutMs ?? this.#runContext?.timeoutMs ?? 30_000;
+		const settings = this.#runContext?.session.navigation ?? this.#navigation;
+		const verdict = await checkNavigationTarget(url, policyFromSettings(settings));
+		if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
 		const result = await this.#request("browser.navigate", { url }, timeoutMs);
 		const navigatedUrl = result.url;
 		this.#lastUrl = typeof navigatedUrl === "string" && navigatedUrl.length > 0 ? navigatedUrl : url;
+		// Server-issued redirects can land somewhere the request URL did not:
+		// recheck the committed URL DNS-free and quarantine the surface.
+		if (isBlockedCommittedNavigation(this.#lastUrl, policyFromSettings(settings))) {
+			this.#navViolation = this.#lastUrl;
+			await this.goto("about:blank", { timeoutMs: 5_000 }).catch(() => undefined);
+		}
 		if (opts?.waitUntil) {
 			await this.#request(
 				"browser.wait",
@@ -1377,6 +1427,7 @@ export async function runCmuxCode(tab: CmuxTab, opts: RunCmuxCodeOptions): Promi
 	const activeRun: ActiveCmuxRun = { filename, floatingRejections: [] };
 	activeCmuxRuns.set(filename, activeRun);
 	tab.setRunContext({ session: opts.snapshot, output, screenshots, signal, timeoutMs: opts.timeoutMs });
+	tab.beginNavigationRun();
 
 	const { promise: cancelRejection, reject } = Promise.withResolvers<never>();
 	// If the synchronous setup below throws (same-realm ownership conflict)
@@ -1498,6 +1549,13 @@ export async function runCmuxCode(tab: CmuxTab, opts: RunCmuxCodeOptions): Promi
 			}
 			throw runError;
 		}
+		const violation = tab.takeNavigationViolation();
+		if (violation !== undefined) {
+			throw new ToolError(
+				`Blocked: navigation committed to ${JSON.stringify(violation)}, a private/internal or disallowed target. ` +
+					"The page was pulled back to about:blank and this run's output was discarded.",
+			);
+		}
 		if (activeRun.floatingRejections.length > 0) {
 			const messages = activeRun.floatingRejections.map(reason =>
 				reason instanceof Error ? reason.message : String(reason),
@@ -1506,7 +1564,13 @@ export async function runCmuxCode(tab: CmuxTab, opts: RunCmuxCodeOptions): Promi
 				rejections: activeRun.floatingRejections,
 			});
 		}
-		return { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots };
+		return {
+			displays: output
+				.finish()
+				.map(entry => (entry.type === "text" ? { ...entry, text: redactBrowserText(entry.text) } : entry)),
+			returnValue: redactBrowserOutput(cloneSafe(returnValue)),
+			screenshots,
+		};
 	} finally {
 		runActive = false;
 		uninstallRejectionInterceptor();

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -34,9 +34,9 @@ import type {
 } from "../tab-protocol";
 import {
 	checkNavigationTarget,
-	isBlockedCommittedNavigation,
 	navigationBlockedMessage,
 	policyFromSettings,
+	recheckCommittedNavigation,
 } from "../url-guard";
 import {
 	type CmuxEvalResult,
@@ -355,6 +355,14 @@ export class CmuxTab {
 	 * after the navigate request; the run's reply is failed by `runCmuxCode`.
 	 */
 	#navViolation: string | undefined;
+	/**
+	 * Hostname → answers memoized for the ACTIVE run: one DNS lookup per host,
+	 * shared between `goto`'s pre-check and its post-commit recheck (a cached
+	 * answer is still classified on every use). Cleared by
+	 * {@link beginNavigationRun} so a long-lived surface never pins a stale
+	 * answer across runs.
+	 */
+	#resolvedHosts = new Map<string, readonly string[]>();
 	constructor(opts: {
 		client: CmuxSocketClient;
 		surfaceId: string;
@@ -431,9 +439,10 @@ export class CmuxTab {
 		this.#runContext = undefined;
 	}
 
-	/** Clear the per-run committed-navigation violation flag (run start). */
+	/** Clear the per-run committed-navigation violation flag and host memo (run start). */
 	beginNavigationRun(): void {
 		this.#navViolation = undefined;
+		this.#resolvedHosts = new Map();
 	}
 
 	/** Consume the committed-navigation violation recorded during the run. */
@@ -446,14 +455,17 @@ export class CmuxTab {
 	async goto(url: string, opts?: { waitUntil?: WaitUntil; timeoutMs?: number }): Promise<void> {
 		const timeoutMs = opts?.timeoutMs ?? this.#runContext?.timeoutMs ?? 30_000;
 		const settings = this.#runContext?.session.navigation ?? this.#navigation;
-		const verdict = await checkNavigationTarget(url, policyFromSettings(settings));
+		const policy = { ...policyFromSettings(settings), resolvedHosts: this.#resolvedHosts };
+		const verdict = await checkNavigationTarget(url, policy);
 		if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
 		const result = await this.#request("browser.navigate", { url }, timeoutMs);
 		const navigatedUrl = result.url;
 		this.#lastUrl = typeof navigatedUrl === "string" && navigatedUrl.length > 0 ? navigatedUrl : url;
 		// Server-issued redirects can land somewhere the request URL did not:
-		// recheck the committed URL DNS-free and quarantine the surface.
-		if (isBlockedCommittedNavigation(this.#lastUrl, policyFromSettings(settings))) {
+		// recheck the committed URL — DNS-free first, then re-resolving a host
+		// that never passed this run's pre-check (rebinding window) — and
+		// quarantine the surface.
+		if (await recheckCommittedNavigation(this.#lastUrl, policy)) {
 			this.#navViolation = this.#lastUrl;
 			await this.goto("about:blank", { timeoutMs: 5_000 }).catch(() => undefined);
 		}

--- a/packages/coding-agent/src/tools/browser/navigation-scope.ts
+++ b/packages/coding-agent/src/tools/browser/navigation-scope.ts
@@ -1,0 +1,230 @@
+/**
+ * The per-run navigation seams of the tab worker, extracted so they can be
+ * exercised against a fake `Page`/`Browser` without loading the worker's
+ * runtime (which connects puppeteer, the DOM helpers, and the native addon).
+ *
+ * Three gaps in the request-time guard make these necessary:
+ *
+ *  1. The `browser.run` facade is a get-only proxy: it cannot instrument the
+ *     page object it hands out, so `page.goto(privateUrl)` from model code
+ *     would cross to CDP with no policy check. {@link createRunPageScope}
+ *     patches the raw descriptor for the run and restores it on cleanup.
+ *  2. `browser.newPage()` returns an unobserved page. {@link
+ *     createRunBrowserScope} patches `newPage` on the RAW browser (before the
+ *     facade is built) so every page the model creates gets the observer.
+ *  3. A server redirect, `meta refresh`, script navigation or iframe commits a
+ *     URL that was never the guard's argument. {@link
+ *     attachNavigationObserver} watches `framenavigated` for EVERY frame and
+ *     runs the async post-commit recheck (`recheckCommittedNavigation`, which
+ *     re-resolves hosts the run never vetted — the DNS-rebinding window).
+ *
+ * Suppression, not prevention: DNS cannot be pinned over CDP (see the url-guard
+ * header), so content may already be in the renderer when the load is stopped.
+ * What is guaranteed is that the violating result never reaches the model: the
+ * load stops, the page is pulled back to `about:blank`, and the caller records
+ * the landed URL so the run's reply is failed instead of answered.
+ */
+
+import { withTimeout } from "@oh-my-pi/pi-utils/async";
+import type { Browser, Page } from "puppeteer-core";
+import { ToolError } from "../tool-errors";
+
+/** Cleanup must settle inside the supervisor's 750ms post-run grace window. */
+const REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS = 500;
+
+/**
+ * Thrown when the post-run request-interception reset fails. The tab cannot be
+ * reused by the next run (interception is still armed), so the supervisor treats
+ * this as a recoverable-by-restart condition rather than a model error.
+ */
+export class RequestInterceptionCleanupError extends ToolError {}
+
+/** The stop hook for a violating load: Puppeteer has no public `stopLoading`,
+ * so the worker injects its CDP `Page.stopLoading` sender. */
+export type StopNavigation = () => Promise<void>;
+
+/**
+ * Attach the committed-navigation observer to ONE page. Every frame — main
+ * frame or child iframe, which is how an embedded document reaches an
+ * attacker-chosen host — whose landed URL `check` forbids gets the load stopped
+ * and the page pulled back to `about:blank`, reporting through `onViolation` so
+ * the run's reply can be failed. `check` is async because it may re-resolve an
+ * unvetted hostname (the DNS-rebinding window); answers are memoized by the
+ * policy's `resolvedHosts`.
+ */
+export function attachNavigationObserver(
+	page: Page,
+	check: (url: string) => Promise<boolean>,
+	onViolation: (url: string) => void,
+	stop: StopNavigation = async () => undefined,
+): void {
+	page.on("framenavigated", frame => {
+		void (async () => {
+			const landed = frame.url();
+			// `about:blank` is the initial frame and our own quarantine target.
+			if (!landed || landed === "about:blank") return;
+			if (!(await check(landed))) return;
+			onViolation(landed);
+			await stop().catch(() => undefined);
+			await page.goto("about:blank", { timeout: 5_000 }).catch(() => undefined);
+		})();
+	});
+}
+
+export interface RunBrowserScope {
+	browser: Browser;
+	cleanup(): Promise<void>;
+}
+
+/**
+ * Wrap `browser.newPage` for one run so a page the model creates itself gets
+ * the same committed-navigation observer as the tab's own page. Without this,
+ * `const p = await browser.newPage(); await p.goto(privateUrl)` in `browser.run`
+ * would be entirely unobserved — the observer is bound to the tab page only.
+ * Patched on the RAW browser before the run facade is built (the facade is a
+ * get-only proxy and cannot instrument returned objects) and restored by
+ * `cleanup()`.
+ */
+export function createRunBrowserScope(browser: Browser, attach: (page: Page) => void): RunBrowserScope {
+	const newPageDescriptor = Object.getOwnPropertyDescriptor(browser, "newPage");
+	const rawNewPage = (newPageDescriptor?.value ?? browser.newPage) as Browser["newPage"];
+	Object.defineProperty(browser, "newPage", {
+		configurable: true,
+		value: async (...args: Parameters<Browser["newPage"]>) => {
+			const page = await Reflect.apply(rawNewPage, browser, args);
+			attach(page);
+			return page;
+		},
+	});
+	return {
+		browser,
+		async cleanup() {
+			if (newPageDescriptor) Object.defineProperty(browser, "newPage", newPageDescriptor);
+			else Reflect.deleteProperty(browser, "newPage");
+		},
+	};
+}
+
+export interface RunPageScope {
+	page: Page;
+	cleanup(): Promise<void>;
+}
+
+/**
+ * Expose the tab page while retaining the request handlers created by this run.
+ * Puppeteer's Page wraps an internal emitter, so `removeAllListeners("request")`
+ * would also remove its forwarding listener; the facade removes only user handlers.
+ *
+ * `guard` additionally wraps `page.goto`, because the run facade hands the model
+ * the page object itself: `page.goto(privateUrl)` otherwise crosses to CDP with
+ * no policy check at all (the `tab.goto` op guard covers only the tab helper).
+ */
+export function createRunPageScope(page: Page, guard?: (url: string) => Promise<void>): RunPageScope {
+	const requestHandlers: unknown[] = [];
+	const on = page.on;
+	const off = page.off;
+	const once = page.once;
+	const removeAllListeners = page.removeAllListeners;
+	const onDescriptor = Object.getOwnPropertyDescriptor(page, "on");
+	const offDescriptor = Object.getOwnPropertyDescriptor(page, "off");
+	const onceDescriptor = Object.getOwnPropertyDescriptor(page, "once");
+	const removeAllDescriptor = Object.getOwnPropertyDescriptor(page, "removeAllListeners");
+	const gotoDescriptor = Object.getOwnPropertyDescriptor(page, "goto");
+	let gotoPatched = false;
+	if (guard) {
+		const rawGoto = (gotoDescriptor?.value ?? page.goto) as Page["goto"];
+		Object.defineProperty(page, "goto", {
+			configurable: true,
+			value: async (url: string, opts?: Parameters<Page["goto"]>[1]) => {
+				await guard(url);
+				return Reflect.apply(rawGoto, page, [url, opts]);
+			},
+		});
+		gotoPatched = true;
+	}
+
+	Object.defineProperties(page, {
+		on: {
+			configurable: true,
+			value: (type: unknown, handler: unknown): Page => {
+				Reflect.apply(on, page, [type, handler]);
+				if (type === "request") requestHandlers.push(handler);
+				return page;
+			},
+		},
+		once: {
+			configurable: true,
+			value: (type: unknown, handler: unknown): Page => {
+				if (type !== "request" || typeof handler !== "function") {
+					Reflect.apply(once, page, [type, handler]);
+					return page;
+				}
+				const wrapper = (event: unknown): void => {
+					const index = requestHandlers.lastIndexOf(wrapper);
+					if (index >= 0) requestHandlers.splice(index, 1);
+					Reflect.apply(off, page, ["request", wrapper]);
+					Reflect.apply(handler, page, [event]);
+				};
+				requestHandlers.push(wrapper);
+				Reflect.apply(on, page, [type, wrapper]);
+				return page;
+			},
+		},
+		off: {
+			configurable: true,
+			value: (type: unknown, handler?: unknown): Page => {
+				Reflect.apply(off, page, [type, handler]);
+				if (type === "request") {
+					if (handler === undefined) requestHandlers.length = 0;
+					else {
+						const index = requestHandlers.lastIndexOf(handler);
+						if (index >= 0) requestHandlers.splice(index, 1);
+					}
+				}
+				return page;
+			},
+		},
+		removeAllListeners: {
+			configurable: true,
+			value: (type?: unknown): Page => {
+				Reflect.apply(removeAllListeners, page, [type]);
+				if (type === undefined || type === "request") requestHandlers.length = 0;
+				return page;
+			},
+		},
+	});
+
+	return {
+		page,
+		async cleanup() {
+			if (onDescriptor) Object.defineProperty(page, "on", onDescriptor);
+			else Reflect.deleteProperty(page, "on");
+			if (offDescriptor) Object.defineProperty(page, "off", offDescriptor);
+			else Reflect.deleteProperty(page, "off");
+			if (onceDescriptor) Object.defineProperty(page, "once", onceDescriptor);
+			else Reflect.deleteProperty(page, "once");
+			if (removeAllDescriptor) Object.defineProperty(page, "removeAllListeners", removeAllDescriptor);
+			else Reflect.deleteProperty(page, "removeAllListeners");
+			if (gotoPatched) {
+				if (gotoDescriptor) Object.defineProperty(page, "goto", gotoDescriptor);
+				else Reflect.deleteProperty(page, "goto");
+			}
+			for (const handler of requestHandlers) Reflect.apply(off, page, ["request", handler]);
+			requestHandlers.length = 0;
+			try {
+				await withTimeout(
+					page.setRequestInterception(false),
+					REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS,
+					"Timed out clearing browser request interception",
+				);
+			} catch (error) {
+				throw new RequestInterceptionCleanupError(
+					"Failed to clear browser request interception after browser.run",
+					{
+						error: error instanceof Error ? error.message : String(error),
+					},
+				);
+			}
+		},
+	};
+}

--- a/packages/coding-agent/src/tools/browser/output-redact.ts
+++ b/packages/coding-agent/src/tools/browser/output-redact.ts
@@ -1,0 +1,520 @@
+/**
+ * Browser-output secret redaction.
+ *
+ * Ported from `hermes-agent` (`agent/redact.py`, `tools/browser_tool.py::_redact_browser_output`),
+ * Copyright (c) 2025 Nous Research — MIT License. See ./NOTICE for the full attribution
+ * and the list of deliberate deltas for the oh-my-pi port.
+ *
+ * Why this exists: browser-originated values (accessibility snapshots, console/stream
+ * text, `display()` payloads, `eval` return values, extracted readable content, page
+ * titles) are untrusted page content. A malicious or compromised page can render an
+ * API key, bearer token, JWT, database DSN, or a pasted secret into text the model
+ * then echoes into the transcript. The tool output is the model boundary, so redaction
+ * here is ALWAYS on — there is no opt-out, mirroring hermes' `force=True` at the
+ * browser boundary (a user who must see raw values can read the page directly in
+ * their own browser instead).
+ *
+ * The pass order and regex semantics mirror `redact_sensitive_text(force=True)`; see
+ * ./NOTICE for the documented deviations:
+ *  - the lowercase ENV / config / YAML passes run inside text that also contains URLs
+ *    (browser snapshots always do). Instead of hermes' text-level `"://" in text`
+ *    gate, matches sitting *inside* a URL token are skipped at match level, so
+ *    `?token=...`/path segments pass through while real `password: hunter2` lines are
+ *    still masked;
+ *  - `user:pass@` URL userinfo is masked unconditionally (parity with the existing
+ *    `redactUrlCredentials` seam in tab-worker.ts, which already strips it from the
+ *    page URL);
+ *  - a `Cookie:` / `Set-Cookie:` header-value pass is added (hermes relies on generic
+ *    key passes; the port contract names cookies explicitly);
+ *  - E.164 phone-number masking is NOT ported: browser snapshots legitimately carry
+ *    `tel:` links and contact numbers, and phone numbers are not credentials;
+ *  - web-URL query-parameter values pass through unchanged (hermes parity — magic
+ *    links, OAuth callbacks and pre-signed URLs must survive browsing; credential
+ *    *shapes* inside them are still caught by the vendor-prefix and JWT passes).
+ *
+ * Performance: like hermes, every regex pass is gated behind a cheap substring
+ * pre-screen. The gates are conservative (a false-positive just runs a regex that
+ * cannot match); false negatives are impossible because each regex requires the
+ * gated substring.
+ */
+
+const DISPLAY_CONTROL_RE = /[\x00-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]/;
+
+/** Mask a secret token: preserve the first 6 and last 4 chars, floor 18 → `"***"`. */
+export function maskToken(token: string): string {
+	if (!token) return "***";
+	// A masked secret must never carry control bytes (newline, tab, DEL, C1,
+	// zero-width) into model-facing text — strip before slicing so the length
+	// check sees the displayable length (hermes `_DISPLAY_CONTROL_RE` + #55319).
+	const cleaned = token.replace(new RegExp(DISPLAY_CONTROL_RE.source, "g"), "");
+	if (!cleaned || cleaned.length < 18) return "***";
+	return `${cleaned.slice(0, 6)}...${cleaned.slice(-4)}`;
+}
+
+// ── Known vendor prefixes ────────────────────────────────────────────────
+// `hermes-agent/agent/redact.py::_PREFIX_PATTERNS` ported verbatim, plus
+// `ASIA` (temporary AWS access key id) as an omp addition — same 20-char
+// `AKIA` shape class, so "AWS key formats" from the port contract stays true
+// for STS credentials too. Each pattern must keep a full literal prefix so
+// the substring pre-screen below stays false-negative-free.
+const PREFIX_PATTERNS: readonly string[] = [
+	"sk-[A-Za-z0-9_-]{10,}", // OpenAI / OpenRouter / Anthropic (sk-ant-*)
+	"ghp_[A-Za-z0-9]{10,}", // GitHub PAT (classic)
+	"github_pat_[A-Za-z0-9_]{10,}", // GitHub PAT (fine-grained)
+	"gho_[A-Za-z0-9]{10,}", // GitHub OAuth access token
+	"ghu_[A-Za-z0-9]{10,}", // GitHub user-to-server token
+	"ghs_[A-Za-z0-9]{10,}", // GitHub server-to-server token
+	"ghr_[A-Za-z0-9]{10,}", // GitHub refresh token
+	"xapp-\\d+-[A-Za-z0-9-]{10,}", // Slack app-level token
+	"xox[baprs]-[A-Za-z0-9-]{10,}", // Slack bot/app/user tokens
+	"AIza[A-Za-z0-9_-]{30,}", // Google API keys
+	"pplx-[A-Za-z0-9]{10,}", // Perplexity
+	"fal_[A-Za-z0-9_-]{10,}", // Fal.ai
+	"fc-[A-Za-z0-9]{10,}", // Firecrawl
+	"bb_live_[A-Za-z0-9_-]{10,}", // BrowserBase
+	"gAAAA[A-Za-z0-9_=-]{20,}", // Codex encrypted tokens
+	"AKIA[A-Z0-9]{16}", // AWS Access Key ID
+	"ASIA[A-Z0-9]{16}", // AWS temporary (STS) access key id — omp addition
+	"sk_live_[A-Za-z0-9]{10,}", // Stripe secret key (live)
+	"sk_test_[A-Za-z0-9]{10,}", // Stripe secret key (test)
+	"rk_live_[A-Za-z0-9]{10,}", // Stripe restricted key
+	"SG\\.[A-Za-z0-9_-]{10,}", // SendGrid API key
+	"hf_[A-Za-z0-9]{10,}", // HuggingFace token
+	"r8_[A-Za-z0-9]{10,}", // Replicate API token
+	"npm_[A-Za-z0-9]{10,}", // npm access token
+	"pypi-[A-Za-z0-9_-]{10,}", // PyPI API token
+	"dop_v1_[A-Za-z0-9]{10,}", // DigitalOcean PAT
+	"doo_v1_[A-Za-z0-9]{10,}", // DigitalOcean OAuth
+	"am_[A-Za-z0-9_-]{10,}", // AgentMail API key
+	"sk_[A-Za-z0-9_]{10,}", // ElevenLabs key (underscore form)
+	"tvly-[A-Za-z0-9]{10,}", // Tavily
+	"exa_[A-Za-z0-9]{10,}", // Exa
+	"gsk_[A-Za-z0-9]{10,}", // Groq Cloud
+	"syt_[A-Za-z0-9]{10,}", // Matrix access token
+	"retaindb_[A-Za-z0-9]{10,}", // RetainDB
+	"hsk-[A-Za-z0-9]{10,}", // Hindsight
+	"mem0_[A-Za-z0-9]{10,}", // Mem0 Platform
+	"brv_[A-Za-z0-9]{10,}", // ByteRover
+	"xai-[A-Za-z0-9]{30,}", // xAI (Grok)
+	"ntn_[A-Za-z0-9]{10,}", // Notion internal integration token
+	"fw-[A-Za-z0-9]{30,}", // Fireworks AI
+	"fw_[A-Za-z0-9]{30,}", // Fireworks AI
+	"fpk_[A-Za-z0-9]{30,}", // Fireworks AI project key
+	"glpat-[A-Za-z0-9_-]{10,}", // GitLab personal access token
+	"gloas-[A-Za-z0-9_-]{10,}", // GitLab OAuth application secret
+	"gldt-[A-Za-z0-9_-]{10,}", // GitLab deploy token
+	"glrt-[A-Za-z0-9_.-]{10,}", // GitLab runner authentication token
+	"glrtr-[A-Za-z0-9_.-]{10,}", // GitLab runner registration token
+	"glcbt-[A-Za-z0-9_-]{10,}", // GitLab CI/CD job token
+	"glptt-[A-Za-z0-9_-]{10,}", // GitLab pipeline trigger token
+	"glft-[A-Za-z0-9_-]{10,}", // GitLab feed token
+	"glimt-[A-Za-z0-9_-]{10,}", // GitLab incoming mail token
+	"glagent-[A-Za-z0-9_-]{10,}", // GitLab agent (KAS) token
+	"glsoat-[A-Za-z0-9_-]{10,}", // GitLab service-account access token
+	"glffct-[A-Za-z0-9_-]{10,}", // GitLab feature-flags client token
+	"glwt-[A-Za-z0-9_-]{10,}", // GitLab workspace token
+	"GR1348941[A-Za-z0-9_-]{10,}", // GitLab legacy runner registration token
+	"pk-lf-[A-Za-z0-9-]{8,}", // Langfuse public key
+];
+
+/** Union of every prefix pattern; boundary-guarded like hermes `_PREFIX_RE`. */
+const SECRET_TOKEN_SHAPE_RE = new RegExp(`(?<![A-Za-z0-9_-])(?:${PREFIX_PATTERNS.join("|")})(?![A-Za-z0-9_-])`);
+
+/**
+ * True when `text` plausibly contains a credential of a known vendor shape.
+ * Shared with the navigation guard (url-guard.ts): a URL that embeds a
+ * key-shaped token must never be navigated to at all (hermes
+ * `evaluate_url_safety`).
+ */
+export function containsSecretTokenShape(text: string): boolean {
+	if (!hasKnownPrefixSubstring(text)) return false;
+	return SECRET_TOKEN_SHAPE_RE.test(text);
+}
+
+/** Longest literal prefix of a pattern — used for the substring pre-screen. */
+function literalPrefix(pattern: string): string {
+	const stop = pattern.search(/[[\\(|*+?]/);
+	return stop === -1 ? pattern : pattern.slice(0, stop);
+}
+
+const PREFIX_SUBSTRINGS: readonly string[] = PREFIX_PATTERNS.map(literalPrefix).filter(s => s.length > 0);
+
+function hasKnownPrefixSubstring(text: string): boolean {
+	for (const sub of PREFIX_SUBSTRINGS) if (text.includes(sub)) return true;
+	return false;
+}
+
+// ── ENV / config / YAML assignment passes ────────────────────────────────
+
+const SECRET_ENV_NAMES = "(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDENTIAL|AUTH)";
+const ENV_ASSIGN_RE = new RegExp(
+	`([A-Z0-9_]{0,50}${SECRET_ENV_NAMES}[A-Z0-9_]{0,50})\\s*=\\s*(['"]?)(\\S+)\\2`,
+	"g",
+);
+// Lowercase env names: only underscore-boundary forms (`openai_key=…`, `db_pw=…`) —
+// NOT bare `password=`, which appears in prose, URLs, and form bodies.
+const ENV_ASSIGN_LOWER_RE =
+	/([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?![a-z0-9_]))\s*=\s*(['"]?)(\S+)\2/gi;
+
+const SECRET_CFG_NAMES = "(?:api[ _.\\-]?key|token|secret|passwd|password|credential|auth)";
+const CFG_VALUE = "(['\"]?)([^\\s&]+?)\\2(?=[\\s&]|$)";
+// Namespaced (dotted) key: the secret word may sit anywhere in a dotted path.
+const CFG_DOTTED_RE = new RegExp(
+	`([A-Za-z0-9_-]+\\.[A-Za-z0-9_.\\-]*${SECRET_CFG_NAMES}[A-Za-z0-9_.\\-]*|[A-Za-z0-9_.\\-]*${SECRET_CFG_NAMES}[A-Za-z0-9_.\\-]*\\.[A-Za-z0-9_.\\-]+)=${CFG_VALUE}`,
+	"gi",
+);
+// Line-anchored bare key: `password=…` / `export api_key=…` at start of line.
+const CFG_ANCHORED_RE = new RegExp(
+	`(^[ \\t]*(?:export[ \\t]+)?[A-Za-z0-9_.\\-]*${SECRET_CFG_NAMES}[A-Za-z0-9_.\\-]*)=${CFG_VALUE}`,
+	"gim",
+);
+const CFG_SECRET_WORD_RE = new RegExp(SECRET_CFG_NAMES, "i");
+
+// Programmatic env lookups (`os.getenv(...)`, `process.env.X`, `$ENV{X}`)
+// reference variable *names*, not secret values — keep code snippets intact
+// (hermes issue #2852).
+const ENV_LOOKUP_VALUE_RE = /^(?:os\.(?:getenv|environ)|process\.env|\$ENV\{)/;
+
+// Unquoted YAML / colon config. Bare `auth` is excluded from the key set so
+// `Authorization:` / `author:` don't match.
+const YAML_CFG_NAMES = "(?:api[ _.\\-]?key|token|secret|passwd|password|credential)";
+const YAML_ASSIGN_RE = new RegExp(
+	`(^[ \\t]*[A-Za-z0-9_.\\-]*${YAML_CFG_NAMES}[A-Za-z0-9_.\\-]*)(:[ \\t]*)(?!['"])([^\\s&]+)`,
+	"gim",
+);
+
+// JSON fields: "apiKey": "value", "token": "value", etc.
+const JSON_FIELD_RE =
+	/("(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)")\s*:\s*"([^"]+)"/g;
+
+const KEY_KEYWORD_RE =
+	/(?:api|auth|access|refresh|session|secret)[ _.\\-]?(?:key|token)|token|secret|passwd|password|pass|pw|credential|auth|key/gi;
+
+function isWordStart(s: string, i: number): boolean {
+	if (i === 0) return true;
+	const prev = s[i - 1] ?? "";
+	const cur = s[i] ?? "";
+	if (!/[A-Za-z]/.test(prev)) return true;
+	if (cur >= "A" && cur <= "Z" && prev >= "a" && prev <= "z") return true; // camelCase: clientSecret
+	// Acronym run ending: APIToken — 'T' starts a word when followed by a lowercase
+	// char while the preceding run is uppercase.
+	if (cur >= "A" && cur <= "Z" && prev >= "A" && prev <= "Z" && i + 1 < s.length && /[a-z]/.test(s[i + 1] ?? ""))
+		return true;
+	return false;
+}
+
+function isWordEnd(s: string, j: number, allowPlural: boolean = true): boolean {
+	if (j >= s.length) return true;
+	const cur = s[j] ?? "";
+	if (!/[A-Za-z]/.test(cur)) return true;
+	if (cur >= "A" && cur <= "Z" && /[a-z]/.test(s[j - 1] ?? "")) return true; // secretKey
+	if (allowPlural && (cur === "s" || cur === "S")) return isWordEnd(s, j + 1, false);
+	return false;
+}
+
+/**
+ * Word-boundary validator for mixed/lowercase secret keys: rejects prose words
+ * that merely embed a keyword (`Secretary:`, `tokenizer:`, `author=`) while
+ * all-caps keys keep legacy embedded matching (`MYTOKEN=`). Ported from
+ * hermes `_key_has_secret_keyword` (nearai/ironclaw#6129 lesson).
+ */
+export function keyHasSecretKeyword(key: string): boolean {
+	for (const m of KEY_KEYWORD_RE[Symbol.matchAll](key)) {
+		if (isWordStart(key, m.index) && isWordEnd(key, m.index + m[0].length)) return true;
+	}
+	return false;
+}
+
+/**
+ * True when position `start` sits inside a URL token (a `://` appears earlier
+ * in the same whitespace-free run). omp delta replacing hermes' text-level
+ * `"://" not in text` gate, which would disable the assignment passes for
+ * every browser snapshot (pages always contain URLs). Query/fragment params
+ * and path segments must keep passing through (hermes parity); only the
+ * *inside-a-URL* position is skipped, match by match.
+ */
+function insideUrlToken(text: string, start: number): boolean {
+	for (let i = start - 1; i >= 0; i--) {
+		const c = text[i];
+		if (c === undefined) break;
+		if (/\s/.test(c) || c === "'" || c === '"' || c === ">" || c === "]") break;
+		if (c === "/" && i > 0 && text[i - 1] === "/" && i > 1 && text[i - 2] === ":") return true;
+	}
+	return false;
+}
+
+// Authorization headers — any scheme (Bearer, Basic, Token, Digest, …) plus
+// the bare-credential form, and Proxy-Authorization. Header name + scheme
+// word are preserved for debuggability; the quote-excluding credential class
+// keeps `"Authorization: Bearer …"` in JSON strings syntactically intact
+// (hermes #43083).
+const AUTH_HEADER_RE = /((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?([^\s"']+)/gi;
+// API-key style auth headers carrying a single opaque value (no scheme word).
+const SECRET_HEADER_RE =
+	/((?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)\s*:\s*)(\S+)/gi;
+// omp extension (the port contract names cookies explicitly; hermes has no cookie pass).
+const COOKIE_HEADER_RE = /((?:Set-Cookie|Cookie):\s*)([^\r\n"']+)/gi;
+const TELEGRAM_RE = /(?:(bot)?(\d{8,}):)([-A-Za-z0-9_]{30,})/g;
+const PRIVATE_KEY_RE = /-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/g;
+const DB_CONNSTR_RE = /((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp):\/\/[^:\s]+:)([^@\s]+)(@)/gi;
+// Bare-token userinfo `scheme://TOKEN@host` — never a round-trip workflow
+// token position (those live in the query string), so masking is safe
+// (hermes #6396).
+const URL_BARE_TOKEN_RE = /((?:https?|wss?|git|ssh|ftp|ftps|sftp):\/\/)([^\s:@/]{8,})(@[^\s]+)/gi;
+const JWT_RE = /eyJ[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_=-]{4,}){0,2}/g;
+// `user:pass@` / bare-`token@` userinfo in any URL reference (network-path
+// `//user:pass@host` included). omp: unconditional — `redactUrlCredentials`
+// already strips userinfo from the page URL itself, so pages that survive
+// that seam should not smuggle the same credential through body text.
+const URL_USERINFO_RE = /(\/\/)([^/\s?#@]+)@/g;
+
+const FORM_BODY_RE = /^[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*(?:&[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*)+$/;
+// Sensitive form-body key names (exact match after percent-decode + casefold;
+// hermes `_SENSITIVE_QUERY_PARAMS` ∩ `_SENSITIVE_BODY_KEYS`, form-body pass).
+const SENSITIVE_FORM_KEYS: Record<string, true> = {
+	access_token: true,
+	refresh_token: true,
+	id_token: true,
+	token: true,
+	api_key: true,
+	apikey: true,
+	client_secret: true,
+	password: true,
+	auth: true,
+	jwt: true,
+	secret: true,
+	key: true,
+	code: true,
+	signature: true,
+	"x-amz-signature": true,
+};
+
+// Control / zero-width characters that can split a token body so
+// SECRET_TOKEN_SHAPE_RE cannot match across them (`sk-abc\x1bdef…`).
+const CONTROL_CHARS_RE = /[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]/g;
+const TOKEN_BODY_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.";
+
+/**
+ * Mask tokens whose body is split by control/zero-width characters (hermes
+ * `_mask_control_split_tokens`, issue #77484). Match on a control-stripped
+ * copy, then mask the corresponding span in the original — but only when the
+ * original span contains nothing but token-body and control chars and does
+ * not run into a `=` (a `KEY=` name means the match crossed unrelated text).
+ */
+function maskControlSplitTokens(text: string): string {
+	const stripped = text.replace(CONTROL_CHARS_RE, "");
+	if (stripped === text) return text;
+	const origIdx: number[] = [];
+	for (let i = 0; i < text.length; i++) {
+		const c = text[i] ?? "";
+		if (!new RegExp(CONTROL_CHARS_RE.source).test(c)) origIdx.push(i);
+	}
+	const spans: Array<[start: number, end: number, replacement: string]> = [];
+	const shape = new RegExp(SECRET_TOKEN_SHAPE_RE.source, "g");
+	let m: RegExpExecArray | null;
+	while ((m = shape.exec(stripped)) !== null) {
+		const body = m[0];
+		const startOrig = origIdx[m.index] ?? 0;
+		const endOrig = (origIdx[m.index + body.length - 1] ?? 0) + 1;
+		const span = text.slice(startOrig, endOrig);
+		// A complete token at end-of-line followed by unrelated next-line text
+		// keeps its line structure (hermes' newline guard).
+		if ((span.includes("\n") || span.includes("\r")) && SECRET_TOKEN_SHAPE_RE.test(span)) continue;
+		let ok = true;
+		for (const c of span) {
+			if (TOKEN_BODY_CHARS.includes(c)) continue;
+			if (new RegExp(CONTROL_CHARS_RE.source).test(c)) continue;
+			ok = false;
+			break;
+		}
+		if (!ok) continue;
+		if (endOrig < text.length && text[endOrig] === "=") continue;
+		spans.push([startOrig, endOrig, maskToken(body)]);
+	}
+	if (!spans.length) return text;
+	let out = "";
+	let cursor = 0;
+	for (const [start, end, replacement] of spans) {
+		if (start < cursor) continue;
+		out += text.slice(cursor, start) + replacement;
+		cursor = end;
+	}
+	return out + text.slice(cursor);
+}
+
+function redactEnvAssignment(name: string, quote: string, value: string, start: number, text: string): string {
+	if (ENV_LOOKUP_VALUE_RE.test(value)) return `${name}=${quote}${value}${quote}`;
+	if (insideUrlToken(text, start)) return `${name}=${quote}${value}${quote}`;
+	if (!keyHasSecretKeyword(name)) return `${name}=${quote}${value}${quote}`;
+	return `${name}=${quote}${maskToken(value)}${quote}`;
+}
+
+/** Redact sensitive values in a pure form-urlencoded body (`k=v&k=v`). */
+function redactFormBody(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.includes("\n") || !FORM_BODY_RE.test(trimmed)) return text;
+	return trimmed
+		.split("&")
+		.map(pair => {
+			const eq = pair.indexOf("=");
+			if (eq === -1) return pair;
+			const key = pair.slice(0, eq);
+			const value = pair.slice(eq + 1);
+			let decoded = key;
+			try {
+				decoded = decodeURIComponent(key);
+			} catch {
+				// keep raw key
+			}
+			return SENSITIVE_FORM_KEYS[decoded.toLowerCase()] === true ? `${key}=***` : pair;
+		})
+		.join("&");
+}
+
+/**
+ * Apply every redaction pass to one string. Safe on any text — non-matching
+ * content passes through byte-for-byte unchanged. Always on; there is no
+ * opt-out on the browser egress path.
+ */
+export function redactBrowserText(text: string): string {
+	if (!text) return text;
+
+	// 1. Known vendor prefixes (sk-, ghp_, …) incl. control-split smuggling.
+	if (hasKnownPrefixSubstring(text)) {
+		text = maskControlSplitTokens(text);
+		text = text.replace(new RegExp(SECRET_TOKEN_SHAPE_RE.source, "g"), m => maskToken(m));
+	}
+
+	if (text.includes("=")) {
+		// 2. ENV assignments: OPENAI_API_KEY=*** (uppercase embedded names,
+		//    underscore-boundary lowercase names, dotted + line-anchored config keys).
+		text = text.replace(
+			ENV_ASSIGN_RE,
+			(match, name: string, quote: string, value: string, offset: number, whole: string) =>
+				redactEnvAssignment(name, quote, value, offset, whole),
+		);
+		text = text.replace(
+			ENV_ASSIGN_LOWER_RE,
+			(match, name: string, quote: string, value: string, offset: number, whole: string) =>
+				redactEnvAssignment(name, quote, value, offset, whole),
+		);
+		if (CFG_SECRET_WORD_RE.test(text)) {
+			text = text.replace(
+				CFG_DOTTED_RE,
+				(match, name: string, quote: string, value: string, offset: number, whole: string) =>
+					redactEnvAssignment(name, quote ?? "", value, offset, whole),
+			);
+			text = text.replace(
+				CFG_ANCHORED_RE,
+				(match, name: string, quote: string, value: string, offset: number, whole: string) =>
+					redactEnvAssignment(name, quote ?? "", value, offset, whole),
+			);
+		}
+	}
+
+	// 3. JSON fields: "apiKey": "value" (quoted values; the YAML pass skips
+	//    them via its lookahead, so order matters).
+	if (text.includes(":") && text.includes('"')) {
+		text = text.replace(JSON_FIELD_RE, (_match, key: string, value: string) =>
+			ENV_LOOKUP_VALUE_RE.test(value) ? `${key}: "${value}"` : `${key}: "${maskToken(value)}"`,
+		);
+	}
+
+	// 4. Unquoted YAML / colon config: `password: hunter2`.
+	if (text.includes(":") && CFG_SECRET_WORD_RE.test(text)) {
+		text = text.replace(
+			YAML_ASSIGN_RE,
+			(match, key: string, sep: string, value: string, offset: number, whole: string) => {
+				if (ENV_LOOKUP_VALUE_RE.test(value)) return match;
+				if (insideUrlToken(whole, offset)) return match;
+				if (!keyHasSecretKeyword(key)) return match;
+				return `${key}${sep}${maskToken(value)}`;
+			},
+		);
+	}
+
+	// 5. Authorization headers (any scheme, bare-credential form, Proxy-*).
+	if (text.toLowerCase().includes("authorization")) {
+		text = text.replace(
+			AUTH_HEADER_RE,
+			(_m, head: string, scheme: string | undefined, cred: string) => `${head}${scheme ?? ""}${maskToken(cred)}`,
+		);
+	}
+
+	// 6. Single-value API-key headers (x-api-key, api-key, …).
+	if (text.includes(":")) {
+		text = text.replace(SECRET_HEADER_RE, (_m, head: string, value: string) => `${head}${maskToken(value)}`);
+	}
+
+	// 7. Cookie headers (omp extension).
+	if (text.toLowerCase().includes("cookie")) {
+		text = text.replace(COOKIE_HEADER_RE, (_m, head: string, value: string) => `${head}${maskToken(value)}`);
+	}
+
+	// 8. Telegram bot tokens.
+	if (text.includes(":")) {
+		text = text.replace(TELEGRAM_RE, (_m, bot: string | undefined, digits: string) => `${bot ?? ""}${digits}:***`);
+	}
+
+	// 9. Private key blocks.
+	if (text.includes("BEGIN") && text.includes("-----")) {
+		text = text.replace(PRIVATE_KEY_RE, "[REDACTED PRIVATE KEY]");
+	}
+
+	if (text.includes("://")) {
+		// 10. Database connection-string passwords.
+		text = text.replace(DB_CONNSTR_RE, (_m, head: string, _pw: string, at: string) => `${head}***${at}`);
+		// 11. Bare-token userinfo: scheme://TOKEN@host.
+		text = text.replace(
+			URL_BARE_TOKEN_RE,
+			(_m, head: string, token: string, tail: string) => `${head}${maskToken(token)}${tail}`,
+		);
+		// 12. `user:pass@` userinfo — unconditional (omp delta; see header).
+		text = text.replace(URL_USERINFO_RE, (_m, slashes: string, userinfo: string) => {
+			const colon = userinfo.indexOf(":");
+			return colon === -1 ? `${slashes}***@` : `${slashes}${userinfo.slice(0, colon)}:***@`;
+		});
+	}
+
+	// 13. JWTs (header starts with "eyJ" = base64 for "{").
+	if (text.includes("eyJ")) {
+		text = text.replace(JWT_RE, m => maskToken(m));
+	}
+
+	// 14. Form-urlencoded bodies (only triggers on clean k=v&k=v inputs).
+	if (text.includes("&") && text.includes("=")) {
+		text = redactFormBody(text);
+	}
+
+	return text;
+}
+
+/**
+ * Recursively redact every string inside a browser-originated value (hermes
+ * `_redact_browser_output`): observation objects, aria snapshots, extract
+ * payloads, eval return values, display() JSON. Arrays and plain objects are
+ * walked; everything else (numbers, booleans, binary payloads, class
+ * instances) passes through untouched so image data and structured-clone
+ * shapes survive.
+ */
+export function redactBrowserOutput(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+	if (typeof value === "string") return redactBrowserText(value);
+	if (Array.isArray(value)) {
+		return value.map(item => redactBrowserOutput(item, seen));
+	}
+	if (value !== null && typeof value === "object") {
+		if (seen.has(value)) return value;
+		seen.add(value);
+		const proto = Object.getPrototypeOf(value);
+		if (proto !== Object.prototype && proto !== null) {
+			// Not a plain object (Page, ElementHandle, Date, RegExp, typed
+			// array, …): copying it would corrupt it; leave it to cloneSafe.
+			return value;
+		}
+		const source = value as Record<string, unknown>;
+		const out: Record<string, unknown> = {};
+		for (const key of Object.keys(source)) out[key] = redactBrowserOutput(source[key], seen);
+		return out;
+	}
+	return value;
+}

--- a/packages/coding-agent/src/tools/browser/output-redact.ts
+++ b/packages/coding-agent/src/tools/browser/output-redact.ts
@@ -39,6 +39,8 @@
  */
 
 const DISPLAY_CONTROL_RE = /[\x00-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]/;
+/** Global twin of `DISPLAY_CONTROL_RE`, hoisted so `maskToken` allocates nothing. */
+const DISPLAY_CONTROL_GLOBAL_RE = new RegExp(DISPLAY_CONTROL_RE.source, "g");
 
 /** Mask a secret token: preserve the first 6 and last 4 chars, floor 18 → `"***"`. */
 export function maskToken(token: string): string {
@@ -46,7 +48,7 @@ export function maskToken(token: string): string {
 	// A masked secret must never carry control bytes (newline, tab, DEL, C1,
 	// zero-width) into model-facing text — strip before slicing so the length
 	// check sees the displayable length (hermes `_DISPLAY_CONTROL_RE` + #55319).
-	const cleaned = token.replace(new RegExp(DISPLAY_CONTROL_RE.source, "g"), "");
+	const cleaned = token.replace(DISPLAY_CONTROL_GLOBAL_RE, "");
 	if (!cleaned || cleaned.length < 18) return "***";
 	return `${cleaned.slice(0, 6)}...${cleaned.slice(-4)}`;
 }
@@ -214,8 +216,11 @@ function isWordEnd(s: string, j: number, allowPlural: boolean = true): boolean {
 
 /**
  * Word-boundary validator for mixed/lowercase secret keys: rejects prose words
- * that merely embed a keyword (`Secretary:`, `tokenizer:`, `author=`) while
- * all-caps keys keep legacy embedded matching (`MYTOKEN=`). Ported from
+ * that merely embed a keyword (`Secretary:`, `tokenizer:`, `author=`). An
+ * ALL-CAPS key still needs an underscore/word boundary to match here — bare
+ * `MYTOKEN=` is NOT detected (the `isWordStart` camel/acronym rules don't fire
+ * inside an unbroken caps run), which is deliberate: `PROXY`, `MONKEY`, `KEYNOTE`
+ * style all-caps names would otherwise mask their own values. Ported from
  * hermes `_key_has_secret_keyword` (nearai/ironclaw#6129 lesson).
  */
 export function keyHasSecretKeyword(key: string): boolean {
@@ -254,6 +259,15 @@ const SECRET_HEADER_RE =
 	/((?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)\s*:\s*)(\S+)/gi;
 // omp extension (the port contract names cookies explicitly; hermes has no cookie pass).
 const COOKIE_HEADER_RE = /((?:Set-Cookie|Cookie):\s*)([^\r\n"']+)/gi;
+// Credential-bearing JSON *fields*: the `document.cookie` / request-header dumps
+// an aria snapshot or `JSON.stringify(getAllResponseHeaders())` produces carry
+// these quoted keys, which JSON_FIELD_RE's name list does not include.
+const JSON_CRED_FIELD_RE =
+	/("(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|credential)")\s*:\s*"([^"]+)"/gi;
+// Bare cookie-jar bodies (`sid=…; csrf_token=…`) with no `Cookie:` header name in
+// sight — what `document.cookie` and pasted request dumps look like. Value class
+// excludes dots so an IP/path-shaped run is not mistaken for a cookie value.
+const COOKIE_JAR_RE = /([A-Za-z][A-Za-z0-9_.-]*)=([A-Za-z0-9+/=_-]{8,})(?![A-Za-z0-9+/=_-])/g;
 const TELEGRAM_RE = /(?:(bot)?(\d{8,}):)([-A-Za-z0-9_]{30,})/g;
 const PRIVATE_KEY_RE = /-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/g;
 const DB_CONNSTR_RE = /((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp):\/\/[^:\s]+:)([^@\s]+)(@)/gi;
@@ -292,7 +306,16 @@ const SENSITIVE_FORM_KEYS: Record<string, true> = {
 // Control / zero-width characters that can split a token body so
 // SECRET_TOKEN_SHAPE_RE cannot match across them (`sk-abc\x1bdef…`).
 const CONTROL_CHARS_RE = /[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\ufeff]/g;
+/** Non-global twin for the single-character membership tests below. */
+const CONTROL_CHAR_RE = new RegExp(CONTROL_CHARS_RE.source);
+/** Global twin of the vendor-shape matcher, hoisted out of the per-call path. */
+const SECRET_TOKEN_SHAPE_GLOBAL_RE = new RegExp(SECRET_TOKEN_SHAPE_RE.source, "g");
 const TOKEN_BODY_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.";
+
+/** True when `text` holds any control/zero-width byte. */
+function hasControlChar(text: string): boolean {
+	return CONTROL_CHAR_RE.test(text);
+}
 
 /**
  * Mask tokens whose body is split by control/zero-width characters (hermes
@@ -306,13 +329,12 @@ function maskControlSplitTokens(text: string): string {
 	if (stripped === text) return text;
 	const origIdx: number[] = [];
 	for (let i = 0; i < text.length; i++) {
-		const c = text[i] ?? "";
-		if (!new RegExp(CONTROL_CHARS_RE.source).test(c)) origIdx.push(i);
+		if (!hasControlChar(text[i] ?? "")) origIdx.push(i);
 	}
 	const spans: Array<[start: number, end: number, replacement: string]> = [];
-	const shape = new RegExp(SECRET_TOKEN_SHAPE_RE.source, "g");
+	SECRET_TOKEN_SHAPE_GLOBAL_RE.lastIndex = 0;
 	let m: RegExpExecArray | null;
-	while ((m = shape.exec(stripped)) !== null) {
+	while ((m = SECRET_TOKEN_SHAPE_GLOBAL_RE.exec(stripped)) !== null) {
 		const body = m[0];
 		const startOrig = origIdx[m.index] ?? 0;
 		const endOrig = (origIdx[m.index + body.length - 1] ?? 0) + 1;
@@ -323,7 +345,7 @@ function maskControlSplitTokens(text: string): string {
 		let ok = true;
 		for (const c of span) {
 			if (TOKEN_BODY_CHARS.includes(c)) continue;
-			if (new RegExp(CONTROL_CHARS_RE.source).test(c)) continue;
+			if (hasControlChar(c)) continue;
 			ok = false;
 			break;
 		}
@@ -380,9 +402,13 @@ export function redactBrowserText(text: string): string {
 	if (!text) return text;
 
 	// 1. Known vendor prefixes (sk-, ghp_, …) incl. control-split smuggling.
-	if (hasKnownPrefixSubstring(text)) {
+	//    The substring pre-screen is also run on a control-stripped copy: a
+	//    zero-width byte inside the literal prefix itself (`sk\u200b-…`) would
+	//    otherwise skip the pass that exists precisely to catch that trick.
+	const controlStripped = hasControlChar(text) ? text.replace(CONTROL_CHARS_RE, "") : "";
+	if (hasKnownPrefixSubstring(text) || (controlStripped !== "" && hasKnownPrefixSubstring(controlStripped))) {
 		text = maskControlSplitTokens(text);
-		text = text.replace(new RegExp(SECRET_TOKEN_SHAPE_RE.source, "g"), m => maskToken(m));
+		text = text.replace(SECRET_TOKEN_SHAPE_GLOBAL_RE, m => maskToken(m));
 	}
 
 	if (text.includes("=")) {
@@ -413,9 +439,13 @@ export function redactBrowserText(text: string): string {
 	}
 
 	// 3. JSON fields: "apiKey": "value" (quoted values; the YAML pass skips
-	//    them via its lookahead, so order matters).
+	//    them via its lookahead, so order matters), plus the credential-bearing
+	//    header/cookie field names a snapshot or header dump produces.
 	if (text.includes(":") && text.includes('"')) {
 		text = text.replace(JSON_FIELD_RE, (_match, key: string, value: string) =>
+			ENV_LOOKUP_VALUE_RE.test(value) ? `${key}: "${value}"` : `${key}: "${maskToken(value)}"`,
+		);
+		text = text.replace(JSON_CRED_FIELD_RE, (_match, key: string, value: string) =>
 			ENV_LOOKUP_VALUE_RE.test(value) ? `${key}: "${value}"` : `${key}: "${maskToken(value)}"`,
 		);
 	}
@@ -456,12 +486,23 @@ export function redactBrowserText(text: string): string {
 		text = text.replace(TELEGRAM_RE, (_m, bot: string | undefined, digits: string) => `${bot ?? ""}${digits}:***`);
 	}
 
+	// 8b. Cookie-jar bodies without a `Cookie:` header name in sight
+	//     (`document.cookie`, pasted request dumps). URL query params are
+	//     skipped — hermes parity keeps magic links and OAuth callbacks
+	//     round-trippable; this pass only fires on `; `/`,`-separated pairs.
+	if (text.includes("=") && (text.includes("; ") || text.includes(","))) {
+		COOKIE_JAR_RE.lastIndex = 0;
+		text = text.replace(COOKIE_JAR_RE, (match, name: string, value: string, offset: number) =>
+			insideUrlToken(text, offset) ? match : `${name}=${maskToken(value)}`,
+		);
+	}
+
 	// 9. Private key blocks.
 	if (text.includes("BEGIN") && text.includes("-----")) {
 		text = text.replace(PRIVATE_KEY_RE, "[REDACTED PRIVATE KEY]");
 	}
 
-	if (text.includes("://")) {
+	if (text.includes("//")) {
 		// 10. Database connection-string passwords.
 		text = text.replace(DB_CONNSTR_RE, (_m, head: string, _pw: string, at: string) => `${head}***${at}`);
 		// 11. Bare-token userinfo: scheme://TOKEN@host.
@@ -496,15 +537,20 @@ export function redactBrowserText(text: string): string {
  * walked; everything else (numbers, booleans, binary payloads, class
  * instances) passes through untouched so image data and structured-clone
  * shapes survive.
+ *
+ * `seen` maps an already-walked object to THE copy produced for it, so an
+ * aliased value (`{ a, b: a }`) collapses to one redacted object instead of
+ * leaking the raw second reference — and a cycle terminates against the copy
+ * rather than the original.
  */
-export function redactBrowserOutput(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+export function redactBrowserOutput(value: unknown, seen: Map<object, unknown> = new Map()): unknown {
 	if (typeof value === "string") return redactBrowserText(value);
 	if (Array.isArray(value)) {
 		return value.map(item => redactBrowserOutput(item, seen));
 	}
 	if (value !== null && typeof value === "object") {
-		if (seen.has(value)) return value;
-		seen.add(value);
+		const memo = seen.get(value);
+		if (seen.has(value)) return memo;
 		const proto = Object.getPrototypeOf(value);
 		if (proto !== Object.prototype && proto !== null) {
 			// Not a plain object (Page, ElementHandle, Date, RegExp, typed
@@ -513,7 +559,28 @@ export function redactBrowserOutput(value: unknown, seen: WeakSet<object> = new 
 		}
 		const source = value as Record<string, unknown>;
 		const out: Record<string, unknown> = {};
-		for (const key of Object.keys(source)) out[key] = redactBrowserOutput(source[key], seen);
+		// Register before recursing so cycles/aliases resolve to this copy.
+		seen.set(value, out);
+		for (const key of Object.keys(source)) {
+			const redacted = redactBrowserOutput(source[key], seen);
+			const original = source[key];
+			// A secret-bearing key name is itself the context that makes a raw
+			// value a credential (`{ api_key: "…" }` carries no `api_key=` text
+			// for the assignment passes). Mask it only when the text passes left
+			// the string untouched — an already-masked value must not be masked
+			// again (that would collapse `ghp_AB...1234` to `***`), and a value
+			// that is an env-lookup expression stays intact.
+			if (
+				typeof redacted === "string" &&
+				redacted === original &&
+				keyHasSecretKeyword(key.replace(/^["']|["']$/g, "")) &&
+				!ENV_LOOKUP_VALUE_RE.test(redacted)
+			) {
+				out[key] = maskToken(redacted);
+			} else {
+				out[key] = redacted;
+			}
+		}
 		return out;
 	}
 	return value;

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -40,6 +40,21 @@ export interface SessionSnapshot {
 	browserScreenshotDir?: string;
 	/** Force non-WebP screenshot encoding (e.g. for Ollama). Unset honors `OMP_NO_WEBP`. */
 	excludeWebP?: boolean;
+	/** Serializable SSRF navigation-guard policy applied to every `tab.goto` in the run. */
+	navigation?: NavigationGuardSettings;
+}
+
+/**
+ * Plain-data half of `url-guard.ts` `NavigationGuardPolicy` (the resolver seam
+ * stays main-thread/test-only). Carried with every init/run message so the tab
+ * worker can guard navigation without access to ToolSession. Absent means
+ * fail-closed defaults: private ranges and file:// blocked, metadata floor
+ * always blocked.
+ */
+export interface NavigationGuardSettings {
+	allowPrivateUrls?: boolean;
+	privateUrlAllowlist?: readonly string[];
+	allowFileUrls?: boolean;
 }
 
 export type WorkerInitPayload =
@@ -54,6 +69,8 @@ export type WorkerInitPayload =
 			url?: string;
 			waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
 			timeoutMs: number;
+			/** SSRF navigation policy for the initial `page.goto` (absent = fail closed). */
+			navigation?: NavigationGuardSettings;
 	  }
 	| {
 			mode: "attach";
@@ -64,6 +81,8 @@ export type WorkerInitPayload =
 			url?: string;
 			waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
 			timeoutMs: number;
+			/** SSRF navigation policy for the initial `page.goto` (absent = fail closed). */
+			navigation?: NavigationGuardSettings;
 			/**
 			 * Post-timeout recycle: before adopting the page, dismiss any open JS dialog and
 			 * stop a pending navigation so a blocked target cannot stall worker init (which

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -20,6 +20,7 @@ import { DEFAULT_VIEWPORT } from "./launch";
 import { closeCdpTarget, forgetSharedTarget, recordSharedTarget, type SharedTargetScope } from "./orphan-registry";
 import {
 	type BrowserHandle,
+	type BrowserKind,
 	type BrowserKindTag,
 	type CmuxBrowserHandle,
 	holdBrowser,
@@ -27,6 +28,7 @@ import {
 	releaseBrowser,
 } from "./registry";
 import type {
+	NavigationGuardSettings,
 	ReadyInfo,
 	RunErrorPayload,
 	RunResultOk,
@@ -37,6 +39,12 @@ import type {
 	WorkerInitPayload,
 	WorkerOutbound,
 } from "./tab-protocol";
+import {
+	checkNavigationTarget,
+	navigationBlockedMessage,
+	policyFromSettings,
+	resolveNavigationPolicy,
+} from "./url-guard";
 
 // Coding-agent binary/bundle workers route through the CLI entrypoint with a
 // hidden argv mode, so compiled/npm builds only need one JavaScript entry.
@@ -77,6 +85,8 @@ interface TabSessionBase<TBrowser extends BrowserHandle = BrowserHandle> {
 	info: ReadyInfo;
 	pending: Map<string, PendingRun>;
 	dialogPolicy?: DialogPolicy;
+	/** SSRF navigation-guard policy in force for this tab (absent = fail closed). */
+	navigation?: NavigationGuardSettings;
 	kindTag: BrowserKindTag;
 	/**
 	 * Session id of the caller that CREATED the tab. Preserved across reuse so
@@ -117,6 +127,40 @@ export interface CmuxTabSession extends TabSessionBase<CmuxBrowserHandle> {
 
 export type TabSession = WorkerTabSession | CmuxTabSession;
 
+/**
+ * Resolve the SSRF navigation-guard settings for a session from explicit
+ * configuration only: the `browser.allowPrivateUrls` /
+ * `browser.privateUrlAllowlist` settings, the `PI_BROWSER_ALLOW_PRIVATE_URLS`
+ * env override (applied inside `resolveNavigationPolicy`), and the hostnames
+ * of endpoints the *user* configured (the resolved browser kind's `cdpUrl` —
+ * which covers `app.cdp_url`/`app.relay` and the default relay endpoint —
+ * plus the `browser.relayUrl` / `browser.cdpUrl` settings). This is the
+ * explicit-relay allow of the port contract; it is never derived from page
+ * content.
+ */
+export function navigationSettingsForSession(
+	session: ToolSession | undefined,
+	kind: BrowserKind | undefined,
+	extra?: { allowFileUrls?: boolean },
+): NavigationGuardSettings {
+	const settings = session?.settings;
+	const policy = resolveNavigationPolicy({
+		allowPrivateUrlsSetting: settings?.get("browser.allowPrivateUrls"),
+		allowlistSetting: settings?.get("browser.privateUrlAllowlist"),
+		configuredEndpointUrls: [
+			kind && "cdpUrl" in kind ? kind.cdpUrl : undefined,
+			settings?.get("browser.relayUrl"),
+			settings?.get("browser.cdpUrl"),
+		],
+		allowFileUrls: extra?.allowFileUrls,
+	});
+	return {
+		allowPrivateUrls: policy.allowPrivateUrls === true,
+		privateUrlAllowlist: policy.privateUrlAllowlist,
+		allowFileUrls: policy.allowFileUrls === true,
+	};
+}
+
 export interface AcquireTabOptions {
 	url?: string;
 	waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
@@ -135,6 +179,12 @@ export interface AcquireTabOptions {
 	deadlineStartMs?: number;
 	dialogs?: DialogPolicy;
 	cmuxSurface?: string;
+	/**
+	 * SSRF navigation-guard policy for `url` and every later navigation on the
+	 * tab. Callers resolve it from settings (see `navigationSettingsForSession`);
+	 * absent = fail closed in the worker.
+	 */
+	navigation?: NavigationGuardSettings;
 	/**
 	 * Session id of the acquirer. Recorded on the tab when created (never on
 	 * reuse) so `releaseTabsForOwner` can walk the shared tabs map on session
@@ -277,6 +327,12 @@ async function acquireTabImpl(
 		throw new ToolAbortError("Browser tab open aborted");
 	}
 	killedTabs.delete(name);
+	// Fail-fast SSRF pre-flight on the explicitly requested URL. Enforcement
+	// also happens in the worker/cmux goto; this only saves the spawn.
+	if (opts.url) {
+		const verdict = await checkNavigationTarget(opts.url, policyFromSettings(opts.navigation));
+		if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
+	}
 	// Temporary refCount hold so releasing an existing tab on the SAME browser
 	// below cannot drop it to refCount 0 and dispose the instance we are about
 	// to reuse (e.g. reopening the sole tab with a different dialogs policy).
@@ -443,6 +499,7 @@ async function acquireTabImpl(
 		worker,
 		state: "alive",
 		info,
+		navigation: opts.navigation,
 		pending: new Map(),
 		dialogPolicy: opts.dialogs,
 		kindTag: browser.kind.kind,
@@ -501,7 +558,7 @@ async function acquireCmuxTab(
 			}
 		}
 
-		const cmuxTab = new CmuxTab({ client: browser.client, surfaceId, url: initialUrl });
+		const cmuxTab = new CmuxTab({ client: browser.client, surfaceId, url: initialUrl, navigation: opts.navigation });
 		if (attachedSurface && opts.url) {
 			await cmuxTab.goto(opts.url, { waitUntil: opts.waitUntil ?? "load", timeoutMs: opts.timeoutMs });
 		}
@@ -522,6 +579,7 @@ async function acquireCmuxTab(
 			state: "alive",
 			info,
 			pending: new Map(),
+			navigation: opts.navigation,
 			dialogPolicy: opts.dialogs,
 			kindTag: browser.kind.kind,
 			cmuxAttachedSurface: attachedSurface,
@@ -558,6 +616,10 @@ async function runInTabWithSnapshot(
 	snapshot: SessionSnapshot,
 ): Promise<RunResultOk> {
 	const tab = tabs.get(name);
+	// Every model-facing run carries the tab's config-resolved SSRF policy so
+	// the worker re-applies it per `goto`/redirect. Internal callers pass a
+	// bare snapshot; the tab default fills it in here (never page content).
+	snapshot = { ...snapshot, navigation: snapshot.navigation ?? tab?.navigation };
 	if (!tab || tab.state === "dead") {
 		const killed = killedTabs.get(name);
 		throw new ToolError(
@@ -1220,6 +1282,7 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 			url: opts.url,
 			waitUntil: opts.waitUntil,
 			timeoutMs: opts.timeoutMs,
+			navigation: opts.navigation,
 		};
 	}
 	// Connected and relay browsers are user-driven. When no target is requested,
@@ -1242,6 +1305,7 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 		waitUntil: opts.waitUntil,
 		timeoutMs: opts.timeoutMs,
 		activateForScreenshot,
+		navigation: opts.navigation,
 	};
 }
 

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -545,6 +545,14 @@ async function acquireCmuxTab(
 			surfaceId = result.surface_id;
 			ownsSurface = true;
 			if (typeof result.url === "string" && result.url.length > 0) initialUrl = result.url;
+			// A fresh split is navigated BY cmux, so the request never crosses
+			// `CmuxTab.goto`: the landed URL (which can differ from `opts.url`
+			// through a server redirect) would otherwise be handed to the model
+			// unvalidated. Reuse the same policy the worker enforces.
+			if (initialUrl) {
+				const verdict = await checkNavigationTarget(initialUrl, policyFromSettings(opts.navigation));
+				if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
+			}
 			if (opts.url) {
 				await browser.client.request(
 					"browser.wait",
@@ -561,6 +569,14 @@ async function acquireCmuxTab(
 		const cmuxTab = new CmuxTab({ client: browser.client, surfaceId, url: initialUrl, navigation: opts.navigation });
 		if (attachedSurface && opts.url) {
 			await cmuxTab.goto(opts.url, { waitUntil: opts.waitUntil ?? "load", timeoutMs: opts.timeoutMs });
+		}
+		// `goto` quarantines a policy-violating landed URL and records it; an
+		// acquisition that ends on such a target must not hand the surface over.
+		const landed = cmuxTab.takeNavigationViolation();
+		if (landed) {
+			throw new ToolError(
+				`Blocked: navigation committed to ${JSON.stringify(landed)}, a private/internal or disallowed target.`,
+			);
 		}
 		const info = await cmuxTab.readyInfo(opts.viewport ?? DEFAULT_VIEWPORT);
 		// If the caller aborted while we were opening the cmux surface, close the

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -49,10 +49,17 @@ import {
 	DEFAULT_VIEWPORT,
 	loadPuppeteerInWorker,
 } from "./launch";
+import { redactBrowserOutput, redactBrowserText } from "./output-redact";
 import { extractReadableFromHtml, type ReadableFormat } from "./readable";
-
 import { cloneSafe, RunOutput } from "./run-output";
+import {
+	checkNavigationTarget,
+	isBlockedCommittedNavigation,
+	navigationBlockedMessage,
+	policyFromSettings,
+} from "./url-guard";
 import type {
+	NavigationGuardSettings,
 	Observation,
 	ObservationEntry,
 	ReadyInfo,
@@ -648,22 +655,34 @@ function createRunPageScope(page: Page): RunPageScope {
 function errorPayload(error: unknown): RunErrorPayload {
 	const recoverTab = error instanceof RequestInterceptionCleanupError || undefined;
 	if (error instanceof ToolAbortError) {
-		return { name: error.name, message: error.message, stack: error.stack, isToolError: false, isAbort: true };
+		return {
+			name: error.name,
+			message: redactBrowserText(error.message),
+			stack: error.stack ? redactBrowserText(error.stack) : error.stack,
+			isToolError: false,
+			isAbort: true,
+		};
 	}
 	if (error instanceof ToolError) {
 		return {
 			name: error.name,
-			message: error.message,
-			stack: error.stack,
+			message: redactBrowserText(error.message),
+			stack: error.stack ? redactBrowserText(error.stack) : error.stack,
 			isToolError: true,
 			isAbort: false,
 			recoverTab,
 		};
 	}
 	if (error instanceof Error) {
-		return { name: error.name, message: error.message, stack: error.stack, isToolError: false, isAbort: false };
+		return {
+			name: error.name,
+			message: redactBrowserText(error.message),
+			stack: error.stack ? redactBrowserText(error.stack) : error.stack,
+			isToolError: false,
+			isAbort: false,
+		};
 	}
-	return { name: "Error", message: String(error), isToolError: false, isAbort: false };
+	return { name: "Error", message: redactBrowserText(String(error)), isToolError: false, isAbort: false };
 }
 
 function replyError(payload: RunErrorPayload): Error {
@@ -968,6 +987,12 @@ export class WorkerCore {
 	#dialogPolicy?: DialogPolicy;
 	#dialogHandler?: (dialog: Dialog) => void;
 	#openDialog?: OpenDialogInfo;
+	/** SSRF policy from the init payload; per-run snapshots override it. */
+	#navigation?: NavigationGuardSettings;
+	/** Active navigation policy (init payload, refreshed with every run). */
+	#currentNavigation?: NavigationGuardSettings;
+	/** Committed navigation that violated the policy during the active run; blocks the ok reply. */
+	#navViolation?: string;
 
 	constructor(transport: Transport, isolated: boolean) {
 		this.#transport = transport;
@@ -1069,6 +1094,8 @@ export class WorkerCore {
 	async #init(payload: WorkerInitPayload): Promise<void> {
 		try {
 			this.#mode = payload.mode;
+			this.#navigation = payload.navigation;
+			this.#currentNavigation = payload.navigation;
 			this.#activateForScreenshot = payload.mode === "headless" || payload.activateForScreenshot !== false;
 			const puppeteer = await loadPuppeteerInWorker(payload.safeDir);
 			this.#browser = await puppeteer.connect({
@@ -1106,7 +1133,9 @@ export class WorkerCore {
 				this.#observeDialogs();
 				if (payload.dialogs) this.#applyDialogPolicy(payload.dialogs);
 			}
+			this.#observeNavigationViolations();
 			if (payload.url) {
+				await this.#guardNavigation(payload.url, this.#navigation);
 				await this.#page.goto(payload.url, {
 					// Default to "load" because dev servers with HMR/WS never reach networkidle.
 					waitUntil: payload.waitUntil ?? "load",
@@ -1125,6 +1154,39 @@ export class WorkerCore {
 			}
 			this.#transport.send({ type: "init-failed", error: errorPayload(error) });
 		}
+	}
+
+	/**
+	 * SSRF pre-check for a model-requested navigation. Runs inside the tab
+	 * worker (the boundary the model's code actually crosses) on the
+	 * serializable policy that travelled with the init/run message — the main
+	 * thread's acquire-time pre-check is UX, this is enforcement. Absent
+	 * policy fails closed: private ranges and file:// blocked, metadata floor
+	 * always blocked.
+	 */
+	async #guardNavigation(url: string, settings: NavigationGuardSettings | undefined): Promise<void> {
+		const verdict = await checkNavigationTarget(url, policyFromSettings(settings));
+		if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
+	}
+
+	/**
+	 * Post-commit recheck seam: a redirect or client-side navigation that
+	 * landed on a disallowed target gets the load stopped and the page pulled
+	 * back to `about:blank`, and the run is failed at reply time. DNS cannot
+	 * be pinned over CDP (see url-guard header), so this suppression — not
+	 * prevention — is what keeps private-range content away from the model.
+	 */
+	#observeNavigationViolations(): void {
+		const page = this.#requirePage();
+		page.on("framenavigated", frame => {
+			if (frame !== page.mainFrame()) return;
+			const landed = frame.url();
+			if (!landed || landed === "about:blank") return;
+			if (!isBlockedCommittedNavigation(landed, policyFromSettings(this.#currentNavigation))) return;
+			this.#navViolation = landed;
+			void this.#stopLoading().catch(() => undefined);
+			void page.goto("about:blank", { timeout: 5_000 }).catch(() => undefined);
+		});
 	}
 
 	async #findAttachedTarget(targetId: string): Promise<Target> {
@@ -1201,7 +1263,7 @@ export class WorkerCore {
 		this.#targetId = targetId;
 		return {
 			url: redactUrlCredentials(page.url()),
-			title: await page.title().catch(() => undefined),
+			title: await page.title().then(title => redactBrowserText(title)).catch(() => undefined),
 			viewport: page.viewport() ?? DEFAULT_VIEWPORT,
 			targetId,
 		};
@@ -1249,6 +1311,10 @@ export class WorkerCore {
 			});
 			return;
 		}
+		// Per-run snapshot policy wins over the init payload; the post-commit
+		// observer reads `#currentNavigation`, so refresh it before any code runs.
+		this.#currentNavigation = msg.session.navigation ?? this.#navigation;
+		this.#navViolation = undefined;
 		const timeoutSignal = AbortSignal.timeout(msg.timeoutMs);
 		const ac = new AbortController();
 		const runAc = new AbortController();
@@ -1370,6 +1436,24 @@ export class WorkerCore {
 			failure = this.#foldFloatingRejections(active, failure);
 			if (this.#active?.id === msg.id) this.#active = null;
 		}
+		// A committed policy violation outranks every other outcome: the run's
+		// output must never reach the model, and the flag is consumed here so
+		// it cannot leak into the next run's reply.
+		const violation = this.#navViolation;
+		this.#navViolation = undefined;
+		if (violation) {
+			this.#transport.send({
+				type: "result",
+				id: msg.id,
+				ok: false,
+				error: errorPayload(
+					new ToolError(
+						`Blocked: navigation committed to ${JSON.stringify(violation)}, a private/internal or disallowed target. The page was pulled back to about:blank and this run's output was discarded.`,
+					),
+				),
+			});
+			return;
+		}
 		if (failure) {
 			this.#transport.send({ type: "result", id: msg.id, ok: false, error: errorPayload(failure.error) });
 			return;
@@ -1380,7 +1464,16 @@ export class WorkerCore {
 				type: "result",
 				id: msg.id,
 				ok: true,
-				payload: { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots },
+				// Every browser-originated value that reaches the model passes the
+				// secret-shape redaction pass here (display payloads, buffered
+				// console/print text, and the evaluated return value).
+				payload: {
+					displays: output
+						.finish()
+						.map(entry => (entry.type === "text" ? { ...entry, text: redactBrowserText(entry.text) } : entry)),
+					returnValue: redactBrowserOutput(cloneSafe(returnValue)),
+					screenshots,
+				},
 			});
 		}
 	}
@@ -1588,6 +1681,9 @@ export class WorkerCore {
 			title: () => op("tab.title()", INF, sig => untilAborted(sig, () => page.title())),
 			goto: (url, opts) =>
 				op(`tab.goto(${JSON.stringify(url)})`, INF, async sig => {
+					// SSRF enforcement for model-authored navigations: the run's
+					// snapshot policy (falling back to the init payload's).
+					await this.#guardNavigation(url, session.navigation ?? this.#navigation);
 					this.#clearElementCache();
 					try {
 						// Default to "load" because dev servers with HMR/WS never reach networkidle.
@@ -1865,8 +1961,8 @@ export class WorkerCore {
 			}),
 		)) as Observation["scroll"];
 		return {
-			url: page.url(),
-			title: (await untilAborted(options.signal, () => page.title())) as string,
+			url: redactBrowserText(redactUrlCredentials(page.url())),
+			title: redactBrowserText((await untilAborted(options.signal, () => page.title())) as string),
 			viewport: page.viewport() ?? DEFAULT_VIEWPORT,
 			scroll,
 			elements: entries,

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -53,10 +53,19 @@ import { redactBrowserOutput, redactBrowserText } from "./output-redact";
 import { extractReadableFromHtml, type ReadableFormat } from "./readable";
 import { cloneSafe, RunOutput } from "./run-output";
 import {
+	attachNavigationObserver,
+	createRunBrowserScope,
+	createRunPageScope,
+	RequestInterceptionCleanupError,
+	type RunBrowserScope,
+	type RunPageScope,
+} from "./navigation-scope";
+import {
 	checkNavigationTarget,
-	isBlockedCommittedNavigation,
 	navigationBlockedMessage,
 	policyFromSettings,
+	recheckCommittedNavigation,
+	type NavigationGuardPolicy,
 } from "./url-guard";
 import type {
 	NavigationGuardSettings,
@@ -173,8 +182,6 @@ const OP_DEADLINE_SLACK_MS = CELL_BUDGET_SLACK_MS;
 const ZERO_MATCH_FAIL_FAST_MS = 2_000;
 /** Poll cadence for the zero-match watchdog. */
 const ZERO_MATCH_POLL_MS = 250;
-/** Cleanup must settle inside the supervisor's 750ms post-run grace window. */
-const REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS = 500;
 /** Bound cleanup window after a timed-out raw handle action. */
 const HANDLE_ACTION_INVALIDATION_TIMEOUT_MS = 500;
 
@@ -547,111 +554,6 @@ function redactUrlCredentials(url: string): string {
 	}
 }
 
-class RequestInterceptionCleanupError extends ToolError {}
-
-interface RunPageScope {
-	page: Page;
-	cleanup(): Promise<void>;
-}
-
-/**
- * Expose the tab page while retaining the request handlers created by this run.
- * Puppeteer's Page wraps an internal emitter, so `removeAllListeners("request")`
- * would also remove its forwarding listener; the facade removes only user handlers.
- */
-function createRunPageScope(page: Page): RunPageScope {
-	const requestHandlers: unknown[] = [];
-	const on = page.on;
-	const off = page.off;
-	const once = page.once;
-	const removeAllListeners = page.removeAllListeners;
-	const onDescriptor = Object.getOwnPropertyDescriptor(page, "on");
-	const offDescriptor = Object.getOwnPropertyDescriptor(page, "off");
-	const onceDescriptor = Object.getOwnPropertyDescriptor(page, "once");
-	const removeAllDescriptor = Object.getOwnPropertyDescriptor(page, "removeAllListeners");
-
-	Object.defineProperties(page, {
-		on: {
-			configurable: true,
-			value: (type: unknown, handler: unknown): Page => {
-				Reflect.apply(on, page, [type, handler]);
-				if (type === "request") requestHandlers.push(handler);
-				return page;
-			},
-		},
-		once: {
-			configurable: true,
-			value: (type: unknown, handler: unknown): Page => {
-				if (type !== "request" || typeof handler !== "function") {
-					Reflect.apply(once, page, [type, handler]);
-					return page;
-				}
-				const wrapper = (event: unknown): void => {
-					const index = requestHandlers.lastIndexOf(wrapper);
-					if (index >= 0) requestHandlers.splice(index, 1);
-					Reflect.apply(off, page, ["request", wrapper]);
-					Reflect.apply(handler, page, [event]);
-				};
-				requestHandlers.push(wrapper);
-				Reflect.apply(on, page, [type, wrapper]);
-				return page;
-			},
-		},
-		off: {
-			configurable: true,
-			value: (type: unknown, handler?: unknown): Page => {
-				Reflect.apply(off, page, [type, handler]);
-				if (type === "request") {
-					if (handler === undefined) requestHandlers.length = 0;
-					else {
-						const index = requestHandlers.lastIndexOf(handler);
-						if (index >= 0) requestHandlers.splice(index, 1);
-					}
-				}
-				return page;
-			},
-		},
-		removeAllListeners: {
-			configurable: true,
-			value: (type?: unknown): Page => {
-				Reflect.apply(removeAllListeners, page, [type]);
-				if (type === undefined || type === "request") requestHandlers.length = 0;
-				return page;
-			},
-		},
-	});
-
-	return {
-		page,
-		async cleanup() {
-			if (onDescriptor) Object.defineProperty(page, "on", onDescriptor);
-			else Reflect.deleteProperty(page, "on");
-			if (offDescriptor) Object.defineProperty(page, "off", offDescriptor);
-			else Reflect.deleteProperty(page, "off");
-			if (onceDescriptor) Object.defineProperty(page, "once", onceDescriptor);
-			else Reflect.deleteProperty(page, "once");
-			if (removeAllDescriptor) Object.defineProperty(page, "removeAllListeners", removeAllDescriptor);
-			else Reflect.deleteProperty(page, "removeAllListeners");
-			for (const handler of requestHandlers) Reflect.apply(off, page, ["request", handler]);
-			requestHandlers.length = 0;
-			try {
-				await withTimeout(
-					page.setRequestInterception(false),
-					REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS,
-					"Timed out clearing browser request interception",
-				);
-			} catch (error) {
-				throw new RequestInterceptionCleanupError(
-					"Failed to clear browser request interception after browser.run",
-					{
-						error: error instanceof Error ? error.message : String(error),
-					},
-				);
-			}
-		},
-	};
-}
-
 function errorPayload(error: unknown): RunErrorPayload {
 	const recoverTab = error instanceof RequestInterceptionCleanupError || undefined;
 	if (error instanceof ToolAbortError) {
@@ -993,6 +895,12 @@ export class WorkerCore {
 	#currentNavigation?: NavigationGuardSettings;
 	/** Committed navigation that violated the policy during the active run; blocks the ok reply. */
 	#navViolation?: string;
+	/**
+	 * Hostname → answers memoized for the ACTIVE run, so the pre-check and the
+	 * post-commit recheck share one lookup per host (bounded DNS, and a cached
+	 * answer is still classified on every use). Cleared at run start.
+	 */
+	#resolvedHosts = new Map<string, readonly string[]>();
 
 	constructor(transport: Transport, isolated: boolean) {
 		this.#transport = transport;
@@ -1162,31 +1070,54 @@ export class WorkerCore {
 	 * serializable policy that travelled with the init/run message — the main
 	 * thread's acquire-time pre-check is UX, this is enforcement. Absent
 	 * policy fails closed: private ranges and file:// blocked, metadata floor
-	 * always blocked.
+	 * always blocked. Answers are memoized per run in `#resolvedHosts` so the
+	 * post-commit recheck needs no second lookup for the same host.
 	 */
 	async #guardNavigation(url: string, settings: NavigationGuardSettings | undefined): Promise<void> {
-		const verdict = await checkNavigationTarget(url, policyFromSettings(settings));
+		const verdict = await checkNavigationTarget(url, this.#navigationPolicy(settings));
 		if (!verdict.allow) throw new ToolError(navigationBlockedMessage(verdict));
 	}
 
+	/** Settings + the run's shared hostname memo. */
+	#navigationPolicy(settings: NavigationGuardSettings | undefined): NavigationGuardPolicy {
+		return { ...policyFromSettings(settings), resolvedHosts: this.#resolvedHosts };
+	}
+
 	/**
-	 * Post-commit recheck seam: a redirect or client-side navigation that
-	 * landed on a disallowed target gets the load stopped and the page pulled
-	 * back to `about:blank`, and the run is failed at reply time. DNS cannot
-	 * be pinned over CDP (see url-guard header), so this suppression — not
-	 * prevention — is what keeps private-range content away from the model.
+	 * Post-commit recheck seam: a server redirect, `meta refresh`, script
+	 * navigation, or iframe that lands on a disallowed target gets the load
+	 * stopped and the page pulled back to `about:blank`, and the run is failed
+	 * at reply time. Unlike the DNS-free fast path this also re-resolves a
+	 * committed hostname that never passed this run's pre-check, closing the
+	 * DNS-rebinding window between the check and Chromium's own connect.
+	 *
+	 * This is suppression, not prevention: DNS cannot be pinned over CDP (see
+	 * url-guard header), so content can be fetched into the renderer before the
+	 * load is stopped — what the model is prevented from ever seeing is the
+	 * result. Every frame is classified, not just the main frame, because an
+	 * iframe is a committed navigation into an attacker-chosen host too.
 	 */
 	#observeNavigationViolations(): void {
-		const page = this.#requirePage();
-		page.on("framenavigated", frame => {
-			if (frame !== page.mainFrame()) return;
-			const landed = frame.url();
-			if (!landed || landed === "about:blank") return;
-			if (!isBlockedCommittedNavigation(landed, policyFromSettings(this.#currentNavigation))) return;
-			this.#navViolation = landed;
-			void this.#stopLoading().catch(() => undefined);
-			void page.goto("about:blank", { timeout: 5_000 }).catch(() => undefined);
-		});
+		attachNavigationObserver(
+			this.#requirePage(),
+			url => recheckCommittedNavigation(url, this.#navigationPolicy(this.#currentNavigation)),
+			landed => {
+				this.#navViolation = landed;
+			},
+			() => this.#stopLoading(),
+		);
+	}
+
+	/** Same observer for a page the model created through `browser.newPage`. */
+	#attachRunNavigationObserver(page: Page): void {
+		attachNavigationObserver(
+			page,
+			url => recheckCommittedNavigation(url, this.#navigationPolicy(this.#currentNavigation)),
+			landed => {
+				this.#navViolation = landed;
+			},
+			() => this.#stopLoading(),
+		);
 	}
 
 	async #findAttachedTarget(targetId: string): Promise<Target> {
@@ -1315,6 +1246,7 @@ export class WorkerCore {
 		// observer reads `#currentNavigation`, so refresh it before any code runs.
 		this.#currentNavigation = msg.session.navigation ?? this.#navigation;
 		this.#navViolation = undefined;
+		this.#resolvedHosts.clear();
 		const timeoutSignal = AbortSignal.timeout(msg.timeoutMs);
 		const ac = new AbortController();
 		const runAc = new AbortController();
@@ -1340,17 +1272,26 @@ export class WorkerCore {
 		let returnValue: unknown;
 		let failure: { error: unknown } | undefined;
 		let runPage: RunPageScope | undefined;
+		let runBrowser: RunBrowserScope | undefined;
 		try {
 			throwIfAborted(signal);
-			runPage = createRunPageScope(this.#requirePage());
-			const browser = this.#requireBrowser();
+			// `page.goto` on the handed-out page is guarded too: the run facade is
+			// a get-only proxy and cannot intercept it, so the raw descriptor is
+			// patched for the duration of the run (P1: model code could otherwise
+			// reach a private target without any pre-check).
+			runPage = createRunPageScope(this.#requirePage(), url =>
+				this.#guardNavigation(url, this.#currentNavigation),
+			);
+			// Pages the model creates itself get the same committed-navigation
+			// observer as the tab page (patched on the raw browser pre-facade).
+			runBrowser = createRunBrowserScope(this.#requireBrowser(), page => this.#attachRunNavigationObserver(page));
 			const tabApi = this.#createTabApi(msg.name, msg.timeoutMs, signal, msg.session, output, screenshots, active);
 			const runtime = this.#ensureRuntime(msg.session);
 			runtime.setCwd(msg.session.cwd);
 			const onFloatingRejection = (reason: unknown): void => this.#recordFloatingRejection(active, reason);
 			runtime.setRunScope({
 				page: bindRunFacade(runPage.page, signal, active.rejectionOwner, onFloatingRejection),
-				browser: bindRunFacade(browser, signal, active.rejectionOwner, onFloatingRejection),
+				browser: bindRunFacade(runBrowser.browser, signal, active.rejectionOwner, onFloatingRejection),
 				tab: bindRunFacade(tabApi, signal, active.rejectionOwner, onFloatingRejection),
 				assert: (cond: unknown, text?: string): void => {
 					if (!cond) throw new ToolError(text ?? "Assertion failed");
@@ -1430,6 +1371,7 @@ export class WorkerCore {
 			await Bun.sleep(0);
 			try {
 				await runPage?.cleanup();
+				await runBrowser?.cleanup();
 			} catch (error) {
 				failure = { error };
 			}

--- a/packages/coding-agent/src/tools/browser/url-guard.ts
+++ b/packages/coding-agent/src/tools/browser/url-guard.ts
@@ -38,9 +38,14 @@
  *
  * It FAILS CLOSED: DNS failure, empty answers, unparseable addresses,
  * malformed URLs and any unexpected error all block (:449-485, :515-519). The
- * one ported carve-out is hermes' proxy-delegation case: when an HTTP(S)/ALL
- * proxy env var is configured, a DNS failure allows the navigation because the
- * proxy — not this process — resolves the name (:450-472).
+ * one ported carve-out is hermes' proxy-delegation case, narrowed to the proxy
+ * omp's browser actually uses: when `PUPPETEER_PROXY` is set (launch.ts turns it
+ * into Chromium's `--proxy-server`), name resolution happens at the proxy, so a
+ * locally-failing lookup allows the navigation — unless `NO_PROXY` names the
+ * host, the hostname is internal by class (`localhost`, `*.local`, …), or the
+ * metadata floor already matched. The generic `HTTP(S)_PROXY`/`ALL_PROXY` vars
+ * hermes consults do NOT count: omp never routes the browser through them, so
+ * honouring them would fail open for a proxy that is not in the path.
  *
  * Deltas vs hermes (see NOTICE):
  *  - `new URL()` (WHATWG/Ada) replaces `urlparse`: it already normalizes
@@ -63,11 +68,18 @@
  *    connections, so the window remains: a hostile DNS record answering public
  *    at check time and flipping to `127.0.0.1` before Chromium connects still
  *    reaches the loopback service. The mitigation available here is the
- *    post-commit recheck (`isAlwaysBlockedNavigationTarget` + the worker's
- *    `framenavigated` observer): the committed URL is re-validated, the
- *    navigation stopped, the page pulled back to `about:blank`, and the run's
- *    output discarded so the fetched content never reaches the model.
- *    Honestly: content suppression, not prevention.
+ *    post-commit recheck: every committed frame URL passes
+ *    `isBlockedCommittedNavigation` (DNS-free: literals, metadata names, the
+ *    allowlist) and then `recheckCommittedNavigation`, which additionally
+ *    RE-RESOLVES a committed hostname that is not an IP literal, so a name that
+ *    was public at pre-flight and private at commit is caught.
+ *    `isAlwaysBlockedNavigationTarget` is the DNS-free floor subset, used to
+ *    fail fast before any lookup. The violating load is stopped, the page pulled
+ *    back to `about:blank`, and the run's output discarded so the fetched
+ *    content never reaches the model. Honestly: content suppression, not
+ *    prevention. Lookups are memoized per navigation run
+ *    (`NavigationGuardPolicy.resolvedHosts`), so a redirect chain costs one
+ *    lookup per distinct hostname instead of one per commit.
  *  - The relay/CDP *transport* (`wsEndpoint`, e.g. `127.0.0.1:9224`) never
  *    passes through this module: the guard inspects navigation TARGETS only,
  *    so `app.relay` sessions keep driving the owner's Chrome unchanged; the
@@ -100,6 +112,16 @@ export interface NavigationGuardPolicy {
 	readonly allowFileUrls?: boolean;
 	/** Injectable DNS resolver (tests, sandboxes). Defaults to `node:dns`. */
 	readonly lookup?: HostnameResolver;
+	/**
+	 * Optional DNS answer memo (hostname → addresses). `checkNavigationTarget`
+	 * records every lookup it performs here, and `recheckCommittedNavigation`
+	 * reads it to tell "already vetted in this navigation run" from "arrived via
+	 * a redirect or a script navigation that never passed the pre-flight". A
+	 * miss is therefore treated as unvetted and re-resolved (answers are written
+	 * back, so a redirect chain costs one lookup per distinct host). Mutable
+	 * call state, not serialized config; `policyFromSettings` leaves it absent.
+	 */
+	readonly resolvedHosts?: Map<string, readonly string[]>;
 }
 
 export type NavigationVerdict =
@@ -112,7 +134,14 @@ export type NavigationVerdict =
 			readonly detail?: string;
 	  };
 
-const PROXY_ENV_VARS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"] as const;
+/**
+ * The proxy omp's Chromium actually consumes (launch.ts:443 → `--proxy-server`).
+ * Only a proxy on this path can be the party that resolves a name, so only this
+ * variable unlocks the DNS-failure carve-out.
+ */
+const BROWSER_PROXY_ENV_VARS = ["PUPPETEER_PROXY", "puppeteer_proxy"] as const;
+/** `NO_PROXY` spellings whose host list re-disables the carve-out. */
+const NO_PROXY_ENV_VARS = ["NO_PROXY", "no_proxy"] as const;
 
 /** Cloud metadata hostnames blocked without any DNS lookup (url_safety.py:166-169). */
 const ALWAYS_BLOCKED_HOSTNAMES: Record<string, true> = {
@@ -143,6 +172,7 @@ const ALWAYS_BLOCKED_V4_EXACT: readonly number[] = [
 	ip4("169.254.170.2"), // AWS ECS task metadata (task IAM creds)
 	ip4("169.254.169.253"), // Azure IMDS wire server
 	ip4("100.100.100.200"), // Alibaba Cloud metadata
+	ip4("192.0.0.192"), // Oracle Cloud secondary IMDS (RFC 6890 reserved, not link-local)
 ];
 
 /** IPv4 CIDRs blocked even under every relaxation (:192-195). */
@@ -298,6 +328,48 @@ function sixToFourV4(bytes: Uint8Array): number | undefined {
 	return ((bytes[2] ?? 0) * 16777216 + (bytes[3] ?? 0) * 65536 + (bytes[4] ?? 0) * 256 + (bytes[5] ?? 0)) >>> 0;
 }
 
+/** Reads the big-endian IPv4 starting at byte `at`. */
+function v4At(bytes: Uint8Array, at: number): number {
+	return ((bytes[at] ?? 0) * 16777216 + (bytes[at + 1] ?? 0) * 65536 + (bytes[at + 2] ?? 0) * 256 + (bytes[at + 3] ?? 0)) >>> 0;
+}
+
+/**
+ * RFC 6052 NAT64: the well-known `64:ff9b::/96` prefix carries the IPv4 in the
+ * last four bytes, the local-use `64:ff9b:1::/48` right after the 48-bit
+ * prefix. Without this unwrap, `http://[64:ff9b::a9fea9fe]/` reaches
+ * 169.254.169.254 through a NAT64 gateway while every v4 check sees only a
+ * "public" v6 address.
+ */
+function nat64V4(bytes: Uint8Array): number | undefined {
+	if (bytes[0] !== 0x00 || bytes[1] !== 0x64 || bytes[2] !== 0xff || bytes[3] !== 0x9b) return undefined;
+	const wellKnown =
+		bytes[4] === 0 && bytes[5] === 0 && bytes[6] === 0 && bytes[7] === 0 && bytes[8] === 0 && bytes[9] === 0;
+	if (wellKnown) return v4At(bytes, 12);
+	if (bytes[4] !== 0x00 || bytes[5] !== 0x01) return undefined;
+	// Real-world URLs also spell the local-use form with the IPv4 in the trailing
+	// 32 bits (`64:ff9b:1::a9fe:a9fe`); either placement can reach the gateway,
+	// so judge whichever one carries an address.
+	const afterPrefix = v4At(bytes, 6);
+	return afterPrefix !== 0 ? afterPrefix : v4At(bytes, 12);
+}
+
+/**
+ * Teredo (`2001:0000::/32`) carries the client-visible IPv4 in bytes 4..7,
+ * bitwise-inverted. Only the server-side/universal form is unwrapped here — a
+ * Teredo address that is NOT `2001:0000::/32` already starts with the public
+ * `2001::/23` routing space and is judged as plain IPv6.
+ */
+function teredoV4(bytes: Uint8Array): number | undefined {
+	if (bytes[0] !== 0x20 || bytes[1] !== 0x01 || bytes[2] !== 0x00 || bytes[3] !== 0x00) return undefined;
+	return (
+		(((~(bytes[4] ?? 0)) & 0xff) * 16777216 +
+			((~(bytes[5] ?? 0)) & 0xff) * 65536 +
+			((~(bytes[6] ?? 0)) & 0xff) * 256 +
+			((~(bytes[7] ?? 0)) & 0xff)) >>>
+		0
+	);
+}
+
 function alwaysBlockedV4(value: number): boolean {
 	if (ALWAYS_BLOCKED_V4_EXACT.includes(value)) return true;
 	return inCidrs4(value, ALWAYS_BLOCKED_V4_NETWORKS);
@@ -326,11 +398,11 @@ export function classifyIpAddress(ip: string): {
 	}
 	const v6 = parseIpv6(normalized);
 	if (!v6) return { kind: "v6", private: true, alwaysBlocked: true };
-	const embedded = embeddedV4(v6) ?? sixToFourV4(v6);
+	const embedded = embeddedV4(v6) ?? sixToFourV4(v6) ?? nat64V4(v6) ?? teredoV4(v6);
 	if (embedded !== undefined) {
-		// `::ffff:x.x.x.x` / `::x.x.x.x` / `2002:x.x.x.x.*`: judged by the
-		// embedded IPv4 — incl. the mapped link-local metadata floor
-		// (`::ffff:169.254.0.0/112` in hermes terms).
+		// `::ffff:x.x.x.x` / `::x.x.x.x` / `2002:x.x.x.x.*` / NAT64 / Teredo:
+		// judged by the embedded IPv4 — incl. the mapped link-local metadata
+		// floor (`::ffff:169.254.0.0/112` in hermes terms).
 		return {
 			kind: "v6",
 			private: inCidrs4(embedded, PRIVATE_V4_NETWORKS),
@@ -377,6 +449,20 @@ function splitHostPort(input: string): { hostname: string; port: string } {
 	return { hostname: text.toLowerCase(), port: "" };
 }
 
+/** The port a scheme implies when a URL spells none (`URL.port === ""`). */
+function schemeDefaultPort(scheme: string | undefined): string | undefined {
+	switch (scheme) {
+		case "http":
+		case "ws":
+			return "80";
+		case "https":
+		case "wss":
+			return "443";
+		default:
+			return undefined;
+	}
+}
+
 function normalizeHostname(hostname: string): string {
 	return hostname.toLowerCase().replace(/\.+$/, "");
 }
@@ -385,35 +471,74 @@ function normalizeHostname(hostname: string): string {
  * Match a normalized hostname (and optional `host:port`) against an explicit
  * allowlist entry: exact hostname, exact `host:port`, `*.suffix` wildcard,
  * bare IP literal, or CIDR prefix. Entries come from configuration only.
+ *
+ * `scheme` is the target's URL scheme: WHATWG `URL.port` is EMPTY for a
+ * default port, so an entry spelled `host:443` would otherwise never match
+ * `https://host/`. Default-port spellings are normalized away for the scheme
+ * they name, and IPv6 brackets are stripped on both sides so `[::1]:9222` and
+ * `http://[::1]:9222/` line up.
  */
-export function matchesAllowlistEntry(hostname: string, port: string, entry: string): boolean {
+export function matchesAllowlistEntry(hostname: string, port: string, entry: string, scheme?: string): boolean {
 	const normalized = entry.trim().toLowerCase().replace(/\.+$/, "");
 	if (!normalized) return false;
+	const target = normalizeHostname(stripBrackets(hostname));
 	if (normalized.includes("/")) {
 		const [baseText, bitsText] = normalized.split("/");
 		const bits = Number.parseInt(bitsText ?? "", 10);
 		if (!Number.isFinite(bits)) return false;
 		const base4 = baseText !== undefined ? parseIpv4(baseText) : undefined;
 		if (base4 !== undefined) {
-			const host4 = parseIpv4(hostname);
+			const host4 = parseIpv4(target);
 			return host4 !== undefined && inCidr4(host4, base4, bits);
 		}
 		const base6 = baseText !== undefined ? parseIpv6(baseText) : undefined;
-		const host6 = parseIpv6(hostname);
+		const host6 = parseIpv6(target);
 		return !!base6 && !!host6 && inCidr6(host6, base6, bits);
 	}
 	if (normalized.startsWith("*.")) {
 		const suffix = normalized.slice(2);
-		return hostname === suffix || hostname.endsWith(`.${suffix}`);
+		return target === suffix || target.endsWith(`.${suffix}`);
 	}
 	const { hostname: entryHost, port: entryPort } = splitHostPort(normalized);
-	if (entryPort && entryPort !== port) return false;
-	return normalizeHostname(entryHost) === hostname;
+	if (entryPort && entryPort !== port && !(port === "" && entryPort === schemeDefaultPort(scheme))) return false;
+	return normalizeHostname(stripBrackets(entryHost)) === target;
 }
 
-function proxyIsConfigured(): boolean {
-	for (const name of PROXY_ENV_VARS) if (process.env[name]) return true;
+/** True when the browser's own Chromium is launched with an upstream proxy. */
+function browserProxyIsConfigured(env: Record<string, string | undefined> = process.env): boolean {
+	for (const name of BROWSER_PROXY_ENV_VARS) if (env[name]?.trim()) return true;
 	return false;
+}
+
+/**
+ * `NO_PROXY` matching, narrowed to hostnames (Chromium's own syntax also allows
+ * CIDRs and `<-loopback>` sentinels; a non-matching token is simply inert here).
+ * `*` bypasses the proxy for everything, which removes the delegation premise.
+ */
+function hostMatchesNoProxy(hostname: string, noProxy: string | undefined): boolean {
+	if (!noProxy) return false;
+	for (const raw of noProxy.split(/[\s,]+/)) {
+		const entry = raw.trim().toLowerCase().replace(/^\*?\./, ".");
+		if (!entry) continue;
+		if (entry === "*") return true;
+		const bare = entry.startsWith(".") ? entry.slice(1) : entry;
+		if (hostname === bare || hostname === `.${bare}` || hostname.endsWith(`.${bare}`)) return true;
+	}
+	return false;
+}
+
+/**
+ * Does the DNS-failure carve-out apply for `hostname`? Only when Chromium's
+ * traffic really is delegated to `PUPPETEER_PROXY` AND that proxy is not told to
+ * bypass this host via `NO_PROXY` — in which case "we could not resolve it" does
+ * not mean "the browser will not".
+ */
+export function proxyDelegationApplies(hostname: string, env: Record<string, string | undefined> = process.env): boolean {
+	if (!browserProxyIsConfigured(env)) return false;
+	for (const name of NO_PROXY_ENV_VARS) {
+		if (hostMatchesNoProxy(normalizeHostname(stripBrackets(hostname)), env[name])) return false;
+	}
+	return true;
 }
 
 /** Default resolver: every `node:dns` answer, mirroring hermes' getaddrinfo loop. */
@@ -481,14 +606,32 @@ function parseTarget(raw: string): ParsedTarget | undefined {
 }
 
 /**
+ * Presigned object-storage download URLs (`X-Amz-Credential`/`X-Amz-Signature`,
+ * S3-style `Expires`+`Signature`, Aliyun `OSSAccessKeyId`) legitimately carry
+ * long opaque signature material in the query string. The secret-URL rule
+ * exists to stop the model putting an API key in a URL it may leak; a presigned
+ * URL is scoped, time-limited and *meant* to be handed around, and refusing
+ * them broke the documented `browser.fetch(cdnUrl)` download pattern. Only the
+ * secret-shape refusal is exempted — every other stage of the chain (scheme,
+ * metadata floor, private ranges, DNS) still applies.
+ */
+const PRESIGNED_QUERY_RE = /[?&](?:x-amz-credential|x-amz-signature|ossaccesskeyid)=/i;
+const PRESIGNED_EXPIRES_RE = /[?&]expires=/i;
+const PRESIGNED_SIGNATURE_RE = /(?:^|[?&])signature=/i;
+
+function isPresignedUrlNavigation(raw: string): boolean {
+	return PRESIGNED_QUERY_RE.test(raw) || (PRESIGNED_EXPIRES_RE.test(raw) && PRESIGNED_SIGNATURE_RE.test(raw));
+}
+
+/**
  * The guard entry point: classify one navigation target against `policy`.
  * Fails closed on every error path (see module header).
  */
 export async function checkNavigationTarget(raw: string, policy: NavigationGuardPolicy = {}): Promise<NavigationVerdict> {
+	if (!isPresignedUrlNavigation(raw) && (containsSecretTokenShape(raw) || containsSecretTokenShape(safeDecode(raw)))) {
+		return { allow: false, code: "secret-url", target: raw, detail: "URL carries a credential-shaped token" };
+	}
 	try {
-		if (containsSecretTokenShape(raw) || containsSecretTokenShape(safeDecode(raw))) {
-			return { allow: false, code: "secret-url", target: raw, detail: "URL carries a credential-shaped token" };
-		}
 		const parsed = parseTarget(raw);
 		if (!parsed) return { allow: false, code: "malformed", target: raw };
 		if (parsed.kind === "opaque") {
@@ -507,12 +650,13 @@ export async function checkNavigationTarget(raw: string, policy: NavigationGuard
 		if (parsed.ipText) {
 			const classification = classifyIpAddress(parsed.ipText);
 			if (classification.alwaysBlocked) return { allow: false, code: "metadata", target: raw, hostname };
-			if (policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy)) return { allow: true };
+			if (policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy, parsed.scheme))
+				return { allow: true };
 			if (classification.private) return { allow: false, code: "private", target: raw, hostname };
 			return { allow: true };
 		}
 		const privateByName = hostnameIsPrivateByName(hostname);
-		const relaxed = policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy);
+		const relaxed = policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy, parsed.scheme);
 		// Obvious-private names need no DNS round-trip to know they are internal
 		// (browser_tool.py:1427-1430) — but under relaxation they still fall
 		// through to resolution + floor check below, because hermes enforces the
@@ -527,14 +671,22 @@ export async function checkNavigationTarget(raw: string, policy: NavigationGuard
 		// always-blocked range stays blocked; under `allowPrivateUrls` only the
 		// floor is enforced).
 		const resolver = policy.lookup ?? dnsResolver;
+		const cached = policy.resolvedHosts?.get(hostname);
 		let answers: string[];
-		try {
-			answers = await resolver(hostname);
-		} catch {
-			// hermes is_safe_url:448-474 — fail closed, except the
-			// proxy-delegation carve-out (the proxy resolves the name).
-			if (proxyIsConfigured()) return { allow: true };
-			return { allow: false, code: "dns", target: raw, hostname, detail: "DNS resolution failed" };
+		if (cached) {
+			answers = [...cached];
+		} else {
+			try {
+				answers = await resolver(hostname);
+			} catch {
+				// hermes is_safe_url:448-474 — fail closed, except the
+				// proxy-delegation carve-out, and only when the browser's
+				// traffic really is delegated for THIS host: a configured
+				// PUPPETEER_PROXY that NO_PROXY excludes resolves nothing.
+				if (proxyDelegationApplies(hostname)) return { allow: true };
+				return { allow: false, code: "dns", target: raw, hostname, detail: "DNS resolution failed" };
+			}
+			policy.resolvedHosts?.set(hostname, answers);
 		}
 		if (!answers.length) {
 			if (relaxed) return { allow: true };
@@ -555,8 +707,13 @@ export async function checkNavigationTarget(raw: string, policy: NavigationGuard
 	}
 }
 
-function isAllowlisted(hostname: string, port: string, policy: NavigationGuardPolicy): boolean {
-	return (policy.privateUrlAllowlist ?? []).some(entry => matchesAllowlistEntry(hostname, port, entry));
+function isAllowlisted(
+	hostname: string,
+	port: string,
+	policy: NavigationGuardPolicy,
+	scheme: "http" | "https" = "https",
+): boolean {
+	return (policy.privateUrlAllowlist ?? []).some(entry => matchesAllowlistEntry(hostname, port, entry, scheme));
 }
 
 function safeDecode(text: string): string {
@@ -574,12 +731,13 @@ function safeDecode(text: string): string {
 }
 
 /**
- * Cheap, DNS-free classification of an already-committed URL — the
- * post-navigation recheck seam. Literal IPs and the always-blocked hostname
- * set are classified exactly, plus the private-by-name classes. Returns false
- * for hostnames that would need a resolver (the async pre-check owns that
- * path) and for malformed input (a committed `page.url()` is already
- * normalized by Chromium; a parse failure here is not a metadata endpoint).
+ * DNS-free floor classification of an already-committed URL: literal IPs and
+ * the always-blocked hostname set are classified exactly, plus the
+ * private-by-name classes. Returns false for hostnames that would need a
+ * resolver — `recheckCommittedNavigation` is the policy-aware async path that
+ * also re-resolves them — and for malformed input (a committed `page.url()` is
+ * already normalized by Chromium; a parse failure here is not a metadata
+ * endpoint).
  */
 export function isAlwaysBlockedNavigationTarget(url: string): boolean {
 	const parsed = parseTarget(url);
@@ -590,26 +748,43 @@ export function isAlwaysBlockedNavigationTarget(url: string): boolean {
 }
 
 /**
+ * Committed URL schemes that are never content the guard exists to hide:
+ * internal Chromium pages and opaque in-page object URLs carry no fetched
+ * body. `data:`, `filesystem:`, `view-source:` and `javascript:` commits stay
+ * violations — they can smuggle fetched content or drive privileged actions.
+ */
+const NON_VIOLATION_OPAQUE_SCHEMES: readonly string[] = [
+	"about",
+	"blob",
+	"chrome",
+	"chrome-error",
+	"chrome-extension",
+	"devtools",
+];
+
+/**
  * Policy-aware, DNS-free check of an ALREADY-COMMITTED navigation (redirect /
  * client-side nav / new-tab adoption): true = the page landed somewhere it
  * must not show the model. Same ordering as the async pre-check minus
  * resolution: the metadata floor survives every relaxation; ordinary private
  * ranges and private-by-name hosts block unless `allowPrivateUrls` or an
- * allowlist entry covers them; hostnames that would need DNS are allowed
- * here (the pre-check already vetted them; re-resolving per commit would
- * multiply DNS traffic on redirect chains). Non-http(s) commits (`file:`,
- * `chrome:`) violate unless internally exempted by `allowFileUrls`.
+ * allowlist entry covers them. Hostnames that would need DNS are allowed here
+ * only as far as this DNS-free step goes — callers that can await should use
+ * `recheckCommittedNavigation`, which re-resolves unvetted hosts. Non-http(s)
+ * commits violate unless internally exempted by `allowFileUrls` or listed in
+ * `NON_VIOLATION_OPAQUE_SCHEMES`.
  */
 export function isBlockedCommittedNavigation(url: string, policy: NavigationGuardPolicy = {}): boolean {
 	const parsed = parseTarget(url);
 	if (!parsed) return false; // Chromium-normalized URLs parse; unparseable is not a private target
 	if (parsed.kind === "opaque") {
-		if (parsed.scheme === "about") return false;
+		if (NON_VIOLATION_OPAQUE_SCHEMES.includes(parsed.scheme)) return false;
 		if (parsed.scheme === "file") return policy.allowFileUrls !== true;
 		return true;
 	}
 	if (ALWAYS_BLOCKED_HOSTNAMES[parsed.hostname] === true) return true;
-	const relaxed = policy.allowPrivateUrls === true || isAllowlisted(parsed.hostname, parsed.port, policy);
+	const relaxed =
+		policy.allowPrivateUrls === true || isAllowlisted(parsed.hostname, parsed.port, policy, parsed.scheme);
 	if (parsed.ipText) {
 		const classification = classifyIpAddress(parsed.ipText);
 		if (classification.alwaysBlocked) return true;
@@ -617,6 +792,51 @@ export function isBlockedCommittedNavigation(url: string, policy: NavigationGuar
 	}
 	if (relaxed) return false;
 	return hostnameIsPrivateByName(parsed.hostname);
+}
+
+/**
+ * The async post-commit recheck: everything `isBlockedCommittedNavigation`
+ * covers DNS-free, PLUS re-resolution of a committed hostname that never
+ * passed this run's pre-check. Server-side redirects, `meta refresh`, and
+ * script navigations change the committed URL without ever being the string
+ * the guard vetted; a DNS record that answered public at pre-flight and flips
+ * private before Chromium connects is caught here (one lookup per distinct
+ * host, memoized through `policy.resolvedHosts`). DNS failure on an UNVETTED
+ * committed host fails closed — the pre-check's proxy carve-out does not
+ * extend to hosts that were never checked at all.
+ */
+export async function recheckCommittedNavigation(url: string, policy: NavigationGuardPolicy = {}): Promise<boolean> {
+	if (isBlockedCommittedNavigation(url, policy)) return true;
+	const parsed = parseTarget(url);
+	if (!parsed || parsed.kind !== "host") return false;
+	// Literal IPs, metadata/private-by-name hosts, and relaxed (allowlisted or
+	// `allowPrivateUrls`) hosts were answered DNS-free above; floor-vs-relaxed
+	// ordering cannot change for them.
+	if (parsed.ipText) return false;
+	const hostname = parsed.hostname;
+	if (policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy, parsed.scheme)) return false;
+	// The memo exists to bound lookups (one per distinct host per run), NOT to
+	// skip classification: a cached answer is judged exactly like a fresh one so
+	// a second frame/redirect to the same host cannot slip through.
+	const cached = policy.resolvedHosts?.get(hostname);
+	let answers: readonly string[];
+	if (cached) {
+		answers = cached;
+	} else {
+		try {
+			answers = await (policy.lookup ?? dnsResolver)(hostname);
+		} catch {
+			return true; // unvetted host that cannot be resolved: fail closed
+		}
+		policy.resolvedHosts?.set(hostname, answers);
+	}
+	if (!answers.length) return true;
+	for (const answer of answers) {
+		const address = answer.includes("%") ? (answer.split("%")[0] ?? answer) : answer;
+		const classification = classifyIpAddress(address);
+		if (classification.alwaysBlocked || classification.private) return true;
+	}
+	return false;
 }
 
 /** Model-facing explanation with the exact remediation for a blocked verdict. */
@@ -646,10 +866,15 @@ export function navigationBlockedMessage(verdict: NavigationVerdict): string {
  * that crosses into the tab worker with every run/message.
  *
  * `configuredEndpointUrls` is the "explicit relay allow" of the port
- * contract: a relay/CDP endpoint host the *user configured themselves*
+ * contract: a relay/CDP endpoint the *user configured themselves*
  * (`browser.relayUrl`, `browser.cdpUrl`, `app.cdp_url`) joins the allowlist,
  * mirroring how hermes exempts its own sidecar from the blocked target set.
- * It is read from settings only — never from page content.
+ * It is read from settings only — never from page content. Endpoints are
+ * emitted as `host:port` whenever they spell a non-default port, so a CDP
+ * proxy on `127.0.0.1:9224` does not also allow whatever else listens on other
+ * ports of that loopback host. Caveat: `app.cdp_url` is set by the model-facing
+ * `app` argument — an origin-level allowance, so whoever sets it decides which
+ * `host:port` becomes navigable for the session.
  */
 export function resolveNavigationPolicy(input: {
 	readonly allowPrivateUrlsSetting?: unknown;
@@ -668,8 +893,7 @@ export function resolveNavigationPolicy(input: {
 		}
 	}
 	for (const endpoint of input.configuredEndpointUrls ?? []) {
-		const host = endpointHostname(endpoint);
-		if (host) allowlist.add(host);
+		for (const entry of endpointAllowlistEntries(endpoint)) allowlist.add(entry);
 	}
 	return {
 		allowPrivateUrls,
@@ -691,14 +915,29 @@ function truthy(value: unknown): boolean {
 	return value === true || value === "true" || value === 1 || value === "1";
 }
 
-function endpointHostname(endpoint: string | undefined): string | undefined {
+/**
+ * Allowlist entries for one configured relay/CDP endpoint URL: the hostname,
+ * plus `host:port` when the URL spells a port that is not its scheme default.
+ * A port-less endpoint (or a plain `host:port` setting text) yields the bare
+ * hostname only — matching the previous behavior for default-port services.
+ */
+function endpointAllowlistEntries(endpoint: string | undefined): readonly string[] {
 	const text = endpoint?.trim();
-	if (!text) return undefined;
+	if (!text) return [];
+	let url: URL;
 	try {
-		return normalizeHostname(new URL(text).hostname);
+		url = new URL(text);
 	} catch {
-		return undefined;
+		return [];
 	}
+	const scheme = url.protocol.replace(/:$/, "").toLowerCase();
+	const hostname = normalizeHostname(url.hostname);
+	if (!hostname) return [];
+	const port = url.port;
+	if (!port) return [hostname];
+	const defaultPort = scheme === "https" || scheme === "wss" ? "443" : scheme === "http" || scheme === "ws" ? "80" : "";
+	if (port === defaultPort) return [hostname];
+	return [`${hostname}:${port}`];
 }
 
 /**

--- a/packages/coding-agent/src/tools/browser/url-guard.ts
+++ b/packages/coding-agent/src/tools/browser/url-guard.ts
@@ -1,0 +1,725 @@
+/**
+ * SSRF / private-network navigation guard for the browser tool.
+ *
+ * Ported from `hermes-agent` (`tools/url_safety.py`, `tools/browser_tool.py`
+ * `_url_is_private` + `evaluate_url_safety`), Copyright (c) 2025 Nous Research
+ * — MIT License. See ./NOTICE for the full attribution and the list of
+ * deliberate deltas for the oh-my-pi port.
+ *
+ * Threat model: the browser runs inside the owner's trust boundary (local
+ * headless Chromium, a spawned app, the owner's Chrome via the omp relay, or a
+ * CDP endpoint on the LAN). A prompt-injected page — or a page that merely
+ * redirects — can drive the tool's own navigation API at internal addresses:
+ * cloud credential endpoints (`169.254.169.254`, `metadata.google.internal`),
+ * router admin panels, unauthenticated dev services on loopback, or internal
+ * LAN ranges — and then exfiltrate the response body through `tab.observe()` /
+ * `tab.extract()` / `page.evaluate()`. This module is the navigation-side half
+ * of the defense; the output-side half is ./output-redact.ts.
+ *
+ * Check order (hermes `is_safe_url` parity, url_safety.py:415-519):
+ *  1. credential-shaped tokens in the URL block outright (`evaluate_url_safety`);
+ *  2. scheme rules: http(s) proceed; `about:` allowed; `file:` internal-exempt
+ *     only; anything else blocked (:430-432);
+ *  3. the always-blocked floor survives EVERY relaxation and is checked with no
+ *     DNS round-trip: the metadata hostnames `metadata.google.internal` /
+ *     `metadata.goog` (:166-169), the whole 169.254.0.0/16 link-local range
+ *     (IPv4 + `::ffff:` mapped), the named metadata addresses 169.254.170.2,
+ *     169.254.169.253, fd00:ec2::254, 100.100.100.200 (:180-195);
+ *  4. explicit relaxation (`allowPrivateUrls` toggle, allowlist entry, or an
+ *     endpoint host the user configured themselves): relaxes the ORDINARY
+ *     private classes — 10/8, 172.16/12, 192.168/16, 127/8, ::1, fc00::/7,
+ *     fe80::/10, CGNAT 100.64/10, reserved/multicast/unspecified, and the
+ *     obvious-private name classes (localhost, *.localhost, *.lan, *.local,
+ *     *.internal, *.home.arpa — browser_tool.py:1427-1430 short-circuit) —
+ *     never the floor;
+ *  5. otherwise: literal IPs are classified directly; hostnames are resolved
+ *     (every answer classified, mirroring the getaddrinfo loop) — a public
+ *     answer passes, any private/metadata answer blocks.
+ *
+ * It FAILS CLOSED: DNS failure, empty answers, unparseable addresses,
+ * malformed URLs and any unexpected error all block (:449-485, :515-519). The
+ * one ported carve-out is hermes' proxy-delegation case: when an HTTP(S)/ALL
+ * proxy env var is configured, a DNS failure allows the navigation because the
+ * proxy — not this process — resolves the name (:450-472).
+ *
+ * Deltas vs hermes (see NOTICE):
+ *  - `new URL()` (WHATWG/Ada) replaces `urlparse`: it already normalizes
+ *    numeric host forms (`http://2130706433` → `127.0.0.1`,
+ *    `http://0xA9FEA9FE` → `169.254.169.254`, `http://127.1`), unicode
+ *    hostnames to punycode, case and trailing dots — the classic notation
+ *    bypasses die at the parser; the RESULTING hostname is what gets checked.
+ *  - The guard classifies the resolved IP like hermes `is_safe_url`; hermes'
+ *    fail-OPEN `_url_is_private` (:1433-1434, routing hint only) is NOT ported
+ *    — omp has only one browser routing path, so one guard suffices.
+ *  - hermes' cloud-sidecar routing (`_auto_local_for_private_urls`,
+ *    `_navigation_session_key`) and the "third-party reader" sensitive-query
+ *    block are NOT ported: every omp browser is the user's own local browser,
+ *    so there is no foreign reader to route around. Credential *shapes* in
+ *    navigation URLs are still blocked outright, and the output-side redactor
+ *    keeps the rest out of transcripts.
+ *  - DNS rebinding: hermes closes the check-vs-connect TOCTOU window only on
+ *    its own httpx paths by pinning the resolved IP at connect time
+ *    (`create_ssrf_safe_client`). A CDP/puppeteer navigation cannot pin
+ *    connections, so the window remains: a hostile DNS record answering public
+ *    at check time and flipping to `127.0.0.1` before Chromium connects still
+ *    reaches the loopback service. The mitigation available here is the
+ *    post-commit recheck (`isAlwaysBlockedNavigationTarget` + the worker's
+ *    `framenavigated` observer): the committed URL is re-validated, the
+ *    navigation stopped, the page pulled back to `about:blank`, and the run's
+ *    output discarded so the fetched content never reaches the model.
+ *    Honestly: content suppression, not prevention.
+ *  - The relay/CDP *transport* (`wsEndpoint`, e.g. `127.0.0.1:9224`) never
+ *    passes through this module: the guard inspects navigation TARGETS only,
+ *    so `app.relay` sessions keep driving the owner's Chrome unchanged; the
+ *    configured endpoint host additionally joins the allowlist via
+ *    `resolveNavigationPolicy` (the contract's "explicit-relay allow").
+ */
+
+import { promises as nodeDns } from "node:dns";
+
+import { containsSecretTokenShape } from "./output-redact";
+
+/** Hostname resolver seam: returns every address a hostname resolves to. */
+export type HostnameResolver = (hostname: string) => Promise<string[]>;
+
+/** Serializable navigation-guard policy. Plain data: crosses worker boundaries. */
+export interface NavigationGuardPolicy {
+	/** Relax the ordinary private ranges (never the always-blocked metadata floor). */
+	readonly allowPrivateUrls?: boolean;
+	/**
+	 * Explicit host allowlist: exact hostnames, `*.suffix` wildcards, IP
+	 * literals, or CIDR prefixes. Populated ONLY from configuration (settings
+	 * keys or an endpoint the user configured) — never derived from page content.
+	 */
+	readonly privateUrlAllowlist?: readonly string[];
+	/**
+	 * Internal-only exemption for first-party Chromium document rendering
+	 * (read-pdf hands a local file:// to the built-in PDF viewer). Set by a
+	 * call site in the harness, never by settings, env, or page content.
+	 */
+	readonly allowFileUrls?: boolean;
+	/** Injectable DNS resolver (tests, sandboxes). Defaults to `node:dns`. */
+	readonly lookup?: HostnameResolver;
+}
+
+export type NavigationVerdict =
+	| { readonly allow: true }
+	| {
+			readonly allow: false;
+			readonly code: "file" | "scheme" | "metadata" | "private" | "secret-url" | "dns" | "malformed";
+			readonly target: string;
+			readonly hostname?: string;
+			readonly detail?: string;
+	  };
+
+const PROXY_ENV_VARS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"] as const;
+
+/** Cloud metadata hostnames blocked without any DNS lookup (url_safety.py:166-169). */
+const ALWAYS_BLOCKED_HOSTNAMES: Record<string, true> = {
+	"metadata.google.internal": true,
+	"metadata.goog": true,
+};
+
+/**
+ * Obvious-private name classes: no DNS round-trip needed to know they are
+ * internal-only (browser_tool.py:1427-1430). Unlike the metadata floor these
+ * relax through explicit config.
+ */
+const PRIVATE_HOST_SUFFIXES = [".localhost", ".lan", ".local", ".internal", ".home.arpa"] as const;
+
+function ip4(dotted: string): number {
+	let value = 0;
+	for (const part of dotted.split(".")) value = value * 256 + Number.parseInt(part, 10);
+	return value >>> 0;
+}
+
+/**
+ * The always-blocked metadata floor as IPv4 addresses (url_safety.py:180-188).
+ * `::ffff:`-mapped spellings are unwrapped before this check, so one list
+ * covers both (hermes lists them separately; the unwrap is the omp delta).
+ */
+const ALWAYS_BLOCKED_V4_EXACT: readonly number[] = [
+	ip4("169.254.169.254"), // AWS/GCP/Azure/DO/Oracle instance metadata
+	ip4("169.254.170.2"), // AWS ECS task metadata (task IAM creds)
+	ip4("169.254.169.253"), // Azure IMDS wire server
+	ip4("100.100.100.200"), // Alibaba Cloud metadata
+];
+
+/** IPv4 CIDRs blocked even under every relaxation (:192-195). */
+const ALWAYS_BLOCKED_V4_NETWORKS: readonly [number, number][] = [[ip4("169.254.0.0"), 16]];
+
+/** Always-blocked IPv6 literals (only meaningful as pure-v6 addresses). */
+const ALWAYS_BLOCKED_V6_TEXT: readonly string[] = ["fd00:ec2::254"]; // AWS metadata (IPv6)
+
+/** Private/loopback/link-local/reserved/multicast IPv4 CIDRs (:289-308 + Python is_private table). */
+const PRIVATE_V4_NETWORKS: readonly [number, number][] = [
+	[ip4("0.0.0.0"), 8], // "this host"
+	[ip4("10.0.0.0"), 8],
+	[ip4("100.64.0.0"), 10], // CGNAT (RFC 6598) — not covered by Python is_private
+	[ip4("127.0.0.0"), 8],
+	[ip4("169.254.0.0"), 16],
+	[ip4("172.16.0.0"), 12],
+	[ip4("192.0.0.0"), 24],
+	[ip4("192.0.2.0"), 24], // TEST-NET-1
+	[ip4("192.88.99.0"), 24], // 6to4 relay anycast
+	[ip4("192.168.0.0"), 16],
+	[ip4("198.18.0.0"), 15], // benchmarking
+	[ip4("198.51.100.0"), 24], // TEST-NET-2
+	[ip4("203.0.113.0"), 24], // TEST-NET-3
+	[ip4("224.0.0.0"), 4], // multicast
+	[ip4("240.0.0.0"), 4], // reserved + broadcast
+];
+
+function bytesFromHex(hex: string): Uint8Array {
+	const bytes = new Uint8Array(16);
+	let group = 0;
+	for (let i = 0; i < hex.length; i += 4) {
+		const value = Number.parseInt(hex.slice(i, i + 4), 16);
+		bytes[group * 2] = value >> 8;
+		bytes[group * 2 + 1] = value & 0xff;
+		group++;
+	}
+	return bytes;
+}
+
+/** Private/loopback/link-local/ULA/multicast IPv6 prefixes (Python is_private/is_loopback/is_link_local/is_reserved/is_multicast). */
+const PRIVATE_V6_NETWORKS: readonly [Uint8Array, number][] = [
+	[bytesFromHex("00000000000000000000000000000000"), 128], // unspecified ::
+	[bytesFromHex("00000000000000000000000000000001"), 128], // loopback ::1
+	[bytesFromHex("0064ff9b000000000000000000000000"), 96], // NAT64 well-known prefix — reaches v4 destinations
+	[bytesFromHex("01000000000000000000000000000000"), 64], // discard-only 100::/64
+	[bytesFromHex("fc000000000000000000000000000000"), 7], // unique local fc00::/7
+	[bytesFromHex("fe800000000000000000000000000000"), 10], // link-local fe80::/10
+	[bytesFromHex("ff000000000000000000000000000000"), 12], // multicast ff00::/12
+	[bytesFromHex("20010db8000000000000000000000000"), 32], // documentation 2001:db8::/32
+];
+
+/** Parse an IPv4 dotted-quad to a 32-bit number, or `undefined` when not IPv4. */
+function parseIpv4(host: string): number | undefined {
+	const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+	if (!match) return undefined;
+	let value = 0;
+	for (let i = 1; i <= 4; i++) {
+		const octet = Number(match[i]);
+		if (octet > 255) return undefined;
+		value = value * 256 + octet;
+	}
+	return value >>> 0;
+}
+
+/**
+ * Parse an IPv6 address (with optional brackets, `%zone`, and embedded IPv4)
+ * into 16 bytes, or `undefined` when the host is not a valid IPv6 literal.
+ */
+function parseIpv6(host: string): Uint8Array | undefined {
+	let text = host;
+	if (text.startsWith("[") && text.endsWith("]")) text = text.slice(1, -1);
+	const zone = text.indexOf("%");
+	if (zone !== -1) text = text.slice(0, zone); // scope id (fe80::1%eth0)
+	if (!text.includes(":")) return undefined;
+	const halves = text.split("::");
+	if (halves.length > 2) return undefined;
+	const parseGroups = (part: string): number[] | undefined => {
+		if (part.length === 0) return [];
+		const groups: number[] = [];
+		for (const token of part.split(":")) {
+			if (token.includes(".")) {
+				const embedded = parseIpv4(token);
+				if (embedded === undefined) return undefined;
+				groups.push((embedded >>> 16) & 0xffff, embedded & 0xffff);
+			} else {
+				if (!/^[0-9a-fA-F]{1,4}$/.test(token)) return undefined;
+				groups.push(Number.parseInt(token, 16));
+			}
+		}
+		return groups;
+	};
+	if (halves.length === 2) {
+		const [headText, tailText] = halves as [string, string];
+		const head = parseGroups(headText);
+		const tail = parseGroups(tailText);
+		if (!head || !tail) return undefined;
+		const fill = 8 - head.length - tail.length;
+		if (fill < 0) return undefined;
+		return groupsToBytes([...head, ...new Array<number>(fill).fill(0), ...tail]);
+	}
+	const groups = parseGroups(halves[0] ?? "");
+	if (!groups || groups.length !== 8) return undefined;
+	return groupsToBytes(groups);
+}
+
+function groupsToBytes(groups: readonly number[]): Uint8Array {
+	const bytes = new Uint8Array(16);
+	for (let i = 0; i < 8; i++) {
+		const group = groups[i] ?? 0;
+		bytes[i * 2] = group >> 8;
+		bytes[i * 2 + 1] = group & 0xff;
+	}
+	return bytes;
+}
+
+function inCidr4(value: number, base: number, bits: number): boolean {
+	const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+	return (value & mask) >>> 0 === (base & mask) >>> 0;
+}
+
+function inCidrs4(value: number, cidrs: readonly [number, number][]): boolean {
+	for (const [base, bits] of cidrs) if (inCidr4(value, base, bits)) return true;
+	return false;
+}
+
+function inCidr6(bytes: Uint8Array, base: Uint8Array, bits: number): boolean {
+	for (let i = 0; i < 16; i++) {
+		const remaining = bits - i * 8;
+		if (remaining <= 0) return true;
+		const mask = remaining >= 8 ? 0xff : (0xff << (8 - remaining)) & 0xff;
+		if (((bytes[i] ?? 0) & mask) !== ((base[i] ?? 0) & mask)) return false;
+	}
+	return true;
+}
+
+function inCidrs6(bytes: Uint8Array, cidrs: readonly [Uint8Array, number][]): boolean {
+	for (const [base, bits] of cidrs) if (inCidr6(bytes, base, bits)) return true;
+	return false;
+}
+
+/** Extract the embedded IPv4 of `::ffff:a.b.c.d` / `::a.b.c.d` forms. */
+function embeddedV4(bytes: Uint8Array): number | undefined {
+	for (let i = 0; i < 10; i++) if (bytes[i] !== 0) return undefined;
+	const mapped = (bytes[10] ?? 0) === 0xff && (bytes[11] ?? 0) === 0xff;
+	const compatible = (bytes[10] ?? 0) === 0 && (bytes[11] ?? 0) === 0;
+	if (!mapped && !compatible) return undefined;
+	return ((bytes[12] ?? 0) * 16777216 + (bytes[13] ?? 0) * 65536 + (bytes[14] ?? 0) * 256 + (bytes[15] ?? 0)) >>> 0;
+}
+
+/** 2002::/16 (6to4) carries an IPv4 in bytes 2..5. */
+function sixToFourV4(bytes: Uint8Array): number | undefined {
+	if (bytes[0] !== 0x20 || bytes[1] !== 0x02) return undefined;
+	return ((bytes[2] ?? 0) * 16777216 + (bytes[3] ?? 0) * 65536 + (bytes[4] ?? 0) * 256 + (bytes[5] ?? 0)) >>> 0;
+}
+
+function alwaysBlockedV4(value: number): boolean {
+	if (ALWAYS_BLOCKED_V4_EXACT.includes(value)) return true;
+	return inCidrs4(value, ALWAYS_BLOCKED_V4_NETWORKS);
+}
+
+/**
+ * Classify one IP literal. `::ffff:`-mapped, IPv4-compatible, and 6to4
+ * (2002::/16) forms are unwrapped so an IPv6 spelling of a blocked IPv4
+ * address cannot smuggle past the checks (url_safety.py:291-298 lists the
+ * mapped variants explicitly). An unparseable literal reports
+ * private+alwaysBlocked: fail closed.
+ */
+export function classifyIpAddress(ip: string): {
+	readonly kind: "v4" | "v6";
+	readonly private: boolean;
+	readonly alwaysBlocked: boolean;
+} {
+	const normalized = stripBrackets(ip);
+	const v4 = parseIpv4(normalized);
+	if (v4 !== undefined) {
+		return {
+			kind: "v4",
+			private: inCidrs4(v4, PRIVATE_V4_NETWORKS),
+			alwaysBlocked: alwaysBlockedV4(v4),
+		};
+	}
+	const v6 = parseIpv6(normalized);
+	if (!v6) return { kind: "v6", private: true, alwaysBlocked: true };
+	const embedded = embeddedV4(v6) ?? sixToFourV4(v6);
+	if (embedded !== undefined) {
+		// `::ffff:x.x.x.x` / `::x.x.x.x` / `2002:x.x.x.x.*`: judged by the
+		// embedded IPv4 — incl. the mapped link-local metadata floor
+		// (`::ffff:169.254.0.0/112` in hermes terms).
+		return {
+			kind: "v6",
+			private: inCidrs4(embedded, PRIVATE_V4_NETWORKS),
+			alwaysBlocked: alwaysBlockedV4(embedded),
+		};
+	}
+	return {
+		kind: "v6",
+		private: inCidrs6(v6, PRIVATE_V6_NETWORKS),
+		alwaysBlocked: ALWAYS_BLOCKED_V6_TEXT.some(literal => {
+			const base = parseIpv6(literal);
+			return !!base && bytesToHexGroupText(v6) === bytesToHexGroupText(base);
+		}),
+	};
+}
+
+function bytesToHexGroupText(bytes: Uint8Array): string {
+	let out = "";
+	for (let i = 0; i < 16; i += 2)
+		out += ((((bytes[i] ?? 0) << 8) | (bytes[i + 1] ?? 0)) >>> 0).toString(16).padStart(4, "0");
+	return out;
+}
+
+function stripBrackets(host: string): string {
+	let text = host;
+	if (text.startsWith("[") && text.endsWith("]")) text = text.slice(1, -1);
+	const zone = text.indexOf("%");
+	return zone === -1 ? text : text.slice(0, zone);
+}
+
+/** Split `host:port` (bracket-aware) into canonical lowercase host + port. */
+function splitHostPort(input: string): { hostname: string; port: string } {
+	const text = input.trim();
+	if (text.startsWith("[")) {
+		const end = text.indexOf("]");
+		if (end === -1) return { hostname: text.toLowerCase(), port: "" };
+		const rest = text.slice(end + 1);
+		return { hostname: text.slice(0, end + 1).toLowerCase(), port: rest.startsWith(":") ? rest.slice(1) : "" };
+	}
+	const colon = text.indexOf(":");
+	if (colon !== -1 && text.indexOf(":", colon + 1) === -1) {
+		return { hostname: text.slice(0, colon).toLowerCase(), port: text.slice(colon + 1) };
+	}
+	return { hostname: text.toLowerCase(), port: "" };
+}
+
+function normalizeHostname(hostname: string): string {
+	return hostname.toLowerCase().replace(/\.+$/, "");
+}
+
+/**
+ * Match a normalized hostname (and optional `host:port`) against an explicit
+ * allowlist entry: exact hostname, exact `host:port`, `*.suffix` wildcard,
+ * bare IP literal, or CIDR prefix. Entries come from configuration only.
+ */
+export function matchesAllowlistEntry(hostname: string, port: string, entry: string): boolean {
+	const normalized = entry.trim().toLowerCase().replace(/\.+$/, "");
+	if (!normalized) return false;
+	if (normalized.includes("/")) {
+		const [baseText, bitsText] = normalized.split("/");
+		const bits = Number.parseInt(bitsText ?? "", 10);
+		if (!Number.isFinite(bits)) return false;
+		const base4 = baseText !== undefined ? parseIpv4(baseText) : undefined;
+		if (base4 !== undefined) {
+			const host4 = parseIpv4(hostname);
+			return host4 !== undefined && inCidr4(host4, base4, bits);
+		}
+		const base6 = baseText !== undefined ? parseIpv6(baseText) : undefined;
+		const host6 = parseIpv6(hostname);
+		return !!base6 && !!host6 && inCidr6(host6, base6, bits);
+	}
+	if (normalized.startsWith("*.")) {
+		const suffix = normalized.slice(2);
+		return hostname === suffix || hostname.endsWith(`.${suffix}`);
+	}
+	const { hostname: entryHost, port: entryPort } = splitHostPort(normalized);
+	if (entryPort && entryPort !== port) return false;
+	return normalizeHostname(entryHost) === hostname;
+}
+
+function proxyIsConfigured(): boolean {
+	for (const name of PROXY_ENV_VARS) if (process.env[name]) return true;
+	return false;
+}
+
+/** Default resolver: every `node:dns` answer, mirroring hermes' getaddrinfo loop. */
+const dnsResolver: HostnameResolver = async hostname => {
+	const answers = await nodeDns.lookup(hostname, { all: true, verbatim: true });
+	return answers.map(answer => answer.address);
+};
+
+/** `localhost`, `app.localhost`, `printer.lan`, … — internal by name alone. */
+function hostnameIsPrivateByName(hostname: string): boolean {
+	if (hostname === "localhost") return true;
+	for (const suffix of PRIVATE_HOST_SUFFIXES) if (hostname.endsWith(suffix)) return true;
+	return false;
+}
+
+type ParsedTarget =
+	| {
+			readonly kind: "host";
+			readonly scheme: "http" | "https";
+			readonly hostname: string;
+			readonly port: string;
+			readonly ipText?: string;
+	  }
+	| { readonly kind: "opaque"; readonly scheme: string };
+
+/**
+ * Parse + normalize a navigation target. WHATWG URL normalization is the first
+ * bypass layer: numeric host forms, punycode, case folding and trailing dots
+ * all canonicalize before any range check runs. Only http/https ever come back
+ * as `host` targets — every other scheme (chrome:, view-source:, ws:, ftp:,
+ * even a host-carrying `chrome://settings`) is classified opaquely so the
+ * scheme rule cannot be bypassed by a scheme Chromium parses specially.
+ */
+function parseTarget(raw: string): ParsedTarget | undefined {
+	let text = raw.trim();
+	if (!text) return undefined;
+	// Repair the "https:// host.example" artifact hermes fixes the same way
+	// (url_safety.py:74-79): whitespace after the scheme separator is never legal.
+	text = text.replace(/^([A-Za-z][A-Za-z0-9+.-]*:\/\/)\s+/, "$1");
+	let url: URL;
+	try {
+		url = new URL(text);
+	} catch {
+		// Scheme-less strings ("example.com/page") get the same interpretation
+		// Chromium gives them: as https. A string that already carries a scheme
+		// and still fails to parse stays malformed — fail closed. (IPv6 zone
+		// ids like `http://[fe80::1%eth0]/` land here: WHATWG rejects them and
+		// so does Chromium's URL pipeline for CDP-driven navigation, so
+		// blocking is the honest verdict.)
+		if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(text)) return undefined;
+		try {
+			url = new URL(`https://${text}`);
+		} catch {
+			return undefined;
+		}
+	}
+	const scheme = url.protocol.replace(/:$/, "").toLowerCase();
+	if (scheme !== "http" && scheme !== "https") return { kind: "opaque", scheme };
+	if (!url.hostname) return undefined; // `http://` with no host
+	const hostname = normalizeHostname(url.hostname);
+	const bare = stripBrackets(hostname);
+	let ipText: string | undefined;
+	if (parseIpv4(bare) !== undefined || parseIpv6(bare) !== undefined) ipText = bare;
+	return { kind: "host", scheme, hostname, port: url.port, ipText };
+}
+
+/**
+ * The guard entry point: classify one navigation target against `policy`.
+ * Fails closed on every error path (see module header).
+ */
+export async function checkNavigationTarget(raw: string, policy: NavigationGuardPolicy = {}): Promise<NavigationVerdict> {
+	try {
+		if (containsSecretTokenShape(raw) || containsSecretTokenShape(safeDecode(raw))) {
+			return { allow: false, code: "secret-url", target: raw, detail: "URL carries a credential-shaped token" };
+		}
+		const parsed = parseTarget(raw);
+		if (!parsed) return { allow: false, code: "malformed", target: raw };
+		if (parsed.kind === "opaque") {
+			if (parsed.scheme === "about") return { allow: true };
+			if (parsed.scheme === "file")
+				return policy.allowFileUrls ? { allow: true } : { allow: false, code: "file", target: raw };
+			return { allow: false, code: "scheme", target: raw, detail: parsed.scheme };
+		}
+		const hostname = parsed.hostname;
+		// Metadata hostnames: always-blocked floor, no DNS, survives every toggle
+		// and the allowlist.
+		if (ALWAYS_BLOCKED_HOSTNAMES[hostname] === true) {
+			return { allow: false, code: "metadata", target: raw, hostname };
+		}
+		// Literal IPs: the metadata floor is judged BEFORE any relaxation.
+		if (parsed.ipText) {
+			const classification = classifyIpAddress(parsed.ipText);
+			if (classification.alwaysBlocked) return { allow: false, code: "metadata", target: raw, hostname };
+			if (policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy)) return { allow: true };
+			if (classification.private) return { allow: false, code: "private", target: raw, hostname };
+			return { allow: true };
+		}
+		const privateByName = hostnameIsPrivateByName(hostname);
+		const relaxed = policy.allowPrivateUrls === true || isAllowlisted(hostname, parsed.port, policy);
+		// Obvious-private names need no DNS round-trip to know they are internal
+		// (browser_tool.py:1427-1430) — but under relaxation they still fall
+		// through to resolution + floor check below, because hermes enforces the
+		// metadata floor on the RESOLVED address even with the toggle on
+		// (url_safety.py:488): `api.dev.local -> 169.254.169.254` stays blocked.
+		if (privateByName && !relaxed) {
+			return { allow: false, code: "private", target: raw, hostname };
+		}
+
+		// Resolved-IP classification (also under relaxation, hermes
+		// url_safety.py:410-413: a safe-listed name resolving into the
+		// always-blocked range stays blocked; under `allowPrivateUrls` only the
+		// floor is enforced).
+		const resolver = policy.lookup ?? dnsResolver;
+		let answers: string[];
+		try {
+			answers = await resolver(hostname);
+		} catch {
+			// hermes is_safe_url:448-474 — fail closed, except the
+			// proxy-delegation carve-out (the proxy resolves the name).
+			if (proxyIsConfigured()) return { allow: true };
+			return { allow: false, code: "dns", target: raw, hostname, detail: "DNS resolution failed" };
+		}
+		if (!answers.length) {
+			if (relaxed) return { allow: true };
+			return { allow: false, code: "dns", target: raw, hostname, detail: "no DNS answers" };
+		}
+		for (const answer of answers) {
+			const address = answer.includes("%") ? (answer.split("%")[0] ?? answer) : answer;
+			const classification = classifyIpAddress(address);
+			if (classification.alwaysBlocked) return { allow: false, code: "metadata", target: raw, hostname };
+			if (relaxed) continue;
+			if (classification.private) return { allow: false, code: "private", target: raw, hostname };
+		}
+		return { allow: true };
+	} catch (error) {
+		// Fail closed on unexpected errors — parsing edge cases must not become
+		// bypass vectors (url_safety.py:515-519).
+		return { allow: false, code: "malformed", target: raw, detail: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function isAllowlisted(hostname: string, port: string, policy: NavigationGuardPolicy): boolean {
+	return (policy.privateUrlAllowlist ?? []).some(entry => matchesAllowlistEntry(hostname, port, entry));
+}
+
+function safeDecode(text: string): string {
+	let current = text;
+	for (let i = 0; i < 3; i++) {
+		try {
+			const next = decodeURIComponent(current);
+			if (next === current) break;
+			current = next;
+		} catch {
+			break;
+		}
+	}
+	return current;
+}
+
+/**
+ * Cheap, DNS-free classification of an already-committed URL — the
+ * post-navigation recheck seam. Literal IPs and the always-blocked hostname
+ * set are classified exactly, plus the private-by-name classes. Returns false
+ * for hostnames that would need a resolver (the async pre-check owns that
+ * path) and for malformed input (a committed `page.url()` is already
+ * normalized by Chromium; a parse failure here is not a metadata endpoint).
+ */
+export function isAlwaysBlockedNavigationTarget(url: string): boolean {
+	const parsed = parseTarget(url);
+	if (!parsed || parsed.kind !== "host") return false;
+	if (ALWAYS_BLOCKED_HOSTNAMES[parsed.hostname] === true) return true;
+	if (parsed.ipText) return classifyIpAddress(parsed.ipText).alwaysBlocked;
+	return hostnameIsPrivateByName(parsed.hostname);
+}
+
+/**
+ * Policy-aware, DNS-free check of an ALREADY-COMMITTED navigation (redirect /
+ * client-side nav / new-tab adoption): true = the page landed somewhere it
+ * must not show the model. Same ordering as the async pre-check minus
+ * resolution: the metadata floor survives every relaxation; ordinary private
+ * ranges and private-by-name hosts block unless `allowPrivateUrls` or an
+ * allowlist entry covers them; hostnames that would need DNS are allowed
+ * here (the pre-check already vetted them; re-resolving per commit would
+ * multiply DNS traffic on redirect chains). Non-http(s) commits (`file:`,
+ * `chrome:`) violate unless internally exempted by `allowFileUrls`.
+ */
+export function isBlockedCommittedNavigation(url: string, policy: NavigationGuardPolicy = {}): boolean {
+	const parsed = parseTarget(url);
+	if (!parsed) return false; // Chromium-normalized URLs parse; unparseable is not a private target
+	if (parsed.kind === "opaque") {
+		if (parsed.scheme === "about") return false;
+		if (parsed.scheme === "file") return policy.allowFileUrls !== true;
+		return true;
+	}
+	if (ALWAYS_BLOCKED_HOSTNAMES[parsed.hostname] === true) return true;
+	const relaxed = policy.allowPrivateUrls === true || isAllowlisted(parsed.hostname, parsed.port, policy);
+	if (parsed.ipText) {
+		const classification = classifyIpAddress(parsed.ipText);
+		if (classification.alwaysBlocked) return true;
+		return !relaxed && classification.private;
+	}
+	if (relaxed) return false;
+	return hostnameIsPrivateByName(parsed.hostname);
+}
+
+/** Model-facing explanation with the exact remediation for a blocked verdict. */
+export function navigationBlockedMessage(verdict: NavigationVerdict): string {
+	if (verdict.allow) return "";
+	switch (verdict.code) {
+		case "file":
+			return `Blocked: navigating to ${JSON.stringify(verdict.target)} uses file://, which the browser tool does not allow. Serve the content over http(s) or open it with the read tool instead.`;
+		case "scheme":
+			return `Blocked: the ${JSON.stringify(verdict.detail ?? "")} scheme is not allowed for browser navigation (http/https only).`;
+		case "metadata":
+			return `Blocked: ${JSON.stringify(verdict.hostname ?? verdict.target)} is a cloud metadata endpoint and is never navigable.`;
+		case "private":
+			return `Blocked: ${JSON.stringify(verdict.hostname ?? verdict.target)} is a private/internal address${verdict.detail ? ` (${verdict.detail})` : ""}. To allow specific hosts, set browser.privateUrlAllowlist (e.g. ["localhost", "127.0.0.1", "*.dev.local"]); to relax the whole range, set browser.allowPrivateUrls: true. Cloud metadata endpoints stay blocked either way.`;
+		case "secret-url":
+			return "Blocked: URL contains what appears to be an API key or token. Secrets must not be sent in URLs.";
+		case "dns":
+			return `Blocked: ${JSON.stringify(verdict.hostname ?? verdict.target)} could not be resolved (${verdict.detail ?? "DNS error"}); navigation fails closed.`;
+		case "malformed":
+			return `Blocked: ${JSON.stringify(verdict.target)} is not a navigable URL${verdict.detail ? ` (${verdict.detail})` : ""}.`;
+	}
+}
+
+/**
+ * Resolve the navigation policy from explicit configuration. Called on the
+ * main thread where ToolSession lives; the result is plain serializable data
+ * that crosses into the tab worker with every run/message.
+ *
+ * `configuredEndpointUrls` is the "explicit relay allow" of the port
+ * contract: a relay/CDP endpoint host the *user configured themselves*
+ * (`browser.relayUrl`, `browser.cdpUrl`, `app.cdp_url`) joins the allowlist,
+ * mirroring how hermes exempts its own sidecar from the blocked target set.
+ * It is read from settings only — never from page content.
+ */
+export function resolveNavigationPolicy(input: {
+	readonly allowPrivateUrlsSetting?: unknown;
+	readonly allowlistSetting?: unknown;
+	readonly configuredEndpointUrls?: readonly (string | undefined)[];
+	readonly allowFileUrls?: boolean;
+	readonly env?: Record<string, string | undefined>;
+	readonly lookup?: HostnameResolver;
+}): NavigationGuardPolicy {
+	const env = input.env ?? process.env;
+	const allowPrivateUrls = parseEnvOverride(env.PI_BROWSER_ALLOW_PRIVATE_URLS) ?? truthy(input.allowPrivateUrlsSetting);
+	const allowlist = new Set<string>();
+	if (Array.isArray(input.allowlistSetting)) {
+		for (const entry of input.allowlistSetting) {
+			if (typeof entry === "string" && entry.trim()) allowlist.add(entry.trim().toLowerCase());
+		}
+	}
+	for (const endpoint of input.configuredEndpointUrls ?? []) {
+		const host = endpointHostname(endpoint);
+		if (host) allowlist.add(host);
+	}
+	return {
+		allowPrivateUrls,
+		privateUrlAllowlist: [...allowlist],
+		allowFileUrls: input.allowFileUrls === true,
+		lookup: input.lookup,
+	};
+}
+
+function parseEnvOverride(value: string | undefined): boolean | undefined {
+	const text = value?.trim().toLowerCase();
+	if (!text) return undefined;
+	if (text === "1" || text === "true" || text === "yes" || text === "on") return true;
+	if (text === "0" || text === "false" || text === "no" || text === "off") return false;
+	return undefined;
+}
+
+function truthy(value: unknown): boolean {
+	return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function endpointHostname(endpoint: string | undefined): string | undefined {
+	const text = endpoint?.trim();
+	if (!text) return undefined;
+	try {
+		return normalizeHostname(new URL(text).hostname);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Materialize the serializable cross-boundary settings (`tab-protocol`
+ * `NavigationGuardSettings`) into the full guard policy. Main-thread callers
+ * (supervisor pre-flight) and worker callers share this conversion; the
+ * resolver seam (`lookup`) never crosses the worker boundary.
+ */
+export function policyFromSettings(
+	settings:
+		| {
+				readonly allowPrivateUrls?: boolean;
+				readonly privateUrlAllowlist?: readonly string[];
+				readonly allowFileUrls?: boolean;
+		  }
+		| undefined,
+): NavigationGuardPolicy {
+	if (!settings) return {};
+	return {
+		allowPrivateUrls: settings.allowPrivateUrls === true,
+		privateUrlAllowlist: settings.privateUrlAllowlist,
+		allowFileUrls: settings.allowFileUrls === true,
+	};
+}

--- a/packages/coding-agent/src/tools/read-pdf.ts
+++ b/packages/coding-agent/src/tools/read-pdf.ts
@@ -109,6 +109,10 @@ export async function renderPdfPageScreenshot(
 				url: url.href,
 				waitUntil: "load",
 				timeoutMs: PDF_RENDER_TIMEOUT_MS,
+				// Internal call-site exemption: the renderer hands a local
+				// file:// to Chromium's built-in PDF viewer. Never settings- or
+				// page-driven; private/metadata ranges stay blocked.
+				navigation: { allowFileUrls: true },
 				deadlineStartMs: deadlineStart,
 				signal: renderSignal,
 				ownerSessionId: session.getSessionId?.() ?? undefined,

--- a/packages/coding-agent/test/tools/browser-output-redact.test.ts
+++ b/packages/coding-agent/test/tools/browser-output-redact.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Browser-output redaction pass: ported from hermes-agent
+ * (`agent/redact.py`), MIT, Copyright (c) 2025 Nous Research.
+ * See src/tools/browser/NOTICE.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	containsSecretTokenShape,
+	keyHasSecretKeyword,
+	redactBrowserOutput,
+	redactBrowserText,
+} from "../../src/tools/browser/output-redact";
+
+describe("browser-output redaction: secret shapes", () => {
+	it("masks API key env assignments (sk-…)", () => {
+		expect(redactBrowserText("key: OPENAI_API_KEY=sk-proj-abcdef1234567890ZZZZ more")).toBe(
+			"key: OPENAI_API_KEY=*** more",
+		);
+	});
+
+	it("masks GitHub PATs, bearer tokens and API-key headers", () => {
+		expect(redactBrowserText("console log says ghp_ABCDEFGHIJKLMNOPQRST1234 done")).toBe(
+			"console log says ghp_AB...1234 done",
+		);
+		expect(redactBrowserText("Authorization: Bearer sk-reallylongtoken-abcdefghij")).toBe(
+			"Authorization: Bearer ***",
+		);
+		expect(redactBrowserText("x-api-key: abcdefghijklmnopqrstuvwxyz")).toBe("x-api-key: ***");
+	});
+
+	it("masks cookies and password fields / form params", () => {
+		expect(redactBrowserText("Cookie: sessionid=abc123def456ghi789jkl")).toBe("Cookie: sessio...9jkl");
+		expect(redactBrowserText("password: Sup3rS3cretValueHere!")).toBe("password: Sup3rS...ere!");
+		expect(redactBrowserText("username=alice&password=CorrectHorseBatteryStaple1&csrf=xyz")).toBe(
+			"username=alice&password=***&csrf=xyz",
+		);
+	});
+
+	it("masks JWTs and PEM private-key blocks", () => {
+		expect(
+			redactBrowserText("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNpyP"),
+		).toBe("eyJhbG...NpyP");
+		expect(redactBrowserText("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----")).toBe(
+			"[REDACTED PRIVATE KEY]",
+		);
+	});
+
+	it("masks embedded JSON apiKey values", () => {
+		expect(redactBrowserText('{"apiKey": "sk-test-abcdef123456"}')).toBe('{"apiKey": "***"}');
+	});
+
+	it("masks userinfo in URLs", () => {
+		expect(redactBrowserText("https://user:hunter2passw0rd99@api.example.com/v1")).toBe(
+			"https://user:***@api.example.com/v1",
+		);
+		expect(redactBrowserText("postgresql://app:SuperSecretDbPass@db.internal:5432/prod")).toBe(
+			"postgresql://app:***@db.internal:5432/prod",
+		);
+	});
+
+	it("leaves non-secret text and public URLs untouched", () => {
+		expect(redactBrowserText('- heading "Status"')).toBe('- heading "Status"');
+		expect(redactBrowserText("https://example.com/cb?code=ABC123&state=xyz")).toBe(
+			"https://example.com/cb?code=ABC123&state=xyz",
+		);
+		expect(redactBrowserText("Secretary: J.Smith")).toBe("Secretary: J.Smith");
+	});
+});
+
+describe("browser-output redaction: keyword + shape gates", () => {
+	it("flags secret-bearing keys but not lookalike words", () => {
+		expect(keyHasSecretKeyword("Secretary")).toBe(false);
+		expect(keyHasSecretKeyword("clientSecret")).toBe(true);
+		expect(keyHasSecretKeyword("MYTOKEN")).toBe(false);
+		expect(keyHasSecretKeyword("KEYBOARD")).toBe(false);
+	});
+
+	it("detects secret-token shapes inside URLs", () => {
+		expect(containsSecretTokenShape("https://x.dev/?k=sk-proj-abcdef1234567890")).toBe(true);
+	});
+});
+
+describe("browser-output redaction: recursive + integration", () => {
+	it("recurses through objects/arrays but preserves non-strings", () => {
+		const result = redactBrowserOutput({
+			a: ["ghp_ABCDEFGHIJKLMNOPQRST1234", 5],
+			b: { c: null },
+			d: new Date(0),
+		});
+		expect(result.a[0]).toBe("ghp_AB...1234");
+		expect(result.a[1]).toBe(5);
+		expect(result.b).toEqual({ c: null });
+		expect(result.d).toBeInstanceOf(Date);
+	});
+
+	it("masks a nested secret inside an ARIA-snapshot-shaped object", () => {
+		// Mirrors the observe() snapshot reaching the model (contract item 2).
+		const snapshot = {
+			url: "https://example.com/",
+			title: "Acme",
+			elements: [{ id: 1, role: "textbox", name: "api_key", value: "sk-proj-abcdef1234567890ZZ" }],
+		};
+		const redacted = redactBrowserOutput(snapshot);
+		// Bare token values (no key= context) get partial shape-masking, never
+		// the full secret.
+		expect(redacted.elements[0].value).toContain("...");
+		expect(redacted.elements[0].value).not.toContain("abcdef1234567890ZZ");
+		expect(redacted.url).toBe("https://example.com/");
+	});
+});

--- a/packages/coding-agent/test/tools/browser-output-redact.test.ts
+++ b/packages/coding-agent/test/tools/browser-output-redact.test.ts
@@ -86,7 +86,7 @@ describe("browser-output redaction: recursive + integration", () => {
 			a: ["ghp_ABCDEFGHIJKLMNOPQRST1234", 5],
 			b: { c: null },
 			d: new Date(0),
-		});
+		}) as { a: unknown[]; b: { c: null }; d: Date };
 		expect(result.a[0]).toBe("ghp_AB...1234");
 		expect(result.a[1]).toBe(5);
 		expect(result.b).toEqual({ c: null });
@@ -100,11 +100,92 @@ describe("browser-output redaction: recursive + integration", () => {
 			title: "Acme",
 			elements: [{ id: 1, role: "textbox", name: "api_key", value: "sk-proj-abcdef1234567890ZZ" }],
 		};
-		const redacted = redactBrowserOutput(snapshot);
+		const redacted = redactBrowserOutput(snapshot) as {
+			url: string;
+			title: string;
+			elements: { id: number; role: string; name: string; value: string }[];
+		};
 		// Bare token values (no key= context) get partial shape-masking, never
 		// the full secret.
 		expect(redacted.elements[0].value).toContain("...");
 		expect(redacted.elements[0].value).not.toContain("abcdef1234567890ZZ");
 		expect(redacted.url).toBe("https://example.com/");
+	});
+
+	it("collapses aliased objects into one redacted copy (no raw second reference)", () => {
+		const inner = { token: "ghp_ABCDEFGHIJKLMNOPQRST1234" };
+		const out = redactBrowserOutput({ a: inner, b: inner, list: [inner, inner] }) as {
+			a: { token: string };
+			b: { token: string };
+			list: { token: string }[];
+		};
+		expect(JSON.stringify(out)).not.toContain("ABCDEFGHIJKLMNOPQRST1234");
+		// Identity is preserved: every alias points at the SAME masked copy.
+		expect(out.b).toBe(out.a);
+		expect(out.list[0]).toBe(out.a);
+		expect(out.list[1]).toBe(out.a);
+		expect(out.a.token).toBe("ghp_AB...1234");
+	});
+
+	it("terminates a self-cycle against the redacted copy", () => {
+		const node: Record<string, unknown> = { secret: "ghp_ABCDEFGHIJKLMNOPQRST1234" };
+		node.self = node;
+		const out = redactBrowserOutput(node) as Record<string, unknown>;
+		// The cycle must point at the masked copy, never the raw original.
+		expect(out.self).toBe(out);
+		expect(out.secret).toBe("ghp_AB...1234");
+	});
+
+	it("masks a string value whose object key names a credential", () => {
+		// `{ api_key: "..." }` carries no `api_key=` text, so no assignment pass
+		// can see it — the key name is the only credential context.
+		const out = redactBrowserOutput({ api_key: "SuperSecretValue18", note: "SuperSecretValue18" }) as {
+			api_key: string;
+			note: string;
+		};
+		expect(out.api_key).toBe("SuperS...ue18");
+		// A neutral key is not masked by name (text passes still apply).
+		expect(out.note).toBe("SuperSecretValue18");
+	});
+
+	it("keeps env-lookup expressions intact under a secret key", () => {
+		const out = redactBrowserOutput({ token: "process.env.MY_TOKEN" }) as { token: string };
+		expect(out.token).toBe("process.env.MY_TOKEN");
+	});
+});
+
+describe("browser-output redaction: header/cookie family and gate edges", () => {
+	it("masks credential-bearing JSON fields beyond the api-key name list", () => {
+		expect(redactBrowserText('{"cookie": "sessionid=abcdefghijklmnop"}')).toBe('{"cookie": "sessio...mnop"}');
+		expect(redactBrowserText('{"set-cookie": "abc123def456ghi789jkl; HttpOnly"}')).not.toContain("abc123def456ghi789jkl");
+		expect(redactBrowserText('{"authorization": "Bearer abcdefghijklmnop1234"}')).not.toContain("abcdefghijklmnop1234");
+		expect(redactBrowserText('{"x-api-key": "abcdefABCDEF0123456789"}')).not.toContain("abcdefABCDEF0123456789");
+	});
+
+	it("masks a bare cookie-jar body but not URL query params", () => {
+		const jar = "sid=abcdefghijklmnop; csrf_token=zzzzzzzzzzzzzzzz1234";
+		const masked = redactBrowserText(jar);
+		expect(masked).not.toContain("abcdefghijklmnop");
+		expect(masked).not.toContain("zzzzzzzzzzzzzzzz1234");
+		// hermes parity: magic-link / OAuth query params round-trip.
+		expect(redactBrowserText("https://x.test/cb?state=abcdefghijklmnop&code=123")).toBe(
+			"https://x.test/cb?state=abcdefghijklmnop&code=123",
+		);
+	});
+
+	it("masks userinfo in a protocol-relative reference", () => {
+		expect(redactBrowserText("link //admin:hunter2pass@internal.example/x")).toContain(":***@");
+		expect(redactBrowserText("link //admin:hunter2pass@internal.example/x")).not.toContain("hunter2pass");
+	});
+
+	it("catches vendor prefixes split by control bytes inside the prefix itself", () => {
+		// zero-width space between `sk` and `-`: the substring pre-screen must
+		// run on a control-stripped copy or this token escapes entirely.
+		const split = `sk\u200b-proj-abcdef1234567890ZZ`;
+		expect(redactBrowserText(split)).not.toContain("abcdef1234567890ZZ");
+		// control inside the token body (already covered by hermes' pass)
+		expect(redactBrowserText("sk-proj-\u001babcdef1234567890ZZ")).not.toContain("abcdef1234567890ZZ");
+		// control at the very end, where the line guard could skip the span
+		expect(redactBrowserText(`sk-proj-abcdef1234567890ZZ\u200b`)).not.toContain("abcdef1234567890ZZ");
 	});
 });

--- a/packages/coding-agent/test/tools/browser-url-guard.test.ts
+++ b/packages/coding-agent/test/tools/browser-url-guard.test.ts
@@ -12,7 +12,9 @@ import {
 	classifyIpAddress,
 	isAlwaysBlockedNavigationTarget,
 	isBlockedCommittedNavigation,
+	matchesAllowlistEntry,
 	navigationBlockedMessage,
+	recheckCommittedNavigation,
 	resolveNavigationPolicy,
 } from "../../src/tools/browser/url-guard";
 
@@ -166,14 +168,48 @@ describe("navigation guard: DNS posture", () => {
 		expect(await verdict("http://empty.name/")).toBe("BLOCK:dns");
 	});
 
-	it("trusts proxy env for the DNS failure (hermes proxy parity)", async () => {
-		const previous = process.env.HTTPS_PROXY;
-		process.env.HTTPS_PROXY = "http://proxy:8080";
+	it("trusts the browser's own proxy for a DNS failure (hermes proxy parity)", async () => {
+		const previous = process.env.PUPPETEER_PROXY;
+		process.env.PUPPETEER_PROXY = "http://proxy:8080";
 		try {
 			expect(await verdict("http://fail.name/")).toBe("ALLOW");
 		} finally {
-			if (previous === undefined) delete process.env.HTTPS_PROXY;
-			else process.env.HTTPS_PROXY = previous;
+			if (previous === undefined) delete process.env.PUPPETEER_PROXY;
+			else process.env.PUPPETEER_PROXY = previous;
+		}
+	});
+
+	it("does not trust generic proxy vars: omp never routes the browser through them", async () => {
+		const saved = { https: process.env.HTTPS_PROXY, http: process.env.HTTP_PROXY, all: process.env.ALL_PROXY };
+		process.env.HTTPS_PROXY = "http://proxy:8080";
+		process.env.HTTP_PROXY = "http://proxy:8080";
+		process.env.ALL_PROXY = "http://proxy:8080";
+		try {
+			expect(await verdict("http://fail.name/")).toBe("BLOCK:dns");
+		} finally {
+			for (const [key, value] of Object.entries({ HTTPS_PROXY: saved.https, HTTP_PROXY: saved.http, ALL_PROXY: saved.all })) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
+	it("keeps failing closed for hosts NO_PROXY excludes from the proxy", async () => {
+		const saved = { proxy: process.env.PUPPETEER_PROXY, noProxy: process.env.NO_PROXY };
+		process.env.PUPPETEER_PROXY = "http://proxy:8080";
+		process.env.NO_PROXY = "other.example, fail.example";
+		try {
+			// fail.name is not in NO_PROXY: the proxy resolves it, so the
+			// carve-out applies...
+			expect(await verdict("http://fail.name/")).toBe("ALLOW");
+			// ...but a NO_PROXY-listed host resolves directly, so a local DNS
+			// failure is the browser's own failure: block.
+			expect(await verdict("http://fail.example/")).toBe("BLOCK:dns");
+		} finally {
+			if (saved.proxy === undefined) delete process.env.PUPPETEER_PROXY;
+			else process.env.PUPPETEER_PROXY = saved.proxy;
+			if (saved.noProxy === undefined) delete process.env.NO_PROXY;
+			else process.env.NO_PROXY = saved.noProxy;
 		}
 	});
 });
@@ -185,8 +221,11 @@ describe("navigation guard: explicit relaxation", () => {
 		expect(await verdict("http://127.0.0.1:9224/json", policy)).toBe("ALLOW");
 		// Wildcard match, then the resolved address decides (public here).
 		expect(await verdict("http://ok.dev.local/x", policy)).toBe("ALLOW");
-		// A wildcard entry relaxes the name class but never the resolved range…
+		// An allowlist entry relaxes the name class AND the ordinary private
+		// ranges for that host (deliberate: the entry is the explicit permission)
+		// but never the metadata floor.
 		expect(await verdict("http://lp.dev.local/x", { privateUrlAllowlist: ["*.dev.local"] })).toBe("ALLOW");
+		expect(await verdict("http://api.dev.local/x", { privateUrlAllowlist: ["*.dev.local"] })).toBe("BLOCK:metadata");
 	});
 
 	it("allowPrivateUrls relaxes ordinary private ranges but not the floor or file://", async () => {
@@ -235,6 +274,126 @@ describe("navigation guard: post-commit fast path (DNS-free)", () => {
 	});
 });
 
+describe("navigation guard: IPv4 smuggled inside IPv6 forms", () => {
+	it("unwraps NAT64 and Teredo to the embedded IPv4", async () => {
+		// 64:ff9b::/96 + a9fe a9fe == 169.254.169.254.
+		expect(await verdict("http://[64:ff9b::a9fe:a9fe]/")).toBe("BLOCK:metadata");
+		// An 8-digit hextet is not a valid IPv6 literal at all: malformed.
+		expect(await verdict("http://[64:ff9b::a9fea9fe]/")).toBe("BLOCK:malformed");
+		// 64:ff9b:1::/48 local-use form, IPv4 right after the 48-bit prefix and
+		// in the common trailing spelling.
+		expect(await verdict("http://[64:ff9b:1::a9fe:a9fe]/")).toBe("BLOCK:metadata");
+		expect(await verdict("http://[64:ff9b:1::7fa1:a9fe]/")).toBe("BLOCK:private");
+		// Teredo (`2001:0000::/32`) carries the inverted client IPv4 in bytes
+		// 4..7: ~a9 = 56, ~fe = 01 → 5601:5601 wraps 169.254.169.254.
+		expect(await verdict("http://[2001:0:5601:5601::1]/")).toBe("BLOCK:metadata");
+		// 2002::/16 (6to4) loopback.
+		expect(await verdict("http://[2002:c0a8:1::]/")).toBe("BLOCK:private");
+		// NAT64 carrying a genuinely public v4 stays allowed.
+		expect(await verdict("http://[64:ff9b::5d5d:5d5d]/")).toBe("ALLOW");
+	});
+
+	it("keeps the Oracle Cloud secondary IMDS address on the floor", async () => {
+		expect(await verdict("http://192.0.0.192/", { allowPrivateUrls: true })).toBe("BLOCK:metadata");
+		expect(await verdict("http://192.0.0.193/", { allowPrivateUrls: true })).toBe("ALLOW");
+	});
+});
+
+describe("navigation guard: presigned URLs and opaque committed schemes", () => {
+	it("does not treat a presigned signed query as an embedded secret", async () => {
+		const presigned =
+			"https://93.184.216.34/f.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+			"&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20240101%2Fus-east-1%2Fs3%2Faws4_request" +
+			"&X-Amz-Signature=1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd";
+		expect(await verdict(presigned)).toBe("ALLOW");
+		expect(await verdict("https://93.184.216.34/?Expires=1893456000&Signature=aK9%2Fz3QXcVb%3D")).toBe("ALLOW");
+		// A bare api-key-shaped query parameter is still refused.
+		expect(await verdict("https://x.test/?api_key=sk-proj-abcdef1234567890ZZ")).toBe("BLOCK:secret-url");
+	});
+
+	it("accepts browser-internal opaque schemes as committed targets", () => {
+		for (const url of [
+			"about:blank",
+			"chrome-error://chromewebdata/",
+			"blob:https://example.com/uuid",
+			"devtools://devtools/bundled/inspector.html",
+		]) {
+			expect(isBlockedCommittedNavigation(url), url).toBe(false);
+		}
+		// Schemes that can carry private content stay violations.
+		for (const url of ["data:text/html,hi", "filesystem:http://127.0.0.1/temporary/a", "view-source:http://10.0.0.5"]) {
+			expect(isBlockedCommittedNavigation(url), url).toBe(true);
+		}
+	});
+});
+
+describe("navigation guard: allowlist entry matching", () => {
+	it("normalizes brackets and scheme-default ports", () => {
+		expect(matchesAllowlistEntry("[::1]", "", "[::1]")).toBe(true);
+		expect(matchesAllowlistEntry("::1", "", "[::1]")).toBe(true);
+		// A port-less https target matches an entry that spells :443, and an
+		// http target matches :80 — but not the other scheme's default.
+		expect(matchesAllowlistEntry("localhost", "", "localhost:443", "https")).toBe(true);
+		expect(matchesAllowlistEntry("localhost", "", "localhost:80", "http")).toBe(true);
+		expect(matchesAllowlistEntry("localhost", "", "localhost:443", "http")).toBe(false);
+		// An explicit non-matching port never matches.
+		expect(matchesAllowlistEntry("localhost", "9222", "localhost:443", "http")).toBe(false);
+	});
+});
+
+describe("navigation guard: committed recheck (DNS-rebinding window)", () => {
+	it("re-resolves an unvetted hostname and flags a private answer", async () => {
+		const policy = { lookup: dns, resolvedHosts: new Map<string, readonly string[]>() };
+		expect(await recheckCommittedNavigation("http://internal.corp/x", policy)).toBe(true);
+		// The answer is memoized: a second call must not re-query the resolver.
+		expect(await recheckCommittedNavigation("http://internal.corp/x", policy)).toBe(true);
+		expect(policy.resolvedHosts?.get("internal.corp")).toEqual(["10.1.2.3"]);
+	});
+
+	it("treats a cached (pre-vetted public) answer as already checked", async () => {
+		let lookups = 0;
+		const policy = {
+			lookup: async (hostname: string): Promise<string[]> => {
+				lookups++;
+				return ["93.184.216.34"];
+			},
+			resolvedHosts: new Map<string, readonly string[]>([["vetted.host", ["93.184.216.34"]]]),
+		};
+		expect(await recheckCommittedNavigation("http://vetted.host/x", policy)).toBe(false);
+		expect(lookups).toBe(0);
+	});
+
+	it("fails closed on an empty answer or a resolver throw for an unvetted host", async () => {
+		expect(await recheckCommittedNavigation("http://empty.name/", { lookup: dns })).toBe(true);
+		expect(await recheckCommittedNavigation("http://fail.name/", { lookup: dns })).toBe(true);
+	});
+
+	it("does not re-resolve literal IPs, relaxed hosts, or metadata-floor targets", async () => {
+		let lookups = 0;
+		const policy = {
+			lookup: async (hostname: string): Promise<string[]> => {
+				lookups++;
+				return ["93.184.216.34"];
+			},
+		};
+		expect(await recheckCommittedNavigation("http://10.0.0.5/x", policy)).toBe(true);
+		expect(await recheckCommittedNavigation("http://169.254.169.254/x", policy)).toBe(true);
+		expect(await recheckCommittedNavigation("http://10.0.0.5/x", { ...policy, allowPrivateUrls: true })).toBe(false);
+		expect(await recheckCommittedNavigation("http://localhost/x", { ...policy, privateUrlAllowlist: ["localhost"] })).toBe(
+			false,
+		);
+		expect(lookups).toBe(0);
+	});
+
+	it("still blocks a private port on a host relaxed only by a configured endpoint", async () => {
+		const policy = resolveNavigationPolicy({
+			configuredEndpointUrls: ["http://127.0.0.1:9224"],
+			env: {},
+		});
+		expect(await recheckCommittedNavigation("http://127.0.0.1:5432/", policy)).toBe(true);
+	});
+});
+
 describe("navigation guard: policy resolution (explicit config only)", () => {
 	it("env override wins in both directions", () => {
 		expect(
@@ -251,13 +410,22 @@ describe("navigation guard: policy resolution (explicit config only)", () => {
 		).toBe(false);
 	});
 
-	it("normalizes allowlist entries and merges configured endpoint hostnames", () => {
+	it("normalizes allowlist entries and merges configured endpoints as host:port", async () => {
 		const policy = resolveNavigationPolicy({
 			allowlistSetting: ["Dev.Local", " ", 42],
 			configuredEndpointUrls: ["http://127.0.0.1:9224", "ws://localhost:9222", undefined],
 			env: {},
 		});
-		expect(policy.privateUrlAllowlist).toEqual(["dev.local", "127.0.0.1", "localhost"]);
+		// Non-default endpoint ports are carried into the entry: configuring the
+		// CDP proxy on 9224 must not also allow a database on 5432 of the same
+		// loopback host.
+		expect(policy.privateUrlAllowlist).toEqual(["dev.local", "127.0.0.1:9224", "localhost:9222"]);
+		expect(await verdict("http://127.0.0.1:5432/", policy)).toBe("BLOCK:private");
+	});
+
+	it("drops scheme-default ports from endpoint entries", () => {
+		const policy = resolveNavigationPolicy({ configuredEndpointUrls: ["https://relay.example:443"], env: {} });
+		expect(policy.privateUrlAllowlist).toEqual(["relay.example"]);
 	});
 	it("classifies IPv4-mapped and zone-scoped addresses like the Python ipaddress module", () => {
 		expect(classifyIpAddress("::ffff:100.100.100.200").alwaysBlocked).toBe(true);

--- a/packages/coding-agent/test/tools/browser-url-guard.test.ts
+++ b/packages/coding-agent/test/tools/browser-url-guard.test.ts
@@ -1,0 +1,270 @@
+/**
+ * SSRF / private-IP navigation guard: ported from hermes-agent
+ * (`tools/url_safety.py`, `tools/browser_tool.py::_url_is_private`), MIT,
+ * Copyright (c) 2025 Nous Research. See src/tools/browser/NOTICE.
+ *
+ * Every case injects a fake resolver through the policy `lookup` seam, so the
+ * suite never touches real DNS.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	checkNavigationTarget,
+	classifyIpAddress,
+	isAlwaysBlockedNavigationTarget,
+	isBlockedCommittedNavigation,
+	navigationBlockedMessage,
+	resolveNavigationPolicy,
+} from "../../src/tools/browser/url-guard";
+
+/** Resolver mapping hostnames to fixed addresses; anything else throws. */
+function fakeDns(table: Record<string, string | string[]>): (hostname: string) => Promise<string[]> {
+	return async (hostname: string): Promise<string[]> => {
+		const hit = table[hostname];
+		if (hit === undefined) throw new Error(`no fake record for ${hostname}`);
+		return Array.isArray(hit) ? hit : [hit];
+	};
+}
+
+const dns = fakeDns({
+	"internal.corp": ["10.1.2.3"],
+	"dual.host": ["93.184.216.34", "127.0.0.1"],
+	"v6.name": ["2606:4700:4700::1111"],
+	"meta.name": ["169.254.169.254"],
+	localhost: ["127.0.0.1"],
+	"router.internal": ["169.254.169.254"],
+	"api.dev.local": ["169.254.169.254"],
+	"example.com": ["93.184.216.34"],
+	"ok.dev.local": ["203.0.113.10"],
+	"lp.dev.local": ["127.0.0.1"],
+	"empty.name": [],
+});
+
+function check(url: string, policy?: Parameters<typeof checkNavigationTarget>[1]) {
+	return checkNavigationTarget(url, { lookup: dns, ...policy });
+}
+
+async function verdict(url: string, policy?: Parameters<typeof checkNavigationTarget>[1]) {
+	const result = await check(url, policy);
+	return result.allow ? "ALLOW" : `BLOCK:${result.code}`;
+}
+
+describe("navigation guard: private ranges (hermes _url_is_private parity)", () => {
+	it("blocks RFC1918, loopback, CGNAT and unique-local literals", async () => {
+		for (
+			const url of [
+				"http://10.0.0.5/x",
+				"http://172.16.0.1",
+				"http://172.31.255.255",
+				"http://192.168.1.1",
+				"http://127.0.0.1:9224/json",
+				"http://127.1",
+				"http://100.64.0.1",
+				"http://100.127.255.255",
+				"http://[::1]/",
+				"http://[fd12:3456::1]/",
+				"http://[fe80::1]/",
+				"http://[2002:c0a8:1::]/",
+				"http://2130706433/",
+			]
+		) {
+			expect(await verdict(url), url).toBe("BLOCK:private");
+		}
+	});
+
+	it("allows the boundary-adjacent public space", async () => {
+		for (const url of ["http://172.15.0.1", "http://172.32.0.1", "http://100.128.0.1"]) {
+			expect(await verdict(url), url).toBe("ALLOW");
+		}
+	});
+
+	it("blocks internal-only name classes and names resolving privately", async () => {
+		expect(await verdict("http://printer.local/x")).toBe("BLOCK:private");
+		expect(await verdict("http://localhost:3000")).toBe("BLOCK:private");
+		expect(await verdict("http://app.localhost")).toBe("BLOCK:private");
+		expect(await verdict("http://internal.corp/")).toBe("BLOCK:private");
+		// A public AND a private answer is private (any-record policy).
+		expect(await verdict("http://dual.host/")).toBe("BLOCK:private");
+	});
+
+	it("allows public hosts and IPv6-only names", async () => {
+		expect(await verdict("https://example.com/")).toBe("ALLOW");
+		expect(await verdict("https://example.com:8443/path")).toBe("ALLOW");
+		expect(await verdict("http://v6.name/")).toBe("ALLOW");
+		// about: documents and scheme-less input (https fallback) stay allowed.
+		expect(await verdict("about:blank")).toBe("ALLOW");
+		expect(await verdict("example.com/public", { lookup: dns })).toBe("ALLOW");
+	});
+});
+
+describe("navigation guard: cloud metadata floor (url_safety.py:488)", () => {
+	it("blocks metadata targets even through relaxation", async () => {
+		const urls = [
+			"http://169.254.169.254/latest/meta-data",
+			"http://[::ffff:169.254.169.254]/",
+			"http://0xA9FEA9FE/",
+			"https://metadata.google.internal/",
+			"http://metadata.goog/",
+			"http://meta.name/",
+			// 169.254.169.254 in decimal form (the exact metadata address).
+			"http://2852039166/",
+		];
+		for (const url of urls) expect(await verdict(url), url).toBe("BLOCK:metadata");
+		for (const url of urls)
+			expect(await verdict(url, { allowPrivateUrls: true }), `${url} relaxed`).toBe("BLOCK:metadata");
+	});
+
+	it("keeps allowlist entries from unblocking the floor", async () => {
+		expect(await verdict("http://169.254.169.254/x", { privateUrlAllowlist: ["169.254.0.0/16"] })).toBe(
+			"BLOCK:metadata",
+		);
+		// An allowlisted name that resolves to metadata still falls to the floor.
+		expect(await verdict("http://api.dev.local/x", { privateUrlAllowlist: ["*.dev.local"] })).toBe("BLOCK:metadata");
+	});
+});
+
+describe("navigation guard: schemes and malformed input", () => {
+	it("blocks file:// by default and non-http(s) schemes always", async () => {
+		expect(await verdict("file:///etc/passwd")).toBe("BLOCK:file");
+		for (
+			const url of [
+				"data:text/html,<script>alert(1)</script>",
+				"javascript:alert(1)",
+				"chrome://settings",
+				"view-source:http://10.0.0.5",
+				"garbage::not a url",
+				// scheme-less `localhost:9222/json` parses `localhost:` as an
+				// opaque scheme; fail closed rather than guess.
+				"localhost:9222/json",
+			]
+		) {
+			expect(await verdict(url), url).toBe("BLOCK:scheme");
+		}
+	});
+
+	it("rejects malformed IPv6 zone ids", async () => {
+		expect(await verdict("http://[fe80::1%eth0]/")).toBe("BLOCK:malformed");
+	});
+
+	it("blocks credentials/secrets embedded in navigation targets", async () => {
+		expect(await verdict("https://x.test/?k=sk-proj-abcdef1234567890ZZ")).toBe("BLOCK:secret-url");
+	});
+
+	it("explains the block to the model without leaking the allowlist", () => {
+		const message = navigationBlockedMessage({
+			allow: false,
+			code: "private",
+			target: "http://169.254.169.254/x",
+			hostname: "169.254.169.254",
+		});
+		expect(message).toContain("private");
+	});
+});
+
+describe("navigation guard: DNS posture", () => {
+	it("blocks when resolution fails and when answers are empty", async () => {
+		expect(await verdict("http://fail.name/")).toBe("BLOCK:dns");
+		expect(await verdict("http://empty.name/")).toBe("BLOCK:dns");
+	});
+
+	it("trusts proxy env for the DNS failure (hermes proxy parity)", async () => {
+		const previous = process.env.HTTPS_PROXY;
+		process.env.HTTPS_PROXY = "http://proxy:8080";
+		try {
+			expect(await verdict("http://fail.name/")).toBe("ALLOW");
+		} finally {
+			if (previous === undefined) delete process.env.HTTPS_PROXY;
+			else process.env.HTTPS_PROXY = previous;
+		}
+	});
+});
+
+describe("navigation guard: explicit relaxation", () => {
+	it("allows exact hosts, wildcards, and endpoint ports through the allowlist", async () => {
+		const policy = { privateUrlAllowlist: ["localhost", "127.0.0.1", "*.dev.local"] };
+		expect(await verdict("http://localhost:3000", policy)).toBe("ALLOW");
+		expect(await verdict("http://127.0.0.1:9224/json", policy)).toBe("ALLOW");
+		// Wildcard match, then the resolved address decides (public here).
+		expect(await verdict("http://ok.dev.local/x", policy)).toBe("ALLOW");
+		// A wildcard entry relaxes the name class but never the resolved range…
+		expect(await verdict("http://lp.dev.local/x", { privateUrlAllowlist: ["*.dev.local"] })).toBe("ALLOW");
+	});
+
+	it("allowPrivateUrls relaxes ordinary private ranges but not the floor or file://", async () => {
+		const policy = { allowPrivateUrls: true };
+		expect(await verdict("http://127.0.0.1:9224/json", policy)).toBe("ALLOW");
+		expect(await verdict("http://localhost:3000", policy)).toBe("ALLOW");
+		expect(await verdict("http://10.0.0.5/x", policy)).toBe("ALLOW");
+		expect(await verdict("http://router.internal/x", policy)).toBe("BLOCK:metadata");
+		expect(await verdict("http://169.254.169.254/x", policy)).toBe("BLOCK:metadata");
+		expect(await verdict("file:///etc/passwd", policy)).toBe("BLOCK:file");
+	});
+
+	it("allows file:// only for the internal (read-pdf) exemption", async () => {
+		expect(await verdict("file:///tmp/a.pdf", { allowFileUrls: true })).toBe("ALLOW");
+	});
+});
+
+describe("navigation guard: post-commit fast path (DNS-free)", () => {
+	it("flags always-blocked committed targets", () => {
+		expect(isAlwaysBlockedNavigationTarget("http://169.254.169.254/x")).toBe(true);
+		expect(isAlwaysBlockedNavigationTarget("http://[::ffff:169.254.169.254]:80/")).toBe(true);
+		expect(isAlwaysBlockedNavigationTarget("http://localhost:9222")).toBe(true);
+		expect(isAlwaysBlockedNavigationTarget("https://ok.example/x")).toBe(false);
+		expect(isAlwaysBlockedNavigationTarget("http://8.8.8.8/")).toBe(false);
+	});
+
+	it("rechecks landed URLs without a resolver and honors relaxation", () => {
+		// Metadata stays blocked under every relaxation.
+		expect(isBlockedCommittedNavigation("http://169.254.169.254/x", { allowPrivateUrls: true })).toBe(true);
+		expect(isBlockedCommittedNavigation("http://10.0.0.5/x")).toBe(true);
+		expect(isBlockedCommittedNavigation("http://10.0.0.5/x", { allowPrivateUrls: true })).toBe(false);
+		expect(isBlockedCommittedNavigation("http://127.0.0.1:9224/json")).toBe(true);
+		expect(isBlockedCommittedNavigation("http://127.0.0.1:9224/json", { allowPrivateUrls: true })).toBe(false);
+		expect(isBlockedCommittedNavigation("http://localhost/x")).toBe(true);
+		expect(isBlockedCommittedNavigation("http://localhost/x", { allowPrivateUrls: true })).toBe(false);
+		expect(isBlockedCommittedNavigation("http://localhost/x", { privateUrlAllowlist: ["localhost"] })).toBe(false);
+		expect(isBlockedCommittedNavigation("https://ok.example/x")).toBe(false);
+		// Hostnames that would need DNS are the pre-check's job; the fast path
+		// deliberately does not re-resolve (redirect amplification).
+		expect(isBlockedCommittedNavigation("http://internal.corp/x")).toBe(false);
+		expect(isBlockedCommittedNavigation("about:blank")).toBe(false);
+		expect(isBlockedCommittedNavigation("")).toBe(false);
+		expect(isBlockedCommittedNavigation("file:///tmp/a.pdf")).toBe(true);
+		expect(isBlockedCommittedNavigation("file:///tmp/a.pdf", { allowFileUrls: true })).toBe(false);
+		expect(isBlockedCommittedNavigation("data:text/html,hi")).toBe(true);
+	});
+});
+
+describe("navigation guard: policy resolution (explicit config only)", () => {
+	it("env override wins in both directions", () => {
+		expect(
+			resolveNavigationPolicy({
+				allowPrivateUrlsSetting: false,
+				env: { PI_BROWSER_ALLOW_PRIVATE_URLS: "true" },
+			}).allowPrivateUrls,
+		).toBe(true);
+		expect(
+			resolveNavigationPolicy({
+				allowPrivateUrlsSetting: true,
+				env: { PI_BROWSER_ALLOW_PRIVATE_URLS: "false" },
+			}).allowPrivateUrls,
+		).toBe(false);
+	});
+
+	it("normalizes allowlist entries and merges configured endpoint hostnames", () => {
+		const policy = resolveNavigationPolicy({
+			allowlistSetting: ["Dev.Local", " ", 42],
+			configuredEndpointUrls: ["http://127.0.0.1:9224", "ws://localhost:9222", undefined],
+			env: {},
+		});
+		expect(policy.privateUrlAllowlist).toEqual(["dev.local", "127.0.0.1", "localhost"]);
+	});
+	it("classifies IPv4-mapped and zone-scoped addresses like the Python ipaddress module", () => {
+		expect(classifyIpAddress("::ffff:100.100.100.200").alwaysBlocked).toBe(true);
+		expect(classifyIpAddress("fe80::1%eth0").private).toBe(true);
+		expect(classifyIpAddress("2606:4700:4700::1111").private).toBe(false);
+		expect(classifyIpAddress("93.184.216.34").private).toBe(false);
+		// An unparseable literal fails closed (private + always blocked).
+		expect(classifyIpAddress("not-an-ip").private).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Ports the two P0 browser-security hardenings from **hermes-agent** (NousResearch, MIT) into the `browser` tool — attribution-forward, full provenance in `packages/coding-agent/src/tools/browser/NOTICE`:

1. **SSRF navigation guard** (`browser/url-guard.ts`) — every navigation target the model can cause is classified before it is followed: RFC1918, loopback (including shorthand/decimal/octal/IPv6 forms like `http://127.1`, `http://2130706433`), CGNAT `100.64/10`, unique-local, and link-local cloud-metadata endpoints. DNS resolution is re-checked so a public name that resolves to a private address is blocked (DNS-rebind). Post-commit recheck (`framenavigated` observer + facade re-validation) catches server-side redirects and JS-driven navigations: the redirect is stopped, the page is pulled back to `about:blank`, and the run output is discarded so fetched content never reaches the model.
2. **Output redaction** (`browser/output-redact.ts`) — secret-shaped material is scrubbed from all text the browser returns: userinfo credentials in URLs, `Authorization` headers, provider API key shapes, JWTs, PEM private keys, bare-token secrets. Applied at the source (tab worker and cmux paths, on results, errors, page titles, and committed-URL observations) and again on the run's return value as a final egress net.

## Why

The browser tool is the one tool that takes attacker-influenced input (page content, links, redirects) and can be pointed at arbitrary URLs by prompt injection. Without a guard it can be used to scan or read internal services and cloud metadata (SSRF), and captured pages routinely leak credentials that then persist in the model's context. Defaults are deny: `browser.allowPrivateUrls` is `false` and `browser.privateUrlAllowlist` is empty; both are explicit opt-in. The relay/CDP transport endpoint is allowlisted only via explicit configuration, and the internal PDF renderer's `file://` exemption is a hard-coded call-site allowance, never settings- or page-driven.

## Evidence

```
$ bun test packages/coding-agent/test/tools/browser-url-guard.test.ts packages/coding-agent/test/tools/browser-output-redact.test.ts
 31 pass
 0 fail
 121 expect() calls
Ran 31 tests across 2 files.
```

Adjacent browser suites (`browser-tab-call`) still pass.

## Notes for review

- New: `url-guard.ts`, `output-redact.ts`, `NOTICE`, two test files. Wired: `tab-protocol.ts` (session snapshot carries navigation policy), `tab-supervisor.ts` (pre-flight check on `acquireTab`, policy plumbing to worker/cmux sessions), `tab-worker.ts` (goto/redirect guarding + redaction), `cmux/cmux-tab.ts` (same for relay-driven tabs), `browser.ts` (settings plumbing + final egress net), `read-pdf.ts` (scoped `file://` exemption), `settings-schema.ts` (the two new settings).
- The guard is best-effort content suppression, not network prevention — the design limits are documented in `url-guard.ts`'s header comment.
