### PR TITLE
fix(utils): resolve Bun.which per call in whichFresh

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `$which` capturing `Bun.which` at import on Linux and Windows, so `Bun.which` stubs installed later (e.g. per-test spies) are honoured and PATH-only language servers no longer leak into test results.
+
 ## [18.1.13] - 2026-09-07
 
 ### Fixed

--- a/packages/utils/src/which.ts
+++ b/packages/utils/src/which.ts
@@ -192,8 +192,13 @@ function darwinWhich(command: string, options?: Bun.WhichOptions): string | null
 	return null;
 }
 
-// Which function that incorporates Darwin Xcode logic if platform reports as 'darwin'
-export const whichFresh = os.platform() === "darwin" ? darwinWhich : Bun.which;
+// Which function that incorporates Darwin Xcode logic if platform reports as 'darwin'.
+// Look `Bun.which` up per call rather than capturing it at import, so a `Bun.which`
+// stub installed later (the per-test seam) is honoured on every platform.
+export const whichFresh =
+	os.platform() === "darwin"
+		? darwinWhich
+		: (command: string, options?: Bun.WhichOptions): string | null => Bun.which(command, options);
 
 // Derive stable cache key from command and lookup options
 function cacheKey(command: string, options?: Bun.WhichOptions): CacheKey {

--- a/packages/utils/test/which.test.ts
+++ b/packages/utils/test/which.test.ts
@@ -1,14 +1,15 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which } from "../src/which";
+import { $which, WhichCachePolicy } from "../src/which";
 
 describe("$which", () => {
 	const originalPath = process.env.PATH;
 	const tempDirs: string[] = [];
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		process.env.PATH = originalPath;
 		for (const dir of tempDirs.splice(0)) {
 			fs.rmSync(dir, { recursive: true, force: true });
@@ -33,5 +34,17 @@ describe("$which", () => {
 
 		process.env.PATH = secondDir;
 		expect($which(command)).toBe(secondExecutable);
+	});
+
+	// Tests stub `Bun.which` per test to keep PATH lookups hermetic. If `$which`
+	// captured the original function at import, such a stub would be bypassed and
+	// host binaries would leak into the result.
+	it("honours a Bun.which stub installed after import", () => {
+		const command = `omp-which-stubbed-${process.pid}`;
+		const stubbedPath = path.join(os.tmpdir(), "omp-which-stub", command);
+		const whichSpy = vi.spyOn(Bun, "which").mockReturnValue(stubbedPath);
+
+		expect($which(command, { cache: WhichCachePolicy.Bypass })).toBe(stubbedPath);
+		expect(whichSpy).toHaveBeenCalledWith(command, expect.objectContaining({ PATH: process.env.PATH }));
 	});
 });


### PR DESCRIPTION
## What

`packages/utils/src/which.ts` exported `whichFresh = os.platform() === "darwin" ? darwinWhich : Bun.which`. On Linux and Windows that stores the `Bun.which` function *value* at import, so a later `vi.spyOn(Bun, "which")` — the seam the `lsp-regressions` TypeScript-server-selection tests and `fetch-kagi-toggle.test.ts` rely on — replaces the property on the global but never reaches `$which`. On macOS the `darwinWhich` wrapper calls `Bun.which(...)` per call, which is why the tests work for their author. This makes the non-darwin branch a per-call lookup (one statement; darwin branch and cache logic untouched), adds a `packages/utils` regression test that stubs `Bun.which` and asserts `$which(..., { cache: WhichCachePolicy.Bypass })` honours it, and adds a `[Unreleased]` CHANGELOG line.

## Why

On any developer machine with extra language servers on PATH (here: `vscode-{html,css,json}-language-server` from an nvm bin dir), `loadConfig` → `resolveCommand` → `$which` resolves every `package.json`-rooted default that is really present, so the three tests' exact `Object.keys(config.servers)` assertions fail on an untouched checkout — CI is green only because its runners have none. Production behaviour is identical: the same `Bun.which` is called with the same arguments, just resolved at call time.

## Testing

Reproduced natively on Linux: `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` → 116 pass / 3 fail before (the three real servers leaked into `config.servers`), 119 pass / 0 fail after. Also confirmed the failure is purely environmental by running the untouched tree with a bare PATH (3 pass) and then with three fake shims prepended (3 fail), and that the fixed tree passes the shim simulation (3/3). New `which.test.ts` case: RED on main (`Received: null`), GREEN after. `fetch-kagi-toggle.test.ts` unchanged at 14/14; whole `packages/utils/test/` 912 pass / 2 skip / 0 fail; `bun run check:ts` clean. One residual caveat, unchanged by this PR: `$which`'s process-wide `toolCache` sits in front of the spy, an exposure macOS developers already have; the CI runner's `--isolate` contains it.

Prepared with AI assistance under the account owner's direction and reviewed against the repo's rules before submission.

---

- [x] `bun check` passes (`bun run check:ts`; Rust lane not affected)
- [x] Tested locally
- [x] CHANGELOG updated (`packages/utils/CHANGELOG.md`)
