### PR TITLE
test(coding-agent): make the project-venv setup test hermetic to an activated env

### DIFF
--- a/packages/coding-agent/test/setup-cli.test.ts
+++ b/packages/coding-agent/test/setup-cli.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { checkPythonSetup } from "../src/cli/setup-cli";
+import { Settings } from "../src/config/settings";
+import { restoreEnvValue } from "./helpers/settings-test-state";
 
 const cliEntry = path.join(import.meta.dir, "..", "src", "cli.ts");
+
+// An activated venv/conda env legitimately outranks the project `.venv`
+// (docs/environment-variables.md: VIRTUAL_ENV, then CONDA_PREFIX, then
+// `<cwd>/.venv`), so probes that assert on the project venv must not see one.
+const ACTIVE_PYTHON_ENV_VARS = ["VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV"] as const;
 
 interface CliProcessResult {
 	exitCode: number;
@@ -51,10 +58,32 @@ async function runSetup(cwd: string, ...setupArgs: string[]): Promise<CliProcess
 	return { exitCode, output: stdout, error: stderr };
 }
 
+/**
+ * Hide any activated Python environment from the in-process probe for the
+ * duration of a test. The resolver reads the live env (`resolveVenvPath`) and
+ * the process-wide cached shell env (`Settings#getShellConfig().env`), so both
+ * are covered. Returns the restore function; the spy is undone by
+ * `vi.restoreAllMocks()` in `afterEach`.
+ */
+function hideActivePythonEnv(): () => void {
+	const previous = new Map<string, string | undefined>(ACTIVE_PYTHON_ENV_VARS.map(name => [name, process.env[name]]));
+	for (const name of ACTIVE_PYTHON_ENV_VARS) delete process.env[name];
+	vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+		shell: "/bin/sh",
+		args: ["-c"],
+		env: { PATH: Bun.env.PATH ?? "", HOME: Bun.env.HOME ?? "" },
+		prefix: undefined,
+	});
+	return () => {
+		for (const [name, value] of previous) restoreEnvValue(name, value);
+	};
+}
+
 describe("omp setup python", () => {
 	let projectDir: TempDir | undefined;
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await projectDir?.remove();
 		projectDir = undefined;
 	});
@@ -87,13 +116,18 @@ describe("omp setup python", () => {
 		await Bun.write(interpreter, "#!/bin/sh\nexit 0\n");
 		await fs.chmod(interpreter, 0o755);
 
-		const result = await checkPythonSetup(cwd);
+		const restoreEnv = hideActivePythonEnv();
+		try {
+			const result = await checkPythonSetup(cwd);
 
-		expect(result).toMatchObject({
-			available: true,
-			pythonPath: interpreter,
-			usingManagedEnv: false,
-		});
+			expect(result).toMatchObject({
+				available: true,
+				pythonPath: interpreter,
+				usingManagedEnv: false,
+			});
+		} finally {
+			restoreEnv();
+		}
 	});
 	it.skipIf(process.platform === "win32")("does not let the global probe bypass skip setup validation", async () => {
 		projectDir = TempDir.createSync("@omp-setup-python-");


### PR DESCRIPTION
## What

The setup-cli test "prefers the project venv" (`packages/coding-agent/test/setup-cli.test.ts`) reads the developer's real Python environment, so it fails on any machine with an activated conda or venv while bare CI stays green. This makes the test hermetic on both seams the resolver reads — a per-test snapshot/delete/restore of `VIRTUAL_ENV`, `CONDA_PREFIX`, `CONDA_DEFAULT_ENV` (restored in `finally` via the file's existing `restoreEnvValue` helper, mirroring its `PI_PYTHON_SKIP_CHECK` handling), plus the repo's existing `vi.spyOn(Settings.prototype, "getShellConfig")` idiom (used in `bash-executor.test.ts` and `agent-session-bash-session-ownership.test.ts`) so the process-wide cached shell-config env cannot leak an activated env either, with `vi.restoreAllMocks()` in `afterEach`. Test-only; production precedence is untouched.

## Why

The resolver's precedence is documented and intended (`docs/environment-variables.md`: `VIRTUAL_ENV`, then `CONDA_PREFIX`, then `<cwd>/.venv`), so production is correct. The test lost its isolation in b279db1790, which converted it from the subprocess helper `runSetupPython` (which deletes the three activation variables) to an in-process `checkPythonSetup(cwd)` call with no env scrub. Both seams are load-bearing: with the env scrub alone, the test still fails once an earlier file in the same CI bucket chunk has filled `procmgr.ts`'s never-reset `cachedShellConfig` while an env was active (verified with a `--preload` that fills the cache: env-scrub-only copy 4 pass / 1 fail, this file 5 / 0).

## Testing

Reproduced on Linux with `CONDA_PREFIX=…/miniconda3` active: before, 4 pass / 1 fail (`pythonPath` came back as the conda interpreter); after, 5 pass / 0 fail. Clean host (`env -u CONDA_PREFIX -u CONDA_DEFAULT_ENV -u VIRTUAL_ENV`): 5 / 0, unchanged. The file's exact 10-file chunk of the `coding-agent-native` bucket: 243/243 under both conda-active and venv-active; full `bun run ci:test:coding-agent:native`: 74/75 chunks green, the remaining chunk being the unrelated `lsp-regressions` PATH-leak already covered by #11386. `bun run check:ts` clean. The file stays in its current CI bucket.

Prepared with AI assistance under the account owner's direction and reviewed against the repo's test rules before submission.

---

- [x] `bun check` passes (`bun run check:ts`; Rust lane not affected)
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing; test-only)
