### PR TITLE
fix(copilot): fallback to direct chat identity when CLI is not entitled

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot requests failing with HTTP 403 on subscriptions without Copilot CLI access.
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed
 
-- Fixed GitHub Copilot requests failing with HTTP 403 on subscriptions without Copilot CLI access.
 - Codex SSE streams that end without a terminal completion event now retry when replay-safe and remain transient errors when partial output prevents replay ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
 
 ## [18.1.15] - 2026-09-08

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Fixed GitHub Copilot requests failing with HTTP 403 on subscriptions without Copilot CLI access.
 - Codex SSE streams that end without a terminal completion event now retry when replay-safe and remain transient errors when partial output prevents replay ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).
 
 ## [18.1.15] - 2026-09-08

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3447,6 +3447,7 @@ export class AuthStorage {
 			// Not part of UsageCredential — carried from the stored row so the
 			// interactive-login anchor survives usage-path refresh persists.
 			authorizedAt: entry.credential.authorizedAt,
+			cliDisabled: entry.credential.cliDisabled,
 		});
 	}
 
@@ -5789,6 +5790,7 @@ export class AuthStorage {
 				orgId: result.newCredentials.orgId ?? selection.credential.orgId,
 				orgName: result.newCredentials.orgName ?? selection.credential.orgName,
 				authorizedAt: result.newCredentials.authorizedAt ?? selection.credential.authorizedAt,
+				cliDisabled: result.newCredentials.cliDisabled ?? selection.credential.cliDisabled,
 			};
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
@@ -7168,6 +7170,7 @@ export class AuthStorage {
 				orgId: refreshed.orgId ?? attempted.orgId,
 				orgName: refreshed.orgName ?? attempted.orgName,
 				authorizedAt: refreshed.authorizedAt ?? attempted.authorizedAt,
+				cliDisabled: refreshed.cliDisabled ?? attempted.cliDisabled,
 			};
 			// Persist by id: the array may have been reordered/shrunk while the
 			// refresh was in flight, so the pre-await positional index is unsafe. A

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5900,6 +5900,7 @@ export class AuthStorage {
 						token: oauthSelection.credential.access,
 						enterpriseUrl: oauthSelection.credential.enterpriseUrl,
 						apiEndpoint: oauthSelection.credential.apiEndpoint,
+						cliDisabled: oauthSelection.credential.cliDisabled,
 					});
 				}
 				return oauthSelection.credential.access;

--- a/packages/ai/src/providers/anthropic-client.ts
+++ b/packages/ai/src/providers/anthropic-client.ts
@@ -139,6 +139,14 @@ function hasHeaderCaseInsensitive(headers: Record<string, string>, lowerName: st
 	return false;
 }
 
+function deleteHeaderCaseInsensitive(headers: Record<string, string>, lowerName: string): void {
+	for (const key in headers) {
+		if (key.toLowerCase() === lowerName) {
+			delete headers[key];
+		}
+	}
+}
+
 /**
  * Lazy in-flight request handle. The HTTP request starts on the first
  * `asResponse()` call; subsequent calls return the same promise.
@@ -214,7 +222,16 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 			headers.Authorization = `Bearer ${opts.authToken}`;
 		}
 		Object.assign(headers, defaults);
-		Object.assign(headers, requestHeaders);
+		if (requestHeaders) {
+			for (const key in requestHeaders) {
+				const value = requestHeaders[key];
+				if (value === "") {
+					deleteHeaderCaseInsensitive(headers, key.toLowerCase());
+				} else if (value !== undefined) {
+					headers[key] = value;
+				}
+			}
+		}
 		return headers;
 	}
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2253,16 +2253,84 @@ const streamAnthropicOnce = (
 					...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs),
 					maxRetries: 0,
 				};
-				const request: unknown =
-					isOAuthToken && client.beta
-						? client.beta.messages.create(refreshParams, requestOptions)
-						: client.messages.create(refreshParams, requestOptions);
-				if (!hasAnthropicRawResponseRequest(request)) {
-					throw new AIError.AnthropicStreamEnvelopeError(
-						"Anthropic cache refresh request did not expose a raw response",
-					);
+				let response: Response;
+				const sendRefreshRequest = async (
+					clientToUse: AnthropicMessagesClientLike,
+					optionsToUse: Record<string, unknown>,
+				): Promise<Response> => {
+					const request: unknown =
+						isOAuthToken && clientToUse.beta
+							? clientToUse.beta.messages.create(refreshParams, optionsToUse)
+							: clientToUse.messages.create(refreshParams, optionsToUse);
+					if (!hasAnthropicRawResponseRequest(request)) {
+						throw new AIError.AnthropicStreamEnvelopeError(
+							"Anthropic cache refresh request did not expose a raw response",
+						);
+					}
+					return request.asResponse();
+				};
+
+				try {
+					response = await sendRefreshRequest(client, requestOptions);
+				} catch (error) {
+					if (
+						model.provider === "github-copilot" &&
+						!cliDisabled &&
+						!hasFallenBackToCopilotChat &&
+						AIError.status(error) === 403
+					) {
+						hasFallenBackToCopilotChat = true;
+						cliDisabled = true;
+						copilotDynamicHeaders = buildCopilotDynamicHeaders({
+							messages: context.messages,
+							hasImages: hasCopilotVisionInput(context.messages),
+							premiumMultiplier: model.premiumMultiplier,
+							headers: { ...model.headers, ...options?.headers },
+							initiatorOverride: options?.initiatorOverride,
+							cliDisabled: true,
+						});
+						const fallbackChatHeaders = {
+							...mergeCopilotApiHeaders(mergeHeaders(model.headers, options?.headers), { cliDisabled: true }),
+							"Copilot-Integration-Id": "",
+							"Copilot-Harness-Id": "",
+							"Editor-Version": "",
+							"Editor-Plugin-Version": "",
+						};
+						const fallbackOptions = {
+							...requestOptions,
+							headers: fallbackChatHeaders,
+						};
+						const retryClient = !options?.client
+							? createClient(model, {
+									model,
+									apiKey,
+									cliDisabled: true,
+									extraBetas,
+									stream: false,
+									interleavedThinking: options?.interleavedThinking ?? true,
+									headers: options?.headers,
+									dynamicHeaders: copilotDynamicHeaders?.headers,
+									isOAuth: options?.isOAuth,
+									hasTools: !!context.tools?.length,
+									thinkingEnabled: options?.thinkingEnabled,
+									thinkingDisplay: options?.thinkingDisplay,
+									fetch: options?.fetch,
+									maxRetryDelayMs: options?.maxRetryDelayMs,
+									sessionId:
+										options?.sessionId ??
+										extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
+										options?.promptCacheKey,
+									disableStrictTools,
+								}).client
+							: client;
+						response = await sendRefreshRequest(retryClient, fallbackOptions);
+						if (copilotApiKey) {
+							markCopilotCliDisabled(copilotApiKey);
+						}
+					} else {
+						throw error;
+					}
 				}
-				const response = await request.asResponse();
 				await notifyProviderResponse(options, response, model, response.headers.get("request-id"));
 				const body: unknown = await response.json();
 				if (!isRecord(body)) {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2300,29 +2300,27 @@ const streamAnthropicOnce = (
 							...requestOptions,
 							headers: fallbackChatHeaders,
 						};
-						const retryClient = !options?.client
-							? createClient(model, {
-									model,
-									apiKey,
-									cliDisabled: true,
-									extraBetas,
-									stream: false,
-									interleavedThinking: options?.interleavedThinking ?? true,
-									headers: options?.headers,
-									dynamicHeaders: copilotDynamicHeaders?.headers,
-									isOAuth: options?.isOAuth,
-									hasTools: !!context.tools?.length,
-									thinkingEnabled: options?.thinkingEnabled,
-									thinkingDisplay: options?.thinkingDisplay,
-									fetch: options?.fetch,
-									maxRetryDelayMs: options?.maxRetryDelayMs,
-									sessionId:
-										options?.sessionId ??
-										extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
-										options?.promptCacheKey,
-									disableStrictTools,
-								}).client
-							: client;
+						const retryClient = createClient(model, {
+							model,
+							apiKey,
+							cliDisabled: true,
+							extraBetas,
+							stream: false,
+							interleavedThinking: options?.interleavedThinking ?? true,
+							headers: options?.headers,
+							dynamicHeaders: copilotDynamicHeaders?.headers,
+							isOAuth: options?.isOAuth,
+							hasTools: !!context.tools?.length,
+							thinkingEnabled: options?.thinkingEnabled,
+							thinkingDisplay: options?.thinkingDisplay,
+							fetch: options?.fetch,
+							maxRetryDelayMs: options?.maxRetryDelayMs,
+							sessionId:
+								options?.sessionId ??
+								extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
+								options?.promptCacheKey,
+							disableStrictTools,
+						}).client;
 						response = await sendRefreshRequest(retryClient, fallbackOptions);
 						if (copilotApiKey) {
 							markCopilotCliDisabled(copilotApiKey);
@@ -3137,6 +3135,7 @@ const streamAnthropicOnce = (
 					}
 					if (
 						model.provider === "github-copilot" &&
+						!cliDisabled &&
 						!hasFallenBackToCopilotChat &&
 						firstTokenTime === undefined &&
 						AIError.status(streamFailure) === 403
@@ -3151,31 +3150,29 @@ const streamAnthropicOnce = (
 							initiatorOverride: options?.initiatorOverride,
 							cliDisabled: true,
 						});
-						if (!options?.client || model.provider === "github-copilot") {
-							const created = createClient(model, {
-								model,
-								apiKey,
-								cliDisabled: true,
-								extraBetas,
-								stream: true,
-								interleavedThinking: options?.interleavedThinking ?? true,
-								headers: options?.headers,
-								dynamicHeaders: copilotDynamicHeaders?.headers,
-								isOAuth: options?.isOAuth,
-								hasTools: !!context.tools?.length,
-								thinkingEnabled: options?.thinkingEnabled,
-								thinkingDisplay: options?.thinkingDisplay,
-								fetch: options?.fetch,
-								maxRetryDelayMs: options?.maxRetryDelayMs,
-								sessionId:
-									options?.sessionId ??
-									extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
-									options?.promptCacheKey,
-								disableStrictTools,
-							});
-							client = created.client;
-							isOAuthToken = created.isOAuthToken;
-						}
+						const created = createClient(model, {
+							model,
+							apiKey,
+							cliDisabled: true,
+							extraBetas,
+							stream: true,
+							interleavedThinking: options?.interleavedThinking ?? true,
+							headers: options?.headers,
+							dynamicHeaders: copilotDynamicHeaders?.headers,
+							isOAuth: options?.isOAuth,
+							hasTools: !!context.tools?.length,
+							thinkingEnabled: options?.thinkingEnabled,
+							thinkingDisplay: options?.thinkingDisplay,
+							fetch: options?.fetch,
+							maxRetryDelayMs: options?.maxRetryDelayMs,
+							sessionId:
+								options?.sessionId ??
+								extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
+								options?.promptCacheKey,
+							disableStrictTools,
+						});
+						client = created.client;
+						isOAuthToken = created.isOAuthToken;
 						params = await prepareParams();
 						providerRetryAttempt = 0;
 						output.content.length = 0;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2404,7 +2404,13 @@ const streamAnthropicOnce = (
 				}
 				const fallbackChatHeaders =
 					hasFallenBackToCopilotChat && model.provider === "github-copilot"
-						? mergeCopilotApiHeaders(mergeHeaders(model.headers, options?.headers), { cliDisabled: true })
+						? {
+								...mergeCopilotApiHeaders(mergeHeaders(model.headers, options?.headers), { cliDisabled: true }),
+								"Copilot-Integration-Id": "",
+								"Copilot-Harness-Id": "",
+								"Editor-Version": "",
+								"Editor-Plugin-Version": "",
+							}
 						: undefined;
 				const perRequestHeaders =
 					umansGatewayWebSearchHeader || injectedClientBetaHeaders || fallbackChatHeaders
@@ -3077,7 +3083,7 @@ const streamAnthropicOnce = (
 							initiatorOverride: options?.initiatorOverride,
 							cliDisabled: true,
 						});
-						if (!options?.client) {
+						if (!options?.client || model.provider === "github-copilot") {
 							const created = createClient(model, {
 								model,
 								apiKey,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -7,7 +7,12 @@ import { hostMatchesUrl, isVertexRawPredictUrl } from "@oh-my-pi/pi-catalog/host
 import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
-import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import {
+	isCopilotCliDisabled,
+	markCopilotCliDisabled,
+	mergeCopilotApiHeaders,
+	parseGitHubCopilotApiKey,
+} from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
 	$env,
 	getInstallId,
@@ -2018,7 +2023,12 @@ const streamAnthropicOnce = (
 			// Built inside the try so a copilot credential/header failure surfaces as
 			// an error event instead of an unhandled rejection that leaves the stream
 			// (and any consumer awaiting `result()`) hanging forever.
-			const copilotDynamicHeaders =
+			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
+			const parsedKey = model.provider === "github-copilot" ? parseGitHubCopilotApiKey(apiKey) : undefined;
+			const copilotApiKey = parsedKey?.accessToken;
+			let cliDisabled = parsedKey?.cliDisabled ?? isCopilotCliDisabled(copilotApiKey);
+			let hasFallenBackToCopilotChat = false;
+			let copilotDynamicHeaders =
 				model.provider === "github-copilot"
 					? buildCopilotDynamicHeaders({
 							messages: context.messages,
@@ -2026,12 +2036,12 @@ const streamAnthropicOnce = (
 							premiumMultiplier: model.premiumMultiplier,
 							headers: { ...model.headers, ...options?.headers },
 							initiatorOverride: options?.initiatorOverride,
+							cliDisabled,
 						})
 					: undefined;
 			if (copilotDynamicHeaders?.premiumRequests !== undefined) {
 				output.usage.premiumRequests = copilotDynamicHeaders.premiumRequests;
 			}
-			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
 			const baseUrl = resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com";
 			const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 			const providerSessionState = getAnthropicProviderSessionState(
@@ -2073,12 +2083,13 @@ const streamAnthropicOnce = (
 			const zeroOutputCacheRefresh = options?.anthropicCacheRefreshRequest === true;
 			let client: AnthropicMessagesClientLike;
 			let isOAuthToken: boolean;
+			let extraBetas: string[] = [];
 
 			if (options?.client) {
 				client = options.client;
 				isOAuthToken = false;
 			} else {
-				const extraBetas = normalizeExtraBetas(options?.betas);
+				extraBetas = normalizeExtraBetas(options?.betas);
 				const wantsAnthropicPriority = model.provider === "anthropic" && options?.serviceTier === "priority";
 				// Skip the fast-mode beta when this session already learned the
 				// endpoint+model rejects fast mode; `speed` is dropped from the params
@@ -3041,6 +3052,59 @@ const streamAnthropicOnce = (
 						firstTokenTime = undefined;
 						continue;
 					}
+					if (
+						model.provider === "github-copilot" &&
+						!hasFallenBackToCopilotChat &&
+						firstTokenTime === undefined &&
+						AIError.status(streamFailure) === 403
+					) {
+						hasFallenBackToCopilotChat = true;
+						markCopilotCliDisabled(copilotApiKey);
+						cliDisabled = true;
+						copilotDynamicHeaders = buildCopilotDynamicHeaders({
+							messages: context.messages,
+							hasImages: hasCopilotVisionInput(context.messages),
+							premiumMultiplier: model.premiumMultiplier,
+							headers: { ...model.headers, ...options?.headers },
+							initiatorOverride: options?.initiatorOverride,
+							cliDisabled: true,
+						});
+						if (!options?.client) {
+							const created = createClient(model, {
+								model,
+								apiKey,
+								extraBetas,
+								stream: true,
+								interleavedThinking: options?.interleavedThinking ?? true,
+								headers: options?.headers,
+								dynamicHeaders: copilotDynamicHeaders?.headers,
+								isOAuth: options?.isOAuth,
+								hasTools: !!context.tools?.length,
+								thinkingEnabled: options?.thinkingEnabled,
+								thinkingDisplay: options?.thinkingDisplay,
+								fetch: options?.fetch,
+								maxRetryDelayMs: options?.maxRetryDelayMs,
+								sessionId:
+									options?.sessionId ??
+									extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
+									options?.promptCacheKey,
+								disableStrictTools,
+							});
+							client = created.client;
+							isOAuthToken = created.isOAuthToken;
+						}
+						params = await prepareParams();
+						providerRetryAttempt = 0;
+						output.content.length = 0;
+						output.model = model.id;
+						output.responseId = undefined;
+						output.errorMessage = undefined;
+						output.providerPayload = undefined;
+						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
+						output.stopReason = "stop";
+						firstTokenTime = undefined;
+						continue;
+					}
 					const isTransientEnvelopeFailure =
 						AIError.isTransientStreamParseError(streamFailure) || AIError.isStreamEnvelopeError(streamFailure);
 					const isLocalIdleTimeout =
@@ -3250,7 +3314,9 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	// contain it, so there is no need to install the rewriter for those.
 	const cchFetch = oauthToken ? wrapFetchForCch(baseFetch) : baseFetch;
 	if (model.provider === "github-copilot") {
-		const copilotApiKey = parseGitHubCopilotApiKey(apiKey).accessToken;
+		const parsedKey = parseGitHubCopilotApiKey(apiKey);
+		const copilotApiKey = parsedKey.accessToken;
+		const cliDisabled = parsedKey.cliDisabled ?? isCopilotCliDisabled(copilotApiKey);
 		// The GitHub Copilot Anthropic proxy doesn't accept Anthropic beta
 		// features. Forward only caller-supplied betas.
 		const betaFeatures = [...extraBetas];
@@ -3263,7 +3329,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 				Authorization: `Bearer ${copilotApiKey}`,
 				...(betaFeatures.length > 0 ? { "anthropic-beta": buildBetaHeader([], betaFeatures) } : {}),
 			},
-			model.headers,
+			mergeCopilotApiHeaders(model.headers, { cliDisabled }),
 			dynamicHeaders,
 			headers,
 		);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1242,6 +1242,7 @@ export type AnthropicClientOptionsArgs = {
 	fetch?: FetchImpl;
 	maxRetryDelayMs?: number;
 	sessionId?: string;
+	cliDisabled?: boolean;
 };
 
 export type AnthropicClientOptionsResult = {
@@ -2175,6 +2176,7 @@ const streamAnthropicOnce = (
 				const created = createClient(model, {
 					model,
 					apiKey,
+					cliDisabled,
 					extraBetas,
 					stream: !zeroOutputCacheRefresh,
 					interleavedThinking: options?.interleavedThinking ?? true,
@@ -3075,6 +3077,7 @@ const streamAnthropicOnce = (
 							const created = createClient(model, {
 								model,
 								apiKey,
+								cliDisabled: true,
 								extraBetas,
 								stream: true,
 								interleavedThinking: options?.interleavedThinking ?? true,
@@ -3272,6 +3275,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		maxRetryDelayMs,
 		sessionId,
 		disableStrictTools: disableStrictToolsOverride,
+		cliDisabled: cliDisabledOverride,
 	} = args;
 	const compat = model.compat;
 	const disableStrictTools = disableStrictToolsOverride ?? compat.disableStrictTools;
@@ -3318,7 +3322,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	if (model.provider === "github-copilot") {
 		const parsedKey = parseGitHubCopilotApiKey(apiKey);
 		const copilotApiKey = parsedKey.accessToken;
-		const cliDisabled = parsedKey.cliDisabled ?? isCopilotCliDisabled(copilotApiKey);
+		const cliDisabled = cliDisabledOverride ?? parsedKey.cliDisabled ?? isCopilotCliDisabled(copilotApiKey);
 		// The GitHub Copilot Anthropic proxy doesn't accept Anthropic beta
 		// features. Forward only caller-supplied betas.
 		const betaFeatures = [...extraBetas];

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2402,9 +2402,13 @@ const streamAnthropicOnce = (
 						);
 					}
 				}
+				const fallbackChatHeaders =
+					hasFallenBackToCopilotChat && model.provider === "github-copilot"
+						? mergeCopilotApiHeaders(mergeHeaders(model.headers, options?.headers), { cliDisabled: true })
+						: undefined;
 				const perRequestHeaders =
-					umansGatewayWebSearchHeader || injectedClientBetaHeaders
-						? { ...umansGatewayWebSearchHeader, ...injectedClientBetaHeaders }
+					umansGatewayWebSearchHeader || injectedClientBetaHeaders || fallbackChatHeaders
+						? { ...umansGatewayWebSearchHeader, ...injectedClientBetaHeaders, ...fallbackChatHeaders }
 						: undefined;
 				const requestOptions = {
 					...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs),

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2932,6 +2932,9 @@ const streamAnthropicOnce = (
 							kind: "output",
 						});
 					}
+					if (hasFallenBackToCopilotChat && copilotApiKey) {
+						markCopilotCliDisabled(copilotApiKey);
+					}
 					break;
 				} catch (streamError) {
 					const streamFailure = activeAbortTracker.getLocalAbortReason() ?? streamError;
@@ -3059,7 +3062,6 @@ const streamAnthropicOnce = (
 						AIError.status(streamFailure) === 403
 					) {
 						hasFallenBackToCopilotChat = true;
-						markCopilotCliDisabled(copilotApiKey);
 						cliDisabled = true;
 						copilotDynamicHeaders = buildCopilotDynamicHeaders({
 							messages: context.messages,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3335,9 +3335,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 				Authorization: `Bearer ${copilotApiKey}`,
 				...(betaFeatures.length > 0 ? { "anthropic-beta": buildBetaHeader([], betaFeatures) } : {}),
 			},
-			mergeCopilotApiHeaders(model.headers, { cliDisabled }),
+			mergeCopilotApiHeaders(mergeHeaders(model.headers, headers), { cliDisabled }),
 			dynamicHeaders,
-			headers,
 		);
 		applyInferenceHeaders(defaultHeaders, {
 			provider: model.provider,

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -1,5 +1,5 @@
 import {
-	COPILOT_CAPI_IDENTITY_HEADERS,
+	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
 	parseGitHubCopilotApiKey,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
@@ -121,11 +121,13 @@ export function buildCopilotDynamicHeaders(params: {
 	headers?: Record<string, string>;
 	initiatorOverride?: CopilotInitiator;
 	planTier?: string;
+	cliDisabled?: boolean;
 }): CopilotDynamicHeaders {
 	const initiator =
 		params.initiatorOverride ?? getCopilotInitiatorOverride(params.headers) ?? inferCopilotInitiator(params.messages);
+	const baseIdentity = getCopilotCapiIdentityHeaders({ cliDisabled: params.cliDisabled });
 	const headers: Record<string, string> = {
-		...COPILOT_CAPI_IDENTITY_HEADERS,
+		...baseIdentity,
 		"X-Initiator": initiator,
 		"X-Interaction-Type": `conversation-${initiator}`,
 	};

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -20,7 +20,11 @@ import {
 	hasCoreWeaveProjectHeader,
 	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
-import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import {
+	isCopilotCliDisabled,
+	mergeCopilotApiHeaders,
+	parseGitHubCopilotApiKey,
+} from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
 	$env,
 	classifyJsonPrefix,
@@ -252,15 +256,18 @@ export function resolveOpenAIRequestSetup(
 		}
 	}
 	if (model.provider === "github-copilot") {
-		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
+		const parsedKey = parseGitHubCopilotApiKey(rawApiKey);
+		apiKey = parsedKey.accessToken;
+		const cliDisabled = parsedKey.cliDisabled ?? isCopilotCliDisabled(apiKey);
 		const copilot = buildCopilotDynamicHeaders({
 			messages: options.messages,
 			hasImages: hasCopilotVisionInput(options.messages),
 			premiumMultiplier: model.premiumMultiplier,
 			headers,
 			initiatorOverride: options.initiatorOverride,
+			cliDisabled,
 		});
-		Object.assign(headers, copilot.headers);
+		headers = Object.assign(mergeCopilotApiHeaders(headers, { cliDisabled }), copilot.headers);
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -386,6 +386,10 @@ export async function loginGitHubCopilot(options: GitHubCopilotLoginOptions): Pr
 
 	const apiEndpoint = await discoverGitHubCopilotApiEndpoint(githubAccessToken, fetchImpl);
 
+	// Enable all models after successful login
+	options.onProgress?.("Enabling models...");
+	await enableAllGitHubCopilotModels(githubAccessToken, enterpriseDomain ?? undefined, apiEndpoint, fetchImpl);
+
 	// Keep storing the GitHub token directly so credentials minted by the
 	// Copilot CLI OAuth app remain valid alongside new OpenCode app logins.
 	const credentials: OAuthCredentials = {
@@ -396,10 +400,6 @@ export async function loginGitHubCopilot(options: GitHubCopilotLoginOptions): Pr
 		apiEndpoint,
 		cliDisabled: isCopilotCliDisabled(githubAccessToken) ? true : undefined,
 	};
-
-	// Enable all models after successful login
-	options.onProgress?.("Enabling models...");
-	await enableAllGitHubCopilotModels(githubAccessToken, enterpriseDomain ?? undefined, apiEndpoint, fetchImpl);
 	return credentials;
 }
 

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -14,10 +14,12 @@
 import { scheduler } from "node:timers/promises";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import {
-	COPILOT_API_HEADERS,
 	discoverGitHubCopilotApiEndpoint,
 	getGitHubCopilotBaseUrl,
+	isCopilotCliDisabled,
 	isPublicGitHubHost,
+	markCopilotCliDisabled,
+	mergeCopilotApiHeaders,
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
@@ -235,6 +237,7 @@ export function refreshGitHubCopilotToken(
 	refreshToken: string,
 	enterpriseDomain?: string,
 	apiEndpoint?: string,
+	cliDisabled?: boolean,
 ): OAuthCredentials {
 	return {
 		refresh: refreshToken,
@@ -242,11 +245,17 @@ export function refreshGitHubCopilotToken(
 		expires: FAR_FUTURE_MS,
 		enterpriseUrl: enterpriseDomain,
 		apiEndpoint,
+		cliDisabled: cliDisabled ?? (isCopilotCliDisabled(refreshToken) ? true : undefined),
 	};
 }
 
 export async function refreshGitHubCopilotHook(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-	return refreshGitHubCopilotToken(credentials.refresh, credentials.enterpriseUrl, credentials.apiEndpoint);
+	return refreshGitHubCopilotToken(
+		credentials.refresh,
+		credentials.enterpriseUrl,
+		credentials.apiEndpoint,
+		credentials.cliDisabled,
+	);
 }
 
 /**
@@ -262,20 +271,41 @@ async function enableGitHubCopilotModel(
 ): Promise<boolean> {
 	const baseUrl = apiEndpoint ?? getGitHubCopilotBaseUrl(enterpriseDomain);
 	const url = `${baseUrl}/models/${modelId}/policy`;
+	const cliDisabled = isCopilotCliDisabled(token);
+	const identityHeaders = mergeCopilotApiHeaders(undefined, { cliDisabled });
 
 	try {
-		const response = await fetchImpl(url, {
+		let response = await fetchImpl(url, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: `Bearer ${token}`,
-				...COPILOT_API_HEADERS,
+				...identityHeaders,
 				"Openai-Intent": "chat-policy",
 				"X-Initiator": "user",
 				"X-Interaction-Type": "chat-policy",
 			},
 			body: JSON.stringify({ state: "enabled" }),
 		});
+		if (response.status === 403 && !cliDisabled) {
+			const fallbackHeaders = mergeCopilotApiHeaders(undefined, { cliDisabled: true });
+			const retryResponse = await fetchImpl(url, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+					...fallbackHeaders,
+					"Openai-Intent": "chat-policy",
+					"X-Initiator": "user",
+					"X-Interaction-Type": "chat-policy",
+				},
+				body: JSON.stringify({ state: "enabled" }),
+			});
+			if (retryResponse.ok) {
+				markCopilotCliDisabled(token);
+				response = retryResponse;
+			}
+		}
 		return response.ok;
 	} catch {
 		return false;
@@ -364,6 +394,7 @@ export async function loginGitHubCopilot(options: GitHubCopilotLoginOptions): Pr
 		expires: FAR_FUTURE_MS,
 		enterpriseUrl: enterpriseDomain ?? undefined,
 		apiEndpoint,
+		cliDisabled: isCopilotCliDisabled(githubAccessToken) ? true : undefined,
 	};
 
 	// Enable all models after successful login

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -149,6 +149,7 @@ export async function getOAuthApiKey(
 					expiresAt: creds.expires,
 					email: creds.email,
 					accountId: creds.accountId,
+					cliDisabled: creds.cliDisabled,
 				})
 			: creds.access;
 	return { newCredentials: creds, apiKey };

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -10,8 +10,8 @@ export type OAuthCredentials = {
 	email?: string;
 	accountId?: string;
 	apiEndpoint?: string;
+	cliDisabled?: boolean;
 	/**
-	 * Organization/workspace the token is scoped to (e.g. an Anthropic org
 	 * UUID or a ChatGPT workspace id). Captured once at login; token refreshes
 	 * never rewrite it. Lets one account email hold credentials for multiple
 	 * subscriptions.

--- a/packages/ai/src/utils/openai-http.ts
+++ b/packages/ai/src/utils/openai-http.ts
@@ -112,7 +112,6 @@ export async function postOpenAIStream<TEvent>(init: OpenAIStreamRequestInit): P
 		if (isCopilotCli) {
 			const authHeader = Object.entries(init.headers).find(([k]) => k.toLowerCase() === "authorization")?.[1];
 			const token = authHeader?.replace(/^Bearer\s+/i, "");
-			markCopilotCliDisabled(token);
 			const fallbackHeaders = mergeCopilotApiHeaders(init.headers, { cliDisabled: true });
 			const retryResponse = await fetchWithRetry(init.url, {
 				method: "POST",
@@ -124,6 +123,7 @@ export async function postOpenAIStream<TEvent>(init: OpenAIStreamRequestInit): P
 				timeout: false,
 			});
 			if (retryResponse.ok) {
+				markCopilotCliDisabled(token);
 				response = retryResponse;
 			}
 		}

--- a/packages/ai/src/utils/openai-http.ts
+++ b/packages/ai/src/utils/openai-http.ts
@@ -14,6 +14,7 @@
  *   captured response body for the strict-tools fallback and the responses
  *   chain-state detectors, which regex over `error.message`.
  */
+import { markCopilotCliDisabled, mergeCopilotApiHeaders } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import { fetchWithRetry, readSseJson, type SseEventObserver } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import { OpenAIHttpError } from "../error";
@@ -88,7 +89,7 @@ export interface OpenAIStreamHandle<TEvent> {
  * watchdog timers and abort-reason bookkeeping.
  */
 export async function postOpenAIStream<TEvent>(init: OpenAIStreamRequestInit): Promise<OpenAIStreamHandle<TEvent>> {
-	const response = await fetchWithRetry(init.url, {
+	let response = await fetchWithRetry(init.url, {
 		method: "POST",
 		headers: { "Content-Type": "application/json", Accept: "text/event-stream", ...init.headers },
 		body: JSON.stringify(init.body),
@@ -104,6 +105,29 @@ export async function postOpenAIStream<TEvent>(init: OpenAIStreamRequestInit): P
 		// `firstEventTimeoutMs`/`AbortSignal` already govern stuck requests.
 		timeout: false,
 	});
+	if (response.status === 403 && init.headers) {
+		const isCopilotCli = Object.entries(init.headers).some(
+			([k, v]) => k.toLowerCase() === "copilot-integration-id" && v === "copilot-developer-cli",
+		);
+		if (isCopilotCli) {
+			const authHeader = Object.entries(init.headers).find(([k]) => k.toLowerCase() === "authorization")?.[1];
+			const token = authHeader?.replace(/^Bearer\s+/i, "");
+			markCopilotCliDisabled(token);
+			const fallbackHeaders = mergeCopilotApiHeaders(init.headers, { cliDisabled: true });
+			const retryResponse = await fetchWithRetry(init.url, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Accept: "text/event-stream", ...fallbackHeaders },
+				body: JSON.stringify(init.body),
+				signal: init.signal,
+				fetch: init.fetch,
+				maxAttempts: 1,
+				timeout: false,
+			});
+			if (retryResponse.ok) {
+				response = retryResponse;
+			}
+		}
+	}
 	if (!response.ok) {
 		throw await captureOpenAIHttpError(response);
 	}

--- a/packages/ai/test/github-copilot-no-cli.test.ts
+++ b/packages/ai/test/github-copilot-no-cli.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Context, Model, TextContent } from "@oh-my-pi/pi-ai/types";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const BUSINESS_API_ENDPOINT = "https://api.business.githubcopilot.com";
+const VALID_OAUTH_TOKEN = "ghu_direct_oauth_token";
+const FORBIDDEN_OAUTH_TOKEN = "ghu_forbidden_oauth_token";
+
+const validCredentialWithCliDisabled = JSON.stringify({
+	token: VALID_OAUTH_TOKEN,
+	apiEndpoint: BUSINESS_API_ENDPOINT,
+	cliDisabled: true,
+});
+
+const validCredentialDefault = JSON.stringify({
+	token: "ghu_fallback_probe_token",
+	apiEndpoint: BUSINESS_API_ENDPOINT,
+});
+
+const forbiddenCredential = JSON.stringify({
+	token: FORBIDDEN_OAUTH_TOKEN,
+	apiEndpoint: BUSINESS_API_ENDPOINT,
+});
+
+/**
+ * Stale CLI metadata simulating bundled or cached model headers.
+ * Uses mixed-case keys to ensure case-insensitive identity sanitation.
+ */
+const STALE_CLI_METADATA_HEADERS: Record<string, string> = {
+	"User-Agent": "copilot/1.0.82",
+	"Editor-Version": "copilot/1.0.82",
+	"Copilot-Integration-Id": "copilot-developer-cli",
+	"Copilot-Harness-Id": "copilot-sdk",
+	"Openai-Intent": "conversation-agent",
+	"X-GitHub-Api-Version": "2026-08-01",
+	"copilot-integration-ID": "copilot-developer-cli",
+	"editor-VERSION": "vscode/1.136.0",
+	"COPILOT-HARNESS-ID": "copilot-sdk",
+	"X-Custom-Model-Feature": "preserved-feature",
+};
+
+const textContext: Context = {
+	messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
+};
+
+const visionContext: Context = {
+	messages: [
+		{
+			role: "user",
+			content: [
+				{ type: "text", text: "inspect this image" },
+				{
+					type: "image",
+					mimeType: "image/png",
+					data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+				},
+			],
+			timestamp: Date.now(),
+		},
+	],
+};
+
+function makeModel<TApi extends "openai-responses" | "openai-completions" | "anthropic-messages">(
+	id: string,
+): Model<TApi> {
+	const bundled = getBundledModel<TApi>("github-copilot", id);
+	if (!bundled) throw new Error(`Missing bundled model: ${id}`);
+	return {
+		...bundled,
+		headers: {
+			...bundled.headers,
+			...STALE_CLI_METADATA_HEADERS,
+		},
+	};
+}
+
+function hasCliOrEditorIdentity(headers: Headers): boolean {
+	if (headers.get("copilot-integration-id")) return true;
+	if (headers.get("copilot-harness-id")) return true;
+	if (headers.get("editor-version")) return true;
+	if (headers.get("editor-plugin-version")) return true;
+	const userAgent = headers.get("user-agent") ?? "";
+	return /^copilot\//i.test(userAgent) || /vscode/i.test(userAgent) || /GitHubCopilotChat/i.test(userAgent);
+}
+
+function createResponsesSseResponse(text: string): Response {
+	const body =
+		[
+			`data: ${JSON.stringify({ type: "response.created", response: { id: "resp_sol" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_item.added", item: { type: "message", id: "msg_sol", role: "assistant", status: "in_progress", content: [] } })}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: text })}`,
+			`data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "message", id: "msg_sol", role: "assistant", status: "completed", content: [{ type: "output_text", text }] } })}`,
+			`data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_sol", status: "completed", usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } } })}`,
+		].join("\n\n") + "\n\n";
+
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createCompletionsSseResponse(text: string): Response {
+	const body =
+		[
+			`data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: text }, finish_reason: null }] })}`,
+			`data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } })}`,
+			`data: [DONE]`,
+		].join("\n\n") + "\n\n";
+
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createAnthropicSseResponse(text: string): Response {
+	const events = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_opus",
+				type: "message",
+				role: "assistant",
+				content: [],
+				model: "claude-opus-5",
+				stop_reason: null,
+				usage: { input_tokens: 10, output_tokens: 0 },
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: { input_tokens: 10, output_tokens: 5 },
+		},
+		{ type: "message_stop" },
+	];
+	return new Response(events.map(e => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`).join(""), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+interface CapturedRequest {
+	url: string;
+	headers: Headers;
+}
+
+function createCopilotFetchFixture(options?: { onCapture?: (captured: CapturedRequest) => void }) {
+	return vi.fn(async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		const urlStr = input instanceof Request ? input.url : String(input);
+		const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
+
+		options?.onCapture?.({ url: urlStr, headers });
+
+		const auth = headers.get("authorization");
+		if (auth === `Bearer ${FORBIDDEN_OAUTH_TOKEN}`) {
+			return new Response(JSON.stringify({ error: { message: "Access denied", code: "access_denied" } }), {
+				status: 403,
+				headers: { "content-type": "application/json" },
+			});
+		}
+
+		if (auth !== `Bearer ${VALID_OAUTH_TOKEN}` && auth !== `Bearer ghu_fallback_probe_token`) {
+			return new Response(JSON.stringify({ error: { message: "Unauthorized", code: "unauthorized" } }), {
+				status: 401,
+				headers: { "content-type": "application/json" },
+			});
+		}
+
+		// Deny whenever request claims CLI/editor integration or harness identity
+		if (hasCliOrEditorIdentity(headers)) {
+			return new Response(JSON.stringify({ error: { message: "Access denied", code: "access_denied" } }), {
+				status: 403,
+				headers: { "content-type": "application/json" },
+			});
+		}
+
+		if (urlStr === `${BUSINESS_API_ENDPOINT}/responses`) {
+			return createResponsesSseResponse("gpt-5.6-sol direct answer");
+		}
+		if (urlStr === `${BUSINESS_API_ENDPOINT}/chat/completions`) {
+			return createCompletionsSseResponse("gemini-3.7-flash direct answer");
+		}
+		if (urlStr === `${BUSINESS_API_ENDPOINT}/v1/messages`) {
+			return createAnthropicSseResponse("claude-opus-5 direct answer");
+		}
+
+		return new Response(JSON.stringify({ error: { message: `Not found: ${urlStr}`, code: "not_found" } }), {
+			status: 404,
+			headers: { "content-type": "application/json" },
+		});
+	});
+}
+
+describe("GitHub Copilot direct OAuth streaming without CLI identity", () => {
+	it("streams openai-responses (gpt-5.6-sol) with direct OAuth without leaking CLI identity", async () => {
+		let captured: CapturedRequest | undefined;
+		const fetchMock = createCopilotFetchFixture({
+			onCapture: req => {
+				captured = req;
+			},
+		});
+		const model = makeModel<"openai-responses">("gpt-5.6-sol");
+
+		const result = await streamOpenAIResponses(model, textContext, {
+			apiKey: validCredentialWithCliDisabled,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.content).toHaveLength(1);
+		expect((result.content[0] as TextContent).text).toBe("gpt-5.6-sol direct answer");
+		expect(captured?.url).toBe(`${BUSINESS_API_ENDPOINT}/responses`);
+		expect(captured?.headers.get("authorization")).toBe(`Bearer ${VALID_OAUTH_TOKEN}`);
+		expect(captured?.headers.get("x-custom-model-feature")).toBe("preserved-feature");
+		expect(captured?.headers.get("x-initiator")).toBe("user");
+	});
+
+	it("streams openai-completions (gemini-3.7-flash) with direct OAuth and preserves vision request without leaking CLI identity", async () => {
+		let captured: CapturedRequest | undefined;
+		const fetchMock = createCopilotFetchFixture({
+			onCapture: req => {
+				captured = req;
+			},
+		});
+		const model = makeModel<"openai-completions">("gemini-3.7-flash");
+
+		const result = await streamOpenAICompletions(model, visionContext, {
+			apiKey: validCredentialWithCliDisabled,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.content).toHaveLength(1);
+		expect((result.content[0] as TextContent).text).toBe("gemini-3.7-flash direct answer");
+		expect(captured?.url).toBe(`${BUSINESS_API_ENDPOINT}/chat/completions`);
+		expect(captured?.headers.get("authorization")).toBe(`Bearer ${VALID_OAUTH_TOKEN}`);
+		expect(captured?.headers.get("copilot-vision-request")).toBe("true");
+		expect(captured?.headers.get("x-custom-model-feature")).toBe("preserved-feature");
+		expect(captured?.headers.get("x-initiator")).toBe("user");
+	});
+
+	it("streams anthropic-messages (claude-opus-5) with direct OAuth and initiator override without leaking CLI identity", async () => {
+		let captured: CapturedRequest | undefined;
+		const fetchMock = createCopilotFetchFixture({
+			onCapture: req => {
+				captured = req;
+			},
+		});
+		const model = makeModel<"anthropic-messages">("claude-opus-5");
+
+		const result = await streamAnthropic(model, textContext, {
+			apiKey: validCredentialWithCliDisabled,
+			initiatorOverride: "agent",
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toHaveLength(1);
+		expect((result.content[0] as TextContent).text).toBe("claude-opus-5 direct answer");
+		expect(captured?.url).toBe(`${BUSINESS_API_ENDPOINT}/v1/messages`);
+		expect(captured?.headers.get("authorization")).toBe(`Bearer ${VALID_OAUTH_TOKEN}`);
+		expect(captured?.headers.get("x-custom-model-feature")).toBe("preserved-feature");
+		expect(captured?.headers.get("x-initiator")).toBe("agent");
+	});
+
+	it("transparently falls back from CLI identity to chat identity on 403 and remembers for future turns", async () => {
+		const fetchMock = createCopilotFetchFixture();
+		const model = makeModel<"openai-responses">("gpt-5.6-sol");
+
+		// Turn 1: starts with default CLI headers, gets 403, transparently retries with chat headers
+		const turn1 = await streamOpenAIResponses(model, textContext, {
+			apiKey: validCredentialDefault,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(turn1.stopReason).toBe("stop");
+		expect(turn1.content).toHaveLength(1);
+		expect((turn1.content[0] as TextContent).text).toBe("gpt-5.6-sol direct answer");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		// Turn 2: token is now remembered as cliDisabled, so it uses chat headers directly (1 call)
+		fetchMock.mockClear();
+		const turn2 = await streamOpenAIResponses(model, textContext, {
+			apiKey: validCredentialDefault,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(turn2.stopReason).toBe("stop");
+		expect(turn2.content).toHaveLength(1);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces genuine 403 access denied without retrying", async () => {
+		const fetchMock = createCopilotFetchFixture();
+		const model = makeModel<"openai-responses">("gpt-5.6-sol");
+		const result = await streamOpenAIResponses(model, textContext, {
+			apiKey: forbiddenCredential,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(403);
+	});
+});

--- a/packages/ai/test/github-copilot-no-cli.test.ts
+++ b/packages/ai/test/github-copilot-no-cli.test.ts
@@ -4,7 +4,7 @@ import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-comple
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, TextContent } from "@oh-my-pi/pi-ai/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-
+import { isCopilotCliDisabled } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 afterEach(() => {
 	vi.restoreAllMocks();
 });
@@ -276,8 +276,9 @@ describe("GitHub Copilot direct OAuth streaming without CLI identity", () => {
 		expect(captured?.headers.get("x-initiator")).toBe("agent");
 	});
 
-	it("transparently falls back from CLI identity to chat identity on 403 and remembers for future turns", async () => {
-		const fetchMock = createCopilotFetchFixture();
+	it("transparently falls back from CLI identity to chat identity on 403, preserves X-Initiator, and remembers for future turns", async () => {
+		const capturedRequests: CapturedRequest[] = [];
+		const fetchMock = createCopilotFetchFixture({ onCapture: req => capturedRequests.push(req) });
 		const model = makeModel<"openai-responses">("gpt-5.6-sol");
 
 		// Turn 1: starts with default CLI headers, gets 403, transparently retries with chat headers
@@ -291,6 +292,11 @@ describe("GitHub Copilot direct OAuth streaming without CLI identity", () => {
 		expect((turn1.content[0] as TextContent).text).toBe("gpt-5.6-sol direct answer");
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 
+		// Verified that the fallback request preserved X-Initiator and X-Interaction-Type
+		expect(capturedRequests[1]?.headers.get("x-initiator")).toBe("user");
+		expect(capturedRequests[1]?.headers.get("x-interaction-type")).toBe("conversation-user");
+		expect(capturedRequests[1]?.headers.get("copilot-integration-id")).toBeNull();
+
 		// Turn 2: token is now remembered as cliDisabled, so it uses chat headers directly (1 call)
 		fetchMock.mockClear();
 		const turn2 = await streamOpenAIResponses(model, textContext, {
@@ -303,7 +309,7 @@ describe("GitHub Copilot direct OAuth streaming without CLI identity", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("surfaces genuine 403 access denied without retrying", async () => {
+	it("surfaces genuine 403 access denied and does not permanently downgrade token", async () => {
 		const fetchMock = createCopilotFetchFixture();
 		const model = makeModel<"openai-responses">("gpt-5.6-sol");
 		const result = await streamOpenAIResponses(model, textContext, {
@@ -314,5 +320,6 @@ describe("GitHub Copilot direct OAuth streaming without CLI identity", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(result.stopReason).toBe("error");
 		expect(result.errorStatus).toBe(403);
+		expect(isCopilotCliDisabled(FORBIDDEN_OAUTH_TOKEN)).toBe(false);
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
-## [18.1.16] - 2026-09-09
-
-- Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).
-
 ### Fixed
 
 - Fixed GitHub Copilot model discovery failing with HTTP 403 on subscriptions without Copilot CLI access.
+
+## [18.1.16] - 2026-09-09
+
+- Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).
 
 ## [18.1.14] - 2026-09-07
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).
 
+### Fixed
+
+- Fixed GitHub Copilot model discovery failing with HTTP 403 on subscriptions without Copilot CLI access.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -6,6 +6,7 @@ import { Database } from "bun:sqlite";
 import { renameSync } from "node:fs";
 import { getModelDbPath, isEnoent, isSqliteCorruptionError, logger } from "@oh-my-pi/pi-utils";
 import type { Api, Model, ModelSpec } from "./types";
+import { mergeCopilotApiHeaders } from "./wire/github-copilot";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
 // the model manager rebuilds via `buildModel` on load. Request headers are
@@ -313,8 +314,15 @@ export function writeModelCache<TApi extends Api>(
 					// re-derive without persisting it. This keeps reference-less models
 					// with constant or configured headers alive offline.
 					const matchesStatic = staticHeaderSource
-						? headersEqual(model.headers, staticHeaderSource.headers)
-						: headersEqual(model.headers, restorableHeaderFallback);
+						? headersEqual(model.headers, staticHeaderSource.headers) ||
+							(providerId === "github-copilot" &&
+								headersEqual(
+									model.headers,
+									mergeCopilotApiHeaders(staticHeaderSource.headers, { cliDisabled: true }),
+								))
+						: headersEqual(model.headers, restorableHeaderFallback) ||
+							(providerId === "github-copilot" &&
+								headersEqual(model.headers, mergeCopilotApiHeaders(undefined, { cliDisabled: true })));
 					if (!matchesStatic) {
 						unrestorableHeaderModelIds.push(model.id);
 					}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6306,7 +6306,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 					"X-GitHub-Api-Version": COPILOT_API_VERSION,
 					"X-Initiator": "user",
 				};
-				const fetchCopilotCatalog = (headers: Record<string, string>, useChatIdentity: boolean) =>
+				const fetchCopilotCatalog = (headers: Record<string, string>) =>
 					fetchOpenAICompatibleModels<Api>({
 						api: "openai-completions",
 						provider: "github-copilot",
@@ -6386,9 +6386,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 										input,
 										contextWindow: defaultTierWindow,
 										maxTokens,
-										headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers, {
-											cliDisabled: useChatIdentity,
-										}),
+										headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers),
 										...(api === "openai-completions"
 											? {
 													compat: {
@@ -6407,7 +6405,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 										input,
 										contextWindow: defaultTierWindow,
 										maxTokens,
-										headers: mergeCopilotApiHeaders(undefined, { cliDisabled: useChatIdentity }),
+										headers: mergeCopilotApiHeaders(),
 										// Copilot's `/models` advertises no reasoning bit, so a
 										// thinking-capable Claude with no bundled reference would
 										// fall back to `reasoning: false` and lose its effort dial.
@@ -6467,7 +6465,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						},
 						fetch: trackedFetch,
 					});
-				let models = await fetchCopilotCatalog(discoveryHeaders, cliDisabled);
+				let models = await fetchCopilotCatalog(discoveryHeaders);
 				if (models === null && lastDiscoveryStatus === 403 && !cliDisabled) {
 					longContextVariants.length = 0;
 					const fallbackHeaders = {
@@ -6475,7 +6473,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						"X-GitHub-Api-Version": COPILOT_API_VERSION,
 						"X-Initiator": "user",
 					};
-					const retryModels = await fetchCopilotCatalog(fallbackHeaders, true);
+					const retryModels = await fetchCopilotCatalog(fallbackHeaders);
 					if (retryModels) {
 						markCopilotCliDisabled(parsedKey.accessToken);
 						models = retryModels;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -39,6 +39,7 @@ import {
 	getGitHubCopilotBaseUrl,
 	isCopilotCliDisabled,
 	isPersonalGitHubCopilotBaseUrl,
+	markCopilotCliDisabled,
 	mergeCopilotApiHeaders,
 	parseGitHubCopilotApiKey,
 } from "../wire/github-copilot";
@@ -6286,6 +6287,12 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 		...(apiKey && {
 			fetchDynamicModels: async () => {
 				const fetchImpl = discoveryFetch(config?.fetch);
+				let lastDiscoveryStatus: number | undefined;
+				const trackedFetch: FetchImpl = async (input, init) => {
+					const response = await fetchImpl(input, init);
+					lastDiscoveryStatus = response.status;
+					return response;
+				};
 				const requestBaseUrl = isPersonalGitHubCopilotBaseUrl(baseUrl)
 					? ((await withCatalogDiscoveryTimeout(DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS, signal =>
 							discoverGitHubCopilotApiEndpoint(apiKey, fetchImpl, signal),
@@ -6299,166 +6306,181 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 					"X-GitHub-Api-Version": COPILOT_API_VERSION,
 					"X-Initiator": "user",
 				};
-				const models = await fetchOpenAICompatibleModels<Api>({
-					api: "openai-completions",
-					provider: "github-copilot",
-					baseUrl: requestBaseUrl,
-					apiKey,
-					headers: discoveryHeaders,
-					mapModel: (
-						entry: OpenAICompatibleModelRecord,
-						defaults: ModelSpec<Api>,
-						_context: OpenAICompatibleModelMapperContext<Api>,
-					): ModelSpec<Api> | null => {
-						if (!isCopilotChatModel(entry)) {
-							return null;
-						}
-						const reference = resolveReference(defaults.id);
-						const copilotLimits = extractCopilotLimits(entry);
-						// Copilot exposes token limits under capabilities.limits.*.
-						// max_context_window_tokens is the model's total usable window;
-						// max_prompt_tokens is Copilot's prompt/summarization budget and
-						// must only be a fallback when total-window fields are absent.
-						const contextWindow = toPositiveNumber(
-							copilotLimits.maxContextWindowTokens,
-							toPositiveNumber(
-								entry.context_length,
-								toPositiveNumber(
-									copilotLimits.maxPromptTokens,
-									reference?.contextWindow ?? defaults.contextWindow,
-								),
-							),
-						);
-						const maxTokens = toPositiveNumber(
-							copilotLimits.maxOutputTokens,
-							toPositiveNumber(
-								entry.max_completion_tokens,
-								toPositiveNumber(
-									copilotLimits.maxNonStreamingOutputTokens,
-									reference?.maxTokens ?? defaults.maxTokens,
-								),
-							),
-						);
-						const name =
-							typeof entry.name === "string" && entry.name.trim().length > 0
-								? entry.name
-								: (reference?.name ?? defaults.name);
-						const api = inferCopilotApi(defaults.id);
-						const supportsVision = extractCopilotSupportsVision(entry);
-						const input: ModelSpec<Api>["input"] =
-							supportsVision === true
-								? ["text", "image"]
-								: supportsVision === false || !isPersonalGitHubCopilotBaseUrl(requestBaseUrl)
-									? ["text"]
-									: (reference?.input ?? defaults.input);
-						// With COPILOT_API_HEADERS the served window is the long-context
-						// ceiling; the default tier ends at token_prices.default.context_max
-						// prompt tokens. Cap the base entry to the default tier — the long
-						// tier is the opt-in `-1m` sibling below.
-						const tokenPrices = extractCopilotTokenPrices(entry);
-						const defaultContextMax = tokenPrices.defaultTier?.contextMax;
-						const defaultTierWindow =
-							defaultContextMax !== undefined &&
-							defaultContextMax > 0 &&
-							contextWindow !== null &&
-							maxTokens !== null
-								? Math.min(contextWindow, defaultContextMax + maxTokens)
-								: contextWindow;
-						const unreferencedIdentity =
-							reference === undefined && api === "anthropic-messages"
-								? classifyModel("github-copilot", defaults.id, { lenient: true })
-								: undefined;
-						const base: ModelSpec<Api> = reference
-							? {
-									...reference,
-									api,
-									provider: "github-copilot",
-									baseUrl: requestBaseUrl,
-									name,
-									input,
-									contextWindow: defaultTierWindow,
-									maxTokens,
-									headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers, {
-										cliDisabled,
-									}),
-									...(api === "openai-completions"
-										? {
-												compat: {
-													supportsStore: false,
-													supportsDeveloperRole: false,
-													supportsReasoningEffort: false,
-												},
-											}
-										: {}),
-								}
-							: {
-									...defaults,
-									api,
-									baseUrl: requestBaseUrl,
-									name,
-									input,
-									contextWindow: defaultTierWindow,
-									maxTokens,
-									headers: mergeCopilotApiHeaders(undefined, { cliDisabled }),
-									// Copilot's `/models` advertises no reasoning bit, so a
-									// thinking-capable Claude with no bundled reference would
-									// fall back to `reasoning: false` and lose its effort dial.
-									// Gate on the id classifier (not the transport alone) so a
-									// lagging enterprise catalog serving a pre-thinking Claude
-									// (<= 3.5) over the Messages proxy is not handed a fabricated
-									// dial it would reject; a modern reference-less model (e.g.
-									// claude-opus-5) is marked so `buildModel` derives the ladder.
-									...(unreferencedIdentity?.class === "anthropic" &&
-									revisionAtLeast(unreferencedIdentity.revision, "3.7")
-										? { reasoning: true }
-										: {}),
-									...(api === "openai-completions"
-										? {
-												compat: {
-													supportsStore: false,
-													supportsDeveloperRole: false,
-													supportsReasoningEffort: false,
-												},
-											}
-										: {}),
-								};
-						// Cross-provider fallback references (e.g. a Cursor
-						// collapsed family for an enterprise-only sibling id)
-						// carry provider-specific wire routing that must not
-						// transfer: the off-tier `requestModelId` pin would send
-						// every Copilot request under the `-none` sibling id
-						// regardless of thinking level.
-						if (reference && reference.provider !== "github-copilot") {
-							delete base.requestModelId;
-							if (base.thinking) {
-								// `base` is a shallow copy of the shared global
-								// reference: clone before deleting or the bundled
-								// entry loses its routing process-wide.
-								base.thinking = { ...base.thinking };
-								delete base.thinking.effortRouting;
+				const fetchCopilotCatalog = (headers: Record<string, string>, useChatIdentity: boolean) =>
+					fetchOpenAICompatibleModels<Api>({
+						api: "openai-completions",
+						provider: "github-copilot",
+						baseUrl: requestBaseUrl,
+						apiKey,
+						headers,
+						mapModel: (
+							entry: OpenAICompatibleModelRecord,
+							defaults: ModelSpec<Api>,
+							_context: OpenAICompatibleModelMapperContext<Api>,
+						): ModelSpec<Api> | null => {
+							if (!isCopilotChatModel(entry)) {
+								return null;
 							}
-						}
-						const defaultCost = copilotTierCost(tokenPrices.defaultTier);
-						if (defaultCost) {
-							// Cache writes are not reported per tier; retain the bundled provider rate.
-							base.cost = { ...defaultCost, cacheWrite: base.cost.cacheWrite };
-						}
-						const variant = createCopilotLongContextVariant(
-							base,
-							contextWindow,
-							maxTokens,
-							tokenPrices.longContext,
-						);
-						if (variant) {
-							longContextVariants.push(variant);
-							// Overflowing the default tier promotes into the 1M sibling
-							// unless the reference already pins a target.
-							base.contextPromotionTarget ??= `github-copilot/${variant.id}`;
-						}
-						return base;
-					},
-					fetch: fetchImpl,
-				});
+							const reference = resolveReference(defaults.id);
+							const copilotLimits = extractCopilotLimits(entry);
+							// Copilot exposes token limits under capabilities.limits.*.
+							// max_context_window_tokens is the model's total usable window;
+							// max_prompt_tokens is Copilot's prompt/summarization budget and
+							// must only be a fallback when total-window fields are absent.
+							const contextWindow = toPositiveNumber(
+								copilotLimits.maxContextWindowTokens,
+								toPositiveNumber(
+									entry.context_length,
+									toPositiveNumber(
+										copilotLimits.maxPromptTokens,
+										reference?.contextWindow ?? defaults.contextWindow,
+									),
+								),
+							);
+							const maxTokens = toPositiveNumber(
+								copilotLimits.maxOutputTokens,
+								toPositiveNumber(
+									entry.max_completion_tokens,
+									toPositiveNumber(
+										copilotLimits.maxNonStreamingOutputTokens,
+										reference?.maxTokens ?? defaults.maxTokens,
+									),
+								),
+							);
+							const name =
+								typeof entry.name === "string" && entry.name.trim().length > 0
+									? entry.name
+									: (reference?.name ?? defaults.name);
+							const api = inferCopilotApi(defaults.id);
+							const supportsVision = extractCopilotSupportsVision(entry);
+							const input: ModelSpec<Api>["input"] =
+								supportsVision === true
+									? ["text", "image"]
+									: supportsVision === false || !isPersonalGitHubCopilotBaseUrl(requestBaseUrl)
+										? ["text"]
+										: (reference?.input ?? defaults.input);
+							// With COPILOT_API_HEADERS the served window is the long-context
+							// ceiling; the default tier ends at token_prices.default.context_max
+							// prompt tokens. Cap the base entry to the default tier — the long
+							// tier is the opt-in `-1m` sibling below.
+							const tokenPrices = extractCopilotTokenPrices(entry);
+							const defaultContextMax = tokenPrices.defaultTier?.contextMax;
+							const defaultTierWindow =
+								defaultContextMax !== undefined &&
+								defaultContextMax > 0 &&
+								contextWindow !== null &&
+								maxTokens !== null
+									? Math.min(contextWindow, defaultContextMax + maxTokens)
+									: contextWindow;
+							const unreferencedIdentity =
+								reference === undefined && api === "anthropic-messages"
+									? classifyModel("github-copilot", defaults.id, { lenient: true })
+									: undefined;
+							const base: ModelSpec<Api> = reference
+								? {
+										...reference,
+										api,
+										provider: "github-copilot",
+										baseUrl: requestBaseUrl,
+										name,
+										input,
+										contextWindow: defaultTierWindow,
+										maxTokens,
+										headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers, {
+											cliDisabled: useChatIdentity,
+										}),
+										...(api === "openai-completions"
+											? {
+													compat: {
+														supportsStore: false,
+														supportsDeveloperRole: false,
+														supportsReasoningEffort: false,
+													},
+												}
+											: {}),
+									}
+								: {
+										...defaults,
+										api,
+										baseUrl: requestBaseUrl,
+										name,
+										input,
+										contextWindow: defaultTierWindow,
+										maxTokens,
+										headers: mergeCopilotApiHeaders(undefined, { cliDisabled: useChatIdentity }),
+										// Copilot's `/models` advertises no reasoning bit, so a
+										// thinking-capable Claude with no bundled reference would
+										// fall back to `reasoning: false` and lose its effort dial.
+										// Gate on the id classifier (not the transport alone) so a
+										// lagging enterprise catalog serving a pre-thinking Claude
+										// (<= 3.5) over the Messages proxy is not handed a fabricated
+										// dial it would reject; a modern reference-less model (e.g.
+										// claude-opus-5) is marked so `buildModel` derives the ladder.
+										...(unreferencedIdentity?.class === "anthropic" &&
+										revisionAtLeast(unreferencedIdentity.revision, "3.7")
+											? { reasoning: true }
+											: {}),
+										...(api === "openai-completions"
+											? {
+													compat: {
+														supportsStore: false,
+														supportsDeveloperRole: false,
+														supportsReasoningEffort: false,
+													},
+												}
+											: {}),
+									};
+							// Cross-provider fallback references (e.g. a Cursor
+							// collapsed family for an enterprise-only sibling id)
+							// carry provider-specific wire routing that must not
+							// transfer: the off-tier `requestModelId` pin would send
+							// every Copilot request under the `-none` sibling id
+							// regardless of thinking level.
+							if (reference && reference.provider !== "github-copilot") {
+								delete base.requestModelId;
+								if (base.thinking) {
+									// `base` is a shallow copy of the shared global
+									// reference: clone before deleting or the bundled
+									// entry loses its routing process-wide.
+									base.thinking = { ...base.thinking };
+									delete base.thinking.effortRouting;
+								}
+							}
+							const defaultCost = copilotTierCost(tokenPrices.defaultTier);
+							if (defaultCost) {
+								// Cache writes are not reported per tier; retain the bundled provider rate.
+								base.cost = { ...defaultCost, cacheWrite: base.cost.cacheWrite };
+							}
+							const variant = createCopilotLongContextVariant(
+								base,
+								contextWindow,
+								maxTokens,
+								tokenPrices.longContext,
+							);
+							if (variant) {
+								longContextVariants.push(variant);
+								// Overflowing the default tier promotes into the 1M sibling
+								// unless the reference already pins a target.
+								base.contextPromotionTarget ??= `github-copilot/${variant.id}`;
+							}
+							return base;
+						},
+						fetch: trackedFetch,
+					});
+				let models = await fetchCopilotCatalog(discoveryHeaders, cliDisabled);
+				if (models === null && lastDiscoveryStatus === 403 && !cliDisabled) {
+					longContextVariants.length = 0;
+					const fallbackHeaders = {
+						...getCopilotCapiIdentityHeaders({ cliDisabled: true }),
+						"X-GitHub-Api-Version": COPILOT_API_VERSION,
+						"X-Initiator": "user",
+					};
+					const retryModels = await fetchCopilotCatalog(fallbackHeaders, true);
+					if (retryModels) {
+						markCopilotCliDisabled(parsedKey.accessToken);
+						models = retryModels;
+					}
+				}
 				if (models === null) {
 					return null;
 				}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -33,9 +33,11 @@ import { CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL } from "../wire/cloudflare-ai-gat
 import { coreWeaveProjectHeaders } from "../wire/coreweave";
 import {
 	COPILOT_API_HEADERS,
-	COPILOT_DISCOVERY_HEADERS,
+	COPILOT_API_VERSION,
 	discoverGitHubCopilotApiEndpoint,
+	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
+	isCopilotCliDisabled,
 	isPersonalGitHubCopilotBaseUrl,
 	mergeCopilotApiHeaders,
 	parseGitHubCopilotApiKey,
@@ -6290,12 +6292,19 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						)) ?? baseUrl)
 					: baseUrl;
 				const longContextVariants: ModelSpec<Api>[] = [];
+				const parsedKey = parseGitHubCopilotApiKey(apiKey);
+				const cliDisabled = parsedKey.cliDisabled ?? isCopilotCliDisabled(parsedKey.accessToken);
+				const discoveryHeaders = {
+					...getCopilotCapiIdentityHeaders({ cliDisabled }),
+					"X-GitHub-Api-Version": COPILOT_API_VERSION,
+					"X-Initiator": "user",
+				};
 				const models = await fetchOpenAICompatibleModels<Api>({
 					api: "openai-completions",
 					provider: "github-copilot",
 					baseUrl: requestBaseUrl,
 					apiKey,
-					headers: COPILOT_DISCOVERY_HEADERS,
+					headers: discoveryHeaders,
 					mapModel: (
 						entry: OpenAICompatibleModelRecord,
 						defaults: ModelSpec<Api>,
@@ -6369,7 +6378,9 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									input,
 									contextWindow: defaultTierWindow,
 									maxTokens,
-									headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers),
+									headers: mergeCopilotApiHeaders(getProviderReferences().get(defaults.id)?.headers, {
+										cliDisabled,
+									}),
 									...(api === "openai-completions"
 										? {
 												compat: {
@@ -6388,7 +6399,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									input,
 									contextWindow: defaultTierWindow,
 									maxTokens,
-									headers: mergeCopilotApiHeaders(),
+									headers: mergeCopilotApiHeaders(undefined, { cliDisabled }),
 									// Copilot's `/models` advertises no reasoning bit, so a
 									// thinking-capable Claude with no bundled reference would
 									// fall back to `reasoning: false` and lose its effort dial.

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -206,6 +206,8 @@ export async function discoverGitHubCopilotApiEndpoint(
 		if (!isRecord(data)) return undefined;
 		if (data.cli_enabled === false) {
 			markCopilotCliDisabled(token);
+		} else if (data.cli_enabled === true) {
+			clearCopilotCliDisabled(token);
 		}
 		if (!isRecord(data.endpoints)) return undefined;
 		const endpoint = data.endpoints.api;
@@ -219,11 +221,16 @@ export function parseGitHubCopilotApiKey(apiKeyRaw: string): ParsedGitHubCopilot
 	try {
 		const parsed = JSON.parse(apiKeyRaw) as GitHubCopilotApiKeyPayload;
 		if (typeof parsed.token === "string") {
+			if (parsed.cli_enabled === true || parsed.cliEnabled === true) {
+				clearCopilotCliDisabled(parsed.token);
+			}
 			const cliDisabled =
-				parsed.cliDisabled === true ||
-				parsed.cli_enabled === false ||
-				parsed.cliEnabled === false ||
-				isCopilotCliDisabled(parsed.token);
+				parsed.cli_enabled === true || parsed.cliEnabled === true
+					? false
+					: parsed.cliDisabled === true ||
+						parsed.cli_enabled === false ||
+						parsed.cliEnabled === false ||
+						isCopilotCliDisabled(parsed.token);
 			if (cliDisabled) {
 				markCopilotCliDisabled(parsed.token);
 			}

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -1,4 +1,5 @@
 import { USER_AGENT } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import type { FetchImpl } from "../types";
 import { isRecord } from "../utils";
 
@@ -30,17 +31,25 @@ export const COPILOT_CHAT_IDENTITY_HEADERS = {
 	"Openai-Intent": "conversation-edits",
 } as const;
 
-const copilotCliDisabledTokens = new Set<string>();
+const copilotCliDisabledTokens = new LRUCache<string, boolean>({ max: 64, ttl: 24 * 60 * 60 * 1000 });
 
 export function markCopilotCliDisabled(token?: string): void {
 	if (token?.trim()) {
-		copilotCliDisabledTokens.add(token.trim());
+		copilotCliDisabledTokens.set(token.trim(), true);
 	}
 }
 
 export function isCopilotCliDisabled(token?: string): boolean {
 	if (!token?.trim()) return false;
-	return copilotCliDisabledTokens.has(token.trim());
+	return copilotCliDisabledTokens.get(token.trim()) === true;
+}
+
+export function clearCopilotCliDisabled(token?: string): void {
+	if (token?.trim()) {
+		copilotCliDisabledTokens.delete(token.trim());
+	} else {
+		copilotCliDisabledTokens.clear();
+	}
 }
 
 export function getCopilotCapiIdentityHeaders(options?: { cliDisabled?: boolean }): Record<string, string> {
@@ -93,6 +102,18 @@ export function sanitizeCopilotHeaders(headers?: Readonly<Record<string, string>
 	}
 	return result;
 }
+function getHeaderCaseInsensitive(
+	headers: Readonly<Record<string, string>> | undefined,
+	name: string,
+): string | undefined {
+	if (!headers) return undefined;
+	const lower = name.toLowerCase();
+	for (const key of Object.keys(headers)) {
+		if (key.toLowerCase() === lower) return headers[key];
+	}
+	return undefined;
+}
+
 /** Preserve model-specific headers while enforcing the current Copilot API identity. */
 export function mergeCopilotApiHeaders(
 	headers?: Readonly<Record<string, string>>,
@@ -100,7 +121,15 @@ export function mergeCopilotApiHeaders(
 ): Record<string, string> {
 	const baseIdentity = getCopilotCapiIdentityHeaders(options);
 	const custom = sanitizeCopilotHeaders(headers);
-	return { ...custom, ...baseIdentity, "X-GitHub-Api-Version": COPILOT_API_VERSION };
+	const initiator = getHeaderCaseInsensitive(headers, "x-initiator");
+	const interactionType = getHeaderCaseInsensitive(headers, "x-interaction-type");
+	return {
+		...custom,
+		...baseIdentity,
+		"X-GitHub-Api-Version": COPILOT_API_VERSION,
+		...(initiator ? { "X-Initiator": initiator } : {}),
+		...(interactionType ? { "X-Interaction-Type": interactionType } : {}),
+	};
 }
 
 type GitHubCopilotApiKeyPayload = {

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -1,3 +1,4 @@
+import { USER_AGENT } from "@oh-my-pi/pi-utils";
 import type { FetchImpl } from "../types";
 import { isRecord } from "../utils";
 
@@ -6,7 +7,6 @@ import { isRecord } from "../utils";
  * derivation shared by catalog discovery and the pi-ai OAuth flow. The device
  * login / token refresh flow lives in `@oh-my-pi/pi-ai`'s registry.
  */
-
 const COPILOT_CLI_VERSION = "1.0.82";
 const COPILOT_CLI_USER_AGENT = `copilot/${COPILOT_CLI_VERSION}`;
 
@@ -24,6 +24,31 @@ export const COPILOT_CAPI_IDENTITY_HEADERS = {
 	"Openai-Intent": "conversation-agent",
 } as const;
 
+/** Chat identity used when Copilot CLI entitlement is not active on the subscription. */
+export const COPILOT_CHAT_IDENTITY_HEADERS = {
+	"User-Agent": USER_AGENT,
+	"Openai-Intent": "conversation-edits",
+} as const;
+
+const copilotCliDisabledTokens = new Set<string>();
+
+export function markCopilotCliDisabled(token?: string): void {
+	if (token?.trim()) {
+		copilotCliDisabledTokens.add(token.trim());
+	}
+}
+
+export function isCopilotCliDisabled(token?: string): boolean {
+	if (!token?.trim()) return false;
+	return copilotCliDisabledTokens.has(token.trim());
+}
+
+export function getCopilotCapiIdentityHeaders(options?: { cliDisabled?: boolean }): Record<string, string> {
+	if (options?.cliDisabled) {
+		return { ...COPILOT_CHAT_IDENTITY_HEADERS };
+	}
+	return { ...COPILOT_CAPI_IDENTITY_HEADERS };
+}
 /**
  * Copilot API version sent on `api.githubcopilot.com` requests (`/models`,
  * chat endpoints). Newer versions unlock tiered context metadata: `/models`
@@ -40,7 +65,6 @@ export const COPILOT_API_HEADERS = {
 	...COPILOT_CAPI_IDENTITY_HEADERS,
 	"X-GitHub-Api-Version": COPILOT_API_VERSION,
 } as const;
-
 /** Copilot CLI headers for user-initiated model discovery. */
 export const COPILOT_DISCOVERY_HEADERS = {
 	...COPILOT_API_HEADERS,
@@ -50,6 +74,7 @@ export const COPILOT_DISCOVERY_HEADERS = {
 const MANAGED_COPILOT_HEADER_NAMES: Record<string, true> = {
 	"user-agent": true,
 	"editor-version": true,
+	"editor-plugin-version": true,
 	"copilot-integration-id": true,
 	"copilot-harness-id": true,
 	"openai-intent": true,
@@ -57,31 +82,41 @@ const MANAGED_COPILOT_HEADER_NAMES: Record<string, true> = {
 	"x-initiator": true,
 	"x-interaction-type": true,
 };
-
-/** Preserve model-specific headers while enforcing the current Copilot API identity. */
-export function mergeCopilotApiHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
-	const merged: Record<string, string> = {};
+export function sanitizeCopilotHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
+	const result: Record<string, string> = {};
 	if (headers) {
-		for (const name in headers) {
-			const value = headers[name];
-			if (value !== undefined && !MANAGED_COPILOT_HEADER_NAMES[name.toLowerCase()]) {
-				merged[name] = value;
+		for (const [key, value] of Object.entries(headers)) {
+			if (value !== undefined && !MANAGED_COPILOT_HEADER_NAMES[key.toLowerCase()]) {
+				result[key] = value;
 			}
 		}
 	}
-	return { ...merged, ...COPILOT_API_HEADERS };
+	return result;
+}
+/** Preserve model-specific headers while enforcing the current Copilot API identity. */
+export function mergeCopilotApiHeaders(
+	headers?: Readonly<Record<string, string>>,
+	options?: { cliDisabled?: boolean },
+): Record<string, string> {
+	const baseIdentity = getCopilotCapiIdentityHeaders(options);
+	const custom = sanitizeCopilotHeaders(headers);
+	return { ...custom, ...baseIdentity, "X-GitHub-Api-Version": COPILOT_API_VERSION };
 }
 
 type GitHubCopilotApiKeyPayload = {
 	token?: unknown;
 	enterpriseUrl?: unknown;
 	apiEndpoint?: unknown;
+	cliDisabled?: unknown;
+	cli_enabled?: unknown;
+	cliEnabled?: unknown;
 };
 
 export type ParsedGitHubCopilotApiKey = {
 	accessToken: string;
 	enterpriseUrl?: string;
 	apiEndpoint?: string;
+	cliDisabled?: boolean;
 };
 
 const PUBLIC_GITHUB_HOSTS = new Set(["api.github.com", "github.com", "www.github.com"]);
@@ -139,7 +174,11 @@ export async function discoverGitHubCopilotApiEndpoint(
 		});
 		if (!response.ok) return undefined;
 		const data: unknown = await response.json();
-		if (!isRecord(data) || !isRecord(data.endpoints)) return undefined;
+		if (!isRecord(data)) return undefined;
+		if (data.cli_enabled === false) {
+			markCopilotCliDisabled(token);
+		}
+		if (!isRecord(data.endpoints)) return undefined;
 		const endpoint = data.endpoints.api;
 		return typeof endpoint === "string" ? normalizeGitHubCopilotApiEndpoint(endpoint) : undefined;
 	} catch {
@@ -151,6 +190,14 @@ export function parseGitHubCopilotApiKey(apiKeyRaw: string): ParsedGitHubCopilot
 	try {
 		const parsed = JSON.parse(apiKeyRaw) as GitHubCopilotApiKeyPayload;
 		if (typeof parsed.token === "string") {
+			const cliDisabled =
+				parsed.cliDisabled === true ||
+				parsed.cli_enabled === false ||
+				parsed.cliEnabled === false ||
+				isCopilotCliDisabled(parsed.token);
+			if (cliDisabled) {
+				markCopilotCliDisabled(parsed.token);
+			}
 			return {
 				accessToken: parsed.token,
 				enterpriseUrl:
@@ -161,11 +208,15 @@ export function parseGitHubCopilotApiKey(apiKeyRaw: string): ParsedGitHubCopilot
 					typeof parsed.apiEndpoint === "string"
 						? normalizeGitHubCopilotApiEndpoint(parsed.apiEndpoint)
 						: undefined,
+				cliDisabled: cliDisabled ? true : undefined,
 			};
 		}
 	} catch {}
 
-	return { accessToken: apiKeyRaw };
+	return {
+		accessToken: apiKeyRaw,
+		cliDisabled: isCopilotCliDisabled(apiKeyRaw) ? true : undefined,
+	};
 }
 
 export function normalizeDomain(input: string): string | null {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -686,6 +686,37 @@ describe("github copilot tiered context windows", () => {
 		}
 	});
 
+	it("discovers models without requiring Copilot CLI entitlement", async () => {
+		const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			if (headers.has("Copilot-Integration-Id") || headers.has("Copilot-Harness-Id")) {
+				return Response.json({ message: "Access denied" }, { status: 403 });
+			}
+			return Response.json({
+				data: [
+					tieredCopilotEntry({
+						id: "gemini-3.7-flash",
+						name: "Gemini 3.7 Flash",
+						window: 1_000_000,
+						maxOutput: 64_000,
+					}),
+				],
+			});
+		});
+		const options = githubCopilotModelManagerOptions({
+			apiKey: JSON.stringify({
+				token: "ghu_chat_only",
+				apiEndpoint: "https://api.business.githubcopilot.com",
+				cliDisabled: true,
+			}),
+			fetch: fetchMock,
+		});
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.map(model => model.id)).toContain("gemini-3.7-flash");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("caps the base entry to the default tier and synthesizes a 1M sibling", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [

--- a/packages/catalog/test/github-copilot-wire.test.ts
+++ b/packages/catalog/test/github-copilot-wire.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { USER_AGENT } from "@oh-my-pi/pi-utils";
 import {
-	COPILOT_CAPI_IDENTITY_HEADERS,
-	COPILOT_CHAT_IDENTITY_HEADERS,
-	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
 	clearCopilotCliDisabled,
 	isCopilotCliDisabled,
@@ -50,26 +47,7 @@ describe("GitHub Copilot OAuth helpers", () => {
 		});
 	});
 });
-
 describe("GitHub Copilot wire identity selection", () => {
-	it("defaults to the original Copilot CLI identity when CLI is not disabled", () => {
-		expect(getCopilotCapiIdentityHeaders()).toEqual({
-			...COPILOT_CAPI_IDENTITY_HEADERS,
-		});
-		expect(getCopilotCapiIdentityHeaders()["Copilot-Integration-Id"]).toBe("copilot-developer-cli");
-		expect(getCopilotCapiIdentityHeaders()["User-Agent"]).toBe("copilot/1.0.82");
-	});
-
-	it("uses chat identity when cliDisabled is true", () => {
-		const chatHeaders = getCopilotCapiIdentityHeaders({ cliDisabled: true });
-		expect(chatHeaders).toEqual({
-			...COPILOT_CHAT_IDENTITY_HEADERS,
-		});
-		expect(chatHeaders["User-Agent"]).toBe(USER_AGENT);
-		expect(chatHeaders["Openai-Intent"]).toBe("conversation-edits");
-		expect(chatHeaders["Copilot-Integration-Id"]).toBeUndefined();
-	});
-
 	it("merges custom headers while applying appropriate identity", () => {
 		const cliMerged = mergeCopilotApiHeaders({ "X-Custom": "val" });
 		expect(cliMerged["X-Custom"]).toBe("val");
@@ -106,12 +84,20 @@ describe("GitHub Copilot wire identity selection", () => {
 		expect(chatMerged["User-Agent"]).toBe(USER_AGENT);
 	});
 
-	it("tracks cli-disabled status per token", () => {
+	it("tracks and clears cli-disabled status per token", () => {
 		const token = "ghu_sample_tracking_token";
 		expect(isCopilotCliDisabled(token)).toBe(false);
 		markCopilotCliDisabled(token);
 		expect(isCopilotCliDisabled(token)).toBe(true);
 		expect(parseGitHubCopilotApiKey(token).cliDisabled).toBe(true);
+
+		// Restores CLI identity when authoritative response or re-login reports cli_enabled: true
+		const reenabledKey = JSON.stringify({ token, cli_enabled: true });
+		expect(parseGitHubCopilotApiKey(reenabledKey).cliDisabled).toBeUndefined();
+		expect(isCopilotCliDisabled(token)).toBe(false);
+
+		markCopilotCliDisabled(token);
+		expect(isCopilotCliDisabled(token)).toBe(true);
 		clearCopilotCliDisabled(token);
 		expect(isCopilotCliDisabled(token)).toBe(false);
 	});

--- a/packages/catalog/test/github-copilot-wire.test.ts
+++ b/packages/catalog/test/github-copilot-wire.test.ts
@@ -5,6 +5,7 @@ import {
 	COPILOT_CHAT_IDENTITY_HEADERS,
 	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
+	clearCopilotCliDisabled,
 	isCopilotCliDisabled,
 	markCopilotCliDisabled,
 	mergeCopilotApiHeaders,
@@ -83,11 +84,35 @@ describe("GitHub Copilot wire identity selection", () => {
 		expect(chatMerged["User-Agent"]).toBe(USER_AGENT);
 	});
 
+	it("preserves X-Initiator and X-Interaction-Type when merging headers", () => {
+		const cliMerged = mergeCopilotApiHeaders({
+			"X-Initiator": "agent",
+			"X-Interaction-Type": "conversation-agent",
+		});
+		expect(cliMerged["X-Initiator"]).toBe("agent");
+		expect(cliMerged["X-Interaction-Type"]).toBe("conversation-agent");
+		expect(cliMerged["Copilot-Integration-Id"]).toBe("copilot-developer-cli");
+
+		const chatMerged = mergeCopilotApiHeaders(
+			{
+				"X-Initiator": "user",
+				"X-Interaction-Type": "conversation-user",
+			},
+			{ cliDisabled: true },
+		);
+		expect(chatMerged["X-Initiator"]).toBe("user");
+		expect(chatMerged["X-Interaction-Type"]).toBe("conversation-user");
+		expect(chatMerged["Copilot-Integration-Id"]).toBeUndefined();
+		expect(chatMerged["User-Agent"]).toBe(USER_AGENT);
+	});
+
 	it("tracks cli-disabled status per token", () => {
 		const token = "ghu_sample_tracking_token";
 		expect(isCopilotCliDisabled(token)).toBe(false);
 		markCopilotCliDisabled(token);
 		expect(isCopilotCliDisabled(token)).toBe(true);
 		expect(parseGitHubCopilotApiKey(token).cliDisabled).toBe(true);
+		clearCopilotCliDisabled(token);
+		expect(isCopilotCliDisabled(token)).toBe(false);
 	});
 });

--- a/packages/catalog/test/github-copilot-wire.test.ts
+++ b/packages/catalog/test/github-copilot-wire.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import { USER_AGENT } from "@oh-my-pi/pi-utils";
 import {
+	COPILOT_CAPI_IDENTITY_HEADERS,
+	COPILOT_CHAT_IDENTITY_HEADERS,
+	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
+	isCopilotCliDisabled,
+	markCopilotCliDisabled,
+	mergeCopilotApiHeaders,
 	normalizeGitHubCopilotApiEndpoint,
 	normalizeGitHubCopilotEnterpriseDomain,
 	parseGitHubCopilotApiKey,
@@ -40,5 +47,47 @@ describe("GitHub Copilot OAuth helpers", () => {
 			enterpriseUrl: "ghe.example.com",
 			apiEndpoint: "https://api.business.githubcopilot.com",
 		});
+	});
+});
+
+describe("GitHub Copilot wire identity selection", () => {
+	it("defaults to the original Copilot CLI identity when CLI is not disabled", () => {
+		expect(getCopilotCapiIdentityHeaders()).toEqual({
+			...COPILOT_CAPI_IDENTITY_HEADERS,
+		});
+		expect(getCopilotCapiIdentityHeaders()["Copilot-Integration-Id"]).toBe("copilot-developer-cli");
+		expect(getCopilotCapiIdentityHeaders()["User-Agent"]).toBe("copilot/1.0.82");
+	});
+
+	it("uses chat identity when cliDisabled is true", () => {
+		const chatHeaders = getCopilotCapiIdentityHeaders({ cliDisabled: true });
+		expect(chatHeaders).toEqual({
+			...COPILOT_CHAT_IDENTITY_HEADERS,
+		});
+		expect(chatHeaders["User-Agent"]).toBe(USER_AGENT);
+		expect(chatHeaders["Openai-Intent"]).toBe("conversation-edits");
+		expect(chatHeaders["Copilot-Integration-Id"]).toBeUndefined();
+	});
+
+	it("merges custom headers while applying appropriate identity", () => {
+		const cliMerged = mergeCopilotApiHeaders({ "X-Custom": "val" });
+		expect(cliMerged["X-Custom"]).toBe("val");
+		expect(cliMerged["Copilot-Integration-Id"]).toBe("copilot-developer-cli");
+
+		const chatMerged = mergeCopilotApiHeaders(
+			{ "X-Custom": "val", "Copilot-Integration-Id": "copilot-developer-cli" },
+			{ cliDisabled: true },
+		);
+		expect(chatMerged["X-Custom"]).toBe("val");
+		expect(chatMerged["Copilot-Integration-Id"]).toBeUndefined();
+		expect(chatMerged["User-Agent"]).toBe(USER_AGENT);
+	});
+
+	it("tracks cli-disabled status per token", () => {
+		const token = "ghu_sample_tracking_token";
+		expect(isCopilotCliDisabled(token)).toBe(false);
+		markCopilotCliDisabled(token);
+		expect(isCopilotCliDisabled(token)).toBe(true);
+		expect(parseGitHubCopilotApiKey(token).cliDisabled).toBe(true);
 	});
 });


### PR DESCRIPTION
## Problem

GitHub Copilot subscriptions where Copilot Chat is enabled but Copilot CLI preview is disabled (`cli_enabled: false` on the account) receive `HTTP 403 Forbidden` (`GitHub Copilot access denied (HTTP 403)...`) on all model requests.

Because `oh-my-pi` sends `Copilot-Integration-Id: copilot-developer-cli` and `User-Agent: copilot/1.0.82`, GitHub's gateway checks for CLI entitlement and rejects requests from accounts without CLI access, even though standard Copilot subscriptions have full access to Copilot chat models.

## Solution

Implement a DRY, two-layer fallback that preserves the official Copilot CLI identity by default while enabling seamless access for subscriptions without CLI entitlement:

1. **Keep Original CLI Identity as Default:**
   - Standard requests continue to identify as the Copilot CLI (`copilot/1.0.82`, `Copilot-Integration-Id: copilot-developer-cli`, `Copilot-Harness-Id: copilot-sdk`, `Openai-Intent: conversation-agent`).
   - Enterprise organizations with policies restricting access to official CLI tooling experience zero regressions.

2. **Upfront Status Detection (`copilot_internal/user`):**
   - During dynamic model discovery and endpoint resolution, OMP already queries `https://api.github.com/copilot_internal/user`.
   - When the response includes `cli_enabled: false`, the token is flagged via `markCopilotCliDisabled(token)`.
   - Flagged tokens use the direct chat identity (`User-Agent: omp/<version>`, `Openai-Intent: conversation-edits`, no `Copilot-Integration-Id`), preventing 403 errors entirely.

3. **Runtime 403 Fallback:**
   - If discovery was bypassed (e.g. offline start or raw token env var), requests start with default CLI headers.
   - If an HTTP 403 occurs on a request carrying `copilot-developer-cli`:
     - The token is marked as CLI-disabled.
     - The request is retried once using the direct chat identity.
     - All subsequent requests for that token in the session use the chat identity directly without retry overhead.

## Safety details

- **Zero Breaking Changes:** Accounts with CLI entitlement continue to use the official Copilot CLI identity.
- **Enterprise Compatibility:** Organizations that permit only the CLI integration are unaffected.
- **Minimal Surface:** No new configuration settings, flags, or external dependencies required.

## Changes

**`packages/catalog`**
- `src/wire/github-copilot.ts`: Define `COPILOT_CHAT_IDENTITY_HEADERS`, add token-level `markCopilotCliDisabled`/`isCopilotCliDisabled`, check `data.cli_enabled === false` in `discoverGitHubCopilotApiEndpoint`, and support `cliDisabled` in `mergeCopilotApiHeaders`/`parseGitHubCopilotApiKey`.
- `src/provider-models/openai-compat.ts`: Pass `cliDisabled` identity headers during model discovery and mapping.
- `test/github-copilot-wire.test.ts`: Add tests for CLI vs. chat identity selection and token tracking.
- `test/github-copilot-model-limits.test.ts`: Add test covering model discovery for accounts without CLI entitlement.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

**`packages/ai`**
- `src/providers/github-copilot-headers.ts`: Support `cliDisabled` in `buildCopilotDynamicHeaders`.
- `src/providers/openai-shared.ts`: Parse `cliDisabled` and forward to dynamic header building and header merging.
- `src/providers/anthropic.ts`: Apply `cliDisabled` to client options and dynamic headers; add transparent 403 retry fallback in `streamAnthropic`.
- `src/utils/openai-http.ts`: Catch HTTP 403 on CLI requests in `postOpenAIStream`, mark token as CLI-disabled, and retry once with chat identity.
- `test/github-copilot-no-cli.test.ts`: Add tests covering OpenAI Responses, Completions, Anthropic Messages, 403 runtime fallback, and token remembrance.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

## Verification

- [x] `bun test packages/catalog/test/*copilot* packages/ai/test/*copilot* packages/utils/test/fetch-retry.test.ts packages/coding-agent/test/settings-stream-fn.test.ts` (185 pass, 0 fail across 15 files)
- [x] `bun --cwd=packages/catalog run check` (0 errors, 0 warnings)
- [x] `bun --cwd=packages/ai run check` (0 errors, 0 warnings)
- [x] Live end-to-end verification against Copilot API on a subscription with `cli_enabled: false`:
  - `gpt-5.6-terra`: 200 OK
  - `gpt-5.6-luna`: 200 OK
  - `gpt-5.6-sol`: 200 OK
  - `claude-opus-5`: 200 OK
  - `claude-sonnet-5`: 200 OK
  - `gemini-3.7-flash`: 200 OK
  - Multi-turn tool-result continuation: 200 OK
