### PR TITLE
docs: point AGENTS.md VCS helpers at natives/vcs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Unless user tells you exactly what to write:
 Before writing a helper, check whether one already exists — `packages/coding-agent/src/utils/`, `@oh-my-pi/pi-utils`, `@oh-my-pi/pi-tui`, and the domain modules next to your callsite. This applies to **everything**: VCS wrappers, formatting/truncation/path-display helpers, image handling, clipboard, streams, temp files, caching. The central versions carry hardening a fresh copy always loses (timeouts, output caps, non-interactive env, lock avoidance, caching, TUI sanitization).
 
 - Search first: `grep` for the operation before implementing it. Two implementations of the same thing is a bug even when both work.
-- Examples of the pattern: `src/utils/git.ts` and `src/utils/jj.ts` are the only sanctioned way to run git/jj (`import * as git from "../utils/git"` — never hand-spawn via `$`/`Bun.spawn`); rendering goes through the helpers in TUI Sanitization below (`replaceTabs`, `truncateToWidth`, `shortenPath`, `PREVIEW_LIMITS`) rather than ad-hoc string math.
+- Examples of the pattern: `@oh-my-pi/pi-natives/vcs` and `src/utils/active-repo-context.ts` are the only sanctioned way to run git/jj (`import * as vcs from "@oh-my-pi/pi-natives/vcs"` — never hand-spawn via `$`/`Bun.spawn`); rendering goes through the helpers in TUI Sanitization below (`replaceTabs`, `truncateToWidth`, `shortenPath`, `PREVIEW_LIMITS`) rather than ad-hoc string math.
 - Missing capability? Extend the central helper (new option, new sub-function on the namespace) and call it — don't fork its logic locally.
 
 ## Bun Over Node


### PR DESCRIPTION
## What

Update the Central Utilities example in `AGENTS.md` so it names the current VCS surface instead of deleted helper files.

I reviewed the full diff; this is a one-line docs fix so new contributors are not sent to `src/utils/git.ts` / `jj.ts`, which are gone, and are pointed at `@oh-my-pi/pi-natives/vcs` plus `src/utils/active-repo-context.ts` instead.

## Why

`AGENTS.md` still said `src/utils/git.ts` and `src/utils/jj.ts` were the only sanctioned way to run git/jj (`import * as git from "../utils/git"`). Those files are not on `main`. Repo discovery and git/jj work now go through `@oh-my-pi/pi-natives/vcs` (`packages/natives/native/vcs`) and `packages/coding-agent/src/utils/active-repo-context.ts`. Leaving the old paths in the onboarding doc sends people to files that do not exist.

No farm PR covers this. Other open `AGENTS.md` PRs touch different sections (imports, PR checklist, local-commit policy) and do not retarget these paths.

## Testing

- Confirmed `packages/coding-agent/src/utils/git.ts` and `jj.ts` are absent on the PR base (`9effebbb19`).
- Confirmed replacements exist: `packages/natives/native/vcs.d.ts` / `vcs.js` (exported as `@oh-my-pi/pi-natives/vcs`) and `packages/coding-agent/src/utils/active-repo-context.ts` (imports `import * as vcs from "@oh-my-pi/pi-natives/vcs"`).
- `rg 'git\.ts|jj\.ts' AGENTS.md` is empty after the edit. Diff is one line in `AGENTS.md`.
- Runtime/`bun check` not run: documentation-only, no code or schema change.

Prepared with AI assistance under the account owner's direction and reviewed against the repo's contribution rules before submission.

---

- [ ] `bun check` passes (not applicable; docs-only)
- [x] Tested locally (path existence + leftover-string check)
- [ ] CHANGELOG updated (not user-facing)


Made with [Cursor](https://cursor.com)