### PR TITLE
fix(coding-agent): complete title signal stub in working-accent harness

### DIFF
--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -62,6 +62,8 @@ async function createHarness(sessionName: string): Promise<Harness> {
 		isStreaming: true,
 		model: undefined,
 		thinkingLevel: undefined,
+		titleGenerationSignal: new AbortController().signal,
+		notifyTitleGenerationStart: () => undefined,
 	} as unknown as AgentSession;
 	const mode = new InteractiveMode(session, "test");
 	harness = { mode, sessionManager, tempDir };


### PR DESCRIPTION
Unblocks CI (red main + red merge builds, e.g. #11368's UI/TUI job). Per review discussion, the root cause is a test-stub deficiency — not production code — so this reverts the earlier production guards in favor of the convention-consistent stub fix; zero production changes.

**Root cause:** #11084 (feat/rename-generated-title) reads `session.titleGenerationSignal` (typed non-optional, always initialized on real sessions) in three staleness guards. The working-accent harness builds a partial session stub lacking it (sibling harnesses `acp-agent.test.ts:2415` and `acp-builtins.test.ts:81` already populate it), so blank `/rename` threw `TypeError`. The same stub gap covered the unguarded read at `command-controller.ts:1313`, reachable via non-blank `/rename <title>` — also fixed structurally by completing the stub.

**Fix (test-only):** populate `titleGenerationSignal: new AbortController().signal` and `notifyTitleGenerationStart: () => undefined` on the stub, matching the existing harnesses. (A duplicate explicit-rename test was removed per review: `rename.test.ts` already covers that contract.)

**Verification:**
- The exact failing CI chunk (working-accent + 4 issue repros): 24 pass, 0 fail (was 23 pass, 1 fail).
- Rename/title suites green except 2 `rename.test.ts` session-switch cases that fail identically without this change (pre-existing Windows-local path issue, green on Linux CI).
- `bun check` exit 0 (lint + types + format).