### PR TITLE
fix(coding-agent/tui): dequeue pops only the last queued message

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Alt+Up (dequeue) now pops only the last queued message back into the composer instead of draining the entire queue, so pressing it no longer destroys composer work ([#11402](https://github.com/can1357/oh-my-pi/issues/11402)).
 - Unset `tiny` model roles now honor the configured `@smol` fallback in direct execution and the `/models` Roles view ([#11311](https://github.com/can1357/oh-my-pi/issues/11311)).
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).
 - Codex turns interrupted before terminal completion now auto-continue after resolved tool calls instead of stopping ([#11349](https://github.com/can1357/oh-my-pi/issues/11349)).

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -21,6 +21,7 @@ import { parseQueueShorthand, splitQueuedMessages } from "../../modes/queue-inpu
 import { buildSkillCommandPrompt, isKnownSkillCommand } from "../../modes/skill-command";
 import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
+import type { RestoredQueuedMessage } from "../../session/agent-session-types";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand, lookupBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { parseSlashCommand } from "../../slash-commands/helpers/parse";
@@ -1254,12 +1255,33 @@ export class InputController {
 	}
 
 	handleDequeue(): void {
-		const restored = this.restoreQueuedMessagesToEditor();
-		if (restored === 0) {
+		const popped = this.#popLastQueuedMessage();
+		if (!popped) {
 			this.ctx.showStatus("No queued messages to restore");
-		} else {
-			this.ctx.showStatus(`Restored ${restored} queued message${restored > 1 ? "s" : ""} to editor`);
+			return;
 		}
+		// Drop only the popped message's local-submission signature; the messages
+		// left in the queue keep theirs so their delivery echo is still recognized
+		// as local and does not blank the editor the dequeue just restored to.
+		this.ctx.locallySubmittedUserSignatures.delete(`${popped.text}\u0000${popped.images?.length ?? 0}`);
+		this.#restoreEntriesToEditor([popped]);
+		this.ctx.showStatus("Restored last queued message to editor");
+	}
+
+	/**
+	 * Pop the single most-recently-queued restorable message for the Alt+Up
+	 * dequeue key. Prefers the agent queues (steering, then follow-up) via the
+	 * session API that steps over hidden companions; falls back to the compaction
+	 * queue for messages typed while compacting, which live outside those queues.
+	 */
+	#popLastQueuedMessage(): RestoredQueuedMessage | undefined {
+		const fromQueue = this.ctx.session.popLastQueuedMessage();
+		if (fromQueue) return fromQueue;
+		const compaction = this.ctx.compactionQueuedMessages;
+		if (compaction.length === 0) return undefined;
+		const last = compaction[compaction.length - 1];
+		this.ctx.compactionQueuedMessages = compaction.slice(0, -1);
+		return { text: last.text, images: last.images };
 	}
 
 	/**
@@ -1562,9 +1584,8 @@ export class InputController {
 		// Messages typed while compacting live in `compactionQueuedMessages`, not the
 		// agent queue `clearQueue()` drains — but the pending bar shows the same
 		// "Alt+Up to edit" hint for them (ui-helpers `updatePendingMessagesDisplay`).
-		// Drain them here too so the dequeue restores every message the hint
-		// advertises; otherwise a skill/text queued during compaction is stranded and
-		// Alt+Up reports "No queued messages to restore".
+		// Drain them here too so the restore recovers every message the hint
+		// advertises; otherwise a skill/text queued during compaction is stranded.
 		const compactionQueued = this.ctx.compactionQueuedMessages;
 		this.ctx.compactionQueuedMessages = [];
 		const allQueued = [
@@ -1573,11 +1594,22 @@ export class InputController {
 			...followUp,
 			...compactionQueued.filter(e => e.mode === "followUp").map(e => ({ text: e.text, images: e.images })),
 		];
-		if (allQueued.length === 0) {
+		const restored = this.#restoreEntriesToEditor(allQueued, options?.currentText);
+		if (options?.abort) {
+			void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
+		}
+		return restored;
+	}
+
+	/**
+	 * Merge queued entries (oldest→newest) ahead of the current draft, folding
+	 * their images back into the pending-image buffer and refreshing the pending
+	 * bar. Shared by the Alt+Up dequeue (one entry) and the Esc restore-all path.
+	 * Returns the number of entries restored.
+	 */
+	#restoreEntriesToEditor(entries: RestoredQueuedMessage[], currentText?: string): number {
+		if (entries.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();
-			if (options?.abort) {
-				void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
-			}
 			return 0;
 		}
 		// Image markers are positional: `[Image #N]` ↔ `pendingImages[N-1]`
@@ -1590,21 +1622,21 @@ export class InputController {
 		// indices by the running offset keeps the merged text aligned with the merged
 		// `pendingImages` order; draft markers stay valid because draft images
 		// keep their original positions.
-		const queuedImages = allQueued.flatMap(e => e.images ?? []);
+		const queuedImages = entries.flatMap(e => e.images ?? []);
 		let queuedText: string;
 		if (queuedImages.length > 0) {
 			const parts: string[] = [];
 			let imageOffset = this.ctx.editor.pendingImages.length;
-			for (const entry of allQueued) {
+			for (const entry of entries) {
 				parts.push(shiftImageMarkers(entry.text, imageOffset));
 				if (entry.images && entry.images.length > 0) imageOffset += entry.images.length;
 			}
 			queuedText = parts.join("\n\n");
 		} else {
-			queuedText = allQueued.map(e => e.text).join("\n\n");
+			queuedText = entries.map(e => e.text).join("\n\n");
 		}
-		const currentText = options?.currentText ?? this.ctx.editor.getText();
-		const combinedText = [queuedText, currentText].filter(t => t.trim()).join("\n\n");
+		const current = currentText ?? this.ctx.editor.getText();
+		const combinedText = [queuedText, current].filter(t => t.trim()).join("\n\n");
 		// Hand queued images back to the pending-image buffer first (links are
 		// re-materialized lazily), then set the text: setCollapsedText folds the
 		// renumbered `[Image #N, WxH]` references back into chip tokens, and the
@@ -1616,10 +1648,7 @@ export class InputController {
 		}
 		this.ctx.editor.setCollapsedText(combinedText);
 		this.ctx.updatePendingMessagesDisplay();
-		if (options?.abort) {
-			void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
-		}
-		return allQueued.length;
+		return entries.length;
 	}
 
 	async #insertPendingImage(imageData: ImageContent, videoPath?: string): Promise<void> {

--- a/packages/coding-agent/test/input-controller-dequeue.test.ts
+++ b/packages/coding-agent/test/input-controller-dequeue.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression (#11402): the Alt+Up dequeue key must pop only the single
+ * most-recently-queued message back into the composer, leaving the rest queued.
+ *
+ * Before the fix `handleDequeue()` called `restoreQueuedMessagesToEditor()`,
+ * which drains the entire queue via `clearQueue()` — pressing Alt+Up with two
+ * messages queued dropped both into the editor and destroyed any composer draft
+ * ordering. The session already exposed `popLastQueuedMessage()` ("restore
+ * messages to editor one at a time") but nothing wired it to the key.
+ *
+ * Contracts defended here:
+ *   - one Alt+Up restores exactly the last queued message and leaves the others
+ *     in the queue (does not call `clearQueue`);
+ *   - the restored text is merged ahead of the existing draft;
+ *   - an empty queue reports "No queued messages to restore";
+ *   - when the agent queues are empty, the compaction queue is the fallback and
+ *     only its last entry is popped.
+ */
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { RestoredQueuedMessage } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+beforeAll(() => {
+	initTheme();
+});
+
+function makeCtx(
+	opts: { queue?: RestoredQueuedMessage[]; compaction?: CompactionQueuedMessage[]; draft?: string } = {},
+) {
+	const queue = [...(opts.queue ?? [])];
+	let editorText = opts.draft ?? "";
+	const statuses: string[] = [];
+
+	// Faithful stub of AgentSession.popLastQueuedMessage: removes and returns the
+	// last queued entry, or undefined when empty. clearQueue is spied so the test
+	// proves the dequeue path never drains the whole queue.
+	const clearQueue = mock(() => ({ steering: [] as RestoredQueuedMessage[], followUp: queue.splice(0) }));
+	const session = {
+		popLastQueuedMessage: () => queue.pop(),
+		clearQueue,
+	};
+
+	const ctx = {
+		session,
+		compactionQueuedMessages: [...(opts.compaction ?? [])],
+		editor: {
+			setCollapsedText: (t: string) => {
+				editorText = t;
+			},
+			getText: () => editorText,
+			imageLinks: undefined as (string | undefined)[] | undefined,
+			pendingImages: [],
+			pendingImageLinks: [],
+		},
+		locallySubmittedUserSignatures: new Set<string>(),
+		updatePendingMessagesDisplay: () => {},
+		showStatus: (msg: string) => {
+			statuses.push(msg);
+		},
+		showError: () => {},
+	} as unknown as InteractiveModeContext;
+
+	return { ctx, session, queue, clearQueue, statuses, getText: () => editorText };
+}
+
+describe("InputController.handleDequeue (Alt+Up)", () => {
+	test("pops only the last queued message and leaves the rest queued", () => {
+		const { ctx, queue, clearQueue, getText } = makeCtx({
+			queue: [{ text: "first message" }, { text: "second message" }],
+		});
+
+		new InputController(ctx).handleDequeue();
+
+		expect(getText()).toBe("second message");
+		expect(queue.map(m => m.text)).toEqual(["first message"]);
+		expect(clearQueue).not.toHaveBeenCalled();
+	});
+
+	test("a second Alt+Up pops the next-last message", () => {
+		const { ctx, getText } = makeCtx({ queue: [{ text: "first" }, { text: "second" }] });
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+		expect(getText()).toBe("second");
+
+		controller.handleDequeue();
+		// Popped message merges ahead of the draft the first pop restored.
+		expect(getText()).toBe("first\n\nsecond");
+	});
+
+	test("merges the popped message ahead of an existing draft", () => {
+		const { ctx, getText } = makeCtx({ queue: [{ text: "queued" }], draft: "typed draft" });
+		new InputController(ctx).handleDequeue();
+		expect(getText()).toBe("queued\n\ntyped draft");
+	});
+
+	test("empty queue reports nothing to restore", () => {
+		const { ctx, statuses, getText } = makeCtx();
+		new InputController(ctx).handleDequeue();
+		expect(statuses).toEqual(["No queued messages to restore"]);
+		expect(getText()).toBe("");
+	});
+
+	test("falls back to the compaction queue and pops only its last entry", () => {
+		const { ctx, getText } = makeCtx({
+			compaction: [
+				{ text: "compaction one", mode: "followUp", images: undefined },
+				{ text: "compaction two", mode: "followUp", images: undefined },
+			],
+		});
+
+		new InputController(ctx).handleDequeue();
+
+		expect(getText()).toBe("compaction two");
+		expect((ctx.compactionQueuedMessages as CompactionQueuedMessage[]).map(m => m.text)).toEqual(["compaction one"]);
+	});
+});


### PR DESCRIPTION
## Repro
With two messages queued (steering or follow-up), a single Alt+Up drops **both** back into the composer instead of only the last one, destroying queue ordering and any existing draft. Reproduced with a controller-level regression test: `handleDequeue()` restored `"first message\n\nsecond message"` when only `"second message"` was expected.

```
bun test packages/coding-agent/test/input-controller-dequeue.test.ts
```

## Cause
`InputController.handleDequeue()` (`packages/coding-agent/src/modes/controllers/input-controller.ts`) called `restoreQueuedMessagesToEditor()`, which runs `AgentSession.clearQueue()` and drains the entire steering + follow-up + compaction queue into the editor. The session already exposes `AgentSession.popLastQueuedMessage()` — documented "Used by dequeue keybinding to restore messages to editor one at a time" — but nothing was wired to it, so it was dead code and the key restored everything.

## Fix
- `handleDequeue()` now calls a new `#popLastQueuedMessage()` that pops exactly one entry via `session.popLastQueuedMessage()` (steering, then follow-up, stepping over hidden companions), falling back to the last compaction-queued entry when the agent queues are empty.
- Extracted the editor-merge + image-realignment logic into `#restoreEntriesToEditor(entries, currentText?)`, shared by the one-entry dequeue and the unchanged Esc restore-all path.
- The dequeue drops only the popped message's `locallySubmittedUserSignatures` entry (not a blanket `clear()`), so messages left in the queue keep their delivery-echo protection and their eventual delivery does not blank the restored draft.

## Verification
`bun test packages/coding-agent/test/input-controller-*.test.ts` — 180 pass, 0 fail (includes the new `input-controller-dequeue.test.ts`: last-only pop, sequential pops, draft merge, empty-queue status, compaction fallback). `bun check` clean for the changed files. Fixes #11402