### PR TITLE
fix(launch): spawn broker via upgrade-stable launcher path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions ([#11047](https://github.com/can1357/oh-my-pi/pull/11047) by [@mgpai22](https://github.com/mgpai22)).
 - Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 - Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
+- Long-running sessions no longer break every `hub` process op (`ps`/`start`/`logs`/`stop`) with `ENOENT ... posix_spawn` after `brew upgrade omp`; the daemon broker and workers now spawn through a launcher path that survives version upgrades (`OMP_BIN` → existing `execPath` → the `omp` launcher on `PATH`) ([#11407](https://github.com/can1357/oh-my-pi/issues/11407)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -3,6 +3,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	$env,
+	$which,
+	APP_NAME,
 	isBunTestRuntime,
 	isCompiledBinary,
 	logger,
@@ -107,6 +109,37 @@ export interface WorkerSpawnCommand {
 export const SMOKE_TEST_TIMEOUT_MS = 30_000;
 
 /**
+ * Resolve the compiled binary's launcher path, preferring a location that
+ * survives version upgrades under a live session.
+ *
+ * `process.execPath` is symlink-resolved, so a Homebrew install reports the
+ * versioned `Cellar/omp/<version>/bin/omp` path rather than the stable
+ * `<prefix>/bin/omp` symlink it was invoked through. `brew upgrade` deletes the
+ * old Cellar directory, so any already-running session holds an `execPath` that
+ * no longer exists: re-spawning a worker or the daemon broker through it fails
+ * with `ENOENT ... posix_spawn`, silently breaking every hub process op for the
+ * session's lifetime (issue #11407). Resolve a launcher that still exists:
+ *   1. `OMP_BIN` when it points at an existing file (operator override).
+ *   2. `process.execPath` when it still exists (the common, un-upgraded case).
+ *   3. the `omp` launcher on `PATH` — the stable `<prefix>/bin/omp` symlink
+ *      Homebrew repoints to the current version on upgrade.
+ *   4. `process.execPath` as a last resort so the spawn's own ENOENT surfaces.
+ *
+ * Only meaningful for the compiled binary, whose `execPath` is the omp
+ * launcher; in source/bundle mode `execPath` is `bun` (always present), so
+ * callers gate this behind {@link isCompiledBinary}.
+ */
+function resolveSelfExecutable(): string {
+	const execPath = stripWindowsExtendedLengthPathPrefix(process.execPath);
+	const override = process.env.OMP_BIN;
+	if (override && fs.existsSync(override)) return stripWindowsExtendedLengthPathPrefix(override);
+	if (fs.existsSync(execPath)) return execPath;
+	const onPath = $which(APP_NAME);
+	if (onPath) return stripWindowsExtendedLengthPathPrefix(onPath);
+	return execPath;
+}
+
+/**
  * Resolve the command that re-enters this CLI's entrypoint: the compiled
  * binary itself, or the runtime plus the declared worker-host entry. Used by
  * the TUI `/restart` relaunch; workers go through {@link resolveWorkerSpawnCmd},
@@ -115,8 +148,8 @@ export const SMOKE_TEST_TIMEOUT_MS = 30_000;
  * absolute path of `src/cli.ts` so the relaunch keeps the caller's cwd.
  */
 export function resolveCliEntryCmd(): string[] {
+	if (isCompiledBinary()) return [resolveSelfExecutable()];
 	const executable = stripWindowsExtendedLengthPathPrefix(process.execPath);
-	if (isCompiledBinary()) return [executable];
 	const hostEntry = workerHostEntry();
 	if (hostEntry) return [executable, hostEntry];
 	return [executable, path.resolve(import.meta.dir, "..", "cli.ts")];
@@ -134,8 +167,8 @@ export function resolveCliEntryCmd(): string[] {
  * IPC handles more reliably under `bun test`.
  */
 export function resolveWorkerSpawnCmd(workerArg: string): WorkerSpawnCommand {
+	if (isCompiledBinary()) return { cmd: [resolveSelfExecutable(), workerArg] };
 	const executable = stripWindowsExtendedLengthPathPrefix(process.execPath);
-	if (isCompiledBinary()) return { cmd: [executable, workerArg] };
 	const hostEntry = workerHostEntry();
 	if (hostEntry) {
 		return { cmd: [executable, hostEntry, workerArg] };

--- a/packages/coding-agent/test/worker-spawn-stable-path.test.ts
+++ b/packages/coding-agent/test/worker-spawn-stable-path.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveCliEntryCmd, resolveWorkerSpawnCmd } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
+import * as utils from "@oh-my-pi/pi-utils";
+
+const BROKER = "__omp_worker_daemon_broker";
+
+// Regression for issue #11407: in a compiled binary the daemon broker and every
+// worker are re-spawned through `process.execPath`, which is symlink-resolved to
+// the versioned Homebrew Cellar path. `brew upgrade` deletes that directory, so a
+// still-running session's spawn fails with `ENOENT ... posix_spawn` and every hub
+// process op breaks for the session's lifetime. The launcher must resolve to a
+// path that still exists.
+describe("compiled-binary launcher resolution survives a vanished execPath", () => {
+	const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+	let root = "";
+
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-launcher-"));
+		spyOn(utils, "isCompiledBinary").mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		if (execPathDescriptor) Object.defineProperty(process, "execPath", execPathDescriptor);
+		delete process.env.OMP_BIN;
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("keeps using execPath when it still exists (the common, un-upgraded case)", () => {
+		const exe = path.join(root, "cellar-18.1.15-omp");
+		fs.writeFileSync(exe, "");
+		const which = spyOn(utils, "$which");
+		Object.defineProperty(process, "execPath", { value: exe, configurable: true, writable: true });
+
+		expect(resolveWorkerSpawnCmd(BROKER)).toEqual({ cmd: [exe, BROKER] });
+		expect(resolveCliEntryCmd()).toEqual([exe]);
+		expect(which).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the omp launcher on PATH when execPath has been deleted by an upgrade", () => {
+		const stable = path.join(root, "prefix-bin-omp");
+		fs.writeFileSync(stable, "");
+		spyOn(utils, "$which").mockReturnValue(stable);
+		// A versioned path the process was launched from, now gone after `brew upgrade`.
+		Object.defineProperty(process, "execPath", {
+			value: path.join(root, "cellar-18.1.14-omp"),
+			configurable: true,
+			writable: true,
+		});
+
+		expect(resolveWorkerSpawnCmd(BROKER)).toEqual({ cmd: [stable, BROKER] });
+		expect(resolveCliEntryCmd()).toEqual([stable]);
+	});
+
+	it("prefers an existing OMP_BIN override over execPath", () => {
+		const override = path.join(root, "omp-bin-override");
+		const exe = path.join(root, "cellar-18.1.15-omp");
+		fs.writeFileSync(override, "");
+		fs.writeFileSync(exe, "");
+		spyOn(utils, "$which");
+		Object.defineProperty(process, "execPath", { value: exe, configurable: true, writable: true });
+		process.env.OMP_BIN = override;
+
+		expect(resolveWorkerSpawnCmd(BROKER).cmd[0]).toBe(override);
+	});
+
+	it("ignores a stale OMP_BIN that no longer exists", () => {
+		const exe = path.join(root, "cellar-18.1.15-omp");
+		fs.writeFileSync(exe, "");
+		spyOn(utils, "$which");
+		Object.defineProperty(process, "execPath", { value: exe, configurable: true, writable: true });
+		process.env.OMP_BIN = path.join(root, "removed-omp");
+
+		expect(resolveWorkerSpawnCmd(BROKER).cmd[0]).toBe(exe);
+	});
+});


### PR DESCRIPTION
## Repro
On a compiled (e.g. Homebrew) install, start an omp session, then `brew upgrade omp` (or `brew uninstall --force` the running version) so its `Cellar/omp/<version>` directory is removed. In the still-running session, every `hub` process op (`ps`/`start`/`logs`/`stop`) then fails with `ENOENT: no such file or directory, posix_spawn '.../Cellar/omp/<old-version>/bin/omp'`, while messaging ops keep working. Modeling that layout in a temp dir — capture `execPath` through the stable `bin/omp` symlink, repoint the symlink to a new version, delete the old Cellar dir — reproduces the exact failure: spawn via the captured `execPath` throws `ENOENT ... posix_spawn`, while spawn via the stable symlink still succeeds.

## Cause
`resolveWorkerSpawnCmd` / `resolveCliEntryCmd` in `packages/coding-agent/src/subprocess/worker-client.ts` spawn the compiled binary via `process.execPath`. `process.execPath` is symlink-resolved, so under Homebrew it is the versioned `Cellar/omp/<version>/bin/omp` path rather than the stable `<prefix>/bin/omp` symlink the process was launched through. `brew upgrade` deletes the old Cellar directory, so an already-running session holds an `execPath` that no longer exists; the daemon-broker client re-spawns the broker (its `broker.pid` lease is empty) through that vanished path and every hub process op fails for the session's lifetime. The broker's own state is fine — this is purely client-side spawn-path resolution.

## Fix
- Add `resolveSelfExecutable()` in `worker-client.ts`, used only in the compiled-binary branch, resolving a launcher that survives version upgrades: `OMP_BIN` (when it points at an existing file) → `process.execPath` (when it still exists, the common un-upgraded case) → the `omp` launcher on `PATH` via `$which` (the stable `<prefix>/bin/omp` symlink Homebrew repoints on upgrade) → `execPath` as a last resort so the spawn's own ENOENT still surfaces.
- Route both `resolveWorkerSpawnCmd` and `resolveCliEntryCmd` through it for compiled binaries; source/bundle mode is unchanged (its `execPath` is `bun`, always present).
- Add a regression test and a changelog entry.

## Verification
`bun test test/worker-spawn-stable-path.test.ts` — 4 pass (execPath-still-exists keeps current behavior and never consults PATH; deleted-execPath falls back to the PATH launcher; existing `OMP_BIN` wins; stale `OMP_BIN` is ignored). `bun test test/worker-selector.test.ts test/tiny-worker-env.test.ts test/launch/spawn-options.test.ts` — 19 pass. `bun check` clean repo-wide. Standalone repro script confirmed the `ENOENT ... posix_spawn` failure and that the stable path succeeds.

Fixes #11407