### PR TITLE
fix(lsp): reconcile open document from disk before semantic queries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions ([#11047](https://github.com/can1357/oh-my-pi/pull/11047) by [@mgpai22](https://github.com/mgpai22)).
 - Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 - Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
+- LSP semantic queries (references, definition, rename, hover) now reconcile an already-open document with disk before running, so an external edit that shifts lines no longer resolves the query against the server's stale document and returns a different symbol ([#11416](https://github.com/can1357/oh-my-pi/issues/11416)).
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1225,6 +1225,14 @@ export async function getActiveOrPendingClient(
 }
 
 /**
+ * Signature of the document text last handed to the server, used to detect when
+ * disk contents have diverged (e.g. an external edit) from the server's copy.
+ */
+function documentSignature(content: string): number | bigint {
+	return Bun.hash(content);
+}
+
+/**
  * Ensure a file is opened in the LSP client.
  * Sends didOpen notification if the file is not already tracked.
  */
@@ -1278,13 +1286,85 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
 			signal,
 		);
 
-		client.openFiles.set(uri, { version: 1, languageId });
+		client.openFiles.set(uri, { version: 1, languageId, syncedHash: documentSignature(content) });
 		client.lastActivity = Date.now();
 	})();
 
 	fileOperationLocks.set(lockKey, openPromise);
 	try {
 		await openPromise;
+	} finally {
+		fileOperationLocks.delete(lockKey);
+	}
+}
+
+/**
+ * Reconcile an already-open document with current disk contents before a semantic query.
+ *
+ * {@link ensureFileOpen} opens an untracked file but no-ops when the URI is already
+ * open, so an external edit — one not routed through OMP's write/edit tools, which
+ * announce their changes via {@link notifyWorkspaceWatchedFiles}/{@link refreshFile} —
+ * leaves the server holding the pre-edit document while callers compute query
+ * positions from disk. This reads the file and, when its contents diverge from the
+ * text last sent to the server, pushes a `didChange` so the server's copy matches
+ * the disk text the position was derived from. Untracked files fall through to
+ * {@link ensureFileOpen}; unchanged files send nothing.
+ */
+export async function reconcileFileFromDisk(client: LspClient, filePath: string, signal?: AbortSignal): Promise<void> {
+	throwIfAborted(signal);
+	const uri = fileToUri(filePath);
+	if (!client.openFiles.has(uri)) {
+		await ensureFileOpen(client, filePath, signal);
+		return;
+	}
+
+	const lockKey = `${client.name}:${uri}`;
+	const existingLock = fileOperationLocks.get(lockKey);
+	if (existingLock) {
+		await untilAborted(signal, () => existingLock);
+	}
+
+	const reconcilePromise = (async () => {
+		throwIfAborted(signal);
+		const info = client.openFiles.get(uri);
+		if (!info) {
+			await ensureFileOpen(client, filePath, signal);
+			return;
+		}
+
+		let content: string;
+		try {
+			content = await Bun.file(filePath).text();
+			throwIfAborted(signal);
+		} catch (err) {
+			if (isEnoent(err)) return;
+			throw err;
+		}
+
+		const signature = documentSignature(content);
+		if (signature === info.syncedHash) return;
+
+		// Drop cached diagnostics computed against the stale document before the
+		// server recomputes them for the reconciled content.
+		client.diagnostics.delete(uri);
+		const version = ++info.version;
+		throwIfAborted(signal);
+		await sendNotification(
+			client,
+			"textDocument/didChange",
+			{
+				textDocument: { uri, version },
+				contentChanges: [{ text: content }],
+			},
+			signal,
+		);
+		info.syncedHash = signature;
+		client.lastActivity = Date.now();
+	})();
+
+	fileOperationLocks.set(lockKey, reconcilePromise);
+	try {
+		await reconcilePromise;
 	} finally {
 		fileOperationLocks.delete(lockKey);
 	}
@@ -1350,7 +1430,7 @@ export async function syncContent(
 				},
 				signal,
 			);
-			client.openFiles.set(uri, { version: 1, languageId });
+			client.openFiles.set(uri, { version: 1, languageId, syncedHash: documentSignature(content) });
 			client.lastActivity = Date.now();
 			return;
 		}
@@ -1366,6 +1446,7 @@ export async function syncContent(
 			},
 			signal,
 		);
+		info.syncedHash = documentSignature(content);
 		client.lastActivity = Date.now();
 	})();
 
@@ -1514,6 +1595,7 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
 			signal,
 		);
 
+		info.syncedHash = documentSignature(content);
 		client.lastActivity = Date.now();
 	})();
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1341,23 +1341,29 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
  * text last sent to the server, pushes a `didChange` so the server's copy matches
  * the disk text the position was derived from. Untracked files fall through to
  * {@link ensureFileOpen}; unchanged files send nothing.
+ * Returns `true` only when a `didChange` was pushed for a reconciled overlay — the
+ * caller can then wait for fresh diagnostics, since the stale ones were dropped.
  * A file with an in-flight OMP write ({@link beginPendingDiskWrite}) is skipped
  * entirely: its overlay leads disk, so reading disk back would revert the server
  * to pre-write content.
  */
-export async function reconcileFileFromDisk(client: LspClient, filePath: string, signal?: AbortSignal): Promise<void> {
+export async function reconcileFileFromDisk(
+	client: LspClient,
+	filePath: string,
+	signal?: AbortSignal,
+): Promise<boolean> {
 	throwIfAborted(signal);
 	const uri = fileToUri(filePath);
 	if (!client.openFiles.has(uri)) {
 		await ensureFileOpen(client, filePath, signal);
-		return;
+		return false;
 	}
 
 	// An in-flight OMP write has already synced newer (possibly formatted) text to
 	// the server ahead of committing it to disk; the on-disk file is the stale side,
 	// so reconciling from it would clobber the overlay. Leave it to the write.
 	if (pendingDiskWrites.has(uri)) {
-		return;
+		return false;
 	}
 
 	const lockKey = `${client.name}:${uri}`;
@@ -1366,6 +1372,7 @@ export async function reconcileFileFromDisk(client: LspClient, filePath: string,
 		await untilAborted(signal, () => existingLock);
 	}
 
+	let didChange = false;
 	const reconcilePromise = (async () => {
 		throwIfAborted(signal);
 		const info = client.openFiles.get(uri);
@@ -1405,6 +1412,7 @@ export async function reconcileFileFromDisk(client: LspClient, filePath: string,
 		);
 		info.syncedHash = signature;
 		client.lastActivity = Date.now();
+		didChange = true;
 	})();
 
 	fileOperationLocks.set(lockKey, reconcilePromise);
@@ -1413,6 +1421,7 @@ export async function reconcileFileFromDisk(client: LspClient, filePath: string,
 	} finally {
 		fileOperationLocks.delete(lockKey);
 	}
+	return didChange;
 }
 
 /**

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -35,6 +35,15 @@ const clientLocks = new Map<string, PendingClient>();
 const invalidatedClientKeys = new Set<string>();
 const clientReloadBarriers = new Map<string, Promise<unknown>>();
 const fileOperationLocks = new Map<string, Promise<void>>();
+/**
+ * URIs whose server overlay OMP has intentionally advanced ahead of the on-disk
+ * file for an in-flight write/edit: the writethrough syncs the new (and possibly
+ * formatted) text to the language server before committing it to disk, so while
+ * a write is pending the file on disk is *older* than the overlay. Refcounted by
+ * {@link beginPendingDiskWrite}/{@link endPendingDiskWrite} so overlapping writes
+ * to the same file stay marked until the last one commits.
+ */
+const pendingDiskWrites = new Map<string, number>();
 
 /** Negative cache of recent init failures so a broken server fails fast instead of re-spawning per call. */
 const INIT_FAILURE_BACKOFF_MS = 3 * 60 * 1000;
@@ -1233,6 +1242,29 @@ function documentSignature(content: string): number | bigint {
 }
 
 /**
+ * Mark a file whose server overlay OMP has advanced ahead of disk for an in-flight
+ * write. While marked, {@link reconcileFileFromDisk} skips reading disk back into
+ * the server, because the on-disk file is the *stale* side until the write commits.
+ * Every call MUST be balanced by {@link endPendingDiskWrite}.
+ */
+export function beginPendingDiskWrite(filePath: string): void {
+	const uri = fileToUri(filePath);
+	pendingDiskWrites.set(uri, (pendingDiskWrites.get(uri) ?? 0) + 1);
+}
+
+/** Release a mark set by {@link beginPendingDiskWrite}; the overlay is authoritative until then. */
+export function endPendingDiskWrite(filePath: string): void {
+	const uri = fileToUri(filePath);
+	const count = pendingDiskWrites.get(uri);
+	if (count === undefined) return;
+	if (count > 1) {
+		pendingDiskWrites.set(uri, count - 1);
+	} else {
+		pendingDiskWrites.delete(uri);
+	}
+}
+
+/**
  * Ensure a file is opened in the LSP client.
  * Sends didOpen notification if the file is not already tracked.
  */
@@ -1309,12 +1341,22 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
  * text last sent to the server, pushes a `didChange` so the server's copy matches
  * the disk text the position was derived from. Untracked files fall through to
  * {@link ensureFileOpen}; unchanged files send nothing.
+ * A file with an in-flight OMP write ({@link beginPendingDiskWrite}) is skipped
+ * entirely: its overlay leads disk, so reading disk back would revert the server
+ * to pre-write content.
  */
 export async function reconcileFileFromDisk(client: LspClient, filePath: string, signal?: AbortSignal): Promise<void> {
 	throwIfAborted(signal);
 	const uri = fileToUri(filePath);
 	if (!client.openFiles.has(uri)) {
 		await ensureFileOpen(client, filePath, signal);
+		return;
+	}
+
+	// An in-flight OMP write has already synced newer (possibly formatted) text to
+	// the server ahead of committing it to disk; the on-disk file is the stale side,
+	// so reconciling from it would clobber the overlay. Leave it to the write.
+	if (pendingDiskWrites.has(uri)) {
 		return;
 	}
 
@@ -1341,6 +1383,9 @@ export async function reconcileFileFromDisk(client: LspClient, filePath: string,
 			throw err;
 		}
 
+		// Re-check after the (awaited) disk read: a write may have started and
+		// synced its overlay in the meantime, making this disk snapshot stale.
+		if (pendingDiskWrites.has(uri)) return;
 		const signature = documentSignature(content);
 		if (signature === info.syncedHash) return;
 

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -1160,8 +1160,9 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			const rustWorkspaceWait =
 				needsProjectIndex && isRustAnalyzerServer && targetFile !== null && hasRustWorkspaceAncestor(targetFile);
 
+			let reconciledFromDisk = false;
 			if (targetFile) {
-				await reconcileFileFromDisk(client, targetFile, signal);
+				reconciledFromDisk = await reconcileFileFromDisk(client, targetFile, signal);
 			}
 			if (rustWorkspaceWait) {
 				await waitForProjectLoaded(client, signal);
@@ -1347,7 +1348,30 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				}
 
 				case "code_actions": {
-					const diagnostics = client.diagnostics.get(uri)?.diagnostics ?? [];
+					let diagnostics = client.diagnostics.get(uri)?.diagnostics ?? [];
+					// A reconcile dropped the stale diagnostics and pushed a didChange;
+					// the server re-publishes (or a pull answers) asynchronously, so read
+					// the map now and quick-fix providers see an empty context.diagnostics.
+					// Wait for diagnostics matching the reconciled document version first.
+					// Non-diagnostic actions (refactors, source actions) still return if the
+					// wait cannot complete, so a diagnostics failure never breaks code_actions.
+					if (reconciledFromDisk) {
+						try {
+							diagnostics = await waitForDiagnostics(client, uri, {
+								timeoutMs: Math.min(
+									isProjectAwareLspServer(serverConfig)
+										? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
+										: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS,
+									timeoutSec * 1000,
+								),
+								signal,
+								expectedDocumentVersion: client.openFiles.get(uri)?.version,
+							});
+						} catch (err) {
+							if (err instanceof ToolAbortError || signal?.aborted) throw err;
+							diagnostics = client.diagnostics.get(uri)?.diagnostics ?? [];
+						}
+					}
 					const context: CodeActionContext = {
 						diagnostics,
 						only: !apply && query ? [query] : undefined,

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -19,11 +19,11 @@ import { clampTimeout } from "../tools/tool-timeouts";
 import {
 	applyWorkspaceEditWithLsp,
 	clearInitializationFailure,
-	ensureFileOpen,
 	getActiveClients,
 	getOrCreateClient,
 	isRustAnalyzerClient,
 	type LspServerStatus,
+	reconcileFileFromDisk,
 	reconcileIdleChecker,
 	refreshFile,
 	sendNotification,
@@ -931,7 +931,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			try {
 				const client = await getOrCreateClient(chosenConfig, this.session.cwd, undefined, signal);
 				if (resolvedTarget) {
-					await ensureFileOpen(client, resolvedTarget, signal);
+					await reconcileFileFromDisk(client, resolvedTarget, signal);
 				}
 				const result = await sendRequest(client, method, requestParams, signal);
 				const formatted =
@@ -1161,7 +1161,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				needsProjectIndex && isRustAnalyzerServer && targetFile !== null && hasRustWorkspaceAncestor(targetFile);
 
 			if (targetFile) {
-				await ensureFileOpen(client, targetFile, signal);
+				await reconcileFileFromDisk(client, targetFile, signal);
 			}
 			if (rustWorkspaceWait) {
 				await waitForProjectLoaded(client, signal);

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -404,6 +404,12 @@ export interface LspTransport {
 export interface OpenFile {
 	version: number;
 	languageId: string;
+	/**
+	 * Hash of the document text last sent to the server, used to detect external
+	 * disk edits. Absent means the last-synced text is unknown, so the next
+	 * reconcile treats the document as dirty and resyncs from disk.
+	 */
+	syncedHash?: number | bigint;
 }
 
 export interface PendingRequest {

--- a/packages/coding-agent/src/lsp/writethrough.ts
+++ b/packages/coding-agent/src/lsp/writethrough.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import { isEnoent, logger, once, untilAborted } from "@oh-my-pi/pi-utils";
 import type { BunFile } from "bun";
 import { isPermissionDeniedError, writeFileWithFallback } from "../tools/file-write-fallback";
-import { FileChangeType, notifyWorkspaceWatchedFiles } from "./client";
+import { beginPendingDiskWrite, endPendingDiskWrite, FileChangeType, notifyWorkspaceWatchedFiles } from "./client";
 import { getConfig, getServersForFile } from "./config";
 import {
 	captureDiagnosticVersions,
@@ -362,6 +362,10 @@ async function runLspWritethrough(
 	let timedOut = false;
 	let synced = false;
 	let operationSignal: AbortSignal | undefined;
+	// The overlay leads disk from the first sync below until the write commits;
+	// bar disk-reconciliation for the file so a concurrent semantic query cannot
+	// revert the server to pre-write content.
+	beginPendingDiskWrite(dst);
 	try {
 		const timeoutSignal = AbortSignal.timeout(5_000);
 		timeoutSignal.addEventListener(
@@ -450,6 +454,8 @@ async function runLspWritethrough(
 		// announce it on the caller's signal — the dead `operationSignal` would
 		// abort the notify before it ever reaches the server.
 		await notifyWriteCommitted();
+	} finally {
+		endPendingDiskWrite(dst);
 	}
 
 	if (synced && enableDiagnostics) {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3451,6 +3451,135 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("waits for reconciled diagnostics before building the code-action context", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-codeaction-reconcile-");
+		const filePath = path.join(tempDir.path(), "target.py");
+		const original = "def target():\n    return 1\n";
+		let overlay = "";
+		let openVersion = 1;
+		// context.diagnostics length seen by the most recent codeAction request.
+		let contextDiagnosticsCount = -1;
+		try {
+			await Bun.write(filePath, original);
+			const serverConfig: ServerConfig = {
+				command: "fake-pyls",
+				fileTypes: ["py"],
+				rootMarkers: [],
+				isLinter: true,
+			};
+			installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					// Pull-model diagnostics: the server answers textDocument/diagnostic.
+					// Only waitForDiagnostics issues that pull, so an unguarded read of
+					// the (reconcile-cleared) map would see nothing.
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: { capabilities: { codeActionProvider: true, diagnosticProvider: true } },
+					});
+				} else if (message.method === "textDocument/didOpen") {
+					const params = message.params;
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"textDocument" in params &&
+						typeof params.textDocument === "object" &&
+						params.textDocument !== null &&
+						"text" in params.textDocument &&
+						typeof params.textDocument.text === "string"
+					) {
+						overlay = params.textDocument.text;
+					}
+				} else if (message.method === "textDocument/didChange") {
+					const params = message.params;
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"textDocument" in params &&
+						typeof params.textDocument === "object" &&
+						params.textDocument !== null &&
+						"version" in params.textDocument &&
+						typeof params.textDocument.version === "number"
+					) {
+						openVersion = params.textDocument.version;
+					}
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"contentChanges" in params &&
+						Array.isArray(params.contentChanges) &&
+						typeof params.contentChanges[0] === "object" &&
+						params.contentChanges[0] !== null &&
+						"text" in params.contentChanges[0] &&
+						typeof params.contentChanges[0].text === "string"
+					) {
+						overlay = params.contentChanges[0].text;
+					}
+				} else if (message.method === "textDocument/diagnostic") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: {
+							kind: "full",
+							items: [
+								{
+									range: { start: { line: 0, character: 4 }, end: { line: 0, character: 10 } },
+									message: "stale-doc marker",
+									severity: 1,
+								},
+							],
+						},
+					});
+				} else if (message.method === "textDocument/codeAction") {
+					const params = message.params;
+					contextDiagnosticsCount =
+						typeof params === "object" &&
+						params !== null &&
+						"context" in params &&
+						typeof params.context === "object" &&
+						params.context !== null &&
+						"diagnostics" in params.context &&
+						Array.isArray(params.context.diagnostics)
+							? params.context.diagnostics.length
+							: -1;
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: [{ title: "Fix stale-doc marker", kind: "quickfix" }],
+					});
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "fake-pyls": serverConfig },
+				idleTimeoutMs: undefined,
+			});
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			// Warm the document (opens it; no reconcile, so no diagnostics wait).
+			await tool.execute("code-actions-warm", { action: "code_actions", file: filePath, line: 1 });
+
+			// External edit: change the file on disk so the next query reconciles.
+			await Bun.write(filePath, `${original}value = target()\n`);
+			contextDiagnosticsCount = -1;
+
+			await tool.execute("code-actions-after-edit", { action: "code_actions", file: filePath, line: 1 });
+
+			// The reconcile dropped the stale diagnostics; code_actions must pull the
+			// fresh set for the reconciled document rather than sending an empty context.
+			expect(openVersion).toBe(2);
+			expect(overlay).toBe(`${original}value = target()\n`);
+			expect(contextDiagnosticsCount).toBe(1);
+		} finally {
+			configCache.delete(tempDir.path());
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("flushes pending descendant text edits before a folder rename", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-folder-rename-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3386,6 +3386,71 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("skips disk reconciliation while an OMP write holds the overlay ahead of disk", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-pending-write-");
+		const filePath = path.join(tempDir.path(), "target.py");
+		const original = "def target():\n    return 1\n";
+		const sent: string[] = [];
+		try {
+			await Bun.write(filePath, original);
+			const serverConfig: ServerConfig = { command: "fake-pyls", fileTypes: ["py"], rootMarkers: [] };
+			const client: LspClient = {
+				name: "pending-write-lsp",
+				cwd: tempDir.path(),
+				config: serverConfig,
+				proc: {
+					stdin: {
+						write(data: string | Uint8Array) {
+							const text = typeof data === "string" ? data : Buffer.from(data).toString("utf-8");
+							const body = text.slice(text.indexOf("\r\n\r\n") + 4);
+							try {
+								const msg: unknown = JSON.parse(body);
+								if (msg && typeof msg === "object" && "method" in msg && typeof msg.method === "string") {
+									sent.push(msg.method);
+								}
+							} catch {
+								// framing chunk without a JSON body; ignore
+							}
+							return typeof data === "string" ? Buffer.byteLength(data) : data.length;
+						},
+						flush: () => {},
+					},
+				} as unknown as LspClient["proc"],
+				requestId: 0,
+				diagnostics: new Map(),
+				diagnosticsVersion: 0,
+				openFiles: new Map(),
+				pendingRequests: new Map(),
+				messageBuffer: new Uint8Array(),
+				isReading: false,
+				status: "ready",
+				lastActivity: Date.now(),
+				writeQueue: Promise.resolve(),
+				activeProgressTokens: new Set(),
+				projectLoaded: Promise.resolve(),
+				resolveProjectLoaded: () => {},
+			};
+
+			await lspClient.ensureFileOpen(client, filePath);
+			expect(sent).toContain("textDocument/didOpen");
+
+			// Simulate an in-flight OMP write: writethrough has synced the new text
+			// to the server and marked the file, but disk still holds the old bytes.
+			lspClient.beginPendingDiskWrite(filePath);
+			await Bun.write(filePath, `\n\n${original}`);
+			sent.length = 0;
+			await lspClient.reconcileFileFromDisk(client, filePath);
+			expect(sent).toHaveLength(0);
+
+			// Once the write commits and clears the mark, the next reconcile syncs.
+			lspClient.endPendingDiskWrite(filePath);
+			await lspClient.reconcileFileFromDisk(client, filePath);
+			expect(sent).toContain("textDocument/didChange");
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
 	it("flushes pending descendant text edits before a folder rename", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-folder-rename-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -3267,6 +3267,125 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("reconciles an open document from disk before a semantic query after an external edit", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-external-edit-sync-");
+		const filePath = path.join(tempDir.path(), "target.py");
+		const uri = fileToUri(filePath);
+		const original = "def target():\n    return 1\ndef wrong():\n    return 2\nvalue = target()\n";
+		let overlay = "";
+		let sawDidChange = false;
+		let referencedSymbol = "";
+		try {
+			await Bun.write(filePath, original);
+			const serverConfig: ServerConfig = {
+				command: "fake-pyls",
+				fileTypes: ["py"],
+				rootMarkers: [],
+				isLinter: true,
+			};
+			installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: { capabilities: { referencesProvider: true } },
+					});
+				} else if (message.method === "textDocument/didOpen") {
+					const params = message.params;
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"textDocument" in params &&
+						typeof params.textDocument === "object" &&
+						params.textDocument !== null &&
+						"text" in params.textDocument &&
+						typeof params.textDocument.text === "string"
+					) {
+						overlay = params.textDocument.text;
+					}
+				} else if (message.method === "textDocument/didChange") {
+					sawDidChange = true;
+					const params = message.params;
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"contentChanges" in params &&
+						Array.isArray(params.contentChanges) &&
+						typeof params.contentChanges[0] === "object" &&
+						params.contentChanges[0] !== null &&
+						"text" in params.contentChanges[0] &&
+						typeof params.contentChanges[0].text === "string"
+					) {
+						overlay = params.contentChanges[0].text;
+					}
+				} else if (message.method === "textDocument/references") {
+					const params = message.params;
+					if (
+						typeof params === "object" &&
+						params !== null &&
+						"position" in params &&
+						typeof params.position === "object" &&
+						params.position !== null &&
+						"line" in params.position &&
+						typeof params.position.line === "number" &&
+						"character" in params.position &&
+						typeof params.position.character === "number"
+					) {
+						// Resolve the identifier the server sees at the queried
+						// coordinates *in its own document*. A stale overlay would
+						// surface `wrong` at the post-edit line.
+						const targetLine = overlay.split("\n")[params.position.line] ?? "";
+						referencedSymbol = /^\w+/.exec(targetLine.slice(params.position.character))?.[0] ?? "";
+					}
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: [{ uri, range: { start: { line: 0, character: 4 }, end: { line: 0, character: 10 } } }],
+					});
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "fake-pyls": serverConfig },
+				idleTimeoutMs: undefined,
+			});
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+
+			// Warm the server document at the original position.
+			await tool.execute("references-before-edit", {
+				action: "references",
+				file: filePath,
+				line: 1,
+				symbol: "target",
+			});
+			expect(referencedSymbol).toBe("target");
+
+			// External edit (not via OMP's write/edit tools): prepend two blank
+			// lines so `target` now lives on line 3 while `wrong` sits where the
+			// server's stale document still has it.
+			await Bun.write(filePath, `\n\n${original}`);
+
+			await tool.execute("references-after-edit", {
+				action: "references",
+				file: filePath,
+				line: 3,
+				symbol: "target",
+			});
+
+			expect(sawDidChange).toBe(true);
+			expect(overlay).toBe(`\n\n${original}`);
+			expect(referencedSymbol).toBe("target");
+		} finally {
+			configCache.delete(tempDir.path());
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("flushes pending descendant text edits before a folder rename", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-folder-rename-");
 		try {


### PR DESCRIPTION
## Repro
With a file already open in the language server, an external edit (one not routed through OMP's write/edit tools) that shifts lines leaves the server holding the pre-edit document while OMP computes the query position from current disk contents. Driving OMP's production client against a recording transport: `ensureFileOpen` on `target.py` sends `didOpen` (version 1); prepending two blank lines on disk then calling `ensureFileOpen` again sends **no** notification, so the server document stays version 1. A subsequent `references` at the symbol's new disk line then resolves against the stale document and returns the wrong symbol (`wrong` instead of `target`). Run: `bun test test/tools/lsp-regressions.test.ts -t "reconciles an open document from disk"`.

## Cause
`ensureFileOpen` (`lsp/client.ts`) early-returns for an already-open URI, and `OpenFile` (`lsp/types.ts`) tracked only `{version, languageId}` with no content signature, so an external disk edit was never reconciled. The semantic action path and the raw `request` path in `lsp/tool.ts` compute their query position from disk via `resolveSymbolColumn` (`lsp/utils.ts`), so the disk-derived coordinates and the server's stale document diverged. OMP-authored edits already reconcile through `notifyWorkspaceWatchedFiles`/`refreshFile`; only the external-edit path was uncovered.

## Fix
- Add a `syncedHash` field to `OpenFile`: a `Bun.hash` of the document text last sent to the server, set at every point the server's copy is written (`ensureFileOpen` `didOpen`, `syncContent` `didOpen`/`didChange`, `refreshFile` `didChange`). Absent means the last-synced text is unknown, so the next reconcile treats the document as dirty.
- Add `reconcileFileFromDisk(client, filePath, signal)`: untracked files fall through to `ensureFileOpen`; for an open file it reads disk and, only when the content hash diverges from `syncedHash`, sends a `didChange` (bumping the version and dropping stale diagnostics) so the server's copy matches the disk text the position was derived from. Unchanged files send nothing.
- `lsp/tool.ts` semantic (`ensureFileOpen(client, targetFile)`) and raw-request paths now call `reconcileFileFromDisk` instead of `ensureFileOpen`.

## Verification
`bun test test/tools/lsp-regressions.test.ts` (120 pass) including the new regression `reconciles an open document from disk before a semantic query after an external edit`, which opens a file, warms the server at the original position, externally edits the file on disk, and asserts the second `references` query resolves `target` (not the stale-document `wrong`) and that a reconciling `didChange` carrying the post-edit text was sent. `bun run check:types` passes. One unrelated pre-existing failure in `test/tools/lsp-diagnostics-freshness.test.ts` (`hashlineStripPrefixes is not a function` from `@oh-my-pi/pi-natives`, in the write-tool path) reproduces identically on the branch head with this diff stashed. Fixes #11416