### PR TITLE
fix(read): avoid partial counts for bounded large-file reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Bounded reads of large files no longer report a partial scan count as the exact file line total ([#11417](https://github.com/can1357/oh-my-pi/issues/11417)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 - Unset `tiny` model roles now honor the configured `@smol` fallback in direct execution and the `/models` Roles view ([#11311](https://github.com/can1357/oh-my-pi/issues/11311)).
 - Extension Control Center (`/extensions`) search now accepts `j` and `k`, so extensions like `jira`/`json` are searchable; bare `j`/`k` no longer move the list selection (use arrow keys or the configured `tui.select.up`/`down`) ([#11350](https://github.com/can1357/oh-my-pi/issues/11350)).

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1856,7 +1856,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					const userLimitedLines = collectedLines.length;
 
 					const totalSelectedLines = totalFileLines - startLine;
-					const wasTruncated = collectedLines.length < totalSelectedLines || stoppedByByteLimit;
+					const wasTruncated = reachedEof && (collectedLines.length < totalSelectedLines || stoppedByByteLimit);
 					const firstLineExceedsLimit = firstLineByteLength !== undefined && firstLineByteLength > maxBytesForRead;
 					const omittedSelectedLine = omittedRequestedLine(
 						byteLimitLine,
@@ -1865,6 +1865,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						leadingContext,
 						collectedLines.length,
 					);
+					const omittedSelectedLineNotice = omittedSelectedLine
+						? formatOmittedRequestedLineNotice(
+								omittedSelectedLine,
+								maxBytesForRead,
+								`:raw:${omittedSelectedLine.index + 1}-${omittedSelectedLine.index + 1}`,
+							)
+						: undefined;
 					// A first line larger than the byte budget collects no complete
 					// line, yet the window still renders a byte-capped preview.
 					// Account for that preview so the notice/meta describe the
@@ -1872,17 +1879,19 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					// ~50 KB shown on screen.
 					const previewBytes = firstLineExceedsLimit ? (firstLinePreview?.bytes ?? 0) : 0;
 
-					const truncation: TruncationResult = {
-						content: selectedContent,
-						truncated: wasTruncated,
-						truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
-						totalLines: totalSelectedLines,
-						totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : selectedBytes,
-						outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
-						outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
-						lastLinePartial: false,
-						firstLineExceedsLimit,
-					};
+					const truncation: TruncationResult | undefined = reachedEof
+						? {
+								content: selectedContent,
+								truncated: wasTruncated,
+								truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
+								totalLines: totalSelectedLines,
+								totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : selectedBytes,
+								outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
+								outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
+								lastLinePartial: false,
+								firstLineExceedsLimit,
+							}
+						: undefined;
 
 					const shouldAddHashLines = !rawSelector && displayMode.hashLines;
 					const shouldAddLineNumbers = rawSelector ? false : shouldAddHashLines ? false : displayMode.lineNumbers;
@@ -1892,7 +1901,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						// model returns validates while the live file is unchanged. The
 						// buffered text is that whole file; above the snapshot cap only a
 						// non-truncated whole-file window can supply it.
-						const isWholeFile = offset === undefined && limit === undefined && !wasTruncated;
+						const isWholeFile = reachedEof && offset === undefined && limit === undefined && !wasTruncated;
 						const tag = buffered
 							? getEditStore(this.session).recordSnapshot(absolutePath, buffered.normalizedText)
 							: isWholeFile
@@ -1955,7 +1964,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 					let outputText: string;
 
-					if (truncation.firstLineExceedsLimit) {
+					if (firstLineExceedsLimit) {
 						const firstLineBytes = firstLineByteLength ?? 0;
 						const snippet = firstLinePreview ?? { text: "", bytes: 0 };
 
@@ -1971,25 +1980,39 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								firstLineBytes,
 							)}, exceeds ${formatBytes(maxBytesForRead)} limit. Unable to display a valid UTF-8 snippet.]`;
 						}
-						details = { truncation };
 						sourcePath = absolutePath;
-						truncationInfo = {
-							result: truncation,
-							options: {
-								direction: "head",
-								startLine: startLineDisplay,
-								totalFileLines: reachedEof ? totalFileLines : undefined,
-							},
-						};
-					} else if (truncation.truncated) {
-						outputText = formatBracketAwareText() ?? formatText(truncation.content, startLineDisplay);
-						if (omittedSelectedLine) {
-							const lineNumber = omittedSelectedLine.index + 1;
-							outputText += `\n\n${formatOmittedRequestedLineNotice(
-								omittedSelectedLine,
-								maxBytesForRead,
-								`:raw:${lineNumber}-${lineNumber}`,
-							)}`;
+						if (truncation) {
+							details = { truncation };
+							truncationInfo = {
+								result: truncation,
+								options: {
+									direction: "head",
+									startLine: startLineDisplay,
+									totalFileLines,
+								},
+							};
+						} else {
+							outputText += `\n\n[Showing line ${startLineDisplay} (partial, ${formatBytes(
+								snippet.bytes,
+							)} of ${formatBytes(firstLineBytes)}); file not scanned to EOF]`;
+							details = {};
+						}
+					} else if (!reachedEof) {
+						const nextOffset = startLine + userLimitedLines + 1;
+						outputText = formatBracketAwareText() ?? formatText(selectedContent, startLineDisplay);
+						if (omittedSelectedLineNotice) {
+							outputText += `\n\n${omittedSelectedLineNotice}`;
+						} else {
+							outputText += `\n\n[More lines in file (${formatBytes(
+								fileSize,
+							)} total; not scanned to EOF). Use :${nextOffset} to continue]`;
+						}
+						details = {};
+						sourcePath = absolutePath;
+					} else if (truncation?.truncated) {
+						outputText = formatBracketAwareText() ?? formatText(selectedContent, startLineDisplay);
+						if (omittedSelectedLineNotice) {
+							outputText += `\n\n${omittedSelectedLineNotice}`;
 						}
 						details = { truncation };
 						sourcePath = absolutePath;
@@ -1998,22 +2021,22 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							options: {
 								direction: "head",
 								startLine: startLineDisplay,
-								totalFileLines: reachedEof ? totalFileLines : undefined,
+								totalFileLines,
 								nextOffset: omittedSelectedLine ? null : undefined,
 							},
 						};
-					} else if (startLine + userLimitedLines < totalFileLines || !reachedEof) {
+					} else if (startLine + userLimitedLines < totalFileLines) {
 						const nextOffset = startLine + userLimitedLines + 1;
 
-						outputText = formatBracketAwareText() ?? formatText(truncation.content, startLineDisplay);
-						outputText += reachedEof
-							? `\n\n[${totalFileLines - (startLine + userLimitedLines)} more lines in file. Use :${nextOffset} to continue]`
-							: `\n\n[More lines in file (${formatBytes(fileSize)} total; not scanned to EOF). Use :${nextOffset} to continue]`;
+						outputText = formatBracketAwareText() ?? formatText(selectedContent, startLineDisplay);
+						outputText += `\n\n[${
+							totalFileLines - (startLine + userLimitedLines)
+						} more lines in file. Use :${nextOffset} to continue]`;
 						details = {};
 						sourcePath = absolutePath;
 					} else {
 						// No truncation, no user limit exceeded
-						outputText = formatBracketAwareText() ?? formatText(truncation.content, startLineDisplay);
+						outputText = formatBracketAwareText() ?? formatText(selectedContent, startLineDisplay);
 						details = {};
 						sourcePath = absolutePath;
 					}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1992,9 +1992,11 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								},
 							};
 						} else {
-							outputText += `\n\n[Showing line ${startLineDisplay} (partial, ${formatBytes(
-								snippet.bytes,
-							)} of ${formatBytes(firstLineBytes)}); file not scanned to EOF]`;
+							outputText += shouldAddHashLines
+								? "\n\n[File not scanned to EOF]"
+								: `\n\n[Showing line ${startLineDisplay} (partial, ${formatBytes(
+										snippet.bytes,
+									)} of ${formatBytes(firstLineBytes)}); file not scanned to EOF]`;
 							details = {};
 						}
 					} else if (!reachedEof) {

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -925,6 +925,22 @@ describe("Coding Agent Tools", () => {
 			expect(output).toContain(`${total} x`);
 		});
 
+		it("does not claim a partial scan count is the total for bounded reads", async () => {
+			const testFile = path.join(testDir, "bounded-large.txt");
+			const lines = Array.from({ length: 10_000 }, (_, i) => `${i + 1} ${"x".repeat(500)}`);
+			fs.writeFileSync(testFile, lines.join("\n"));
+			expect(fs.statSync(testFile).size).toBeGreaterThan(4 * 1024 * 1024);
+
+			const result = await readTool.execute("test-bounded-large", { path: `${testFile}:1-3` });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("not scanned to EOF");
+			expect(output).toContain("Use :7 to continue");
+			expect(output).not.toMatch(/\[Showing lines 1-6 of \d+/);
+			expect(result.details?.meta?.truncation).toBeUndefined();
+			expect(result.details?.truncation).toBeUndefined();
+		});
+
 		it("tail selector is verbatim under :raw and clamps to the whole file when N exceeds it", async () => {
 			const testFile = path.join(testDir, "tail-raw.txt");
 			fs.writeFileSync(testFile, "alpha\nbeta\ngamma\n");

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -941,6 +941,22 @@ describe("Coding Agent Tools", () => {
 			expect(result.details?.truncation).toBeUndefined();
 		});
 
+		it("does not claim a suppressed hashline preview was shown", async () => {
+			Bun.env.PI_EDIT_VARIANT = "hashline";
+			const testFile = path.join(testDir, "hashline-preview-large.txt");
+			const firstLine = "x".repeat(70_000);
+			const tail = Array.from({ length: 9_000 }, () => "y".repeat(500)).join("\n");
+			fs.writeFileSync(testFile, `${firstLine}\n${tail}`);
+			expect(fs.statSync(testFile).size).toBeGreaterThan(4 * 1024 * 1024);
+
+			const result = await readTool.execute("test-hashline-preview-large", { path: `${testFile}:1-1` });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("Hashline output requires full lines");
+			expect(output).toContain("[File not scanned to EOF]");
+			expect(output).not.toContain("Showing line 1");
+		});
+
 		it("tail selector is verbatim under :raw and clamps to the whole file when N exceeds it", async () => {
 			const testFile = path.join(testDir, "tail-raw.txt");
 			fs.writeFileSync(testFile, "alpha\nbeta\ngamma\n");


### PR DESCRIPTION
## Repro
Generate a 10,000-line, 5,088,890-byte JSONL file and run `read rows.jsonl:1-3`; current `main` returns six context-expanded lines followed by `[Showing lines 1-6 of 16. Use :7 to continue]`, although the source has 10,000 lines.

## Cause
`streamLinesFromFile` in `packages/coding-agent/src/tools/read.ts` intentionally stops scanning large files after collecting a bounded window, leaving `totalFileLines` as a lower bound with `reachedEof === false`. `ReadTool.#executeInner` still constructed a `TruncationResult` from that lower bound, and `OutputMetaBuilder.truncation` treated it as the exact denominator.

## Fix
- Construct line-total truncation metadata only after the scanner reaches EOF.
- Emit continuation guidance without a denominator when a bounded scan stops early, including partial-line previews.
- Cover a context-expanded bounded read above the snapshot threshold and record the user-facing fix in the changelog.

## Verification
`bun test packages/coding-agent/test/tools.test.ts --test-name-pattern "does not claim a partial scan count|should handle limit parameter|should truncate when byte limit exceeded|should truncate files exceeding line limit"` passes 4 tests; `bun check` passes.

Fixes #11417