### PR TITLE
fix(ai): map Ollama prompt_eval_cached_count into usage cacheRead

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ollama cache hits now populate cached-token usage: `prompt_eval_cached_count` from the `/api/chat` done chunk maps to `cacheRead`, with `input` reduced to the uncached portion, so status-line `cache_turn`/`cache_hit` segments and cache-prefix audits report real hit rates instead of false misses.
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -82,6 +82,7 @@ type OllamaChatChunk = {
 	done?: boolean;
 	done_reason?: string;
 	prompt_eval_count?: number;
+	prompt_eval_cached_count?: number;
 	eval_count?: number;
 };
 
@@ -698,9 +699,17 @@ const streamOllamaOnce = (
 					if (healedToolCallEmitted && output.stopReason === "stop") {
 						output.stopReason = "toolUse";
 					}
-					output.usage.input = chunk.prompt_eval_count ?? 0;
+					// Ollama reports prompt cache splits as prompt_eval_cached_count
+					// (cached) vs prompt_eval_count (total; cached + uncached =
+					// total). Map cached → cacheRead, uncached → input so
+					// cache_turn/cache_hit status segments and the cache-prefix
+					// audit see real hit rates. Local Ollama omits the cached
+					// field; the ?? 0 fallbacks keep local behavior
+					// byte-identical to before.
+					output.usage.cacheRead = chunk.prompt_eval_cached_count ?? 0;
+					output.usage.input = (chunk.prompt_eval_count ?? 0) - output.usage.cacheRead;
 					output.usage.output = chunk.eval_count ?? 0;
-					output.usage.totalTokens = output.usage.input + output.usage.output;
+					output.usage.totalTokens = output.usage.input + output.usage.output + output.usage.cacheRead;
 				}
 			}
 			if (streamMarkupHealing) {

--- a/packages/ai/test/ollama-cache-usage.test.ts
+++ b/packages/ai/test/ollama-cache-usage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import type { Context } from "@oh-my-pi/pi-ai";
+import { streamOllama } from "@oh-my-pi/pi-ai/providers/ollama";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+function createOllamaModel() {
+	return buildModel({
+		id: "deepseek-v4-flash",
+		name: "DeepSeek V4 Flash",
+		api: "ollama-chat",
+		provider: "ollama-cloud",
+		baseUrl: "https://ollama.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 8192,
+	});
+}
+
+const context: Context = {
+	messages: [{ role: "user", content: "What is 17*23?", timestamp: 0 }],
+};
+
+describe("Ollama chat usage accounting", () => {
+	it("maps prompt_eval_cached_count to cacheRead and subtracts it from input", async () => {
+		const fetchMock = async (): Promise<Response> => {
+			return new Response(
+				'{"message":{"content":"391"},"done":true,"done_reason":"stop","prompt_eval_count":1000,"prompt_eval_cached_count":800,"eval_count":50}\n',
+				{ status: 200 },
+			);
+		};
+
+		const result = await streamOllama(createOllamaModel(), context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.usage.cacheRead).toBe(800);
+		expect(result.usage.input).toBe(200);
+		expect(result.usage.output).toBe(50);
+		expect(result.usage.totalTokens).toBe(1050);
+	});
+
+	it("keeps local behavior when prompt_eval_cached_count is absent", async () => {
+		const fetchMock = async (): Promise<Response> => {
+			return new Response(
+				'{"message":{"content":"391"},"done":true,"done_reason":"stop","prompt_eval_count":1000,"eval_count":50}\n',
+				{ status: 200 },
+			);
+		};
+
+		const result = await streamOllama(createOllamaModel(), context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.usage.cacheRead).toBe(0);
+		expect(result.usage.input).toBe(1000);
+		expect(result.usage.output).toBe(50);
+		expect(result.usage.totalTokens).toBe(1050);
+	});
+});


### PR DESCRIPTION
## Problem

Ollama Cloud returns `prompt_eval_cached_count` (cached prompt tokens) in the `/api/chat` done chunk, but `OllamaChatChunk` never declared the field and the done handler only set `input`/`output`, leaving `cacheRead` at 0.

Consequences:
- Status-line `cache_turn` / `cache_hit` segments hide whenever `cacheRead` is 0 (their render guard is `if (!usage?.cacheRead) return { content: "", visible: false }`).
- The cache-prefix audit reports `MISS` even when the request prefix is fully intact (verified: `sharedPrefix` advancing +2 per turn, pure tail append, yet `cacheRead: 0`).

## Fix

In `packages/ai/src/providers/ollama.ts`:

1. Declare `prompt_eval_cached_count?: number` on `OllamaChatChunk`.
2. In the done handler:
   - `cacheRead = prompt_eval_cached_count ?? 0`
   - `input = prompt_eval_count - cacheRead` (uncached portion)
   - `totalTokens` now includes `cacheRead`

Local Ollama omits the cached field; the `?? 0` fallback keeps local behavior byte-identical.

## Verification

- Field name confirmed empirically against `https://ollama.com/api/chat` (non-streaming and streaming done chunk) — it is `prompt_eval_cached_count`, not the OpenAI-style `prompt_cache_hit_tokens`.
- After the fix, a live session's cache-prefix audit flipped from `MISS (strict 0.0%)` to `hit (strict 99.7%)` with `cacheRead: 138623`, and the `cache_turn`/`cache_hit` status segments now render.