### PR TITLE
fix(shell): decode Windows ACP command output instead of UTF-8 mojibake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,17 +290,18 @@ webrtc = "0.17.2"
 libc = "0.2"
 os_pipe = "1"
 windows-sys = { version = "0.61", features = [
-   "Win32_Foundation",
-   "Win32_Media_Audio",
-   "Win32_Media_Multimedia",
-   "Win32_Security",
-   "Win32_Storage_FileSystem",
-   "Win32_Storage_ProjectedFileSystem",
-   "Win32_System_Com",
-   "Win32_System_LibraryLoader",
-   "Win32_System_IO",
-   "Win32_System_Ioctl",
-   "Win32_System_Threading",
+	"Win32_Foundation",
+	"Win32_Globalization",
+	"Win32_Media_Audio",
+	"Win32_Media_Multimedia",
+	"Win32_Security",
+	"Win32_Storage_FileSystem",
+	"Win32_Storage_ProjectedFileSystem",
+	"Win32_System_Com",
+	"Win32_System_LibraryLoader",
+	"Win32_System_IO",
+	"Win32_System_Ioctl",
+	"Win32_System_Threading",
 ] }
 winreg = "0.56"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,18 +290,18 @@ webrtc = "0.17.2"
 libc = "0.2"
 os_pipe = "1"
 windows-sys = { version = "0.61", features = [
-	"Win32_Foundation",
-	"Win32_Globalization",
-	"Win32_Media_Audio",
-	"Win32_Media_Multimedia",
-	"Win32_Security",
-	"Win32_Storage_FileSystem",
-	"Win32_Storage_ProjectedFileSystem",
-	"Win32_System_Com",
-	"Win32_System_LibraryLoader",
-	"Win32_System_IO",
-	"Win32_System_Ioctl",
-	"Win32_System_Threading",
+   "Win32_Foundation",
+   "Win32_Globalization",
+   "Win32_Media_Audio",
+   "Win32_Media_Multimedia",
+   "Win32_Security",
+   "Win32_Storage_FileSystem",
+   "Win32_Storage_ProjectedFileSystem",
+   "Win32_System_Com",
+   "Win32_System_LibraryLoader",
+   "Win32_System_IO",
+   "Win32_System_Ioctl",
+   "Win32_System_Threading",
 ] }
 winreg = "0.56"
 

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -7,7 +7,6 @@
 use std::{
 	collections::HashMap,
 	io::{Read, Write},
-	str,
 	sync::{
 		Arc,
 		atomic::{AtomicBool, Ordering},

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -22,6 +22,7 @@ use napi::{
 };
 use napi_derive::napi;
 use parking_lot::Mutex;
+use pi_shell::output_decode::OutputDecoder;
 use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 
 use crate::{js::into_string, ps, task};
@@ -402,84 +403,24 @@ fn run_pty_sync(
 	let (reader_tx, reader_rx) = flume::bounded::<ReaderEvent>(READER_QUEUE_CHUNKS);
 	let queued = reader_tx.clone();
 	let reader_thread = std::thread::spawn(move || {
-		const REPLACEMENT: &str = "\u{FFFD}";
 		const BUF: usize = 65536;
-		let mut buf = vec![0u8; BUF + 4];
-		let mut it = 0;
+		let mut buf = vec![0u8; BUF];
+		let mut decoder = OutputDecoder::new();
 		loop {
-			match reader.read(&mut buf[it..BUF]) {
-				Ok(0) => {
-					break;
-				},
+			match reader.read(&mut buf) {
+				Ok(0) => break,
 				Ok(n) => {
-					it += n;
-					while it > 0 {
-						let pending = &buf[..it];
-						match str::from_utf8(pending) {
-							Ok(text) => {
-								if reader_tx
-									.send(ReaderEvent::Chunk(text.to_string()))
-									.is_err()
-								{
-									return;
-								}
-								it = 0;
-								break;
-							},
-							Err(err) => {
-								let valid_up_to = err.valid_up_to();
-								if valid_up_to > 0 {
-									// SAFETY: [..valid_up_to] is guaranteed valid UTF-8 by valid_up_to().
-									let text = unsafe { str::from_utf8_unchecked(&pending[..valid_up_to]) };
-									if reader_tx
-										.send(ReaderEvent::Chunk(text.to_string()))
-										.is_err()
-									{
-										return;
-									}
-									buf.copy_within(valid_up_to..it, 0);
-									it -= valid_up_to;
-								}
-								match err.error_len() {
-									Some(invalid_len) => {
-										if reader_tx
-											.send(ReaderEvent::Chunk(REPLACEMENT.to_string()))
-											.is_err()
-										{
-											return;
-										}
-										buf.copy_within(invalid_len..it, 0);
-										it -= invalid_len;
-									},
-									None => {
-										break;
-									},
-								}
-							},
-						}
+					let text = decoder.push(&buf[..n]);
+					if !text.is_empty() && reader_tx.send(ReaderEvent::Chunk(text)).is_err() {
+						return;
 					}
 				},
-				Err(_) => {
-					break;
-				},
+				Err(_) => break,
 			}
 		}
-		for chunk in buf[..it].utf8_chunks() {
-			let valid = chunk.valid();
-			if !valid.is_empty()
-				&& reader_tx
-					.send(ReaderEvent::Chunk(valid.to_string()))
-					.is_err()
-			{
-				return;
-			}
-			if !chunk.invalid().is_empty()
-				&& reader_tx
-					.send(ReaderEvent::Chunk(REPLACEMENT.to_string()))
-					.is_err()
-			{
-				return;
-			}
+		let rest = decoder.finish();
+		if !rest.is_empty() && reader_tx.send(ReaderEvent::Chunk(rest)).is_err() {
+			return;
 		}
 		let _ = reader_tx.send(ReaderEvent::Done);
 	});

--- a/crates/pi-shell/src/lib.rs
+++ b/crates/pi-shell/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod cancel;
 pub mod minimizer;
+pub mod output_decode;
 pub mod process;
 pub mod shell;
+
 #[cfg(windows)]
 pub mod windows;
 

--- a/crates/pi-shell/src/output_decode.rs
+++ b/crates/pi-shell/src/output_decode.rs
@@ -5,9 +5,15 @@
 //! (GBK) on Simplified Chinese — and treating those bytes as UTF-8 replaces
 //! them with U+FFFD (乱码).
 //!
-//! Decode as UTF-8 until a complete invalid sequence; on Windows, switch the
-//! remainder to the process ANSI code page (`GetACP`) unless that page is
-//! already UTF-8.
+//! Policy: decode as UTF-8 until a complete invalid sequence; on Windows,
+//! switch the remainder of that stream to the process ANSI code page
+//! (`GetACP`) unless that page is already UTF-8.
+//!
+//! Valid UTF-8 always wins, including bytes that are also valid ACP (GBK 一 is
+//! `D2 BB`, which is U+04BB in UTF-8). Overlap is ambiguous; this prefers the
+//! modern-tool default over guessing language. The ACP switch is permanent
+//! for the stream: command output is one encoding, not mixed. A single
+//! invalid byte therefore ACP-decodes everything after it.
 
 use std::str;
 
@@ -104,10 +110,14 @@ impl OutputDecoder {
 					if let Some(invalid_len) = err.error_len() {
 						#[cfg(windows)]
 						if self.can_fallback_to_acp() {
+							// One encoding per command. Do not resume UTF-8 after
+							// a bad byte: later UTF-8 would be ACP-mojibake, but
+							// cmd/chcp emit ACP for the whole stream.
 							self.mode = Mode::Acp;
 							out.push_str(&self.drain_acp(eof));
 							return out;
 						}
+
 						out.push_str(REPLACEMENT);
 						self.pending.drain(..invalid_len);
 					} else {

--- a/crates/pi-shell/src/output_decode.rs
+++ b/crates/pi-shell/src/output_decode.rs
@@ -1,0 +1,325 @@
+//! Decode child-process stdout/stderr into Unicode.
+//!
+//! Modern tools emit UTF-8 (Python with `PYTHONUTF8`, Node, Rust). Native
+//! Windows programs on a CJK system write the ANSI code page to pipes — CP936
+//! (GBK) on Simplified Chinese — and treating those bytes as UTF-8 replaces
+//! them with U+FFFD (乱码).
+//!
+//! Decode as UTF-8 until a complete invalid sequence; on Windows, switch the
+//! remainder to the process ANSI code page (`GetACP`) unless that page is
+//! already UTF-8.
+
+use std::str;
+
+const REPLACEMENT: &str = "\u{FFFD}";
+/// UTF-8 console / system code page. Fallback is a no-op: invalid UTF-8 stays
+/// replacement characters rather than being re-decoded as itself.
+#[cfg(windows)]
+const CP_UTF8: u32 = 65001;
+
+enum Mode {
+	Utf8,
+	#[cfg(windows)]
+	Acp,
+}
+
+/// Incremental decoder for one stdout/stderr stream.
+pub struct OutputDecoder {
+	pending:           Vec<u8>,
+	mode:              Mode,
+	#[cfg(windows)]
+	fallback_codepage: u32,
+}
+
+impl Default for OutputDecoder {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl OutputDecoder {
+	/// Decode with the host ANSI code page as the Windows fallback.
+	pub fn new() -> Self {
+		Self {
+			pending: Vec::new(),
+			mode: Mode::Utf8,
+			#[cfg(windows)]
+			fallback_codepage: acp(),
+		}
+	}
+
+	/// Decode with an explicit ANSI fallback. Used by tests so GBK fixtures
+	/// run on any Windows host, not only a Chinese ACP.
+	#[cfg(windows)]
+	pub const fn with_fallback_codepage(codepage: u32) -> Self {
+		Self {
+			pending:           Vec::new(),
+			mode:              Mode::Utf8,
+			fallback_codepage: codepage,
+		}
+	}
+
+	/// Push the next pipe read. Returns text that is safe to emit now;
+	/// incomplete UTF-8 / DBCS sequences stay buffered.
+	pub fn push(&mut self, bytes: &[u8]) -> String {
+		if bytes.is_empty() {
+			return String::new();
+		}
+		self.pending.extend_from_slice(bytes);
+		self.drain(false)
+	}
+
+	/// Flush held bytes at EOF.
+	pub fn finish(&mut self) -> String {
+		self.drain(true)
+	}
+
+	fn drain(&mut self, eof: bool) -> String {
+		match self.mode {
+			Mode::Utf8 => self.drain_utf8(eof),
+			#[cfg(windows)]
+			Mode::Acp => self.drain_acp(eof),
+		}
+	}
+
+	fn drain_utf8(&mut self, eof: bool) -> String {
+		let mut out = String::new();
+		loop {
+			if self.pending.is_empty() {
+				return out;
+			}
+			match str::from_utf8(&self.pending) {
+				Ok(text) => {
+					out.push_str(text);
+					self.pending.clear();
+					return out;
+				},
+				Err(err) => {
+					let valid_up_to = err.valid_up_to();
+					if valid_up_to > 0 {
+						// SAFETY: [..valid_up_to] is valid UTF-8 by valid_up_to().
+						out.push_str(unsafe { str::from_utf8_unchecked(&self.pending[..valid_up_to]) });
+						self.pending.drain(..valid_up_to);
+					}
+					if let Some(invalid_len) = err.error_len() {
+						#[cfg(windows)]
+						if self.can_fallback_to_acp() {
+							self.mode = Mode::Acp;
+							out.push_str(&self.drain_acp(eof));
+							return out;
+						}
+						out.push_str(REPLACEMENT);
+						self.pending.drain(..invalid_len);
+					} else {
+						if eof {
+							out.push_str(REPLACEMENT);
+							self.pending.clear();
+						}
+						return out;
+					}
+				},
+			}
+		}
+	}
+
+	#[cfg(windows)]
+	const fn can_fallback_to_acp(&self) -> bool {
+		self.fallback_codepage != 0 && self.fallback_codepage != CP_UTF8
+	}
+
+	#[cfg(windows)]
+	fn drain_acp(&mut self, eof: bool) -> String {
+		if self.pending.is_empty() {
+			return String::new();
+		}
+		let len = complete_acp_len(self.fallback_codepage, &self.pending, eof);
+		if len == 0 {
+			return String::new();
+		}
+		let decoded = decode_codepage(self.fallback_codepage, &self.pending[..len])
+			.unwrap_or_else(|| String::from_utf8_lossy(&self.pending[..len]).into_owned());
+		self.pending.drain(..len);
+		decoded
+	}
+}
+
+/// Decode a complete buffer with the same UTF-8-then-ACP policy as
+/// [`OutputDecoder`].
+pub fn decode_bytes(bytes: &[u8]) -> String {
+	let mut decoder = OutputDecoder::new();
+	let mut out = decoder.push(bytes);
+	out.push_str(&decoder.finish());
+	out
+}
+
+#[cfg(windows)]
+fn acp() -> u32 {
+	// SAFETY: GetACP has no preconditions.
+	unsafe { windows_sys::Win32::Globalization::GetACP() }
+}
+
+#[cfg(windows)]
+fn is_dbcs_lead(codepage: u32, byte: u8) -> bool {
+	// SAFETY: `IsDBCSLeadByteEx` accepts any code-page id; unknown pages return
+	// false.
+	unsafe { windows_sys::Win32::Globalization::IsDBCSLeadByteEx(codepage, byte) != 0 }
+}
+
+/// Bytes at the start of `bytes` that form complete ACP characters.
+///
+/// A trail byte in GBK/Shift-JIS can itself be a lead-byte value, so holding
+/// back whatever happens to be last is wrong — walk from the start of the
+/// ACP segment instead.
+#[cfg(windows)]
+fn complete_acp_len(codepage: u32, bytes: &[u8], eof: bool) -> usize {
+	let mut index = 0;
+	while index < bytes.len() {
+		if is_dbcs_lead(codepage, bytes[index]) {
+			if index + 1 < bytes.len() {
+				index += 2;
+			} else {
+				return if eof { bytes.len() } else { index };
+			}
+		} else {
+			index += 1;
+		}
+	}
+	index
+}
+
+#[cfg(windows)]
+fn decode_codepage(codepage: u32, bytes: &[u8]) -> Option<String> {
+	if bytes.is_empty() {
+		return Some(String::new());
+	}
+	let len = i32::try_from(bytes.len()).ok()?;
+	// SAFETY: `bytes` is a valid slice of `len` bytes; a null wide-char buffer
+	// with cchWideChar=0 is the documented size-query form.
+	let needed = unsafe {
+		windows_sys::Win32::Globalization::MultiByteToWideChar(
+			codepage,
+			0,
+			bytes.as_ptr(),
+			len,
+			std::ptr::null_mut(),
+			0,
+		)
+	};
+	if needed <= 0 {
+		return None;
+	}
+	let mut wide = vec![0u16; needed as usize];
+	// SAFETY: `wide` has `needed` UTF-16 units, matching the size query.
+	let written = unsafe {
+		windows_sys::Win32::Globalization::MultiByteToWideChar(
+			codepage,
+			0,
+			bytes.as_ptr(),
+			len,
+			wide.as_mut_ptr(),
+			needed,
+		)
+	};
+	if written <= 0 {
+		return None;
+	}
+	Some(String::from_utf16_lossy(&wide[..written as usize]))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn utf8_passthrough() {
+		let mut decoder = OutputDecoder::new();
+		assert_eq!(decoder.push("hello 中文\n".as_bytes()), "hello 中文\n");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[test]
+	fn incomplete_utf8_is_held_then_flushed() {
+		let mut decoder = OutputDecoder::new();
+		// First byte of UTF-8 中 (E4 B8 AD).
+		assert_eq!(decoder.push(&[0xe4]), "");
+		assert_eq!(decoder.push(&[0xb8, 0xad]), "中");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[test]
+	fn incomplete_utf8_at_eof_becomes_replacement() {
+		let mut decoder = OutputDecoder::new();
+		assert_eq!(decoder.push(&[0xe4]), "");
+		assert_eq!(decoder.finish(), "\u{FFFD}");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn gbk_decodes_to_chinese() {
+		// GBK for 中文.
+		let mut decoder = OutputDecoder::with_fallback_codepage(936);
+		assert_eq!(decoder.push(&[0xd6, 0xd0, 0xce, 0xc4]), "中文");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn host_acp_decodes_gbk_when_system_is_936() {
+		if acp() != 936 {
+			return;
+		}
+		assert_eq!(decode_bytes(&[0xd6, 0xd0, 0xce, 0xc4]), "中文");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn gbk_character_split_across_reads() {
+		let mut decoder = OutputDecoder::with_fallback_codepage(936);
+		assert_eq!(decoder.push(&[0xd6]), "");
+		assert_eq!(decoder.push(&[0xd0, 0xce, 0xc4, b'\n']), "中文\n");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn gbk_holds_real_lead_not_trail_that_looks_like_lead() {
+		let mut decoder = OutputDecoder::with_fallback_codepage(936);
+		// 文 is CE C4; C4 is also a GBK lead value, so a last-byte heuristic
+		// would hold it back and mangle 文.
+		assert_eq!(decoder.push(&[0xce, 0xc4]), "文");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn ascii_prefix_then_gbk() {
+		let mut decoder = OutputDecoder::with_fallback_codepage(936);
+		assert_eq!(decoder.push(b"cmd"), "cmd");
+		assert_eq!(decoder.push(&[0xd6, 0xd0, 0xce, 0xc4]), "中文");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn utf8_preferred_over_gbk_fallback() {
+		let mut decoder = OutputDecoder::with_fallback_codepage(936);
+		assert_eq!(decoder.push("中文".as_bytes()), "中文");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn utf8_system_codepage_keeps_replacement() {
+		let mut decoder = OutputDecoder::with_fallback_codepage(65001);
+		assert_eq!(decoder.push(&[0xff]), "\u{FFFD}");
+		assert_eq!(decoder.finish(), "");
+	}
+
+	#[cfg(not(windows))]
+	#[test]
+	fn invalid_utf8_becomes_replacement() {
+		let mut decoder = OutputDecoder::new();
+		assert_eq!(decoder.push(&[0xff]), "\u{FFFD}");
+		assert_eq!(decoder.finish(), "");
+	}
+}

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -6,7 +6,6 @@ use std::{
 	collections::HashMap,
 	fs,
 	io::{self},
-	str,
 	sync::Arc,
 	time::Duration,
 };
@@ -31,7 +30,9 @@ use tokio_util::sync::CancellationToken;
 use crate::windows::configure_windows_path;
 use crate::{
 	cancel::{AbortReason, AbortToken, CancelToken},
-	minimizer, process,
+	minimizer,
+	output_decode::{OutputDecoder, decode_bytes},
+	process,
 };
 
 struct ShellSessionCore {
@@ -1618,10 +1619,9 @@ async fn read_output(
 	cancel_token: CancellationToken,
 	activity: Sender<()>,
 ) {
-	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
-	let mut buf = vec![0u8; BUF + 4]; // +4 for max UTF-8 char
-	let mut it = 0;
+	let mut buf = vec![0u8; BUF];
+	let mut decoder = OutputDecoder::new();
 
 	#[cfg(unix)]
 	let Ok(reader) = register_nonblocking_pipe(reader) else {
@@ -1641,7 +1641,7 @@ async fn read_output(
 			}) else {
 				break;
 			};
-			match readiness.try_io(|inner| read_nonblocking(inner.get_ref(), &mut buf[it..BUF])) {
+			match readiness.try_io(|inner| read_nonblocking(inner.get_ref(), &mut buf)) {
 				Ok(Ok(0)) => break,
 				Ok(Ok(n)) => n,
 				Ok(Err(e)) if e.kind() == io::ErrorKind::Interrupted => continue,
@@ -1651,7 +1651,7 @@ async fn read_output(
 		};
 		#[cfg(not(unix))]
 		let n = {
-			let read_future = reader.read(&mut buf[it..BUF]);
+			let read_future = reader.read(&mut buf);
 			tokio::pin!(read_future);
 			match tokio::select! {
 				res = &mut read_future => res,
@@ -1665,58 +1665,16 @@ async fn read_output(
 		};
 		if n > 0 {
 			let _ = activity.try_send(());
-		}
-		it += n;
-
-		// Consume as much of `pending` as is decodable *right now*.
-		while it > 0 {
-			let pending = &buf[..it];
-			match str::from_utf8(pending) {
-				Ok(text) => {
-					emit_chunk(text, on_chunk.as_ref()).await;
-					it = 0;
-					break;
-				},
-				Err(err) => {
-					let p = err.valid_up_to();
-					if p > 0 {
-						// SAFETY: [..p] is guaranteed valid UTF-8 by valid_up_to().
-						let text = unsafe { str::from_utf8_unchecked(&pending[..p]) };
-						emit_chunk(text, on_chunk.as_ref()).await;
-						// copy p..it to the beginning of the buffer
-						buf.copy_within(p..it, 0);
-						it -= p;
-					}
-
-					match err.error_len() {
-						Some(p) => {
-							// Invalid byte sequence: emit replacement and drop those bytes.
-							emit_chunk(REPLACEMENT, on_chunk.as_ref()).await;
-							// copy p..it to the beginning of the buffer
-							buf.copy_within(p..it, 0);
-							it -= p;
-							// continue loop in case more bytes remain after the
-							// invalid sequence
-						},
-						None => {
-							// Incomplete UTF-8 sequence at end: keep bytes for next read.
-							break;
-						},
-					}
-				},
+			let text = decoder.push(&buf[..n]);
+			if !text.is_empty() {
+				emit_chunk(&text, on_chunk.as_ref()).await;
 			}
 		}
 	}
 
-	// Flush whatever is left at EOF (including an incomplete final sequence).
-	for chunk in buf[..it].utf8_chunks() {
-		let valid = chunk.valid();
-		if !valid.is_empty() {
-			emit_chunk(valid, on_chunk.as_ref()).await;
-		}
-		if !chunk.invalid().is_empty() {
-			emit_chunk(REPLACEMENT, on_chunk.as_ref()).await;
-		}
+	let rest = decoder.finish();
+	if !rest.is_empty() {
+		emit_chunk(&rest, on_chunk.as_ref()).await;
 	}
 }
 
@@ -1727,16 +1685,12 @@ async fn read_output_buffered(
 	activity: Sender<()>,
 	max_capture_bytes: usize,
 ) -> BufferedOutput {
-	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
 	let mut buf = vec![0u8; BUF];
 	let mut input_bytes = 0usize;
 	let mut captured = Vec::new();
 	let mut exceeded = false;
-	// Pending bytes from a prior read that ended mid-UTF-8 sequence. We hold
-	// them back so we emit only valid UTF-8 to the streaming callback while
-	// still capturing every byte into `captured` for post-processing.
-	let mut pending = Vec::<u8>::new();
+	let mut decoder = OutputDecoder::new();
 
 	#[cfg(unix)]
 	let Ok(reader) = register_nonblocking_pipe(reader) else {
@@ -1794,52 +1748,18 @@ async fn read_output_buffered(
 			}
 		}
 
-		// Stream whatever is validly decodable *right now* to the callback,
-		// carrying incomplete trailing UTF-8 bytes over to the next iteration.
-		if let Some(cb) = on_chunk.as_ref() {
-			pending.extend_from_slice(&buf[..n]);
-			while !pending.is_empty() {
-				match str::from_utf8(&pending) {
-					Ok(text) => {
-						emit_chunk(text, Some(cb)).await;
-						pending.clear();
-						break;
-					},
-					Err(err) => {
-						let p = err.valid_up_to();
-						if p > 0 {
-							// SAFETY: [..p] is valid UTF-8 per valid_up_to().
-							let text = unsafe { str::from_utf8_unchecked(&pending[..p]) };
-							emit_chunk(text, Some(cb)).await;
-							pending.drain(..p);
-						}
-						match err.error_len() {
-							Some(skip) => {
-								emit_chunk(REPLACEMENT, Some(cb)).await;
-								pending.drain(..skip);
-							},
-							None => break,
-						}
-					},
-				}
-			}
+		let text = decoder.push(&buf[..n]);
+		if !text.is_empty() {
+			emit_chunk(&text, on_chunk.as_ref()).await;
 		}
 	}
 
-	// Flush any trailing bytes the streaming decoder held back at EOF.
-	if let Some(cb) = on_chunk.as_ref() {
-		for chunk in pending.utf8_chunks() {
-			let valid = chunk.valid();
-			if !valid.is_empty() {
-				emit_chunk(valid, Some(cb)).await;
-			}
-			if !chunk.invalid().is_empty() {
-				emit_chunk(REPLACEMENT, Some(cb)).await;
-			}
-		}
+	let rest = decoder.finish();
+	if !rest.is_empty() {
+		emit_chunk(&rest, on_chunk.as_ref()).await;
 	}
 
-	BufferedOutput { text: String::from_utf8_lossy(&captured).into_owned(), input_bytes, exceeded }
+	BufferedOutput { text: decode_bytes(&captured), input_bytes, exceeded }
 }
 
 #[cfg(unix)]
@@ -1993,6 +1913,22 @@ mod tests {
 		.expect("shell execution");
 		let output = rx.try_iter().collect();
 		(result, output)
+	}
+
+	/// Native Windows tools write the ANSI code page to pipes. On a Chinese
+	/// system that is GBK; treating it as UTF-8 used to turn `echo 中文` into
+	/// replacement characters.
+	#[cfg(windows)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn cmd_echo_chinese_decodes_from_system_acp() {
+		// SAFETY: GetACP has no preconditions.
+		let acp = unsafe { windows_sys::Win32::Globalization::GetACP() };
+		if acp != 936 {
+			return;
+		}
+		let (result, output) = execute_captured("cmd.exe /c echo 中文".to_string()).await;
+		assert_eq!(result.exit_code, Some(0), "{output:?}");
+		assert!(output.contains("中文"), "garbled command output: {output:?}");
 	}
 
 	/// Regression for issue #8925: a host env entry whose key or value is not

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Command output from native Windows tools on Chinese (and other non-UTF-8) locales is decoded using the system ANSI code page instead of turning into replacement characters.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added
@@ -23,9 +27,6 @@
 - Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions ([#11047](https://github.com/can1357/oh-my-pi/pull/11047) by [@mgpai22](https://github.com/mgpai22)).
 - Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 - Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
-### Fixed
-
-- Command output from native Windows tools on Chinese (and other non-UTF-8) locales is decoded using the system ANSI code page instead of turning into replacement characters.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Extensions loaded by the npm CLI now apply settings overrides to the active session, so generated agents and model choices remain isolated between sessions ([#11047](https://github.com/can1357/oh-my-pi/pull/11047) by [@mgpai22](https://github.com/mgpai22)).
 - Live task dispatch now reloads added, changed, removed, and deleted project task and retry settings before resolving subagents ([#11191](https://github.com/can1357/oh-my-pi/issues/11191)).
 - Reset `/loop` iterations combined with `--while` / `--until` no longer keep submitting without resetting when vibe mode is enabled while the condition command is still running; the loop now disables itself instead ([#10858](https://github.com/can1357/oh-my-pi/pull/10858)).
+### Fixed
+
+- Command output from native Windows tools on Chinese (and other non-UTF-8) locales is decoded using the system ANSI code page instead of turning into replacement characters.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Shell and PTY command output on Windows now falls back from UTF-8 to the system ANSI code page (e.g. GBK on Chinese locales) instead of emitting replacement characters.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed


### PR DESCRIPTION
## What

Decode bash/PTY command output on Windows with a UTF-8-then-ANSI-code-page fallback, so native console tools that emit GBK/CP936 (or another system ACP) no longer turn into replacement characters.

## Why

On Chinese Windows the OEM/ANSI code page is 936. Python/Node already emit UTF-8 (we set `PYTHONIOENCODING`), but `cmd`, `chcp`, and other Win32 tools write ACP bytes to pipes. The shell and PTY readers treated every invalid UTF-8 sequence as `U+FFFD`, so output looked like `����` / `�����ҳ`.

## Testing

- Unit tests in `crates/pi-shell/src/output_decode.rs` cover UTF-8 passthrough, GBK `中文`, split DBCS reads, and trail bytes that also look like lead bytes.
- `cmd_echo_chinese_decodes_from_system_acp` runs `cmd.exe /c echo 中文` through the real shell on ACP 936.
- After installing the rebuilt native addon, `cmd.exe /c echo 中文` prints `中文` and `chcp` prints `活动代码页: 936`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)