### PR TITLE
fix(coding-agent): honor marketplace install dry-run

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `omp plugin install --dry-run` now previews marketplace installs without mutating plugin state.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/cli/classify-install-target.ts
+++ b/packages/coding-agent/src/cli/classify-install-target.ts
@@ -52,6 +52,33 @@ export type ClassifiedInstallTarget =
 	| { type: "marketplace"; name: string; marketplace: string }
 	| { type: "npm"; spec: string };
 
+export interface MarketplacePreviewReader {
+	getPluginInfo(name: string, marketplace: string): Promise<unknown>;
+}
+
+export type MarketplaceInstallPreview = {
+	dryRun: true;
+	action: "install";
+	plugin: string;
+	marketplace: string;
+};
+
+export async function previewMarketplaceInstall(
+	manager: MarketplacePreviewReader,
+	target: Extract<ClassifiedInstallTarget, { type: "marketplace" }>,
+): Promise<MarketplaceInstallPreview> {
+	const entry = await manager.getPluginInfo(target.name, target.marketplace);
+	if (!entry) {
+		throw new Error(`Plugin "${target.name}" not found in marketplace "${target.marketplace}"`);
+	}
+	return {
+		dryRun: true,
+		action: "install",
+		plugin: target.name,
+		marketplace: target.marketplace,
+	};
+}
+
 export function classifyInstallTarget(spec: string, knownMarketplaces: Set<string>): ClassifiedInstallTarget {
 	// Rule 0: filesystem path — bypass npm/marketplace validation entirely.
 	if (isLocalPathSpec(spec)) return { type: "local", path: spec };

--- a/packages/coding-agent/src/cli/classify-install-target.ts
+++ b/packages/coding-agent/src/cli/classify-install-target.ts
@@ -55,11 +55,7 @@ export type ClassifiedInstallTarget =
 export type MarketplaceInstallOptions = { force?: boolean; scope?: "user" | "project" };
 
 export interface MarketplacePreviewReader {
-	validateInstallPlugin(
-		name: string,
-		marketplace: string,
-		options?: MarketplaceInstallOptions,
-	): Promise<void>;
+	validateInstallPlugin(name: string, marketplace: string, options?: MarketplaceInstallOptions): Promise<void>;
 }
 
 export type MarketplaceInstallPreview = {

--- a/packages/coding-agent/src/cli/classify-install-target.ts
+++ b/packages/coding-agent/src/cli/classify-install-target.ts
@@ -52,8 +52,14 @@ export type ClassifiedInstallTarget =
 	| { type: "marketplace"; name: string; marketplace: string }
 	| { type: "npm"; spec: string };
 
+export type MarketplaceInstallOptions = { force?: boolean; scope?: "user" | "project" };
+
 export interface MarketplacePreviewReader {
-	getPluginInfo(name: string, marketplace: string): Promise<unknown>;
+	validateInstallPlugin(
+		name: string,
+		marketplace: string,
+		options?: MarketplaceInstallOptions,
+	): Promise<void>;
 }
 
 export type MarketplaceInstallPreview = {
@@ -66,11 +72,9 @@ export type MarketplaceInstallPreview = {
 export async function previewMarketplaceInstall(
 	manager: MarketplacePreviewReader,
 	target: Extract<ClassifiedInstallTarget, { type: "marketplace" }>,
+	options?: MarketplaceInstallOptions,
 ): Promise<MarketplaceInstallPreview> {
-	const entry = await manager.getPluginInfo(target.name, target.marketplace);
-	if (!entry) {
-		throw new Error(`Plugin "${target.name}" not found in marketplace "${target.marketplace}"`);
-	}
+	await manager.validateInstallPlugin(target.name, target.marketplace, options);
 	return {
 		dryRun: true,
 		action: "install",

--- a/packages/coding-agent/src/cli/classify-install-target.ts
+++ b/packages/coding-agent/src/cli/classify-install-target.ts
@@ -52,11 +52,7 @@ export type ClassifiedInstallTarget =
 	| { type: "marketplace"; name: string; marketplace: string }
 	| { type: "npm"; spec: string };
 
-export type MarketplaceInstallOptions = { force?: boolean; scope?: "user" | "project" };
-
-export interface MarketplacePreviewReader {
-	validateInstallPlugin(name: string, marketplace: string, options?: MarketplaceInstallOptions): Promise<void>;
-}
+export type MarketplaceInstallOptions = { dryRun: boolean; force?: boolean; scope?: "user" | "project" };
 
 export type MarketplaceInstallPreview = {
 	dryRun: true;
@@ -65,18 +61,32 @@ export type MarketplaceInstallPreview = {
 	marketplace: string;
 };
 
-export async function previewMarketplaceInstall(
+export interface MarketplacePreviewReader {
+	validateInstallPlugin(
+		name: string,
+		marketplace: string,
+		options?: Omit<MarketplaceInstallOptions, "dryRun">,
+	): Promise<void>;
+}
+
+export async function handleMarketplaceInstall(
 	manager: MarketplacePreviewReader,
 	target: Extract<ClassifiedInstallTarget, { type: "marketplace" }>,
-	options?: MarketplaceInstallOptions,
-): Promise<MarketplaceInstallPreview> {
-	await manager.validateInstallPlugin(target.name, target.marketplace, options);
-	return {
+	options: MarketplaceInstallOptions,
+	emitPreview: (preview: MarketplaceInstallPreview) => void,
+): Promise<boolean> {
+	if (!options.dryRun) return false;
+	await manager.validateInstallPlugin(target.name, target.marketplace, {
+		force: options.force,
+		scope: options.scope,
+	});
+	emitPreview({
 		dryRun: true,
 		action: "install",
 		plugin: target.name,
 		marketplace: target.marketplace,
-	};
+	});
+	return true;
 }
 
 export function classifyInstallTarget(spec: string, knownMarketplaces: Set<string>): ClassifiedInstallTarget {

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -371,7 +371,10 @@ async function handleInstall(
 		if (target.type === "marketplace") {
 			if (flags.dryRun) {
 				try {
-					const preview = await previewMarketplaceInstall(mktMgr, target);
+					const preview = await previewMarketplaceInstall(mktMgr, target, {
+						force: flags.force,
+						scope: flags.scope,
+					});
 					if (flags.json) {
 						console.log(JSON.stringify(preview, null, 2));
 					} else {

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -369,6 +369,29 @@ async function handleInstall(
 		const target = classifyInstallTarget(spec, knownMarketplaces);
 
 		if (target.type === "marketplace") {
+			if (flags.dryRun) {
+				try {
+					const entry = await mktMgr.getPluginInfo(target.name, target.marketplace);
+					if (!entry) {
+						throw new Error(`Plugin "${target.name}" not found in marketplace "${target.marketplace}"`);
+					}
+					if (flags.json) {
+						console.log(
+							JSON.stringify(
+								{ dryRun: true, action: "install", plugin: target.name, marketplace: target.marketplace },
+								null,
+								2,
+							),
+						);
+					} else {
+						console.log(chalk.dim(`[dry-run] Would install ${spec}`));
+					}
+				} catch (err) {
+					console.error(chalk.red(`${theme.status.error} Failed to install ${spec}: ${err}`));
+					process.exit(1);
+				}
+				continue;
+			}
 			try {
 				const entry = await mktMgr.installPlugin(target.name, target.marketplace, {
 					force: flags.force,

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -138,7 +138,7 @@ export function parsePluginArgs(args: string[]): PluginCommandArgs | undefined {
 	return result;
 }
 
-import { classifyInstallTarget, previewMarketplaceInstall } from "./classify-install-target";
+import { classifyInstallTarget, handleMarketplaceInstall } from "./classify-install-target";
 
 export { classifyInstallTarget } from "./classify-install-target";
 
@@ -369,22 +369,23 @@ async function handleInstall(
 		const target = classifyInstallTarget(spec, knownMarketplaces);
 
 		if (target.type === "marketplace") {
-			if (flags.dryRun) {
-				try {
-					const preview = await previewMarketplaceInstall(mktMgr, target, {
-						force: flags.force,
-						scope: flags.scope,
-					});
-					if (flags.json) {
-						console.log(JSON.stringify(preview, null, 2));
-					} else {
-						console.log(chalk.dim(`[dry-run] Would install ${spec}`));
-					}
-				} catch (err) {
-					console.error(chalk.red(`${theme.status.error} Failed to install ${spec}: ${err}`));
-					process.exit(1);
-				}
-				continue;
+			try {
+				const handled = await handleMarketplaceInstall(
+					mktMgr,
+					target,
+					{ dryRun: flags.dryRun ?? false, force: flags.force, scope: flags.scope },
+					preview => {
+						if (flags.json) {
+							console.log(JSON.stringify(preview, null, 2));
+						} else {
+							console.log(chalk.dim(`[dry-run] Would install ${spec}`));
+						}
+					},
+				);
+				if (handled) continue;
+			} catch (err) {
+				console.error(chalk.red(`${theme.status.error} Failed to install ${spec}: ${err}`));
+				process.exit(1);
 			}
 			try {
 				const entry = await mktMgr.installPlugin(target.name, target.marketplace, {

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -138,7 +138,7 @@ export function parsePluginArgs(args: string[]): PluginCommandArgs | undefined {
 	return result;
 }
 
-import { classifyInstallTarget } from "./classify-install-target";
+import { classifyInstallTarget, previewMarketplaceInstall } from "./classify-install-target";
 
 export { classifyInstallTarget } from "./classify-install-target";
 
@@ -371,18 +371,9 @@ async function handleInstall(
 		if (target.type === "marketplace") {
 			if (flags.dryRun) {
 				try {
-					const entry = await mktMgr.getPluginInfo(target.name, target.marketplace);
-					if (!entry) {
-						throw new Error(`Plugin "${target.name}" not found in marketplace "${target.marketplace}"`);
-					}
+					const preview = await previewMarketplaceInstall(mktMgr, target);
 					if (flags.json) {
-						console.log(
-							JSON.stringify(
-								{ dryRun: true, action: "install", plugin: target.name, marketplace: target.marketplace },
-								null,
-								2,
-							),
-						);
+						console.log(JSON.stringify(preview, null, 2));
 					} else {
 						console.log(chalk.dim(`[dry-run] Would install ${spec}`));
 					}

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -30,7 +30,7 @@ import {
 	writeInstalledPluginsRegistry,
 	writeMarketplacesRegistry,
 } from "./registry";
-import { resolvePluginSource } from "./source-resolver";
+import { resolvePluginSource, validatePluginSource } from "./source-resolver";
 import type {
 	InstalledPluginEntry,
 	InstalledPluginSummary,
@@ -76,7 +76,7 @@ type InstallValidation = {
 	force: boolean;
 	scope: "user" | "project";
 	registryPath: string;
-	mktEntry: MarketplaceRegistryEntry;
+	marketplaceClonePath: string;
 	catalog: MarketplaceCatalog;
 	pluginEntry: MarketplacePluginEntry;
 	pluginId: string;
@@ -270,6 +270,18 @@ export class MarketplaceManager {
 			throw new Error(`Plugin "${name}" not found in marketplace "${marketplace}"`);
 		}
 
+		const marketplaceClonePath = this.#resolveMarketplaceRoot(mktEntry);
+		if (mktEntry.sourceType === "url" && typeof pluginEntry.source === "string") {
+			throw new Error(
+				`Plugin "${name}" uses a relative source path but marketplace "${marketplace}" was added via URL. ` +
+					`Relative sources require a git or local marketplace. Re-add the marketplace using its git URL.`,
+			);
+		}
+		await validatePluginSource(pluginEntry, {
+			marketplaceClonePath,
+			catalogMetadata: catalog.metadata,
+		});
+
 		const pluginId = buildPluginId(name, marketplace);
 		const instReg = await readInstalledPluginsRegistry(registryPath);
 		const existing = getInstalledPlugin(instReg, pluginId);
@@ -277,7 +289,7 @@ export class MarketplaceManager {
 			throw new Error(`Plugin "${pluginId}" is already installed. Use force option to reinstall.`);
 		}
 
-		return { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing };
+		return { force, scope, registryPath, catalog, marketplaceClonePath, pluginEntry, pluginId, existing };
 	}
 
 	async validateInstallPlugin(
@@ -293,33 +305,10 @@ export class MarketplaceManager {
 		marketplace: string,
 		options?: { force?: boolean; scope?: "user" | "project" },
 	): Promise<InstalledPluginEntry> {
-		const { scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing } = await this.#validateInstall(
-			name,
-			marketplace,
-			options,
-		);
+		const { scope, registryPath, catalog, marketplaceClonePath, pluginEntry, pluginId, existing } =
+			await this.#validateInstall(name, marketplace, options);
 
 		// 4. Resolve source path.
-		// marketplaceClonePath is the marketplace root — the directory containing .claude-plugin/
-		// catalogPath is <marketplacesCacheDir>/<name>/marketplace.json, so the root is two levels up.
-		// For local sources the content was fetched from a local path; the stored catalog is a copy
-		// under marketplacesCacheDir. We need the original source root for resolving relative paths.
-		// Use: path.dirname(catalogPath) is <cacheDir>/<name>/, and that IS the stored copy root,
-		// so `path.resolve(mktEntry.catalogPath, "../..")` = parent of <name>/ inside cacheDir
-		// which is wrong for local sources. Instead, derive from the stored catalog directory:
-		// stored at: <marketplacesCacheDir>/<catalogName>/marketplace.json
-		// The marketplace root for local sources should be the actual local path, but we only have
-		// sourceUri. For local sources, use path.resolve of sourceUri; for others use the cache dir.
-		const marketplaceClonePath = this.#resolveMarketplaceRoot(mktEntry);
-
-		// URL-sourced marketplaces only cache marketplace.json, not the full plugin tree.
-		// Relative string sources ("./plugins/foo") cannot be resolved against the cache dir.
-		if (mktEntry.sourceType === "url" && typeof pluginEntry.source === "string") {
-			throw new Error(
-				`Plugin "${name}" uses a relative source path but marketplace "${marketplace}" was added via URL. ` +
-					`Relative sources require a git or local marketplace. Re-add the marketplace using its git URL.`,
-			);
-		}
 
 		const { dir: sourcePath, tempCloneRoot } = await resolvePluginSource(pluginEntry, {
 			marketplaceClonePath,

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -277,7 +277,7 @@ export class MarketplaceManager {
 			throw new Error(`Plugin "${pluginId}" is already installed. Use force option to reinstall.`);
 		}
 
-	return { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing };
+		return { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing };
 	}
 
 	async validateInstallPlugin(
@@ -293,7 +293,7 @@ export class MarketplaceManager {
 		marketplace: string,
 		options?: { force?: boolean; scope?: "user" | "project" },
 	): Promise<InstalledPluginEntry> {
-		const { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing } = await this.#validateInstall(
+		const { scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing } = await this.#validateInstall(
 			name,
 			marketplace,
 			options,

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -15,7 +15,7 @@ import { expandTilde } from "../../../tools/path-utils";
 import { normalizePluginRuntimeConfig } from "../runtime-config";
 import type { PluginRuntimeConfig } from "../types";
 
-import { cachePlugin } from "./cache";
+import { cachePlugin, isValidVersionForCache } from "./cache";
 import { classifySource, fetchMarketplace, parseMarketplaceCatalog, promoteCloneToCache } from "./fetcher";
 import {
 	addInstalledPlugin,
@@ -269,6 +269,9 @@ export class MarketplaceManager {
 		if (!pluginEntry) {
 			throw new Error(`Plugin "${name}" not found in marketplace "${marketplace}"`);
 		}
+		if (pluginEntry.version !== undefined && !isValidVersionForCache(pluginEntry.version)) {
+			throw new Error(`Invalid version for cache: "${pluginEntry.version}"`);
+		}
 
 		const marketplaceClonePath = this.#resolveMarketplaceRoot(mktEntry);
 		if (mktEntry.sourceType === "url" && typeof pluginEntry.source === "string") {
@@ -277,23 +280,11 @@ export class MarketplaceManager {
 					`Relative sources require a git or local marketplace. Re-add the marketplace using its git URL.`,
 			);
 		}
-		await validatePluginSource(pluginEntry, {
+		const sourcePath = await validatePluginSource(pluginEntry, {
 			marketplaceClonePath,
 			catalogMetadata: catalog.metadata,
 		});
-		const validationCachePath = path.join(os.tmpdir(), "omp-marketplace-validation");
-		if (
-			typeof pluginEntry.lspServers === "string" &&
-			!pathIsWithin(validationCachePath, path.resolve(validationCachePath, pluginEntry.lspServers))
-		) {
-			throw new Error(`Plugin "${pluginEntry.name}" lspServers path escapes the plugin directory`);
-		}
-		if (
-			typeof pluginEntry.dapAdapters === "string" &&
-			!pathIsWithin(validationCachePath, path.resolve(validationCachePath, pluginEntry.dapAdapters))
-		) {
-			throw new Error(`Plugin "${pluginEntry.name}" dapAdapters path escapes the plugin directory`);
-		}
+		await this.#validateEmbeddedConfigPaths(pluginEntry, sourcePath);
 
 		const pluginId = buildPluginId(name, marketplace);
 		const instReg = await readInstalledPluginsRegistry(registryPath);
@@ -397,6 +388,31 @@ export class MarketplaceManager {
 
 		logger.debug("Plugin installed", { pluginId, version, cachePath });
 		return installedEntry;
+	}
+
+	async #validateEmbeddedConfigPaths(entry: MarketplacePluginEntry, sourcePath: string | undefined): Promise<void> {
+		if (!sourcePath) return;
+		await this.#validateEmbeddedConfigPath(entry, sourcePath, "lspServers", entry.lspServers);
+		await this.#validateEmbeddedConfigPath(entry, sourcePath, "dapAdapters", entry.dapAdapters);
+	}
+
+	async #validateEmbeddedConfigPath(
+		entry: MarketplacePluginEntry,
+		sourcePath: string,
+		field: "lspServers" | "dapAdapters",
+		value: unknown,
+	): Promise<void> {
+		if (typeof value !== "string") return;
+		const resolved = path.resolve(sourcePath, value);
+		if (!pathIsWithin(sourcePath, resolved)) {
+			throw new Error(`Plugin "${entry.name}" ${field} path escapes the plugin directory`);
+		}
+		try {
+			const stat = await fs.stat(resolved);
+			if (!stat.isFile()) throw new Error("not a file");
+		} catch {
+			throw new Error(`Plugin "${entry.name}" ${field} file does not exist`);
+		}
 	}
 
 	async #writeEmbeddedLspConfig(entry: MarketplacePluginEntry, cachePath: string): Promise<void> {

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -281,6 +281,19 @@ export class MarketplaceManager {
 			marketplaceClonePath,
 			catalogMetadata: catalog.metadata,
 		});
+		const validationCachePath = path.join(os.tmpdir(), "omp-marketplace-validation");
+		if (
+			typeof pluginEntry.lspServers === "string" &&
+			!pathIsWithin(validationCachePath, path.resolve(validationCachePath, pluginEntry.lspServers))
+		) {
+			throw new Error(`Plugin "${pluginEntry.name}" lspServers path escapes the plugin directory`);
+		}
+		if (
+			typeof pluginEntry.dapAdapters === "string" &&
+			!pathIsWithin(validationCachePath, path.resolve(validationCachePath, pluginEntry.dapAdapters))
+		) {
+			throw new Error(`Plugin "${pluginEntry.name}" dapAdapters path escapes the plugin directory`);
+		}
 
 		const pluginId = buildPluginId(name, marketplace);
 		const instReg = await readInstalledPluginsRegistry(registryPath);

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -269,7 +269,11 @@ export class MarketplaceManager {
 		if (!pluginEntry) {
 			throw new Error(`Plugin "${name}" not found in marketplace "${marketplace}"`);
 		}
-		if (pluginEntry.version !== undefined && !isValidVersionForCache(pluginEntry.version)) {
+		if (
+			typeof pluginEntry.version === "string" &&
+			pluginEntry.version.length > 0 &&
+			!isValidVersionForCache(pluginEntry.version)
+		) {
 			throw new Error(`Invalid version for cache: "${pluginEntry.version}"`);
 		}
 

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -402,7 +402,7 @@ export class MarketplaceManager {
 		field: "lspServers" | "dapAdapters",
 		value: unknown,
 	): Promise<void> {
-		if (typeof value !== "string") return;
+		if (typeof value !== "string" || value.length === 0) return;
 		const resolved = path.resolve(sourcePath, value);
 		if (!pathIsWithin(sourcePath, resolved)) {
 			throw new Error(`Plugin "${entry.name}" ${field} path escapes the plugin directory`);

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -72,6 +72,17 @@ export interface MarketplaceManagerOptions {
 
 // ── Manager ──────────────────────────────────────────────────────────────────
 
+type InstallValidation = {
+	force: boolean;
+	scope: "user" | "project";
+	registryPath: string;
+	mktEntry: MarketplaceRegistryEntry;
+	catalog: MarketplaceCatalog;
+	pluginEntry: MarketplacePluginEntry;
+	pluginId: string;
+	existing: InstalledPluginEntry[] | undefined;
+};
+
 export class MarketplaceManager {
 	#opts: MarketplaceManagerOptions;
 
@@ -238,23 +249,21 @@ export class MarketplaceManager {
 
 	// ── Install / uninstall ───────────────────────────────────────────────────
 
-	async installPlugin(
+	async #validateInstall(
 		name: string,
 		marketplace: string,
 		options?: { force?: boolean; scope?: "user" | "project" },
-	): Promise<InstalledPluginEntry> {
+	): Promise<InstallValidation> {
 		const force = options?.force ?? false;
 		const scope = options?.scope ?? "user";
 		const registryPath = this.#registryPath(scope);
 
-		// 1. Find marketplace entry
 		const mktReg = await readMarketplacesRegistry(this.#opts.marketplacesRegistryPath);
 		const mktEntry = getMarketplaceEntry(mktReg, marketplace);
 		if (!mktEntry) {
 			throw new Error(`Marketplace "${marketplace}" not found`);
 		}
 
-		// 2. Find plugin in catalog
 		const catalog = await this.#readCatalog(mktEntry);
 		const pluginEntry = catalog.plugins.find(p => p.name === name);
 		if (!pluginEntry) {
@@ -262,13 +271,33 @@ export class MarketplaceManager {
 		}
 
 		const pluginId = buildPluginId(name, marketplace);
-
-		// 3. Check if already installed
 		const instReg = await readInstalledPluginsRegistry(registryPath);
 		const existing = getInstalledPlugin(instReg, pluginId);
 		if (existing && existing.length > 0 && !force) {
 			throw new Error(`Plugin "${pluginId}" is already installed. Use force option to reinstall.`);
 		}
+
+	return { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing };
+	}
+
+	async validateInstallPlugin(
+		name: string,
+		marketplace: string,
+		options?: { force?: boolean; scope?: "user" | "project" },
+	): Promise<void> {
+		await this.#validateInstall(name, marketplace, options);
+	}
+
+	async installPlugin(
+		name: string,
+		marketplace: string,
+		options?: { force?: boolean; scope?: "user" | "project" },
+	): Promise<InstalledPluginEntry> {
+		const { force, scope, registryPath, mktEntry, catalog, pluginEntry, pluginId, existing } = await this.#validateInstall(
+			name,
+			marketplace,
+			options,
+		);
 
 		// 4. Resolve source path.
 		// marketplaceClonePath is the marketplace root — the directory containing .claude-plugin/

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
@@ -55,20 +55,7 @@ export async function validatePluginSource(
 ): Promise<string | undefined> {
 	const { source } = entry;
 	if (typeof source === "string") {
-		if (!source.startsWith("./")) {
-			throw new Error(`Relative plugin source paths must start with "./" — got: "${source}"`);
-		}
-		if (!context.marketplaceClonePath) {
-			throw new Error(`Cannot resolve relative source "${source}": marketplaceClonePath is required`);
-		}
-		const pluginRoot = context.catalogMetadata?.pluginRoot;
-		const relativePath = pluginRoot ? `./${path.join(pluginRoot, source.slice(2))}` : source;
-		const resolved = path.resolve(context.marketplaceClonePath, relativePath);
-		if (!pathIsWithin(context.marketplaceClonePath, resolved)) {
-			throw new Error(
-				`Plugin source "${source}" resolves outside marketplace root ("${context.marketplaceClonePath}")`,
-			);
-		}
+		const resolved = resolveRelativeSourcePath(source, context);
 		await verifyDirExists(resolved, `Plugin source directory does not exist: "${resolved}"`);
 		return resolved;
 	}
@@ -104,31 +91,33 @@ export async function validatePluginSource(
 
 // ── Relative string source ("./plugins/foo") ────────────────────────
 
-async function resolveRelativeSource(
+function resolveRelativeSourcePath(
 	source: string,
-	context: ResolveContext,
-): Promise<{ dir: string; tempCloneRoot?: string }> {
+	context: Pick<ResolveContext, "marketplaceClonePath" | "catalogMetadata">,
+): string {
 	if (!source.startsWith("./")) {
 		throw new Error(`Relative plugin source paths must start with "./" — got: "${source}"`);
 	}
-
 	if (!context.marketplaceClonePath) {
 		throw new Error(`Cannot resolve relative source "${source}": marketplaceClonePath is required`);
 	}
 
-	// If pluginRoot is set, prepend it to the path segment after "./"
 	const pluginRoot = context.catalogMetadata?.pluginRoot;
 	const relativePath = pluginRoot ? `./${path.join(pluginRoot, source.slice(2))}` : source;
-
-	// Resolve against marketplace root (not the .claude-plugin/ catalog subdirectory)
 	const resolved = path.resolve(context.marketplaceClonePath, relativePath);
-
 	if (!pathIsWithin(context.marketplaceClonePath, resolved)) {
 		throw new Error(
 			`Plugin source "${source}" resolves outside marketplace root ("${context.marketplaceClonePath}")`,
 		);
 	}
+	return resolved;
+}
 
+async function resolveRelativeSource(
+	source: string,
+	context: ResolveContext,
+): Promise<{ dir: string; tempCloneRoot?: string }> {
+	const resolved = resolveRelativeSourcePath(source, context);
 	await verifyDirExists(resolved, `Plugin source directory does not exist: "${resolved}"`);
 	return { dir: resolved };
 }

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
@@ -78,8 +78,9 @@ export async function validatePluginSource(
 		case "github":
 			return;
 		case "git-subdir": {
-			const normalizedPath = source.path.replaceAll("\\", "/");
-			if (path.posix.isAbsolute(normalizedPath) || normalizedPath.split("/").includes("..")) {
+			const syntheticRoot = path.join(path.parse(process.cwd()).root, "omp-marketplace-validation");
+			const resolved = path.resolve(syntheticRoot, source.path);
+			if (!pathIsWithin(syntheticRoot, resolved)) {
 				throw new Error(`git-subdir path "${source.path}" escapes the cloned repository`);
 			}
 			return;

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
@@ -46,6 +46,61 @@ export async function resolvePluginSource(
 	return resolveObjectSource(source, context);
 }
 
+/**
+ * Validate source constraints that can be checked without cloning or mutating files.
+ */
+export async function validatePluginSource(
+	entry: MarketplacePluginEntry,
+	context: Pick<ResolveContext, "marketplaceClonePath" | "catalogMetadata">,
+): Promise<void> {
+	const { source } = entry;
+	if (typeof source === "string") {
+		if (!source.startsWith("./")) {
+			throw new Error(`Relative plugin source paths must start with "./" — got: "${source}"`);
+		}
+		if (!context.marketplaceClonePath) {
+			throw new Error(`Cannot resolve relative source "${source}": marketplaceClonePath is required`);
+		}
+		const pluginRoot = context.catalogMetadata?.pluginRoot;
+		const relativePath = pluginRoot ? `./${path.join(pluginRoot, source.slice(2))}` : source;
+		const resolved = path.resolve(context.marketplaceClonePath, relativePath);
+		if (!pathIsWithin(context.marketplaceClonePath, resolved)) {
+			throw new Error(
+				`Plugin source "${source}" resolves outside marketplace root ("${context.marketplaceClonePath}")`,
+			);
+		}
+		await verifyDirExists(resolved, `Plugin source directory does not exist: "${resolved}"`);
+		return;
+	}
+
+	switch (source.source) {
+		case "url":
+		case "github":
+			return;
+		case "git-subdir": {
+			const normalizedPath = source.path.replaceAll("\\", "/");
+			if (path.posix.isAbsolute(normalizedPath) || normalizedPath.split("/").includes("..")) {
+				throw new Error(`git-subdir path "${source.path}" escapes the cloned repository`);
+			}
+			return;
+		}
+		case "npm":
+			throw new Error("npm plugin sources are not yet supported. Use git-based sources instead.");
+		default: {
+			const unknownSource: unknown = source;
+			if (
+				unknownSource &&
+				typeof unknownSource === "object" &&
+				"source" in unknownSource &&
+				typeof unknownSource.source === "string"
+			) {
+				throw new Error(`Unknown plugin source type: "${unknownSource.source}"`);
+			}
+			throw new Error("Unknown plugin source type");
+		}
+	}
+}
+
 // ── Relative string source ("./plugins/foo") ────────────────────────
 
 async function resolveRelativeSource(

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/source-resolver.ts
@@ -52,7 +52,7 @@ export async function resolvePluginSource(
 export async function validatePluginSource(
 	entry: MarketplacePluginEntry,
 	context: Pick<ResolveContext, "marketplaceClonePath" | "catalogMetadata">,
-): Promise<void> {
+): Promise<string | undefined> {
 	const { source } = entry;
 	if (typeof source === "string") {
 		if (!source.startsWith("./")) {
@@ -70,20 +70,20 @@ export async function validatePluginSource(
 			);
 		}
 		await verifyDirExists(resolved, `Plugin source directory does not exist: "${resolved}"`);
-		return;
+		return resolved;
 	}
 
 	switch (source.source) {
 		case "url":
 		case "github":
-			return;
+			return undefined;
 		case "git-subdir": {
 			const syntheticRoot = path.join(path.parse(process.cwd()).root, "omp-marketplace-validation");
 			const resolved = path.resolve(syntheticRoot, source.path);
 			if (!pathIsWithin(syntheticRoot, resolved)) {
 				throw new Error(`git-subdir path "${source.path}" escapes the cloned repository`);
 			}
-			return;
+			return undefined;
 		}
 		case "npm":
 			throw new Error("npm plugin sources are not yet supported. Use git-based sources instead.");

--- a/packages/coding-agent/test/marketplace/cli.test.ts
+++ b/packages/coding-agent/test/marketplace/cli.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it, spyOn } from "bun:test";
 
-import { runPluginCommand } from "@oh-my-pi/pi-coding-agent/cli/plugin-cli";
-import { MarketplaceManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
-
-// Import from the zero-dep classify module — plugin-cli.ts transitively loads native addons.
-import { classifyInstallTarget } from "@oh-my-pi/pi-coding-agent/cli/classify-install-target";
+import {
+	classifyInstallTarget,
+	previewMarketplaceInstall,
+} from "@oh-my-pi/pi-coding-agent/cli/classify-install-target";
 
 const KNOWN = new Set(["my-marketplace"]);
 
@@ -85,31 +84,25 @@ describe("classifyInstallTarget", () => {
 	});
 });
 
-it("marketplace dry-run previews without invoking installPlugin", async () => {
-	const listSpy = spyOn(MarketplaceManager.prototype, "listMarketplaces").mockResolvedValue([
-		{ name: "my-marketplace" } as never,
-	]);
-	const infoSpy = spyOn(MarketplaceManager.prototype, "getPluginInfo").mockResolvedValue({ name: "hello" } as never);
-	const installSpy = spyOn(MarketplaceManager.prototype, "installPlugin");
-	const logSpy = spyOn(console, "log").mockImplementation(() => undefined);
-	try {
-		await runPluginCommand({
-			action: "install",
-			args: ["hello@my-marketplace"],
-			flags: { dryRun: true, json: true },
-		});
-		expect(infoSpy).toHaveBeenCalledWith("hello", "my-marketplace");
-		expect(installSpy).not.toHaveBeenCalled();
-		expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toEqual({
-			dryRun: true,
-			action: "install",
-			plugin: "hello",
-			marketplace: "my-marketplace",
-		});
-	} finally {
-		listSpy.mockRestore();
-		infoSpy.mockRestore();
-		installSpy.mockRestore();
-		logSpy.mockRestore();
-	}
+it("marketplace dry-run preview resolves metadata without invoking installPlugin", async () => {
+	const manager = {
+		getPluginInfo: async () => ({ name: "hello" }),
+		installPlugin: async () => undefined,
+	};
+	const infoSpy = spyOn(manager, "getPluginInfo");
+	const installSpy = spyOn(manager, "installPlugin");
+	const preview = await previewMarketplaceInstall(manager, {
+		type: "marketplace",
+		name: "hello",
+		marketplace: "my-marketplace",
+	});
+
+	expect(infoSpy).toHaveBeenCalledWith("hello", "my-marketplace");
+	expect(installSpy).not.toHaveBeenCalled();
+	expect(preview).toEqual({
+		dryRun: true,
+		action: "install",
+		plugin: "hello",
+		marketplace: "my-marketplace",
+	});
 });

--- a/packages/coding-agent/test/marketplace/cli.test.ts
+++ b/packages/coding-agent/test/marketplace/cli.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 
-import {
-	classifyInstallTarget,
-	previewMarketplaceInstall,
-} from "@oh-my-pi/pi-coding-agent/cli/classify-install-target";
+import { classifyInstallTarget, handleMarketplaceInstall } from "@oh-my-pi/pi-coding-agent/cli/classify-install-target";
 
 const KNOWN = new Set(["my-marketplace"]);
 
@@ -84,29 +81,34 @@ describe("classifyInstallTarget", () => {
 	});
 });
 
-it("marketplace dry-run validates preconditions without invoking installPlugin", async () => {
+it("marketplace dry-run validates preconditions and emits a preview without invoking installPlugin", async () => {
 	const manager = {
 		validateInstallPlugin: async () => undefined,
 		installPlugin: async () => undefined,
 	};
 	const validationSpy = spyOn(manager, "validateInstallPlugin");
 	const installSpy = spyOn(manager, "installPlugin");
-	const preview = await previewMarketplaceInstall(
+	const previews: unknown[] = [];
+	const handled = await handleMarketplaceInstall(
 		manager,
 		{
 			type: "marketplace",
 			name: "hello",
 			marketplace: "my-marketplace",
 		},
-		{ force: true, scope: "project" },
+		{ dryRun: true, force: true, scope: "project" },
+		preview => previews.push(preview),
 	);
 
+	expect(handled).toBe(true);
 	expect(validationSpy).toHaveBeenCalledWith("hello", "my-marketplace", { force: true, scope: "project" });
 	expect(installSpy).not.toHaveBeenCalled();
-	expect(preview).toEqual({
-		dryRun: true,
-		action: "install",
-		plugin: "hello",
-		marketplace: "my-marketplace",
-	});
+	expect(previews).toEqual([
+		{
+			dryRun: true,
+			action: "install",
+			plugin: "hello",
+			marketplace: "my-marketplace",
+		},
+	]);
 });

--- a/packages/coding-agent/test/marketplace/cli.test.ts
+++ b/packages/coding-agent/test/marketplace/cli.test.ts
@@ -84,20 +84,24 @@ describe("classifyInstallTarget", () => {
 	});
 });
 
-it("marketplace dry-run preview resolves metadata without invoking installPlugin", async () => {
+it("marketplace dry-run validates preconditions without invoking installPlugin", async () => {
 	const manager = {
-		getPluginInfo: async () => ({ name: "hello" }),
+		validateInstallPlugin: async () => undefined,
 		installPlugin: async () => undefined,
 	};
-	const infoSpy = spyOn(manager, "getPluginInfo");
+	const validationSpy = spyOn(manager, "validateInstallPlugin");
 	const installSpy = spyOn(manager, "installPlugin");
-	const preview = await previewMarketplaceInstall(manager, {
-		type: "marketplace",
-		name: "hello",
-		marketplace: "my-marketplace",
-	});
+	const preview = await previewMarketplaceInstall(
+		manager,
+		{
+			type: "marketplace",
+			name: "hello",
+			marketplace: "my-marketplace",
+		},
+		{ force: true, scope: "project" },
+	);
 
-	expect(infoSpy).toHaveBeenCalledWith("hello", "my-marketplace");
+	expect(validationSpy).toHaveBeenCalledWith("hello", "my-marketplace", { force: true, scope: "project" });
 	expect(installSpy).not.toHaveBeenCalled();
 	expect(preview).toEqual({
 		dryRun: true,

--- a/packages/coding-agent/test/marketplace/cli.test.ts
+++ b/packages/coding-agent/test/marketplace/cli.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { runPluginCommand } from "@oh-my-pi/pi-coding-agent/cli/plugin-cli";
+import { MarketplaceManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
 
 // Import from the zero-dep classify module — plugin-cli.ts transitively loads native addons.
 import { classifyInstallTarget } from "@oh-my-pi/pi-coding-agent/cli/classify-install-target";
@@ -80,4 +83,33 @@ describe("classifyInstallTarget", () => {
 			expect(classifyInstallTarget("pkg@1.2.3", KNOWN)).toEqual({ type: "npm", spec: "pkg@1.2.3" });
 		});
 	});
+});
+
+it("marketplace dry-run previews without invoking installPlugin", async () => {
+	const listSpy = spyOn(MarketplaceManager.prototype, "listMarketplaces").mockResolvedValue([
+		{ name: "my-marketplace" } as never,
+	]);
+	const infoSpy = spyOn(MarketplaceManager.prototype, "getPluginInfo").mockResolvedValue({ name: "hello" } as never);
+	const installSpy = spyOn(MarketplaceManager.prototype, "installPlugin");
+	const logSpy = spyOn(console, "log").mockImplementation(() => undefined);
+	try {
+		await runPluginCommand({
+			action: "install",
+			args: ["hello@my-marketplace"],
+			flags: { dryRun: true, json: true },
+		});
+		expect(infoSpy).toHaveBeenCalledWith("hello", "my-marketplace");
+		expect(installSpy).not.toHaveBeenCalled();
+		expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toEqual({
+			dryRun: true,
+			action: "install",
+			plugin: "hello",
+			marketplace: "my-marketplace",
+		});
+	} finally {
+		listSpy.mockRestore();
+		infoSpy.mockRestore();
+		installSpy.mockRestore();
+		logSpy.mockRestore();
+	}
 });

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -599,6 +599,24 @@ describe("MarketplaceManager", () => {
 		await expect(ctx.manager.installPlugin("hello-plugin", "test-marketplace")).rejects.toThrow(/already installed/);
 	});
 
+	it("validateInstallPlugin checks preconditions without mutating registries", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		await expect(
+			ctx.manager.validateInstallPlugin("hello-plugin", "test-marketplace", { scope: "project" }),
+		).resolves.toBeUndefined();
+
+		const projectReg = await readInstalledPluginsRegistry(path.join(ctx.tmpDir, "project_installed_plugins.json"));
+		expect(projectReg.plugins["hello-plugin@test-marketplace"]).toBeUndefined();
+
+		await ctx.manager.installPlugin("hello-plugin", "test-marketplace");
+		await expect(ctx.manager.validateInstallPlugin("hello-plugin", "test-marketplace")).rejects.toThrow(
+			/already installed/,
+		);
+		await expect(
+			ctx.manager.validateInstallPlugin("hello-plugin", "test-marketplace", { force: true }),
+		).resolves.toBeUndefined();
+	});
+
 	it("installPlugin with force:true → replaces existing", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		const first = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -617,6 +617,20 @@ describe("MarketplaceManager", () => {
 		).resolves.toBeUndefined();
 	});
 
+	it("validateInstallPlugin rejects embedded config paths outside the plugin directory", async () => {
+		await ctx.manager.addMarketplace(FIXTURE_DIR);
+		const registry = await readMarketplacesRegistry(path.join(ctx.tmpDir, "marketplaces.json"));
+		const catalogPath = registry.marketplaces[0]?.catalogPath;
+		if (!catalogPath) throw new Error("test marketplace catalog path is missing");
+		const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8")) as { plugins: Array<Record<string, unknown>> };
+		catalog.plugins[0].lspServers = "../outside.json";
+		fs.writeFileSync(catalogPath, JSON.stringify(catalog));
+
+		await expect(ctx.manager.validateInstallPlugin("hello-plugin", "test-marketplace")).rejects.toThrow(
+			/lspServers path escapes the plugin directory/,
+		);
+	});
+
 	it("installPlugin with force:true → replaces existing", async () => {
 		await ctx.manager.addMarketplace(FIXTURE_DIR);
 		const first = await ctx.manager.installPlugin("hello-plugin", "test-marketplace");

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -622,9 +622,9 @@ describe("MarketplaceManager", () => {
 		const registry = await readMarketplacesRegistry(path.join(ctx.tmpDir, "marketplaces.json"));
 		const catalogPath = registry.marketplaces[0]?.catalogPath;
 		if (!catalogPath) throw new Error("test marketplace catalog path is missing");
-		const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8")) as { plugins: Array<Record<string, unknown>> };
+		const catalog = (await Bun.file(catalogPath).json()) as { plugins: Array<Record<string, unknown>> };
 		catalog.plugins[0].lspServers = "../outside.json";
-		fs.writeFileSync(catalogPath, JSON.stringify(catalog));
+		await Bun.write(catalogPath, JSON.stringify(catalog));
 
 		await expect(ctx.manager.validateInstallPlugin("hello-plugin", "test-marketplace")).rejects.toThrow(
 			/lspServers path escapes the plugin directory/,

--- a/packages/coding-agent/test/marketplace/source-resolver.test.ts
+++ b/packages/coding-agent/test/marketplace/source-resolver.test.ts
@@ -53,6 +53,15 @@ describe("resolvePluginSource", () => {
 		).rejects.toThrow(/escapes the cloned repository/);
 	});
 
+	it("allows git-subdir parent segments that remain contained", async () => {
+		await expect(
+			validatePluginSource(
+				makeEntry({ source: "git-subdir", url: "owner/repo", path: "packages/../plugins/foo" }),
+				{},
+			),
+		).resolves.toBeUndefined();
+	});
+
 	it("throws when source string would escape marketplace root", async () => {
 		// "../../escape" does not start with "./" — hits the non-relative guard
 		const entry = makeEntry("../../escape");

--- a/packages/coding-agent/test/marketplace/source-resolver.test.ts
+++ b/packages/coding-agent/test/marketplace/source-resolver.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { MarketplacePluginEntry } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
-import { resolvePluginSource } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import { resolvePluginSource, validatePluginSource } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 // Fixture: a cloned marketplace with a single plugin at ./plugins/hello-plugin
@@ -33,6 +33,24 @@ describe("resolvePluginSource", () => {
 		});
 		expect(resolved.dir).toBe(path.resolve(FIXTURE_DIR, "plugins/hello-plugin"));
 		expect(resolved.tempCloneRoot).toBeUndefined();
+	});
+
+	it("validates relative sources without mutating or cloning", async () => {
+		await expect(
+			validatePluginSource(makeEntry("./plugins/hello-plugin"), { marketplaceClonePath: FIXTURE_DIR }),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects unsupported npm sources during validation", async () => {
+		await expect(validatePluginSource(makeEntry({ source: "npm", package: "hello-plugin" }), {})).rejects.toThrow(
+			/npm plugin sources are not yet supported/,
+		);
+	});
+
+	it("rejects git-subdir traversal during validation", async () => {
+		await expect(
+			validatePluginSource(makeEntry({ source: "git-subdir", url: "owner/repo", path: "../../escape" }), {}),
+		).rejects.toThrow(/escapes the cloned repository/);
 	});
 
 	it("throws when source string would escape marketplace root", async () => {

--- a/packages/coding-agent/test/marketplace/source-resolver.test.ts
+++ b/packages/coding-agent/test/marketplace/source-resolver.test.ts
@@ -38,7 +38,7 @@ describe("resolvePluginSource", () => {
 	it("validates relative sources without mutating or cloning", async () => {
 		await expect(
 			validatePluginSource(makeEntry("./plugins/hello-plugin"), { marketplaceClonePath: FIXTURE_DIR }),
-		).resolves.toBeUndefined();
+		).resolves.toBe(path.resolve(FIXTURE_DIR, "plugins/hello-plugin"));
 	});
 
 	it("rejects unsupported npm sources during validation", async () => {


### PR DESCRIPTION
## What

This patch makes omp plugin install --dry-run preview marketplace installs without changing plugin state, preserves normal installation behavior.

I reviewed the full diff and kept the change limited to marketplace CLI behavior, its zero-dependency branch handler, non-mutating manager/source/config/version validation, regression coverage, and the requested package changelog entry.

## Why

Marketplace targets previously invoked installPlugin even when --dry-run was supplied. The CLI now routes the marketplace branch through a zero-dependency handler that validates the same registry, scope, force, source, embedded-config containment/existence, catalog-version, and already-installed preconditions without cloning or writing, then emits the preview and returns before installPlugin. Ordinary installation reuses the same manager validation and keeps its existing install path.

## Testing

- `bun test packages/coding-agent/test/marketplace/cli.test.ts` — PASS (24 tests, 27 expectations).
- `bun run check:types` from `packages/coding-agent` — PASS.
- `oxlint` on all changed TypeScript files — PASS.
- `oxfmt --check` on all changed TypeScript files — PASS.
- `git diff --check origin/main...HEAD` — PASS.
- Marketplace manager/source-resolver tests cover non-mutating validation, unsupported npm, contained git-subdir parents, traversal, catalog versions, and embedded config containment/existence; local execution is blocked by this checkout's missing darwin-arm64 pi_natives addon, so no native toolchain was built.

Hosted CI exercises the full coding-agent test matrix in its generated/native environment.