### PR TITLE
fix: preserve live macOS executable backups during self-update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS self-updates preserve executable backups still used by running sessions, preventing lost privacy-permission attribution.
+- Startup and daemon commands no longer crash when project-directory canonicalization encounters EPERM or EACCES.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1234,12 +1234,33 @@ async function unlinkIfExists(filePath: string): Promise<void> {
  *
  * On Windows the executable that was just moved aside is still mapped as the
  * running process image, so unlinking it fails with EPERM/EACCES until this
- * process exits (issue #845). The replacement and verification already
- * succeeded by the time we get here, so every error is swallowed; the leftover
- * is reclaimed by {@link sweepStaleUpdateArtifacts} on the next update once it
- * is no longer in use. Returns whether the file is gone.
+ * process exits (issue #845). On macOS the same unlink would instead succeed
+ * while breaking the live process's TCC permission attribution — macOS
+ * resolves grants against the executable's on-disk image path — so a `.bak`
+ * still mapped by any process is retained for a later sweep. The replacement
+ * and verification already succeeded by the time we get here, so every error
+ * is swallowed; the leftover is reclaimed by {@link sweepStaleUpdateArtifacts}
+ * on the next update once it is no longer in use. Returns whether the file is
+ * gone.
  */
 async function removeBackupBestEffort(filePath: string): Promise<boolean> {
+	// macOS only, `.bak` only: a `.new` temp file is a download in progress,
+	// never an installed image, and Windows/Linux locking is already handled by
+	// the swallow below — so both stay ungated.
+	if (process.platform === "darwin" && filePath.endsWith(".bak")) {
+		// `/usr/sbin/lsof -t` prints the PIDs holding the file; exit 1 with
+		// empty stdout and stderr is the only result that proves the file is
+		// unused. Live users, a missing lsof, or diagnostics on stderr all
+		// retain the file for a later sweep.
+		let provenUnused = false;
+		try {
+			const result = await $`/usr/sbin/lsof -t -- ${filePath}`.quiet().nothrow();
+			provenUnused = result.exitCode === 1 && result.stdout.length === 0 && result.stderr.length === 0;
+		} catch {
+			// lsof missing or failed to spawn — retain conservatively.
+		}
+		if (!provenUnused) return false;
+	}
 	try {
 		await fs.promises.unlink(filePath);
 		return true;
@@ -1255,8 +1276,12 @@ async function removeBackupBestEffort(filePath: string): Promise<boolean> {
  * previous executable to `<binary>.<timestamp>.<pid>.bak` before swapping the
  * new one in. On Windows a backup cannot be deleted while the updating process
  * is alive (it is the running process image), so it is left for a later run to
- * reclaim once its owning process has exited. A `.new` temp file only survives
- * a hard kill mid-download; it is reaped once older than the download window,
+ * reclaim once its owning process has exited. On macOS the sweep must also
+ * spare a backup that any process still maps as its executable image —
+ * unlinking it would break the live process's TCC permission attribution — so
+ * a live image survives until its process exits. A `.new` temp file only
+ * survives a hard kill mid-download; it is reaped once older than the download
+ * window,
  * which a live download cannot exceed without timing out and cleaning up after
  * itself — so a concurrent run's in-progress temp is never deleted. Legacy
  * fixed `<binary>.bak` / `<binary>.new` names (from before suffixes were made
@@ -1328,8 +1353,10 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
 
 		backupReady = false;
 		// Swap done and verified. On Windows the backup is still the running
-		// process image and cannot be unlinked until this process exits, so a
-		// failure here must NOT fail an otherwise-successful update.
+		// process image and cannot be unlinked until this process exits, and on
+		// macOS unlinking the still-mapped backup would break the live image's
+		// TCC permission attribution, so either way a failure here must NOT fail
+		// an otherwise-successful update.
 		await removeBackupBestEffort(options.backupPath);
 		return verification;
 	} catch (err) {

--- a/packages/coding-agent/src/launch/paths.ts
+++ b/packages/coding-agent/src/launch/paths.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getDaemonRuntimeDir, isEisdir, isEnoent } from "@oh-my-pi/pi-utils";
+import { getDaemonRuntimeDir, hasFsCode, isEacces, isEisdir, isEnoent } from "@oh-my-pi/pi-utils";
 
 /** Resolve the private runtime directory shared by omp processes in one project directory. */
 export { getDaemonRuntimeDir as daemonRuntimeDir };
@@ -11,14 +11,15 @@ const SCOPE_FILE = "scope.json";
 /**
  * Canonicalize a project directory the same way every broker client does, so
  * hash-keyed runtime dirs and Windows pipe names agree across processes.
- * Missing paths resolve without realpath instead of failing.
+ * Missing paths and permission-denied lookups (EPERM/EACCES on protected
+ * parent directories) resolve without realpath instead of failing.
  */
 export async function canonicalProjectDir(projectDir: string): Promise<string> {
 	const resolved = path.resolve(projectDir);
 	try {
 		return await fs.realpath(resolved);
 	} catch (error) {
-		if (isEnoent(error) || isEisdir(error)) return resolved;
+		if (isEnoent(error) || isEisdir(error) || isEacces(error) || hasFsCode(error, "EPERM")) return resolved;
 		throw error;
 	}
 }

--- a/packages/coding-agent/test/tools/launch-canonical-dir-permission.test.ts
+++ b/packages/coding-agent/test/tools/launch-canonical-dir-permission.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { PathLike } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { canonicalProjectDir } from "../../src/launch/paths";
+
+describe("canonicalProjectDir permission fallback", () => {
+	const originalRealpath = fs.realpath.bind(fs);
+
+	afterEach(() => vi.restoreAllMocks());
+
+	function throwErrno(code: string, errno: number): never {
+		const err = new Error(`${code}: permission denied`) as NodeJS.ErrnoException;
+		err.code = code;
+		err.errno = errno;
+		err.syscall = "realpath";
+		throw err;
+	}
+
+	for (const [code, errno] of [
+		["EPERM", -1],
+		["EACCES", -13],
+	] as const) {
+		it(`resolves the normalized absolute path when realpath throws ${code}`, async () => {
+			const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-${code.toLowerCase()}-fallback-`));
+			const resolvedProjectDir = path.resolve(projectDir);
+
+			vi.spyOn(fs, "realpath").mockImplementation((async (p: PathLike) => {
+				if (path.resolve(String(p)) === resolvedProjectDir) {
+					throwErrno(code, errno);
+				}
+				return originalRealpath(p);
+			}) as typeof fs.realpath);
+
+			try {
+				await expect(canonicalProjectDir(projectDir)).resolves.toBe(resolvedProjectDir);
+			} finally {
+				await fs.rm(projectDir, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("still resolves symlinks to their real target when realpath succeeds", async () => {
+		const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-canonical-target-"));
+		const linkDir = path.join(os.tmpdir(), `omp-canonical-link-${Date.now()}-${process.pid}`);
+		await fs.symlink(targetDir, linkDir, "dir");
+
+		try {
+			await expect(canonicalProjectDir(linkDir)).resolves.toBe(await fs.realpath(targetDir));
+		} finally {
+			await fs.rm(linkDir, { force: true });
+			await fs.rm(targetDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rethrows realpath errors that are not missing-path or permission errors", async () => {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-eloop-rethrow-"));
+		const resolvedProjectDir = path.resolve(projectDir);
+
+		vi.spyOn(fs, "realpath").mockImplementation((async (p: PathLike) => {
+			if (path.resolve(String(p)) === resolvedProjectDir) {
+				throwErrno("ELOOP", -62);
+			}
+			return originalRealpath(p);
+		}) as typeof fs.realpath);
+
+		try {
+			await expect(canonicalProjectDir(projectDir)).rejects.toMatchObject({ code: "ELOOP" });
+		} finally {
+			await fs.rm(projectDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1236,6 +1236,72 @@ describe("update-cli stale update artifact sweep", () => {
 	});
 });
 
+describe.skipIf(process.platform !== "darwin")("update-cli macOS live backup images", () => {
+	// Regression for the macOS TCC image-path requirement: a `.bak` is the
+	// previous executable and another process may still be running it, so it
+	// must survive both the immediate post-swap cleanup and later sweeps until
+	// its image exits, then be reclaimable. `process.execPath` under `bun
+	// test` is the bun runtime — a real Mach-O whose copy can be held live.
+	// (Copies of Apple trust-cache binaries like /bin/sleep are SIGKILLed by
+	// macOS when executed from a new path, so they cannot serve here.)
+	it("retains a backup whose image a live process runs across cleanup and sweep, then reclaims it after the process exits", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, "omp");
+		await fs.copyFile(process.execPath, targetPath);
+		const live = Bun.spawn([targetPath, "-e", "await Bun.sleep(30000)"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// Real-time waits, not fake timers: these wait on genuine kernel and
+			// process state (lsof visibility of the live image, vnode release
+			// after exit) that no in-test clock controls.
+			// The image must actually be live and visible to lsof, or the
+			// retention assertions below would pass for the wrong reason.
+			let liveImageVisible = false;
+			for (let i = 0; i < 20 && !liveImageVisible; i++) {
+				const seen = Bun.spawnSync(["/usr/sbin/lsof", "-t", "--", targetPath]);
+				liveImageVisible = seen.exitCode === 0 && seen.stdout.toString().includes(String(live.pid));
+				if (!liveImageVisible) await Bun.sleep(100);
+			}
+			expect(liveImageVisible).toBe(true);
+
+			const attempt = "1700000000000.4242";
+			const tempPath = `${targetPath}.${attempt}.new`;
+			const backupPath = `${targetPath}.${attempt}.bak`;
+			await Bun.write(tempPath, "new binary");
+
+			const result = await replaceBinaryForUpdate({
+				targetPath,
+				tempPath,
+				backupPath,
+				expectedVersion: "15.1.8",
+				verifyInstalledVersion: async () => ({ ok: true, actual: "15.1.8", path: targetPath }),
+			});
+			expect(result.ok).toBe(true);
+			// The swap landed and the temp was consumed, but the live image's
+			// backup must remain on disk.
+			expect(await Bun.file(targetPath).text()).toBe("new binary");
+			expect(await Bun.file(tempPath).exists()).toBe(false);
+			expect(await Bun.file(backupPath).exists()).toBe(true);
+
+			// A later sweep must spare it too.
+			await sweepStaleUpdateArtifacts(targetPath);
+			expect(await Bun.file(backupPath).exists()).toBe(true);
+
+			live.kill();
+			await live.exited;
+
+			// Once the image is gone, the backup is reclaimable.
+			for (let i = 0; i < 20 && (await Bun.file(backupPath).exists()); i++) {
+				await sweepStaleUpdateArtifacts(targetPath);
+				await Bun.sleep(100);
+			}
+			expect(await Bun.file(backupPath).exists()).toBe(false);
+		} finally {
+			live.kill();
+			await live.exited;
+		}
+	});
+});
+
 describe("update-cli binary-only release gating", () => {
 	it("honors an explicit omp.dist field from the registry manifest", () => {
 		expect(resolveReleaseDist({ omp: { dist: "binary" } })).toBe("binary");


### PR DESCRIPTION
## Summary

- Preserve macOS executable backups while any running process still holds the old image, both immediately after replacement and during later artifact sweeps.
- Fall back to the normalized absolute project path when `realpath` fails with `EPERM` or `EACCES`, matching the existing missing-path fallback. Other errors still propagate.
- Add regression coverage for a real running Mach-O image across replacement, sweeping, and process exit, plus permission-denied path resolution.

## Problem

A binary update renames the installed executable to an attempt-specific `.bak`, installs the new binary, then unlinks the backup. Other OMP sessions can still be running the old executable. Unlike Windows, macOS permits that unlink, but the process then loses its resolvable executable path for privacy authorization.

Observed on macOS arm64 with OMP 18.1.14 sessions after updating to 18.1.15:

- Full Disk Access grants existed for OMP and the terminal, and their stored code requirements matched the current executables.
- `lsof` showed the affected sessions mapped an updater-created `.bak` that no longer existed.
- `proc_pidpath` returned `ENOENT` for those live sessions; it succeeded for a session running the current executable.
- TCC logged `proc_pidpath_audittoken() failed ... No such file or directory` and `Failed to create Attribution Chain from message`.

Separately, a denied `realpath` in `canonicalProjectDir` propagates through daemon presence registration and terminates startup. The same failure can be exercised with `omp ps --dir <protected-directory>`. Handling that error prevents the crash; it does not grant access to protected files or repair already-unlinked running images.

## Implementation

On macOS, `.bak` cleanup uses `/usr/sbin/lsof -t -- <path>` and deletes only when the result is exit status 1 with empty stdout and stderr. Live holders, diagnostics, unexpected exit codes, and spawn failures retain the backup conservatively. This checks actual holders rather than the updater PID encoded in the filename. Windows/Linux cleanup and the age guard for `.new` downloads are unchanged.

## Verification

- `bun test test/tools/launch-canonical-dir-permission.test.ts test/tools/launch-eisdir-fallback.test.ts test/update-cli.test.ts test/cli/update-cli.test.ts` from `packages/coding-agent`: **103 passed, 0 failed** on macOS arm64 / Bun 1.3.14.
- The new macOS test runs a copy of Bun as a real executable, verifies its backup survives both replacement and a subsequent sweep, then verifies reclamation after process exit.
- Installed 18.1.15 `omp ps --dir <protected-directory>` failed with the reported `EPERM`; the patched source CLI completed and displayed the project scope.
- `oxlint` passed on all four changed TypeScript files; formatted with `oxfmt`.

The source checkout used the installed 18.1.15 native addon for local verification; no native code is changed. No installed binary, privacy database, or live user session was modified.
