### PR TITLE
fix(coding-agent): honor configured slow fallback for advisor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Unset `advisor` model roles now honor the configured `@slow` fallback without inheriting an unconfigured primary model ([#11428](https://github.com/can1357/oh-my-pi/issues/11428)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1209,6 +1209,22 @@ function resolveDefaultInheritedPatterns(
 	return resolved;
 }
 
+/**
+ * Apply an explicit outer thinking level to a resolved model pattern, replacing
+ * any level the pattern already carries. A selector like `@advisor:high` must
+ * win over an inherited role's own suffix (e.g. `slow = custom-slow:max`)
+ * instead of producing a doubled `custom-slow:max:high` the matcher cannot
+ * resolve.
+ */
+function overrideThinkingSuffix(pattern: string, level: ConfiguredThinkingLevel): string {
+	const { base } = splitThinkingSuffix(
+		pattern,
+		modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
+		MAX_THINKING_SUFFIX_OPTIONS,
+	);
+	return `${base}:${level}`;
+}
+
 function resolveConfiguredRolePattern(
 	value: string,
 	settings?: ModelRoleLookup,
@@ -1269,7 +1285,7 @@ function resolveConfiguredRolePattern(
 		return undefined;
 	}
 
-	return thinkingLevel ? resolved.map(pattern => `${pattern}:${thinkingLevel}`) : resolved;
+	return thinkingLevel ? resolved.map(pattern => overrideThinkingSuffix(pattern, thinkingLevel)) : resolved;
 }
 
 /**

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1209,22 +1209,6 @@ function resolveDefaultInheritedPatterns(
 	return resolved;
 }
 
-/**
- * Apply an explicit outer thinking level to a resolved model pattern, replacing
- * any level the pattern already carries. A selector like `@advisor:high` must
- * win over an inherited role's own suffix (e.g. `slow = custom-slow:max`)
- * instead of producing a doubled `custom-slow:max:high` the matcher cannot
- * resolve.
- */
-function overrideThinkingSuffix(pattern: string, level: ConfiguredThinkingLevel): string {
-	const { base } = splitThinkingSuffix(
-		pattern,
-		modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
-		MAX_THINKING_SUFFIX_OPTIONS,
-	);
-	return `${base}:${level}`;
-}
-
 function resolveConfiguredRolePattern(
 	value: string,
 	settings?: ModelRoleLookup,
@@ -1285,7 +1269,7 @@ function resolveConfiguredRolePattern(
 		return undefined;
 	}
 
-	return thinkingLevel ? resolved.map(pattern => overrideThinkingSuffix(pattern, thinkingLevel)) : resolved;
+	return thinkingLevel ? resolved.map(pattern => `${pattern}:${thinkingLevel}`) : resolved;
 }
 
 /**

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1167,6 +1167,40 @@ function rolePriorityDefaults(role: ModelRole): string[] {
 	return normalizeModelPatternList(MODEL_PRIO[key]);
 }
 
+/** Resolve aliases inside a configured pattern list without leaking cycles to model matching. */
+function resolveNestedRolePatterns(
+	value: string,
+	roleDefaults: string[],
+	settings: ModelRoleLookup | undefined,
+	visited: Set<string>,
+): string[] {
+	const resolved: string[] = [];
+	for (const pattern of normalizeModelPatternList(value)) {
+		const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
+			pattern,
+			modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
+			MAX_THINKING_SUFFIX_OPTIONS,
+		);
+		const aliasRole = getModelRoleAlias(aliasCandidate, settings);
+		if (!aliasRole) {
+			resolved.push(pattern);
+			continue;
+		}
+		if (visited.has(aliasRole)) {
+			resolved.push(
+				...(thinkingLevel
+					? roleDefaults.map(defaultPattern => `${defaultPattern}:${thinkingLevel}`)
+					: roleDefaults),
+			);
+			continue;
+		}
+
+		const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
+		if (recursed) resolved.push(...recursed);
+	}
+	return resolved;
+}
+
 function resolveDefaultInheritedPatterns(
 	role: ModelRole,
 	configuredDefault: string | undefined,
@@ -1175,38 +1209,7 @@ function resolveDefaultInheritedPatterns(
 	visited: Set<string>,
 ): string[] {
 	if (!shouldInheritDefaultBeforePriority(role) || !configuredDefault) return [];
-
-	const resolved: string[] = [];
-	for (const pattern of normalizeModelPatternList(configuredDefault)) {
-		const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
-			pattern,
-			modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
-			MAX_THINKING_SUFFIX_OPTIONS,
-		);
-		const aliasRole = getModelRoleAlias(aliasCandidate, settings);
-		if (aliasRole && visited.has(aliasRole)) {
-			// Cycle (self-alias like modelRoles.default = "@smol", or tiny → smol
-			// → default = "@tiny") would loop back to a visited role: fall back
-			// to the built-in chain instead of leaking the unresolved alias.
-			resolved.push(
-				...(thinkingLevel
-					? roleDefaults.map(defaultPattern => `${defaultPattern}:${thinkingLevel}`)
-					: roleDefaults),
-			);
-			continue;
-		}
-		if (aliasRole) {
-			// Cross-role alias (e.g. modelRoles.default = "@slow"): resolve the
-			// concrete model patterns instead of another role alias.
-			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
-			if (recursed && recursed.length > 0) {
-				resolved.push(...recursed);
-				continue;
-			}
-		}
-		resolved.push(pattern);
-	}
-	return resolved;
+	return resolveNestedRolePatterns(configuredDefault, roleDefaults, settings, visited);
 }
 
 function resolveConfiguredRolePattern(
@@ -1236,27 +1239,9 @@ function resolveConfiguredRolePattern(
 		!configuredFallback ||
 		(configuredFallback.configuredOnly && !settings?.getModelRole(configuredFallback.role)?.trim())
 			? undefined
-			: (
-					resolveConfiguredRolePattern(
-						formatModelRoleAlias(configuredFallback.role),
-						settings,
-						new Set(visited),
-					) ?? []
-				).flatMap(pattern => {
-					const { base, level } = splitThinkingSuffix(
-						pattern,
-						modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
-						MAX_THINKING_SUFFIX_OPTIONS,
-					);
-					const patternRole = getModelRoleAlias(base, settings);
-					if (!patternRole || !visited.has(patternRole)) return [pattern];
-					// Cyclic fallback alias (e.g. smol = "@tiny:high" while resolving
-					// @tiny): expand to the built-in chain, preserving the requested
-					// thinking level instead of dropping the suffix.
-					return level ? roleDefaults.map(defaultPattern => `${defaultPattern}:${level}`) : [];
-				});
+			: resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback.role), settings, new Set(visited));
 	const resolved = configured
-		? normalizeModelPatternList(configured)
+		? resolveNestedRolePatterns(configured, roleDefaults, settings, visited)
 		: fallbackPatterns
 			? fallbackPatterns
 			: isModelRole(role)

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1138,21 +1138,27 @@ function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
 
 /**
  * Roles that have no priority.json chain of their own reuse another role's
- * list. The advisor — a second-opinion reviewer — defaults to the `slow`
- * reasoning chain, but (unlike the `slow` role, see
- * {@link shouldInheritDefaultBeforePriority}) never inherits the primary's
- * model, so it stays a distinct strong model out of the box. The `tiny` role —
- * the override for online title/memory/classifier tasks — reuses the `smol`
- * fast chain so an unset tiny role auto-resolves to the same fast model smol
- * would pick.
+ * list. The advisor — a second-opinion reviewer — uses a configured `slow`
+ * role before that list, but never inherits the primary's model when `slow`
+ * is unset, so it stays a distinct strong model out of the box. The `tiny`
+ * role — the override for online title/memory/classifier tasks — resolves
+ * through `smol` so it picks the same configured, inherited, or built-in fast
+ * model.
  */
 const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> = {
 	advisor: "slow",
 	tiny: "smol",
 };
 
-const ROLE_CONFIGURED_FALLBACK: Partial<Record<ModelRole, ModelRole>> = {
-	tiny: "smol",
+interface ConfiguredRoleFallback {
+	role: ModelRole;
+	/** Skip the target role's default inheritance when it has no explicit configuration. */
+	configuredOnly: boolean;
+}
+
+const ROLE_CONFIGURED_FALLBACK: Partial<Record<ModelRole, ConfiguredRoleFallback>> = {
+	advisor: { role: "slow", configuredOnly: true },
+	tiny: { role: "smol", configuredOnly: false },
 };
 
 /** Built-in priority patterns for a role, following {@link ROLE_PRIORITY_ALIAS}. */
@@ -1226,10 +1232,16 @@ function resolveConfiguredRolePattern(
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
 	const configuredFallback = isModelRole(role) ? ROLE_CONFIGURED_FALLBACK[role] : undefined;
 	const fallbackPatterns =
-		configured || !configuredFallback
+		configured ||
+		!configuredFallback ||
+		(configuredFallback.configuredOnly && !settings?.getModelRole(configuredFallback.role)?.trim())
 			? undefined
 			: (
-					resolveConfiguredRolePattern(formatModelRoleAlias(configuredFallback), settings, new Set(visited)) ?? []
+					resolveConfiguredRolePattern(
+						formatModelRoleAlias(configuredFallback.role),
+						settings,
+						new Set(visited),
+					) ?? []
 				).flatMap(pattern => {
 					const { base, level } = splitThinkingSuffix(
 						pattern,
@@ -1691,10 +1703,10 @@ export function resolveRoleSelection(
 /**
  * Resolve the model for the `advisor` role. A configured `modelRoles.advisor`
  * wins outright (a bad override surfaces as no model rather than silently
- * running something else); when unset it falls back to the `slow` priority
- * chain via {@link ROLE_PRIORITY_ALIAS} — a strong reasoning model that, unlike
- * the `slow` role itself, never inherits the primary's model. Returns undefined
- * only when no candidate in the resolved chain is available.
+ * running something else); when unset it uses a configured `slow` role before
+ * the built-in slow priority chain. It never inherits the primary model through
+ * an unconfigured `slow` role. Returns undefined only when no candidate in the
+ * resolved chain is available.
  */
 export function resolveAdvisorRoleSelection(
 	settings: Settings,

--- a/packages/coding-agent/test/model-browser.test.ts
+++ b/packages/coding-agent/test/model-browser.test.ts
@@ -63,6 +63,23 @@ describe("resolveRoleAssignments", () => {
 		expect(roles.tiny?.model).toBe(smol);
 		expect(roles.tiny?.autoSelected).toBe(true);
 	});
+
+	test("shows configured slow for an unconfigured advisor role", () => {
+		const slow = makeModel("demo", "custom-slow");
+		const priorityHead = makeModel("demo", "gpt-5.6-sol");
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "demo/default",
+				slow: "demo/custom-slow",
+			},
+		});
+
+		const roles = resolveRoleAssignments(settings, [slow, priorityHead], [slow, priorityHead]);
+
+		expect(roles.slow?.model).toBe(slow);
+		expect(roles.advisor?.model).toBe(slow);
+		expect(roles.advisor?.autoSelected).toBe(true);
+	});
 });
 
 describe("ModelBrowser search ranking", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1149,6 +1149,21 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@advisor", settings })).toEqual(["baseten/custom-slow:max"]);
 	});
 
+	test("expands nested role aliases from the configured slow fallback", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "openrouter/qwen/qwen3-coder:exacto",
+				smol: "@default",
+				slow: "@smol",
+			},
+		});
+
+		const result = resolveModelRoleValue("@advisor", allModels, { settings });
+
+		expect(result.model?.provider).toBe("openrouter");
+		expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
+	});
+
 	test("outer advisor thinking level overrides the inherited slow effort", () => {
 		const settings = Settings.isolated({
 			modelRoles: { slow: "nanogpt/coding-router:max" },

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1149,6 +1149,19 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@advisor", settings })).toEqual(["baseten/custom-slow:max"]);
 	});
 
+	test("outer advisor thinking level overrides the inherited slow suffix", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "local/default",
+				slow: "baseten/custom-slow:max",
+			},
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@advisor:high", settings })).toEqual([
+			"baseten/custom-slow:high",
+		]);
+	});
+
 	test("keeps advisor on the built-in slow chain when slow is unconfigured", () => {
 		const baseline = resolveAgentModelPatterns({ agentModel: "@advisor", settings: Settings.isolated() });
 		const settings = Settings.isolated({ modelRoles: { default: "local/default" } });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1149,17 +1149,28 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@advisor", settings })).toEqual(["baseten/custom-slow:max"]);
 	});
 
-	test("outer advisor thinking level overrides the inherited slow suffix", () => {
+	test("outer advisor thinking level overrides the inherited slow effort", () => {
 		const settings = Settings.isolated({
-			modelRoles: {
-				default: "local/default",
-				slow: "baseten/custom-slow:max",
-			},
+			modelRoles: { slow: "nanogpt/coding-router:max" },
 		});
 
-		expect(resolveAgentModelPatterns({ agentModel: "@advisor:high", settings })).toEqual([
-			"baseten/custom-slow:high",
-		]);
+		const result = resolveModelRoleValue("@advisor:high", [mockMaxSuffixModels[0]], { settings });
+
+		expect(result.model?.id).toBe("coding-router");
+		expect(result.thinkingLevel).toBe(Effort.High);
+		expect(result.explicitThinkingLevel).toBe(true);
+	});
+
+	test("outer advisor thinking level preserves an inherited literal suffix model id", () => {
+		const settings = Settings.isolated({
+			modelRoles: { slow: "nanogpt/coding-router:max" },
+		});
+
+		const result = resolveModelRoleValue("@advisor:high", mockMaxSuffixModels, { settings });
+
+		expect(result.model?.id).toBe("coding-router:max");
+		expect(result.thinkingLevel).toBe(Effort.High);
+		expect(result.explicitThinkingLevel).toBe(true);
 	});
 
 	test("keeps advisor on the built-in slow chain when slow is unconfigured", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1138,6 +1138,27 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@tiny", settings })).toEqual(["baseten/custom-smol:max"]);
 	});
 
+	test("uses configured slow for unconfigured advisor before priority defaults", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "local/default",
+				slow: "baseten/custom-slow:max",
+			},
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@advisor", settings })).toEqual(["baseten/custom-slow:max"]);
+	});
+
+	test("keeps advisor on the built-in slow chain when slow is unconfigured", () => {
+		const baseline = resolveAgentModelPatterns({ agentModel: "@advisor", settings: Settings.isolated() });
+		const settings = Settings.isolated({ modelRoles: { default: "local/default" } });
+
+		const advisor = resolveAgentModelPatterns({ agentModel: "@advisor", settings });
+
+		expect(advisor).not.toContain("local/default");
+		expect(advisor).toEqual(baseline);
+	});
+
 	test("breaks the tiny/smol fallback cycle via a default alias", () => {
 		const settings = Settings.isolated({ modelRoles: { default: "@tiny" } });
 		const baseline = resolveAgentModelPatterns({ agentModel: "@smol", settings: Settings.isolated() });


### PR DESCRIPTION
## Repro
With `modelRoles.slow` set to `baseten/custom-slow:max`, `modelRoles.default` set to `local/default`, and `advisor` unset, run `bun test packages/coding-agent/test/model-resolver.test.ts --test-name-pattern "uses configured slow for unconfigured advisor"`. Before the fix, `@advisor` returned the 25-entry built-in slow chain headed by `openai-codex/gpt-5.6-sol` instead of the configured slow model.

## Cause
`resolveConfiguredRolePattern` in `packages/coding-agent/src/config/model-resolver.ts` gave `advisor` the built-in slow priority list through `ROLE_PRIORITY_ALIAS`, but `ROLE_CONFIGURED_FALLBACK` only redirected `tiny` through its configured companion role. As a result, advisor resolution never consulted `modelRoles.slow`.

## Fix
- Resolve an unset advisor through an explicitly configured slow role before built-in priority defaults.
- Preserve advisor's distinct-model default by skipping slow's primary-model inheritance when slow is unconfigured.
- Cover direct role resolution and the `/models` Roles view, and record the corrected behavior in the changelog.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/model-browser.test.ts` passed: 189 tests, 0 failures. `bun run check:types` passed, and the pre-publish `bun check` gate passed.

Fixes #11428