### PR TITLE
fix(session): scope set_auto_compaction/set_auto_retry to the session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The `set_auto_compaction` and `set_auto_retry` RPC commands are now session-scoped like `set_thinking_level`, so a short-lived RPC client no longer silently writes `compaction.enabled`/`retry.enabled` to the machine-global `config.yml` ([#11431](https://github.com/can1357/oh-my-pi/issues/11431)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -520,7 +520,7 @@ export class SelectorController {
 		switch (id) {
 			// Session-managed settings (not in SettingsManager)
 			case "autoCompact":
-				this.ctx.session.setAutoCompactionEnabled(value as boolean);
+				this.ctx.session.setAutoCompactionEnabled(value as boolean, true);
 				this.ctx.statusLine.setAutoCompactEnabled(value as boolean);
 				break;
 			case "composer.shape":

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5447,9 +5447,9 @@ export class AgentSession {
 		await this.#maintenance.runIdleCompaction();
 	}
 
-	/** Toggle automatic compaction. */
-	setAutoCompactionEnabled(enabled: boolean): void {
-		this.#maintenance.setAutoCompactionEnabled(enabled);
+	/** Toggle automatic compaction. `persist` saves it to global config; the default applies a session-scoped override. */
+	setAutoCompactionEnabled(enabled: boolean, persist = false): void {
+		this.#maintenance.setAutoCompactionEnabled(enabled, persist);
 	}
 
 	/** Whether automatic compaction is enabled. */
@@ -8654,9 +8654,9 @@ export class AgentSession {
 		return this.#recovery.autoRetryEnabled;
 	}
 
-	/** Toggle the auto-retry setting. */
-	setAutoRetryEnabled(enabled: boolean): void {
-		this.#recovery.setAutoRetryEnabled(enabled);
+	/** Toggle the auto-retry setting. `persist` saves it to global config; the default applies a session-scoped override. */
+	setAutoRetryEnabled(enabled: boolean, persist = false): void {
+		this.#recovery.setAutoRetryEnabled(enabled, persist);
 	}
 
 	/** Whether the last turn ended aborted/failed on a tool call, so {@link retry} would re-attempt it. */

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -4652,12 +4652,24 @@ export class SessionMaintenance {
 	}
 
 	/**
-	 * Toggle auto-compaction setting.
+	 * Toggle auto-compaction. When `persist` is false (the default) the change is
+	 * applied as a session-scoped runtime override — like `setThinkingLevel` — so
+	 * transient callers (e.g. the `set_auto_compaction` RPC command) configure
+	 * only their own session instead of mutating the machine-global `config.yml`.
+	 * The settings panel passes `persist: true` to save the preference durably.
 	 */
-	setAutoCompactionEnabled(enabled: boolean): void {
-		this.#host.settings.set("compaction.enabled", enabled);
+	setAutoCompactionEnabled(enabled: boolean, persist = false): void {
+		if (persist) {
+			this.#host.settings.set("compaction.enabled", enabled);
+		} else {
+			this.#host.settings.override("compaction.enabled", enabled);
+		}
 		if (enabled && resolveCompactionMethodOrder(this.#host.settings.get("compaction.methodOrder")).length === 0) {
-			this.#host.settings.set("compaction.methodOrder", [...DEFAULT_COMPACTION_METHOD_ORDER]);
+			if (persist) {
+				this.#host.settings.set("compaction.methodOrder", [...DEFAULT_COMPACTION_METHOD_ORDER]);
+			} else {
+				this.#host.settings.override("compaction.methodOrder", [...DEFAULT_COMPACTION_METHOD_ORDER]);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2630,10 +2630,17 @@ export class TurnRecovery {
 	}
 
 	/**
-	 * Toggle auto-retry setting.
+	 * Toggle auto-retry. When `persist` is false (the default) the change is a
+	 * session-scoped runtime override rather than a durable global write, so the
+	 * `set_auto_retry` RPC command configures only its own session instead of
+	 * mutating the machine-global `config.yml`.
 	 */
-	setAutoRetryEnabled(enabled: boolean): void {
-		this.#host.settings.set("retry.enabled", enabled);
+	setAutoRetryEnabled(enabled: boolean, persist = false): void {
+		if (persist) {
+			this.#host.settings.set("retry.enabled", enabled);
+		} else {
+			this.#host.settings.override("retry.enabled", enabled);
+		}
 	}
 	/**
 	 * Whether the transcript tail is a failed/aborted assistant turn whose most

--- a/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
@@ -17,4 +17,18 @@ describe("SelectorController prompt-affecting settings", () => {
 		expect(refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
+
+	it("persists the Auto-Compact toggle globally from the settings panel", () => {
+		const setAutoCompactionEnabled = vi.fn();
+		const ctx = {
+			session: { setAutoCompactionEnabled },
+			statusLine: { setAutoCompactEnabled: vi.fn() },
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.handleSettingChange("autoCompact", false);
+
+		// persist=true: panel edits are durable, unlike the session-scoped RPC path (#11431).
+		expect(setAutoCompactionEnabled).toHaveBeenCalledWith(false, true);
+	});
 });

--- a/packages/coding-agent/test/session/rpc-auto-maintenance-scope.test.ts
+++ b/packages/coding-agent/test/session/rpc-auto-maintenance-scope.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression guard for #11431: `set_auto_compaction`/`set_auto_retry` (which drive
+ * `AgentSession.setAutoCompactionEnabled`/`setAutoRetryEnabled`) must configure only
+ * the calling session by default, never write the machine-global `config.yml`. The
+ * explicit `persist` flag — used by the TUI settings panel — is the only path that
+ * mutates durable global state.
+ */
+describe("AgentSession auto-maintenance controls are session-scoped by default", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let settings: Settings;
+	let session: AgentSession;
+	let configPath: string;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-auto-scope-");
+		const agentDir = tempDir.path();
+		configPath = path.join(agentDir, "config.yml");
+
+		authStorage = await AuthStorage.create(path.join(agentDir, "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5") as Model;
+		settings = await Settings.loadIsolated({ agentDir, cwd: agentDir });
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(agentDir, agentDir),
+			settings,
+			modelRegistry,
+			obfuscator: new SecretObfuscator([]),
+		});
+	});
+
+	afterEach(async () => {
+		authStorage.close();
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	it("applies the change in-session without persisting to global config.yml", async () => {
+		session.setAutoCompactionEnabled(false);
+		session.setAutoRetryEnabled(false);
+		await settings.flush();
+
+		// Value is live for this session.
+		expect(settings.get("compaction.enabled")).toBe(false);
+		expect(settings.get("retry.enabled")).toBe(false);
+
+		// ...but it never touched the persisted global layer or disk.
+		expect(settings.getGlobalSettings()).toEqual({});
+		expect(await Bun.file(configPath).exists()).toBe(false);
+	});
+
+	it("persists to global config.yml when persist=true (settings panel path)", async () => {
+		session.setAutoCompactionEnabled(false, true);
+		session.setAutoRetryEnabled(false, true);
+		await settings.flush();
+
+		expect(settings.getGlobalSettings()).toMatchObject({
+			compaction: { enabled: false },
+			retry: { enabled: false },
+		});
+		const onDisk = await Bun.file(configPath).text();
+		expect(onDisk).toContain("enabled: false");
+	});
+});


### PR DESCRIPTION
## Repro
Against a fresh, empty agent dir, an RPC client that calls `set_auto_compaction(false)` / `set_auto_retry(false)` to configure the child it spawned silently persists that choice to the machine-global `config.yml` and every later session inherits it. Reproduced by running the exact mutation the handlers perform — `settings.set("compaction.enabled", false)` + `settings.set("retry.enabled", false)` against a persisting `Settings` — then flushing: `config.yml` goes from `ABSENT` to `compaction:\n  enabled: false\nretry:\n  enabled: false`. The sibling `set_thinking_level` on the same client writes nothing.

## Cause
The `set_auto_compaction`/`set_auto_retry` RPC handlers in `rpc-mode.ts` call `AgentSession.setAutoCompactionEnabled`/`setAutoRetryEnabled`, which route through `SessionMaintenance.setAutoCompactionEnabled` (`session-maintenance.ts`) and `TurnRecovery.setAutoRetryEnabled` (`turn-recovery.ts`). Both used `settings.set(...)`, which writes the global layer (`#global`) and queues a debounced disk save — durable, machine-wide, and outliving the session. `set_thinking_level` stays session-local because `setThinkingLevel(level, persist=false)` never persists.

## Fix
- `SessionMaintenance.setAutoCompactionEnabled(enabled, persist=false)` and `TurnRecovery.setAutoRetryEnabled(enabled, persist=false)`: default to `settings.override(...)` (a session-scoped, non-persisted runtime layer) and only use `settings.set(...)` when `persist` is true — mirroring `setThinkingLevel(level, persist)`.
- `AgentSession` wrappers forward the `persist` flag.
- The TUI settings-panel handler (`selector-controller.ts` `autoCompact` case) passes `persist: true` to keep saving the preference globally, matching the panel's semantics.
- RPC handlers are unchanged, so they now default to session scope.

## Verification
`bun test test/session/rpc-auto-maintenance-scope.test.ts test/modes/controllers/selector-controller-settings.test.ts` — 4 pass (default is session-scoped with no disk write; `persist=true` writes `config.yml`; panel path passes `persist=true`). `bun test test/agent-session-handoff.test.ts` — 27 pass (the empty-order re-enable path still restores default methods via the override layer). Fixes #11431