### PR TITLE
fix(registry): rebind stale lifecycle global after registry reset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `AgentLifecycleManager.global()` now rebinds to the current global registry after a lone `AgentRegistry` reset, so a test that resets only the registry can no longer strand the lifecycle manager on a dead instance and hang the collab kill path ([#11432](https://github.com/can1357/oh-my-pi/issues/11432)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -90,27 +90,42 @@ export class AgentLifecycleManager {
 	static #global: AgentLifecycleManager | undefined;
 
 	static global(): AgentLifecycleManager {
-		if (!AgentLifecycleManager.#global) {
-			AgentLifecycleManager.#global = new AgentLifecycleManager();
+		const current = AgentLifecycleManager.#global;
+		if (current) {
+			// The manager captures its registry at construction and subscribes to
+			// it for the manager's lifetime. A test that swaps the global registry
+			// (`AgentRegistry.resetGlobalForTests`) without also resetting this
+			// manager would strand it on the dead instance: terminal transitions
+			// (`release`) would mutate the old registry while consumers subscribe
+			// to the new one, so `status_changed` never reaches them (issue #11432).
+			// Rebind by retiring the stale manager and reconstructing against the
+			// current global registry. In production the registry is never reset, so
+			// this always short-circuits and the singleton is stable.
+			if (current.#registry === AgentRegistry.global()) return current;
+			current.#retire();
 		}
+		AgentLifecycleManager.#global = new AgentLifecycleManager();
 		return AgentLifecycleManager.#global;
 	}
 
 	/** Reset the global manager. Test-only. */
 	static resetGlobalForTests(): void {
 		const current = AgentLifecycleManager.#global;
-		if (current) {
-			current.#unsubscribe?.();
-			current.#unsubscribe = undefined;
-			for (const adopted of current.#adopted.values()) {
-				clearTimeout(adopted.timer);
-			}
-			current.#adopted.clear();
-			current.#revivals.clear();
-			current.#parks.clear();
-			current.#persistedReviverFactory = undefined;
-		}
+		if (current) current.#retire();
 		AgentLifecycleManager.#global = undefined;
+	}
+
+	/** Detach from the registry and cancel every pending timer/park/revival. */
+	#retire(): void {
+		this.#unsubscribe?.();
+		this.#unsubscribe = undefined;
+		for (const adopted of this.#adopted.values()) {
+			clearTimeout(adopted.timer);
+		}
+		this.#adopted.clear();
+		this.#revivals.clear();
+		this.#parks.clear();
+		this.#persistedReviverFactory = undefined;
 	}
 
 	readonly #registry: AgentRegistry;

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -88,6 +88,38 @@ describe("AgentLifecycleManager", () => {
 		expect(registry.get("generation-Sub")).toBeUndefined();
 	});
 
+	it("global() rebinds to the current registry after a lone AgentRegistry reset so release still emits aborted", async () => {
+		// A prior test file constructed the lifecycle global against registry A,
+		// then reset only the registry — the global is now registry B. The stranded
+		// manager (issue #11432) would run the terminal transition on the dead A
+		// while consumers subscribe to B, so status_changed never arrives.
+		const staleManager = lifecycle;
+		AgentRegistry.resetGlobalForTests();
+		const rebound = AgentLifecycleManager.global();
+		expect(rebound).not.toBe(staleManager);
+
+		const current = AgentRegistry.global();
+		const ref = current.register({
+			id: "Remote-Killed-Sub",
+			displayName: "remote kill",
+			kind: "sub",
+			session: makeSessionStub().session,
+			sessionFile: null,
+			status: "running",
+		});
+		const killed = deferred();
+		const unsubscribe = current.onChange(event => {
+			if (event.ref === ref && event.type === "status_changed" && event.ref.status === "aborted") killed.resolve();
+		});
+		try {
+			await rebound.release("Remote-Killed-Sub", ref, { tombstone: true });
+			await killed.promise;
+			expect(current.get("Remote-Killed-Sub")).toMatchObject({ status: "aborted", session: null });
+		} finally {
+			unsubscribe();
+		}
+	});
+
 	it("adopt arms the TTL: an idle agent is parked — session disposed, ref + sessionFile retained", async () => {
 		vi.useFakeTimers();
 		const stub = makeSessionStub();


### PR DESCRIPTION
## Repro
`collab read-only links > keeps a remotely killed subagent tombstoned` (`packages/coding-agent/test/collab/read-only.test.ts:216`) passes in isolation but hangs to its 5000ms budget when collab files share one `bun test` process with runtime-bucket files, because a sibling suite reset the global registry out from under the lifecycle manager. Reduced to a deterministic in-process repro: construct the lifecycle global, reset only the registry, then run the collab kill path.

```
AgentLifecycleManager.global();       // captures #registry = registry A
AgentRegistry.resetGlobalForTests();  // global registry is now B
// register a running sub on B, subscribe onChange for aborted
await AgentLifecycleManager.global().release(id, ref, { tombstone: true });
await killed.promise;                 // never resolves -> 3000ms timeout
```

## Cause
`AgentLifecycleManager` captures its registry once in the constructor (`packages/coding-agent/src/registry/agent-lifecycle.ts:133-135`) and subscribes to it for the manager's lifetime. `AgentRegistry.resetGlobalForTests()` (`agent-registry.ts:127-130`) swaps `AgentRegistry.#global` to a fresh instance without rebinding the manager. Suites that reset only the registry (collab, internal-urls, agent-hub) therefore strand a live lifecycle manager on the dead registry. The collab kill handler (`collab/host.ts:623-629`) resolves the ref from the current global registry but performs the terminal transition via `AgentLifecycleManager.global().release(..., {tombstone:true})`, whose `detachSession`/`setStatus('aborted')` (`agent-lifecycle.ts:452`) mutate the stale registry. The `status_changed`->`aborted` event never reaches the registry the test (and `CollabHost`) subscribe to, so the awaited promise hangs.

## Fix
- `AgentLifecycleManager.global()` now compares its captured `#registry` against the current `AgentRegistry.global()`; when they diverge it retires the stale manager and reconstructs against the current registry, so a lone `AgentRegistry` reset can no longer strand it. Production never resets the registry, so this always short-circuits and the singleton stays stable.
- Extracted the manager teardown (`#retire()`) shared by `resetGlobalForTests()` and the rebind path.
- Added a regression test in `test/registry/agent-lifecycle.test.ts` asserting `global()` rebinds after a lone registry reset and `release(tombstone)` emits `aborted` to the current registry's subscribers.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/registry/agent-lifecycle.test.ts` -> 33 pass. `bun test test/collab/read-only.test.ts` -> 6 pass. Pre-fix, the reduced repro timed out at its budget; post-fix it passes in ~110ms. (Two unrelated collab/html-export tests fail in this worktree because the generated `tool-views.generated.js` bundle is absent — produced by `gen:tool-views` on install/prepack — and fail identically in isolation.)

Fixes #11432