### PR TITLE
fix(ci): run checks for omp2 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
          - "patches/**"
          - ".github/**"
    pull_request:
-      branches: [main]
+      branches: [main, omp2]
       paths:
          - "packages/**"
          - "crates/**"


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'const workflow = Bun.YAML.parse(await Bun.file(".github/workflows/ci.yml").text()); console.log(JSON.stringify(workflow.on.pull_request.branches)); if (!workflow.on.pull_request.branches.includes("omp2")) process.exit(1);'` prints `["main"]` and exits 1, proving the CI workflow excludes `omp2`-targeted pull requests.

## Cause
The `pull_request` event filter in `.github/workflows/ci.yml` listed only `main`, so GitHub did not schedule the workflow when a pull request's base branch was `omp2`.

## Fix
- Add `omp2` to the CI workflow's pull-request branch filter while preserving the existing `main` trigger.

## Verification
The reproduction command now prints `["main","omp2"]` and exits 0. The pre-publish gate completed `bun run fix` and `bun check` successfully.

Fixes #11447