### PR TITLE
test(natives): force plain diff driver in vcs test git helper

### DIFF
--- a/packages/natives/test/vcs.test.ts
+++ b/packages/natives/test/vcs.test.ts
@@ -11,6 +11,11 @@ afterEach(async () => {
 });
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
+	// Neutralize any ambient diff driver / textconv (e.g. a user's `diff.external`
+	// like difftastic) so raw unified-diff assertions stay stable regardless of the
+	// host's global git config. `--no-ext-diff` is the reliable switch here; setting
+	// `diff.external=` to empty makes git execute "" as the driver and fail.
+	if (args[0] === "diff") args = ["diff", "--no-ext-diff", "--no-textconv", ...args.slice(1)];
 	const process = Bun.spawn(["git", ...args], { cwd, stderr: "pipe", stdout: "pipe" });
 	const [stdout, stderr, exitCode] = await Promise.all([
 		new Response(process.stdout).text(),
@@ -69,7 +74,7 @@ describe("in-process VCS bindings", () => {
 		expect(await repo!.statusSummary()).toEqual({ staged: 0, unstaged: 1, untracked: 1 });
 
 		const nativePatch = await repo!.diffText({});
-		const cliPatch = await git(root, "diff", "--no-ext-diff", "--no-textconv");
+		const cliPatch = await git(root, "diff");
 		expect(nativePatch.trimEnd()).toBe(cliPatch);
 		expect(nativePatch).toContain("diff --git a/tracked.txt b/tracked.txt");
 		expect(nativePatch).toContain("@@");


### PR DESCRIPTION
## Repro
The pi-natives vcs suite (`packages/natives/test/vcs.test.ts`) asserts native diff output byte-equals `git diff`. Two callsites shell out without neutralizing ambient config: `git diff HEAD` (the `uncommittedDiff` check) and `git diff --cached`. With `diff.external` configured globally (e.g. difftastic), git runs the external driver instead of emitting a unified diff, so the assertions never match — and often git aborts entirely. Reproduced by pointing `diff.external` at a stand-in driver and running `git diff HEAD`:

```
gc=$(mktemp); printf '[diff]\n\texternal = sed s/^/EXT:/\n' > "$gc"
root=$(mktemp -d); cd "$root"
export GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_SYSTEM=/dev/null
git init -q -b main; git config user.name t; git config user.email t@t.test
printf 'one\ntwo\n' > tracked.txt; git add tracked.txt; git commit -qm initial
printf 'one\nchanged\n' > tracked.txt
git diff HEAD
# -> EXT:-prefixed lines then: fatal: external diff died, stopping at tracked.txt (exit 128)
```

## Cause
The test `git()` helper (`packages/natives/test/vcs.test.ts`) spawns `git` with the caller's args and inherits the host's global config. Only one diff assertion (line 72) passed `--no-ext-diff --no-textconv`; the `git diff HEAD` and `git diff --cached` invocations did not, so an ambient `diff.external`/textconv driver leaked into the compared output.

## Fix
- In the test `git()` helper, inject `--no-ext-diff --no-textconv` whenever the first arg is `diff`, isolating every diff invocation from ambient git config in one place.
- Drop the now-redundant explicit flags from the single callsite that already carried them, so there is one mechanism.

Note: the issue suggested `git -c diff.external=` as an equivalent; that does not work — git executes the empty value as the driver command and fails. `--no-ext-diff` is the correct switch.

## Verification
Native full-suite run is blocked in this environment (the pi-natives addon needs `cmake` to build the opus dep, which is absent — unrelated to this change), so the fixed invocations were exercised directly against an ambient driver:

```
git diff --no-ext-diff --no-textconv HEAD      # -> plain unified diff, exit 0
git diff --no-ext-diff --no-textconv --cached  # -> empty, exit 0
```

Both now emit the unified diff the native bindings produce, regardless of `diff.external`. `bun run fix` + `bun check` ran clean via the push gate.

Fixes #11449