### PR TITLE
[omp2] Repair license exceptions to match the lockfile

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,7 @@ exceptions = [
     { allow = ["MPL-2.0"], crate = "im@15.1.0" },
     { allow = ["MPL-2.0"], crate = "option-ext@0.2.0" },
     { allow = ["MPL-2.0"], crate = "sized-chunks@0.6.5" },
-    { allow = ["WTFPL"], crate = "terminfo@0.9.0" },
+    { allow = ["MPL-2.0"], crate = "uluru@3.1.0" },
 ]
 
 # tree-sitter-graphql 0.1.0 omits a manifest expression; cargo-deny identifies


### PR DESCRIPTION
Replaces #11451, which was accidentally based on the #11444 prerequisite range and carried 371 unrelated files. This PR is based directly on `omp2` and contains exactly one line: the `terminfo@0.9.0` exception (crate absent from the lock; fails `unmatched-allow`) is replaced by a scoped `uluru@3.1.0` MPL-2.0 exception (via gix-pack), matching its im-family siblings.

Proof: `cargo deny --locked check licenses sources` green on the pristine tree (`licenses ok, sources ok`). No production change.