### PR TITLE
fix(ai): hoist interleaved messages after orphan repair in responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed openai-responses replay wedging a repaired orphan tool-result note between another call's `function_call` and `function_call_output`, which broke round pairing on strict validators (e.g. DeepSeek) with `400 No tool output found for tool call …`: orphan-output/call repair now runs before the interleaved-message hoist, so any injected note is relocated out of the tool-call batch ([#11473](https://github.com/can1357/oh-my-pi/issues/11473)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -2091,10 +2091,16 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 		msgIndex++;
 	}
 
-	const hoisted = hoistInterleavedResponsesToolBatchMessages(messages);
-	const withRepairedOutputs = options.repairOrphanOutputs ? repairOrphanResponsesToolOutputs(hoisted) : hoisted;
+	// Repair orphan outputs/calls first: both can inject an assistant `message`
+	// (an `[Orphan … result]` note, a `[Computer call interrupted …]` note) in
+	// place of, or beside, a tool item — wedging it between another call's
+	// `function_call` and `function_call_output`. Hoist runs last so it relocates
+	// any wedged message — model-streamed or repair-injected — out of the batch,
+	// preserving the Responses call→output pairing (#11473, extends #8789).
+	const withRepairedOutputs = options.repairOrphanOutputs ? repairOrphanResponsesToolOutputs(messages) : messages;
 	const withRepairedCalls = repairOrphanResponsesToolCalls(withRepairedOutputs);
-	return stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(withRepairedCalls);
+	const hoisted = hoistInterleavedResponsesToolBatchMessages(withRepairedCalls);
+	return stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(hoisted);
 }
 
 type ResponsesReplayAssistantMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };

--- a/packages/ai/test/issue-11473-orphan-output-wedge.test.ts
+++ b/packages/ai/test/issue-11473-orphan-output-wedge.test.ts
@@ -1,0 +1,115 @@
+import { expect, it } from "bun:test";
+import type { ResponseInput } from "@oh-my-pi/pi-ai/providers/openai-responses-wire";
+import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { AssistantMessage, Context, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
+import { createOpenAIResponsesHistoryPayload } from "@oh-my-pi/pi-ai/utils";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// DeepSeek via openai-responses (#11473): its validator pairs tool calls by
+// turn, so an assistant `message` wedged between a `function_call` and its
+// `function_call_output` closes the round early → `400 No tool output found`.
+const model = buildModel({
+	id: "deepseek-v4-flash",
+	name: "DeepSeek V4 Flash",
+	api: "openai-responses",
+	provider: "opencode-go",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_000,
+});
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function wireType(item: ResponseInput[number]): string {
+	if ("type" in item && typeof item.type === "string") return item.type;
+	if ("role" in item && typeof item.role === "string") return `message:${item.role}`;
+	return "unknown";
+}
+
+function toolResult(callId: string, toolName: string, text: string, isError = false): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: callId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError,
+		timestamp: 2,
+	};
+}
+
+it("does not wedge a repaired orphan-output note between a call and its output (#11473)", () => {
+	// One turn: model issued parallel `todo` (call_00) + `bash` (call_01). `todo`
+	// failed omp-side arg validation, so the native-replay snapshot (dt:false)
+	// carries only the landed `bash` call; `todo` survives as an orphan result.
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{ type: "toolCall", id: "call_00", name: "todo", arguments: {} },
+			{ type: "toolCall", id: "call_01", name: "bash", arguments: { command: "ls" } },
+		],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: zeroUsage,
+		stopReason: "toolUse",
+		providerPayload: createOpenAIResponsesHistoryPayload(
+			model.provider,
+			[
+				{ type: "reasoning", id: "rs_1", summary: [], content: [] },
+				{ type: "function_call", call_id: "call_01", name: "bash", arguments: "{}" },
+			],
+			false,
+		),
+		timestamp: 1,
+	};
+	const context: Context = {
+		messages: [
+			assistant,
+			toolResult("call_00", "todo", "Invalid todo arguments: op must be operation to apply", true),
+			toolResult("call_01", "bash", "file listing"),
+			{ role: "user", content: "continue", timestamp: 5 },
+		],
+	};
+
+	const items = buildResponsesInput({
+		model,
+		context,
+		strictResponsesPairing: false,
+		supportsImageDetailOriginal: false,
+		repairOrphanOutputs: true,
+		nativeHistory: { replay: true, filterReasoning: false },
+	});
+	const types = items.map(wireType);
+
+	// The orphan result is preserved as an assistant note (call_id + output text).
+	const note = items.find(item => {
+		if (!item || typeof item !== "object") return false;
+		const candidate = item as { type?: unknown; role?: unknown; content?: unknown };
+		return (
+			candidate.type === "message" &&
+			candidate.role === "assistant" &&
+			typeof candidate.content === "string" &&
+			candidate.content.includes("call_00")
+		);
+	}) as { content?: string } | undefined;
+	expect(note?.content).toContain("[Orphan tool result; call_id=call_00]");
+	expect(note?.content).toContain("Invalid todo arguments");
+
+	// Invariant: no message sits between a function_call and a function_call_output.
+	// Before the fix the note landed at index 2, wedged inside the bash batch.
+	const firstOutput = types.indexOf("function_call_output");
+	const lastCall = types.lastIndexOf("function_call");
+	expect(firstOutput).toBeGreaterThanOrEqual(0);
+	expect(lastCall).toBeLessThan(firstOutput);
+	expect(types.slice(lastCall + 1, firstOutput)).toEqual([]);
+});


### PR DESCRIPTION
## Repro
One assistant turn issues two parallel tool calls — `todo` (call_00, fails omp-side argument validation) and `bash` (call_01, succeeds). On a native-replay `dt:false` snapshot the landed history carries only the `bash` `function_call`, so `todo`'s result arrives as an orphan `function_call_output` positioned between `bash`'s `function_call` and its `function_call_output`. `repairOrphanResponsesToolOutputs` converts the orphan into an assistant `[Orphan tool result; …]` message in place, leaving a `message` wedged inside the tool-call batch. DeepSeek's Responses validator pairs calls by turn and rejects this with `400 No tool output found for tool call call_01…`, permanently poisoning the session (retries only append `user` items).

Repro: `bun test packages/ai/test/issue-11473-orphan-output-wedge.test.ts` — a `buildResponsesInput` case mirroring the turn emits `["reasoning","function_call","message","function_call_output","message:user"]`, i.e. the orphan note wedged at index 2.

## Cause
`buildResponsesInput` (`packages/ai/src/providers/openai-shared.ts`) ran `hoistInterleavedResponsesToolBatchMessages` **before** `repairOrphanResponsesToolOutputs` / `repairOrphanResponsesToolCalls`. Hoist (#8789) is exactly the pass that relocates a wedged assistant message out of a `function_call` → `function_call_output` batch, but it ran first — before the orphan `function_call_output` had been rewritten into a `message`. The repair passes then injected the note in place, re-introducing a wedge hoist had already walked past, which reached the wire.

## Fix
- Reorder the replay-finalize pipeline in `buildResponsesInput`: run `repairOrphanResponsesToolOutputs` then `repairOrphanResponsesToolCalls` first, and `hoistInterleavedResponsesToolBatchMessages` last, so any repair-injected note (orphan-output note or `[Computer call interrupted …]` note) is relocated ahead of its tool-call batch and the call→output pairing is preserved.
- Add `packages/ai/test/issue-11473-orphan-output-wedge.test.ts` asserting the orphan note is preserved and no `message` sits between a `function_call` and its `function_call_output`.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test packages/ai/test/issue-11473-orphan-output-wedge.test.ts` passes; wire is now `["reasoning","message","function_call","function_call_output","message:user"]`. `bun test packages/ai/test/openai-responses-orphan-repair.test.ts packages/ai/test/issue-8789-responses-interleaved-message.test.ts packages/ai/test/openai-responses-history-payload.test.ts` → 44 pass. Full `packages/ai` suite: 4477 pass, 1 fail in `proxy.test.ts` (proxy env-var normalization, unrelated to this diff and passing in isolation — a full-suite env-pollution flake). Fixes #11473