### PR TITLE
fix(config): preserve config.yml comments on model-role writes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
         "@opentelemetry/sdk-trace-base": "catalog:",
         "@opentelemetry/sdk-trace-node": "catalog:",
         "puppeteer-core": "catalog:",
+        "yaml": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -393,6 +394,7 @@
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
     "vite-plugin-solid": "^2.11.12",
+    "yaml": "^2.9.0",
   },
   "packages": {
     "@anush008/tokenizers": ["@anush008/tokenizers@0.0.0", "", { "optionalDependencies": { "@anush008/tokenizers-darwin-universal": "0.0.0", "@anush008/tokenizers-linux-x64-gnu": "0.0.0", "@anush008/tokenizers-win32-x64-msvc": "0.0.0" } }, "sha512-IQD9wkVReKAhsEAbDjh/0KrBGTEXelqZLpOBRDaIRvlzZ9sjmUP+gKbpvzyJnei2JHQiE8JAgj7YcNloINbGBw=="],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
 			"ts-morph": "^28.0.0",
 			"typescript": "^7.0.2",
 			"vite": "^8.1.4",
-			"vite-plugin-solid": "^2.11.12"
+			"vite-plugin-solid": "^2.11.12",
+			"yaml": "^2.9.0"
 		}
 	},
 	"type": "module",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Persisting a model-role assignment (`/model`, `/models`) no longer rewrites the whole profile `config.yml`; comments, quoting, blank lines, and the trailing newline are preserved, and only the changed key is touched ([#11477](https://github.com/can1357/oh-my-pi/issues/11477)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -70,7 +70,8 @@
     "@opentelemetry/sdk-metrics": "catalog:",
     "@opentelemetry/sdk-trace-base": "catalog:",
     "@opentelemetry/sdk-trace-node": "catalog:",
-    "puppeteer-core": "catalog:"
+    "puppeteer-core": "catalog:",
+    "yaml": "catalog:"
   },
   "optionalDependencies": {
     "@huggingface/transformers": "catalog:",

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { OmpErrors, type Type } from "@oh-my-pi/omptype";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
-import { Document, isCollection, parseDocument } from "yaml";
+import { Document, isCollection, isMap, isSeq, type ParsedNode, parseDocument } from "yaml";
 
 const YAML_MAPPING_HEADER_TRAILING_SPACE = /: +$/gm;
 
@@ -52,20 +52,39 @@ function reconcileRecord(
 }
 
 /**
+ * Column of the first non-whitespace character on the line containing `offset`.
+ * For a block-mapping key or sequence dash this is the node's own indentation.
+ */
+function lineIndentAt(text: string, offset: number): number {
+	const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+	const rel = text.slice(lineStart, offset + 1).search(/\S/);
+	return rel < 0 ? 0 : rel;
+}
+
+/**
  * Infer the indentation step (in spaces) a hand-maintained YAML file uses, so
  * reserialization does not reflow untouched blocks from 4-space to 2-space
- * (see #11478). Returns the smallest positive leading-space count across all
- * content lines, clamped to a sane range; defaults to 2 when nothing is nested.
+ * (see #11478). Read it from the first top-level nested collection's own
+ * indentation via structural node ranges — never from raw line whitespace,
+ * which block-scalar content and freely-indented comments would mislead.
+ * Defaults to 2 when nothing is nested in block style.
  */
-function detectYamlIndent(text: string): number {
-	let min = 0;
-	for (const line of text.split("\n")) {
-		if (line.trim().length === 0) continue;
-		const spaces = line.length - line.trimStart().length;
-		if (spaces > 0 && (min === 0 || spaces < min)) min = spaces;
+function detectYamlIndent(doc: Document, text: string): number {
+	const contents = doc.contents;
+	if (!isMap(contents)) return 2;
+	for (const pair of contents.items) {
+		const value = pair.value;
+		const child: ParsedNode | undefined =
+			isMap(value) && value.items.length > 0
+				? (value.items[0].key as ParsedNode)
+				: isSeq(value) && value.items.length > 0
+					? (value.items[0] as ParsedNode)
+					: undefined;
+		if (!child?.range) continue;
+		const step = lineIndentAt(text, child.range[0]);
+		if (step >= 1) return Math.min(step, 8);
 	}
-	if (min < 1) return 2;
-	return Math.min(min, 8);
+	return 2;
 }
 
 /**
@@ -89,7 +108,7 @@ export function reconcileYamlPreservingComments(
 	reconcileRecord(doc, [], isPlainRecord(current) ? current : {}, target);
 	// Match the original indentation and never fold long scalars, so untouched
 	// blocks are emitted byte-for-byte as they were authored.
-	return doc.toString({ indent: hasOriginal ? detectYamlIndent(originalText as string) : 2, lineWidth: 0 });
+	return doc.toString({ indent: hasOriginal ? detectYamlIndent(doc, originalText as string) : 2, lineWidth: 0 });
 }
 
 /** Minimal subset of the AJV ConfigSchemaError shape this module actually relies on. */

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -3,12 +3,68 @@ import * as path from "node:path";
 import { OmpErrors, type Type } from "@oh-my-pi/omptype";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
+import { Document, parseDocument } from "yaml";
 
 const YAML_MAPPING_HEADER_TRAILING_SPACE = /: +$/gm;
 
 /** Serialize config YAML without Bun's trailing space on block mapping headers. */
 export function stringifyYamlConfig(value: unknown): string {
 	return YAML.stringify(value, null, 2).replace(YAML_MAPPING_HEADER_TRAILING_SPACE, ":");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reconcile the map at `path` toward `target`: delete keys that `target` no
+ * longer has, recurse into nested maps, and rewrite only the leaves whose
+ * value actually changed. Untouched nodes keep their original comments,
+ * quoting, and formatting because their YAML nodes are never replaced.
+ */
+function reconcileRecord(
+	doc: Document,
+	path: ReadonlyArray<string>,
+	current: Record<string, unknown>,
+	target: Record<string, unknown>,
+): void {
+	for (const key in current) {
+		if (!Object.hasOwn(target, key) || target[key] === undefined) {
+			doc.deleteIn([...path, key]);
+		}
+	}
+	for (const key in target) {
+		const targetValue = target[key];
+		if (targetValue === undefined) continue;
+		const childPath = [...path, key];
+		const currentValue = current[key];
+		if (isPlainRecord(targetValue) && isPlainRecord(currentValue)) {
+			reconcileRecord(doc, childPath, currentValue, targetValue);
+		} else if (!Bun.deepEquals(currentValue, targetValue)) {
+			doc.setIn(childPath, targetValue);
+		}
+	}
+}
+
+/**
+ * Serialize `target` into the shape of an existing config file, preserving
+ * comments, quoting, blank lines, and key order of every node whose value did
+ * not change. This is the comment-preserving counterpart to
+ * {@link stringifyYamlConfig}: a persisted role/setting change touches only its
+ * own key instead of rewriting the whole file (see #11477).
+ *
+ * Removals and migrations are honored — keys absent from `target` are deleted
+ * from the document. When `originalText` is absent or empty a fresh document is
+ * produced, matching a first-time file write.
+ */
+export function reconcileYamlPreservingComments(
+	originalText: string | null | undefined,
+	target: Record<string, unknown>,
+): string {
+	const doc = originalText && originalText.trim().length > 0 ? parseDocument(originalText) : new Document();
+	const current = doc.toJS() as unknown;
+	reconcileRecord(doc, [], isPlainRecord(current) ? current : {}, target);
+	return doc.toString({ indent: 2 });
 }
 
 /** Minimal subset of the AJV ConfigSchemaError shape this module actually relies on. */

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { OmpErrors, type Type } from "@oh-my-pi/omptype";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
-import { Document, parseDocument } from "yaml";
+import { Document, isCollection, parseDocument } from "yaml";
 
 const YAML_MAPPING_HEADER_TRAILING_SPACE = /: +$/gm;
 
@@ -38,7 +38,12 @@ function reconcileRecord(
 		if (targetValue === undefined) continue;
 		const childPath = [...path, key];
 		const currentValue = current[key];
-		if (isPlainRecord(targetValue) && isPlainRecord(currentValue)) {
+		// `toJS()` resolves aliases, so an aliased mapping (`modelRoles: *roles`)
+		// looks like a record here while its document node is an `Alias` that
+		// `setIn` cannot descend into. Only recurse when the node is a real
+		// collection; otherwise fall through and replace the whole branch (which
+		// dereferences the alias to a concrete map), matching the old serializer.
+		if (isPlainRecord(targetValue) && isPlainRecord(currentValue) && isCollection(doc.getIn(childPath, true))) {
 			reconcileRecord(doc, childPath, currentValue, targetValue);
 		} else if (!Bun.deepEquals(currentValue, targetValue)) {
 			doc.setIn(childPath, targetValue);

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -47,9 +47,26 @@ function reconcileRecord(
 }
 
 /**
+ * Infer the indentation step (in spaces) a hand-maintained YAML file uses, so
+ * reserialization does not reflow untouched blocks from 4-space to 2-space
+ * (see #11478). Returns the smallest positive leading-space count across all
+ * content lines, clamped to a sane range; defaults to 2 when nothing is nested.
+ */
+function detectYamlIndent(text: string): number {
+	let min = 0;
+	for (const line of text.split("\n")) {
+		if (line.trim().length === 0) continue;
+		const spaces = line.length - line.trimStart().length;
+		if (spaces > 0 && (min === 0 || spaces < min)) min = spaces;
+	}
+	if (min < 1) return 2;
+	return Math.min(min, 8);
+}
+
+/**
  * Serialize `target` into the shape of an existing config file, preserving
- * comments, quoting, blank lines, and key order of every node whose value did
- * not change. This is the comment-preserving counterpart to
+ * comments, quoting, blank lines, indentation, and key order of every node
+ * whose value did not change. This is the comment-preserving counterpart to
  * {@link stringifyYamlConfig}: a persisted role/setting change touches only its
  * own key instead of rewriting the whole file (see #11477).
  *
@@ -61,10 +78,13 @@ export function reconcileYamlPreservingComments(
 	originalText: string | null | undefined,
 	target: Record<string, unknown>,
 ): string {
-	const doc = originalText && originalText.trim().length > 0 ? parseDocument(originalText) : new Document();
+	const hasOriginal = !!originalText && originalText.trim().length > 0;
+	const doc = hasOriginal ? parseDocument(originalText as string) : new Document();
 	const current = doc.toJS() as unknown;
 	reconcileRecord(doc, [], isPlainRecord(current) ? current : {}, target);
-	return doc.toString({ indent: 2 });
+	// Match the original indentation and never fold long scalars, so untouched
+	// blocks are emitted byte-for-byte as they were authored.
+	return doc.toString({ indent: hasOriginal ? detectYamlIndent(originalText as string) : 2, lineWidth: 0 });
 }
 
 /** Minimal subset of the AJV ConfigSchemaError shape this module actually relies on. */

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -44,7 +44,7 @@ import { applyHyperlinkSetting } from "../tui/hyperlink";
 import { replaceFileAtomically } from "../utils/atomic-file";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { isSearchProviderId, SEARCH_PROVIDER_ORDER } from "../web/search/types";
-import { stringifyYamlConfig } from "./config-file";
+import { reconcileYamlPreservingComments, stringifyYamlConfig } from "./config-file";
 import {
 	type BashInterceptorRule,
 	type GroupPrefix,
@@ -2660,14 +2660,15 @@ export class Settings {
 	// Saving
 	// ─────────────────────────────────────────────────────────────────────────
 
-	async #writeYamlAtomically(filePath: string, settings: RawSettings): Promise<void> {
+	/** Atomically replace `filePath` with `text` via a temp file + rename. */
+	async #writeYamlTextAtomically(filePath: string, text: string): Promise<void> {
 		const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
 		let removeTemp = false;
 		try {
 			const handle = await fs.promises.open(tempPath, "wx", 0o600);
 			removeTemp = true;
 			try {
-				await handle.writeFile(stringifyYamlConfig(settings), "utf8");
+				await handle.writeFile(text, "utf8");
 				await handle.sync();
 			} finally {
 				await handle.close();
@@ -2679,6 +2680,36 @@ export class Settings {
 				await fs.promises.rm(tempPath, { force: true }).catch(() => {});
 			}
 		}
+	}
+
+	/** Reserialize the whole settings object and write it (comment-oblivious). */
+	async #writeYamlAtomically(filePath: string, settings: RawSettings): Promise<void> {
+		await this.#writeYamlTextAtomically(filePath, stringifyYamlConfig(settings));
+	}
+
+	/**
+	 * Persist `settings` while preserving the existing file's comments, quoting,
+	 * and formatting (see #11477): only the keys whose value changed are
+	 * rewritten. Falls back to a full reserialization when no readable original
+	 * exists (fresh file or a quarantined config recovered from in-memory state).
+	 */
+	async #writeYamlReconciledAtomically(
+		filePath: string,
+		settings: RawSettings,
+		hasReadableOriginal: boolean,
+	): Promise<void> {
+		if (!hasReadableOriginal) {
+			await this.#writeYamlAtomically(filePath, settings);
+			return;
+		}
+		let originalText: string | null;
+		try {
+			originalText = await Bun.file(filePath).text();
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
+			originalText = null;
+		}
+		await this.#writeYamlTextAtomically(filePath, reconcileYamlPreservingComments(originalText, settings));
 	}
 
 	#queueSave(): void {
@@ -2809,11 +2840,14 @@ export class Settings {
 					setByPath(current, ["modelRoles"], mergedRoles);
 					shouldWrite = true;
 				}
-
 				// Update our global with any external changes we preserved.
 				this.#global = current;
 				if (shouldWrite) {
-					await this.#writeYamlAtomically(writePath, this.#global);
+					await this.#writeYamlReconciledAtomically(
+						writePath,
+						this.#global,
+						!this.#quarantinedYamlTargets.has(configPath),
+					);
 				}
 				this.#quarantinedYamlTargets.delete(configPath);
 				// These pending roles were included in this write. Remove each
@@ -2926,7 +2960,11 @@ export class Settings {
 					setByPath(projectSettings, ["modelRoles", role], value);
 				}
 
-				await this.#writeYamlAtomically(writePath, projectSettings);
+				await this.#writeYamlReconciledAtomically(
+					writePath,
+					projectSettings,
+					!this.#quarantinedYamlTargets.has(projectConfigPath),
+				);
 				this.#projectFileSettings = structuredClone(projectSettings);
 				this.#quarantinedYamlTargets.delete(projectConfigPath);
 			});

--- a/packages/coding-agent/test/config-comment-preservation.test.ts
+++ b/packages/coding-agent/test/config-comment-preservation.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+describe("config.yml comment preservation on model-role writes (#11477)", () => {
+	let tempDir: TempDir;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-config-comments-");
+		agentDir = tempDir.join("agent");
+		projectDir = tempDir.join("project");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		await tempDir?.remove();
+	});
+
+	const HAND_MAINTAINED = `modelRoles:
+  default: anthropic/claude-fable-5-1:xhigh # daily driver
+# Deny floor (keep in step with the other profile)
+bash:
+  patterns:
+    - match: "git push --force*"
+      approval: deny
+defaultThinkingLevel: high
+`;
+
+	it("preserves comments, quoting, and the trailing newline when adding a global role", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		await Bun.write(configPath, HAND_MAINTAINED);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+
+		// Only the intended change landed.
+		expect(after).toContain("smol: anthropic/claude-haiku-4-5");
+		expect(after).toContain("default: anthropic/claude-fable-5-1:xhigh");
+		// Everything else survives verbatim.
+		expect(after).toContain("# daily driver");
+		expect(after).toContain("# Deny floor (keep in step with the other profile)");
+		expect(after).toContain('- match: "git push --force*"');
+		expect(after).toContain("defaultThinkingLevel: high");
+		expect(after.endsWith("\n")).toBe(true);
+	});
+
+	it("preserves surrounding comments when clearing a global role", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		await Bun.write(
+			configPath,
+			`modelRoles:
+  default: anthropic/claude-fable-5-1
+  smol: anthropic/claude-haiku-4-5 # cheap tier
+# keep this note
+defaultThinkingLevel: high
+`,
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", undefined);
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+		expect(after).not.toContain("smol:");
+		expect(after).toContain("default: anthropic/claude-fable-5-1");
+		expect(after).toContain("# keep this note");
+		expect(after).toContain("defaultThinkingLevel: high");
+		expect(after.endsWith("\n")).toBe(true);
+	});
+
+	it("preserves comments on a non-role setting write", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		await Bun.write(
+			configPath,
+			`# top comment
+theme:
+  dark: anthracite # my theme
+defaultThinkingLevel: high
+`,
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.set("theme.dark", "titanium");
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+		expect(after).toContain("# top comment");
+		expect(after).toContain("dark: titanium");
+		expect(after).toContain("# my theme");
+		expect(after).toContain("defaultThinkingLevel: high");
+	});
+
+	it("still writes a well-formed config when no prior file exists", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+		expect(after).toContain("modelRoles:");
+		expect(after).toContain("smol: anthropic/claude-haiku-4-5");
+		expect(after.endsWith("\n")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/config-comment-preservation.test.ts
+++ b/packages/coding-agent/test/config-comment-preservation.test.ts
@@ -110,4 +110,32 @@ defaultThinkingLevel: high
 		expect(after).toContain("smol: anthropic/claude-haiku-4-5");
 		expect(after.endsWith("\n")).toBe(true);
 	});
+
+	it("preserves four-space indentation on untouched blocks", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		await Bun.write(
+			configPath,
+			`modelRoles:
+    default: anthropic/claude-fable-5-1:xhigh
+# deny floor
+bash:
+    patterns:
+        - match: "git push --force*"
+          approval: deny
+`,
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+		// New key adopts the file's own 4-space step; untouched blocks keep theirs.
+		expect(after).toContain("\n    default: anthropic/claude-fable-5-1:xhigh");
+		expect(after).toContain("\n    smol: anthropic/claude-haiku-4-5");
+		expect(after).toContain("\n    patterns:");
+		expect(after).toContain('\n        - match: "git push --force*"');
+		expect(after).toContain("# deny floor");
+		expect(after).not.toContain("\n  default:");
+	});
 });

--- a/packages/coding-agent/test/config-comment-preservation.test.ts
+++ b/packages/coding-agent/test/config-comment-preservation.test.ts
@@ -140,6 +140,35 @@ bash:
 		expect(after).not.toContain("\n  default:");
 	});
 
+	it("detects 4-space step structurally despite a shallower-indented block scalar", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		// The block scalar's body is indented 2 spaces — less than the 4-space
+		// mapping step. A whitespace-minimum detector would pick 2 and reflow the
+		// maps; structural detection reads the step from the nested map node.
+		await Bun.write(
+			configPath,
+			`shellPath: |
+  echo hi
+  echo bye
+modelRoles:
+    default: anthropic/claude-fable-5-1
+`,
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+		await settings.flush();
+
+		const after = await Bun.file(configPath).text();
+		expect(after).toContain("\n    default: anthropic/claude-fable-5-1");
+		expect(after).toContain("\n    smol: anthropic/claude-haiku-4-5");
+		expect(after).not.toContain("\n  default:");
+		expect(after).not.toContain("\n  smol:");
+		// Block scalar content is retained (its body reindents to the document step).
+		expect(after).toContain("echo hi");
+		expect(after).toContain("echo bye");
+	});
+
 	it("persists a role write against an aliased modelRoles mapping without throwing", async () => {
 		const configPath = path.join(agentDir, "config.yml");
 		await Bun.write(

--- a/packages/coding-agent/test/config-comment-preservation.test.ts
+++ b/packages/coding-agent/test/config-comment-preservation.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
 
 describe("config.yml comment preservation on model-role writes (#11477)", () => {
 	let tempDir: TempDir;
@@ -137,5 +138,29 @@ bash:
 		expect(after).toContain('\n        - match: "git push --force*"');
 		expect(after).toContain("# deny floor");
 		expect(after).not.toContain("\n  default:");
+	});
+
+	it("persists a role write against an aliased modelRoles mapping without throwing", async () => {
+		const configPath = path.join(agentDir, "config.yml");
+		await Bun.write(
+			configPath,
+			`roles: &roles
+  default: anthropic/claude-fable-5-1
+modelRoles: *roles
+defaultThinkingLevel: high
+`,
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+		await settings.flush();
+
+		// The aliased branch is dereferenced to a concrete map so the write
+		// succeeds (the old alias node would make setIn throw).
+		const after = await Bun.file(configPath).text();
+		const parsed = YAML.parse(after) as { modelRoles: Record<string, string> };
+		expect(parsed.modelRoles.default).toBe("anthropic/claude-fable-5-1");
+		expect(parsed.modelRoles.smol).toBe("anthropic/claude-haiku-4-5");
+		expect(after).toContain("defaultThinkingLevel: high");
 	});
 });


### PR DESCRIPTION
## Repro
With a hand-maintained profile `config.yml` (comments, quoted deny patterns, a role carrying a `:thinkingLevel` suffix, trailing newline), a single persisted role write destroys the file's formatting. Reproduced at the settings layer:

```
settings.setModelRole("smol", "anthropic/claude-haiku-4-5")
await settings.flush()
```

After flush every comment is gone, `- match: "git push --force*"` is unquoted, and the trailing newline is stripped — only `modelRoles.smol` should have changed.

## Cause
`Settings.#saveNow` re-reads the file and surgically merges only the changed role into a plain JS object (`current`), preserving sibling *values*. But the actual write goes through `#writeYamlAtomically` → `stringifyYamlConfig` → `Bun.YAML.stringify(this.#global)`, which serializes the parsed object and cannot preserve comments, quoting, blank lines, or the trailing newline. `#saveProjectNow` had the same whole-object write.

## Fix
- Add `reconcileYamlPreservingComments(originalText, target)` in `config/config-file.ts` (using the `yaml` package's comment-preserving `Document` API): parse the existing file, then recursively delete keys the target dropped and rewrite only the leaves whose value changed, leaving untouched nodes verbatim. This also honors migration-driven key removals, so schema migrations still strip legacy keys.
- Split `#writeYamlAtomically` into a text writer (`#writeYamlTextAtomically`) plus a reconcile writer (`#writeYamlReconciledAtomically`) that reads the on-disk text and reconciles; it falls back to full serialization only for fresh or quarantined files.
- Route both `#saveNow` (global) and `#saveProjectNow` (project) role/setting writes through the reconcile writer.
- Add `yaml` to the workspace catalog and `coding-agent` dependencies.

## Verification
`bun test test/config-comment-preservation.test.ts test/settings-manager.test.ts test/settings-reload-cwd.test.ts test/selector-settings-side-effects.test.ts` → 194 pass, 0 fail. New `config-comment-preservation.test.ts` asserts comments/quoting/trailing-newline survive a role add, a role clear, and a non-role setting write, plus a well-formed fresh-file write. `bun run check:types` clean. The migration suite (which relies on legacy-key removal on save) still passes, confirming the reconcile path preserves the removal semantics the old full-serialize path had.

Fixes #11477