### PR TITLE
fix(agent): count developer messages and images in user content

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the token estimator counting developer messages as free and ignoring images in user content, which let context budgeting, pruning and the compaction trigger read a transcript as far smaller than the one sent to the provider.
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -219,14 +219,22 @@ export class Tokenizer {
 		}
 
 		switch (message.role) {
-			case "user": {
-				const content: string | Array<{ type: string; text?: string }> = message.content;
+			case "user":
+			case "developer": {
+				// Both roles carry `string | (TextContent | ImageContent)[]` and both are
+				// sent to the provider -- convertMessageToLlm handles developer alongside
+				// user -- so they are counted alike. Without the developer case the switch
+				// fell through to `default: return 0`, and the old annotation narrowed the
+				// blocks to text-only, hiding the image charge the toolResult arm applies.
+				const content = message.content;
 				if (typeof content === "string") {
 					fragments.push(content);
 				} else if (Array.isArray(content)) {
 					for (const block of content) {
 						if (block.type === "text" && block.text) {
 							fragments.push(block.text);
+						} else if (block.type === "image") {
+							extra += IMAGE_TOKEN_ESTIMATE;
 						}
 					}
 				}

--- a/packages/agent/test/tokenizer.test.ts
+++ b/packages/agent/test/tokenizer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as natives from "@oh-my-pi/pi-natives";
 import { Tokenizer, tokenizerEncodingForModel } from "../src/tokenizer";
+import type { AgentMessage } from "../src/types";
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -108,3 +109,72 @@ describe("countTokens with modes", () => {
 		);
 	});
 });
+
+// Contract: countMessage charges for every part of a message the provider will
+// bill for. A role or block type the switch does not name reads as free, and the
+// transcript, pruning and compaction math built on these numbers then plans
+// against a context window larger than the real one.
+describe("countMessage", () => {
+	const TEXT = "x".repeat(4000);
+	const IMAGE = { type: "image", data: "A".repeat(40_000), mimeType: "image/png" };
+
+	test("counts a developer message like the user message it mirrors", () => {
+		const tokenizer = new Tokenizer();
+		const user = tokenizer.countMessage({ role: "user", content: TEXT, timestamp: 0 } as AgentMessage);
+		const developer = tokenizer.countMessage({ role: "developer", content: TEXT, timestamp: 0 } as AgentMessage);
+
+		expect(user).toBeGreaterThan(0);
+		// developer is a core role: convertMessageToLlm ships it to the provider next
+		// to user. It used to miss the switch and land on `default: return 0`.
+		expect(developer).toBe(user);
+	});
+
+	test("charges the image estimate on user and developer content, as tool results do", () => {
+		const tokenizer = new Tokenizer();
+		const inToolResult = tokenizer.countMessage({
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [IMAGE],
+			isError: false,
+			timestamp: 0,
+		} as unknown as AgentMessage);
+
+		expect(inToolResult).toBeGreaterThan(0);
+		expect(tokenizer.countMessage({ role: "user", content: [IMAGE], timestamp: 0 } as unknown as AgentMessage)).toBe(
+			inToolResult,
+		);
+		expect(
+			tokenizer.countMessage({ role: "developer", content: [IMAGE], timestamp: 0 } as unknown as AgentMessage),
+		).toBe(inToolResult);
+	});
+
+	test("adds the image estimate on top of the text beside it", () => {
+		const tokenizer = new Tokenizer();
+		const textOnly = tokenizer.countMessage({
+			role: "user",
+			content: [{ type: "text", text: TEXT }],
+			timestamp: 0,
+		} as AgentMessage);
+		const withImage = tokenizer.countMessage({
+			role: "user",
+			content: [{ type: "text", text: TEXT }, IMAGE],
+			timestamp: 0,
+		} as unknown as AgentMessage);
+
+		expect(textOnly).toBeGreaterThan(0);
+		expect(withImage).toBe(textOnly + inToolResultImageEstimate(tokenizer));
+	});
+});
+
+/** The per-image charge, read back through the arm that already applied it. */
+function inToolResultImageEstimate(tokenizer: Tokenizer): number {
+	return tokenizer.countMessage({
+		role: "toolResult",
+		toolCallId: "call-probe",
+		toolName: "read",
+		content: [{ type: "image", data: "A".repeat(40_000), mimeType: "image/png" }],
+		isError: false,
+		timestamp: 0,
+	} as unknown as AgentMessage);
+}


### PR DESCRIPTION
## What

`Tokenizer#measureMessage` returns 0 for two kinds of content the provider is
billed for: every `developer` message, and every image inside `user` content.
Both now go through one arm that charges for them the way tool results already do.

## Why

**`developer` was never named in the switch.** The arms are `user`, `assistant`,
`hookMessage`/`toolResult`, `branchSummary`/`compactionSummary`, then
`default: return 0`. `developer` is a core role — `Message = UserMessage |
DeveloperMessage | AssistantMessage | ToolResultMessage` (`packages/ai/src/types.ts:1051`) —
and `convertMessageToLlm` ships it to the provider right next to `user`:

```ts
case "developer":
    return { ...message, attribution: message.attribution ?? "agent" };
```

so it was counted as free while being fully paid for. `/todo` appends one
(`todo-command-controller.ts:459`), and so does the auto-continue prompt.

**Images in `user` content charged nothing.** The `user` arm annotated its blocks
as text-only:

```ts
const content: string | Array<{ type: string; text?: string }> = message.content;
```

which hides that `UserMessage.content` is `string | (TextContent | ImageContent)[]`,
so there was no `image` branch. The `toolResult` arm four lines below does have one
(`extra += IMAGE_TOKEN_ESTIMATE`), and `countMessage`'s own doc says:

> Image blocks charge a fixed per-image estimate.

The same image therefore cost 1200 arriving from a tool and 0 arriving from
`agent.prompt("What's in this image?", [image])` — the call the README documents at
line 189, and the path a pasted screenshot takes.

`user` and `developer` carry the identical content type and are both sent to the
provider, so they now share one arm.

## Testing

`bun run check` in `packages/agent` is clean (oxlint, oxfmt, tsgo). `bun test` in
`packages/agent`: **541 pass, 0 fail** across 38 files.

**Reproduced the bug, then confirmed the same reproduction stops failing.**
Directly against `Tokenizer`, `NODE_ENV=test`:

```
                       before      after
  text as user          1000        1000
  text as developer        0        1000
  image in user            0        1200
  image in developer       0        1200
  image in toolResult   1200        1200     (unchanged)
```

Then on a transcript shaped like a real session — a pasted screenshot, some
assistant turns, and one `/todo` reminder:

```
                 before            after
  user                7             1207
  assistant         140              140
  developer           0              518
  assistant         100              100
  TOTAL             247             1965
```

An 8× undercount. `estimateTranscriptTokens`, `pruning.ts` and the compaction
trigger all read these numbers, so they were planning against a context window
they believed was 8× roomier than the real one.

Three tests added to `packages/agent/test/tokenizer.test.ts`, which had no
`countMessage` coverage. They assert against the sibling rather than a magic
number: a `developer` message must count the same as the `user` message it
mirrors, and an image must cost the same in `user`/`developer` content as the
identical block does in a tool result. Reverting `tokenizer.ts` alone makes
exactly those three fail (14 pass → 11 pass / 3 fail); the 11 pre-existing tests
pass either way.

Not exercised: the in-app context indicator in a live `omp` session. I verified
through `Tokenizer`'s public API instead, which is what every one of those readers
calls.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
