### PR TITLE
fix(session): attempt compaction for unknown-window payload 413s when configured

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Custom `Other` answers are now applied before the Ask dialog becomes interactive again, so the next Enter is no longer discarded ([#11558](https://github.com/can1357/oh-my-pi/pull/11558) by [@schickling-assistant](https://github.com/schickling-assistant)).
 - Explicit per-model price overrides retain their configured flat rates instead of inheriting time-based pricing.
 - Fixed wrong-typed `compat.stripImageInput` in `models.yml` being silently accepted, so the documented vision opt-out is now validated like its neighbours ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
+### Fixed
+
+- Unknown-context-window providers (e.g. a custom/self-hosted OpenAI-compatible profile the model registry has no metadata for) no longer permanently dead-end on a non-media payload-rejection 413 when a usable compaction method is configured; the session now gets the same promotion/compaction attempt a known-window overflow would ([#11479](https://github.com/can1357/oh-my-pi/issues/11479)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2334,14 +2334,24 @@ export class SessionMaintenance {
 		// Provider-reported usage above a known window is authoritative proof of a
 		// genuine token overflow (not a byte/media-only rejection), computed once
 		// up front so both the media-exclusion decision below and the terminal
-		// notice selection further down agree with each other.
+		// dead-end check further down agree with each other.
 		const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);
+		// Concrete media-limit wording (e.g. "image count exceeds the limit of 20")
+		// in the error text — computed up front (independent of window or
+		// compaction availability) so both the media-exclusion decision below and
+		// the terminal dead-end check further down agree with each other.
+		const explicitMediaRejection =
+			payloadRejection && hasExplicitMediaRejectionEvidence(assistantMessage.errorMessage);
 		// `payloadRejection` alone is not sufficient reason to exclude media
 		// compaction methods (snapcompact): a *usage-backed* overflow proves the
 		// rejection is a genuine token-context problem, not a byte/media budget
 		// one, so a user configured with e.g. `methodOrder: ["snapcompact"]` must
-		// still be able to use it instead of being told no recovery exists (#11482).
-		const excludeMediaForPayloadRejection = payloadRejection && !usageBackedOverflow;
+		// still be able to use it instead of being told no recovery exists.
+		// Explicit media-limit evidence overrides that exception, though: usage
+		// proving a token overflow doesn't negate a provider *simultaneously*
+		// reporting an image-count limit, and snapcompact adds image frames before
+		// retrying — guaranteeing the retry stays over that limit (#11482).
+		const excludeMediaForPayloadRejection = payloadRejection && (!usageBackedOverflow || explicitMediaRejection);
 		// Whether a compaction method actually exists to attempt shrinking the
 		// history. Computed up front so the unknown-context-window branch below
 		// can fall through to a real attempt instead of always assuming defeat.
@@ -2370,24 +2380,30 @@ export class SessionMaintenance {
 		// registry has no metadata for) used to be treated the same as a
 		// confirmed media/byte-budget rejection and blocked outright — even
 		// when the payload bloat is plain message-count growth that ordinary
-		// compaction would shrink just fine (#11479). Only skip straight to
-		// the honest "can't help" notice here when there is genuinely no
-		// compaction method configured to try, or the error text itself
-		// already names media/images as the cause (#11482) — that's positive
-		// evidence compaction can't fix, not just an absence of proof.
-		const explicitMediaRejection =
-			payloadRejection && hasExplicitMediaRejectionEvidence(assistantMessage.errorMessage);
-		// Explicit media evidence overrides the ambiguity guard: a message like
-		// "image count exceeds the limit of 20" also trips the generic numeric
-		// pattern and gets dual-flagged ContextOverflow (ambiguousPayloadRejection
-		// = true), but the text itself already proves the byte budget is
-		// media-driven — that certainty shouldn't be discarded just because the
-		// classifier's separate numeric-limit heuristic also fired (#11482).
+		// compaction would shrink just fine (#11479). Only skip straight to the
+		// honest "can't help" notice here when there is genuinely no compaction
+		// method configured to try — an absence of proof, gated to the
+		// unknown-window case since a known window's own evidence (below) already
+		// covers it.
 		const unknownWindowDeadEnd =
-			payloadRejection &&
-			contextWindow <= 0 &&
-			(explicitMediaRejection || (!ambiguousPayloadRejection && !compactionAvailable));
-		if (unknownWindowDeadEnd || trustedPayloadRejection) {
+			payloadRejection && contextWindow <= 0 && !ambiguousPayloadRejection && !compactionAvailable;
+		// Explicit media evidence is a terminal signal independent of whether the
+		// context window is known: a known window's `trustedPayloadRejection` only
+		// requires local headroom, so a message like "too many images" can still
+		// fail that check (e.g. the local estimate is near the occupancy ceiling)
+		// and fall through to promotion/compaction despite proving an image-count
+		// limit neither can raise. Gated to `!usageBackedOverflow` though: when
+		// provider-reported usage *also* proves a genuine token overflow, that's a
+		// real, separately fixable problem — compaction should still get a shot at
+		// it (with media methods excluded per `excludeMediaForPayloadRejection`
+		// above), not be discarded just because the same response also named a
+		// media limit (#11482).
+		if (unknownWindowDeadEnd || trustedPayloadRejection || (explicitMediaRejection && !usageBackedOverflow)) {
+			// Every disjunct above implies `!usageBackedOverflow` (unknown window ⇒
+			// `isUsageBackedContextOverflow` is false by definition; trusted requires
+			// `reportedInputTokens <= contextWindow`; the third is explicit), so this
+			// is always the honest "NOT a token-context problem" notice — the sibling
+			// usage-backed selection lives further down, where that case is reachable.
 			this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
 			this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");
 			logger.debug("Payload-shaped 413 withheld from token compaction", {
@@ -2427,19 +2443,20 @@ export class SessionMaintenance {
 				);
 				// A statically usable method (per `hasUsableCompactionMethod`) can still
 				// reclaim nothing at runtime — e.g. `methodOrder: ["shake"]` with no
-				// heavy/droppable content on a plain text history. When that happens for
-				// a payload rejection, `runRecoveryCompactionWithRollback` has already
-				// restored the failed turn, but an unconverted no-op result here has
-				// neither a scheduled continuation nor a block: the caller would treat
-				// it as an ordinary turn end and could resubmit the same oversized
-				// history on the next auto-continue, looping the same 413 silently with
-				// no notice ever shown (#11482). Convert that specific no-progress
-				// outcome into the same honest dead end used when no method was
-				// available at all.
+				// heavy/droppable content on a plain text history — or `runAutoCompaction`
+				// itself can already return `automaticContinuationBlocked` without a
+				// rewrite (e.g. a single oversized latest turn `prepareCompaction` can't
+				// shrink). Either way, when a payload rejection sees no history rewrite
+				// and no scheduled continuation, `runRecoveryCompactionWithRollback` has
+				// already restored the failed turn into active context (and, unless
+				// already blocked, an unconverted no-op result here has neither a
+				// scheduled continuation nor a block: the caller would treat it as an
+				// ordinary turn end and could resubmit the same oversized history on the
+				// next auto-continue, looping the same 413 silently with no notice ever
+				// shown) (#11482).
 				if (
 					payloadRejection &&
 					!compactionResult.continuationScheduled &&
-					compactionResult.automaticContinuationBlocked !== true &&
 					compactionResult.historyRewritten !== true
 				) {
 					// `runRecoveryCompactionWithRollback`'s no-rewrite path re-appends the
@@ -2453,6 +2470,12 @@ export class SessionMaintenance {
 					// persisted session history (separate from this active-context view)
 					// still keeps the turn visible.
 					this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
+					if (compactionResult.automaticContinuationBlocked === true) {
+						// `runAutoCompaction` already blocked and emitted its own notice for
+						// this outcome (e.g. its own compaction dead end) — only the cleanup
+						// above was missing; forward its result unchanged (#11482).
+						return compactionResult;
+					}
 					// Same usage-backed/byte-shaped notice selection as the sibling
 					// "no compaction available" dead end below: a payload rejection
 					// with provider-reported usage above the window IS a genuine

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2339,11 +2339,16 @@ export class SessionMaintenance {
 		// evidence compaction can't fix, not just an absence of proof.
 		const explicitMediaRejection =
 			payloadRejection && hasExplicitMediaRejectionEvidence(assistantMessage.errorMessage);
+		// Explicit media evidence overrides the ambiguity guard: a message like
+		// "image count exceeds the limit of 20" also trips the generic numeric
+		// pattern and gets dual-flagged ContextOverflow (ambiguousPayloadRejection
+		// = true), but the text itself already proves the byte budget is
+		// media-driven — that certainty shouldn't be discarded just because the
+		// classifier's separate numeric-limit heuristic also fired (#11482).
 		const unknownWindowDeadEnd =
 			payloadRejection &&
-			!ambiguousPayloadRejection &&
 			contextWindow <= 0 &&
-			(explicitMediaRejection || !compactionAvailable);
+			(explicitMediaRejection || (!ambiguousPayloadRejection && !compactionAvailable));
 		if (unknownWindowDeadEnd || trustedPayloadRejection) {
 			this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
 			this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -183,19 +183,29 @@ function hasUsableCompactionMethod(
 }
 
 /**
- * Explicit media/image wording in a payload-rejection error (e.g.
- * `request_too_large: too many images`). `ambiguousPayloadRejection` (dual
- * `ContextOverflow` + `PayloadRejected`) only catches text that *also* matches
- * a generic numeric-limit pattern — a digit-free media rejection like this one
- * sails through as non-ambiguous. That text is still definitive media-budget
- * evidence: token compaction can't raise a provider's image-count limit, and
- * some methods (snapcompact) *add* image frames, making it worse. Such
- * rejections must stay on the terminal payload-dead-end path regardless of
- * compaction availability (#11482).
+ * Concrete media-limit wording in a payload-rejection error (e.g.
+ * `request_too_large: too many images`, `image count exceeds the limit of
+ * 20`). `ambiguousPayloadRejection` (dual `ContextOverflow` + `PayloadRejected`)
+ * only catches text that *also* matches a generic numeric-limit pattern — a
+ * digit-free media rejection like the first example sails through as
+ * non-ambiguous. That text is still definitive media-budget evidence: token
+ * compaction can't raise a provider's image-count limit, and some methods
+ * (snapcompact) *add* image frames, making it worse. Such rejections must
+ * stay on the terminal payload-dead-end path regardless of compaction
+ * availability (#11482).
+ *
+ * Deliberately narrower than matching bare "images"/"media"/"vision"/"frames"/
+ * "pixels" anywhere in the text: a custom provider's error that merely names a
+ * vision model (`llava-vision`) or an unrelated `Content-Type` (`media type
+ * application/json`) is not evidence the *request* was rejected for a media
+ * budget — treating it as such would permanently dead-end an unknown-window
+ * session that ordinary compaction could actually recover (#11482). Require
+ * the noun to co-occur with a count/limit signal instead.
  */
-const PAYLOAD_MEDIA_EVIDENCE_PATTERN = /\b(?:images?|media|vision|frames?|pixels?)\b/i;
+const PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN =
+	/\btoo many (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\s*(?:count|limit)\b|\blimit of \d+\s*(?:images?|frames?|pixels?)\b/i;
 function hasExplicitMediaRejectionEvidence(errorMessage: string | undefined): boolean {
-	return errorMessage !== undefined && PAYLOAD_MEDIA_EVIDENCE_PATTERN.test(errorMessage);
+	return errorMessage !== undefined && PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN.test(errorMessage);
 }
 
 /**

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -175,6 +175,22 @@ function hasUsableCompactionMethod(
 }
 
 /**
+ * Explicit media/image wording in a payload-rejection error (e.g.
+ * `request_too_large: too many images`). `ambiguousPayloadRejection` (dual
+ * `ContextOverflow` + `PayloadRejected`) only catches text that *also* matches
+ * a generic numeric-limit pattern — a digit-free media rejection like this one
+ * sails through as non-ambiguous. That text is still definitive media-budget
+ * evidence: token compaction can't raise a provider's image-count limit, and
+ * some methods (snapcompact) *add* image frames, making it worse. Such
+ * rejections must stay on the terminal payload-dead-end path regardless of
+ * compaction availability (#11482).
+ */
+const PAYLOAD_MEDIA_EVIDENCE_PATTERN = /\b(?:images?|media|vision|frames?|pixels?)\b/i;
+function hasExplicitMediaRejectionEvidence(errorMessage: string | undefined): boolean {
+	return errorMessage !== undefined && PAYLOAD_MEDIA_EVIDENCE_PATTERN.test(errorMessage);
+}
+
+/**
  * User-facing notice for a compaction dead end: maintenance freed too little
  * to retry safely. `remedies` names the recovery actions left on the emitting
  * path — by the time the post-pass dead end fires, the tiered rescue has
@@ -2318,9 +2334,16 @@ export class SessionMaintenance {
 		// when the payload bloat is plain message-count growth that ordinary
 		// compaction would shrink just fine (#11479). Only skip straight to
 		// the honest "can't help" notice here when there is genuinely no
-		// compaction method configured to try.
+		// compaction method configured to try, or the error text itself
+		// already names media/images as the cause (#11482) — that's positive
+		// evidence compaction can't fix, not just an absence of proof.
+		const explicitMediaRejection =
+			payloadRejection && hasExplicitMediaRejectionEvidence(assistantMessage.errorMessage);
 		const unknownWindowDeadEnd =
-			payloadRejection && !ambiguousPayloadRejection && contextWindow <= 0 && !compactionAvailable;
+			payloadRejection &&
+			!ambiguousPayloadRejection &&
+			contextWindow <= 0 &&
+			(explicitMediaRejection || !compactionAvailable);
 		if (unknownWindowDeadEnd || trustedPayloadRejection) {
 			this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
 			this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");
@@ -2376,7 +2399,20 @@ export class SessionMaintenance {
 					compactionResult.automaticContinuationBlocked !== true &&
 					compactionResult.historyRewritten !== true
 				) {
-					this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");
+					// Same usage-backed/byte-shaped notice selection as the sibling
+					// "no compaction available" dead end below: a payload rejection
+					// with provider-reported usage above the window IS a genuine
+					// token-context problem even though compaction (attempted here,
+					// unsuccessfully) couldn't resolve it — say so accurately instead
+					// of always claiming "not a token problem" (#11482).
+					const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);
+					this.#host.emitNotice(
+						"warning",
+						usageBackedOverflow
+							? usageOverflowDeadEndNotice(reportedInputTokens, contextWindow)
+							: payloadRejectionNotice(storedTokens, contextWindow),
+						"compaction",
+					);
 					logger.debug("Payload-shaped 413 compaction attempt made no progress; blocking automatic continuation", {
 						provider: assistantMessage.provider,
 						model: assistantMessage.model,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -202,11 +202,13 @@ function hasUsableCompactionMethod(
  * session that ordinary compaction could actually recover (#11482). Require
  * the noun to co-occur with a count/limit signal instead — covering the
  * common phrasings: "too many images", "image count"/"image limit", "limit
- * of N images", "maximum (of N) images", "number/count of images", and
- * "images exceeds ... maximum" (#11482).
+ * of N images", "maximum (of N) images", "number/count of images",
+ * "images exceeds ... maximum", and per-image size/dimension rejections
+ * like "image is too large" or "image dimensions exceed 8000 pixels"
+ * (#11482).
  */
 const PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN =
-	/\btoo many (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\s*(?:count|limit)\b|\blimit of \d+\s*(?:images?|frames?|pixels?)\b|\bmaximum(?: of \d+)? (?:images?|frames?|pixels?)\b|\b(?:number|count) of (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\b.{0,20}\bexceeds?\b.{0,20}\bmaximum\b/i;
+	/\btoo many (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\s*(?:count|limit)\b|\blimit of \d+\s*(?:images?|frames?|pixels?)\b|\bmaximum(?: of \d+)? (?:images?|frames?|pixels?)\b|\b(?:number|count) of (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\b.{0,20}\bexceeds?\b.{0,20}\bmaximum\b|\b(?:images?|frames?) (?:is |are )?too large\b|\b(?:images?|frames?) dimensions?\b.{0,30}\bexceeds?\b.{0,30}\b(?:pixels?|\d+)\b/i;
 function hasExplicitMediaRejectionEvidence(errorMessage: string | undefined): boolean {
 	return errorMessage !== undefined && PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN.test(errorMessage);
 }

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2353,9 +2353,40 @@ export class SessionMaintenance {
 
 			// No promotion target available fall through to compaction
 			if (compactionAvailable) {
-				return await this.#host.runRecoveryCompactionWithRollback("overflow", assistantMessage, allowDefer, {
-					autoContinue,
-				});
+				const compactionResult = await this.#host.runRecoveryCompactionWithRollback(
+					"overflow",
+					assistantMessage,
+					allowDefer,
+					{ autoContinue },
+				);
+				// A statically usable method (per `hasUsableCompactionMethod`) can still
+				// reclaim nothing at runtime — e.g. `methodOrder: ["shake"]` with no
+				// heavy/droppable content on a plain text history. When that happens for
+				// a payload rejection, `runRecoveryCompactionWithRollback` has already
+				// restored the failed turn, but an unconverted no-op result here has
+				// neither a scheduled continuation nor a block: the caller would treat
+				// it as an ordinary turn end and could resubmit the same oversized
+				// history on the next auto-continue, looping the same 413 silently with
+				// no notice ever shown (#11482). Convert that specific no-progress
+				// outcome into the same honest dead end used when no method was
+				// available at all.
+				if (
+					payloadRejection &&
+					!compactionResult.continuationScheduled &&
+					compactionResult.automaticContinuationBlocked !== true &&
+					compactionResult.historyRewritten !== true
+				) {
+					this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");
+					logger.debug("Payload-shaped 413 compaction attempt made no progress; blocking automatic continuation", {
+						provider: assistantMessage.provider,
+						model: assistantMessage.model,
+						message: assistantMessage.errorMessage,
+						storedTokens,
+						contextWindow,
+					});
+					return COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION;
+				}
+				return compactionResult;
 			}
 			if (payloadRejection) {
 				const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2259,7 +2259,25 @@ export class SessionMaintenance {
 			contextWindow > 0 &&
 			reportedInputTokens <= contextWindow &&
 			storedTokens < contextWindow * PAYLOAD_REJECTION_OCCUPANCY_CEILING;
-		if ((payloadRejection && !ambiguousPayloadRejection && contextWindow <= 0) || trustedPayloadRejection) {
+		// Whether a compaction method actually exists to attempt shrinking the
+		// history. Computed up front so the unknown-context-window branch below
+		// can fall through to a real attempt instead of always assuming defeat.
+		// (Named distinctly from the `compactionSettings` used further down in
+		// this function's later, unrelated threshold check.)
+		const payloadCompactionSettings = this.#host.settings.getGroup("compaction");
+		const compactionAvailable =
+			payloadCompactionSettings.enabled &&
+			(this.#usesExperimentalContextManagement() || hasConfiguredCompactionMethod(payloadCompactionSettings));
+		// Unknown context window (common for custom/self-hosted models the
+		// registry has no metadata for) used to be treated the same as a
+		// confirmed media/byte-budget rejection and blocked outright — even
+		// when the payload bloat is plain message-count growth that ordinary
+		// compaction would shrink just fine (#11479). Only skip straight to
+		// the honest "can't help" notice here when there is genuinely no
+		// compaction method configured to try.
+		const unknownWindowDeadEnd =
+			payloadRejection && !ambiguousPayloadRejection && contextWindow <= 0 && !compactionAvailable;
+		if (unknownWindowDeadEnd || trustedPayloadRejection) {
 			this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
 			this.#host.emitNotice("warning", payloadRejectionNotice(storedTokens, contextWindow), "compaction");
 			logger.debug("Payload-shaped 413 withheld from token compaction", {
@@ -2290,11 +2308,7 @@ export class SessionMaintenance {
 			}
 
 			// No promotion target available fall through to compaction
-			const compactionSettings = this.#host.settings.getGroup("compaction");
-			if (
-				compactionSettings.enabled &&
-				(this.#usesExperimentalContextManagement() || hasConfiguredCompactionMethod(compactionSettings))
-			) {
+			if (compactionAvailable) {
 				return await this.#host.runRecoveryCompactionWithRollback("overflow", assistantMessage, allowDefer, {
 					autoContinue,
 				});

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2321,6 +2321,17 @@ export class SessionMaintenance {
 			contextWindow > 0 &&
 			reportedInputTokens <= contextWindow &&
 			storedTokens < contextWindow * PAYLOAD_REJECTION_OCCUPANCY_CEILING;
+		// Provider-reported usage above a known window is authoritative proof of a
+		// genuine token overflow (not a byte/media-only rejection), computed once
+		// up front so both the media-exclusion decision below and the terminal
+		// notice selection further down agree with each other.
+		const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);
+		// `payloadRejection` alone is not sufficient reason to exclude media
+		// compaction methods (snapcompact): a *usage-backed* overflow proves the
+		// rejection is a genuine token-context problem, not a byte/media budget
+		// one, so a user configured with e.g. `methodOrder: ["snapcompact"]` must
+		// still be able to use it instead of being told no recovery exists (#11482).
+		const excludeMediaForPayloadRejection = payloadRejection && !usageBackedOverflow;
 		// Whether a compaction method actually exists to attempt shrinking the
 		// history. Computed up front so the unknown-context-window branch below
 		// can fall through to a real attempt instead of always assuming defeat.
@@ -2339,7 +2350,12 @@ export class SessionMaintenance {
 		const compactionAvailable =
 			payloadCompactionSettings.enabled &&
 			(this.#usesExperimentalContextManagement() ||
-				hasUsableCompactionMethod("overflow", this.#model, payloadCompactionSettings, payloadRejection));
+				hasUsableCompactionMethod(
+					"overflow",
+					this.#model,
+					payloadCompactionSettings,
+					excludeMediaForPayloadRejection,
+				));
 		// Unknown context window (common for custom/self-hosted models the
 		// registry has no metadata for) used to be treated the same as a
 		// confirmed media/byte-budget rejection and blocked outright — even
@@ -2397,7 +2413,7 @@ export class SessionMaintenance {
 					"overflow",
 					assistantMessage,
 					allowDefer,
-					{ autoContinue, excludeMediaMethods: payloadRejection },
+					{ autoContinue, excludeMediaMethods: excludeMediaForPayloadRejection },
 				);
 				// A statically usable method (per `hasUsableCompactionMethod`) can still
 				// reclaim nothing at runtime — e.g. `methodOrder: ["shake"]` with no
@@ -2433,7 +2449,6 @@ export class SessionMaintenance {
 					// token-context problem even though compaction (attempted here,
 					// unsuccessfully) couldn't resolve it — say so accurately instead
 					// of always claiming "not a token problem" (#11482).
-					const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);
 					this.#host.emitNotice(
 						"warning",
 						usageBackedOverflow
@@ -2453,7 +2468,6 @@ export class SessionMaintenance {
 				return compactionResult;
 			}
 			if (payloadRejection) {
-				const usageBackedOverflow = AIError.isUsageBackedContextOverflow(assistantMessage, contextWindow);
 				this.#host.emitNotice(
 					"warning",
 					usageBackedOverflow

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -140,17 +140,24 @@ function hasConfiguredCompactionMethod(settings: ConfiguredCompactionSettings): 
  * Whether `candidate` is actually selectable for `reason` on `model` — mirrors the
  * per-candidate availability check in {@link SessionMaintenance.runAutoCompaction}'s
  * method-order loop so every caller agrees with what would really be selected.
+ *
+ * `excludeMedia` skips `snapcompact` regardless of model support: it archives
+ * history onto base64-encoded image frames (up to ~3 MB), which is the opposite
+ * of what a byte/payload-limit 413 recovery needs — a request already rejected
+ * for being too large in bytes should not be retried with an even larger,
+ * media-heavy one (#11482).
  */
 function isCompactionMethodUsable(
 	candidate: CompactionMethod,
 	reason: "overflow" | "threshold" | "idle" | "incomplete",
 	model: Model | undefined,
 	settings: ConfiguredCompactionSettings,
+	excludeMedia = false,
 ): boolean {
 	return candidate === "remote"
 		? canUseRemoteCompaction(model, resolveMethodSettings(settings, candidate))
 		: candidate === "snapcompact"
-			? model?.input.includes("image") === true
+			? !excludeMedia && model?.input.includes("image") === true
 			: candidate === "handoff"
 				? reason !== "overflow"
 				: true;
@@ -168,9 +175,10 @@ function hasUsableCompactionMethod(
 	reason: "overflow" | "threshold" | "idle" | "incomplete",
 	model: Model | undefined,
 	settings: ConfiguredCompactionSettings,
+	excludeMedia = false,
 ): boolean {
 	return resolveCompactionMethodOrder(settings.methodOrder).some(candidate =>
-		isCompactionMethodUsable(candidate, reason, model, settings),
+		isCompactionMethodUsable(candidate, reason, model, settings, excludeMedia),
 	);
 }
 
@@ -398,7 +406,7 @@ export interface SessionMaintenanceHost {
 		reason: "overflow" | "incomplete",
 		message: AssistantMessage,
 		allowDefer: boolean,
-		options: { autoContinue: boolean; triggerContextTokens?: number },
+		options: { autoContinue: boolean; triggerContextTokens?: number; excludeMediaMethods?: boolean },
 	): Promise<CompactionCheckResult>;
 	parseRetryAfterMsFromError(errorMessage: string): number | undefined;
 	setModelTemporary(
@@ -2321,13 +2329,17 @@ export class SessionMaintenance {
 		// configuration — e.g. `methodOrder: ["handoff"]`, or `snapcompact`-only
 		// on a text-only model — isn't reported as available and then silently
 		// no-ops instead of surfacing the payload-rejection notice (#11482).
+		// For a payload rejection specifically, `snapcompact` is excluded from
+		// this availability check too: it archives history onto base64 image
+		// frames, which only grows the byte size a payload/byte-limit 413 is
+		// already complaining about (#11482).
 		// (Named distinctly from the `compactionSettings` used further down in
 		// this function's later, unrelated threshold check.)
 		const payloadCompactionSettings = this.#host.settings.getGroup("compaction");
 		const compactionAvailable =
 			payloadCompactionSettings.enabled &&
 			(this.#usesExperimentalContextManagement() ||
-				hasUsableCompactionMethod("overflow", this.#model, payloadCompactionSettings));
+				hasUsableCompactionMethod("overflow", this.#model, payloadCompactionSettings, payloadRejection));
 		// Unknown context window (common for custom/self-hosted models the
 		// registry has no metadata for) used to be treated the same as a
 		// confirmed media/byte-budget rejection and blocked outright — even
@@ -2385,7 +2397,7 @@ export class SessionMaintenance {
 					"overflow",
 					assistantMessage,
 					allowDefer,
-					{ autoContinue },
+					{ autoContinue, excludeMediaMethods: payloadRejection },
 				);
 				// A statically usable method (per `hasUsableCompactionMethod`) can still
 				// reclaim nothing at runtime — e.g. `methodOrder: ["shake"]` with no
@@ -2404,6 +2416,17 @@ export class SessionMaintenance {
 					compactionResult.automaticContinuationBlocked !== true &&
 					compactionResult.historyRewritten !== true
 				) {
+					// `runRecoveryCompactionWithRollback`'s no-rewrite path re-appends the
+					// failed turn to active context (so it isn't silently lost) before
+					// returning here. Unlike the immediate and no-method dead ends above/
+					// below, this branch discovers the no-progress outcome only *after*
+					// that restoration, so it must re-remove the turn itself — otherwise
+					// the next prompt's pre-prompt maintenance finds the same error via
+					// `#findLastAssistantMessage()` and repeats this entire no-progress
+					// compaction + warning before accepting new input (#11482). The
+					// persisted session history (separate from this active-context view)
+					// still keeps the turn visible.
+					this.#host.removeAssistantMessageFromActiveContext(assistantMessage);
 					// Same usage-backed/byte-shaped notice selection as the sibling
 					// "no compaction available" dead end below: a payload rejection
 					// with provider-reported usage above the window IS a genuine
@@ -3558,6 +3581,12 @@ export class SessionMaintenance {
 			 * capability is no longer present at dispatch time.
 			 */
 			explicitNewContextRequest?: boolean;
+			/**
+			 * Skip `snapcompact` regardless of model image support — a byte/payload-
+			 * limit 413 recovery must not retry with an even larger, media-heavy
+			 * request (#11482).
+			 */
+			excludeMediaMethods?: boolean;
 		} = {},
 	): Promise<CompactionCheckResult> {
 		const compactionSettings = this.#host.settings.getGroup("compaction");
@@ -3589,7 +3618,16 @@ export class SessionMaintenance {
 		let method: CompactionMethod | undefined;
 		for (let index = startIndex; index < methods.length; index++) {
 			const candidate = methods[index];
-			if (!isCompactionMethodUsable(candidate, reason, this.#model, compactionSettings)) continue;
+			if (
+				!isCompactionMethodUsable(
+					candidate,
+					reason,
+					this.#model,
+					compactionSettings,
+					options.excludeMediaMethods === true,
+				)
+			)
+				continue;
 			method = candidate;
 			methodIndex = index;
 			break;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -137,6 +137,44 @@ function hasConfiguredCompactionMethod(settings: ConfiguredCompactionSettings): 
 }
 
 /**
+ * Whether `candidate` is actually selectable for `reason` on `model` — mirrors the
+ * per-candidate availability check in {@link SessionMaintenance.runAutoCompaction}'s
+ * method-order loop so every caller agrees with what would really be selected.
+ */
+function isCompactionMethodUsable(
+	candidate: CompactionMethod,
+	reason: "overflow" | "threshold" | "idle" | "incomplete",
+	model: Model | undefined,
+	settings: ConfiguredCompactionSettings,
+): boolean {
+	return candidate === "remote"
+		? canUseRemoteCompaction(model, resolveMethodSettings(settings, candidate))
+		: candidate === "snapcompact"
+			? model?.input.includes("image") === true
+			: candidate === "handoff"
+				? reason !== "overflow"
+				: true;
+}
+
+/**
+ * Whether the configured method order contains at least one method that
+ * `runAutoCompaction` would actually select for `reason` on `model` — a non-empty
+ * `methodOrder` alone (see {@link hasConfiguredCompactionMethod}) is not enough: an
+ * unusable-for-this-reason configuration (e.g. `methodOrder: ["handoff"]` for an
+ * `"overflow"` reason, or `snapcompact`-only on a text-only model) would otherwise be
+ * reported as available and then silently no-op in `runAutoCompaction` (#11482).
+ */
+function hasUsableCompactionMethod(
+	reason: "overflow" | "threshold" | "idle" | "incomplete",
+	model: Model | undefined,
+	settings: ConfiguredCompactionSettings,
+): boolean {
+	return resolveCompactionMethodOrder(settings.methodOrder).some(candidate =>
+		isCompactionMethodUsable(candidate, reason, model, settings),
+	);
+}
+
+/**
  * User-facing notice for a compaction dead end: maintenance freed too little
  * to retry safely. `remedies` names the recovery actions left on the emitting
  * path — by the time the post-pass dead end fires, the tiered rescue has
@@ -2262,12 +2300,18 @@ export class SessionMaintenance {
 		// Whether a compaction method actually exists to attempt shrinking the
 		// history. Computed up front so the unknown-context-window branch below
 		// can fall through to a real attempt instead of always assuming defeat.
+		// Uses the same reason/model-specific selection as `runAutoCompaction`
+		// (not just a non-empty `methodOrder`) so an unusable-for-overflow
+		// configuration — e.g. `methodOrder: ["handoff"]`, or `snapcompact`-only
+		// on a text-only model — isn't reported as available and then silently
+		// no-ops instead of surfacing the payload-rejection notice (#11482).
 		// (Named distinctly from the `compactionSettings` used further down in
 		// this function's later, unrelated threshold check.)
 		const payloadCompactionSettings = this.#host.settings.getGroup("compaction");
 		const compactionAvailable =
 			payloadCompactionSettings.enabled &&
-			(this.#usesExperimentalContextManagement() || hasConfiguredCompactionMethod(payloadCompactionSettings));
+			(this.#usesExperimentalContextManagement() ||
+				hasUsableCompactionMethod("overflow", this.#model, payloadCompactionSettings));
 		// Unknown context window (common for custom/self-hosted models the
 		// registry has no metadata for) used to be treated the same as a
 		// confirmed media/byte-budget rejection and blocked outright — even
@@ -3473,15 +3517,7 @@ export class SessionMaintenance {
 		let method: CompactionMethod | undefined;
 		for (let index = startIndex; index < methods.length; index++) {
 			const candidate = methods[index];
-			const available =
-				candidate === "remote"
-					? canUseRemoteCompaction(this.#model, resolveMethodSettings(compactionSettings, candidate))
-					: candidate === "snapcompact"
-						? this.#model?.input.includes("image") === true
-						: candidate === "handoff"
-							? reason !== "overflow"
-							: true;
-			if (!available) continue;
+			if (!isCompactionMethodUsable(candidate, reason, this.#model, compactionSettings)) continue;
 			method = candidate;
 			methodIndex = index;
 			break;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -200,10 +200,13 @@ function hasUsableCompactionMethod(
  * application/json`) is not evidence the *request* was rejected for a media
  * budget — treating it as such would permanently dead-end an unknown-window
  * session that ordinary compaction could actually recover (#11482). Require
- * the noun to co-occur with a count/limit signal instead.
+ * the noun to co-occur with a count/limit signal instead — covering the
+ * common phrasings: "too many images", "image count"/"image limit", "limit
+ * of N images", "maximum (of N) images", "number/count of images", and
+ * "images exceeds ... maximum" (#11482).
  */
 const PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN =
-	/\btoo many (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\s*(?:count|limit)\b|\blimit of \d+\s*(?:images?|frames?|pixels?)\b/i;
+	/\btoo many (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\s*(?:count|limit)\b|\blimit of \d+\s*(?:images?|frames?|pixels?)\b|\bmaximum(?: of \d+)? (?:images?|frames?|pixels?)\b|\b(?:number|count) of (?:images?|frames?|pixels?)\b|\b(?:images?|frames?|pixels?)\b.{0,20}\bexceeds?\b.{0,20}\bmaximum\b/i;
 function hasExplicitMediaRejectionEvidence(errorMessage: string | undefined): boolean {
 	return errorMessage !== undefined && PAYLOAD_MEDIA_LIMIT_EVIDENCE_PATTERN.test(errorMessage);
 }

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -230,6 +230,9 @@ export interface TurnRecoveryHost {
 			suppressHandoff?: boolean;
 			phase?: CodexCompactionContext["phase"];
 			terminalTextAnswer?: boolean;
+			/** Skip `snapcompact` — a byte/payload-limit 413 recovery must not
+			 *  retry with an even larger, media-heavy request (#11482). */
+			excludeMediaMethods?: boolean;
 		},
 	): Promise<RecoveryCompactionResult>;
 	withBashBranchTransition<T>(operation: () => T): T;
@@ -562,7 +565,7 @@ export class TurnRecovery {
 		reason: "overflow" | "incomplete",
 		message: AssistantMessage,
 		allowDefer: boolean,
-		options: { autoContinue: boolean; triggerContextTokens?: number },
+		options: { autoContinue: boolean; triggerContextTokens?: number; excludeMediaMethods?: boolean },
 	): Promise<RecoveryCompactionResult> {
 		return this.#runRecoveryCompactionWithRollback(reason, message, allowDefer, options);
 	}
@@ -1051,7 +1054,7 @@ export class TurnRecovery {
 		reason: "overflow" | "incomplete",
 		assistantMessage: AssistantMessage,
 		allowDefer: boolean,
-		options: { autoContinue: boolean; triggerContextTokens?: number },
+		options: { autoContinue: boolean; triggerContextTokens?: number; excludeMediaMethods?: boolean },
 	): Promise<RecoveryCompactionResult> {
 		const compactionEntryBefore = getLatestCompactionEntry(this.#host.sessionManager.getBranch());
 		await this.dropPersistedAssistantTurn(assistantMessage);
@@ -1059,6 +1062,7 @@ export class TurnRecovery {
 			autoContinue: options.autoContinue,
 			triggerContextTokens: options.triggerContextTokens,
 			phase: "mid_turn",
+			excludeMediaMethods: options.excludeMediaMethods,
 		});
 		const compactionEntryAfter = getLatestCompactionEntry(this.#host.sessionManager.getBranch());
 		if (result.historyRewritten !== true && compactionEntryAfter === compactionEntryBefore) {

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -435,22 +435,27 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
-	it("excludes snapcompact from the payload-rejection compaction attempt (#11482)", async () => {
+	it("skips snapcompact and lands on soft for a payload-rejection compaction attempt (#11482)", async () => {
 		// The `session_before_compact` hook mocked in `createSession` supplies a
 		// canned summary regardless of which method actually runs, so it can't
-		// distinguish snapcompact from soft/shake by observable side effects
-		// alone. Spy on `runAutoCompaction` directly to verify the wiring: a
-		// payload rejection must ask for `excludeMediaMethods: true` so
-		// `runAutoCompaction`'s own method-selection loop skips snapcompact —
-		// which archives history onto base64 image frames, growing the exact
-		// byte budget a payload/byte-limit 413 already exceeded.
-		await createSession(null);
-		const runAutoCompactionSpy = vi.spyOn(SessionMaintenance.prototype, "runAutoCompaction");
+		// distinguish methods by that side effect. Assert on the compaction
+		// lifecycle's own `action` field instead (session-maintenance.ts: the
+		// dispatched `action` is literally "snapcompact" for that method, and
+		// "context-full" for "soft"/"handoff"-summary methods) — a real,
+		// observable proof of which method ran, not just that an option was
+		// forwarded. The bundled test model supports image input
+		// (`input: ["text","image"]`), so with `methodOrder: ["snapcompact",
+		// "soft"]` an unfixed selection loop would pick snapcompact first.
+		await createSession(null, undefined, {
+			extraSettings: { "compaction.methodOrder": ["snapcompact", "soft"] },
+		});
 		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
 		vi.spyOn(session.agent, "continue").mockResolvedValue();
 
+		const startActions: unknown[] = [];
 		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
 		session.subscribe(event => {
+			if (event.type === "auto_compaction_start") startActions.push((event as { action?: unknown }).action);
 			if (event.type === "auto_compaction_end") onCompactionDone();
 		});
 
@@ -461,9 +466,9 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		await compactionDone;
 		await session.waitForIdle();
 
-		expect(runAutoCompactionSpy).toHaveBeenCalled();
-		const overflowCall = runAutoCompactionSpy.mock.calls.find(call => call[0] === "overflow");
-		expect(overflowCall?.[4]?.excludeMediaMethods).toBe(true);
+		expect(startActions.length).toBeGreaterThanOrEqual(1);
+		expect(startActions).not.toContain("snapcompact");
+		expect(startActions).toContain("context-full");
 	});
 
 	it("still blocks a payload-only 413 with no context window when the only configured method can't run for overflow (#11482)", async () => {

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -601,6 +601,42 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
 	});
 
+	it("keeps a dual-flagged media rejection ('image count exceeds the limit of 20') on the terminal path even with no context window (#11482)", async () => {
+		// Unlike the digit-free case above, "image count exceeds the limit of 20"
+		// also trips GENERIC_LIMIT_OVERFLOW_PATTERN, so AIError.classifyMessage
+		// dual-flags it (PayloadRejected + ContextOverflow) and
+		// ambiguousPayloadRejection is true. Explicit media evidence must win
+		// over that ambiguity guard — otherwise this falls into the same
+		// overflow-compaction attempt (including snapcompact, which can add
+		// image frames) despite the text proving a media/image-count budget.
+		await createSession(null);
+		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+
+		const assistantMsg = mediaBudgetPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(startCount()).toBe(0);
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+		expect(payloadNotices.length).toBe(1);
+		const checkResults = await Promise.all(
+			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
+		);
+		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
 	function activateOngoingGoal(id: string): void {
 		const now = Date.now();
 		session.setGoalModeState({

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -443,6 +443,39 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
 	});
 
+	it("blocks a payload-only 413 with no context window when a usable method is configured but reclaims nothing (#11482)", async () => {
+		// `shake` is statically usable for reason "overflow" (unlike `handoff`),
+		// so it passes `hasUsableCompactionMethod` and `runRecoveryCompactionWithRollback`
+		// is attempted. With no seeded heavy tool output there is nothing to elide,
+		// so shake reclaims 0 tokens, the method list is exhausted, and the
+		// underlying `runAutoCompaction` returns a plain no-op. Without converting
+		// that no-progress outcome back into the payload dead end, the failed turn
+		// would be silently restored with neither a notice nor a block, letting
+		// the next auto-continue resubmit the same oversized history.
+		await createSession(null, undefined, { extraSettings: { "compaction.methodOrder": ["shake"] } });
+		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+
+		const assistantMsg = payloadRejectionAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+		expect(payloadNotices.length).toBe(1);
+		const checkResults = await Promise.all(
+			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
+		);
+		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
 	it("reports a usage-backed payload-shaped dead end as a token-context problem", async () => {
 		await createSession(200_000, undefined, { extraSettings: { "compaction.enabled": false } });
 		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -262,6 +262,33 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		return message;
 	}
 
+	/** Plain (non-media) payload rejection whose reported usage exceeds a known
+	 *  context window — `isUsageBackedContextOverflow` proves a genuine token
+	 *  overflow, unlike `usageBackedMediaBudgetAssistant` this carries no media
+	 *  wording, so it should not disqualify media compaction methods (#11482). */
+	function usageBackedPlainPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: PAYLOAD_ERROR_MESSAGE,
+			usage: {
+				input: 250_000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 250_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
 	it("honestly skips token compaction for a low-token payload-shaped 413", async () => {
 		await createSession(200_000);
 		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
@@ -606,6 +633,41 @@ describe("AgentSession payload-rejection 413 handling", () => {
 			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
 		);
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
+	it("does not exclude snapcompact from a usage-backed payload rejection with a known context window (#11482)", async () => {
+		// Plain (non-media) payload rejection, but reported usage (250k) exceeds
+		// the known 200k context window: `isUsageBackedContextOverflow` proves
+		// this is a genuine token overflow, not a byte/media-only rejection.
+		// A user configured with `methodOrder: ["snapcompact"]` must still be
+		// able to use their only configured method instead of being told no
+		// recovery exists just because the error is payload-shaped.
+		await createSession(200_000, undefined, {
+			extraSettings: { "compaction.methodOrder": ["snapcompact"] },
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startActions: unknown[] = [];
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_start") startActions.push((event as { action?: unknown }).action);
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = usageBackedPlainPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(startActions).toContain("snapcompact");
+		const unavailableNotices = notices.filter(
+			n => n.source === NOTICE_SOURCE && n.message.includes("automatic compaction is unavailable"),
+		);
+		expect(unavailableNotices.length).toBe(0);
 	});
 
 	it("keeps a digit-free explicit media rejection ('too many images') on the terminal path even with no context window and compaction available (#11482)", async () => {

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -318,6 +318,61 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		return message;
 	}
 
+	/** Per-image size rejection: "image is too large" — no count/limit/digit,
+	 *  so classifies non-ambiguous (PayloadRejected only, no ContextOverflow).
+	 *  A definitive per-image constraint that token compaction cannot fix —
+	 *  the oversized image stays in the kept region regardless (#11482). */
+	function imageSizeTooLargePayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: "request_too_large: image is too large",
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
+	/** Per-image dimension rejection: "image dimensions exceed 8000 pixels" —
+	 *  no count/limit noun, so classifies non-ambiguous (PayloadRejected only,
+	 *  no ContextOverflow). A definitive per-image pixel constraint that token
+	 *  compaction cannot fix — the oversized image stays in the kept region
+	 *  regardless (#11482). */
+	function imageDimensionsExceedPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: "request_too_large: image dimensions exceed 8000 pixels",
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
 	function usageBackedMediaBudgetAssistant(): AssistantMessage {
 		const message = {
 			role: "assistant",
@@ -850,11 +905,14 @@ describe("AgentSession payload-rejection 413 handling", () => {
 	it.each([
 		["maximum of N images", mediaMaximumLimitPayloadAssistant] as const,
 		["number of images exceeds the maximum", mediaNumberOfImagesPayloadAssistant] as const,
+		["per-image size too large", imageSizeTooLargePayloadAssistant] as const,
+		["per-image dimensions exceed pixels", imageDimensionsExceedPayloadAssistant] as const,
 	])(
 		"keeps a %s media rejection on the terminal path even with no context window and compaction available (#11482)",
 		async (_label, buildAssistant) => {
-			// "maximum of 20 images allowed" and "the number of images exceeds the
-			// maximum" are both definitive media-limit evidence but matched neither
+			// "maximum of 20 images allowed", "the number of images exceeds the
+			// maximum", "image is too large", and "image dimensions exceed 8000
+			// pixels" are all definitive media-limit evidence but matched neither
 			// the original bare-word pattern's replacement nor "too many images" /
 			// "image count/limit" / "limit of N images" — the narrowed matcher
 			// needs explicit coverage for these common phrasings too, or they fall

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -267,6 +267,57 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		return message;
 	}
 
+	/** "maximum of N images" phrasing — doesn't match "exceeds the limit of N"
+	 *  so classifies non-ambiguous (PayloadRejected only, no ContextOverflow),
+	 *  same shape as `explicitMediaNoDigitPayloadAssistant` (#11482). */
+	function mediaMaximumLimitPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: "request_too_large: maximum of 20 images allowed",
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
+	/** "number of images exceeds the maximum" phrasing — no digit, so classifies
+	 *  non-ambiguous (PayloadRejected only, no ContextOverflow) (#11482). */
+	function mediaNumberOfImagesPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: "request_too_large: the number of images exceeds the maximum",
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
 	function usageBackedMediaBudgetAssistant(): AssistantMessage {
 		const message = {
 			role: "assistant",
@@ -795,6 +846,42 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		);
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
 	});
+
+	it.each([
+		["maximum of N images", mediaMaximumLimitPayloadAssistant] as const,
+		["number of images exceeds the maximum", mediaNumberOfImagesPayloadAssistant] as const,
+	])(
+		"keeps a %s media rejection on the terminal path even with no context window and compaction available (#11482)",
+		async (_label, buildAssistant) => {
+			// "maximum of 20 images allowed" and "the number of images exceeds the
+			// maximum" are both definitive media-limit evidence but matched neither
+			// the original bare-word pattern's replacement nor "too many images" /
+			// "image count/limit" / "limit of N images" — the narrowed matcher
+			// needs explicit coverage for these common phrasings too, or they fall
+			// through to a compaction attempt that may drop or retry with images.
+			await createSession(null);
+			const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+			const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+			const notices = collectNotices();
+			const startCount = countCompactionEvents("auto_compaction_start");
+
+			const assistantMsg = buildAssistant();
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+			await session.waitForIdle();
+
+			expect(startCount()).toBe(0);
+			expect(prepareSpy).not.toHaveBeenCalled();
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(continueSpy).not.toHaveBeenCalled();
+
+			const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+			expect(payloadNotices.length).toBe(1);
+		},
+	);
 
 	it("keeps a dual-flagged media rejection ('image count exceeds the limit of 20') on the terminal path even with no context window (#11482)", async () => {
 		// Unlike the digit-free case above, "image count exceeds the limit of 20"

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -435,6 +435,37 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
+	it("excludes snapcompact from the payload-rejection compaction attempt (#11482)", async () => {
+		// The `session_before_compact` hook mocked in `createSession` supplies a
+		// canned summary regardless of which method actually runs, so it can't
+		// distinguish snapcompact from soft/shake by observable side effects
+		// alone. Spy on `runAutoCompaction` directly to verify the wiring: a
+		// payload rejection must ask for `excludeMediaMethods: true` so
+		// `runAutoCompaction`'s own method-selection loop skips snapcompact —
+		// which archives history onto base64 image frames, growing the exact
+		// byte budget a payload/byte-limit 413 already exceeded.
+		await createSession(null);
+		const runAutoCompactionSpy = vi.spyOn(SessionMaintenance.prototype, "runAutoCompaction");
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = payloadRejectionAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(runAutoCompactionSpy).toHaveBeenCalled();
+		const overflowCall = runAutoCompactionSpy.mock.calls.find(call => call[0] === "overflow");
+		expect(overflowCall?.[4]?.excludeMediaMethods).toBe(true);
+	});
+
 	it("still blocks a payload-only 413 with no context window when the only configured method can't run for overflow (#11482)", async () => {
 		// `handoff` explicitly refuses reason === "overflow" (session-maintenance.ts
 		// `isCompactionMethodUsable`). A methodOrder of just `["handoff"]` must not
@@ -500,6 +531,13 @@ describe("AgentSession payload-rejection 413 handling", () => {
 			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
 		);
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+
+		// `runRecoveryCompactionWithRollback`'s no-rewrite path re-appends the
+		// failed turn to active context before the no-progress conversion runs;
+		// the block must remove it again so the next prompt's pre-prompt
+		// maintenance doesn't find the same error and repeat this whole cycle.
+		const lastActiveMessage = session.agent.state.messages.at(-1);
+		expect(lastActiveMessage?.role === "assistant" && lastActiveMessage.stopReason === "error").toBe(false);
 	});
 
 	it("reports a usage-backed payload-shaped dead end as a token-context problem", async () => {

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -213,6 +213,34 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		return message;
 	}
 
+	/** Incidental "vision"/"media" wording with no count/limit evidence — a
+	 *  model name and an unrelated Content-Type, not proof the *request* was
+	 *  rejected for a media budget. Classifies non-ambiguous (PayloadRejected
+	 *  only, no ContextOverflow), same shape as `explicitMediaNoDigitPayloadAssistant`,
+	 *  but must NOT be treated as explicit media evidence (#11482). */
+	function incidentalMediaWordPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: `${PAYLOAD_ERROR_MESSAGE} for model llava-vision`,
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
 	/** Digit-free media wording: doesn't match GENERIC_LIMIT_OVERFLOW_PATTERN
 	 *  (no "exceeds the limit of N"), so unlike `mediaBudgetPayloadAssistant`
 	 *  this is classified non-ambiguous (PayloadRejected only, no ContextOverflow). */
@@ -740,6 +768,39 @@ describe("AgentSession payload-rejection 413 handling", () => {
 			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
 		);
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
+	it("attempts compaction for a payload-only 413 that merely names a vision model, not an actual media-limit rejection (#11482)", async () => {
+		// "for model llava-vision" contains "vision" but no count/limit evidence —
+		// the request wasn't rejected for exceeding an image/frame/pixel budget,
+		// it just happens to run a vision-capable model. Before narrowing the
+		// media-evidence pattern, bare "vision"/"media" occurrences anywhere in
+		// the text were enough to permanently dead-end the session even when
+		// ordinary text compaction could recover it.
+		await createSession(null);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = incidentalMediaWordPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(startCount()).toBeGreaterThanOrEqual(1);
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413")).length).toBe(0);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
 	function activateOngoingGoal(id: string): void {

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -409,6 +409,40 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
+	it("still blocks a payload-only 413 with no context window when the only configured method can't run for overflow (#11482)", async () => {
+		// `handoff` explicitly refuses reason === "overflow" (session-maintenance.ts
+		// `isCompactionMethodUsable`). A methodOrder of just `["handoff"]` must not
+		// be treated as "compaction available" for this dead end — otherwise
+		// `runAutoCompaction` finds no usable method, silently no-ops, and neither
+		// the payload notice nor the automatic-continuation block ever fires.
+		await createSession(null, undefined, { extraSettings: { "compaction.methodOrder": ["handoff"] } });
+		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const endCount = countCompactionEvents("auto_compaction_end");
+
+		const assistantMsg = payloadRejectionAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(endCount()).toBe(0);
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+		expect(payloadNotices.length).toBe(1);
+		const checkResults = await Promise.all(
+			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
+		);
+		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
 	it("reports a usage-backed payload-shaped dead end as a token-context problem", async () => {
 		await createSession(200_000, undefined, { extraSettings: { "compaction.enabled": false } });
 		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -213,6 +213,32 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		return message;
 	}
 
+	/** Digit-free media wording: doesn't match GENERIC_LIMIT_OVERFLOW_PATTERN
+	 *  (no "exceeds the limit of N"), so unlike `mediaBudgetPayloadAssistant`
+	 *  this is classified non-ambiguous (PayloadRejected only, no ContextOverflow). */
+	function explicitMediaNoDigitPayloadAssistant(): AssistantMessage {
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "error",
+			errorMessage: "request_too_large: too many images",
+			usage: {
+				input: 1000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		} as AssistantMessage;
+		message.errorId = AIError.classifyMessage(message);
+		return message;
+	}
+
 	function usageBackedMediaBudgetAssistant(): AssistantMessage {
 		const message = {
 			role: "assistant",
@@ -500,6 +526,75 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(deadEndNotices[0].message).toContain("IS a token-context problem");
 		expect(deadEndNotices[0].message).not.toContain("NOT a token-context problem");
 
+		const checkResults = await Promise.all(
+			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
+		);
+		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
+	it("reports a usage-backed dead end (not 'not a token problem') when a configured method reclaims nothing (#11482)", async () => {
+		// Same usage-backed evidence as above, but this time compaction IS
+		// enabled with a method ("shake") that's statically usable yet reclaims
+		// nothing on this minimal session. The no-progress conversion path must
+		// select the same usage-backed notice the "no compaction available"
+		// path already does, not unconditionally claim "not a token problem".
+		await createSession(200_000, undefined, { extraSettings: { "compaction.methodOrder": ["shake"] } });
+		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+
+		const assistantMsg = usageBackedMediaBudgetAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const deadEndNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.level === "warning");
+		expect(deadEndNotices.length).toBe(1);
+		expect(deadEndNotices[0].message).toContain("IS a token-context problem");
+		expect(deadEndNotices[0].message).not.toContain("NOT a token-context problem");
+
+		const checkResults = await Promise.all(
+			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
+		);
+		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
+	it("keeps a digit-free explicit media rejection ('too many images') on the terminal path even with no context window and compaction available (#11482)", async () => {
+		// "request_too_large: too many images" matches PAYLOAD_REJECTION_PATTERNS
+		// but none of the token-context or generic-numeric-limit patterns, so it
+		// classifies as non-ambiguous PayloadRejected only. Without positive
+		// media evidence gating, the default (compaction-available) install
+		// would route this into a compaction attempt — including snapcompact,
+		// which can *add* image frames — even though the text already proves
+		// this is a media budget, not message-count bloat.
+		await createSession(null);
+		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+
+		const assistantMsg = explicitMediaNoDigitPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(startCount()).toBe(0);
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+		expect(payloadNotices.length).toBe(1);
 		const checkResults = await Promise.all(
 			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
 		);

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -340,8 +340,12 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
-	it("treats a payload-only 413 as terminal without a local context window", async () => {
-		await createSession(null);
+	it("treats a payload-only 413 as terminal without a local context window when no compaction method is configured", async () => {
+		// Unknown context window used to always dead-end here regardless of
+		// compaction availability (#11479). With no compaction method configured
+		// there is genuinely nothing to attempt, so this case still blocks — see
+		// the sibling test below for the case where compaction *is* configured.
+		await createSession(null, undefined, { extraSettings: { "compaction.enabled": false } });
 		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
 		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
@@ -371,6 +375,38 @@ describe("AgentSession payload-rejection 413 handling", () => {
 			checkSpy.mock.results.map(r => r.value as { automaticContinuationBlocked?: boolean }),
 		);
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
+	});
+
+	it("attempts compaction for a payload-only 413 with no local context window when a compaction method is configured (#11479)", async () => {
+		// Self-hosted/custom-provider models the registry has no metadata for
+		// report contextWindow: null. The 413 text here carries no media/image
+		// evidence, so byte bloat driven by plain message-count growth should
+		// get the same compaction chance a known-window overflow would, instead
+		// of being lumped in with a confirmed media/byte-budget rejection.
+		await createSession(null);
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = payloadRejectionAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(startCount()).toBeGreaterThanOrEqual(1);
+		expect(prepareSpy).toHaveBeenCalled();
+		expect(notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413")).length).toBe(0);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
 	it("reports a usage-backed payload-shaped dead end as a token-context problem", async () => {
@@ -863,8 +899,11 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		const providerCtx = sessionManager.buildSessionContext().messages;
 		expect(providerCtx.some(m => m.role === "assistant" && m.stopReason === "error")).toBe(false);
 	});
-	it("blocks status-only Content Too Large rejections with no context window", async () => {
-		await createSession(null);
+	it("blocks status-only Content Too Large rejections with no context window and no compaction method configured", async () => {
+		// See the "attempts compaction ... (#11479)" test above: with unknown
+		// context window this now only dead-ends when there is genuinely no
+		// compaction method available to try.
+		await createSession(null, undefined, { extraSettings: { "compaction.enabled": false } });
 		const checkSpy = vi.spyOn(SessionMaintenance.prototype, "checkCompaction");
 		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);

--- a/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
+++ b/packages/coding-agent/test/agent-session-payload-rejection-413.test.ts
@@ -663,6 +663,68 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(checkResults.some(r => r.automaticContinuationBlocked === true)).toBe(true);
 	});
 
+	it("removes the restored turn when runAutoCompaction itself blocks without rewriting history (#11482)", async () => {
+		// Reproduces `prepareCompaction` finding nothing to summarize (a single
+		// oversized latest turn) with nothing seeded for the tiered rescue to elide
+		// either — `runAutoCompaction` returns `automaticContinuationBlocked: true`
+		// directly (its own compaction-dead-end notice), with no history rewrite.
+		// `runRecoveryCompactionWithRollback` still restores the failed turn into
+		// active context before returning that result; the immediate/no-method
+		// dead ends clean that restoration up, but this already-blocked shape
+		// used to skip the cleanup entirely.
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		await createSession(200_000, undefined, { extraSettings: { "compaction.methodOrder": ["soft"] } });
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+
+		// Usage-backed overflow (not local-headroom-driven) so the top dead-end
+		// check doesn't intercept it before a compaction attempt is even made.
+		const assistantMsg = usageBackedPlainPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(notices.some(n => n.message.includes("Compaction freed too little context to make progress"))).toBe(true);
+
+		const lastActiveMessage = session.agent.state.messages.at(-1);
+		expect(lastActiveMessage?.role === "assistant" && lastActiveMessage.stopReason === "error").toBe(false);
+	});
+
+	it("keeps snapcompact excluded when usage-backed overflow and explicit media evidence co-occur (#11482)", async () => {
+		// `usageBackedMediaBudgetAssistant` reports usage above the window AND
+		// explicit media wording ("image count exceeds the limit of 20") in the
+		// same response. Usage proving a token overflow doesn't negate the
+		// provider's simultaneous image-count rejection — snapcompact must stay
+		// excluded (it would only add more image frames before retrying), even
+		// though the usage-backed exception alone would otherwise re-admit it.
+		await createSession(200_000, undefined, {
+			extraSettings: { "compaction.methodOrder": ["snapcompact"] },
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+
+		const assistantMsg = usageBackedMediaBudgetAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		// `snapcompact` is the only configured method; excluded, there is nothing
+		// left to attempt, so no compaction ever starts.
+		expect(startCount()).toBe(0);
+		const deadEndNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.level === "warning");
+		expect(deadEndNotices.length).toBe(1);
+		expect(deadEndNotices[0].message).toContain("IS a token-context problem");
+	});
+
 	it("does not exclude snapcompact from a usage-backed payload rejection with a known context window (#11482)", async () => {
 		// Plain (non-media) payload rejection, but reported usage (250k) exceeds
 		// the known 200k context window: `isUsageBackedContextOverflow` proves
@@ -801,6 +863,37 @@ describe("AgentSession payload-rejection 413 handling", () => {
 		expect(notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413")).length).toBe(0);
 		expect(promptSpy).not.toHaveBeenCalled();
 		expect(continueSpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps an explicit media rejection terminal on a known context window with no local headroom (#11482)", async () => {
+		// A known context window's `trustedPayloadRejection` only proves *local*
+		// headroom (`storedTokens < 90% of contextWindow`) — a low reported-usage,
+		// digit-free media rejection ("too many images") can still fail that check
+		// when the local estimate is near the ceiling, same as any other payload
+		// rejection. Before gating the terminal dead end to `contextWindow <= 0`,
+		// this fell through to a real promotion/compaction attempt despite the
+		// text already proving an image-count limit neither can raise.
+		await createSession(8_000, { toolText: "y".repeat(60_000) });
+		const prepareSpy = vi.spyOn(compactionModule, "prepareCompaction");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const notices = collectNotices();
+		const startCount = countCompactionEvents("auto_compaction_start");
+
+		const assistantMsg = explicitMediaNoDigitPayloadAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await session.waitForIdle();
+
+		expect(startCount()).toBe(0);
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+
+		const payloadNotices = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("413"));
+		expect(payloadNotices.length).toBe(1);
 	});
 
 	function activateOngoingGoal(id: string): void {


### PR DESCRIPTION
## Summary

Fixes the class of bug reported in #11479: a `PayloadRejected` HTTP 413 (byte/media rejection, `packages/ai/src/error/flags.ts`) on a model with an **unknown context window** (`contextWindow <= 0`, e.g. any custom/self-hosted OpenAI-compatible provider the model registry has no metadata for) always dead-ended in `session-maintenance.ts#checkCompaction` — automatic continuation was blocked with an honest "not a token problem" notice, but **compaction was never even attempted**, regardless of whether a compaction method was configured.

That's the right call when the 413 really is media/byte-budget driven (the scenario #9235 investigated: base64 image frames are "token-cheap but byte-expensive", so token compaction can't shrink them). But it's overly broad for a **non-ambiguous, non-media** payload rejection where the byte bloat is plain message-count growth — ordinary compaction (which drops/summarizes old turns) *does* shrink that. Self-hosted/custom providers are exactly the case most likely to have `contextWindow: null` in the registry, so they got permanently stuck on the first such 413 with no recovery path, replaying the same oversized history on every follow-up.

## What changed

`packages/coding-agent/src/session/session-maintenance.ts` (`checkCompaction`): compute compaction availability (`compactionSettings.enabled && (experimentalContextManagement || hasConfiguredCompactionMethod(...))`) *before* the payload-rejection dead-end check, and only take the immediate "no compaction possible" block when `contextWindow <= 0` **and** no compaction method is actually configured. When one is configured, the unknown-window case now falls into the same promotion/compaction attempt path a known-window overflow already gets — bounded by the same existing dead-end/rollback safety net (`runRecoveryCompactionWithRollback`) that already handles "compaction made no progress" gracefully.

The `trustedPayloadRejection` branch (known context window, provider-reported tokens under budget) is untouched — that's a different, well-evidenced case (proven local headroom) and stays a hard block.

## Tests

- Updated the two existing tests that exercised "unknown context window" payload rejections (`agent-session-payload-rejection-413.test.ts`) to explicitly disable compaction (`compaction.enabled: false`), since they were specifically asserting the "no compaction available" dead-end, which is unchanged.
- Added `attempts compaction for a payload-only 413 with no local context window when a compaction method is configured (#11479)` — asserts the new behavior: compaction starts, `prepareCompaction` is called, and no blocking "413" notice is emitted.
- `bun test packages/coding-agent/test/agent-session-payload-rejection-413.test.ts` — all passing locally (see CI).

## Flagging for discussion

Per @can1357's own note in #9235: *"whether omp should special-case byte-size 413s ... is a maintainer call"* — this PR takes one specific position on that (media-ambiguous stays blocked; non-ambiguous + unknown window gets a compaction attempt bounded by the existing safety net) but I want to flag the tradeoff explicitly rather than assume it's uncontroversial:

- Upside: self-hosted/custom-provider sessions (no registry `contextWindow`) that balloon in message count — not media — get a real recovery path instead of a permanent dead end.
- Risk: if a custom model *does* have heavy media in context and also has no registered `contextWindow`, this now spends a compaction cycle before reporting the dead end, instead of reporting it immediately. I believe this is safe (the existing tiered rescue already tries eliding/dropping images during that compaction attempt, and the dead-end/rollback path already produces a neutral "compaction made no progress" message if it doesn't help), but it is a behavior change in a deliberately-hardened area, so please weigh in if there's a case this doesn't account for.

Happy to adjust the gating (e.g. restrict to sessions with zero image content in the active branch) if that's the preferred shape.

Closes #11479 (proposes a fix for the auto-recovery gap; open to discussion on the exact policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
