### PR TITLE
fix(export): reject missing session inputs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `--export` now reports missing input files instead of creating empty sessions and successful transcript-less exports ([#11481](https://github.com/can1357/oh-my-pi/issues/11481)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/export/html/index.ts
+++ b/packages/coding-agent/src/export/html/index.ts
@@ -295,7 +295,10 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 
 	let sm: SessionManager;
 	try {
-		sm = await SessionManager.open(inputPath, undefined, undefined, { suppressBreadcrumb: true });
+		sm = await SessionManager.open(inputPath, undefined, undefined, {
+			suppressBreadcrumb: true,
+			throwIfMissing: true,
+		});
 	} catch (err) {
 		if (isEnoent(err)) throw new Error(`File not found: ${inputPath}`);
 		throw err;

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -33,6 +33,12 @@ export interface VisitEntriesFromFileStreamOptions {
 	onMalformedRecord?: () => void;
 }
 
+/** Controls how a missing session file is handled. */
+export interface LoadSessionOptions {
+	/** Propagate ENOENT instead of treating the path as a new empty session. */
+	throwIfMissing?: boolean;
+}
+
 /** Parsed session entries plus corruption metadata needed by writable loaders. */
 export interface SessionLoadResult {
 	entries: FileEntry[];
@@ -279,11 +285,14 @@ async function loadWithKnownSize(filePath: string, storage: SessionStorage, size
 export async function loadSessionFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	options: LoadSessionOptions = {},
 ): Promise<SessionLoadResult> {
 	try {
 		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
 	} catch (err) {
-		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		if (isEnoent(err) && !options.throwIfMissing) {
+			return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		}
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2921,14 +2921,15 @@ export class SessionManager {
 	 * Open a specific session file.
 	 * @param sessionDir Optional dir for /new or /branch; defaults to the file's parent.
 	 * @param options.initialCwd Cwd to use when the file is empty or missing.
+	 * @param options.throwIfMissing Propagate ENOENT instead of creating a new session at a missing path.
 	 */
 	static async open(
 		filePath: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { initialCwd?: string; suppressBreadcrumb?: boolean },
+		options?: { initialCwd?: string; suppressBreadcrumb?: boolean; throwIfMissing?: boolean },
 	): Promise<SessionManager> {
-		const loaded = await loadSessionFile(filePath, storage);
+		const loaded = await loadSessionFile(filePath, storage, { throwIfMissing: options?.throwIfMissing });
 		const header = loaded.entries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		// Resume into the session's recorded cwd only when it is verifiably
 		// accessible. A deleted or permission-blocked (macOS TCC denial) project

--- a/packages/coding-agent/test/export-subsessions.test.ts
+++ b/packages/coding-agent/test/export-subsessions.test.ts
@@ -89,6 +89,15 @@ describe("collectSubSessions", () => {
 		expect(html).not.toContain(subPreviousPath);
 	});
 
+	test("rejects a missing input without creating session or export files", async () => {
+		const missingInput = path.join(root, "missing.jsonl");
+		const outputPath = path.join(root, "export.html");
+
+		await expect(exportFromFile(missingInput, { outputPath })).rejects.toThrow(`File not found: ${missingInput}`);
+		expect(await Bun.file(missingInput).exists()).toBe(false);
+		expect(await Bun.file(outputPath).exists()).toBe(false);
+	});
+
 	test("skips corrupt, empty, backup, and non-jsonl files", async () => {
 		await Bun.write(path.join(root, "main/Good.jsonl"), sessionJsonl("good", ["g1"]));
 		await Bun.write(path.join(root, "main/corrupt.jsonl"), "{not json\n");


### PR DESCRIPTION
## Repro
Running `bun packages/coding-agent/src/cli.ts --export /tmp/omp-11481/missing.jsonl /tmp/omp-11481/export.html` with no input file exited 0, printed `Exported to: ...`, and created both a 425-byte empty session and a 392,276-byte transcript-less HTML export.

## Cause
`exportFromFile` in `packages/coding-agent/src/export/html/index.ts` expected `SessionManager.open` to propagate ENOENT, but `loadSessionFile` in `packages/coding-agent/src/session/session-loader.ts` deliberately converted ENOENT into an empty load result so explicit `--session` paths can create fresh sessions. `SessionManager.#setSessionFile` therefore materialized the missing export input before the existing error handler could run.

## Fix
- Added an opt-in `throwIfMissing` load/open mode while retaining missing-path creation for normal session opens.
- Enabled that mode only for standalone HTML exports, making the existing `File not found` mapping reachable.
- Added regression coverage that verifies neither the missing input nor requested output is created.
- Added the user-facing fix to the coding-agent changelog.

## Verification
`bun test test/export-subsessions.test.ts` passed 5 tests. `bun run check` passed for `packages/coding-agent` with one pre-existing unused-variable warning. A direct CLI run exited 1 with `Error: File not found: ...` and left the temporary directory empty.

Fixes #11481