### PR TITLE
coding-agent: guard-subset env merge, user-policy-conditional critical prompts, runtime trace TLS keys

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `omp claude-trace` now requires `openssl` on PATH for its MITM debug proxy and reports a targeted prerequisite error naming the missing dependency instead of an opaque spawn failure.
+
+### Fixed
+
+- Critical bash patterns now prompt in auto-approve modes (yolo, CLI `--auto-approve`) when no explicit user policy matches; an explicit `tools.approval.bash` allow/deny/policy remains authoritative.
+- Direnv-loaded environment no longer overrides the non-interactive credential-prompt guards.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/cli/claude-trace-cli.ts
+++ b/packages/coding-agent/src/cli/claude-trace-cli.ts
@@ -5,11 +5,14 @@
  * certificate, drives Claude Code through a headless PTY/xterm, and returns the
  * first completed /v1/messages request/response exchange.
  */
+import * as fs from "node:fs/promises";
 import * as net from "node:net";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as tls from "node:tls";
 import * as zlib from "node:zlib";
 import { PtySession } from "@oh-my-pi/pi-natives";
+import { $which } from "@oh-my-pi/pi-utils";
 import xterm from "@oh-my-pi/pi-utils/vterm";
 
 const DEFAULT_PROXY_HOST = "127.0.0.1";
@@ -24,57 +27,60 @@ const DOUBLE_CRLF = Buffer.from("\r\n\r\n", "latin1");
 const CRLF = Buffer.from("\r\n", "latin1");
 const TEXT_DECODER = new TextDecoder();
 
-// Debug-only local MITM certificate. Claude is launched with
-// NODE_TLS_REJECT_UNAUTHORIZED=0, so the certificate has no trust value; it only
-// lets Node's TLS stack complete the CONNECT tunnel handshake.
-export const CLAUDE_TRACE_DEBUG_CERT = `-----BEGIN CERTIFICATE-----
-MIIDFzCCAf+gAwIBAgIUAe9omAqLbydZc5ZYZGhwbbpMSF0wDQYJKoZIhvcNAQEL
-BQAwGzEZMBcGA1UEAwwQb21wLWNsYXVkZS10cmFjZTAeFw0yNjA2MDIwODA2MjFa
-Fw0zNjA1MzAwODA2MjFaMBsxGTAXBgNVBAMMEG9tcC1jbGF1ZGUtdHJhY2UwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmpGe5T8B0oA2L82Rn5JJdXOBS
-ZX0DyBjiIK+Tqe8T3oAr41XDLnweqtrMDSBDYbVqAoKjNbaTUSYYcxSm0MAVs63w
-08SfJmShZM9pElfANqXqMiyhksFgji7JEyt/rbbId207a7s5KvRvm3g/sxN/wGtr
-C5LCLMlc2GWEGD8qrVIQbmLw884qvtXi70RFUPP3Wpy4wGMWSdE+9IA27R5cMJS5
-oHsO4HGB6J8VzLY+HGY2yr4BJ9qrAyjd1UetFd9RdcjyWpsbAfX8nWP+uleTNOiT
-ExNz7dPt/k6OPLNmI1iT/ruRS0uUzHZTimPd67TPQR/70RaW7Bh5wArawGw9AgMB
-AAGjUzBRMB0GA1UdDgQWBBQa4Ir8P3GAolZoPiuB4V2cq3riAjAfBgNVHSMEGDAW
-gBQa4Ir8P3GAolZoPiuB4V2cq3riAjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
-DQEBCwUAA4IBAQClPYki235gDEUu7eDm60qsAGWxbKVv4pSh+vB+xgNgzMk4aOuU
-mSfp8Y8covwklph8VfDoKTaEGqqX0Q5s74Ctl6Mwy7b0u8Zztk/g4GynLocI7TQD
-ftZMgZka49+FkEsjp+XZtQbO4vOL5UsccpsLhFQQQuhVyiJ4gNo/VzgvSDkBuf3Q
-Rz7xFiDKCqFEoMPty4+nKEw5832FJ5mDCOyMk6fGSO8Wbt/hmRQQFu2cSdoBs0OT
-AQQJETQjPkKeTDX4jdSAlOeKwfyjfdfgeQuMkzX8xafisJa66MLPzOVbIuGbvbWD
-QVCd76iYPcfNK+JZUhmAUvTHSuwgJMZ6+NgI
------END CERTIFICATE-----`;
-
-export const CLAUDE_TRACE_DEBUG_KEY = `-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCmpGe5T8B0oA2L
-82Rn5JJdXOBSZX0DyBjiIK+Tqe8T3oAr41XDLnweqtrMDSBDYbVqAoKjNbaTUSYY
-cxSm0MAVs63w08SfJmShZM9pElfANqXqMiyhksFgji7JEyt/rbbId207a7s5KvRv
-m3g/sxN/wGtrC5LCLMlc2GWEGD8qrVIQbmLw884qvtXi70RFUPP3Wpy4wGMWSdE+
-9IA27R5cMJS5oHsO4HGB6J8VzLY+HGY2yr4BJ9qrAyjd1UetFd9RdcjyWpsbAfX8
-nWP+uleTNOiTExNz7dPt/k6OPLNmI1iT/ruRS0uUzHZTimPd67TPQR/70RaW7Bh5
-wArawGw9AgMBAAECggEADX2mhA3H0pPuj35J36X/5Me9xWM//AwOr6febwGalazg
-Ctg3EOZ01/VptzaiKQetAdhoLmxidooNn9HD7JQJKPid7q7w7m1+R26mN/xrLD2A
-WyBqv+iQoo+ANs5y1BMChuIxmVY/FwFk6UWDNlekuXqgzPln4okbrYTmBbaszniO
-Mu1SI/3fpnTA3iJ634FUSRVoUPP8r0WEEUtpW1wAhsJR701gvKRYw/+YcRglkhm7
-T4l6TuBcgIVzUqAc3oZLHVIMKN0ZprZSeopSRozTcUANfYONakvK9Hx1qf+/rmTR
-qZHg2uOxlqvxyABnwdk8rmyFx8YqUeN9jaAbbXxtBQKBgQDQRjc0gVg4STqcFqUu
-FW35MZ88S7+xTuRd/EG1dpsu2lptx1yhSLTsF5GfxBQKXCQUfWrpkyuCmlV6s+wJ
-H0LSyAJQ4ffBsFterQz7dRKTlhRJNk5PYn8jjNCAuBYVSbQZqZ3yZgG3CT3G5+PZ
-8Ln3tJHqTRfP5B8KTMcNYiLI0wKBgQDM0/gdb9Dvdz/32GIpxwNNIb52IxnNVVrm
-M69+4XNg6CqvctZFuaMQ03W2J5IKAdESaCGLz9pwHZRjfBORcw3BPKD2QkfN5NJg
-hWvLlfAsblCYiCCjTCB6rf1OJOQ5fHoNFh1wqDaQCk0flsb9nlZmQQR5ZUHaJhSC
-QqMmeKvMrwKBgQDDzp+sH0Z/dGlDwg59auw/caWRHG4WFmOg8L4eCmoO/H4z41B0
-2VQu+mGQYNmue733/Yl8Gz62xL5EY88vLFK4tA1pWWiCknj0Y6Fm70QNuPVNd17c
-R2/cTlDgEzG/xdEqp0q1T62hFXEdBXoztZxBA2SDcQNIEeIU3uXs8SxevQKBgFp4
-acf+wody4aNERR900sV32RtvJ49lWxAA1kwxone0NF5oV7JWa2scK4r4cW3QHZuG
-uQJ7HV2WAxvqCu6cpf+rGuGKpxKPNkkBxXoX0Qye8SReRCQ8lL/7J74jV1b43yP2
-l6xR8D+w/R2tyFjvXfQuVZ6VFgAX/8kFS/DLLf7rAoGAcnFgCwyzcq6FWL8iW23J
-GnbZ0IQk6SPch87MzMmnOFlEXrCf5l832vwI65tNzOoB0yQoWVfBv5sb4Zy9zeFj
-FbkpRZC0Kfi9PLzDV4IawoIINYthOJxIKJg+yrmrUWCggXxwdzYIYKLRIskMXoYs
-mNMXfUstElEcKO7+DKiPi6U=
------END PRIVATE KEY-----`;
+// Debug-only MITM TLS material, generated per session with `openssl req
+// -x509` into a private temp dir and read into memory before the dir is
+// removed — nothing persists beyond the process. Claude is launched with
+// NODE_TLS_REJECT_UNAUTHORIZED=0, so the certificate has no trust value; it
+// only lets Node's TLS stack complete the CONNECT tunnel handshake.
+interface ClaudeTraceTlsMaterial {
+	cert: string;
+	key: string;
+}
+async function generateClaudeTraceTlsMaterial(): Promise<ClaudeTraceTlsMaterial> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-claude-trace-"));
+	const certPath = path.join(dir, "cert.pem");
+	const keyPath = path.join(dir, "key.pem");
+	const opensslPath = $which("openssl");
+	if (!opensslPath) {
+		throw new Error(
+			"`omp claude-trace` requires the `openssl` executable, which was not found on PATH. " +
+				"openssl generates the temporary TLS key/certificate used by the local trace proxy; " +
+				"install it and retry.",
+		);
+	}
+	try {
+		const proc = Bun.spawn(
+			[
+				opensslPath,
+				"req",
+				"-x509",
+				"-newkey",
+				"rsa:2048",
+				"-nodes",
+				"-days",
+				"1",
+				"-subj",
+				"/CN=omp-claude-trace",
+				"-keyout",
+				keyPath,
+				"-out",
+				certPath,
+			],
+			{ stdin: "ignore", stdout: "ignore", stderr: "pipe" },
+		);
+		const [stderr, exitCode] = await Promise.all([
+			new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+			proc.exited,
+		]);
+		if (exitCode !== 0) {
+			throw new Error(`openssl req -x509 failed (exit ${exitCode}): ${stderr.trim()}`);
+		}
+		const [cert, key] = await Promise.all([Bun.file(certPath).text(), Bun.file(keyPath).text()]);
+		return { cert, key };
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
 
 export interface HeaderEntry {
 	name: string;
@@ -467,6 +473,7 @@ export class ClaudeMessagesProxy {
 	#waiters: CaptureWaiter[] = [];
 	#stopped = false;
 	#port = 0;
+	#tlsMaterial: ClaudeTraceTlsMaterial | null = null;
 
 	constructor(options: ClaudeMessagesProxyOptions = {}) {
 		this.#host = options.host ?? DEFAULT_PROXY_HOST;
@@ -488,6 +495,9 @@ export class ClaudeMessagesProxy {
 
 	async start(): Promise<void> {
 		if (this.#server) return;
+		// Generate before the listener opens so every CONNECT tunnel has
+		// material available; only one session-scoped keypair per proxy run.
+		this.#tlsMaterial = await generateClaudeTraceTlsMaterial();
 		const server = net.createServer(socket => this.#handleConnection(socket));
 		this.#server = server;
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
@@ -628,11 +638,18 @@ export class ClaudeMessagesProxy {
 	}
 
 	#openMitmTunnel(socket: net.Socket, target: ConnectTarget, rest: Buffer): void {
+		const material = this.#tlsMaterial;
+		if (!material) {
+			// start() always generates before the listener opens; unreachable
+			// in practice, but a socket callback must never throw.
+			socket.destroy();
+			return;
+		}
 		const clientTls = this.#track(
 			new tls.TLSSocket(socket, {
 				isServer: true,
-				cert: CLAUDE_TRACE_DEBUG_CERT,
-				key: CLAUDE_TRACE_DEBUG_KEY,
+				cert: material.cert,
+				key: material.key,
 				ALPNProtocols: ["http/1.1"],
 			}),
 		);

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -28,6 +28,7 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	EDITOR: "true",
 	GIT_TERMINAL_PROMPT: "0",
 	SSH_ASKPASS: REJECT_PROMPT_COMMAND,
+	GIT_ASKPASS: REJECT_PROMPT_COMMAND,
 	CI: "true",
 	AGENT: "1",
 	// Package manager defaults for unattended execution.
@@ -51,6 +52,32 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	COMPOSER_NO_INTERACTION: "1",
 	CLOUDSDK_CORE_DISABLE_PROMPTS: "1",
 };
+
+/**
+ * Keys forced over per-command override maps: they suppress credential and
+ * editor prompts, so override-provided env (e.g. direnv output, per-command
+ * assignments) must not weaken them. All other keys keep user precedence:
+ * overrides win over defaults.
+ */
+const GUARD_ENV_KEYS: ReadonlyArray<string> = [
+	"SSH_ASKPASS",
+	"GIT_ASKPASS",
+	"GIT_TERMINAL_PROMPT",
+	"GIT_EDITOR",
+	"EDITOR",
+	"VISUAL",
+	"CI",
+];
+
+/** Guard-key entries present in `env`, to be merged last over override maps. */
+function guardEntries(env: Readonly<Record<string, string>>): Record<string, string> {
+	const guards: Record<string, string> = {};
+	for (const key of GUARD_ENV_KEYS) {
+		const value = env[key];
+		if (value !== undefined) guards[key] = value;
+	}
+	return guards;
+}
 
 const WINDOWS_UTF8_ENV_DEFAULT_GROUPS: ReadonlyArray<ReadonlyArray<readonly [key: string, value: string]>> = [
 	[
@@ -119,7 +146,11 @@ export function buildNonInteractiveEnv(
 	const base =
 		baseEnv.PI_BASH_NO_CI || baseEnv.CLAUDE_BASH_NO_CI ? withoutCI(NON_INTERACTIVE_ENV) : NON_INTERACTIVE_ENV;
 	if (platform !== "win32") {
-		return overrides ? { ...base, ...overrides } : base;
+		if (!overrides) return base;
+		// Guard keys must beat overrides (e.g. direnv-provided env arrives here
+		// and must not re-enable credential or editor prompts); non-guard
+		// override keys still pass through over the defaults.
+		return { ...base, ...overrides, ...guardEntries(base) };
 	}
 
 	const env: Record<string, string> = { ...base };
@@ -131,5 +162,5 @@ export function buildNonInteractiveEnv(
 			env[key] = value;
 		}
 	}
-	return overrides ? { ...env, ...overrides } : env;
+	return overrides ? { ...env, ...overrides, ...guardEntries(env) } : env;
 }

--- a/packages/coding-agent/src/secrets/index.ts
+++ b/packages/coding-agent/src/secrets/index.ts
@@ -181,8 +181,8 @@ export async function loadSecrets(cwd: string, agentDir: string): Promise<Secret
 /** Minimum env var value length to consider as a secret. */
 const MIN_ENV_VALUE_LENGTH = 8;
 
-/** Env var name patterns that indicate secret values. */
-const SECRET_ENV_PATTERNS = /(?:KEY|SECRET|TOKEN|PASSWORD|PASS|AUTH|CREDENTIAL|PRIVATE|OAUTH)(?:_|$)/i;
+/** Env var name patterns that indicate secret values (incl. BEARER/JWT-shaped names). */
+const SECRET_ENV_PATTERNS = /(?:KEY|SECRET|TOKEN|PASSWORD|PASS|AUTH|CREDENTIAL|PRIVATE|OAUTH|BEARER|JWT)(?:_|$)/i;
 
 /** Collect environment variable values that look like secrets. */
 export function collectEnvSecrets(): SecretEntry[] {

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -114,8 +114,9 @@ function modeApprovesTier(mode: ApprovalMode, tier: ToolTier): boolean {
  *  2. User per-tool override, if set and valid.
  *  3. Active mode tier comparison.
  *
- * In yolo mode, override-based tool prompts are ignored; user `tools.approval`
- * settings remain authoritative.
+ * In yolo mode, override-based tool prompts are ignored and user
+ * `tools.approval` settings remain authoritative; a tool-demanded safety
+ * prompt applies only when no explicit user policy matched.
  */
 export function resolveApproval(
 	tool: ApprovalSubject,
@@ -154,9 +155,9 @@ export function resolveApproval(
 	}
 
 	if (mode === "yolo") {
-		if (decision.policy) {
+		if (decision.policy === "allow") {
 			return {
-				policy: decision.policy,
+				policy: "allow",
 				tier: decision.tier,
 				override: false,
 				source: "tool",
@@ -164,13 +165,29 @@ export function resolveApproval(
 				...(decision.reason ? { reason: decision.reason } : {}),
 			};
 		}
-		return {
-			policy: effectiveUserPolicy ?? "allow",
-			tier: decision.tier,
-			override: false,
-			source: effectiveUserPolicy ? "user" : "mode",
-			...(effectiveUserPolicy ? { policyKey: userPolicyKey } : {}),
-		};
+		if (effectiveUserPolicy) {
+			return {
+				policy: effectiveUserPolicy,
+				tier: decision.tier,
+				override: false,
+				source: "user",
+				policyKey: userPolicyKey,
+			};
+		}
+		if (decision.policy === "prompt") {
+			// Tool-demanded safety prompts (e.g. critical bash patterns) force a
+			// prompt only when no explicit user policy matched — user
+			// `tools.approval` settings remain authoritative in yolo mode.
+			return {
+				policy: "prompt",
+				tier: decision.tier,
+				override: false,
+				source: "tool",
+				...(decision.policyKey ? { policyKey: decision.policyKey } : {}),
+				...(decision.reason ? { reason: decision.reason } : {}),
+			};
+		}
+		return { policy: "allow", tier: decision.tier, override: false, source: "mode" };
 	}
 
 	if (decision.override) {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -632,7 +632,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		}
 		const criticalCommand = command !== "" && CRITICAL_BASH_PATTERNS.some(pattern => pattern.test(command));
 		if (!compoundSegments && criticalCommand) {
-			return { tier: "exec", override: true, reason: "Critical pattern detected" };
+			return { tier: "exec", override: true, policy: "prompt", reason: "Critical pattern detected" };
 		}
 		if (compoundSegments) {
 			let promptRule: BashApprovalPatternRule | undefined = patternRule;
@@ -661,7 +661,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			for (const segment of compoundSegments) {
 				const literalCommand = segment.argv.join(" ");
 				if (criticalCommand || CRITICAL_BASH_PATTERNS.some(pattern => pattern.test(literalCommand))) {
-					return { tier: "exec", override: true, reason: "Critical pattern detected" };
+					return { tier: "exec", override: true, policy: "prompt", reason: "Critical pattern detected" };
 				}
 			}
 			// Unmatched segments retain the standalone tool-policy and mode fallback.

--- a/packages/coding-agent/test/claude-trace-cli.test.ts
+++ b/packages/coding-agent/test/claude-trace-cli.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { runClaudeMessagesCapture } from "../src/cli/claude-trace-cli";
+
+// Contract: when the `openssl` executable is missing, `omp claude-trace` must
+// surface a targeted prerequisite error — naming openssl and its purpose
+// (generating the temporary TLS key/certificate for the local trace proxy) —
+// instead of the opaque Bun.spawn failure that used to escape from proxy
+// startup on Windows/minimal installs.
+describe("claude-trace openssl prerequisite", () => {
+	test("missing openssl surfaces a targeted prerequisite error before the proxy starts", async () => {
+		const which = spyOn(piUtils, "$which").mockReturnValue(null);
+		let error: unknown;
+		try {
+			try {
+				await runClaudeMessagesCapture({});
+			} catch (caught) {
+				error = caught;
+			}
+		} finally {
+			which.mockRestore();
+		}
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toMatch(/openssl/);
+		expect(message).toMatch(/TLS key\/certificate/);
+	});
+});

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { buildNonInteractiveEnv, NON_INTERACTIVE_ENV } from "@oh-my-pi/pi-coding-agent/exec/non-interactive-env";
+import {
+	buildNonInteractiveEnv,
+	NON_INTERACTIVE_ENV,
+	REJECT_PROMPT_COMMAND,
+} from "@oh-my-pi/pi-coding-agent/exec/non-interactive-env";
 
 describe("buildNonInteractiveEnv", () => {
 	it("defaults Windows child-process encoding to UTF-8 when inherited env is unset", () => {
@@ -83,6 +87,47 @@ describe("buildNonInteractiveEnv", () => {
 
 	it("lets a per-command CI override win over the opt-out", () => {
 		expect(buildNonInteractiveEnv({ CI: "0" }, { PI_BASH_NO_CI: "1" }, "linux").CI).toBe("0");
+	});
+
+	it("lets non-guard overrides win over defaults (TERM stays overridable)", () => {
+		const env = buildNonInteractiveEnv({ TERM: "xterm-256color" }, {}, "linux");
+
+		expect(env.TERM).toBe("xterm-256color");
+	});
+
+	it("forces credential and editor prompt guards over per-command overrides", () => {
+		const evil = "/evil/askpass";
+		const env = buildNonInteractiveEnv(
+			{
+				SSH_ASKPASS: evil,
+				GIT_ASKPASS: evil,
+				GIT_TERMINAL_PROMPT: "1",
+				GIT_EDITOR: evil,
+				EDITOR: evil,
+				VISUAL: evil,
+			},
+			{},
+			"linux",
+		);
+
+		expect(env.SSH_ASKPASS).toBe(REJECT_PROMPT_COMMAND);
+		expect(env.GIT_ASKPASS).toBe(REJECT_PROMPT_COMMAND);
+		expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+		expect(env.GIT_EDITOR).toBe("true");
+		expect(env.EDITOR).toBe("true");
+		expect(env.VISUAL).toBe("true");
+	});
+
+	it("passes direnv-style overrides through for non-guard keys", () => {
+		const env = buildNonInteractiveEnv(
+			{ DIRENV_DIR: "-/project", DIRENV_DIFF: "abc123", MY_VAR: "hello" },
+			{},
+			"linux",
+		);
+
+		expect(env.DIRENV_DIR).toBe("-/project");
+		expect(env.DIRENV_DIFF).toBe("abc123");
+		expect(env.MY_VAR).toBe("hello");
 	});
 });
 

--- a/packages/coding-agent/test/tools/approval-mode.test.ts
+++ b/packages/coding-agent/test/tools/approval-mode.test.ts
@@ -157,6 +157,42 @@ describe("tools.approvalMode setting", () => {
 		expect(textOf(result)).toContain("(no output)");
 	});
 
+	it("critical bash patterns prompt in yolo mode with no user policy", async () => {
+		const settings = approvalSettings({
+			"tools.approvalMode": "yolo",
+			"tools.approval": {},
+		});
+		await expect(
+			bashTool().execute(
+				"critical-no-policy",
+				{ command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
+				undefined,
+				undefined,
+				{
+					settings,
+				} as AgentToolContext,
+			),
+		).rejects.toThrow(/requires approval but no interactive UI available/);
+	});
+
+	it("critical bash patterns prompt in write mode", async () => {
+		const settings = approvalSettings({
+			"tools.approvalMode": "write",
+			"tools.approval": {},
+		});
+		await expect(
+			bashTool().execute(
+				"critical-write-mode",
+				{ command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
+				undefined,
+				undefined,
+				{
+					settings,
+				} as AgentToolContext,
+			),
+		).rejects.toThrow(/requires approval but no interactive UI available/);
+	});
+
 	it("attributes bash pattern denies to tool policy", async () => {
 		const settings = approvalSettings({
 			"tools.approvalMode": "yolo",
@@ -178,10 +214,31 @@ describe("tools.approvalMode setting", () => {
 		expect(textOf(result)).toContain("override");
 	});
 
-	it("CLI --auto-approve also bypasses safety-override patterns", async () => {
+	it("CLI --auto-approve still prompts critical patterns with no user policy", async () => {
+		// Critical-pattern safety prompts apply in auto-approve modes when no
+		// explicit user policy matched; see resolveApproval's yolo branch.
 		const settings = approvalSettings({ "tools.approvalMode": "always-ask" });
+		await expect(
+			bashTool().execute(
+				"cli-critical",
+				{ command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
+				undefined,
+				undefined,
+				{
+					settings,
+					autoApprove: true,
+				} as AgentToolContext,
+			),
+		).rejects.toThrow(/requires approval but no interactive UI available/);
+	});
+
+	it("CLI --auto-approve honors an explicit bash allow policy for critical patterns", async () => {
+		const settings = approvalSettings({
+			"tools.approvalMode": "always-ask",
+			"tools.approval": { bash: "allow" },
+		});
 		const result = await bashTool().execute(
-			"cli-critical",
+			"cli-critical-allowed",
 			{ command: "rm -f /tmp/bun-fake-timer-probe.test.ts" },
 			undefined,
 			undefined,


### PR DESCRIPTION
## Summary

Security-review hardening for the exec/env/approval path, split out of #11443 per review feedback:

- **Non-interactive env**: only an explicit guard subset (`SSH_ASKPASS`, `GIT_ASKPASS`, `GIT_TERMINAL_PROMPT`, `GIT_EDITOR`, `EDITOR`, `VISUAL`, `CI`) overrides per-command/direnv-provided env. Every other default (`TERM`, pagers, `npm_config_*`) stays overridable — direnv env can no longer re-enable credential prompts or pagers, but legitimate overrides no longer regress.
- **Approval**: the yolo branch keeps user policy strictly authoritative; the built-in `CRITICAL_BASH_PATTERNS` force a prompt only when no user policy matched. The existing allowed-yolo pin is preserved and passing.
- **claude-trace**: MITM TLS material is generated at runtime (per-session, temp dir, never persisted) instead of shipping an embedded private key; a missing `openssl` binary surfaces a targeted prerequisite error via the repo's `` helper.
- **secrets**: env-secret name patterns now cover `BEARER_*`/JWT-shaped names.

## Tests

Focused suites pass: `approval-mode` (15, incl. critical+yolo+no-policy→prompt, critical+allow→allow), `non-interactive-env` (15, guarded + non-guard + direnv passthrough + CI opt-out + win32 UTF-8), `claude-trace-cli` (hermetic missing-openssl case). `bun run check:ts` green across the workspace.