### PR TITLE
pi-ai: credential-store file permissions + request-debug redaction

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed auth credential store file permissions: the SQLite database and its WAL/SHM sidecars are chmod'ed owner-only (0600) independently, so a missing sidecar no longer leaves another one world-readable from an earlier run.
+- Fixed `PI_REQ_DEBUG` session logs leaking sensitive response headers: the `.res.log` header block now redacts `authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `cookie`, and `set-cookie` values, matching the redaction already applied to request dumps.
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/ai/src/auth-broker/server.ts
+++ b/packages/ai/src/auth-broker/server.ts
@@ -55,7 +55,7 @@ export interface AuthBrokerServerOptions {
 	storage: AuthStorage;
 	/** Listen address; accepts `host:port` or just `port`. */
 	bind?: string;
-	/** Accept any of these bearer tokens. Empty disables auth (loopback only). */
+	/** Accept any of these bearer tokens. An empty set only allows unauthenticated access on a loopback bind. */
 	bearerTokens: string[];
 	/** Broker version string surfaced on `/v1/healthz`. */
 	version?: string;
@@ -97,8 +97,15 @@ function empty(status: number, headers?: Record<string, string>): Response {
 	return new Response(null, { status, headers });
 }
 
-function isAuthorized(req: Request, tokens: ReadonlySet<string>): boolean {
-	if (tokens.size === 0) return true;
+/**
+ * Invariant: an empty token set never grants unauthenticated access on a
+ * non-loopback bind. `allowUnauthenticated` is true only when the caller
+ * explicitly opted in (empty token set) AND the server is bound to loopback,
+ * where no off-host peer can reach it anyway. Every other case requires a
+ * matching bearer token — fail closed.
+ */
+function isAuthorized(req: Request, tokens: ReadonlySet<string>, allowUnauthenticated: boolean): boolean {
+	if (allowUnauthenticated) return true;
 	const header = req.headers.get("authorization");
 	if (!header) return false;
 	const match = header.match(/^Bearer\s+(.+)$/i);
@@ -648,6 +655,16 @@ function serveSnapshotStream(
 export function startAuthBroker(opts: AuthBrokerServerOptions): AuthBrokerServerHandle {
 	const bind = parseBind(opts.bind ?? DEFAULT_AUTH_BROKER_BIND);
 	const tokens = new Set<string>(opts.bearerTokens);
+	// Empty token set = explicit unauthenticated opt-in, tolerated only on a
+	// loopback bind (see {@link isAuthorized}); any non-loopback bind always
+	// enforces bearer auth — fail closed.
+	// parseBind retains brackets on `[::1]`, and Bun may report either form.
+	const allowUnauthenticated =
+		tokens.size === 0 &&
+		(bind.hostname === "localhost" ||
+			bind.hostname === "127.0.0.1" ||
+			bind.hostname === "::1" ||
+			bind.hostname === "[::1]");
 	const version = opts.version;
 	const streamKeepaliveMs = opts.streamKeepaliveMs ?? DEFAULT_STREAM_KEEPALIVE_MS;
 	const externalChangePollMs = opts.externalChangePollMs ?? DEFAULT_EXTERNAL_CHANGE_POLL_MS;
@@ -676,7 +693,7 @@ export function startAuthBroker(opts: AuthBrokerServerOptions): AuthBrokerServer
 					const body: HealthzResponse = { ok: true, version };
 					return json(200, body);
 				}
-				if (!isAuthorized(req, tokens)) {
+				if (!isAuthorized(req, tokens, allowUnauthenticated)) {
 					logger.info("auth-broker request unauthorized", { method: req.method, path: pathname, peer });
 					return json(401, { error: "unauthorized" });
 				}

--- a/packages/ai/src/auth/sqlite-credential-store.ts
+++ b/packages/ai/src/auth/sqlite-credential-store.ts
@@ -12,6 +12,7 @@ import { parseCloudflareAiGatewayCredential } from "@oh-my-pi/pi-catalog/wire/cl
 import {
 	getAgentDbPath,
 	getDbBusyTimeoutMs,
+	isEnoent,
 	isSqliteBusyError,
 	isSqliteCorruptionError,
 	logger,
@@ -528,6 +529,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		let lastBusyError: Error | undefined;
 		for (let attempt = 0; attempt < maxAttempts; attempt++) {
 			let db: Database | undefined;
+			// Pre-create the file with owner-only permissions: `new Database`
+			// would otherwise create it with default (world-readable) perms, and
+			// this DB holds provider credentials. Opening with "a" is a no-op
+			// when the file already exists.
+			const preCreated = await fs.open(dbPath, "a", 0o600);
+			await preCreated.close();
 			try {
 				db = new Database(dbPath);
 				// Install the busy handler BEFORE the first lock-taking statement
@@ -536,10 +543,21 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				// non-zero `busy_timeout` they fail immediately with SQLITE_BUSY.
 				// See issue #2421.
 				SqliteAuthCredentialStore.#installBusyTimeout(db);
-				try {
-					await fs.chmod(dbPath, 0o600);
-				} catch {
-					// Ignore chmod failures (e.g., Windows)
+				// Tighten permissions after open: the main file may predate the
+				// 0600 pre-create, and the WAL/SHM sidecars may survive from an
+				// earlier run. Sidecars are legitimately absent on a fresh DB
+				// (ENOENT); chmod itself is unsupported on some platforms
+				// (e.g. Windows) — log that instead of silently swallowing it.
+				// Each path is hardened independently so one expected absence
+				// (or one failure) cannot suppress hardening of the others.
+				for (const hardenPath of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+					try {
+						await fs.chmod(hardenPath, 0o600);
+					} catch (err) {
+						if (!isEnoent(err)) {
+							logger.debug("auth db chmod skipped", { path: hardenPath, error: String(err) });
+						}
+					}
 				}
 				SqliteAuthCredentialStore.#ensureAuthCredentialRefreshLeasesTable(db);
 				return new SqliteAuthCredentialStore(db);

--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -172,14 +172,15 @@ function redactHeaders(headers: Record<string, string> | undefined): Record<stri
  * names case-insensitively. Header names are preserved so dumps still show
  * what was sent. Single shared implementation for every dump path
  * (http-inspector error dumps and request-debug session logs alike).
+ * Returns a new record; the input is never mutated (callers may pass shared
+ * header state, e.g. provider request contexts).
  */
 export function redactSensitiveHeaderValues<T>(headers: Record<string, T>): Record<string, T> {
+	const redacted: Record<string, T> = {};
 	for (const key in headers) {
-		if (SENSITIVE_HEADERS.includes(key.toLowerCase())) {
-			headers[key] = "[redacted]" as T;
-		}
+		redacted[key] = SENSITIVE_HEADERS.includes(key.toLowerCase()) ? ("[redacted]" as T) : headers[key];
 	}
-	return headers;
+	return redacted;
 }
 
 function formatCapturedHttpError(captured: CapturedHttpErrorResponse | undefined): string | undefined {

--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -164,16 +164,22 @@ function redactHeaders(headers: Record<string, string> | undefined): Record<stri
 	if (!headers) {
 		return undefined;
 	}
+	return redactSensitiveHeaderValues(headers);
+}
 
-	const redacted: Record<string, string> = {};
-	for (const [key, value] of Object.entries(headers)) {
+/**
+ * Replace the values of sensitive headers with a fixed marker, matching header
+ * names case-insensitively. Header names are preserved so dumps still show
+ * what was sent. Single shared implementation for every dump path
+ * (http-inspector error dumps and request-debug session logs alike).
+ */
+export function redactSensitiveHeaderValues<T>(headers: Record<string, T>): Record<string, T> {
+	for (const key in headers) {
 		if (SENSITIVE_HEADERS.includes(key.toLowerCase())) {
-			redacted[key] = "[redacted]";
-			continue;
+			headers[key] = "[redacted]" as T;
 		}
-		redacted[key] = value;
 	}
-	return redacted;
+	return headers;
 }
 
 function formatCapturedHttpError(captured: CapturedHttpErrorResponse | undefined): string | undefined {

--- a/packages/ai/src/utils/request-debug.ts
+++ b/packages/ai/src/utils/request-debug.ts
@@ -1,12 +1,12 @@
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs/promises";
+import { redactSensitiveHeaderValues } from "./http-inspector";
 
 const REQUEST_DEBUG_ENV = "PI_REQ_DEBUG";
 const textEncoder = new TextEncoder();
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 let nextSessionId = 1;
-
 type RequestBodyInit = NonNullable<RequestInit["body"]>;
 
 type RequestDebugBody = { body: unknown } | { bodyText: string } | { bodyBase64: string } | { bodyUnavailable: string };
@@ -62,7 +62,7 @@ export async function createRequestDebugSession(payload: RequestDebugPayload): P
 		url: payload.url,
 	};
 	const headers = headersToRecord(payload.headers);
-	if (headers) requestDump.headers = headers;
+	if (headers) requestDump.headers = redactSensitiveHeaderValues(headers);
 	if (payload.body !== undefined) requestDump.body = payload.body;
 	if (payload.bodyText !== undefined) requestDump.bodyText = payload.bodyText;
 	if (payload.bodyBase64 !== undefined) requestDump.bodyBase64 = payload.bodyBase64;
@@ -289,7 +289,7 @@ function looksLikeJson(text: string): boolean {
 
 function formatResponseHeaderBlock(statusLine: string, headers?: RequestDebugHeaders): string {
 	const lines = [statusLine];
-	const record = headersToRecord(headers);
+	const record = redactSensitiveHeaderValues(headersToRecord(headers) ?? {});
 	if (record) {
 		for (const name in record) {
 			const value = record[name];
@@ -320,6 +320,7 @@ function headersToRecord(headers: RequestDebugHeaders): Record<string, string | 
 			record[key] = Array.isArray(value) ? value.map(String) : String(value);
 		}
 	}
+
 	return hasHeaders ? record : undefined;
 }
 

--- a/packages/ai/test/auth-broker-empty-tokens.test.ts
+++ b/packages/ai/test/auth-broker-empty-tokens.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Contract: an EMPTY bearerTokens set is only an unauthenticated opt-in on a
+ * loopback bind (see `startAuthBroker`'s `allowUnauthenticated` gate). A
+ * non-loopback bind with no tokens must fail closed — the health probe stays
+ * public so liveness checks keep working, but every protected route requires
+ * a bearer token no caller can possess.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { type AuthBrokerServerHandle, startAuthBroker } from "@oh-my-pi/pi-ai/auth-broker";
+import { removeWithRetries } from "../../utils/src/temp";
+
+describe("broker with empty bearerTokens on a non-loopback bind", () => {
+	let tempDir = "";
+	let storage: AuthStorage | undefined;
+	let handle: AuthBrokerServerHandle | undefined;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auth-broker-empty-tokens-"));
+		const store = await SqliteAuthCredentialStore.open(path.join(tempDir, "broker.db"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+		// 0.0.0.0 bind with zero tokens: unauthenticated access must stay OFF.
+		handle = startAuthBroker({
+			storage,
+			bind: "0.0.0.0:0",
+			bearerTokens: [],
+			disableRefresher: true,
+		});
+	});
+
+	afterEach(async () => {
+		await handle?.close();
+		storage?.close();
+		await removeWithRetries(tempDir);
+	});
+
+	/** Connect via loopback regardless of the bind address the server reports. */
+	function loopbackUrl(pathname: string): string {
+		return `http://127.0.0.1:${handle!.port}${pathname}`;
+	}
+
+	test("health endpoint stays public and protected routes reject without a token", async () => {
+		const health = await fetch(loopbackUrl("/v1/healthz"));
+		expect(health.status).toBe(200);
+		expect(await health.json()).toMatchObject({ ok: true });
+
+		const snapshot = await fetch(loopbackUrl("/v1/snapshot"));
+		expect(snapshot.status).toBe(401);
+		expect(await snapshot.json()).toEqual({ error: "unauthorized" });
+
+		// Any presented bearer token fails too: the token set is empty, so no
+		// value can ever match.
+		const bearer = await fetch(loopbackUrl("/v1/snapshot"), {
+			headers: { authorization: "Bearer whatever" },
+		});
+		expect(bearer.status).toBe(401);
+	});
+});

--- a/packages/ai/test/request-debug.test.ts
+++ b/packages/ai/test/request-debug.test.ts
@@ -156,13 +156,64 @@ describe("PI_REQ_DEBUG request/response recording", () => {
 			url: "https://provider.test/v1/messages",
 			body: { model: "debug-model", messages: [{ role: "user", content: "hi" }] },
 		});
-		expect(request.headers).toMatchObject({ authorization: "Bearer test-token", "content-type": "application/json" });
+		expect(request.headers).toMatchObject({ authorization: "[redacted]", "content-type": "application/json" });
 
 		const log = splitResponseLog(await fs.readFile(responsePath));
 		expect(log.headers).toContain("HTTP 201 Created");
 		expect(log.headers).toContain("content-type: text/plain");
 		expect(log.headers).toContain("x-request-id: resp-1");
 		expect(log.body).toEqual(responseBody);
+	});
+
+	it("redacts sensitive request headers regardless of header-name case", async () => {
+		Bun.env.PI_REQ_DEBUG = "1";
+		const fetchImpl: FetchImpl = async () => new Response("ok");
+		const response = await transportFetch(debugModel(), fetchImpl)("https://provider.test/case", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				Authorization: "Bearer Mixed-Case-Token",
+				"X-API-KEY": "mixed-case-key",
+				Cookie: "session=mixed-case-secret",
+			},
+			body: JSON.stringify({ case: true }),
+		});
+		await response.text();
+
+		const { requestPath } = await findDebugFiles();
+		const request = JSON.parse(await fs.readFile(requestPath, "utf8")) as Record<string, unknown>;
+		expect(request.headers).toMatchObject({
+			// Headers normalizes names to lowercase; sending mixed-case names still
+			// proves the redaction list matches case-insensitively.
+			authorization: "[redacted]",
+			"x-api-key": "[redacted]",
+			cookie: "[redacted]",
+		});
+	});
+
+	it("redacts sensitive response headers in the response log", async () => {
+		Bun.env.PI_REQ_DEBUG = "1";
+		const fetchImpl: FetchImpl = async () =>
+			new Response("ok", {
+				status: 201,
+				statusText: "Created",
+				headers: {
+					"content-type": "text/plain",
+					"Set-Cookie": "session=response-secret",
+					Authorization: "Bearer response-secret",
+				},
+			});
+		const response = await transportFetch(debugModel(), fetchImpl)("https://provider.test/res-secret", {
+			method: "POST",
+		});
+		await response.text();
+
+		const { responsePath } = await findDebugFiles();
+		const log = splitResponseLog(await fs.readFile(responsePath));
+		expect(log.headers).toContain("HTTP 201 Created");
+		expect(log.headers).toContain("set-cookie: [redacted]");
+		expect(log.headers).toContain("authorization: [redacted]");
+		expect(log.headers).not.toContain("response-secret");
 	});
 
 	it("keeps the partial response log when the response body is cancelled", async () => {


### PR DESCRIPTION
## Summary

Security-review hardening for credential storage and debug dumps, split out of #11443 per review feedback:

- **SQLite credential store**: the DB file is created 0600 from the start; db/−wal/−shm are chmod'ed independently so one expected ENOENT can no longer leave another sidecar permissive; chmod failures are logged instead of silently swallowed.
- **PI_REQ_DEBUG dumps**: sensitive headers are redacted on both the request and response sides (authorization, proxy-authorization, x-api-key, api-key, cookie, set-cookie), case-insensitively, via one shared helper also used by http-inspector error dumps.
- **Auth-broker**: an empty bearer-token set is now fail-closed on any non-loopback bind (loopback installs may still opt into open access explicitly).

## Tests

`request-debug` (8: case-insensitive names, response-side redaction, passthrough), new `auth-broker-empty-tokens` contract test (broker on 0.0.0.0:0 → health public, protected routes 401), throwaway sqlite proof (0644 db + stale 0644 −shm + absent −wal → all 0600 after open). Workspace `bun run check:ts` green.