### PR TITLE
fix(cli): reject missing share session paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `omp share` now reports missing session paths instead of creating and publishing empty sessions ([#11483](https://github.com/can1357/oh-my-pi/issues/11483)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/commands/share.ts
+++ b/packages/coding-agent/src/commands/share.ts
@@ -7,7 +7,7 @@
  * `share.redactSecrets`.
  */
 
-import { getAgentDir } from "@oh-my-pi/pi-utils";
+import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { shareHelp as commandHelp } from "../cli/command-help";
 import { Settings } from "../config/settings";
@@ -35,18 +35,25 @@ export default class Share extends Command {
 		const { args, flags } = await this.parse(Share);
 
 		const sessionArg = args.session ?? "";
-		let sessionPath = sessionArg;
+		let sessionPath: string | undefined = sessionArg;
 		if (!sessionArg.includes("/") && !sessionArg.includes("\\") && !sessionArg.endsWith(".jsonl")) {
 			const match = await resolveResumableSession(sessionArg, process.cwd());
-			if (!match) {
-				process.stderr.write(`Session "${sessionArg}" not found.\n`);
-				process.exitCode = 1;
-				return;
-			}
-			sessionPath = match.session.path;
+			sessionPath = match?.session.path;
 		}
 
-		const sm = await SessionManager.open(sessionPath);
+		let sm: SessionManager | undefined;
+		if (sessionPath) {
+			try {
+				sm = await SessionManager.open(sessionPath, undefined, undefined, { throwIfMissing: true });
+			} catch (err) {
+				if (!isEnoent(err)) throw err;
+			}
+		}
+		if (!sm) {
+			process.stderr.write(`Session "${sessionArg}" not found.\n`);
+			process.exitCode = 1;
+			return;
+		}
 		// Settings resolve against the session's own project so its
 		// share.redactSecrets/secrets.enabled policy governs, not the invoking cwd's.
 		const settings = await Settings.loadReadOnly({ cwd: sm.getCwd() });

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -33,6 +33,12 @@ export interface VisitEntriesFromFileStreamOptions {
 	onMalformedRecord?: () => void;
 }
 
+/** Controls how a missing session file is handled. */
+export interface LoadSessionOptions {
+	/** Propagate ENOENT instead of treating the path as a new empty session. */
+	throwIfMissing?: boolean;
+}
+
 /** Parsed session entries plus corruption metadata needed by writable loaders. */
 export interface SessionLoadResult {
 	entries: FileEntry[];
@@ -279,11 +285,14 @@ async function loadWithKnownSize(filePath: string, storage: SessionStorage, size
 export async function loadSessionFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	options: LoadSessionOptions = {},
 ): Promise<SessionLoadResult> {
 	try {
 		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
 	} catch (err) {
-		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		if (isEnoent(err) && !options.throwIfMissing) {
+			return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		}
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2921,14 +2921,15 @@ export class SessionManager {
 	 * Open a specific session file.
 	 * @param sessionDir Optional dir for /new or /branch; defaults to the file's parent.
 	 * @param options.initialCwd Cwd to use when the file is empty or missing.
+	 * @param options.throwIfMissing Propagate ENOENT instead of creating a new session at a missing path.
 	 */
 	static async open(
 		filePath: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { initialCwd?: string; suppressBreadcrumb?: boolean },
+		options?: { initialCwd?: string; suppressBreadcrumb?: boolean; throwIfMissing?: boolean },
 	): Promise<SessionManager> {
-		const loaded = await loadSessionFile(filePath, storage);
+		const loaded = await loadSessionFile(filePath, storage, { throwIfMissing: options?.throwIfMissing });
 		const header = loaded.entries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		// Resume into the session's recorded cwd only when it is verifiably
 		// accessible. A deleted or permission-blocked (macOS TCC denial) project

--- a/packages/coding-agent/test/share.test.ts
+++ b/packages/coding-agent/test/share.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import type { SessionData } from "../src/export/html";
 import {
 	buildShareSnapshot,
@@ -13,6 +15,7 @@ import type { SessionManager } from "../src/session/session-manager";
 
 const IV_LENGTH = 12;
 const TEST_MAX_SEALED_BYTES = 4_000;
+const CLI_ENTRY = path.join(import.meta.dir, "..", "src", "cli.ts");
 
 async function makeKey(): Promise<CryptoKey> {
 	const bytes = new Uint8Array(32);
@@ -589,5 +592,33 @@ describe("shareSession", () => {
 		} finally {
 			server.stop(true);
 		}
+	});
+});
+
+describe("share command", () => {
+	test("rejects a missing path without creating or uploading a session", async () => {
+		using tempDir = TempDir.createSync("@omp-share-missing-");
+		const sessionArg = "./ghost.jsonl";
+		const missingSession = path.join(tempDir.path(), "ghost.jsonl");
+		const proc = Bun.spawn([process.execPath, CLI_ENTRY, "share", sessionArg], {
+			cwd: tempDir.path(),
+			env: {
+				...process.env,
+				NO_COLOR: "1",
+				PI_CODING_AGENT_DIR: path.join(tempDir.path(), "agent"),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+
+		expect(exitCode).toBe(1);
+		expect(stdout).toBe("");
+		expect(stderr).toBe(`Session "${sessionArg}" not found.\n`);
+		expect(await Bun.file(missingSession).exists()).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
With `share.serverUrl` pointed at `http://127.0.0.1:9`, running `PI_CODING_AGENT_DIR=/tmp/omp-11483/agent bun packages/coding-agent/src/cli.ts share ./ghost.jsonl` reached the upload boundary and left a newly minted 400-byte session file at the missing input path.

## Cause
`Share.run` in `packages/coding-agent/src/commands/share.ts` opened path-form arguments with `SessionManager.open` without requiring an existing file. `loadSessionFile` deliberately maps ENOENT to an empty load for fresh `--session` paths, so `SessionManager.#setSessionFile` materialized that empty session before `shareSession` uploaded it.

## Fix
- Added an opt-in `throwIfMissing` session load/open mode while preserving normal fresh-session creation.
- Enabled it for `omp share` and mapped ENOENT to the same `Session "<arg>" not found.` exit-1 path used by unresolved IDs.
- Added CLI regression coverage and the coding-agent changelog entry.

## Verification
`bun test test/share.test.ts` passed 15 tests. `bun run check` passed for `packages/coding-agent` with one pre-existing unused-variable warning. A direct CLI run exited 1 with `Session "./ghost-fixed.jsonl" not found.` and did not create the path.

Fixes #11483