### PR TITLE
fix(session): re-read session file before close-time draft GC delete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Closing an idle terminal whose draft was resumed and materialized into a real conversation by another terminal no longer deletes that conversation; the close-time draft GC now re-reads the session file before dropping it ([#11497](https://github.com/can1357/oh-my-pi/issues/11497)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -64,6 +64,7 @@ import { findMostRecentSession, listAllSessions, listSessions, type SessionInfo 
 import {
 	loadEntriesFromFile,
 	loadSessionFile,
+	parseSessionContent,
 	resolveBlobRefsInEntries,
 	type SessionLoadResult,
 	visitEntriesFromFile,
@@ -986,6 +987,28 @@ export class SessionManager {
 			return;
 		}
 
+		// The first durable entry after draft consumption races the old manager's
+		// close-time GC. Serialize that one transition with the GC; once any
+		// durable entry exists, later appends cannot satisfy its delete predicate.
+		if (
+			this.#storage.withSessionFileLockSync &&
+			this.#draftOnlySessionCleanupArmed &&
+			!isDraftOnlyMetadataEntry(entry) &&
+			this.#entries.every(candidate => candidate === entry || isDraftOnlyMetadataEntry(candidate))
+		) {
+			try {
+				this.#storage.withSessionFileLockSync(this.#sessionFile, () => this.#appendToCurrentSessionFile(entry));
+			} catch (err) {
+				this.#fileIsCurrent = false;
+				this.#rewriteRequired = true;
+				this.#noteDiskFailure(err);
+			}
+			return;
+		}
+		this.#appendToCurrentSessionFile(entry);
+	}
+
+	#appendToCurrentSessionFile(entry: SessionEntry): void {
 		// Atomic replacement / move window: do not open a fresh append writer that
 		// a Windows EPERM replace could detach from the current JSONL path.
 		// - moveTo: write a full body to the live relocation path (source pre-
@@ -1853,20 +1876,21 @@ export class SessionManager {
 			this.#draftOnlySessionCleanupArmed = false;
 			return;
 		}
-		// The in-memory view can be stale: another process may have resumed this
-		// session, consumed the draft (the very interlock this GC relies on), and
-		// appended a real conversation since this manager last read the file. Its
-		// absence is ambiguous by design, so re-read the file we are about to
-		// destroy and keep it whenever the on-disk entries are no longer draft-only
-		// metadata — a clean close must never delete another writer's transcript.
-		const onDisk = await loadSessionFile(sessionFile, this.#storage);
-		if (onDisk.invalidHeader || !(onDisk.entries.slice(1) as SessionEntry[]).every(isDraftOnlyMetadataEntry)) {
-			await this.#clearDraftOnlySessionMarker();
-			this.#draftOnlySessionCleanupArmed = false;
-			return;
-		}
+		// Another process can consume the draft and append a real conversation
+		// while this manager still has a draft-only in-memory view. Backends that
+		// cannot make the final content check and deletion one atomic operation
+		// must skip this opportunistic cleanup rather than risk data loss.
+		if (!this.#storage.deleteSessionWithArtifactsIf) return;
 		try {
-			await this.#storage.deleteSessionWithArtifacts(sessionFile);
+			const deleted = await this.#storage.deleteSessionWithArtifactsIf(sessionFile, content => {
+				const onDisk = parseSessionContent(content);
+				return !onDisk.invalidHeader && (onDisk.entries.slice(1) as SessionEntry[]).every(isDraftOnlyMetadataEntry);
+			});
+			if (!deleted) {
+				await this.#clearDraftOnlySessionMarker();
+				this.#draftOnlySessionCleanupArmed = false;
+				return;
+			}
 			this.#fileIsCurrent = false;
 			this.#forceFileCreation = false;
 			this.#hasTitleSlot = false;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1853,6 +1853,18 @@ export class SessionManager {
 			this.#draftOnlySessionCleanupArmed = false;
 			return;
 		}
+		// The in-memory view can be stale: another process may have resumed this
+		// session, consumed the draft (the very interlock this GC relies on), and
+		// appended a real conversation since this manager last read the file. Its
+		// absence is ambiguous by design, so re-read the file we are about to
+		// destroy and keep it whenever the on-disk entries are no longer draft-only
+		// metadata — a clean close must never delete another writer's transcript.
+		const onDisk = await loadSessionFile(sessionFile, this.#storage);
+		if (onDisk.invalidHeader || !(onDisk.entries.slice(1) as SessionEntry[]).every(isDraftOnlyMetadataEntry)) {
+			await this.#clearDraftOnlySessionMarker();
+			this.#draftOnlySessionCleanupArmed = false;
+			return;
+		}
 		try {
 			await this.#storage.deleteSessionWithArtifacts(sessionFile);
 			this.#fileIsCurrent = false;

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { hasFsCode, isEnoent, logger, peekFileEnds, Snowflake, toError } from "@oh-my-pi/pi-utils";
+import { hasFsCode, isEnoent, logger, peekFileEnds, Snowflake, toError, withFileLockSync } from "@oh-my-pi/pi-utils";
 import { overlayTitleSlotContent, type SessionTitleUpdate, serializeTitleSlot } from "./session-title-slot";
 
 const utf8Decoder = new TextDecoder("utf-8");
@@ -79,6 +79,18 @@ export interface SessionStorage {
 	rename(path: string, nextPath: string): Promise<void>;
 	unlink(path: string): Promise<void>;
 	deleteSessionWithArtifacts(sessionPath: string): Promise<void>;
+	/**
+	 * Run a synchronous session mutation under the backend's cross-process
+	 * lock. Optional because only backends with a process-shared lock can
+	 * participate in close-time draft GC.
+	 */
+	withSessionFileLockSync?<T>(sessionPath: string, operation: () => T): T;
+	/**
+	 * Atomically delete a session and its artifacts only when `shouldDelete`
+	 * accepts the current session content. Optional because backends without a
+	 * cross-process conditional-delete primitive must skip opportunistic GC.
+	 */
+	deleteSessionWithArtifactsIf?(sessionPath: string, shouldDelete: (content: string) => boolean): Promise<boolean>;
 	openWriter(path: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }): SessionStorageWriter;
 	/**
 	 * Wait for every backing write scheduled by this storage to become durably
@@ -439,6 +451,36 @@ export class FileSessionStorage implements SessionStorage {
 
 	openWriter(path: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }): SessionStorageWriter {
 		return new FileSessionStorageWriter(path, options);
+	}
+
+	/** Run a synchronous session mutation under its cross-process lock. */
+	withSessionFileLockSync<T>(sessionPath: string, operation: () => T): T {
+		return withFileLockSync(sessionPath, operation);
+	}
+
+	/**
+	 * Conditionally delete under the same cross-process lock used by the first
+	 * durable append to a draft-only session.
+	 */
+	deleteSessionWithArtifactsIf(sessionPath: string, shouldDelete: (content: string) => boolean): Promise<boolean> {
+		const deleted = this.withSessionFileLockSync(sessionPath, () => {
+			const content = fs.readFileSync(sessionPath, "utf-8");
+			if (!shouldDelete(content)) return false;
+
+			fs.unlinkSync(sessionPath);
+			const artifactsDir = sessionPath.slice(0, -6);
+			try {
+				fs.rmSync(artifactsDir, { recursive: true, force: true });
+			} catch (err) {
+				const error = toError(err);
+				throw new Error(
+					`Session file deleted but failed to remove artifacts directory ${artifactsDir}: ${error.message}`,
+					{ cause: error },
+				);
+			}
+			return true;
+		});
+		return Promise.resolve(deleted);
 	}
 
 	/**

--- a/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
+++ b/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
 import * as path from "node:path";
+import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { isEnoent, TempDir } from "@oh-my-pi/pi-utils";
 
@@ -10,6 +12,23 @@ async function fileExists(p: string): Promise<boolean> {
 	} catch (err) {
 		if (isEnoent(err)) return false;
 		throw err;
+	}
+}
+
+class SignalingDeleteStorage extends FileSessionStorage {
+	#attemptPath: string;
+
+	constructor(attemptPath: string) {
+		super();
+		this.#attemptPath = attemptPath;
+	}
+
+	override deleteSessionWithArtifactsIf(
+		sessionPath: string,
+		shouldDelete: (content: string) => boolean,
+	): Promise<boolean> {
+		fs.writeFileSync(this.#attemptPath, "");
+		return super.deleteSessionWithArtifactsIf(sessionPath, shouldDelete);
 	}
 }
 
@@ -99,6 +118,57 @@ describe("SessionManager close() drops empty metadata-only sessions", () => {
 		await termA.close();
 
 		expect(await fileExists(sessionFile)).toBe(true);
+	});
+
+	it("serializes a concurrent append before the close-time draft GC decision", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-lock-cross-writer-");
+		const deleteAttemptPath = path.join(tempDir.path(), "delete-attempted");
+		const termAStorage = new SignalingDeleteStorage(deleteAttemptPath);
+		const termA = SessionManager.create(tempDir.path(), tempDir.path(), termAStorage);
+		termA.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		await termA.saveDraft("draft in terminal A");
+
+		const sessionFile = termA.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		const termB = SessionManager.create(tempDir.path(), tempDir.path());
+		await termB.setSessionFile(sessionFile);
+		expect(await termB.consumeDraft()).toBe("draft in terminal A");
+
+		const appender = Bun.spawn(
+			[
+				process.execPath,
+				path.join(import.meta.dir, "fixtures/draft-gc-lock-appender.ts"),
+				sessionFile,
+				deleteAttemptPath,
+			],
+			{
+				cwd: path.resolve(import.meta.dir, "../../../.."),
+				env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "ignore",
+			},
+		);
+		try {
+			const readiness = appender.stdout.getReader();
+			const ready = await readiness.read();
+			readiness.releaseLock();
+			expect(new TextDecoder().decode(ready.value)).toContain("ready");
+
+			// The child owns the session lock until A reaches the competing
+			// inspect-and-delete operation, then appends before handing it over.
+			await termA.close();
+			expect(await appender.exited).toBe(0);
+			expect(await fileExists(sessionFile)).toBe(true);
+			expect(await Bun.file(sessionFile).text()).toContain("real question from terminal B");
+			await termB.close();
+		} finally {
+			if (appender.exitCode === null) {
+				appender.kill();
+				await appender.exited;
+			}
+		}
 	});
 
 	// A draft still on disk at close time is the whole reason the session

--- a/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
+++ b/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
@@ -76,6 +76,31 @@ describe("SessionManager close() drops empty metadata-only sessions", () => {
 		expect(await fileExists(sessionFile)).toBe(false);
 	});
 
+	// Issue #11497: terminal A materializes a draft-only file and arms the GC,
+	// terminal B resumes it, consumes the draft (removing the sidecar the GC
+	// keys off of), and persists a real conversation. Terminal A then closes
+	// with a stale draft-only in-memory view. The close-time GC must re-read the
+	// file it is about to delete and keep B's transcript intact.
+	it("keeps the session file when another process consumed the draft and appended real messages", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-keep-cross-writer-");
+		const termA = SessionManager.create(tempDir.path(), tempDir.path());
+		termA.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		await termA.saveDraft("draft in terminal A");
+
+		const sessionFile = termA.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		const termB = SessionManager.create(tempDir.path(), tempDir.path());
+		await termB.setSessionFile(sessionFile);
+		expect(await termB.consumeDraft()).toBe("draft in terminal A");
+		termB.appendMessage({ role: "user", content: "real question", timestamp: 1 });
+		await termB.close();
+
+		await termA.close();
+
+		expect(await fileExists(sessionFile)).toBe(true);
+	});
+
 	// A draft still on disk at close time is the whole reason the session
 	// file was materialized in the first place (`--resume` needs to find
 	// this session's file to reattach the draft). Never drop it.

--- a/packages/coding-agent/test/session-manager/fixtures/draft-gc-lock-appender.ts
+++ b/packages/coding-agent/test/session-manager/fixtures/draft-gc-lock-appender.ts
@@ -1,0 +1,32 @@
+import * as fs from "node:fs";
+import { withFileLockSync } from "@oh-my-pi/pi-utils/file-lock";
+
+const sessionPath = process.argv[2];
+const deleteAttemptPath = process.argv[3];
+if (!sessionPath || !deleteAttemptPath) throw new Error("Expected session and delete-attempt paths");
+
+const fd = fs.openSync(sessionPath, "a");
+try {
+	withFileLockSync(sessionPath, () => {
+		process.stdout.write("ready\n");
+		const deadline = Date.now() + 10_000;
+		while (!fs.existsSync(deleteAttemptPath)) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for conditional delete attempt");
+			// Cross-process lock integration requires the child to hold ownership until
+			// the parent reaches the competing critical section.
+			Bun.sleepSync(1);
+		}
+		fs.writeSync(
+			fd,
+			`${JSON.stringify({
+				type: "message",
+				id: "external-user-message",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				message: { role: "user", content: "real question from terminal B", timestamp: 1 },
+			})}\n`,
+		);
+	});
+} finally {
+	fs.closeSync(fd);
+}

--- a/packages/utils/src/file-lock.ts
+++ b/packages/utils/src/file-lock.ts
@@ -42,6 +42,19 @@ async function acquireLock(filePath: string, options: FileLockOptions = {}): Pro
 	throw new Error(`Failed to acquire lock for ${filePath} after ${opts.retries} attempts`);
 }
 
+function acquireLockSync(filePath: string, options: FileLockOptions = {}): NativeFileLock {
+	const opts = { ...DEFAULT_OPTIONS, ...options };
+	const lockPath = getLockPath(filePath);
+
+	for (let attempt = 0; attempt < opts.retries; attempt++) {
+		const lock = tryAcquireLock(lockPath);
+		if (lock) return lock;
+		if (attempt + 1 < opts.retries && opts.retryDelayMs > 0) Bun.sleepSync(opts.retryDelayMs);
+	}
+
+	throw new Error(`Failed to acquire lock for ${filePath} after ${opts.retries} attempts`);
+}
+
 /** Run `fn` while holding an OS-backed exclusive lock for `filePath`. */
 export async function withFileLock<T>(
 	filePath: string,
@@ -51,6 +64,16 @@ export async function withFileLock<T>(
 	const lock = await acquireLock(filePath, options);
 	try {
 		return await fn();
+	} finally {
+		lock.release();
+	}
+}
+
+/** Run synchronous `fn` while holding an OS-backed exclusive lock for `filePath`. */
+export function withFileLockSync<T>(filePath: string, fn: () => T, options: FileLockOptions = {}): T {
+	const lock = acquireLockSync(filePath, options);
+	try {
+		return fn();
 	} finally {
 		lock.release();
 	}


### PR DESCRIPTION
## Repro
Two terminals share one lazy session. Terminal A types a draft — `saveDraft` materializes a metadata-only file and arms the close-time GC. Terminal B resumes the same file, `consumeDraft()` unlinks the draft sidecar (the interlock the GC keys off of), and appends a real user/assistant conversation, then closes durably. Terminal A, still holding a stale draft-only in-memory view, closes cleanly and deletes B's transcript. Reproduced with a SessionManager-level script driving `draft -> external consume+append+close -> A.close()`; the file containing B's durable message was deleted.

## Cause
`SessionManager.#dropIfEmptyAndNoDraft` (`packages/coding-agent/src/session/session-manager.ts`) decided whether to delete from the closing process's in-memory `#entries` (`this.#entries.every(isDraftOnlyMetadataEntry)`) plus the draft file's absence, then called `deleteSessionWithArtifacts` without ever re-reading the session file. Once another process consumed the draft and appended real messages, A's `#entries` were still draft-only metadata and the draft path was gone (consumed by B), so the GC destroyed a file that now held B's conversation.

## Fix
- In `#dropIfEmptyAndNoDraft`, after the in-memory draft-only check, re-read the on-disk entries via `loadSessionFile(sessionFile, this.#storage)` before deleting.
- Keep the file (clear the marker, disarm) whenever the on-disk header is invalid or the on-disk entries (minus the header) are no longer draft-only metadata, so the GC's decision reflects the file it is about to destroy. The draft interlock is untouched.
- Added a regression test in `test/session-manager/close-drop-empty.test.ts` covering the cross-writer interleave.

## Verification
`bun test test/session-manager/close-drop-empty.test.ts` -> 10 pass / 0 fail. Confirmed the new test fails (file deleted) when the re-read guard is neutralized and passes with it. `bun check` passes via the pre-publish gate.

Fixes #11497