### PR TITLE
fix(agent): compact oversized retained history across turns

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compaction retaining oversized older steps beyond the recent-history budget and skipping previously retained history on later passes, preventing long tool loops from freeing enough context ([#11365](https://github.com/can1357/oh-my-pi/issues/11365)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -455,6 +455,17 @@ function findValidCutPoints(entries: SessionEntry[], startIndex: number, endInde
 	return cutPoints;
 }
 
+function isTurnStartEntry(entry: SessionEntry): boolean {
+	if (entry.type === "branch_summary" || entry.type === "custom_message") {
+		return true;
+	}
+	if (entry.type === "message") {
+		const role = entry.message.role as string;
+		return role === "user" || role === "bashExecution";
+	}
+	return false;
+}
+
 /**
  * Find the user message (or bashExecution) that starts the turn containing the given entry index.
  * Returns -1 if no turn start found before the index.
@@ -462,16 +473,8 @@ function findValidCutPoints(entries: SessionEntry[], startIndex: number, endInde
  */
 export function findTurnStartIndex(entries: SessionEntry[], entryIndex: number, startIndex: number): number {
 	for (let i = entryIndex; i >= startIndex; i--) {
-		const entry = entries[i];
-		// branch_summary and custom_message are user-role messages, can start a turn
-		if (entry.type === "branch_summary" || entry.type === "custom_message") {
+		if (isTurnStartEntry(entries[i])) {
 			return i;
-		}
-		if (entry.type === "message") {
-			const role = entry.message.role as string;
-			if (role === "user" || role === "bashExecution") {
-				return i;
-			}
 		}
 	}
 	return -1;
@@ -533,30 +536,28 @@ export function findCutPoint(
 		cutPointIndex--;
 	}
 
-	// Scan backwards from cutIndex to include any non-message entries (bash, settings, etc.)
+	const isTurnStart = isTurnStartEntry(entries[cutIndex]);
+	const turnStartIndex = isTurnStart ? -1 : findTurnStartIndex(entries, cutIndex, startIndex);
+
+	// Scan backwards from cutIndex to include any non-message entries (settings changes, etc.)
 	while (cutIndex > startIndex) {
 		const prevEntry = entries[cutIndex - 1];
-		// Stop at session header or compaction boundaries
-		if (prevEntry.type === "compaction") {
+		// Stop at session header, compaction, or reset boundaries
+		if (prevEntry.type === "compaction" || prevEntry.type === "reset_boundary") {
 			break;
 		}
-		if (prevEntry.type === "message") {
-			// Stop if we hit any message
+		if (getMessageFromEntry(prevEntry)) {
+			// Stop if we hit any entry that contributes a message
 			break;
 		}
-		// Include this non-message entry (bash, settings change, etc.)
+		// Include this non-message entry (settings change, label, etc.)
 		cutIndex--;
 	}
-
-	// Determine if this is a split turn
-	const cutEntry = entries[cutIndex];
-	const isUserMessage = cutEntry.type === "message" && cutEntry.message.role === "user";
-	const turnStartIndex = isUserMessage ? -1 : findTurnStartIndex(entries, cutIndex, startIndex);
 
 	return {
 		firstKeptEntryIndex: cutIndex,
 		turnStartIndex,
-		isSplitTurn: !isUserMessage && turnStartIndex !== -1,
+		isSplitTurn: !isTurnStart && turnStartIndex !== -1,
 	};
 }
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -487,10 +487,11 @@ export interface CutPointResult {
 }
 
 /**
- * Find the cut point in session entries that keeps approximately `keepRecentTokens`.
+ * Find the oldest complete recent-history suffix that fits `keepRecentTokens`.
  *
- * Algorithm: Walk backwards from newest, accumulating estimated message sizes.
- * Stop when we've accumulated >= keepRecentTokens. Cut at that point.
+ * Walk backwards by valid cut points, measuring whole assistant/tool groups.
+ * Keep the newest group even when it alone exceeds the budget; never retain
+ * an additional older group that would push an otherwise fitting suffix over.
  *
  * Can cut at user OR assistant messages (never tool results). When cutting at an
  * assistant message with tool calls, its tool results come after and will be kept.
@@ -515,29 +516,21 @@ export function findCutPoint(
 		return { firstKeptEntryIndex: startIndex, turnStartIndex: -1, isSplitTurn: false };
 	}
 
-	// Walk backwards from newest, accumulating estimated message sizes
+	// Evaluate the budget only at valid boundaries, after counting all results
+	// belonging to an assistant. Checking individual messages can either retain
+	// the oversized older assistant or miss its boundary and retain all history.
 	let accumulatedTokens = 0;
-	let cutIndex = cutPoints[0]; // Default: keep from first message (not header)
+	let cutPointIndex = cutPoints.length - 1;
+	let cutIndex = cutPoints[cutPointIndex];
 
 	for (let i = endIndex - 1; i >= startIndex; i--) {
 		const entry = entries[i];
-		if (entry.type !== "message") continue;
-
-		// Estimate this message's size
-		const messageTokens = tokenizer.countMessage(entry.message);
-		accumulatedTokens += messageTokens;
-
-		// Check if we've exceeded the budget
-		if (accumulatedTokens >= keepRecentTokens) {
-			// Find the closest valid cut point at or after this entry
-			for (let c = 0; c < cutPoints.length; c++) {
-				if (cutPoints[c] >= i) {
-					cutIndex = cutPoints[c];
-					break;
-				}
-			}
-			break;
-		}
+		const message = getMessageFromEntry(entry);
+		if (message) accumulatedTokens += tokenizer.countMessage(message);
+		if (i !== cutPoints[cutPointIndex]) continue;
+		if (accumulatedTokens > keepRecentTokens) break;
+		cutIndex = i;
+		cutPointIndex--;
 	}
 
 	// Scan backwards from cutIndex to include any non-message entries (bash, settings, etc.)
@@ -1349,7 +1342,21 @@ export function prepareCompaction(
 	if (resetBoundaryIndex > prevCompactionIndex) {
 		prevCompactionIndex = -1;
 	}
-	const boundaryStart = Math.max(prevCompactionIndex, resetBoundaryIndex) + 1;
+	let boundaryStart = Math.max(prevCompactionIndex, resetBoundaryIndex) + 1;
+	if (prevCompactionIndex >= 0) {
+		const previous = pathEntries[prevCompactionIndex] as CompactionEntry;
+		// A local summary covers only the discarded prefix. Its retained tail is
+		// still live input and must be eligible for the next compaction, even
+		// though those entries precede the journal's compaction marker. Remote
+		// replacement payloads already own that history and must not duplicate it.
+		const remote =
+			getCompactionV2PreserveData(previous.preserveData) ??
+			getPreservedOpenAiRemoteCompactionData(previous.preserveData);
+		if (!remote) {
+			const retainedStart = pathEntries.findIndex(entry => entry.id === previous.firstKeptEntryId);
+			if (retainedStart >= 0 && retainedStart < prevCompactionIndex) boundaryStart = retainedStart;
+		}
+	}
 	const boundaryEnd = pathEntries.length;
 
 	const lastUsage = getLastAssistantUsage(pathEntries);

--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -266,6 +266,7 @@ export class Tokenizer {
 				}
 				break;
 			}
+			case "custom":
 			case "hookMessage":
 			case "toolResult": {
 				if (typeof message.content === "string") {

--- a/packages/agent/test/compaction-cut-point.test.ts
+++ b/packages/agent/test/compaction-cut-point.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type BranchSummaryEntry,
+	type CustomMessageEntry,
+	DEFAULT_COMPACTION_SETTINGS,
+	findCutPoint,
+	prepareCompaction,
+	type SessionMessageEntry,
+} from "@oh-my-pi/pi-agent-core/compaction";
+import { Tokenizer } from "@oh-my-pi/pi-agent-core/tokenizer";
+import { createAssistantMessage } from "./helpers";
+
+const tokenizer = new Tokenizer();
+
+let seq = 0;
+function base(type: string) {
+	const id = `e${seq++}`;
+	return { id, parentId: null, timestamp: new Date().toISOString(), type };
+}
+
+function assistantEntry(text: string): SessionMessageEntry {
+	return {
+		...base("message"),
+		type: "message",
+		message: createAssistantMessage([{ type: "text", text }]),
+	};
+}
+
+function customMessageEntry(content: string): CustomMessageEntry {
+	return {
+		...base("custom_message"),
+		type: "custom_message",
+		customType: "test",
+		content,
+		display: true,
+	};
+}
+
+function branchSummaryEntry(summary: string): BranchSummaryEntry {
+	return {
+		...base("branch_summary"),
+		type: "branch_summary",
+		fromId: "branch-root",
+		summary,
+	};
+}
+
+describe("findCutPoint backward scan boundaries", () => {
+	test("does not re-admit an oversized custom_message during backward scan", () => {
+		const custom = customMessageEntry("x".repeat(100_000));
+		const assistant = assistantEntry("small answer");
+		const entries = [custom, assistant];
+
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(1);
+		expect(cut.isSplitTurn).toBe(true);
+		expect(cut.turnStartIndex).toBe(0);
+
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(assistant.id);
+		expect(preparation?.recentMessages).toEqual([assistant.message]);
+		expect(tokenizer.countMessages(preparation!.recentMessages)).toBeLessThanOrEqual(20_000);
+	});
+
+	test("does not re-admit an oversized branch_summary during backward scan", () => {
+		const branch = branchSummaryEntry("s".repeat(100_000));
+		const assistant = assistantEntry("small answer");
+		const entries = [branch, assistant];
+
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(1);
+		expect(cut.isSplitTurn).toBe(true);
+		expect(cut.turnStartIndex).toBe(0);
+
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(assistant.id);
+		expect(preparation?.recentMessages).toEqual([assistant.message]);
+		expect(tokenizer.countMessages(preparation!.recentMessages)).toBeLessThanOrEqual(20_000);
+	});
+
+	test("retains fitting custom_message without marking a split turn", () => {
+		const oldAssistant = assistantEntry("x".repeat(100_000));
+		const custom = customMessageEntry("small question");
+		const assistant = assistantEntry("small answer");
+		const entries = [oldAssistant, custom, assistant];
+
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(1);
+		expect(cut.isSplitTurn).toBe(false);
+		expect(cut.turnStartIndex).toBe(-1);
+
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(custom.id);
+		expect(preparation?.messagesToSummarize).toEqual([oldAssistant.message]);
+		expect(preparation?.turnPrefixMessages).toEqual([]);
+		expect(preparation?.recentMessages).toHaveLength(2);
+	});
+});

--- a/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
+++ b/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
-import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockHandler, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -46,7 +46,10 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 	});
 
 	async function createSession(options: {
-		responses: MockResponse[];
+		responses: MockHandler[];
+		contextWindow?: number;
+		maxTokens?: number;
+		thresholdTokens?: number;
 		/** Optional `session_before_compact` short-circuit so a viable compaction makes no LLM call. */
 		shortCircuitCompaction?: boolean;
 		/** Delay message-end hooks so the turn is absent until the persistence barrier resolves. */
@@ -56,7 +59,11 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		authStorage.setRuntimeApiKey("mock", "test-key");
 		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
-		const mock = createMockModel({ responses: options.responses });
+		const mock = createMockModel({
+			responses: options.responses,
+			contextWindow: options.contextWindow,
+			maxTokens: options.maxTokens,
+		});
 		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([mock]);
 
 		let extensionRunner: ExtensionRunner | undefined;
@@ -102,7 +109,7 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		});
 		const settings = Settings.isolated({
 			"compaction.methodOrder": ["soft"],
-			"compaction.thresholdTokens": 100_000,
+			"compaction.thresholdTokens": options.thresholdTokens ?? 100_000,
 			"compaction.midTurnEnabled": true,
 			"compaction.autoContinue": false,
 			"retry.enabled": false,
@@ -128,6 +135,54 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		});
 		return state;
 	}
+
+	it("compacts older reasoning before continuing a long turn with the full output allowance", async () => {
+		const olderThinking = "older-step " + "r".repeat(87_382);
+		const latestThinking = "latest-step " + "r".repeat(67_448);
+		let continued = false;
+		let continuedThinking: string[] = [];
+		let continuedMaxTokens: number | null | undefined;
+		const state = await createSession({
+			contextWindow: 117_120,
+			maxTokens: 55_000,
+			thresholdTokens: 45_000,
+			shortCircuitCompaction: true,
+			responses: [
+				{
+					content: [
+						{ type: "thinking", thinking: olderThinking },
+						{ type: "toolCall", id: "first", name: "noop", arguments: {} },
+					],
+					usage: { input: 44_654, output: 22_608 },
+				},
+				{
+					content: [
+						{ type: "thinking", thinking: latestThinking },
+						{ type: "toolCall", id: "second", name: "noop", arguments: {} },
+					],
+					usage: { input: 44_806, output: 18_840 },
+				},
+				(context, options) => {
+					continuedThinking = context.messages.flatMap(message =>
+						message.role === "assistant"
+							? message.content.filter(block => block.type === "thinking").map(block => block.thinking)
+							: [],
+					);
+					continuedMaxTokens = options?.maxTokens ?? session.model?.maxTokens;
+					continued = true;
+					return { content: ["done"] };
+				},
+			],
+		});
+
+		await session.prompt("Continue the review");
+		expect(continued).toBe(true);
+		expect(continuedThinking).not.toContain(olderThinking);
+		expect(continuedThinking).toContain(latestThinking);
+		expect(continuedMaxTokens).toBe(55_000);
+		expect(state.compactionResults).toBe(2);
+		expect(state.notices.filter(message => message.includes(DEAD_END_WARNING))).toEqual([]);
+	});
 
 	it("attempts and warns once per oversized tool-loop turn when no cut point ever appears", async () => {
 		// The genuinely-unrecoverable shape: prepareCompaction can never find a cut

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -20,7 +20,9 @@ import type { AssistantMessage, Model, ProviderPayload, Usage } from "@oh-my-pi/
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type {
+	BranchSummaryEntry,
 	CompactionEntry,
+	CustomMessageEntry,
 	ModelChangeEntry,
 	SessionEntry,
 	SessionMessageEntry,
@@ -170,6 +172,35 @@ function createThinkingLevelEntry(thinkingLevel: string): ThinkingLevelChangeEnt
 		parentId: lastId,
 		timestamp: new Date().toISOString(),
 		thinkingLevel,
+	};
+	lastId = id;
+	return entry;
+}
+
+function createCustomMessageEntry(content: string, customType = "test"): CustomMessageEntry {
+	const id = `test-id-${entryCounter++}`;
+	const entry: CustomMessageEntry = {
+		type: "custom_message",
+		id,
+		parentId: lastId,
+		timestamp: new Date().toISOString(),
+		customType,
+		content,
+		display: true,
+	};
+	lastId = id;
+	return entry;
+}
+
+function createBranchSummaryEntry(summary: string, fromId = "branch-root"): BranchSummaryEntry {
+	const id = `test-id-${entryCounter++}`;
+	const entry: BranchSummaryEntry = {
+		type: "branch_summary",
+		id,
+		parentId: lastId,
+		timestamp: new Date().toISOString(),
+		fromId,
+		summary,
 	};
 	lastId = id;
 	return entry;
@@ -1179,6 +1210,38 @@ describe("findCutPoint", () => {
 		];
 		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
 		expect(cut.firstKeptEntryIndex).toBe(2);
+	});
+
+	it("does not re-admit an oversized custom_message during backward scan", () => {
+		const custom = createCustomMessageEntry("x".repeat(100_000));
+		const assistant = createMessageEntry(createAssistantMessage("small answer"));
+		const entries = [custom, assistant];
+
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(1);
+		expect(cut.isSplitTurn).toBe(true);
+		expect(cut.turnStartIndex).toBe(0);
+
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(assistant.id);
+		expect(preparation?.recentMessages).toEqual([assistant.message]);
+		expect(tokenizer.countMessages(preparation!.recentMessages)).toBeLessThanOrEqual(20_000);
+	});
+
+	it("does not re-admit an oversized branch_summary during backward scan", () => {
+		const branch = createBranchSummaryEntry("s".repeat(100_000));
+		const assistant = createMessageEntry(createAssistantMessage("small answer"));
+		const entries = [branch, assistant];
+
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(1);
+		expect(cut.isSplitTurn).toBe(true);
+		expect(cut.turnStartIndex).toBe(0);
+
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(assistant.id);
+		expect(preparation?.recentMessages).toEqual([assistant.message]);
+		expect(tokenizer.countMessages(preparation!.recentMessages)).toBeLessThanOrEqual(20_000);
 	});
 
 	it("should find cut point based on actual token differences", () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -955,6 +955,8 @@ describe("remote compaction setting", () => {
 		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
 		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
 		const previousCompaction = createCompactionEntry("Split snapcompact frame summary", oldAssistant.id);
+		// This archive absorbed the entire old turn; no pre-marker tail remains live.
+		previousCompaction.firstKeptEntryId = previousCompaction.id;
 		previousCompaction.preserveData = {
 			otherState: "keep-me",
 			snapcompact: {
@@ -1123,6 +1125,62 @@ describe("remote compaction setting", () => {
 });
 
 describe("findCutPoint", () => {
+	it("summarizes the older reasoning step when retaining it would exceed the recent-history budget", () => {
+		// #11365: one user turn contains a 22k-token reasoning step followed by
+		// an 18k-token step. Keeping both defeats the 20k retention budget.
+		const older = createAssistantMessage("");
+		older.content = [
+			{ type: "thinking", thinking: "r".repeat(87_382) },
+			{ type: "toolCall", id: "older-call", name: "read", arguments: {} },
+		];
+		const latest = createAssistantMessage("", createMockUsage(44_806, 18_840));
+		latest.content = [
+			{ type: "thinking", thinking: "r".repeat(67_448) },
+			{ type: "text", text: "t".repeat(1_412) },
+			{ type: "toolCall", id: "latest-call", name: "read", arguments: {} },
+		];
+		const result = (id: string): AgentMessage => ({
+			role: "toolResult",
+			toolCallId: id,
+			toolName: "read",
+			content: [{ type: "text", text: "small result" }],
+			isError: false,
+			timestamp: 0,
+		});
+		const entries = [
+			createMessageEntry(createUserMessage("Continue the review")),
+			createMessageEntry(older),
+			createMessageEntry(result("older-call")),
+			createMessageEntry(latest),
+			createMessageEntry(result("latest-call")),
+		];
+		const preparation = prepareCompaction(entries, { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 });
+		expect(preparation?.firstKeptEntryId).toBe(entries[3].id);
+		expect(preparation?.turnPrefixMessages).toContain(older);
+		expect(preparation?.recentMessages).toEqual([latest, entries[4].message]);
+		expect(tokenizer.countMessages(preparation!.recentMessages)).toBeLessThanOrEqual(20_000);
+	});
+
+	it("retains the newest oversized tool group without dragging all earlier history into the tail", () => {
+		const latest = createAssistantMessage("");
+		latest.content = [{ type: "toolCall", id: "large-call", name: "read", arguments: {} }];
+		const entries = [
+			createMessageEntry(createUserMessage("Old request")),
+			createMessageEntry(createAssistantMessage("Old answer")),
+			createMessageEntry(latest),
+			createMessageEntry({
+				role: "toolResult",
+				toolCallId: "large-call",
+				toolName: "read",
+				content: [{ type: "text", text: "x".repeat(100_000) }],
+				isError: false,
+				timestamp: 0,
+			}),
+		];
+		const cut = findCutPoint(entries, tokenizer, 0, entries.length, 20_000);
+		expect(cut.firstKeptEntryIndex).toBe(2);
+	});
+
 	it("should find cut point based on actual token differences", () => {
 		// Create entries with cumulative token counts
 		const entries: SessionEntry[] = [];


### PR DESCRIPTION
## What

Fix repeated mid-turn compaction so older completed assistant/tool steps can be summarized instead of remaining in the model context indefinitely.

- Select the oldest complete recent-history suffix that fits the retention budget. Preserve the newest assistant/tool group even if that group alone is oversized.
- Include the previous local compaction's retained tail when preparing the next compaction. Keep remote replacement payload handling unchanged to avoid duplicating history.
- Add regressions for oversized reasoning steps, an oversized newest tool group, and continued execution after two successive compactions with the full 55,000-token output allowance.

## Why

Fixes #11365: https://github.com/can1357/oh-my-pi/issues/11365

The captured request contained two large reasoning steps. With a 20,000-token retention target, the old selector retained approximately 41,716 tokens even though the newest complete step fit at 19,131 tokens. It included the older step that crossed the budget. Subsequent compaction also skipped retained entries before the previous compaction marker, leaving that reasoning in the request but unavailable for summarization.

The corrected selector retains approximately 19,131 tokens for that request, and later compactions can summarize previously retained history. The configured output allowance is unchanged. Regression fixtures use synthetic content matching the relevant transcript sizes; private transcript content is not included.

## Testing

- Agent package: `bun test --parallel` — 538 passed.
- `bun test packages/coding-agent/test/*compaction*.test.ts` — 184 passed, 13 skipped.
- Final session regression rerun — 3 passed.
- `bun check` passed in both `packages/agent` and `packages/coding-agent`.
- `git diff --check` passed.
- Local token-selection probe against the captured request confirmed the retained-history reduction. No live provider replay was performed.

---

- [x] `bun check` passes (affected packages)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
