### PR TITLE
fix(cli): return non-zero for JSON turn failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- JSON print mode now exits non-zero when the provider turn ends in an error or non-silent abort, matching text mode ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -110,7 +110,7 @@ import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChange
 import { EventBus } from "./utils/event-bus";
 
 type RunAcpMode = (createSession: AcpSessionFactory) => Promise<never>;
-type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promise<void>;
+type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promise<number>;
 type RunRpcMode = (
 	session: AgentSession,
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
@@ -2113,7 +2113,7 @@ export async function runRootCommand(
 				// Branch-only single-shot runner: keep print-mode code out of normal interactive startup.
 				stopStartupWatchdog();
 				const runPrintMode: RunPrintMode = (await import("./modes/print-mode")).runPrintMode;
-				await runPrintMode(session, {
+				const exitCode = await runPrintMode(session, {
 					mode,
 					messages: initialArgs.messages,
 					initialMessage,
@@ -2126,7 +2126,7 @@ export async function runRootCommand(
 				}
 				await session.dispose();
 				stopThemeWatcher();
-				await postmortem.quit(0);
+				await postmortem.quit(exitCode);
 			}
 		}
 	} catch (error) {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -88,9 +88,11 @@ export function printableEvent(event: AgentSessionEvent): unknown {
 
 /**
  * Run in print (single-shot) mode.
- * Sends prompts to the agent and outputs the result.
+ *
+ * Sends prompts, writes the selected output format, and returns the process
+ * exit code the CLI must use for the completed turn.
  */
-export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
+export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<number> {
 	const { mode, messages = [], initialMessage, initialImages, printThoughts, planYolo = false } = options;
 
 	// process.stdout.write is fire-and-forget: a large final record (e.g. a
@@ -184,39 +186,20 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// primary turn whose response print mode would never emit.
 	session.prepareForHeadlessAdvisorDrain();
 
-	// In text mode, output final response
-	if (mode === "text") {
-		// Read via the session accessor, not the raw state tail: a classifier
-		// refusal is pruned from active context at settle, and an aborted turn
-		// can trail synthetic tool results — both would hide the terminal
-		// assistant message (and its error) from a last-element read.
-		const assistantMsg = session.getLastAssistantMessage();
+	// Read via the session accessor, not the raw state tail: a classifier
+	// refusal is pruned from active context at settle, and an aborted turn
+	// can trail synthetic tool results — both would hide the terminal
+	// assistant message (and its error) from a last-element read.
+	const assistantMsg = session.getLastAssistantMessage();
+	const terminalFailure =
+		assistantMsg !== undefined &&
+		(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
+		!isSilentAbort(assistantMsg);
 
+	// In text mode, output the final response. JSON mode already emitted the
+	// assistant message and stop reason through the event subscription.
+	if (mode === "text" && !terminalFailure) {
 		if (assistantMsg) {
-			// Check for error/aborted — skip silent-abort (plan-mode compaction transition)
-			if (
-				(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
-				!isSilentAbort(assistantMsg)
-			) {
-				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
-				// This branch hard-exits, bypassing the `await session.dispose()` at
-				// the end of runPrintMode. Flush telemetry and dispose the session
-				// HERE so error spans reach the exporter (the postmortem `exit`
-				// handler can't await) and the browser reaper installed in
-				// `dispose()` (releaseTabsForOwner) actually runs — otherwise an
-				// OMP-owned Chromium survives this exit (issue #5643). `dispose()`
-				// is idempotent, so the unreachable call below is a harmless no-op.
-				await session.waitForAdvisorCatchup(PRINT_MODE_ERROR_ADVISOR_DRAIN_TIMEOUT_MS);
-				await flushTelemetryExport();
-				await session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
-				const flushed = process.stderr.write(`${errorLine}\n`);
-				if (flushed) {
-					process.exit(1);
-				} else {
-					process.stderr.once("drain", () => process.exit(1));
-				}
-			}
-
 			if (
 				assistantMsg.errorMessage &&
 				assistantMsg.stopReason !== "error" &&
@@ -225,7 +208,6 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				process.stderr.write(`${sanitizeText(assistantMsg.errorMessage)}\n`);
 			}
 
-			// Output text content
 			for (const content of assistantMsg.content) {
 				if (content.type === "text") {
 					writeStdoutLine(`${sanitizeText(content.text)}\n`);
@@ -237,11 +219,25 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		session.setTextOutputCommitted(true);
 	}
 
-	await session.waitForAdvisorCatchup(PRINT_MODE_ADVISOR_DRAIN_TIMEOUT_MS);
+	await session.waitForAdvisorCatchup(
+		terminalFailure ? PRINT_MODE_ERROR_ADVISOR_DRAIN_TIMEOUT_MS : PRINT_MODE_ADVISOR_DRAIN_TIMEOUT_MS,
+	);
+	if (terminalFailure) await flushTelemetryExport();
 
 	// Block shutdown until every serialized stdout write (including the final
 	// agent_end and late JSON advisor events) has drained; process.exit would
 	// otherwise discard the buffered tail and truncate the last record.
 	await stdoutTail;
 	await session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+
+	if (mode === "text" && terminalFailure && assistantMsg) {
+		const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+		if (!process.stderr.write(`${errorLine}\n`)) {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			process.stderr.once("drain", resolve);
+			await promise;
+		}
+	}
+
+	return terminalFailure ? 1 : 0;
 }

--- a/packages/coding-agent/test/print-mode-json-flush.test.ts
+++ b/packages/coding-agent/test/print-mode-json-flush.test.ts
@@ -38,6 +38,7 @@ function createFlushHarness(): FlushHarness {
 			getEntries: () => [],
 		},
 		settings: { get: () => false },
+		getLastAssistantMessage: () => undefined,
 		extensionRunner: undefined,
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			subscriber = listener;

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -322,7 +322,7 @@ describe("print mode working indicator", () => {
 		expect(stdoutEvents.at(-1)).toBe("flush");
 	});
 
-	it("waits for advisor catch-up before hard-exit disposal", async () => {
+	it("waits for advisor catch-up before returning a terminal failure", async () => {
 		const message = makeAssistantMessage("");
 		message.stopReason = "error";
 		message.errorMessage = "primary request failed";
@@ -330,12 +330,7 @@ describe("print mode working indicator", () => {
 		const { promise: catchup, resolve: resolveCatchup } = Promise.withResolvers<void>();
 		const { promise: catchupStarted, resolve: markCatchupStarted } = Promise.withResolvers<void>();
 		let disposed = false;
-		let exitCode: number | undefined;
 		let catchupTimeoutMs: number | undefined;
-		vi.spyOn(process, "exit").mockImplementation(code => {
-			exitCode = code as number;
-			throw new Error("process exit");
-		});
 		const session = {
 			state: { messages },
 			getLastAssistantMessage: () => messages.findLast(message => message.role === "assistant"),
@@ -368,9 +363,8 @@ describe("print mode working indicator", () => {
 		expect(disposed).toBe(false);
 		resolveCatchup();
 
-		await expect(run).rejects.toThrow("process exit");
+		expect(await run).toBe(1);
 		expect(disposed).toBe(true);
-		expect(exitCode).toBe(1);
 		expect(catchupTimeoutMs).toBe(PRINT_MODE_ERROR_ADVISOR_DRAIN_TIMEOUT_MS);
 		expect(stderrOutput.join("")).toContain("primary request failed");
 	});

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -96,12 +96,10 @@ describe("Print-mode silent-abort regression", () => {
 		});
 
 		const session = createMockSession([silentAbortMsg]);
-		await runPrintMode(session, { mode: "text" });
+		const status = await runPrintMode(session, { mode: "text" });
 
-		// The silent-abort marker MUST NOT appear in stderr
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).not.toContain(SILENT_ABORT_MARKER);
-		// process.exit MUST NOT have been called (clean termination)
+		expect(status).toBe(0);
+		expect(stderrOutput.join("")).not.toContain(SILENT_ABORT_MARKER);
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
@@ -125,13 +123,14 @@ describe("Print-mode silent-abort regression", () => {
 		});
 
 		const session = createMockSession([silentAbortMsg]);
-		await runPrintMode(session, { mode: "text" });
+		const status = await runPrintMode(session, { mode: "text" });
 
+		expect(status).toBe(0);
 		expect(stderrOutput.join("")).toBe("");
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
-	it("writes real error messages to stderr and exits non-zero", async () => {
+	it("writes real text-mode errors to stderr and returns a failing status", async () => {
 		const errorMsg = makeAssistantMessage({
 			stopReason: "error",
 			errorMessage: "Rate limit exceeded",
@@ -142,14 +141,25 @@ describe("Print-mode silent-abort regression", () => {
 		const session = createMockSession([errorMsg], async options => {
 			disposeOptions = options;
 		});
-		await runPrintMode(session, { mode: "text" });
+		const status = await runPrintMode(session, { mode: "text" });
 
-		// A real error SHOULD be written to stderr
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).toContain("Rate limit exceeded");
-		// process.exit(1) SHOULD have been called
-		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(status).toBe(1);
+		expect(stderrOutput.join("")).toContain("Rate limit exceeded");
+		expect(exitSpy).not.toHaveBeenCalled();
 		expect(disposeOptions?.mnemopiConsolidateTimeoutMs).toBe(SHUTDOWN_CONSOLIDATE_BUDGET_MS);
+	});
+
+	it("returns a failing status for terminal errors in JSON mode", async () => {
+		const errorMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage: "Unable to connect",
+			content: [],
+		});
+
+		const status = await runPrintMode(createMockSession([errorMsg]), { mode: "json" });
+
+		expect(status).toBe(1);
+		expect(stderrOutput.join("")).toBe("");
 	});
 
 	it("prints thinking blocks only when printThoughts is enabled", async () => {


### PR DESCRIPTION
## Repro
With a terminal assistant message carrying `stopReason: "error"`, JSON print mode returned no status while text mode hard-exited. The focused repro is `cd packages/coding-agent && bun test test/silent-abort-print-mode.test.ts`; before the fix its JSON assertion failed with `Expected: 1, Received: undefined`.

## Cause
`runPrintMode` in `packages/coding-agent/src/modes/print-mode.ts` read and handled the last assistant message only inside the text-output branch. The non-interactive caller in `packages/coding-agent/src/main.ts` therefore always passed `0` to `postmortem.quit` after JSON runs, regardless of the terminal stop reason.

## Fix
- Inspect the terminal assistant message for every print output mode and return a shared exit status.
- Preserve text-only stderr rendering while routing the returned status through `postmortem.quit`.
- Cover JSON failure status, silent abort success, bounded failure cleanup, and buffered JSON output.

## Verification
`cd packages/coding-agent && bun test test/silent-abort-print-mode.test.ts test/print-mode-json-flush.test.ts test/print-mode-working-indicator.test.ts test/modes/print-mode.test.ts` passes 19 tests. `cd packages/coding-agent && bun run check` passes. Manual CLI smoke against a retry-disabled dead loopback provider confirms both `--mode json` and text mode exit 1; JSON still emits the terminal error events and text still writes the provider error to stderr.

Fixes #11498