### PR TITLE
fix(session): prevent stale rewrites from erasing durable turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Session rewrites now refuse to replace a file changed by another process, preserving durable turns from concurrent terminals ([#11496](https://github.com/can1357/oh-my-pi/issues/11496)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/session/indexed-session-storage.ts
+++ b/packages/coding-agent/src/session/indexed-session-storage.ts
@@ -29,7 +29,17 @@ export interface SessionStorageBackend {
 	loadIndex(): Promise<Iterable<SessionStorageIndexEntry>>;
 	readFull(path: string): Promise<string | null>;
 	readSlices(path: string, prefixBytes: number, suffixBytes: number): Promise<[string, string]>;
-	writeFull(path: string, content: string, mtimeMs: number, title?: SessionTitleUpdate): Promise<void>;
+	/**
+	 * Replace content, atomically rejecting when the shared backend's current
+	 * UTF-8 byte length differs from `expectedSize`.
+	 */
+	writeFull(
+		path: string,
+		content: string,
+		mtimeMs: number,
+		title?: SessionTitleUpdate,
+		expectedSize?: number | null,
+	): Promise<void>;
 	append(path: string, line: string, mtimeMs: number): Promise<void>;
 	updateSessionTitle(path: string, title: SessionTitleUpdate, mtimeMs: number): Promise<void>;
 	truncate(path: string, mtimeMs: number): Promise<void>;
@@ -152,10 +162,18 @@ export class IndexedSessionStorage implements SessionStorage {
 
 	writeTextSync(path: string, content: string, options?: SessionStorageWriteOptions): void {
 		this.#assertExpectedSize(path, options?.expectedSize);
+		const previous = this.#index.get(path);
 		const mtimeMs = this.#allocMtimeMs();
 		const title = titleUpdateFromSlot(parseTitleSlotFromContent(content));
 		this.#setIndex(path, byteLength(content), mtimeMs, title ?? null);
-		this.#enqueuePath(path, () => this.#backend.writeFull(path, content, mtimeMs, title), { trackDrain: true });
+		const write = this.#enqueuePath(
+			path,
+			() => this.#backend.writeFull(path, content, mtimeMs, title, options?.expectedSize),
+			{ trackDrain: true },
+		);
+		void write.catch(() => {
+			if (this.#index.get(path)?.mtimeMs === mtimeMs) this.#restoreIndex(path, previous);
+		});
 	}
 
 	async updateSessionTitle(path: string, title: SessionTitleUpdate): Promise<void> {
@@ -281,7 +299,7 @@ export class IndexedSessionStorage implements SessionStorage {
 						if (current?.mtimeMs === mtimeMs) this.#restoreIndex(path, previous);
 						return;
 					}
-					await this.#backend.writeFull(path, content, mtimeMs, title);
+					await this.#backend.writeFull(path, content, mtimeMs, title, options?.expectedSize);
 				},
 				{ trackDrain: false },
 			);

--- a/packages/coding-agent/src/session/indexed-session-storage.ts
+++ b/packages/coding-agent/src/session/indexed-session-storage.ts
@@ -1,9 +1,11 @@
 import { toError } from "@oh-my-pi/pi-utils";
-import type {
-	SessionStorage,
-	SessionStorageStat,
-	SessionStorageWriter,
-	WriteTextAtomicOptions,
+import {
+	SessionWriteConflictError,
+	type SessionStorage,
+	type SessionStorageStat,
+	type SessionStorageWriter,
+	type SessionStorageWriteOptions,
+	type WriteTextAtomicOptions,
 } from "./session-storage";
 import {
 	overlayTitleSlotContent,
@@ -97,6 +99,13 @@ export class IndexedSessionStorage implements SessionStorage {
 	readonly #drainPending = new Set<Promise<void>>();
 	#nextMtimeMs = 0;
 	#firstDrainError: Error | undefined;
+	#assertExpectedSize(path: string, expectedSize: number | null | undefined): void {
+		if (expectedSize === undefined) return;
+		const actualSize = this.#index.get(path)?.size ?? null;
+		if (actualSize !== expectedSize) {
+			throw new SessionWriteConflictError(path, expectedSize, actualSize);
+		}
+	}
 
 	constructor(backend: SessionStorageBackend) {
 		this.#backend = backend;
@@ -141,7 +150,8 @@ export class IndexedSessionStorage implements SessionStorage {
 		return this.#index.has(path);
 	}
 
-	writeTextSync(path: string, content: string): void {
+	writeTextSync(path: string, content: string, options?: SessionStorageWriteOptions): void {
+		this.#assertExpectedSize(path, options?.expectedSize);
 		const mtimeMs = this.#allocMtimeMs();
 		const title = titleUpdateFromSlot(parseTitleSlotFromContent(content));
 		this.#setIndex(path, byteLength(content), mtimeMs, title ?? null);
@@ -252,6 +262,7 @@ export class IndexedSessionStorage implements SessionStorage {
 		// awaitPath yield and bumped the epoch. Re-check before touching the
 		// index or enqueueing the backend publish.
 		if (commitGuard && !commitGuard()) return;
+		this.#assertExpectedSize(path, options?.expectedSize);
 		const previous = this.#index.get(path);
 		const mtimeMs = this.#allocMtimeMs();
 		const title = titleUpdateFromSlot(parseTitleSlotFromContent(content));

--- a/packages/coding-agent/src/session/redis-session-storage.ts
+++ b/packages/coding-agent/src/session/redis-session-storage.ts
@@ -4,6 +4,7 @@ import {
 	type SessionStorageBackend,
 	type SessionStorageIndexEntry,
 } from "./indexed-session-storage";
+import { SessionWriteConflictError } from "./session-storage";
 import type { SessionTitleUpdate } from "./session-title-slot";
 
 /**
@@ -47,6 +48,16 @@ const DEFAULT_PREFIX = "omp:sessions:";
 const DEFAULT_SCAN_COUNT = 500;
 
 const WRITE_FULL_SCRIPT = `-- OMP_WRITE_FULL
+local expected = ARGV[6]
+if expected ~= "" then
+	local actual = -1
+	if redis.call("EXISTS", KEYS[1]) == 1 then
+		actual = redis.call("STRLEN", KEYS[1])
+	end
+	if actual ~= tonumber(expected) then
+		return {0, actual}
+	end
+end
 redis.call("SET", KEYS[1], ARGV[1])
 redis.call("HSET", KEYS[2], ARGV[2], ARGV[3])
 if ARGV[4] == "1" then
@@ -54,7 +65,7 @@ if ARGV[4] == "1" then
 else
 	redis.call("HDEL", KEYS[3], ARGV[2])
 end
-return 1`;
+return {1, string.len(ARGV[1])}`;
 
 const APPEND_SCRIPT = `-- OMP_APPEND
 local size = redis.call("APPEND", KEYS[1], ARGV[1])
@@ -175,8 +186,14 @@ class RedisSessionStorageBackend implements SessionStorageBackend {
 		return Promise.all([head, tail]);
 	}
 
-	async writeFull(path: string, content: string, mtimeMs: number, title?: SessionTitleUpdate): Promise<void> {
-		await this.#client.send("EVAL", [
+	async writeFull(
+		path: string,
+		content: string,
+		mtimeMs: number,
+		title?: SessionTitleUpdate,
+		expectedSize?: number | null,
+	): Promise<void> {
+		const result = await this.#client.send("EVAL", [
 			WRITE_FULL_SCRIPT,
 			"3",
 			this.#fileKey(path),
@@ -187,7 +204,14 @@ class RedisSessionStorageBackend implements SessionStorageBackend {
 			String(mtimeMs),
 			title ? "1" : "0",
 			title ? encodeTitleMeta(title) : "",
+			expectedSize === undefined ? "" : String(expectedSize ?? -1),
 		]);
+		if (expectedSize === undefined) return;
+		const written = Array.isArray(result) && Number(result[0]) === 1;
+		if (written) return;
+		const encodedActual = Array.isArray(result) ? Number(result[1]) : Number.NaN;
+		const actualSize = encodedActual === -1 ? null : Number.isFinite(encodedActual) ? encodedActual : null;
+		throw new SessionWriteConflictError(path, expectedSize, actualSize);
 	}
 
 	async append(path: string, line: string, mtimeMs: number): Promise<void> {

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -38,6 +38,8 @@ export interface SessionLoadResult {
 	entries: FileEntry[];
 	titleSlot: SessionTitleUpdate | undefined;
 	malformedRecords: number;
+	/** Byte length observed before loading, or `null` when the path did not exist. */
+	sourceSize?: number | null;
 	/** Whether non-empty session data was found without a valid leading session header. */
 	invalidHeader: boolean;
 }
@@ -281,9 +283,18 @@ export async function loadSessionFile(
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<SessionLoadResult> {
 	try {
-		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
+		const sourceSize = storage.statSync(filePath).size;
+		return { ...(await loadWithKnownSize(filePath, storage, sourceSize)), sourceSize };
 	} catch (err) {
-		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		if (isEnoent(err)) {
+			return {
+				entries: [],
+				titleSlot: undefined,
+				malformedRecords: 0,
+				sourceSize: null,
+				invalidHeader: false,
+			};
+		}
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1427,11 +1427,16 @@ export class SessionManager {
 				`could not relocate the session back to ${snapshot.sessionDir} (${error instanceof Error ? error.message : String(error)}); the session file remains at ${movedFile}`,
 			);
 		}
+		// The inverse moveTo already rewrote the restored source file and left
+		// #expectedDiskSize describing that on-disk body. restoreState resets it
+		// to the pre-move snapshot size, so capture the post-relocation size and
+		// reapply it — otherwise the final rewrite would compare a stale size and
+		// reject an otherwise successful rollback.
+		const relocatedDiskSize = this.#expectedDiskSize;
 		this.restoreState(snapshot);
-		// The inverse moveTo already rewrote the source file with the
-		// target-filtered header. Persist the captured one so disk and memory
-		// agree after a fresh open.
+		// Persist the captured header so disk and memory agree after a fresh open.
 		if (this.#persist && this.#sessionFile) {
+			this.#expectedDiskSize = relocatedDiskSize;
 			this.#forceFileCreation = true;
 			this.#rewriteRequired = true;
 			await this.#rewriteAtomically();
@@ -1688,6 +1693,12 @@ export class SessionManager {
 				}
 
 				this.#sessionFile = newSessionFile;
+				// The freshness expectation must describe the NEW path. A successful
+				// rename carried this manager's tracked bytes to `newSessionFile`, so
+				// #expectedDiskSize still applies; without a rename the destination
+				// holds no bytes this manager wrote, so a recreate-from-memory must
+				// publish against an absent file rather than a stale size.
+				if (sessionPathChanged && !sessionMoved) this.#expectedDiskSize = null;
 				this.#artifactManager = null;
 				this.#artifactManagerSessionFile = null;
 				// Path is repointed; hot-path appends may use `#sessionFile` again.

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -406,6 +406,7 @@ interface SessionManagerStateSnapshot {
 	sessionName: string | undefined;
 	titleSource: SessionTitleSource | undefined;
 	sessionFile: string | undefined;
+	expectedDiskSize: number | null;
 	titleUpdatedAt: string;
 	hasTitleSlot: boolean;
 	onDisk: boolean;
@@ -499,6 +500,8 @@ export class SessionManager {
 	#fileIsCurrent = false;
 	/** In-memory entries diverged from disk (load-migration/sanitize) → next persist must full-rewrite. */
 	#rewriteRequired = false;
+	/** Byte length this manager last loaded or durably wrote; `null` means the path was absent. */
+	#expectedDiskSize: number | null = null;
 	/** Lazy gate crossed (ensureOnDisk / loaded file): every entry must persist from now on. */
 	#forceFileCreation = false;
 	/**
@@ -762,6 +765,7 @@ export class SessionManager {
 				const body = this.#fileBody();
 				try {
 					await this.#storage.writeTextAtomic(sessionFile, body, {
+						expectedSize: this.#expectedDiskSize,
 						commitGuard: () => !this.#released && this.#diskEpoch === epoch,
 					});
 				} catch (error) {
@@ -783,6 +787,7 @@ export class SessionManager {
 						throw this.#latchIndeterminate(operationError, recoveryErrors);
 					}
 				}
+				this.#recordFullRewrite(body);
 				if (this.#diskEpoch !== epoch) {
 					throw this.#latchIndeterminate(operationError, [
 						new Error("Authoritative session repair was superseded before verification."),
@@ -816,6 +821,13 @@ export class SessionManager {
 
 	#lineFor(entry: FileEntry): string {
 		return `${stringifyJson(prepareEntryForPersistence(entry, this.#blobs)) ?? "null"}\n`;
+	}
+	#recordDurableAppend(line: string): void {
+		this.#expectedDiskSize = (this.#expectedDiskSize ?? 0) + Buffer.byteLength(line, "utf8");
+	}
+
+	#recordFullRewrite(body: string): void {
+		this.#expectedDiskSize = Buffer.byteLength(body, "utf8");
 	}
 
 	#titleSlotLine(): string {
@@ -876,7 +888,8 @@ export class SessionManager {
 			this.#diskEpoch++;
 			this.#diskTail = Promise.resolve();
 			this.#closeWriterEventually();
-			this.#storage.writeTextSync(targetPath, body);
+			this.#storage.writeTextSync(targetPath, body, { expectedSize: this.#expectedDiskSize });
+			this.#recordFullRewrite(body);
 			this.#clearDiskError();
 			// Only mark the manager current when writing the active session path.
 			// Mid-move writes update the live relocation path; `#sessionFile` is
@@ -945,10 +958,22 @@ export class SessionManager {
 				const sessionFile = this.#sessionFile;
 				if (!sessionFile) return false;
 				if (this.#diskEpoch !== epoch) return false;
-				await this.#storage.writeTextAtomic(sessionFile, this.#fileBody(), {
-					commitGuard: () => !this.#released && this.#diskEpoch === epoch,
-				});
+				const body = this.#fileBody();
+				try {
+					await this.#storage.writeTextAtomic(sessionFile, body, {
+						expectedSize: this.#expectedDiskSize,
+						commitGuard: () => !this.#released && this.#diskEpoch === epoch,
+					});
+				} catch (error) {
+					try {
+						if ((await this.#storage.readText(sessionFile)) === body) this.#recordFullRewrite(body);
+					} catch {
+						// Preserve the publish error when durable state cannot be read back.
+					}
+					throw error;
+				}
 				if (this.#diskEpoch !== epoch) return false;
+				this.#recordFullRewrite(body);
 			} while (this.#atomicRewriteDirty);
 			return true;
 		} finally {
@@ -1024,12 +1049,16 @@ export class SessionManager {
 			const line = this.#lineFor(entry);
 			if (writer.appendSync) {
 				writer.appendSync(line);
+				this.#recordDurableAppend(line);
 			} else {
-				void writer.append(line).catch(err => {
-					this.#fileIsCurrent = false;
-					this.#rewriteRequired = true;
-					this.#noteDiskFailure(err);
-				});
+				void writer
+					.append(line)
+					.then(() => this.#recordDurableAppend(line))
+					.catch(err => {
+						this.#fileIsCurrent = false;
+						this.#rewriteRequired = true;
+						this.#noteDiskFailure(err);
+					});
 			}
 		} catch (err) {
 			this.#fileIsCurrent = false;
@@ -1081,6 +1110,7 @@ export class SessionManager {
 				if (!sessionFile) return;
 				try {
 					await this.#appendWriter().append(line);
+					this.#recordDurableAppend(line);
 					await this.#storage.updateSessionTitle(sessionFile, update);
 					if (this.#diskEpoch === epoch) this.#fileIsCurrent = true;
 				} catch {
@@ -1109,6 +1139,7 @@ export class SessionManager {
 	#resetToNewSession(options?: NewSessionOptions, forcedSessionFile?: string): string | undefined {
 		this.#diskTail = Promise.resolve();
 		this.#clearDiskError();
+		this.#expectedDiskSize = null;
 		this.#reconcileSessionDirForFallback();
 		this.#sessionId = mintSessionId();
 		this.#sessionName = undefined;
@@ -1311,6 +1342,7 @@ export class SessionManager {
 			titleUpdatedAt: this.#titleUpdatedAt,
 			hasTitleSlot: this.#hasTitleSlot,
 			sessionFile: this.#sessionFile,
+			expectedDiskSize: this.#expectedDiskSize,
 			onDisk: this.#fileIsCurrent,
 			needsRewrite: this.#rewriteRequired,
 			draftOnlySessionCleanupArmed: this.#draftOnlySessionCleanupArmed,
@@ -1337,6 +1369,7 @@ export class SessionManager {
 		clone.restoreState(this.captureState());
 		if (!persist) {
 			clone.#sessionFile = undefined;
+			clone.#expectedDiskSize = null;
 			clone.#fileIsCurrent = false;
 			clone.#rewriteRequired = false;
 			clone.#forceFileCreation = false;
@@ -1352,6 +1385,7 @@ export class SessionManager {
 		this.#cwd = snapshot.cwd;
 		this.#sessionDir = snapshot.sessionDir;
 		this.#sessionFile = snapshot.sessionFile;
+		this.#expectedDiskSize = snapshot.expectedDiskSize;
 		this.#fileIsCurrent = snapshot.onDisk;
 		this.#rewriteRequired = snapshot.needsRewrite;
 		this.#forceFileCreation = snapshot.onDisk;
@@ -1415,6 +1449,12 @@ export class SessionManager {
 
 		const resolvedSessionFile = path.resolve(sessionFile);
 		const loaded = loadedSession ?? (await loadSessionFile(resolvedSessionFile, this.#storage));
+		const sourceSize =
+			loaded.sourceSize !== undefined
+				? loaded.sourceSize
+				: this.#storage.existsSync(resolvedSessionFile)
+					? this.#storage.statSync(resolvedSessionFile).size
+					: null;
 		if (loaded.invalidHeader) {
 			throw new Error(
 				`Cannot resume session "${resolvedSessionFile}": the session header is missing or malformed. The file was not modified.`,
@@ -1429,6 +1469,7 @@ export class SessionManager {
 			// Explicit but empty/missing path (e.g. --session flag): start fresh but
 			// keep the requested path and materialize the header immediately.
 			this.#resetToNewSession(undefined, resolvedSessionFile);
+			this.#expectedDiskSize = sourceSize;
 			this.#forceFileCreation = true;
 			await this.#rewriteAtomically();
 			this.#fileIsCurrent = true;
@@ -1464,6 +1505,7 @@ export class SessionManager {
 		}
 
 		this.#applyEntries(header, fileEntries.slice(1) as SessionEntry[]);
+		this.#expectedDiskSize = sourceSize;
 		this.#additionalDirectories = header.additionalDirectories ?? [];
 		this.#titleUpdatedAt = titleSlot?.updatedAt ?? header.timestamp;
 		this.#hasTitleSlot = titleSlot !== undefined;
@@ -1515,6 +1557,7 @@ export class SessionManager {
 		const timestamp = nowIso();
 		this.#sessionId = mintSessionId();
 		this.#sessionFile = path.join(this.#sessionDir, `${fileSafeTimestamp(timestamp)}_${this.#sessionId}.jsonl`);
+		this.#expectedDiskSize = null;
 		this.#header = {
 			type: "session",
 			version: CURRENT_SESSION_VERSION,
@@ -2795,6 +2838,7 @@ export class SessionManager {
 		}
 
 		this.#sessionFile = newSessionFile;
+		this.#expectedDiskSize = null;
 		this.#rewriteSynchronously();
 		this.#rememberBreadcrumb(this.#cwd, newSessionFile);
 		return newSessionFile;

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -43,22 +43,47 @@ export interface SessionStorageWriter {
 	getError(): Error | undefined;
 }
 
+/** Optimistic precondition for replacing a session file. */
+export interface SessionStorageWriteOptions {
+	/** Current UTF-8 byte length, or `null` when the target must not exist. */
+	expectedSize?: number | null;
+}
+
 /**
- * Optional guard applied by {@link SessionStorage.writeTextAtomic}. The
- * backend MUST call `commitGuard()` synchronously immediately before it makes
- * the staged content visible at `path`. If it returns `false`, the staged
- * write is discarded and the target is left untouched. Backends MUST NOT
- * yield between calling the guard and publishing the write, so a concurrent
- * synchronous rewrite that took over cannot be overwritten by a stale body.
+ * The session changed after a writer loaded it, so replacing it would discard
+ * another writer's durable entries.
  */
-export interface WriteTextAtomicOptions {
+export class SessionWriteConflictError extends Error {
+	readonly path: string;
+	readonly expectedSize: number | null;
+	readonly actualSize: number | null;
+
+	constructor(path: string, expectedSize: number | null, actualSize: number | null) {
+		const expected = expectedSize === null ? "missing" : `${expectedSize} bytes`;
+		const actual = actualSize === null ? "missing" : `${actualSize} bytes`;
+		super(`Session file changed before rewrite: ${path} (expected ${expected}, found ${actual}).`);
+		this.name = "SessionWriteConflictError";
+		this.path = path;
+		this.expectedSize = expectedSize;
+		this.actualSize = actualSize;
+	}
+}
+
+/**
+ * Optional guards applied by {@link SessionStorage.writeTextAtomic}. The
+ * backend MUST check `expectedSize` and call `commitGuard()` synchronously
+ * immediately before it makes the staged content visible at `path`. Failed
+ * preconditions leave the target untouched. Backends MUST NOT yield between
+ * the checks and publishing the write.
+ */
+export interface WriteTextAtomicOptions extends SessionStorageWriteOptions {
 	commitGuard?: () => boolean;
 }
 
 export interface SessionStorage {
 	ensureDirSync(dir: string): void;
 	existsSync(path: string): boolean;
-	writeTextSync(path: string, content: string): void;
+	writeTextSync(path: string, content: string, options?: SessionStorageWriteOptions): void;
 	/**
 	 * Update the current session title through the storage backend.
 	 *
@@ -201,6 +226,20 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 }
 
 export class FileSessionStorage implements SessionStorage {
+	#assertExpectedSize(fpath: string, expectedSize: number | null | undefined): void {
+		if (expectedSize === undefined) return;
+		let actualSize: number | null;
+		try {
+			actualSize = fs.statSync(fpath).size;
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
+			actualSize = null;
+		}
+		if (actualSize !== expectedSize) {
+			throw new SessionWriteConflictError(fpath, expectedSize, actualSize);
+		}
+	}
+
 	ensureDirSync(dir: string): void {
 		if (!fs.existsSync(dir)) {
 			fs.mkdirSync(dir, { recursive: true });
@@ -211,7 +250,7 @@ export class FileSessionStorage implements SessionStorage {
 		return fs.existsSync(path);
 	}
 
-	writeTextSync(fpath: string, content: string): void {
+	writeTextSync(fpath: string, content: string, options?: SessionStorageWriteOptions): void {
 		const dir = path.dirname(fpath);
 		this.ensureDirSync(dir);
 		const tempPath = path.join(dir, `.${path.basename(fpath)}.${Snowflake.next()}.tmp`);
@@ -222,6 +261,7 @@ export class FileSessionStorage implements SessionStorage {
 			throw toError(err);
 		}
 		try {
+			this.#assertExpectedSize(fpath, options?.expectedSize);
 			this.renameSync(tempPath, fpath);
 		} catch (err) {
 			if (!hasFsCode(err, "EPERM")) {
@@ -313,6 +353,7 @@ export class FileSessionStorage implements SessionStorage {
 			return;
 		}
 		try {
+			this.#assertExpectedSize(fpath, options?.expectedSize);
 			this.renameSync(tempPath, fpath);
 			return;
 		} catch (err) {
@@ -683,7 +724,11 @@ export class MemorySessionStorage implements SessionStorage {
 		return this.#files.has(path);
 	}
 
-	writeTextSync(path: string, content: string): void {
+	writeTextSync(path: string, content: string, options?: SessionStorageWriteOptions): void {
+		const actualSize = this.#files.get(path)?.size ?? null;
+		if (options?.expectedSize !== undefined && actualSize !== options.expectedSize) {
+			throw new SessionWriteConflictError(path, options.expectedSize, actualSize);
+		}
 		this.#files.set(path, createMemoryFileEntry(content, Date.now()));
 	}
 
@@ -756,7 +801,7 @@ export class MemorySessionStorage implements SessionStorage {
 
 	writeTextAtomic(path: string, content: string, options?: WriteTextAtomicOptions): Promise<void> {
 		if (options?.commitGuard && !options.commitGuard()) return Promise.resolve();
-		this.writeTextSync(path, content);
+		this.writeTextSync(path, content, { expectedSize: options?.expectedSize });
 		return Promise.resolve();
 	}
 

--- a/packages/coding-agent/src/session/sql-session-storage.ts
+++ b/packages/coding-agent/src/session/sql-session-storage.ts
@@ -3,6 +3,7 @@ import {
 	type SessionStorageBackend,
 	type SessionStorageIndexEntry,
 } from "./indexed-session-storage";
+import { SessionWriteConflictError } from "./session-storage";
 import type { SessionTitleUpdate } from "./session-title-slot";
 
 /**
@@ -19,8 +20,13 @@ export type SqlSessionStorageAdapter = "postgres" | "mysql" | "sqlite";
  * the table identifier is validated and then inlined while values remain bound
  * parameters.
  */
+/** Array result returned by `Bun.SQL`, including MySQL mutation metadata. */
+export interface SqlSessionStorageResult extends Array<unknown> {
+	affectedRows?: number;
+}
+
 export interface SqlSessionStorageClient {
-	unsafe(query: string, values?: unknown[]): Promise<unknown[]>;
+	unsafe(query: string, values?: unknown[]): Promise<SqlSessionStorageResult>;
 	/**
 	 * `Bun.SQL` exposes the parsed connection options here. We only consult
 	 * `adapter` to pick the dialect; the field is typed as
@@ -60,6 +66,10 @@ interface DialectQueries {
 	addTitleColumns: readonly string[];
 	/** Insert or replace the full content for `path`. Used for `writeText`/`flags="w"` truncate. */
 	upsertReplace: string;
+	/** Insert a full body only when `path` does not exist. */
+	insertIfMissing: string;
+	/** Replace a full body only when its current UTF-8 byte length matches. */
+	replaceIfSize: string;
 	/** Insert if missing; otherwise append the new chunk to existing content. Used for `writeLine`. */
 	upsertAppend: string;
 	/** Update indexed title metadata without rewriting the JSONL body. */
@@ -140,6 +150,10 @@ function buildQueries(adapter: SqlSessionStorageAdapter, table: string): Dialect
 			upsertReplace:
 				`INSERT INTO ${table} (path, content, mtime_ms, title, title_source, title_updated_at) VALUES (?, ?, ?, ?, ?, ?) ` +
 				`ON DUPLICATE KEY UPDATE content = VALUES(content), mtime_ms = VALUES(mtime_ms), title = VALUES(title), title_source = VALUES(title_source), title_updated_at = VALUES(title_updated_at)`,
+			insertIfMissing: `INSERT IGNORE INTO ${table} (path, content, mtime_ms, title, title_source, title_updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+			replaceIfSize:
+				`UPDATE ${table} SET content = ?, mtime_ms = ?, title = ?, title_source = ?, title_updated_at = ? ` +
+				`WHERE path = ? AND length(content) = ?`,
 			upsertAppend:
 				`INSERT INTO ${table} (path, content, mtime_ms) VALUES (?, ?, ?) ` +
 				`ON DUPLICATE KEY UPDATE content = CONCAT(content, VALUES(content)), mtime_ms = VALUES(mtime_ms)`,
@@ -188,6 +202,14 @@ function buildQueries(adapter: SqlSessionStorageAdapter, table: string): Dialect
 			`INSERT INTO ${table} (path, content, mtime_ms, title, title_source, title_updated_at) ` +
 			`VALUES (${placeholder(1)}, ${placeholder(2)}, ${placeholder(3)}, ${placeholder(4)}, ${placeholder(5)}, ${placeholder(6)}) ` +
 			`ON CONFLICT (path) DO UPDATE SET content = excluded.content, mtime_ms = excluded.mtime_ms, title = excluded.title, title_source = excluded.title_source, title_updated_at = excluded.title_updated_at`,
+		insertIfMissing:
+			`INSERT INTO ${table} (path, content, mtime_ms, title, title_source, title_updated_at) ` +
+			`VALUES (${placeholder(1)}, ${placeholder(2)}, ${placeholder(3)}, ${placeholder(4)}, ${placeholder(5)}, ${placeholder(6)}) ` +
+			`ON CONFLICT (path) DO NOTHING RETURNING path`,
+		replaceIfSize:
+			`UPDATE ${table} SET content = ${placeholder(1)}, mtime_ms = ${placeholder(2)}, title = ${placeholder(3)}, ` +
+			`title_source = ${placeholder(4)}, title_updated_at = ${placeholder(5)} ` +
+			`WHERE path = ${placeholder(6)} AND ${byteLengthExpr} = ${placeholder(7)} RETURNING path`,
 		upsertAppend:
 			`INSERT INTO ${table} (path, content, mtime_ms) ` +
 			`VALUES (${placeholder(1)}, ${placeholder(2)}, ${placeholder(3)}) ` +
@@ -332,15 +354,29 @@ class SqlSessionStorageBackend implements SessionStorageBackend {
 		return [decodeSqlBytes(row.head), decodeSqlBytes(row.tail)];
 	}
 
-	async writeFull(path: string, content: string, mtimeMs: number, title?: SessionTitleUpdate): Promise<void> {
-		await this.#client.unsafe(this.#q.upsertReplace, [
-			path,
-			content,
-			mtimeMs,
-			title?.title ?? null,
-			title?.source ?? null,
-			title?.updatedAt ?? null,
-		]);
+	async writeFull(
+		path: string,
+		content: string,
+		mtimeMs: number,
+		title?: SessionTitleUpdate,
+		expectedSize?: number | null,
+	): Promise<void> {
+		const titleValues = [title?.title ?? null, title?.source ?? null, title?.updatedAt ?? null];
+		if (expectedSize === undefined) {
+			await this.#client.unsafe(this.#q.upsertReplace, [path, content, mtimeMs, ...titleValues]);
+			return;
+		}
+
+		const result =
+			expectedSize === null
+				? await this.#client.unsafe(this.#q.insertIfMissing, [path, content, mtimeMs, ...titleValues])
+				: await this.#client.unsafe(this.#q.replaceIfSize, [content, mtimeMs, ...titleValues, path, expectedSize]);
+		const written = this.#adapter === "mysql" ? result.affectedRows === 1 : result.length === 1;
+		if (written) return;
+
+		const current = await this.readFull(path);
+		const actualSize = current === null ? null : Buffer.byteLength(current, "utf8");
+		throw new SessionWriteConflictError(path, expectedSize, actualSize);
 	}
 
 	async updateSessionTitle(path: string, title: SessionTitleUpdate, mtimeMs: number): Promise<void> {

--- a/packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts
+++ b/packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts
@@ -9,10 +9,13 @@ import {
 	SessionPersistenceIndeterminateError,
 } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
+	FileSessionStorage,
 	MemorySessionStorage,
 	type SessionStorageWriter,
+	SessionWriteConflictError,
 	type WriteTextAtomicOptions,
 } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import type { SessionTitleUpdate } from "@oh-my-pi/pi-coding-agent/session/session-title-slot";
 
 interface DetachableWriter extends SessionStorageWriter {
@@ -322,6 +325,42 @@ describe("SessionManager atomic rewrite race", () => {
 		expect(afterRelease).toContain("newer summary");
 		expect(storage.guardRejections).toBeGreaterThanOrEqual(1);
 		expect(storage.detachedLines).toEqual([]);
+	});
+});
+describe("SessionManager cross-process rewrite freshness", () => {
+	it("refuses to erase a durable turn appended by another manager", async () => {
+		const tempDir = TempDir.createSync("@omp-session-rewrite-conflict-");
+		try {
+			const first = SessionManager.create(tempDir.path(), tempDir.path(), new FileSessionStorage());
+			await first.ensureOnDisk();
+			const sessionFile = first.getSessionFile();
+			if (!sessionFile) throw new Error("Expected session file");
+
+			const second = await SessionManager.open(sessionFile, tempDir.path(), new FileSessionStorage(), {
+				suppressBreadcrumb: true,
+			});
+			second.appendMessage({ role: "user", content: "durable second-writer turn", timestamp: Date.now() });
+			await second.close();
+
+			await expect(first.rewriteEntries()).rejects.toBeInstanceOf(SessionWriteConflictError);
+
+			const reopened = await SessionManager.open(sessionFile, tempDir.path(), new FileSessionStorage(), {
+				suppressBreadcrumb: true,
+			});
+			expect(
+				reopened
+					.getEntries()
+					.some(
+						entry =>
+							entry.type === "message" &&
+							entry.message.role === "user" &&
+							entry.message.content === "durable second-writer turn",
+					),
+			).toBe(true);
+			await reopened.close();
+		} finally {
+			await tempDir.remove();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/session/redis-session-storage-manager.test.ts
+++ b/packages/coding-agent/test/session/redis-session-storage-manager.test.ts
@@ -15,6 +15,7 @@ import {
 	type RedisSessionStorageClient,
 } from "@oh-my-pi/pi-coding-agent/session/redis-session-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SessionWriteConflictError } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 
 interface FakeRedis extends RedisSessionStorageClient {
 	strings: Map<string, string>;
@@ -45,12 +46,15 @@ function createFakeRedis(): FakeRedis {
 			const argv = args.slice(2 + keyCount);
 			if (script.includes("OMP_WRITE_FULL")) {
 				const [fileKey, metaKey, titleKey] = keys;
-				const [content, filePath, mtimeMs, hasTitle, title] = argv;
+				const [content, filePath, mtimeMs, hasTitle, title, expectedSize] = argv;
+				const current = strings.get(fileKey);
+				const actualSize = current === undefined ? -1 : Buffer.byteLength(current, "utf8");
+				if (expectedSize !== "" && actualSize !== Number(expectedSize)) return [0, actualSize];
 				strings.set(fileKey, content);
 				getHash(metaKey).set(filePath, mtimeMs);
 				if (hasTitle === "1") getHash(titleKey).set(filePath, title);
 				else getHash(titleKey).delete(filePath);
-				return 1;
+				return [1, Buffer.byteLength(content, "utf8")];
 			}
 			if (script.includes("OMP_APPEND")) {
 				const [fileKey, metaKey] = keys;
@@ -247,5 +251,22 @@ describe("SessionManager + RedisSessionStorage", () => {
 		const sessionFiles = sessions.map(s => s.path).sort();
 		expect(sessionFiles).toContain(aFile as string);
 		expect(sessionFiles).toContain(bFile as string);
+	});
+
+	it("rejects a stale rewrite after another Redis storage appends", async () => {
+		const redis = createFakeRedis();
+		const firstStorage = await RedisSessionStorage.create({ client: redis });
+		const first = SessionManager.create("/cwd", "/sessions/shared", firstStorage);
+		await first.ensureOnDisk();
+		const sessionFile = first.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+
+		const secondStorage = await RedisSessionStorage.create({ client: redis });
+		const second = await SessionManager.open(sessionFile, "/sessions/shared", secondStorage);
+		second.appendMessage({ role: "user", content: "durable Redis peer turn", timestamp: Date.now() });
+		await second.close();
+
+		await expect(first.rewriteEntries()).rejects.toBeInstanceOf(SessionWriteConflictError);
+		expect(redis.strings.get(`omp:sessions:file:${sessionFile}`)).toContain("durable Redis peer turn");
 	});
 });

--- a/packages/coding-agent/test/session/sql-session-storage-manager.test.ts
+++ b/packages/coding-agent/test/session/sql-session-storage-manager.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "bun:test";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { SqlSessionStorage } from "@oh-my-pi/pi-coding-agent/session/sql-session-storage";
+import { SessionWriteConflictError } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { SQL } from "bun";
 
 function fakeUsage(input: number, output: number): Usage {
@@ -121,6 +122,24 @@ describe("SessionManager + SqlSessionStorage (SQLite)", () => {
 		const sessionFiles = sessions.map(s => s.path).sort();
 		expect(sessionFiles).toContain(aFile as string);
 		expect(sessionFiles).toContain(bFile as string);
+		await client.end();
+	});
+
+	it("rejects a stale rewrite after another SQL storage appends", async () => {
+		const client = new SQL("sqlite::memory:");
+		const firstStorage = await SqlSessionStorage.create({ client });
+		const first = SessionManager.create("/cwd", "/sessions/shared", firstStorage);
+		await first.ensureOnDisk();
+		const sessionFile = first.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+
+		const secondStorage = await SqlSessionStorage.create({ client });
+		const second = await SessionManager.open(sessionFile, "/sessions/shared", secondStorage);
+		second.appendMessage({ role: "user", content: "durable SQL peer turn", timestamp: Date.now() });
+		await second.close();
+
+		await expect(first.rewriteEntries()).rejects.toBeInstanceOf(SessionWriteConflictError);
+		expect(await secondStorage.readText(sessionFile)).toContain("durable SQL peer turn");
 		await client.end();
 	});
 });


### PR DESCRIPTION
## Repro

Two independent `FileSessionStorage`/`SessionManager` instances opened the same JSONL. The second appended and closed, then the stale first instance ran `rewriteEntries()`; `bun /tmp/omp-11496-repro.ts` produced `{"before":2,"afterAppend":3,"afterRewrite":2,"bTurnErased":true}` before the fix.

## Cause

`SessionManager.#runFencedAtomicRewrite` in `packages/coding-agent/src/session/session-manager.ts` guarded only the manager-local epoch, while `FileSessionStorage.writeTextAtomic` in `packages/coding-agent/src/session/session-storage.ts` replaced the target without checking whether another process had appended since this manager loaded or wrote it.

## Fix

- Track the loaded or last-written UTF-8 byte length across session loads, appends, rewrites, forks, moves, and manager state snapshots.
- Add an expected-size precondition to file, memory, and indexed storage replacement paths; mismatches throw `SessionWriteConflictError` before publication and leave the target untouched.
- Cover two independent file-backed managers where the stale manager attempts to rewrite after the second manager durably appends.
- Document the user-visible fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts packages/coding-agent/test/session-storage.test.ts packages/coding-agent/test/memory-session-storage.test.ts packages/coding-agent/test/session-loader-stream.test.ts packages/coding-agent/test/session-manager-close-race.test.ts packages/coding-agent/test/session-manager-immediate-persist.test.ts` — 60 passed, 0 failed. `bun check` passed. The fixed repro produced `{"before":2,"afterAppend":3,"afterRewrite":3,"bTurnPreserved":true,"rewriteError":"SessionWriteConflictError"}`.

Fixes #11496