### PR TITLE
fix(catalog): disable forced deepseek tool choice

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct DeepSeek thinking models rejecting plan-mode tool selection with HTTP 400 ([#11505](https://github.com/can1357/oh-my-pi/issues/11505)).
+
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7953,7 +7953,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:10",
+				"source": "providers/deepseek.kdl:11",
 				"class": "deepseek",
 				"providers": [
 					"deepseek"
@@ -7963,7 +7963,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:14",
+				"source": "providers/deepseek.kdl:15",
 				"providers": [
 					"deepseek"
 				],
@@ -7977,8 +7977,7 @@
 					"maxTokensField": "max_tokens",
 					"reasoningContentField": "reasoning_content",
 					"requiresAssistantContentForToolCalls": true,
-					"requiresReasoningContentForToolCalls": true,
-					"supportsToolChoice": false
+					"requiresReasoningContentForToolCalls": true
 				}
 			},
 			{
@@ -7992,7 +7991,8 @@
 							"type": "enabled"
 						}
 					},
-					"supportsReasoningEffort": true
+					"supportsReasoningEffort": true,
+					"supportsToolChoice": false
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/providers/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/providers/deepseek.kdl
@@ -7,6 +7,7 @@ provider "deepseek" {
 		}
 	}
 	supports-reasoning-effort #true
+	supports-tool-choice #false
 	class "deepseek" {
 		thinking-mode "effort"
 	}
@@ -16,6 +17,5 @@ provider "deepseek" {
 		reasoning-content-field "reasoning_content"
 		requires-assistant-content-for-tool-calls #true
 		requires-reasoning-content-for-tool-calls #true
-		supports-tool-choice #false
 	}
 }

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -450,6 +450,25 @@ describe("openai-completions wire-quirk compat detection", () => {
 		).toBe(false);
 	});
 
+	it("omits tool_choice for direct DeepSeek models with provider-enabled thinking", () => {
+		const model = buildModel(
+			completionsSpec({
+				id: "deepseek-flash",
+				name: "DeepSeek Flash",
+				provider: "deepseek",
+				baseUrl: "https://api.deepseek.com",
+				reasoning: false,
+				contextWindow: null,
+				maxTokens: null,
+			}),
+		);
+
+		expect(model.compat).toMatchObject({
+			supportsToolChoice: false,
+			extraBody: { thinking: { type: "enabled" } },
+		});
+	});
+
 	it("downgrades forced tool choice only for DeepSeek reasoning models on OpenCode gateways", () => {
 		const deepseekReasoning = {
 			id: "deepseek-v4-flash",


### PR DESCRIPTION
## Repro

Build a dynamically discovered direct-provider model with `bun -e 'import { buildModel } from "@oh-my-pi/pi-catalog/build"; /* build deepseek/deepseek-flash */'`: current policy resolved `supportsToolChoice: true` together with `extraBody: { thinking: { type: "enabled" } }`, allowing plan-mode convergence to send the combination DeepSeek rejects with HTTP 400.

## Cause

`packages/catalog/src/compat/rules/providers/deepseek.kdl` applied the thinking toggle to the entire `deepseek` provider but applied `supports-tool-choice #false` only to the exact `deepseek-v4-flash` id, so dynamically discovered `deepseek-flash` inherited thinking without the corresponding wire restriction.

## Fix

- Apply `supports-tool-choice #false` at the direct DeepSeek provider scope and regenerate `rules.json`.
- Cover a non-reasoning `deepseek-flash` discovery row through `buildModel`, asserting that thinking stays enabled while explicit tool choice is omitted.
- Document the user-visible plan-mode fix in the catalog changelog.

## Verification

`bun test packages/catalog/test/build.test.ts packages/catalog/test/compat-compile.test.ts packages/catalog/test/issue-830-repro.test.ts` — 74 pass, 0 fail. `bun run check` in `packages/catalog` passed. The original policy probe now prints `{"supportsToolChoice":false,"extraBody":{"thinking":{"type":"enabled"}}}` and exits 0. Fixes #11505