### PR TITLE
feat(catalog): add DeepSeek V4.1 Flash (deepseek-flash)

### DIFF
--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -461,7 +461,8 @@ describe("openai-completions convertMessages", () => {
 		// convertMessages must never forward `image_url` parts.
 		const deepseekModelIds = [
 			{ id: "deepseek-v4-pro", provider: "deepseek", baseUrl: "https://api.deepseek.com/v1" },
-			{ id: "deepseek-v4-flash", provider: "deepseek", baseUrl: "https://api.deepseek.com/v1" },
+			// `deepseek-v4-flash` is absent on purpose: since 2026-09-10 it is routed to
+			// the multimodal V4.1 Flash and covered by the preserve test below.
 			{ id: "deepseek-chat", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
 			{ id: "deepseek-reasoner", provider: "deepseek", baseUrl: "https://api.deepseek.com" },
 			{ id: "deepseek-ai/DeepSeek-V4-Pro", provider: "litellm", baseUrl: "https://llm-proxy.example.com/v1" },
@@ -569,32 +570,35 @@ describe("openai-completions convertMessages", () => {
 			},
 		]);
 	});
-	it("preserves image_url for the multimodal DeepSeek vision SKU", () => {
-		// deepseek-v4-flash-vision-exp is genuinely multimodal: the blanket
-		// DeepSeek text-only guard must not strip its image parts.
-		const model = getBundledModel("deepseek", "deepseek-v4-flash-vision-exp") as Model<"openai-completions">;
-		const context: Context = {
-			messages: [
+	it("preserves image_url for the multimodal DeepSeek V4.1 Flash SKUs", () => {
+		// deepseek-flash (DeepSeek V4.1 Flash) is genuinely multimodal, and the
+		// retired deepseek-v4-flash alias is routed to it: the blanket DeepSeek
+		// text-only guard must not strip their image parts.
+		for (const id of ["deepseek-flash", "deepseek-v4-flash"]) {
+			const model = getBundledModel("deepseek", id) as Model<"openai-completions">;
+			const context: Context = {
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Describe this image" },
+							{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+						],
+						timestamp: Date.now(),
+					},
+				],
+			};
+
+			const messages = convertMessages(model, context, compat);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0].content).toEqual([
+				{ type: "text", text: "Describe this image" },
 				{
-					role: "user",
-					content: [
-						{ type: "text", text: "Describe this image" },
-						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
-					],
-					timestamp: Date.now(),
+					type: "image_url",
+					image_url: { url: "data:image/png;base64,ZmFrZQ==" },
 				},
-			],
-		};
-
-		const messages = convertMessages(model, context, compat);
-
-		expect(messages).toHaveLength(1);
-		expect(messages[0].content).toEqual([
-			{ type: "text", text: "Describe this image" },
-			{
-				type: "image_url",
-				image_url: { url: "data:image/png;base64,ZmFrZQ==" },
-			},
-		]);
+			]);
+		}
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Fixed Command Code models outside the verified effort registry offering unsupported reasoning effort controls, and bundled the live Command Code catalog so fresh installs resolve the default model without waiting for discovery ([#11595](https://github.com/can1357/oh-my-pi/pull/11595) by [@H4vC](https://github.com/H4vC)).
 - Fixed the bundled `deepseek-flash` row shipping without context limits: it now carries its documented 1M context / 384K output so offline context accounting enforces the real window.
+- Fixed DeepSeek V4.1 Flash (`deepseek-flash`) classification so the bare canonical id joins the `flash` family and flows through the models.dev descriptor instead of surviving only as a previous-snapshot row; declared its native image input (also on the retired `deepseek-v4-flash` alias, which upstream now routes to V4.1 Flash); retired `deepseek-v4-flash-vision-exp` from the roster, live discovery, and stale model caches; and dropped the withdrawn 2026-09-14 V4 Pro-to-Flash price transition ([#11508](https://github.com/can1357/oh-my-pi/issues/11508), [#11509](https://github.com/can1357/oh-my-pi/pull/11509)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -429,6 +429,11 @@
 						"priority": 0
 					},
 					{
+						"id": "flash",
+						"glob": "*deepseek-flash*",
+						"priority": 0
+					},
+					{
 						"id": "pro",
 						"glob": "*deepseek*v4*pro*",
 						"priority": 0
@@ -9717,7 +9722,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:52",
+				"source": "providers/deepseek.kdl:54",
 				"providers": [
 					"deepseek"
 				],
@@ -9747,21 +9752,37 @@
 								"startMinute": 360,
 								"endMinute": 600
 							}
-						},
-						"effectiveRates": {
-							"flashPricing": {
-								"effectiveFrom": "2026-09-14T04:00:00Z",
-								"input": 0.3,
-								"output": 1.2,
-								"cacheRead": 0.006,
-								"cacheWrite": 0
-							}
 						}
 					}
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:89",
+				"source": "providers/deepseek.kdl:81",
+				"providers": [
+					"deepseek"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "deepseek-flash"
+					},
+					{
+						"kind": "exact",
+						"value": "deepseek-v4-flash"
+					}
+				],
+				"wire": {
+					"stripImageInput": false
+				},
+				"catalog": {
+					"inputModalities": [
+						"text",
+						"image"
+					]
+				}
+			},
+			{
+				"source": "providers/deepseek.kdl:90",
 				"providers": [
 					"deepseek"
 				],
@@ -16646,6 +16667,14 @@
 				"match": {
 					"prefix": [
 						"accounts/fireworks/"
+					]
+				}
+			},
+			{
+				"provider": "deepseek",
+				"match": {
+					"exact": [
+						"deepseek-v4-flash-vision-exp"
 					]
 				}
 			},

--- a/packages/catalog/src/compat/rules/providers/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/providers/deepseek.kdl
@@ -48,7 +48,9 @@ provider "deepseek" {
 			max-tokens 384000
 		}
 	}
-	// residue: the dated price transition applies to the documented exact Pro SKU only.
+	// residue: the Pro card applies to the documented exact Pro SKU only. The
+	// 2026-09-14 Pro-to-Flash transition was withdrawn upstream (change log
+	// 2026-09-10: V4 Pro continues "with the billing method remaining unchanged").
 	models "deepseek-v4-pro" {
 		cost-patch {
 			input 1.32
@@ -70,22 +72,21 @@ provider "deepseek" {
 					end-minute 600
 				}
 			}
-			effective-rates {
-				flash-pricing {
-					effective-from "2026-09-14T04:00:00Z"
-					input 0.30
-					output 1.20
-					cache-read 0.006
-					cache-write 0
-				}
-			}
 		}
+	}
+	// DeepSeek-V4.1-Flash is natively multimodal and also serves the retired
+	// `deepseek-v4-flash` alias (change log 2026-09-10). Live `/models` discovery
+	// seeds `input: ["text"]` and the wire guard requires the declared modality,
+	// so the modality is declared alongside the class-wide strip opt-out.
+	models "deepseek-flash" "deepseek-v4-flash" {
+		input-modalities "text" "image"
+		strip-image-input #false
 	}
 	// residue: taxonomy ranks and exact globs do not isolate these models.
 	// The bare `deepseek-flash` alias serves DeepSeek-V4.1-Flash, so it shares
 	// the V4.1 wire contract: max_tokens + reasoning_content, mandatory replay
 	// (synthetic placeholders rejected upstream), no tool choice, and the
-	// low/high/max effort ladder the bare alias cannot inherit by family.
+	// low/high/max effort ladder.
 	models "deepseek-flash" "deepseek-v4-flash" "deepseek-v4.1-flash-expires-on-0910" {
 		// Stale source capability data: discovery reports the bare alias as
 		// non-reasoning, so opt into the cascade upgrade for the exact ladder.
@@ -96,8 +97,8 @@ provider "deepseek" {
 		requires-reasoning-content-for-tool-calls #true
 		allows-synthetic-reasoning-content-for-tool-calls #false
 		supports-tool-choice #false
-		// The bare alias carries no taxonomy family, so it cannot inherit the
-		// flash ladder; the exact rule owns it instead.
+		// Pinned on the exact rule so the expiring endpoint id, which no family
+		// glob isolates, gets the same ladder as the canonical ids.
 		thinking-efforts "low" "high" "max"
 	}
 }

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -116,6 +116,8 @@ behavior {
 	// Control-plane resource ids are not accepted by the inference API.
 	exclude-models provider="fireworks" prefix="accounts/fireworks/"
 	exclude-models provider="firepass" prefix="accounts/fireworks/"
+	// deepseek-v4-flash-vision-exp retired 2026-09-10, aliased to V4.1 Flash.
+	exclude-models provider="deepseek" exact="deepseek-v4-flash-vision-exp"
 	// Text-chat transports cannot serve Xiaomi's audio-only models.
 	exclude-models provider="xiaomi" substring="-tts" substring="-asr"
 	exclude-models provider="xiaomi-token-plan-ams" substring="-tts" substring="-asr"

--- a/packages/catalog/src/compat/rules/taxonomy/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/taxonomy/deepseek.kdl
@@ -5,6 +5,8 @@ class "deepseek" {
     family "r1" glob="*deepseek-r1*"
     family "reasoner" glob="*deepseek-reasoner*"
     family "flash" glob="*deepseek*v4*flash*"
+    // Bare V4.1 Flash canonical id (`deepseek-flash`, 2026-09-10); the V4 rule above keeps the dated/legacy ids.
+    family "flash" glob="*deepseek-flash*"
     family "pro" glob="*deepseek*v4*pro*"
     // Bare V4 chat/reasoner ids without a flash/pro segment.
     family "v4" glob="*deepseek-v4*"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -76093,378 +76093,7 @@
 	"deepseek": {
 		"deepseek-flash": {
 			"id": "deepseek-flash",
-			"name": "deepseek-flash",
-			"api": "openai-completions",
-			"provider": "deepseek",
-			"baseUrl": "https://api.deepseek.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.006,
-				"cacheWrite": 0,
-				"timeBased": {
-					"offPeakMultiplier": 0.5,
-					"peakWindows": [
-						{
-							"weekdays": [
-								1,
-								2,
-								3,
-								4,
-								5
-							],
-							"startMinute": 60,
-							"endMinute": 240
-						},
-						{
-							"weekdays": [
-								1,
-								2,
-								3,
-								4,
-								5
-							],
-							"startMinute": 360,
-							"endMinute": 600
-						}
-					]
-				}
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"identity": {
-				"class": "deepseek"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": true,
-				"supportsToolChoice": false,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "zai-thinking-disabled",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresReasoningContentForAllAssistantTurns": true,
-				"allowsSyntheticReasoningContentForToolCalls": false,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": true,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": true,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": true,
-				"streamMarkupHealingPattern": "dsml",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": true,
-				"stripImageInput": true,
-				"thinkingLoopGuard": "deepseek",
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false,
-				"streamIdleTimeoutMs": 300000,
-				"whenThinking": {
-					"supportsStore": false,
-					"supportsDeveloperRole": false,
-					"supportsMultipleSystemMessages": true,
-					"supportsReasoningEffort": true,
-					"supportsReasoningParams": true,
-					"supportsSamplingParams": true,
-					"supportsPenaltyAndStopParams": true,
-					"reasoningEffortMap": {},
-					"supportsUsageInStreaming": true,
-					"alwaysSendMaxTokens": false,
-					"disableReasoningOnForcedToolChoice": false,
-					"disableReasoningOnToolChoice": true,
-					"supportsToolChoice": false,
-					"supportsForcedToolChoice": true,
-					"supportsNamedToolChoice": true,
-					"maxTokensField": "max_tokens",
-					"requiresToolResultName": false,
-					"requiresAssistantAfterToolResult": false,
-					"requiresThinkingAsText": false,
-					"requiresMistralToolIds": false,
-					"thinkingFormat": "openai",
-					"reasoningDisableMode": "lowest-effort",
-					"omitReasoningEffort": false,
-					"includeEncryptedReasoning": true,
-					"filterReasoningHistory": false,
-					"reasoningContentField": "reasoning_content",
-					"requiresReasoningContentForToolCalls": true,
-					"requiresReasoningContentForAllAssistantTurns": true,
-					"allowsSyntheticReasoningContentForToolCalls": false,
-					"replayReasoningContent": false,
-					"qwenPreserveThinking": false,
-					"qwenTemplateReasoningEffort": false,
-					"requiresAssistantContentForToolCalls": true,
-					"supportsPromptCacheBreakpoints": false,
-					"isOpenRouterHost": false,
-					"wireModelIdMode": "raw",
-					"isVercelGatewayHost": false,
-					"supportsStrictMode": true,
-					"extraBody": {
-						"thinking": {
-							"type": "enabled"
-						}
-					},
-					"toolStrictMode": "mixed",
-					"streamIdleTimeoutMs": 300000,
-					"stripDeepseekSpecialTokens": true,
-					"streamMarkupHealingPattern": "dsml",
-					"reasoningDeltasMayBeCumulative": false,
-					"emptyLengthFinishIsContextError": false,
-					"usesOpenAIToolCallIdLimit": false,
-					"dropThinkingWhenReasoningEffort": false,
-					"nativeKimiK3Reasoning": false,
-					"zaiReasoningEffortDialect": false,
-					"clampOutputToModelMax": true,
-					"stripImageInput": true,
-					"thinkingLoopGuard": "deepseek",
-					"rejectRootObjectUnion": false,
-					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
-			},
-			"supportsComputerUse": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			}
-		},
-		"deepseek-v4-flash": {
-			"id": "deepseek-v4-flash",
-			"name": "DeepSeek V4 Flash",
-			"api": "openai-completions",
-			"provider": "deepseek",
-			"baseUrl": "https://api.deepseek.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.006,
-				"cacheWrite": 0,
-				"timeBased": {
-					"offPeakMultiplier": 0.5,
-					"peakWindows": [
-						{
-							"weekdays": [
-								1,
-								2,
-								3,
-								4,
-								5
-							],
-							"startMinute": 60,
-							"endMinute": 240
-						},
-						{
-							"weekdays": [
-								1,
-								2,
-								3,
-								4,
-								5
-							],
-							"startMinute": 360,
-							"endMinute": 600
-						}
-					]
-				}
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "deepseek",
-				"family": "flash"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": true,
-				"supportsToolChoice": false,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "zai-thinking-disabled",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresReasoningContentForAllAssistantTurns": true,
-				"allowsSyntheticReasoningContentForToolCalls": false,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": true,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": true,
-				"toolStrictMode": "mixed",
-				"streamIdleTimeoutMs": 300000,
-				"stripDeepseekSpecialTokens": true,
-				"streamMarkupHealingPattern": "dsml",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": true,
-				"stripImageInput": true,
-				"thinkingLoopGuard": "deepseek",
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false,
-				"whenThinking": {
-					"supportsStore": false,
-					"supportsDeveloperRole": false,
-					"supportsMultipleSystemMessages": true,
-					"supportsReasoningEffort": true,
-					"supportsReasoningParams": true,
-					"supportsSamplingParams": true,
-					"supportsPenaltyAndStopParams": true,
-					"reasoningEffortMap": {},
-					"supportsUsageInStreaming": true,
-					"alwaysSendMaxTokens": false,
-					"disableReasoningOnForcedToolChoice": false,
-					"disableReasoningOnToolChoice": true,
-					"supportsToolChoice": false,
-					"supportsForcedToolChoice": true,
-					"supportsNamedToolChoice": true,
-					"maxTokensField": "max_tokens",
-					"requiresToolResultName": false,
-					"requiresAssistantAfterToolResult": false,
-					"requiresThinkingAsText": false,
-					"requiresMistralToolIds": false,
-					"thinkingFormat": "openai",
-					"reasoningDisableMode": "lowest-effort",
-					"omitReasoningEffort": false,
-					"includeEncryptedReasoning": true,
-					"filterReasoningHistory": false,
-					"reasoningContentField": "reasoning_content",
-					"requiresReasoningContentForToolCalls": true,
-					"requiresReasoningContentForAllAssistantTurns": true,
-					"allowsSyntheticReasoningContentForToolCalls": false,
-					"replayReasoningContent": false,
-					"qwenPreserveThinking": false,
-					"qwenTemplateReasoningEffort": false,
-					"requiresAssistantContentForToolCalls": true,
-					"supportsPromptCacheBreakpoints": false,
-					"isOpenRouterHost": false,
-					"wireModelIdMode": "raw",
-					"isVercelGatewayHost": false,
-					"supportsStrictMode": true,
-					"extraBody": {
-						"thinking": {
-							"type": "enabled"
-						}
-					},
-					"toolStrictMode": "mixed",
-					"streamIdleTimeoutMs": 300000,
-					"stripDeepseekSpecialTokens": true,
-					"streamMarkupHealingPattern": "dsml",
-					"reasoningDeltasMayBeCumulative": false,
-					"emptyLengthFinishIsContextError": false,
-					"usesOpenAIToolCallIdLimit": false,
-					"dropThinkingWhenReasoningEffort": false,
-					"nativeKimiK3Reasoning": false,
-					"zaiReasoningEffortDialect": false,
-					"clampOutputToModelMax": true,
-					"stripImageInput": true,
-					"thinkingLoopGuard": "deepseek",
-					"rejectRootObjectUnion": false,
-					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
-			},
-			"supportsComputerUse": false,
-			"compatConfig": {
-				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true,
-				"maxTokensField": "max_tokens",
-				"supportsToolChoice": false,
-				"extraBody": {
-					"thinking": {
-						"type": "enabled"
-					}
-				},
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresAssistantContentForToolCalls": true
-			}
-		},
-		"deepseek-v4-flash-vision-exp": {
-			"id": "deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek V4 Flash Vision Exp",
+			"name": "DeepSeek V4.1 Flash",
 			"api": "openai-completions",
 			"provider": "deepseek",
 			"baseUrl": "https://api.deepseek.com",
@@ -76508,20 +76137,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "deepseek",
-				"family": "flash"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76639,6 +76254,215 @@
 					"supportsPromptCacheKey": false
 				}
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"maxTokensField": "max_tokens",
+				"supportsToolChoice": false,
+				"extraBody": {
+					"thinking": {
+						"type": "enabled"
+					}
+				},
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresAssistantContentForToolCalls": true
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "deepseek",
+			"baseUrl": "https://api.deepseek.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0,
+				"timeBased": {
+					"offPeakMultiplier": 0.5,
+					"peakWindows": [
+						{
+							"weekdays": [
+								1,
+								2,
+								3,
+								4,
+								5
+							],
+							"startMinute": 60,
+							"endMinute": 240
+						},
+						{
+							"weekdays": [
+								1,
+								2,
+								3,
+								4,
+								5
+							],
+							"startMinute": 360,
+							"endMinute": 600
+						}
+					]
+				}
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"int": 34.5,
+			"tps": 210.1,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": false,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "zai-thinking-disabled",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 300000,
+				"stripDeepseekSpecialTokens": true,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": true,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": true,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": true,
+					"supportsToolChoice": false,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": true,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": true,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": true,
+					"extraBody": {
+						"thinking": {
+							"type": "enabled"
+						}
+					},
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 300000,
+					"stripDeepseekSpecialTokens": true,
+					"streamMarkupHealingPattern": "dsml",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": true,
+					"stripImageInput": false,
+					"thinkingLoopGuard": "deepseek",
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false,
@@ -76695,22 +76519,13 @@
 							"startMinute": 360,
 							"endMinute": 600
 						}
-					],
-					"effectiveRates": [
-						{
-							"effectiveFrom": 1789358400000,
-							"input": 0.3,
-							"output": 1.2,
-							"cacheRead": 0.006,
-							"cacheWrite": 0
-						}
 					]
 				}
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 72.3,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1873,10 +1873,27 @@ export interface DeepSeekModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+// `deepseek-v4-flash-vision-exp` was retired upstream on 2026-09-10 (requests are
+// temporarily routed to V4.1 Flash) and is excluded by KDL. Caches written before
+// that exclusion still carry the id, so drop it explicitly: an offline or failed
+// refresh would otherwise resurrect a model the provider no longer serves.
+const DEEPSEEK_CACHE_MIGRATION_MODEL_IDS = ["deepseek-v4-flash-vision-exp"] as const;
+
 export function deepseekModelManagerOptions(
 	config?: DeepSeekModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions("deepseek", "https://api.deepseek.com", config);
+	return createOpenAICompatibleModelManagerOptions({
+		api: "openai-completions",
+		providerId: "deepseek",
+		defaultBaseUrl: "https://api.deepseek.com",
+		config,
+		requireApiKey: true,
+		dropCachedModelIdsOnStaticMismatch: DEEPSEEK_CACHE_MIGRATION_MODEL_IDS,
+		// The live roster keeps serving retired aliases during the routing window;
+		// keep KDL-excluded ids out of discovery instead of trusting `/models`.
+		filterModel: (_entry, model) => !isExcludedModel("deepseek", model.id),
+		mapModel: mapWithBundledReference,
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -6923,7 +6940,8 @@ function buildClinePassThinking(raw: ModelsDevModel, model: ModelSpec<Api>): Thi
 }
 
 /**
- * DeepSeek's V4-generation lineage (`v4`, `v4-flash`, `v4.1-pro`) by
+ * DeepSeek's V4-generation lineage (`v4`, `v4-flash`, `v4.1-pro`, and the
+ * bare `deepseek-flash` canonical id introduced for V4.1 Flash) by
  * structured family. The native roster serves only V4-era SKUs today; the
  * `tool_call` gate on the descriptor filters the rest.
  */

--- a/packages/catalog/test/compat-taxonomy.test.ts
+++ b/packages/catalog/test/compat-taxonomy.test.ts
@@ -30,6 +30,20 @@ describe("classifyModel", () => {
 		});
 	});
 
+	test("deepseek bare V4.1 canonical ids classify alongside legacy V4 ids", () => {
+		expect(classifyModel("deepseek", "deepseek-flash")).toEqual({ class: "deepseek", family: "flash" });
+		expect(classifyModel("deepseek", "deepseek-v4-flash")).toEqual({ class: "deepseek", family: "flash" });
+		expect(classifyModel("deepseek", "deepseek-v4-pro")).toEqual({ class: "deepseek", family: "pro" });
+		expect(classifyModel("deepseek", "deepseek-v4-flash-vision-exp")).toEqual({
+			class: "deepseek",
+			family: "flash",
+		});
+		expect(classifyModel("deepseek-ai", "deepseek-ai/DeepSeek-V4-Flash")).toEqual({
+			class: "deepseek",
+			family: "flash",
+		});
+	});
+
 	test("bare o-series names carry no revision", () => {
 		expect(classifyModel("openai", "o3")).toEqual({ class: "openai", family: "o-series" });
 		expect(classifyModel("openai", "o3-mini")).toEqual({

--- a/packages/catalog/test/issue-830-repro.test.ts
+++ b/packages/catalog/test/issue-830-repro.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
 import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { isExcludedModel } from "@oh-my-pi/pi-catalog/compat/behavior";
 import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
-import { MODELS_DEV_PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { OpenAICompat } from "@oh-my-pi/pi-catalog/types";
+import {
+	deepseekModelManagerOptions,
+	MODELS_DEV_PROVIDER_DESCRIPTORS,
+	type ModelsDevModel,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl, ModelSpec, OpenAICompat } from "@oh-my-pi/pi-catalog/types";
 
 describe("deepseek built-in provider (issue #830)", () => {
 	test("registers built-in runtime descriptor with DEEPSEEK_API_KEY env discovery", () => {
@@ -12,6 +18,75 @@ describe("deepseek built-in provider (issue #830)", () => {
 		expect(descriptor?.defaultModel).toBe("deepseek-v4-pro");
 		expect(descriptor?.catalogDiscovery?.envVars).toContain("DEEPSEEK_API_KEY");
 		expect(DEFAULT_MODEL_PER_PROVIDER.deepseek).toBe("deepseek-v4-pro");
+	});
+
+	test("V4.1 Flash ids declare image input even when discovery seeds text-only", () => {
+		// DeepSeek-V4.1-Flash is natively multimodal and also serves the retired
+		// `deepseek-v4-flash` alias; live `/models` discovery seeds `input: ["text"]`,
+		// so the modality and the strip opt-out are rule-owned.
+		const seed = (id: string): ModelSpec<"openai-completions"> => ({
+			id,
+			provider: "deepseek",
+			name: id,
+			api: "openai-completions",
+			baseUrl: "https://api.deepseek.com",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 1_000_000,
+			maxTokens: 384_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+		for (const id of ["deepseek-flash", "deepseek-v4-flash"]) {
+			const model = buildModel(seed(id));
+			expect(model.input).toEqual(["text", "image"]);
+			expect(model.compat?.stripImageInput).toBe(false);
+		}
+		const pro = buildModel(seed("deepseek-v4-pro"));
+		expect(pro.input).toEqual(["text"]);
+		expect(pro.compat?.stripImageInput).toBe(true);
+	});
+
+	test("V4.1 Flash migration (issue #11508) retires deepseek-v4-flash-vision-exp by policy", () => {
+		expect(isExcludedModel("deepseek", "deepseek-v4-flash-vision-exp")).toBe(true);
+		expect(isExcludedModel("deepseek", "deepseek-flash")).toBe(false);
+		expect(isExcludedModel("deepseek", "deepseek-v4-flash")).toBe(false);
+	});
+
+	test("models.dev admission covers the bare V4.1 ids and still rejects pre-V4 chat", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "deepseek");
+		const filterModel = descriptor?.filterModel;
+		expect(filterModel).toBeDefined();
+		// models.dev rows only need `tool_call` for the DeepSeek gate; the rest of
+		// the admission decision comes from the taxonomy family.
+		const row: ModelsDevModel = { tool_call: true };
+		expect(filterModel?.("deepseek-flash", row)).toBe(true);
+		expect(filterModel?.("deepseek-v4-flash", row)).toBe(true);
+		expect(filterModel?.("deepseek-v4-pro", row)).toBe(true);
+		expect(filterModel?.("deepseek-chat", row)).toBe(false);
+	});
+
+	test("manager drops the retired vision-exp id from caches and from live discovery", async () => {
+		const options = deepseekModelManagerOptions({ apiKey: "k" });
+		expect(options.dropCachedModelIdsOnStaticMismatch).toContain("deepseek-v4-flash-vision-exp");
+
+		// The upstream roster keeps answering for the retired alias while it is
+		// routed to V4.1 Flash; discovery must not re-list it.
+		const fetch: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{ id: "deepseek-flash", object: "model" },
+						{ id: "deepseek-v4-flash", object: "model" },
+						{ id: "deepseek-v4-flash-vision-exp", object: "model" },
+					],
+				}),
+				{ status: 200 },
+			);
+		const models = await deepseekModelManagerOptions({ apiKey: "k", fetch }).fetchDynamicModels?.();
+		const ids = (models ?? []).map(model => model.id);
+		expect(ids).toContain("deepseek-flash");
+		expect(ids).toContain("deepseek-v4-flash");
+		expect(ids).not.toContain("deepseek-v4-flash-vision-exp");
 	});
 
 	test("registers DeepSeek as an API-key login provider", () => {

--- a/packages/catalog/test/time-based-pricing.test.ts
+++ b/packages/catalog/test/time-based-pricing.test.ts
@@ -97,7 +97,8 @@ describe("time-based token pricing", () => {
 		expect(first.cost.total + second.cost.total).toBeCloseTo(2.259, 12);
 	});
 
-	it("switches Pro to Flash prices exactly at the dated cutoff, then resumes Flash peak rates", () => {
+	it("keeps Pro at the Pro card across the withdrawn 2026-09-14 transition", () => {
+		// Change log 2026-09-10: V4 Pro continues after September 14 with billing unchanged.
 		const model = buildModel(spec("deepseek-v4-pro"));
 		const cutoff = Date.parse("2026-09-14T04:00:00Z");
 		const before = calculateCost(model, usage(), cutoff - 1);
@@ -107,8 +108,10 @@ describe("time-based token pricing", () => {
 		expect(before.output).toBeCloseTo(3.96, 12);
 		expect(before.cacheRead).toBeCloseTo(0.044, 12);
 		expect(before.total).toBeCloseTo(5.324, 12);
-		expect(after.total).toBeCloseTo(0.753, 12);
-		expect(nextPeak.total).toBeCloseTo(1.506, 12);
+		// 04:00Z closes the morning peak window: the off-peak half of the Pro card, not the Flash card.
+		expect(after.total).toBeCloseTo(2.662, 12);
+		expect(nextPeak.total).toBeCloseTo(5.324, 12);
+		expect(model.cost.timeBased?.effectiveRates).toBeUndefined();
 	});
 
 	it("applies first-party policies to documented aliases but not reseller or expiring products", () => {


### PR DESCRIPTION
Closes #11508

## What

DeepSeek shipped **V4.1 Flash** on 2026-09-10 ([changelog](https://api-docs.deepseek.com/updates/), [pricing](https://api-docs.deepseek.com/quick_start/pricing)). Canonical id is `deepseek-flash` (natively multimodal); `deepseek-v4-flash` / `deepseek-v4-flash-vision-exp` are retired and temporarily routed to it. Upstream has since **withdrawn the 2026-09-14 V4 Pro retirement** — V4 Pro continues "with the billing method remaining unchanged".

Rebased on main, which already carries the `deepseek-flash` pricing/limits/wire rules. What was still missing:

- **Taxonomy** (`rules/taxonomy/deepseek.kdl`): bare `deepseek-flash` classified as `{class: deepseek}` with no family, so `isDeepseekV4Generation` rejected it in the models.dev descriptor and the bundled row only survived as a stale previous-snapshot merge (text-only, `name: "deepseek-flash"`). `*deepseek-flash*` → `flash` fixes that; the row now flows through `gen:models` like the dated ids. The speculative `deepseek-pro` glob is dropped.
- **Modality** (`rules/providers/deepseek.kdl`): `input-modalities "text" "image"` + `strip-image-input #false` for `deepseek-flash` and the aliased `deepseek-v4-flash` (same pattern as the opencode-go carve-out). models.dev also lists both as `text,image` now.
- **Pricing** (`rules/providers/deepseek.kdl`): removed the `effective-rates` block that would have re-priced `deepseek-v4-pro` at the Flash card from 2026-09-14 — upstream cancelled that transition.
- **Retirement** (`rules/runtime/behavior.kdl`): `exclude-models provider="deepseek" exact="deepseek-v4-flash-vision-exp"` — this is the sanctioned path; `filterModelsDevCatalogRows` runs after the previous-snapshot merge in `gen:models`, so the row is pruned on every regen.
- **Cache / discovery** (`openai-compat.ts`): `deepseekModelManagerOptions` now sets `dropCachedModelIdsOnStaticMismatch: ["deepseek-v4-flash-vision-exp"]` (stale caches can't resurrect it on an offline/failed refresh) and `filterModel: !isExcludedModel("deepseek", id)` (live `/models` can't re-list it while upstream keeps answering for the alias).
- **Generated**: `rules.json` via `gen:compat`; `models.json` via `gen:models`, delta scoped to the `deepseek` key (`deepseek-flash` refreshed from models.dev with name/modality, `deepseek-v4-flash` gains image input, vision-exp dropped, `deepseek-v4-pro` loses the withdrawn effective rate).
- **Default model**: left at `deepseek-v4-pro`. The original flip's rationale (Pro about to be downgraded) no longer holds, and the P2 gate is moot.

## Tests

Regression coverage targets the policy sources, not bundled JSON:
- `compat-taxonomy.test.ts`: `classifyModel("deepseek","deepseek-flash")` → `{class:"deepseek", family:"flash"}`.
- `issue-830-repro.test.ts`: `isExcludedModel` for the retired id; models.dev descriptor `filterModel` admits `deepseek-flash`/`deepseek-v4-flash`/`deepseek-v4-pro`, rejects `deepseek-chat`; `buildModel` yields `input: ["text","image"]` + `stripImageInput: false` for the V4.1 ids from a text-only seed; manager drop list + stubbed `/models` discovery excludes vision-exp.
- `time-based-pricing.test.ts`: Pro stays on the Pro card across 2026-09-14.
- `openai-completions-tool-result-images.test.ts`: `deepseek-flash` and `deepseek-v4-flash` preserve `image_url`; `deepseek-v4-flash` removed from the strip list.

## Verification

```
bun run check:ts               -> exit 0 (oxlint, oxfmt, tsgo across workspace)
bun run ci:test:ts:workspace   -> exit 0, 0 failures (catalog 936 pass, ai 4609 pass, ...)
```
