### PR TITLE
fix(discovery): honor marketplace-root skill selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -61,6 +61,13 @@ interface ResolvedPluginDir {
 	warnings: string[];
 }
 
+interface ResolvePluginDirOptions {
+	manifestKeys: ReadonlyArray<keyof ClaudePluginManifest>;
+	fallback: string;
+	includeFallback: boolean;
+	marketplaceRootManifest?: ClaudePluginManifest | null;
+}
+
 interface ResolvedMCPConfig {
 	/** On-disk config file to read, or null when servers are inline or nothing applies. */
 	path: string | null;
@@ -98,20 +105,25 @@ function isStringRecord(value: unknown): value is Record<string, string> {
 	return isRecord(value) && Object.values(value).every(v => typeof v === "string");
 }
 
-async function skillsManifestReplacesFallback(root: ClaudePluginRoot): Promise<boolean> {
+async function readMarketplaceRootManifest(root: ClaudePluginRoot): Promise<ClaudePluginManifest | null> {
 	const raw = await readFile(path.join(root.path, "marketplace.json"));
-	if (raw === null) return false;
+	if (raw === null) return null;
 
 	try {
 		const parsed: unknown = JSON.parse(raw);
-		if (!isRecord(parsed)) return false;
-		const plugins = parsed.plugins;
-		return (
-			Array.isArray(plugins) &&
-			plugins.some(entry => isRecord(entry) && entry.name === root.plugin && entry.source === "./")
+		if (!isRecord(parsed) || !Array.isArray(parsed.plugins)) return null;
+		const entry = parsed.plugins.find(
+			candidate => isRecord(candidate) && candidate.name === root.plugin && candidate.source === "./",
 		);
+		if (!isRecord(entry)) return null;
+
+		if (typeof entry.skills === "string") return { skills: entry.skills };
+		if (Array.isArray(entry.skills)) {
+			return { skills: entry.skills.filter((value): value is string => typeof value === "string") };
+		}
+		return {};
 	} catch {
-		return false;
+		return null;
 	}
 }
 
@@ -121,80 +133,65 @@ function isWithinPluginRoot(rootPath: string, targetPath: string): boolean {
 }
 
 /**
- * Resolve a manifest-declared directory field to absolute paths within the
- * plugin root.
+ * Resolve manifest-declared component paths within a plugin root.
  *
  * Manifest path fields may be `string` or `string[]`
- * (https://code.claude.com/docs/en/plugins-reference#path-behavior-rules);
- * both shapes are normalized here. The first `manifestKeys` entry that
- * supplies at least one non-empty path wins (later keys are ignored — used for
- * the `commands` > `slash-commands` legacy fallback).
+ * (https://code.claude.com/docs/en/plugins-reference#path-behavior-rules).
+ * The first populated key wins within each manifest, preserving the
+ * `commands` > `slash-commands` legacy fallback.
  *
- * `fallback` is the default subdirectory (e.g. `skills/`, `commands/`) and
- * `includeFallback` controls the Claude-documented merge semantic per field:
- *
- * - `skills` **adds to** the default: `fallback` is always scanned, and any
- *   manifest entries load alongside it. Callers pass `includeFallback: true`.
- * - `commands` / `slash-commands` **replace** the default: an explicit
- *   manifest key means the default `commands/` directory is not scanned.
- *   Callers pass `includeFallback: false` (the manifest itself may still
- *   list `./commands` explicitly to keep it).
- *
- * When no matching key is set, the fallback is used regardless. Entries that
- * resolve outside the plugin root are dropped with a warning so misconfigured
- * manifests remain observable and cannot escape via traversal.
+ * Skills normally add to the default `skills/` directory. For a marketplace
+ * entry whose source is the marketplace root, its listed skill paths and any
+ * plugin-manifest paths are the complete selection, so the shared root
+ * `skills/` directory is not scanned. If neither manifest declares a matching
+ * path, the conventional fallback is still used.
  */
-async function resolvePluginDir(
-	root: ClaudePluginRoot,
-	manifestKeys: ReadonlyArray<keyof ClaudePluginManifest>,
-	fallback: string,
-	includeFallback: boolean,
-): Promise<ResolvedPluginDir> {
-	const manifest = await readPluginManifest(root);
-	const fallbackDir = path.join(root.path, fallback);
+async function resolvePluginDir(root: ClaudePluginRoot, options: ResolvePluginDirOptions): Promise<ResolvedPluginDir> {
+	const pluginManifest = await readPluginManifest(root);
+	const manifests = options.marketplaceRootManifest
+		? [pluginManifest, options.marketplaceRootManifest]
+		: [pluginManifest];
+	const fallbackDir = path.join(root.path, options.fallback);
+	const configured: Array<{ entryPath: string; key: keyof ClaudePluginManifest }> = [];
 
-	let configured: string[] | undefined;
-	let matchedKey: keyof ClaudePluginManifest | undefined;
-	for (const key of manifestKeys) {
-		const val = manifest?.[key];
-		const candidates: string[] = [];
-		if (typeof val === "string") {
-			const trimmed = val.trim();
-			if (trimmed) candidates.push(trimmed);
-		} else if (Array.isArray(val)) {
-			for (const entry of val) {
-				if (typeof entry !== "string") continue;
-				const trimmed = entry.trim();
+	for (const manifest of manifests) {
+		if (manifest === null) continue;
+		for (const key of options.manifestKeys) {
+			const val = manifest[key];
+			const candidates: string[] = [];
+			if (typeof val === "string") {
+				const trimmed = val.trim();
 				if (trimmed) candidates.push(trimmed);
+			} else if (Array.isArray(val)) {
+				for (const entry of val) {
+					if (typeof entry !== "string") continue;
+					const trimmed = entry.trim();
+					if (trimmed) candidates.push(trimmed);
+				}
 			}
-		}
-		if (candidates.length > 0) {
-			configured = candidates;
-			matchedKey = key;
-			break;
+			if (candidates.length > 0) {
+				configured.push(...candidates.map(entryPath => ({ entryPath, key })));
+				break;
+			}
 		}
 	}
 
-	if (configured === undefined) {
+	if (configured.length === 0) {
 		return { dirs: [fallbackDir], warnings: [] };
 	}
 
-	// Dedup preserves order: default entry (when included) first, then declared
-	// entries in manifest order. Deduping the paths themselves means a plugin
-	// author can still list `./commands` explicitly when they want the default
-	// alongside extras without producing double-loads.
 	const seen = new Set<string>();
 	const dirs: string[] = [];
 	const warnings: string[] = [];
-	if (includeFallback) {
+	if (options.includeFallback && !options.marketplaceRootManifest) {
 		seen.add(fallbackDir);
 		dirs.push(fallbackDir);
 	}
-	for (const entry of configured) {
-		const resolved = path.resolve(root.path, entry);
+	for (const { entryPath, key } of configured) {
+		const resolved = path.resolve(root.path, entryPath);
 		if (!isWithinPluginRoot(root.path, resolved)) {
 			warnings.push(
-				`[claude-plugins] Ignoring ${String(matchedKey)} path outside plugin root for ${root.id}: ${entry}`,
+				`[claude-plugins] Ignoring ${String(key)} path outside plugin root for ${root.id}: ${entryPath}`,
 			);
 			continue;
 		}
@@ -217,13 +214,13 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	warnings.push(...rootWarnings);
 	const results = await Promise.all(
 		roots.map(async root => {
-			const includeFallback = !(await skillsManifestReplacesFallback(root));
-			const { dirs: skillsDirs, warnings: resolveWarnings } = await resolvePluginDir(
-				root,
-				["skills"],
-				"skills",
-				includeFallback,
-			);
+			const marketplaceRootManifest = await readMarketplaceRootManifest(root);
+			const { dirs: skillsDirs, warnings: resolveWarnings } = await resolvePluginDir(root, {
+				manifestKeys: ["skills"],
+				fallback: "skills",
+				includeFallback: true,
+				marketplaceRootManifest,
+			});
 			const scanResults = await Promise.all(
 				skillsDirs.map(dir =>
 					scanSkillsFromDir(ctx, {
@@ -290,12 +287,11 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const { dirs: commandsDirs, warnings: resolveWarnings } = await resolvePluginDir(
-				root,
-				["commands", "slash-commands"],
-				"commands",
-				false,
-			);
+			const { dirs: commandsDirs, warnings: resolveWarnings } = await resolvePluginDir(root, {
+				manifestKeys: ["commands", "slash-commands"],
+				fallback: "commands",
+				includeFallback: false,
+			});
 			const commandResults = await Promise.all(
 				commandsDirs.map(async dir => {
 					try {

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -106,25 +106,34 @@ function isStringRecord(value: unknown): value is Record<string, string> {
 }
 
 async function readMarketplaceRootManifest(root: ClaudePluginRoot): Promise<ClaudePluginManifest | null> {
-	const raw = await readFile(path.join(root.path, "marketplace.json"));
-	if (raw === null) return null;
+	const catalogs = await Promise.all(
+		[
+			path.join(root.path, "marketplace.json"),
+			path.join(root.path, ".omp-plugin", "marketplace.json"),
+			path.join(root.path, ".claude-plugin", "marketplace.json"),
+		].map(catalogPath => readFile(catalogPath)),
+	);
 
-	try {
-		const parsed: unknown = JSON.parse(raw);
-		if (!isRecord(parsed) || !Array.isArray(parsed.plugins)) return null;
-		const entry = parsed.plugins.find(
-			candidate => isRecord(candidate) && candidate.name === root.plugin && candidate.source === "./",
-		);
-		if (!isRecord(entry)) return null;
+	for (const raw of catalogs) {
+		if (raw === null) continue;
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (!isRecord(parsed) || !Array.isArray(parsed.plugins)) continue;
+			const entry = parsed.plugins.find(
+				candidate => isRecord(candidate) && candidate.name === root.plugin && candidate.source === "./",
+			);
+			if (!isRecord(entry)) continue;
 
-		if (typeof entry.skills === "string") return { skills: entry.skills };
-		if (Array.isArray(entry.skills)) {
-			return { skills: entry.skills.filter((value): value is string => typeof value === "string") };
+			if (typeof entry.skills === "string") return { skills: entry.skills };
+			if (Array.isArray(entry.skills)) {
+				return { skills: entry.skills.filter((value): value is string => typeof value === "string") };
+			}
+			return {};
+		} catch {
+			continue;
 		}
-		return {};
-	} catch {
-		return null;
 	}
+	return null;
 }
 
 function isWithinPluginRoot(rootPath: string, targetPath: string): boolean {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -614,6 +614,63 @@ describe("listClaudePluginRoots", () => {
 		expect(skills.map(s => s.name)).not.toContain("claude-demo");
 	});
 
+	test("marketplace-root entry limits shared skills to declared paths", async () => {
+		const pluginPath = path.join(tempDir, "plugins", "anthropic-skills");
+		const registryPath = path.join(tempDir, ".omp", "plugins", "installed_plugins.json");
+		await Promise.all([
+			fs.mkdir(path.join(pluginPath, "skills", "xlsx"), { recursive: true }),
+			fs.mkdir(path.join(pluginPath, "skills", "skill-creator"), { recursive: true }),
+			fs.mkdir(path.dirname(registryPath), { recursive: true }),
+		]);
+		await Promise.all([
+			fs.writeFile(
+				path.join(pluginPath, "skills", "xlsx", "SKILL.md"),
+				"---\nname: xlsx\ndescription: Spreadsheet skill\n---\nBody\n",
+			),
+			fs.writeFile(
+				path.join(pluginPath, "skills", "skill-creator", "SKILL.md"),
+				"---\nname: skill-creator\ndescription: Skill creation skill\n---\nBody\n",
+			),
+			fs.writeFile(
+				path.join(pluginPath, "marketplace.json"),
+				JSON.stringify({
+					name: "anthropic-agent-skills",
+					owner: { name: "Anthropic" },
+					plugins: [
+						{
+							name: "document-skills",
+							source: "./",
+							strict: false,
+							skills: ["./skills/xlsx"],
+						},
+						{
+							name: "example-skills",
+							source: "./",
+							strict: false,
+							skills: ["./skills/skill-creator"],
+						},
+					],
+				}),
+			),
+			fs.writeFile(
+				registryPath,
+				JSON.stringify({
+					version: 2,
+					plugins: {
+						"document-skills@anthropic-agent-skills": [
+							{ scope: "user", installPath: pluginPath, version: "1.0.0" },
+						],
+					},
+				}),
+			),
+		]);
+
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
+
+		expect(result.all.find(skill => skill.name === "xlsx")).toBeDefined();
+		expect(result.all.find(skill => skill.name === "skill-creator")).toBeUndefined();
+	});
+
 	test("defaults scope to user when not specified", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		await fs.mkdir(pluginsDir, { recursive: true });

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -614,62 +614,65 @@ describe("listClaudePluginRoots", () => {
 		expect(skills.map(s => s.name)).not.toContain("claude-demo");
 	});
 
-	test("marketplace-root entry limits shared skills to declared paths", async () => {
-		const pluginPath = path.join(tempDir, "plugins", "anthropic-skills");
-		const registryPath = path.join(tempDir, ".omp", "plugins", "installed_plugins.json");
-		await Promise.all([
-			fs.mkdir(path.join(pluginPath, "skills", "xlsx"), { recursive: true }),
-			fs.mkdir(path.join(pluginPath, "skills", "skill-creator"), { recursive: true }),
-			fs.mkdir(path.dirname(registryPath), { recursive: true }),
-		]);
-		await Promise.all([
-			fs.writeFile(
-				path.join(pluginPath, "skills", "xlsx", "SKILL.md"),
-				"---\nname: xlsx\ndescription: Spreadsheet skill\n---\nBody\n",
-			),
-			fs.writeFile(
-				path.join(pluginPath, "skills", "skill-creator", "SKILL.md"),
-				"---\nname: skill-creator\ndescription: Skill creation skill\n---\nBody\n",
-			),
-			fs.writeFile(
-				path.join(pluginPath, "marketplace.json"),
-				JSON.stringify({
-					name: "anthropic-agent-skills",
-					owner: { name: "Anthropic" },
-					plugins: [
-						{
-							name: "document-skills",
-							source: "./",
-							strict: false,
-							skills: ["./skills/xlsx"],
-						},
-						{
-							name: "example-skills",
-							source: "./",
-							strict: false,
-							skills: ["./skills/skill-creator"],
-						},
-					],
-				}),
-			),
-			fs.writeFile(
-				registryPath,
-				JSON.stringify({
-					version: 2,
-					plugins: {
-						"document-skills@anthropic-agent-skills": [
-							{ scope: "user", installPath: pluginPath, version: "1.0.0" },
+	for (const catalogDir of [".claude-plugin", ".omp-plugin"]) {
+		test(`marketplace-root ${catalogDir} entry limits shared skills to declared paths`, async () => {
+			const pluginPath = path.join(tempDir, "plugins", "anthropic-skills");
+			const registryPath = path.join(tempDir, ".omp", "plugins", "installed_plugins.json");
+			await Promise.all([
+				fs.mkdir(path.join(pluginPath, "skills", "xlsx"), { recursive: true }),
+				fs.mkdir(path.join(pluginPath, "skills", "skill-creator"), { recursive: true }),
+				fs.mkdir(path.dirname(registryPath), { recursive: true }),
+				fs.mkdir(path.join(pluginPath, catalogDir), { recursive: true }),
+			]);
+			await Promise.all([
+				fs.writeFile(
+					path.join(pluginPath, "skills", "xlsx", "SKILL.md"),
+					"---\nname: xlsx\ndescription: Spreadsheet skill\n---\nBody\n",
+				),
+				fs.writeFile(
+					path.join(pluginPath, "skills", "skill-creator", "SKILL.md"),
+					"---\nname: skill-creator\ndescription: Skill creation skill\n---\nBody\n",
+				),
+				fs.writeFile(
+					path.join(pluginPath, catalogDir, "marketplace.json"),
+					JSON.stringify({
+						name: "anthropic-agent-skills",
+						owner: { name: "Anthropic" },
+						plugins: [
+							{
+								name: "document-skills",
+								source: "./",
+								strict: false,
+								skills: ["./skills/xlsx"],
+							},
+							{
+								name: "example-skills",
+								source: "./",
+								strict: false,
+								skills: ["./skills/skill-creator"],
+							},
 						],
-					},
-				}),
-			),
-		]);
+					}),
+				),
+				fs.writeFile(
+					registryPath,
+					JSON.stringify({
+						version: 2,
+						plugins: {
+							"document-skills@anthropic-agent-skills": [
+								{ scope: "user", installPath: pluginPath, version: "1.0.0" },
+							],
+						},
+					}),
+				),
+			]);
 
-		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
+			const result = await loadCapability<Skill>("skills", { cwd: tempDir });
 
-		expect(result.all.find(skill => skill.name === "xlsx")).toBeDefined();
-		expect(result.all.find(skill => skill.name === "skill-creator")).toBeUndefined();
-	});
+			expect(result.all.find(skill => skill.name === "xlsx")).toBeDefined();
+			expect(result.all.find(skill => skill.name === "skill-creator")).toBeUndefined();
+		});
+	}
 
 	test("defaults scope to user when not specified", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");


### PR DESCRIPTION
## Repro
Installing `document-skills@anthropic-agent-skills` from `https://github.com/anthropics/skills` registers a plugin whose `source` is the marketplace root and whose `skills` field selects only document skill directories. `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts -t "marketplace-root entry limits shared skills to declared paths"` reproduced the bug by loading the undeclared `skill-creator` sibling and failed 0/1 before the fix.

## Cause
`packages/coding-agent/src/discovery/claude-plugins.ts` detected a marketplace-root entry only to suppress the default scan, while `resolvePluginDir` still read component paths exclusively from `.claude-plugin/plugin.json`. Anthropic's `strict: false` entry has no plugin manifest, so the resolver fell back to the shared root `skills/` directory and exposed every category.

## Fix
- Read the installed plugin's matching marketplace-root entry and merge its declared skill paths into directory resolution.
- Treat declared marketplace-root paths as the complete selection while retaining the conventional fallback when no paths are declared.
- Cover the shared-root Anthropic marketplace layout and document the user-visible fix.

## Verification
`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` passes 20/20; `bun run check` in `packages/coding-agent` passes formatting and type checks with one pre-existing unused-variable warning. The publish gate also completed `bun run fix` and `bun check`.

Fixes #11513