### PR TITLE
fix(compaction): preserve retained history across soft compactions

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -232,13 +232,15 @@ The flag never reaches provider wire formats, and flagged pairs are never remove
 
 ### Boundary and cut-point logic
 
-`prepareCompaction()` only considers entries since the last compaction entry (if any).
+`prepareCompaction()` builds one effective message sequence for estimation, cut-point selection, and the history-summary, turn-prefix, and retained-message regions.
 
-1. Find previous compaction index.
-2. Honor the latest `/clear` `reset_boundary` marker: a boundary after the last reusable compaction supersedes it, so a compaction after an in-place `/clear` only summarizes messages created after the reset (issue #8718).
-3. Compute `boundaryStart = prevCompactionIndex + 1`.
-4. Adapt `keepRecentTokens` using measured usage ratio when available.
-5. Run `findCutPoint()` over the boundary window.
+1. Find the latest compaction whose summary or provider-native history is reusable by the active model.
+2. Honor the latest `/clear` `reset_boundary`: a newer reset discards the previous summary, and an older reset remains the lower bound for recovering retained messages.
+3. For a local summary, recover the original entries from `firstKeptEntryId` up to the previous compaction record, then append entries after that record. When a reusable provider-native payload is selected, preparation retains the existing native replay handling instead of re-expanding that payload's original entries.
+4. Exclude compaction records and other non-message metadata. Pass the previous summary separately through `previousSummary`; retain message-bearing `custom_message` and `branch_summary` entries.
+5. Adapt `keepRecentTokens` using the measured usage ratio, then run `findCutPoint()` and partition that same sequence into `messagesToSummarize`, `turnPrefixMessages`, and `recentMessages`.
+
+When updating a local summary, every effective original message belongs to exactly one of those three regions. For example, after `summary(A) + B` grows to `summary(A) + B + C`, the next preparation distributes both B and C, not just C. The new `firstKeptEntryId` refers to an original entry; preparation does not move, duplicate, or rewrite journal entries. This is a local-summary preparation guarantee, not an end-to-end guarantee for provider-native or speculative native replay.
 
 Valid cut points include:
 
@@ -248,7 +250,7 @@ Valid cut points include:
 
 Hard rule: never cut at `toolResult`.
 
-If there are non-message metadata entries immediately before the cut point (`model_change`, `thinking_level_change`, labels, etc.), they are pulled into the kept region by moving cut index backward until a message or compaction boundary is hit.
+Preparation filters out pure metadata (`model_change`, `thinking_level_change`, labels, etc.) before selecting the retained-message boundary. Those records remain in the journal but are not conversation input.
 
 ### Split-turn handling
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed repeated local compaction omitting messages retained before the previous compaction record, while preserving original entry IDs and `/clear` boundaries.
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -395,22 +395,6 @@ export function resolveThresholdTokens(contextWindow: number, settings: Compacti
 // Cut point detection
 // ============================================================================
 
-function estimateEntriesTokens(
-	entries: SessionEntry[],
-	tokenizer: Tokenizer,
-	startIndex: number,
-	endIndex: number,
-): number {
-	let total = 0;
-	for (let i = startIndex; i < endIndex; i++) {
-		const msg = getMessageFromEntry(entries[i]);
-		if (msg) {
-			total += tokenizer.countMessage(msg);
-		}
-	}
-	return total;
-}
-
 /**
  * Find valid cut points: indices of user, assistant, custom, or bashExecution messages.
  * Never cut at tool results (they must follow their tool call).
@@ -1331,16 +1315,10 @@ export function prepareCompaction(
 
 	let prevCompactionIndex = findReadableCompactionIndex(pathEntries, settings, activeModel);
 
-	// Honor the latest `/clear` reset boundary. `/clear` records a
-	// `reset_boundary` marker and reports the model context empty, so compaction
-	// must not resurrect the dropped pre-clear turns into its summary — matching
-	// how buildSessionContext starts the model-context rebuild after the boundary.
-	// A boundary after the last reusable compaction supersedes it: the pre-reset
-	// summary was cleared too, so drop the previous-compaction reuse and start
-	// fresh after the boundary. A boundary at or before that compaction is already
-	// superseded by it, so only scan newer entries.
+	// A reset after the reusable compaction clears its summary too. An older
+	// reset still bounds how far we may recover that compaction's kept messages.
 	let resetBoundaryIndex = -1;
-	for (let i = pathEntries.length - 1; i > prevCompactionIndex; i--) {
+	for (let i = pathEntries.length - 1; i >= 0; i--) {
 		if (pathEntries[i].type === "reset_boundary") {
 			resetBoundaryIndex = i;
 			break;
@@ -1349,14 +1327,43 @@ export function prepareCompaction(
 	if (resetBoundaryIndex > prevCompactionIndex) {
 		prevCompactionIndex = -1;
 	}
-	const boundaryStart = Math.max(prevCompactionIndex, resetBoundaryIndex) + 1;
-	const boundaryEnd = pathEntries.length;
+	const previousCompaction =
+		prevCompactionIndex >= 0 ? (pathEntries[prevCompactionIndex] as CompactionEntry) : undefined;
+	let boundaryStart = Math.max(prevCompactionIndex, resetBoundaryIndex) + 1;
+	if (
+		previousCompaction &&
+		!getCompactionV2PreserveData(previousCompaction.preserveData) &&
+		!getPreservedOpenAiRemoteCompactionData(previousCompaction.preserveData)
+	) {
+		// Local summaries exclude the retained tail, whose original entries precede
+		// the compaction record. Native replay already carries that tail. Only look
+		// backwards: advisor snapshots put all retained messages after the summary
+		// and may carry a keep ID from their previous, differently indexed snapshot.
+		for (let i = resetBoundaryIndex + 1; i < prevCompactionIndex; i++) {
+			if (pathEntries[i].id === previousCompaction.firstKeptEntryId) {
+				boundaryStart = i;
+				break;
+			}
+		}
+	}
+
+	// Keep original IDs beside the converted messages so estimation, cutting,
+	// and all three output regions share one sequence without journal metadata.
+	const compactionEntries: SessionEntry[] = [];
+	const compactionMessages: AgentMessage[] = [];
+	for (let i = boundaryStart; i < pathEntries.length; i++) {
+		const entry = pathEntries[i];
+		const message = getMessageFromEntry(entry);
+		if (!message) continue;
+		compactionEntries.push(entry);
+		compactionMessages.push(message);
+	}
 
 	const lastUsage = getLastAssistantUsage(pathEntries);
 	const tokensBefore = lastUsage ? calculateContextTokens(lastUsage) : 0;
 	let keepRecentTokens = settings.keepRecentTokens;
 	if (lastUsage) {
-		const estimatedTokens = estimateEntriesTokens(pathEntries, tokenizer, boundaryStart, boundaryEnd);
+		const estimatedTokens = tokenizer.countMessages(compactionMessages);
 		const promptTokens = calculatePromptTokens(lastUsage);
 		const ratio = estimatedTokens > 0 ? promptTokens / estimatedTokens : 0;
 		if (Number.isFinite(ratio) && ratio > 1) {
@@ -1364,10 +1371,10 @@ export function prepareCompaction(
 		}
 	}
 
-	const cutPoint = findCutPoint(pathEntries, tokenizer, boundaryStart, boundaryEnd, keepRecentTokens);
+	const cutPoint = findCutPoint(compactionEntries, tokenizer, 0, compactionEntries.length, keepRecentTokens);
 
 	// Get ID of first kept entry
-	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];
+	const firstKeptEntry = compactionEntries[cutPoint.firstKeptEntryIndex];
 	if (!firstKeptEntry?.id) {
 		return undefined; // Session needs migration
 	}
@@ -1375,40 +1382,14 @@ export function prepareCompaction(
 
 	const historyEnd = cutPoint.isSplitTurn ? cutPoint.turnStartIndex : cutPoint.firstKeptEntryIndex;
 
-	// Messages to summarize (will be discarded after summary)
-	const messagesToSummarize: AgentMessage[] = [];
-	for (let i = boundaryStart; i < historyEnd; i++) {
-		const msg = getMessageFromEntry(pathEntries[i]);
-		if (msg) messagesToSummarize.push(msg);
-	}
-
-	// Messages for turn prefix summary (if splitting a turn)
-	const turnPrefixMessages: AgentMessage[] = [];
-	if (cutPoint.isSplitTurn) {
-		for (let i = cutPoint.turnStartIndex; i < cutPoint.firstKeptEntryIndex; i++) {
-			const msg = getMessageFromEntry(pathEntries[i]);
-			if (msg) turnPrefixMessages.push(msg);
-		}
-	}
-
-	// Messages kept after compaction (recent history)
-	const recentMessages: AgentMessage[] = [];
-	for (let i = cutPoint.firstKeptEntryIndex; i < boundaryEnd; i++) {
-		const msg = getMessageFromEntry(pathEntries[i]);
-		if (msg) recentMessages.push(msg);
-	}
+	const messagesToSummarize = compactionMessages.slice(0, historyEnd);
+	const turnPrefixMessages = cutPoint.isSplitTurn
+		? compactionMessages.slice(cutPoint.turnStartIndex, cutPoint.firstKeptEntryIndex)
+		: [];
+	const recentMessages = compactionMessages.slice(cutPoint.firstKeptEntryIndex);
 	// Nothing to summarize means compaction would be a no-op.
 	if (messagesToSummarize.length === 0 && turnPrefixMessages.length === 0) {
 		return undefined;
-	}
-
-	// Get previous summary and preserved data for iterative updates
-	let previousSummary: string | undefined;
-	let previousPreserveData: Record<string, unknown> | undefined;
-	if (prevCompactionIndex >= 0) {
-		const prevCompaction = pathEntries[prevCompactionIndex] as CompactionEntry;
-		previousSummary = prevCompaction.summary;
-		previousPreserveData = prevCompaction.preserveData;
 	}
 
 	// Extract file operations from messages and previous compaction
@@ -1428,8 +1409,8 @@ export function prepareCompaction(
 		recentMessages,
 		isSplitTurn: cutPoint.isSplitTurn,
 		tokensBefore,
-		previousSummary,
-		previousPreserveData,
+		previousSummary: previousCompaction?.summary,
+		previousPreserveData: previousCompaction?.preserveData,
 		fileOps,
 		settings,
 	};

--- a/packages/agent/test/compact-reset-boundary.test.ts
+++ b/packages/agent/test/compact-reset-boundary.test.ts
@@ -80,12 +80,14 @@ describe("prepareCompaction reset boundary", () => {
 	});
 
 	test("a reset boundary before the last compaction is superseded by it", () => {
+		const keptUser = userEntry("MID user");
+		const keptAssistant = assistantEntry("MID assistant");
 		const entries: SessionEntry[] = [
 			userEntry("PRE user"),
 			resetBoundary(),
-			userEntry("MID user"),
-			assistantEntry("MID assistant"),
-			compaction("KEEP SUMMARY", "kept-mid"),
+			keptUser,
+			keptAssistant,
+			compaction("KEEP SUMMARY", keptUser.id),
 			userEntry("TAIL one"),
 			assistantEntry("TAIL one answer"),
 			userEntry("TAIL two"),
@@ -97,6 +99,8 @@ describe("prepareCompaction reset boundary", () => {
 		expect(prep?.previousSummary).toBe("KEEP SUMMARY");
 		const summarized = JSON.stringify(prep?.messagesToSummarize ?? []);
 		expect(summarized).toContain("TAIL one");
-		expect(summarized).not.toContain("MID");
+		expect(summarized).toContain("MID user");
+		expect(summarized).toContain("MID assistant");
+		expect(summarized).not.toContain("PRE user");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/test/agent-session-snapcompact-frame-dead-end.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-frame-dead-end.test.ts
@@ -237,13 +237,15 @@ describe("AgentSession snapcompact frame dead-end rescue", () => {
 		};
 	}
 
-	async function triggerMaintenance(): Promise<void> {
+	async function triggerMaintenance(options: { appendAssistant?: boolean } = {}): Promise<void> {
 		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
 		session.subscribe(event => {
 			if (event.type === "auto_compaction_end") onCompactionDone();
 		});
 		const assistantMsg = highUsageAssistant();
-		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		// Resume maintenance without extending the archived branch. Appending an
+		// assistant would make the retained user turn legitimately compactable.
+		if (options.appendAssistant) session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
 		await compactionDone;
 		await session.waitForIdle();
@@ -349,7 +351,7 @@ describe("AgentSession snapcompact frame dead-end rescue", () => {
 
 		const notices = collectNotices();
 		const emitSpy = vi.spyOn(ExtensionRunner.prototype, "emit");
-		await triggerMaintenance();
+		await triggerMaintenance({ appendAssistant: true });
 
 		expect(compactSpy).toHaveBeenCalledTimes(1);
 		const compactions = sessionManager

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -954,7 +954,8 @@ describe("remote compaction setting", () => {
 
 		const oldUser = createMessageEntry(createUserMessage("Archived turn"));
 		const oldAssistant = createMessageEntry(createAssistantMessage("Archived answer"));
-		const previousCompaction = createCompactionEntry("Split snapcompact frame summary", oldAssistant.id);
+		const retainedUser = createMessageEntry(createUserMessage("Turn spanning archive"));
+		const previousCompaction = createCompactionEntry("Split snapcompact frame summary", retainedUser.id);
 		previousCompaction.preserveData = {
 			otherState: "keep-me",
 			snapcompact: {
@@ -968,8 +969,8 @@ describe("remote compaction setting", () => {
 		const entries: SessionEntry[] = [
 			oldUser,
 			oldAssistant,
+			retainedUser,
 			previousCompaction,
-			createMessageEntry(createUserMessage("Turn after archive")),
 			createMessageEntry(createAssistantMessage("Prefix answer")),
 			createMessageEntry(createAssistantMessage("Kept answer")),
 		];
@@ -982,7 +983,10 @@ describe("remote compaction setting", () => {
 		if (!preparation) throw new Error("Expected compaction preparation");
 		expect(preparation.isSplitTurn).toBe(true);
 		expect(preparation.messagesToSummarize).toHaveLength(0);
-		expect(preparation.turnPrefixMessages.length).toBeGreaterThan(0);
+		expect(preparation.turnPrefixMessages).toMatchObject([
+			{ role: "user", content: "Turn spanning archive" },
+			{ role: "assistant", content: [{ type: "text", text: "Prefix answer" }] },
+		]);
 
 		const completeSimpleSpy = vi
 			.spyOn(ai, "completeSimple")
@@ -1119,6 +1123,222 @@ describe("remote compaction setting", () => {
 				compactionItem: { type: "compaction", encrypted_content: "new_encrypted" },
 			},
 		});
+	});
+});
+
+describe("prepareCompaction retained history", () => {
+	const settings = { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false };
+
+	it("partitions retained history across successive compactions without rewriting the journal", () => {
+		const a = createMessageEntry(createUserMessage("Already summarized A"));
+		const b1 = createMessageEntry(createUserMessage("Retained B1"));
+		const modelChange = createModelChangeEntry("anthropic", "claude-sonnet-4-5");
+		const b2 = createMessageEntry(createUserMessage("Retained B2"));
+		const entries: SessionEntry[] = [a, b1, modelChange, b2];
+		const first = prepareCompaction(entries, {
+			...settings,
+			keepRecentTokens: tokenizer.countMessages([b1.message, b2.message]),
+		});
+		if (!first) throw new Error("Expected first compaction");
+		expect(first.messagesToSummarize).toEqual([a.message]);
+		expect(first.recentMessages).toEqual([b1.message, b2.message]);
+		entries.push(createCompactionEntry("Summary A", first.firstKeptEntryId));
+		entries.push(createThinkingLevelEntry("high"));
+		const c = createMessageEntry(createUserMessage("New C"));
+		entries.push(c);
+
+		// C alone fits the budget; B1 must still be summarized rather than returning a no-op.
+		const second = prepareCompaction(entries, {
+			...settings,
+			keepRecentTokens: tokenizer.countMessages([b2.message, c.message]),
+		});
+		if (!second) throw new Error("Expected retained history to remain compactable");
+		expect(second.previousSummary).toBe("Summary A");
+		expect(second.messagesToSummarize).toEqual([b1.message]);
+		expect(second.turnPrefixMessages).toEqual([]);
+		expect(second.recentMessages).toEqual([b2.message, c.message]);
+		expect(second.firstKeptEntryId).toBe(b2.id);
+		entries.push(createCompactionEntry("Summary A+B1", second.firstKeptEntryId));
+		expect(buildSessionContext(entries).messages.slice(1)).toEqual([b2.message, c.message]);
+
+		const d = createMessageEntry(createUserMessage("New D"));
+		entries.push(d);
+		const originalJournal = structuredClone(entries);
+		// The keep boundary still precedes both old compaction records.
+		const third = prepareCompaction(entries, {
+			...settings,
+			keepRecentTokens: tokenizer.countMessage(d.message),
+		});
+		if (!third) throw new Error("Expected third compaction");
+		expect(third.previousSummary).toBe("Summary A+B1");
+		expect(third.messagesToSummarize).toEqual([b2.message, c.message]);
+		expect(third.turnPrefixMessages).toEqual([]);
+		expect(third.recentMessages).toEqual([d.message]);
+		expect(third.firstKeptEntryId).toBe(d.id);
+		expect(entries).toEqual(originalJournal);
+		entries.push(createCompactionEntry("Summary A+B1+B2+C", third.firstKeptEntryId));
+		expect(buildSessionContext(entries).messages.slice(1)).toEqual([d.message]);
+	});
+
+	it("summarizes a retained tool turn prefix across the previous compaction record", () => {
+		const a = createMessageEntry(createUserMessage("Summarized request"));
+		const b = createMessageEntry(createUserMessage("Inspect retained.ts"));
+		const call = createMessageEntry({
+			...createAssistantMessage("", createMockUsage(0, 0)),
+			content: [{ type: "toolCall", id: "read-retained", name: "read", arguments: { path: "retained.ts" } }],
+			stopReason: "toolUse",
+		});
+		const result = createMessageEntry({
+			role: "toolResult",
+			toolCallId: "read-retained",
+			toolName: "read",
+			content: [{ type: "text", text: "Retained file contents" }],
+			isError: false,
+			timestamp: 1,
+		});
+		const previous = createCompactionEntry("Summary A", b.id);
+		const answer = createMessageEntry(createAssistantMessage("Inspection complete", createMockUsage(0, 0)));
+		const preparation = prepareCompaction([a, b, call, result, previous, answer], {
+			...settings,
+			keepRecentTokens: 1,
+		});
+		if (!preparation) throw new Error("Expected split-turn compaction");
+		expect(preparation.previousSummary).toBe("Summary A");
+		expect(preparation.isSplitTurn).toBe(true);
+		expect(preparation.messagesToSummarize).toEqual([]);
+		expect(preparation.turnPrefixMessages).toEqual([b.message, call.message, result.message]);
+		expect(preparation.recentMessages).toEqual([answer.message]);
+		expect(preparation.firstKeptEntryId).toBe(answer.id);
+	});
+
+	it("includes the retained region when calibrating the keep budget against provider usage", () => {
+		const a = createMessageEntry(createUserMessage("Summarized A"));
+		const b = createMessageEntry(createUserMessage("Uncompressed reasoning in B. ".repeat(256)));
+		const previous = createCompactionEntry("Summary A", b.id);
+		const c = createMessageEntry(createUserMessage("Recent request C"));
+		const answer = createAssistantMessage("Recent answer C", createMockUsage(0, 0));
+		answer.usage = createMockUsage(tokenizer.countMessages([b.message, c.message, answer]), 0);
+		const last = createMessageEntry(answer);
+		const preparation = prepareCompaction([a, b, previous, c, last], {
+			...settings,
+			keepRecentTokens: tokenizer.countMessages([c.message, answer]),
+		});
+		if (!preparation) throw new Error("Expected compaction of B");
+		expect(preparation.messagesToSummarize).toEqual([b.message]);
+		expect(preparation.turnPrefixMessages).toEqual([]);
+		expect(preparation.recentMessages).toEqual([c.message, answer]);
+		expect(preparation.firstKeptEntryId).toBe(c.id);
+	});
+
+	it("keeps message-bearing custom entries and branch summaries out of journal metadata", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "a",
+				parentId: null,
+				timestamp: "2026-09-10T00:00:00Z",
+				message: createUserMessage("A"),
+			},
+			{
+				type: "custom_message",
+				id: "custom",
+				parentId: "a",
+				timestamp: "2026-09-10T00:00:01Z",
+				customType: "note",
+				content: "Retained note",
+				display: true,
+			},
+			{
+				type: "branch_summary",
+				id: "branch",
+				parentId: "custom",
+				timestamp: "2026-09-10T00:00:02Z",
+				fromId: "a",
+				summary: "Retained branch context",
+			},
+			{
+				type: "compaction",
+				id: "compact",
+				parentId: "branch",
+				timestamp: "2026-09-10T00:00:03Z",
+				summary: "Summary A",
+				firstKeptEntryId: "custom",
+				tokensBefore: 0,
+			},
+			{
+				type: "custom",
+				id: "metadata",
+				parentId: "compact",
+				timestamp: "2026-09-10T00:00:04Z",
+				customType: "state",
+				data: { secret: "not a message" },
+			},
+			{
+				type: "message",
+				id: "c1",
+				parentId: "metadata",
+				timestamp: "2026-09-10T00:00:05Z",
+				message: createUserMessage("New C1"),
+			},
+			{
+				type: "message",
+				id: "c2",
+				parentId: "c1",
+				timestamp: "2026-09-10T00:00:06Z",
+				message: createUserMessage("New C2"),
+			},
+		];
+		const preparation = prepareCompaction(entries, { ...settings, keepRecentTokens: 1 });
+		if (!preparation) throw new Error("Expected custom history compaction");
+		expect(preparation.messagesToSummarize).toMatchObject([
+			{ role: "custom", customType: "note", content: "Retained note" },
+			{ role: "branchSummary", summary: "Retained branch context" },
+			{ role: "user", content: "New C1" },
+		]);
+		expect(preparation.turnPrefixMessages).toEqual([]);
+		expect(preparation.recentMessages).toMatchObject([{ role: "user", content: "New C2" }]);
+	});
+
+	it("preserves all post-summary messages in reindexed advisor snapshots", () => {
+		const previous = createCompactionEntry("Summary A", "pending");
+		const b = createMessageEntry(createUserMessage("Retained B"));
+		const c = createMessageEntry(createUserMessage("New C"));
+		const d = createMessageEntry(createUserMessage("New D"));
+		// Advisor snapshots rebuild IDs; an old keep ID can name a later message now.
+		previous.firstKeptEntryId = d.id;
+		const preparation = prepareCompaction([previous, b, c, d], { ...settings, keepRecentTokens: 1 });
+		if (!preparation) throw new Error("Expected advisor compaction");
+		expect(preparation.messagesToSummarize).toEqual([b.message, c.message]);
+		expect(preparation.recentMessages).toEqual([d.message]);
+	});
+
+	it("recovers a local kept region behind an unreadable remote compaction without duplicating reusable replay", () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected anthropic test model");
+		const a = createMessageEntry(createUserMessage("Summarized A"));
+		const b = createMessageEntry(createUserMessage("Retained B"));
+		const local = createCompactionEntry("Summary A", b.id);
+		const c = createMessageEntry(createUserMessage("Original remote C"));
+		const remote = createCompactionEntry("Opaque remote summary", c.id);
+		remote.preserveData = {
+			openaiRemoteCompaction: {
+				provider: "openai",
+				replacementHistory: [{ type: "compaction", encrypted_content: "replay" }],
+				compactionItem: { type: "compaction", encrypted_content: "replay" },
+			},
+		};
+		const d = createMessageEntry(createUserMessage("New D"));
+		const e = createMessageEntry(createUserMessage("New E"));
+		const entries: SessionEntry[] = [a, b, local, c, remote, d, e];
+		const reused = prepareCompaction(entries, { ...settings, remoteEnabled: true, keepRecentTokens: 1 });
+		if (!reused) throw new Error("Expected native replay reuse");
+		expect(reused.messagesToSummarize).toEqual([d.message]);
+		expect(reused.recentMessages).toEqual([e.message]);
+		const expanded = prepareCompaction(entries, { ...settings, keepRecentTokens: 1 }, model);
+		if (!expanded) throw new Error("Expected local history re-expansion");
+		expect(expanded.previousSummary).toBe("Summary A");
+		expect(expanded.messagesToSummarize).toEqual([b.message, c.message, d.message]);
+		expect(expanded.recentMessages).toEqual([e.message]);
 	});
 });
 


### PR DESCRIPTION
## What

Fix repeated soft compaction losing messages retained by the previous pass.

- Recover the previous local compaction's retained entries using `firstKeptEntryId`, then include entries appended after that compaction.
- Use one effective entry/message sequence for token estimation, cut-point selection, and history-summary, turn-prefix, and retained-message allocation.
- Keep the previous summary separate from conversation input and exclude non-message journal metadata.
- Preserve original entry IDs and `/clear` boundaries without rewriting history.
- Add retained-history regressions, correct affected archive fixtures, and update documentation and changelogs.

## Why

The session journal and active context have different shapes after compaction:

    Journal: A -> B -> compaction record -> C
    Context: summary(A) + B + C

Previously, `prepareCompaction()` scanned only entries after the previous compaction record. B was still active context, but its original entries remained before that record.

A subsequent compaction could therefore omit B from both summarization input and retained messages, silently dropping it from rebuilt context. It could also incorrectly return no preparation when all newly appended messages fit the retention budget, even though the previous retained region remained compactable.

The preparation now partitions the complete effective local history rather than only the post-compaction suffix.

## Testing

- Red/green regression verification: six expected failures before the production fix, all passing afterward.
- Related compaction, remote, snapcompact, and advisor tests:
  **370 passed, 13 skipped, 0 failed across 43 files**.
- Regressions cover:
  - successive compactions with retained IDs preceding older compaction records;
  - retained tool-call/result turn prefixes;
  - token-budget calibration including the retained region;
  - custom messages, branch summaries, and metadata exclusion;
  - reindexed advisor snapshots;
  - local-history recovery behind an unreadable remote compaction;
  - `/clear` boundaries.
- Ran an independent `prepareCompaction()` -> `compact()` -> `buildSessionContext()` smoke with the supported offline completion transport: the second history-summary request contained B + C1, C2 remained verbatim, and the original journal entries were unchanged.
- An additional in-memory coverage sweep checked 258 successful preparations across four compaction generations, varying budgets, continued turns, metadata, and reset boundaries.
- `bun run check`: passed.
  - One existing unused-variable warning for `ensureLive` in
    `test/task/executor-subagent-reminders.test.ts`.
  - Rust checks were skipped because no Rust-affecting changes were present.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
