### PR TITLE
fix(mcp): resolve Claude-Code-style double-underscore tool names

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Claude-Code-style `mcp__<server>__<tool>` calls (double underscore) now resolve to the tool OMP registers as `mcp__<server>_<tool>`, instead of failing with `Tool <name> not found`. OMP presents a Claude Code identity to Anthropic endpoints, so models trained on that client emit its separator; the repair re-mints both segments through `createMCPToolName`, so lossy sanitization still applies (server `context7` resolves to `mcp__context_resolve_library_id`) and an unregistered result keeps the original failure rather than guessing a target ([#11516](https://github.com/can1357/oh-my-pi/issues/11516)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Claude-Code-style `mcp__<server>__<tool>` calls (double underscore) now resolve to the tool OMP registers as `mcp__<server>_<tool>`, instead of failing with `Tool <name> not found`. OMP presents a Claude Code identity to Anthropic endpoints, so models trained on that client emit its separator; the repair re-mints both segments through `createMCPToolName`, so lossy sanitization still applies (server `context7` resolves to `mcp__context_resolve_library_id`) and an unregistered result keeps the original failure rather than guessing a target ([#11516](https://github.com/can1357/oh-my-pi/issues/11516)).
+- Claude-Code-style `mcp__<server>__<tool>` calls (double underscore) are now rewritten to the key OMP registers, `mcp__<server>_<tool>`, instead of failing with `Tool <name> not found`. OMP presents a Claude Code identity to Anthropic endpoints, so models trained on that client emit its separator. The name is repaired on the assistant message before dispatch, so the exact-match path stays authoritative — active-set gating and execution wrappers still apply, and history, persistence, and provider replay all record an advertised name. Both segments are re-minted through `createMCPToolName`, so lossy sanitization applies (server `context7` resolves to `mcp__context_resolve_library_id`) and a name that is not an advertised tool keeps its original failure rather than binding to a substitute ([#11516](https://github.com/can1357/oh-my-pi/issues/11516) by [@oldschoola](https://github.com/oldschoola)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -532,6 +532,41 @@ export function parseMCPToolName(name: string): { serverName: string; toolName: 
 }
 
 /**
+ * Re-mint a Claude-Code-shaped `mcp__<server>__<tool>` name into the registry
+ * key OMP actually assigns ({@link createMCPToolName}).
+ *
+ * OMP presents a Claude Code identity to Anthropic endpoints, so a model
+ * trained on that client emits its double-underscore separator. Dispatch is
+ * strict exact-match, so the call fails with `Tool <name> not found` even
+ * though the server and tool both exist (#11516).
+ *
+ * Splitting on the first `__` is unambiguous: {@link sanitizeMCPToolNamePart}
+ * squashes runs of `_`, so a minted name carries no `__` after the `mcp__`
+ * prefix and a second `__` marks a name OMP never minted. The two halves go
+ * back through {@link createMCPToolName} rather than being spliced, so
+ * sanitization, redundant-server-prefix stripping, and length capping all
+ * apply — `context7` sanitizes to `context`, making the key
+ * `mcp__context_resolve_library_id`, which a literal collapse would miss.
+ * Re-minting is idempotent when the model already emitted sanitized segments.
+ *
+ * `isRegistered` gates the result: registry names are unique, so a hit is the
+ * intended tool and a miss preserves the original failure rather than guessing.
+ */
+export function collapseMCPToolNameSeparator(
+	name: string,
+	isRegistered: (candidate: string) => boolean,
+): string | undefined {
+	if (!name.startsWith("mcp__")) return undefined;
+
+	const rest = name.slice(5);
+	const separatorIdx = rest.indexOf("__");
+	if (separatorIdx <= 0) return undefined;
+
+	const candidate = createMCPToolName(rest.slice(0, separatorIdx), rest.slice(separatorIdx + 2));
+	return candidate !== name && isRegistered(candidate) ? candidate : undefined;
+}
+
+/**
  * CustomTool wrapping an MCP tool with an active connection.
  */
 export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3013,15 +3013,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (!state) return undefined;
 			return resolveMountedXdevExecutable(state, name);
 		};
-		// Last-resort name repair before the loop reports `Tool <name> not found`.
-		// Keeps `resolveDeviceTool` itself untouched so Cursor's `getExecutableTool`
-		// keeps resolving device mounts only.
-		const resolveFallbackTool = (name: string): AgentTool | undefined => {
-			const mounted = resolveDeviceTool(name);
-			if (mounted) return mounted;
-			const collapsed = collapseMCPToolNameSeparator(name, candidate => toolRegistry.has(candidate));
-			return collapsed === undefined ? undefined : toolRegistry.get(collapsed);
-		};
 		// Cursor's resource frames ask what THIS client's servers advertise; only
 		// live connections have any. Built once: the advisor bridges answer from
 		// the same connections the primary does.
@@ -3602,6 +3593,20 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// A stray sloppy payload in plain text becomes a real edit tool call so
 			// the normal pipeline (validation, approval, rendering) executes it.
 			transformAssistantMessage: message => {
+				// Repair a Claude-Code-shaped `mcp__<server>__<tool>` name into the key
+				// OMP mints (#11516). Rewriting the call itself — rather than resolving
+				// a substitute tool at dispatch — keeps the exact-match path authoritative,
+				// so active-set gating and execution wrappers still apply, and history,
+				// persistence, and provider replay all record an advertised name.
+				for (const block of message.content) {
+					if (block.type !== "toolCall") continue;
+					const canonical = collapseMCPToolNameSeparator(block.name, candidate =>
+						agent.state.tools.some(tool => tool.name === candidate),
+					);
+					if (canonical === undefined) continue;
+					logger.info("repaired Claude Code MCP tool name separator", { from: block.name, to: canonical });
+					block.name = canonical;
+				}
 				if (!settings.get("edit.recoverInlineEdits")) return;
 				// The live tool is an ExtensionToolWrapper whose proxy forwards the
 				// EditTool `mode` getter; a bridge/custom edit tool without a sloppy
@@ -3613,7 +3618,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					logger.info("recovered inline sloppy edit payload into edit tool call", { regions: recovered });
 				}
 			},
-			resolveFallbackTool,
+			resolveFallbackTool: resolveDeviceTool,
 			intentTracing: !!intentField,
 			pruneToolDescriptions: inlineToolDescriptors,
 			dialect: resolveDialect(settings.get("tools.format"), model),
@@ -4180,7 +4185,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					getToolContext: toolCall => toolContextStore.getContext(toolCall),
 					streamFn: settingsAwareStreamFn,
 					transformToolCallArguments,
-					resolveFallbackTool,
+					resolveFallbackTool: resolveDeviceTool,
 					intentTracing: !!intentField,
 					pruneToolDescriptions: inlineToolDescriptors,
 					dialect: resolveDialect(settings.get("tools.format"), captureModel),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -130,6 +130,7 @@ import { LocalProtocolHandler, type LocalProtocolOptions } from "./internal-urls
 import { setSharedLspEnabled } from "./lsp/client";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-events";
 import {
+	collapseMCPToolNameSeparator,
 	deduplicateMCPToolsByName,
 	discoverAndLoadMCPTools,
 	getMCPToolOriginKey,
@@ -3012,6 +3013,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (!state) return undefined;
 			return resolveMountedXdevExecutable(state, name);
 		};
+		// Last-resort name repair before the loop reports `Tool <name> not found`.
+		// Keeps `resolveDeviceTool` itself untouched so Cursor's `getExecutableTool`
+		// keeps resolving device mounts only.
+		const resolveFallbackTool = (name: string): AgentTool | undefined => {
+			const mounted = resolveDeviceTool(name);
+			if (mounted) return mounted;
+			const collapsed = collapseMCPToolNameSeparator(name, candidate => toolRegistry.has(candidate));
+			return collapsed === undefined ? undefined : toolRegistry.get(collapsed);
+		};
 		// Cursor's resource frames ask what THIS client's servers advertise; only
 		// live connections have any. Built once: the advisor bridges answer from
 		// the same connections the primary does.
@@ -3603,7 +3613,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					logger.info("recovered inline sloppy edit payload into edit tool call", { regions: recovered });
 				}
 			},
-			resolveFallbackTool: resolveDeviceTool,
+			resolveFallbackTool,
 			intentTracing: !!intentField,
 			pruneToolDescriptions: inlineToolDescriptors,
 			dialect: resolveDialect(settings.get("tools.format"), model),
@@ -4170,7 +4180,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					getToolContext: toolCall => toolContextStore.getContext(toolCall),
 					streamFn: settingsAwareStreamFn,
 					transformToolCallArguments,
-					resolveFallbackTool: resolveDeviceTool,
+					resolveFallbackTool,
 					intentTracing: !!intentField,
 					pruneToolDescriptions: inlineToolDescriptors,
 					dialect: resolveDialect(settings.get("tools.format"), captureModel),

--- a/packages/coding-agent/test/mcp-tool-name-separator.test.ts
+++ b/packages/coding-agent/test/mcp-tool-name-separator.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test: a Claude-Code-shaped `mcp__<server>__<tool>` call must
+ * resolve to the registry key OMP mints, `mcp__<server>_<tool>` (#11516).
+ *
+ * OMP advertises a Claude Code identity to Anthropic endpoints, so a model
+ * trained on that client emits its double-underscore separator while dispatch
+ * exact-matches OMP's single-underscore key — the call fails with
+ * `Tool <name> not found` though the server and tool both exist.
+ *
+ * The repair re-mints through `createMCPToolName` rather than splicing the
+ * separator, because sanitization is lossy: `sanitizeMCPToolNamePart` maps
+ * `[^a-z_]+` to `_` and strips edges, so server `context7` becomes `context`
+ * and the real key is `mcp__context_resolve_library_id`. A literal collapse
+ * yields `mcp__context7_resolve_library_id` and still misses.
+ */
+import { describe, expect, it } from "bun:test";
+import { collapseMCPToolNameSeparator, createMCPToolName } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
+
+/** Exactly what `createMCPToolName` mints for these servers. */
+const REGISTERED: Record<string, true> = {
+	[createMCPToolName("context7", "resolve_library_id")]: true,
+	[createMCPToolName("brave-search", "web_search")]: true,
+	[createMCPToolName("github", "create_issue")]: true,
+};
+
+const isRegistered = (candidate: string): boolean => REGISTERED[candidate] === true;
+
+describe("collapseMCPToolNameSeparator", () => {
+	it("re-mints segments to the registry key, applying lossy sanitization", () => {
+		// Trailing-strip branch: the digit becomes `_`, then edge-strips away, so
+		// the key is `context`, not `context7`. A literal separator splice misses.
+		expect(REGISTERED["mcp__context_resolve_library_id"]).toBe(true);
+		expect(collapseMCPToolNameSeparator("mcp__context7__resolve_library_id", isRegistered)).toBe(
+			"mcp__context_resolve_library_id",
+		);
+		// Internal-replace branch: the hyphen becomes an underscore.
+		expect(collapseMCPToolNameSeparator("mcp__brave-search__web_search", isRegistered)).toBe(
+			"mcp__brave_search_web_search",
+		);
+		// Already-sanitized segments re-mint unchanged.
+		expect(collapseMCPToolNameSeparator("mcp__github__create_issue", isRegistered)).toBe("mcp__github_create_issue");
+	});
+
+	it("preserves the failure when the re-minted key is not registered", () => {
+		// Unknown server: repairing a separator must not invent a target.
+		expect(collapseMCPToolNameSeparator("mcp__stripe__create_charge", isRegistered)).toBeUndefined();
+	});
+
+	it("does not repair a name the model reconstructed rather than mis-separated", () => {
+		// Doubled-prefix and bare-namespace shapes are transcription damage, not a
+		// separator mismatch; they must keep failing rather than bind to some
+		// unrelated tool.
+		expect(
+			collapseMCPToolNameSeparator("mcp__oclqnh2yz7ln__mcp__oclqnh2yz7ln__k3wwvy6fs5ah_read", isRegistered),
+		).toBeUndefined();
+		expect(collapseMCPToolNameSeparator("mcp__oclqnh2yz7ln__glob", isRegistered)).toBeUndefined();
+	});
+
+	it("leaves already-correct and non-MCP names untouched", () => {
+		// Already the registry key: no second separator, so nothing to repair.
+		expect(collapseMCPToolNameSeparator("mcp__github_create_issue", isRegistered)).toBeUndefined();
+		// Builtins must never be rewritten by MCP name repair.
+		expect(collapseMCPToolNameSeparator("read", isRegistered)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Refs #11516 — implements direction 3 only (the separator mismatch), flagged there as "the most defensible as an OMP-owned inconsistency, since we assert the Claude Code identity while registering a different separator".

Deliberately **not** `Fixes`: #11516 reports three failure classes and this addresses one. The bare-namespace (`mcp__<NS>__glob`) and doubled-prefix shapes are model-side reconstruction damage and still fail — the fourth test pins that they must. The issue should stay open for @can1357.

## Problem

OMP presents a Claude Code identity to Anthropic endpoints (`claude-code-fingerprint.ts:20`), so a model trained on that client emits Claude Code's tool-name separator:

```
mcp__context7__resolve_library_id     <- what the model emits (double underscore)
mcp__context_resolve_library_id       <- what OMP registers
```

Dispatch is strict exact-match, so the call fails with `Tool <name> not found` even though the server is connected and the tool exists.

## Fix

Repair the **name on the assistant message**, in `transformAssistantMessage`, before dispatch:

```ts
const canonical = collapseMCPToolNameSeparator(block.name, candidate =>
    agent.state.tools.some(tool => tool.name === candidate),
);
```

`collapseMCPToolNameSeparator` splits at the first `__` after the `mcp__` prefix and **re-mints both halves through `createMCPToolName`** rather than splicing the separator. Re-minting is load-bearing: sanitization is lossy — `sanitizeMCPToolNamePart` maps `[^a-z_]+` to `_` and strips edges — so `context7` becomes `context` and the key is `mcp__context_resolve_library_id`. A literal collapse yields `mcp__context7_resolve_library_id` and still misses. Re-minting also picks up redundant-server-prefix stripping and `capMCPToolNameLength`, and is idempotent on already-sanitized segments.

Splitting on the first `__` is unambiguous: sanitization squashes runs of `_`, so a minted name carries no `__` after the prefix.

### Why rewrite the call rather than resolve a substitute at dispatch

The first revision of this PR resolved out of `toolRegistry` in `resolveFallbackTool`. @chatgpt-codex-connector correctly flagged that as P1: the registry holds every registered tool, including `defaultInactive`/hidden entries and MCP tools the user deselected. That would have let a deselected tool execute, returned the raw registry entry instead of the caller's execution-wrapped instance (bypassing the ACP permission wrapper from `SessionTools.#applyActiveToolsByName`), and exposed every registered MCP tool to the auto-learn capture agent, whose advertised set is only `learn`/`manage_skill`.

Rewriting the name instead means dispatch goes through the normal exact-match path against `agent.state.tools` — the set actually advertised to this caller — so active-set gating and execution wrappers stay in force. Nothing can resolve to a tool the model was never offered.

It also canonicalizes everything keyed off `toolCall.name`: `ToolResultMessage.toolName`, the `tool_execution_*` events, telemetry, and `recoverTransientErrorToolTurn` — which requires *every* call name in a message to be advertised, so a single unrepaired alias would have silently disabled transient-error recovery for the whole message.

`resolveFallbackTool` is back to plain `resolveDeviceTool`; device-mount resolution is untouched. The capture loop sets no `transformAssistantMessage`, so it stays unrepaired — correct, given its advertised set is two tools.

## No guessing

- The transform is deterministic: one input, one candidate.
- The candidate must already be an advertised tool name.
- A miss preserves the original `not found`.

```
mcp__<NS>__mcp__<NS>__<ID>_read   -> still not found (doubled prefix)
mcp__<NS>__glob                   -> still not found (fabricated namespace)
```

## Tests

`packages/coding-agent/test/mcp-tool-name-separator.test.ts` — 4 tests, one per branch:

- re-mints lossy segments (`context7` digit-strip, `brave-search` hyphen, clean `github`)
- unregistered candidate returns `undefined`, preserving the failure
- reconstruction damage is not repaired
- already-correct keys and non-MCP names (`read`) untouched

`context7` is asserted explicitly because it's the case a naive splice gets wrong.

## Verification

```
bun test <new test + 2 neighbouring MCP suites>   11 pass, 0 fail
bun run check:tools                               lint + format clean
bun --cwd=packages/coding-agent run check:types   no errors in changed files
```

The typecheck reports errors only in an unrelated untracked `src/config/profiles.ts` in my working tree; nothing in the changed files, and it is not part of this branch.
