### PR TITLE
fix(agent): suggest the intended tool when a name miss is recoverable

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `Tool <name> not found` now names a plausible intended target when the advertised set contains one, e.g. `Tool mcp__abc123__xyz789_read not found. Did you mean read?`. A model that mis-transcribes a long opaque tool name reliably keeps the trailing segment, which is the only part carrying meaning, so the miss becomes recoverable in the same turn instead of costing a round trip. Purely advisory — the suggestion is only ever a string in the error, never a dispatch target, so an unrecognized name still fails ([#10109](https://github.com/can1357/oh-my-pi/issues/10109) by [@oldschoola](https://github.com/oldschoola)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2269,6 +2269,66 @@ function resolveToolForCall(
 	);
 }
 
+/** Shortest suggestable segment; below this the match is noise (`id`, `to`). */
+const MIN_TOOL_NAME_SUGGESTION_SEGMENT = 3;
+/** Cap on names listed for an ambiguous miss, so the error stays readable. */
+const MAX_TOOL_NAME_SUGGESTIONS = 3;
+
+/**
+ * Advertised tool names sharing a trailing `_`-delimited segment with `name`.
+ *
+ * A model that mis-transcribes a long opaque tool name reliably keeps the
+ * trailing verb — that segment is the only part carrying meaning, while any
+ * leading id segments are high-entropy and mnemonic-free. Matching on it turns
+ * an otherwise dead `not found` into a self-correcting one.
+ *
+ * Both the last `__` and last `_` boundary are tried, so a name that lost only
+ * its separator (`…__resolve_library_id`) and one that lost a whole id segment
+ * (`…__read`) both recover. Purely advisory: this only builds an error string
+ * and never selects a tool, so dispatch semantics are unchanged.
+ */
+function suggestToolNames(
+	name: string,
+	tools: ReadonlyArray<Pick<AgentTool, "name" | "customWireName">> | undefined,
+): string[] {
+	if (!tools || tools.length === 0) return [];
+	const segments = new Set<string>();
+	for (const boundary of ["__", "_"]) {
+		const idx = name.lastIndexOf(boundary);
+		if (idx < 0) continue;
+		const segment = name.slice(idx + boundary.length);
+		if (segment.length >= MIN_TOOL_NAME_SUGGESTION_SEGMENT) segments.add(segment);
+	}
+	if (segments.size === 0) return [];
+	const matches: string[] = [];
+	for (const tool of tools) {
+		for (const candidate of [tool.name, tool.customWireName]) {
+			if (candidate === undefined || candidate === name || matches.includes(candidate)) continue;
+			for (const segment of segments) {
+				if (candidate === segment || candidate.endsWith(`_${segment}`)) {
+					matches.push(candidate);
+					break;
+				}
+			}
+		}
+	}
+	return matches;
+}
+
+/**
+ * `Tool <name> not found`, plus a suggestion when the advertised set contains a
+ * plausible intended target. Exact wording is not a contract; the model reads it.
+ */
+function formatToolNotFoundMessage(
+	name: string,
+	tools: ReadonlyArray<Pick<AgentTool, "name" | "customWireName">> | undefined,
+): string {
+	const suggestions = suggestToolNames(name, tools);
+	if (suggestions.length === 0) return `Tool ${name} not found`;
+	if (suggestions.length === 1) return `Tool ${name} not found. Did you mean ${suggestions[0]}?`;
+	return `Tool ${name} not found. Closest available: ${suggestions.slice(0, MAX_TOOL_NAME_SUGGESTIONS).join(", ")}`;
+}
+
 /**
  * Pre-dispatch phase for every pending tool call on `assistantMessage`, run in
  * call order: intent extraction, argument validation, and the `beforeToolCall`
@@ -2312,7 +2372,7 @@ async function prepareToolCallDispatch(
 		}
 		const validate = (args: Record<string, unknown>): Record<string, unknown> | undefined => {
 			try {
-				if (!tool) throw new Error(`Tool ${toolCall.name} not found`);
+				if (!tool) throw new Error(formatToolNotFoundMessage(toolCall.name, context.tools));
 				return validateToolArguments(tool, { ...toolCall, arguments: args });
 			} catch (validationError) {
 				if (tool?.lenientArgValidation) {
@@ -2637,7 +2697,7 @@ async function executeToolCalls(
 
 		await runInActiveSpan(toolSpan, async () => {
 			try {
-				if (!tool) throw new Error(`Tool ${toolCall.name} not found`);
+				if (!tool) throw new Error(formatToolNotFoundMessage(toolCall.name, tools));
 				if (record.signal.aborted) {
 					result = createToolSignalAbortedResult(record.signal);
 					isError = true;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2292,23 +2292,25 @@ function suggestToolNames(
 	tools: ReadonlyArray<Pick<AgentTool, "name" | "customWireName">> | undefined,
 ): string[] {
 	if (!tools || tools.length === 0) return [];
-	const segments = new Set<string>();
+	const segments: string[] = [];
 	for (const boundary of ["__", "_"]) {
 		const idx = name.lastIndexOf(boundary);
 		if (idx < 0) continue;
 		const segment = name.slice(idx + boundary.length);
-		if (segment.length >= MIN_TOOL_NAME_SUGGESTION_SEGMENT) segments.add(segment);
+		if (segment.length >= MIN_TOOL_NAME_SUGGESTION_SEGMENT && !segments.includes(segment)) segments.push(segment);
 	}
-	if (segments.size === 0) return [];
+	if (segments.length === 0) return [];
+	// Longest tail first. A distinctive `__` tail (`resolve_library_get`) is a
+	// far stronger signal than the generic `_` tail it contains (`get`), and the
+	// caller truncates the list — so the strongest match has to sort ahead of
+	// however many tools happen to share the weak one.
+	segments.sort((a, b) => b.length - a.length);
 	const matches: string[] = [];
-	for (const tool of tools) {
-		for (const candidate of [tool.name, tool.customWireName]) {
-			if (candidate === undefined || candidate === name || matches.includes(candidate)) continue;
-			for (const segment of segments) {
-				if (candidate === segment || candidate.endsWith(`_${segment}`)) {
-					matches.push(candidate);
-					break;
-				}
+	for (const segment of segments) {
+		for (const tool of tools) {
+			for (const candidate of [tool.name, tool.customWireName]) {
+				if (candidate === undefined || candidate === name || matches.includes(candidate)) continue;
+				if (candidate === segment || candidate.endsWith(`_${segment}`)) matches.push(candidate);
 			}
 		}
 	}

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1211,6 +1211,61 @@ describe("agentLoop with AgentMessage", () => {
 		);
 	});
 
+	it("suggests the intended tool when a miss shares its trailing segment", async () => {
+		const toolSchema = type({ path: "string" });
+		const makeTool = (name: string): AgentTool<typeof toolSchema, { path: string }> => ({
+			name,
+			label: name,
+			description: "Advertised tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: params.path }], details: params };
+			},
+		});
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [],
+			tools: [makeTool("read"), makeTool("mcp__context_resolve_library_id")],
+		};
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						// Whole id segment lost; only the trailing verb survived.
+						{ type: "toolCall", id: "tool-1", name: "mcp__abc123__xyz789_read", arguments: { path: "p" } },
+						// Separator lost; the tail after the last `__` still identifies it.
+						{
+							type: "toolCall",
+							id: "tool-2",
+							name: "mcp__context7__resolve_library_id",
+							arguments: { path: "p" },
+						},
+						// Nothing in the advertised set shares a trailing segment.
+						{ type: "toolCall", id: "tool-3", name: "totally_unrelated", arguments: {} },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await agentLoop([createUserMessage("go")], context, config, undefined, mock.stream).result();
+		const results = messages.filter((m): m is ToolResultMessage => m.role === "toolResult");
+		const textOf = (id: string): string =>
+			(results.find(r => r.toolCallId === id)?.content ?? [])
+				.filter((c): c is { type: "text"; text: string } => c.type === "text")
+				.map(c => c.text)
+				.join("\n");
+
+		// The model reliably keeps the trailing verb, so the miss is recoverable
+		// in-turn instead of costing a round trip.
+		expect(textOf("tool-1")).toContain("Did you mean read?");
+		expect(textOf("tool-2")).toContain("Did you mean mcp__context_resolve_library_id?");
+		// No plausible target: the bare failure is preserved, never a guess.
+		expect(textOf("tool-3")).toContain("Tool totally_unrelated not found");
+		expect(textOf("tool-3")).not.toContain("Did you mean");
+	});
+
 	it("injects and strips intent when intent tracing is enabled", async () => {
 		const toolSchema = type({ value: "string" });
 		const executedParams: Record<string, unknown>[] = [];

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1266,6 +1266,53 @@ describe("agentLoop with AgentMessage", () => {
 		expect(textOf("tool-3")).not.toContain("Did you mean");
 	});
 
+	it("ranks the distinctive tail ahead of tools sharing only the generic one", async () => {
+		const toolSchema = type({ path: "string" });
+		const makeTool = (name: string): AgentTool<typeof toolSchema, { path: string }> => ({
+			name,
+			label: name,
+			description: "Advertised tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: params.path }], details: params };
+			},
+		});
+		const context: AgentContext = {
+			systemPrompt: [""],
+			messages: [],
+			// Three tools share the weak `_get` tail and are listed first; only the
+			// last matches the distinctive `resolve_library_get` tail.
+			tools: [
+				makeTool("alpha_get"),
+				makeTool("beta_get"),
+				makeTool("gamma_get"),
+				makeTool("mcp__context_resolve_library_get"),
+			],
+		};
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "bad__resolve_library_get", arguments: { path: "p" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await agentLoop([createUserMessage("go")], context, config, undefined, mock.stream).result();
+		const result = messages.find((m): m is ToolResultMessage => m.role === "toolResult");
+		const text = (result?.content ?? [])
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("\n");
+
+		// Listing is capped, so a uniquely-matching distinctive tail must survive
+		// truncation rather than being crowded out by generic `_get` siblings.
+		expect(text).toContain("mcp__context_resolve_library_get");
+	});
+
 	it("injects and strips intent when intent tracing is enabled", async () => {
 		const toolSchema = type({ value: "string" });
 		const executedParams: Record<string, unknown>[] = [];


### PR DESCRIPTION
Refs #10109 — implements suggestion 1 ("suggest on miss"), the cheapest of the three directions in that report and the only one that doesn't touch dispatch semantics.

## Problem

Tool dispatch is strict exact-match, and a miss produces exactly `Tool <name> not found`. No suggestion, no recovery path — the turn is wasted even when the intended target is obvious.

To be precise about what is and isn't OMP's: `createMCPToolName` mints a **single** underscore between segments, so no OMP-advertised name carries `__` after the `mcp__` prefix, and `sanitizeMCPToolNamePart` maps `[^a-z_]+` to `_`, so no minted name retains digits. Names like `mcp__esgscwwkmv7h__groj2yhoa6h3_read` therefore cannot originate in this repo — whatever applies that namespacing sits below the tool registry, outside OMP. #10109 was closed partly on that point, and it's correct.

What *is* OMP's is the dead end. Whatever produced the name, the model emitted something close to a real tool, and the harness answered with a message it cannot act on:

```
advertised:   read
emitted:      mcp__<id>__<id>_read
response:     Tool mcp__<id>__<id>_read not found
```

The trailing segment survived. That's the part carrying meaning — leading id segments are high-entropy and mnemonic-free — so the intended target was recoverable and simply wasn't offered.

## Fix

`suggestToolNames` matches advertised names on that trailing segment and names the candidate:

```
Tool mcp__abc123__xyz789_read not found. Did you mean read?
```

Both the last `__` and the last `_` boundary are tried, so two different corruptions recover:

| emitted | recovers via |
| --- | --- |
| `mcp__abc123__xyz789_read` | last `_` → `read` |
| `mcp__context7__resolve_library_id` | last `__` → `mcp__context_resolve_library_id` |

Guards against noise:

- segments under 3 characters are ignored, so `_id`-style tails can't match everything
- an ambiguous miss lists up to 3 candidates instead of picking one
- no plausible target leaves the message exactly as it was

## Dispatch semantics are unchanged

This was the maintainer's stated objection to the auto-routing variant on #10109:

> rejecting an unregistered name is the intended boundary; guessing or auto-routing a different executable tool would change dispatch semantics

`suggestToolNames` is only ever called to build a string. `resolveToolForCall` never consults it. An unrecognized name still fails, still errors, still returns `isError: true` — it just says something useful. Same reply also allowed for exactly this shape of change:

> Client-side suggestions would therefore be a recovery enhancement

## Scope

Deliberately **not** `Fixes #10109`: that report also asks for auto-routing (suggestion 2, which the maintainer declined) and a rethink of the two-opaque-segment naming scheme (suggestion 3). Neither is addressed here. The issue should stay open.

## Tests

New case in `packages/agent/test/agent-loop.test.ts`, driven through the real loop rather than the private helper:

- whole id segment lost (`mcp__abc123__xyz789_read`) → suggests `read`
- separator lost (`mcp__context7__resolve_library_id`) → suggests `mcp__context_resolve_library_id`
- nothing plausible (`totally_unrelated`) → bare failure preserved, asserts `not.toContain("Did you mean")`
- distinctive tail outranks the generic one it contains: `bad__resolve_library_get` surfaces `mcp__context_resolve_library_get` even with three `_get` tools listed ahead of it

Coverage note: an unknown tool fails in `validate()` during `prepareToolCallDispatch`, so this exercises that throw site and the emitted tool result. The second throw inside `executeToolCalls` is only reachable for calls that bypass preparation (Cursor-resolved blocks), which this test does not construct; both sites are updated, one is covered.

The existing `routes unadvertised tool calls through resolveFallbackTool` test, which asserts the bare `Tool nonexistent not found` wording, still passes — `nonexistent` has no `_` boundary, so it yields no segments and no suggestion.

## Verification

```
bun test packages/agent/test/agent-loop.test.ts   106 pass, 0 fail
bun run check:tools                               lint + format clean
bun --cwd=packages/agent run check:types          clean
```
