### PR TITLE
feat(agents): add named model presets to the /agents hub

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -387,6 +387,7 @@ See [Advisor and WATCHDOG.md](./advisor-watchdog.md) for runtime behavior, `WATC
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `advisor.enabled`     | boolean | `false` | Enable the advisor runtime when `modelRoles.advisor` resolves to an available model.                                                                 |
 | `task.agentAdvisor`   | record  | `{}`    | Per-agent subagent advisor: agent name → `"on"` / `"off"` / advisor model pattern. Overrides agent frontmatter `advisor`; configured from the `/agents` hub. |
+| `task.agentPresets`   | record  | `{}`    | Named groups of per-agent model overrides: preset name → (agent name → model selector). Managed from the `/agents` hub; applying a preset writes `task.agentModelOverrides` (`apply` replaces the record, `merge` only overwrites the agents the preset names). In the UI, project-layer presets are read-only and all edits persist to global configuration. |
 | `advisor.syncBacklog` | enum    | `off`   | Bounded advisor catch-up delay: `off`, `1`, `3`, or `5`. The primary waits up to 30 seconds only while advisor backlog is at or above the threshold. |
 | `advisor.immuneTurns` | number  | `3`     | After a `concern`/`blocker` interrupts, route further concerns/blockers as non-interrupting asides for this many completed primary turns.            |
 

--- a/docs/task-agent-discovery.md
+++ b/docs/task-agent-discovery.md
@@ -208,6 +208,8 @@ For task dispatch, model precedence is:
 
 Role aliases in either of the first two sources are expanded through `modelRoles`. The shared eval bridge can also supply an invocation-local model override ahead of the settings override; the task wire schema does not expose that field.
 
+Named agent presets (`task.agentPresets`, managed from the `/agents` hub) are a UI-level convenience: applying one expands its `agent → model` map into `task.agentModelOverrides` — `apply` replaces the whole record, `merge` only overwrites the agents the preset names — so the precedence list above is unchanged at spawn time.
+
 Runtime output schema precedence is:
 
 1. the task item's explicit `outputSchema`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- The `/agents` hub gains named presets (`task.agentPresets`): save the current per-agent model overrides as a preset, then re-apply it later with `apply` (replace) or `merge`, plus rename and delete.
 - Added `advisor.maxNotesPerUpdate` setting and `WATCHDOG.yml` configuration (default `4`): allows reasoning verifiers to batch findings in a single review update without being rate-limited.
 - Headless browser tabs now freeze when a turn settles so idle animated/WebGL pages stop burning CPU/GPU, resuming automatically on next use; tabs idle past `browser.idleCloseSec` (default 30 minutes) are closed. `persist: true` on `browser.open` opts a tab out of both ([#8246](https://github.com/can1357/oh-my-pi/issues/8246) by [@H4vC](https://github.com/H4vC)).
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -472,6 +472,8 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 
 const DEFAULT_AGENT_MODEL_OVERRIDES: Record<string, string | string[]> = {};
 
+const DEFAULT_AGENT_PRESETS: Record<string, Record<string, string>> = {};
+
 export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
 	// General settings (no UI)
@@ -5210,6 +5212,10 @@ export const SETTINGS_SCHEMA = {
 	"task.agentAdvisor": {
 		type: "record",
 		default: {} as Record<string, string>,
+	},
+	"task.agentPresets": {
+		type: "record",
+		default: DEFAULT_AGENT_PRESETS,
 	},
 	"task.prewalk": {
 		type: "boolean",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -153,6 +153,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"task.agentModelOverrides",
 	"task.agentPrewalk",
 	"task.agentAdvisor",
+	"task.agentPresets",
 	// Memory subsystems are off-by-default for RPC/ACP hosts; embedders that want
 	// memory should opt in explicitly through their own settings layer.
 	"memory.backend",

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -27,7 +27,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
-import { isEnoent, prompt } from "@oh-my-pi/pi-utils";
+import { isEnoent, isRecord, prompt } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import type { EffectiveExtensionRoots } from "../../capability/types";
 import { getConfigDirs } from "../../config";
@@ -78,9 +78,10 @@ const SOURCE_ORDER: Record<AgentSource, number> = { project: 0, user: 1, bundled
 
 interface SidebarEntry {
 	id: string;
-	kind: "all" | "source" | "new" | "separator";
+	kind: "all" | "source" | "new" | "separator" | "preset" | "new-preset";
 	label: string;
 	source?: AgentSource;
+	presetName?: string;
 	annotation?: string;
 }
 
@@ -98,12 +99,20 @@ interface StripChip {
 		| { kind: "property"; property: PropertyKind }
 		| { kind: "set"; property: PropertyKind; value: string | undefined }
 		| { kind: "pick"; property: PropertyKind }
-		| { kind: "pattern"; property: PropertyKind };
+		| { kind: "pattern"; property: PropertyKind }
+		| { kind: "preset-apply"; preset: string; mode: "replace" | "merge" }
+		| { kind: "preset-rename"; preset: string }
+		| { kind: "preset-delete"; preset: string }
+		| { kind: "preset-cancel" };
 }
 
 type StripState =
 	| { kind: "chips"; agent: HubAgent; property?: PropertyKind; chips: StripChip[]; index: number }
+	| { kind: "preset"; preset: string; chips: StripChip[]; index: number }
 	| { kind: "pattern"; agent: HubAgent; property: PropertyKind; input: Input };
+
+/** `task.agentPresets`: preset name → (agent name → model selector). */
+type AgentPresets = Record<string, Record<string, string>>;
 
 /** Recorded chip hit-range on the footer row (columns relative to frame col 0). */
 interface ChipRange {
@@ -236,6 +245,14 @@ export class AgentsHubComponent implements Component {
 	#assigning: { agent: HubAgent; property: PropertyKind } | null = null;
 	#browser: ModelBrowser;
 
+	/** Non-null while the body shows one preset's agent→model table. */
+	#presetDetail: string | null = null;
+	/** Non-null while typing a new preset name or renaming an existing one. */
+	#presetInput: Input | null = null;
+	#presetInputMode: "create" | "rename" | null = null;
+	/** >0 while the apply confirmation strip shows this many droppable entries. */
+	#presetConfirmDrop = 0;
+
 	// Create flow (AI-generated agent definition).
 	#createInput: Editor | null = null;
 	#createDescription = "";
@@ -333,6 +350,12 @@ export class AgentsHubComponent implements Component {
 				});
 			this.#buildSidebar();
 			this.#buildRows();
+			const presets = this.#presets();
+			if (this.#presetDetail && !Object.hasOwn(presets, this.#presetDetail)) {
+				this.#presetDetail = null;
+				this.#presetConfirmDrop = 0;
+				if (this.#strip?.kind === "preset") this.#closeStrip();
+			}
 			if (selectedName) {
 				const index = this.#rows.findIndex(r => r.kind === "agent" && r.agent.name === selectedName);
 				if (index >= 0) this.#rowIndex = index;
@@ -366,6 +389,19 @@ export class AgentsHubComponent implements Component {
 				});
 			}
 		}
+		const presets = this.#presets();
+		const activePreset = this.#activePresetName();
+		entries.push({ id: "sep:presets", kind: "separator", label: "" });
+		for (const name of Object.keys(presets).sort((a, b) => a.localeCompare(b))) {
+			entries.push({
+				id: `preset:${name}`,
+				kind: "preset",
+				label: replaceTabs(name),
+				presetName: name,
+				annotation: name === activePreset ? "active" : String(Object.keys(presets[name] ?? {}).length),
+			});
+		}
+		entries.push({ id: "new-preset", kind: "new-preset", label: "New preset" });
 		entries.push({ id: "sep:actions", kind: "separator", label: "" });
 		entries.push({ id: "new", kind: "new", label: "New agent" });
 		this.#entries = entries;
@@ -511,6 +547,287 @@ export class AgentsHubComponent implements Component {
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════
+	// Presets
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** `task.agentPresets` normalized: blank names and non-string entries dropped. */
+	#presets(): AgentPresets {
+		return this.#normalizePresets(this.#settings.get("task.agentPresets"));
+	}
+
+	/** The global layer's own `task.agentPresets`, without the project merge. */
+	#globalPresets(): AgentPresets {
+		const rawGlobal = this.#settings.getGlobalSettings();
+		const task = isRecord(rawGlobal) ? rawGlobal.task : undefined;
+		return this.#normalizePresets(isRecord(task) ? task.agentPresets : undefined);
+	}
+
+	/** Agent names owned by the project layer's overrides; the UI cannot change these. */
+	#projectOverrideNames(): Set<string> {
+		const rawProject = this.#settings.getProjectSettings();
+		const task = isRecord(rawProject) ? rawProject.task : undefined;
+		const overrides = isRecord(task) && isRecord(task.agentModelOverrides) ? task.agentModelOverrides : undefined;
+		return new Set(Object.keys(overrides ?? {}));
+	}
+
+	#normalizePresets(raw: unknown): AgentPresets {
+		const presets: AgentPresets = {};
+		if (!isRecord(raw)) return presets;
+		for (const [rawName, rawEntries] of Object.entries(raw)) {
+			const name = rawName.trim();
+			if (!name) continue;
+			if (!isRecord(rawEntries)) continue;
+			const entries: Record<string, string> = {};
+			for (const [agent, selector] of Object.entries(rawEntries)) {
+				if (typeof selector !== "string") continue;
+				const trimmed = selector.trim();
+				if (trimmed) entries[agent] = trimmed;
+			}
+			presets[name] = entries;
+		}
+		return presets;
+	}
+
+	#normalizeSelector(value: string | string[] | undefined): string {
+		return (Array.isArray(value) ? value.join(",") : (value ?? "")).trim();
+	}
+
+	/**
+	 * Preset currently in effect: every entry matches the effective override and no
+	 * UI-owned override sits outside the preset. Project-layer overrides are ignored —
+	 * they outrank anything a preset can write, so they must not mask "active".
+	 */
+	#activePresetName(): string | undefined {
+		const current = this.#settings.get("task.agentModelOverrides") ?? {};
+		const projectOwned = this.#projectOverrideNames();
+		const extras = Object.keys(current).filter(agent => !projectOwned.has(agent));
+		for (const [name, preset] of Object.entries(this.#presets())) {
+			const entries = Object.entries(preset);
+			if (entries.some(([agent, selector]) => this.#normalizeSelector(current[agent]) !== selector)) continue;
+			if (extras.some(agent => !Object.hasOwn(preset, agent))) continue;
+			return name;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Writes the preset record to the global layer. Project-owned names are read-only in
+	 * the UI, so an existing global entry under such a name is re-emitted rather than
+	 * dropped: a global preset colliding with a project one must survive edits elsewhere.
+	 */
+	#persistPresets(presets: AgentPresets): void {
+		const global = this.#globalPresets();
+		const next: AgentPresets = {};
+		for (const [name, entries] of Object.entries(presets)) {
+			if (this.#isProjectPreset(name)) {
+				if (Object.hasOwn(global, name)) next[name] = global[name];
+				continue;
+			}
+			next[name] = entries;
+		}
+		this.#settings.set("task.agentPresets", next);
+		this.#tui.requestRender();
+	}
+
+	/** Live override entries that `preset` does not mention and that are not owned by the project layer. */
+	#presetDropNames(name: string): string[] {
+		const preset = this.#presets()[name] ?? {};
+		const current = this.#settings.get("task.agentModelOverrides") ?? {};
+		const projectOwned = this.#projectOverrideNames();
+		return Object.keys(current).filter(agent => !Object.hasOwn(preset, agent) && !projectOwned.has(agent));
+	}
+
+	#isProjectPreset(name: string): boolean {
+		const rawProject = this.#settings.getProjectSettings();
+		const task = isRecord(rawProject) ? rawProject.task : undefined;
+		const projectPresets = isRecord(task) && isRecord(task.agentPresets) ? task.agentPresets : undefined;
+		return Boolean(projectPresets && Object.hasOwn(projectPresets, name));
+	}
+
+	#applyPreset(name: string, mode: "replace" | "merge"): void {
+		const preset = this.#presets()[name];
+		if (!preset) return;
+		const next: Record<string, string> = {};
+		if (mode === "merge") {
+			// Merge only the entries this layer owns: re-writing project-layer overrides
+			// would duplicate project config into the global file.
+			const projectOwned = this.#projectOverrideNames();
+			for (const [agent, value] of Object.entries(this.#settings.get("task.agentModelOverrides") ?? {})) {
+				if (projectOwned.has(agent)) continue;
+				const selector = this.#normalizeSelector(value);
+				if (selector) next[agent] = selector;
+			}
+		}
+		for (const [agent, selector] of Object.entries(preset)) next[agent] = selector;
+		this.#settings.set("task.agentModelOverrides", next);
+		this.#notice = `Applied preset ${name} (${mode}) · ${Object.keys(preset).length} agents`;
+		this.#presetConfirmDrop = 0;
+		this.#closeStrip();
+		void this.#reload();
+	}
+
+	/** Snapshot the live overrides under `name`. */
+	#createPreset(name: string): void {
+		const trimmed = name.trim();
+		if (!trimmed) {
+			this.#notice = "Preset name is required";
+			return;
+		}
+		if (trimmed.length > 32 || /\s/.test(trimmed)) {
+			this.#notice = "Preset name must be ≤32 chars without spaces";
+			return;
+		}
+		const presets = this.#presets();
+		if (Object.hasOwn(presets, trimmed)) {
+			this.#notice = `Preset ${trimmed} already exists`;
+			return;
+		}
+		const snapshot: Record<string, string> = {};
+		for (const [agent, value] of Object.entries(this.#settings.get("task.agentModelOverrides") ?? {})) {
+			const selector = this.#normalizeSelector(value);
+			if (selector) snapshot[agent] = selector;
+		}
+		presets[trimmed] = snapshot;
+		this.#persistPresets(presets);
+		this.#activeEntryId = `preset:${trimmed}`;
+		this.#presetDetail = trimmed;
+		this.#notice = `Created preset ${trimmed} (${Object.keys(snapshot).length} agents)`;
+		void this.#reload();
+	}
+
+	#renamePreset(from: string, to: string): void {
+		const trimmed = to.trim();
+		if (!trimmed || trimmed === from) return;
+		if (this.#isProjectPreset(from)) {
+			this.#notice = `Preset "${from}" is defined in project config and is read-only in the UI`;
+			return;
+		}
+		if (trimmed.length > 32 || /\s/.test(trimmed)) {
+			this.#notice = "Preset name must be ≤32 chars without spaces";
+			return;
+		}
+		const presets = this.#presets();
+		if (Object.hasOwn(presets, trimmed)) {
+			this.#notice = `Preset ${trimmed} already exists`;
+			return;
+		}
+		if (!Object.hasOwn(presets, from)) return;
+		const next: AgentPresets = {};
+		for (const [name, entries] of Object.entries(presets)) next[name === from ? trimmed : name] = entries;
+		this.#persistPresets(next);
+		this.#activeEntryId = `preset:${trimmed}`;
+		this.#presetDetail = trimmed;
+		this.#notice = `Renamed preset ${from} → ${trimmed}`;
+		void this.#reload();
+	}
+	#deletePreset(name: string): void {
+		if (this.#isProjectPreset(name)) {
+			this.#notice = `Preset "${name}" is defined in project config and is read-only in the UI`;
+			return;
+		}
+		const presets = this.#presets();
+		if (!Object.hasOwn(presets, name)) return;
+		delete presets[name];
+		this.#persistPresets(presets);
+		this.#presetDetail = null;
+		this.#presetConfirmDrop = 0;
+		this.#closeStrip();
+		this.#activeEntryId = "all";
+		this.#notice = `Deleted preset ${name}`;
+		void this.#reload();
+	}
+
+	#openPresetDetail(name: string): void {
+		this.#presetDetail = name;
+		this.#tui.requestRender();
+	}
+
+	#closePresetDetail(): void {
+		this.#presetDetail = null;
+		this.#presetConfirmDrop = 0;
+		this.#tui.requestRender();
+	}
+
+	#openPresetStrip(name: string): void {
+		if (!Object.hasOwn(this.#presets(), name)) return;
+		const chips: StripChip[] = [];
+		if (this.#presetConfirmDrop > 0) {
+			chips.push({
+				label: "replace",
+				styled: theme.fg("warning", `replace — drop ${this.#presetConfirmDrop}`),
+				action: { kind: "preset-apply", preset: name, mode: "replace" },
+			});
+			chips.push({
+				label: "merge",
+				styled: theme.fg("accent", "merge instead"),
+				action: { kind: "preset-apply", preset: name, mode: "merge" },
+			});
+			chips.push({ label: "cancel", styled: theme.fg("dim", "cancel"), action: { kind: "preset-cancel" } });
+		} else {
+			chips.push({
+				label: "apply",
+				styled: theme.fg("success", `${theme.status.enabled} apply`),
+				action: { kind: "preset-apply", preset: name, mode: "replace" },
+			});
+			chips.push({
+				label: "merge",
+				styled: theme.fg("muted", "merge"),
+				action: { kind: "preset-apply", preset: name, mode: "merge" },
+			});
+			chips.push({
+				label: "rename",
+				styled: theme.fg("muted", "rename…"),
+				action: { kind: "preset-rename", preset: name },
+			});
+			chips.push({
+				label: "delete",
+				styled: theme.fg("warning", "delete"),
+				action: { kind: "preset-delete", preset: name },
+			});
+		}
+		this.#strip = { kind: "preset", preset: name, chips, index: 0 };
+		this.#tui.requestRender();
+	}
+
+	#beginPresetInput(mode: "create" | "rename"): void {
+		const input = new Input();
+		if (mode === "rename" && this.#presetDetail) input.setValue(this.#presetDetail);
+		this.#presetInput = input;
+		this.#presetInputMode = mode;
+		this.#closeStrip();
+		this.#tui.requestRender();
+	}
+
+	#clearPresetInput(): void {
+		this.#presetInput = null;
+		this.#presetInputMode = null;
+		this.#tui.requestRender();
+	}
+
+	#submitPresetInput(): void {
+		const value = this.#presetInput?.getValue() ?? "";
+		const mode = this.#presetInputMode;
+		const renameFrom = this.#presetDetail;
+		this.#presetInput = null;
+		this.#presetInputMode = null;
+		if (mode === "create") this.#createPreset(value);
+		else if (mode === "rename" && renameFrom) this.#renamePreset(renameFrom, value);
+		this.#tui.requestRender();
+	}
+
+	#handlePresetInput(data: string): void {
+		if (matchesSelectCancel(data)) {
+			this.#clearPresetInput();
+			return;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			this.#submitPresetInput();
+			return;
+		}
+		this.#presetInput?.handleInput(data);
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
 	// Strips
 	// ═══════════════════════════════════════════════════════════════════════
 
@@ -622,9 +939,36 @@ export class AgentsHubComponent implements Component {
 
 	#activateStripChip(): void {
 		const strip = this.#strip;
-		if (strip?.kind !== "chips") return;
+		if (!strip || strip.kind === "pattern") return;
 		const chip = strip.chips[strip.index];
 		if (!chip) return;
+		if (strip.kind === "preset") {
+			switch (chip.action.kind) {
+				case "preset-apply": {
+					const { preset, mode } = chip.action;
+					const drops = mode === "replace" ? this.#presetDropNames(preset) : [];
+					if (drops.length > 0 && this.#presetConfirmDrop === 0) {
+						this.#presetConfirmDrop = drops.length;
+						this.#openPresetStrip(preset);
+						return;
+					}
+					this.#applyPreset(preset, mode);
+					return;
+				}
+				case "preset-rename":
+					this.#beginPresetInput("rename");
+					return;
+				case "preset-delete":
+					this.#deletePreset(chip.action.preset);
+					return;
+				case "preset-cancel":
+					this.#presetConfirmDrop = 0;
+					this.#openPresetStrip(strip.preset);
+					return;
+				default:
+					return;
+			}
+		}
 		const action = chip.action;
 		switch (action.kind) {
 			case "toggle":
@@ -848,6 +1192,12 @@ export class AgentsHubComponent implements Component {
 			return;
 		}
 
+		if (this.#presetInputMode) {
+			this.#handlePresetInput(data);
+			this.#tui.requestRender();
+			return;
+		}
+
 		if (this.#createActive) {
 			this.#handleCreateInput(data);
 			this.#tui.requestRender();
@@ -857,6 +1207,10 @@ export class AgentsHubComponent implements Component {
 		if (matchesSelectCancel(data)) {
 			if (this.#assigning) {
 				this.#cancelAssign();
+				return;
+			}
+			if (this.#presetDetail) {
+				this.#closePresetDetail();
 				return;
 			}
 			if (this.#searchQuery.length > 0) {
@@ -882,8 +1236,10 @@ export class AgentsHubComponent implements Component {
 		}
 
 		if (matchesKey(data, "tab") || matchesKey(data, "shift+tab")) {
-			this.#focus = this.#focus === "scope" ? "list" : "scope";
-			this.#tui.requestRender();
+			if (!this.#presetDetail) {
+				this.#focus = this.#focus === "scope" ? "list" : "scope";
+				this.#tui.requestRender();
+			}
 			return;
 		}
 		if (matchesKey(data, "left")) {
@@ -892,8 +1248,10 @@ export class AgentsHubComponent implements Component {
 			return;
 		}
 		if (matchesKey(data, "right")) {
-			this.#focus = "list";
-			this.#tui.requestRender();
+			if (!this.#presetDetail) {
+				this.#focus = "list";
+				this.#tui.requestRender();
+			}
 			return;
 		}
 
@@ -909,14 +1267,27 @@ export class AgentsHubComponent implements Component {
 				return;
 			}
 			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
-				if (this.#activeEntry().kind === "new") {
+				const entry = this.#activeEntry();
+				if (entry.kind === "new") {
 					this.#beginCreateFlow();
+				} else if (entry.kind === "new-preset") {
+					this.#beginPresetInput("create");
+				} else if (entry.kind === "preset" && entry.presetName) {
+					this.#openPresetDetail(entry.presetName);
+					this.#openPresetStrip(entry.presetName);
 				} else {
 					this.#focus = "list";
 				}
 				this.#tui.requestRender();
 				return;
 			}
+		}
+		if (this.#presetDetail) {
+			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+				this.#openPresetStrip(this.#presetDetail);
+				this.#tui.requestRender();
+			}
+			return;
 		}
 
 		if (matchesSelectUp(data)) {
@@ -972,6 +1343,15 @@ export class AgentsHubComponent implements Component {
 		const strip = this.#strip;
 		if (!strip) return;
 		if (matchesSelectCancel(data)) {
+			if (strip.kind === "preset") {
+				if (this.#presetConfirmDrop > 0) {
+					this.#presetConfirmDrop = 0;
+					this.#openPresetStrip(strip.preset);
+					return;
+				}
+				this.#closeStrip();
+				return;
+			}
 			// A property strip steps back up to the agent strip instead of closing.
 			if (strip.kind === "chips" && strip.property) {
 				this.#openAgentStrip(strip.agent);
@@ -1060,7 +1440,20 @@ export class AgentsHubComponent implements Component {
 			const entry = this.#entries[index];
 			if (entry && entry.kind !== "separator") {
 				this.#activeEntryId = entry.id;
-				if (entry.kind !== "new") {
+				if (entry.kind === "preset" && entry.presetName) {
+					this.#closeStrip();
+					this.#presetConfirmDrop = 0;
+					this.#openPresetDetail(entry.presetName);
+					if (this.#searchQuery.length > 0) {
+						this.#searchQuery = "";
+						this.#rowIndex = 0;
+						this.#listScroll = 0;
+					}
+					this.#buildRows();
+					return;
+				}
+				if (this.#presetDetail) this.#closePresetDetail();
+				if (entry.kind !== "new" && entry.kind !== "new-preset") {
 					this.#buildRows();
 					this.#rowIndex = 0;
 					this.#listScroll = 0;
@@ -1083,7 +1476,7 @@ export class AgentsHubComponent implements Component {
 		const overBody = overContent && event.col >= bodyColStart;
 		const bodyLine = contentLine - 1; // body row 0 is the status row
 
-		if (event.row === this.#footerRow && this.#strip?.kind === "chips") {
+		if (event.row === this.#footerRow && (this.#strip?.kind === "chips" || this.#strip?.kind === "preset")) {
 			const strip = this.#strip;
 			if (event.leftClick) {
 				for (const range of this.#chipRanges) {
@@ -1101,13 +1494,13 @@ export class AgentsHubComponent implements Component {
 			if (overBody) this.#browser.routeMouse(event, bodyLine);
 			return true;
 		}
-		if (this.#createActive || this.#strip) return true;
+		if (this.#createActive || this.#strip || this.#presetInputMode) return true;
 
 		if (event.wheel !== null) {
 			if (overSidebar) {
 				const maxScroll = Math.max(0, this.#entries.length - this.#contentRowCount);
 				this.#sidebarScroll = Math.max(0, Math.min(this.#sidebarScroll + event.wheel, maxScroll));
-			} else if (overBody) {
+			} else if (overBody && !this.#presetDetail) {
 				this.#rowIndex = Math.max(0, Math.min(this.#rows.length - 1, this.#rowIndex + event.wheel));
 			}
 			return true;
@@ -1116,7 +1509,8 @@ export class AgentsHubComponent implements Component {
 		if (event.motion) {
 			// Hover is stored as an absolute row index so paint and click agree.
 			const hoverRow = bodyLine - this.#listRowStart + this.#listScroll;
-			this.#rowHover = overBody && hoverRow >= 0 && hoverRow < this.#rows.length ? hoverRow : null;
+			this.#rowHover =
+				!this.#presetDetail && overBody && hoverRow >= 0 && hoverRow < this.#rows.length ? hoverRow : null;
 			return true;
 		}
 
@@ -1128,8 +1522,16 @@ export class AgentsHubComponent implements Component {
 			if (clicked && clicked.kind !== "separator") {
 				if (clicked.kind === "new") {
 					this.#beginCreateFlow();
+				} else if (clicked.kind === "new-preset") {
+					this.#beginPresetInput("create");
+				} else if (clicked.kind === "preset" && clicked.presetName) {
+					this.#activeEntryId = clicked.id;
+					this.#focus = "scope";
+					this.#openPresetDetail(clicked.presetName);
+					this.#openPresetStrip(clicked.presetName);
 				} else {
 					this.#activeEntryId = clicked.id;
+					if (this.#presetDetail) this.#closePresetDetail();
 					this.#buildRows();
 					this.#rowIndex = 0;
 					this.#focus = "scope";
@@ -1138,6 +1540,7 @@ export class AgentsHubComponent implements Component {
 			return true;
 		}
 		if (overBody) {
+			if (this.#presetDetail) return true;
 			this.#focus = "list";
 			const listLine = bodyLine - this.#listRowStart + this.#listScroll;
 			if (listLine >= 0 && listLine < this.#rows.length) {
@@ -1185,9 +1588,17 @@ export class AgentsHubComponent implements Component {
 			}
 			const active = entry.id === this.#activeEntryId;
 			const cursor = active && this.#focus === "scope" ? theme.fg("accent", theme.nav.cursor) : " ";
-			const icon = entry.kind === "all" ? theme.icon.model : entry.kind === "new" ? "+" : theme.status.enabled;
+			const isAction = entry.kind === "new" || entry.kind === "new-preset";
+			const icon =
+				entry.kind === "all"
+					? theme.icon.model
+					: entry.kind === "preset"
+						? theme.icon.loop
+						: isAction
+							? "+"
+							: theme.status.enabled;
 			const labelStyled = active ? theme.bold(theme.fg("accent", entry.label)) : entry.label;
-			const left = `${cursor} ${theme.fg(entry.kind === "new" ? "dim" : "accent", icon)} ${labelStyled}`;
+			const left = `${cursor} ${theme.fg(isAction ? "dim" : "accent", icon)} ${labelStyled}`;
 			const annotation = theme.fg("dim", entry.annotation ?? "");
 			const leftWidth = visibleWidth(left);
 			const annWidth = visibleWidth(annotation);
@@ -1215,7 +1626,16 @@ export class AgentsHubComponent implements Component {
 		if (this.#createActive) {
 			return truncateToWidth(theme.fg("accent", " New agent — describe it and let the architect draft it"), width);
 		}
-		if (this.#notice) return truncateToWidth(theme.fg("success", ` ${this.#notice}`), width);
+		if (this.#notice) return truncateToWidth(theme.fg("success", ` ${replaceTabs(this.#notice)}`), width);
+		if (this.#presetDetail) {
+			const preset = this.#presets()[this.#presetDetail];
+			const suffix = this.#activePresetName() === this.#presetDetail ? " · active" : "";
+			const count = preset ? Object.keys(preset).length : 0;
+			return truncateToWidth(
+				theme.fg("muted", ` Preset ${replaceTabs(this.#presetDetail)} · ${count} agents${suffix}`),
+				width,
+			);
+		}
 		const entry = this.#activeEntry();
 		const scopeLabel = entry.kind === "source" ? `${entry.label} agents` : "All agents";
 		const count = this.#rows.filter(rowDef => rowDef.kind === "agent").length;
@@ -1314,6 +1734,65 @@ export class AgentsHubComponent implements Component {
 		return lines.slice(0, rows);
 	}
 
+	#renderPreset(width: number, rows: number): string[] {
+		const name = this.#presetDetail;
+		const preset = name ? this.#presets()[name] : undefined;
+		const lines: string[] = [""];
+		if (!name || !preset) {
+			lines.push(truncateToWidth(theme.fg("dim", " Preset no longer exists — Esc to go back"), width));
+			while (lines.length < rows) lines.push("");
+			return lines.slice(0, rows);
+		}
+		const active = this.#activePresetName() === name;
+		const entries = Object.entries(preset).sort(([a], [b]) => a.localeCompare(b));
+		lines.push(
+			truncateToWidth(
+				` ${theme.bold(theme.fg("accent", `Preset ${replaceTabs(name)}`))}${active ? theme.fg("success", "  (active)") : ""}`,
+				width,
+			),
+		);
+		lines.push(
+			truncateToWidth(theme.fg("dim", ` ${entries.length} agents · apply writes task.agentModelOverrides`), width),
+		);
+		lines.push("");
+		const current = this.#settings.get("task.agentModelOverrides") ?? {};
+		const defined = new Set(this.#allAgents.map(a => a.name));
+		const projectOwned = this.#projectOverrideNames();
+		let nameWidth = 0;
+		for (const [agent] of entries) nameWidth = Math.max(nameWidth, visibleWidth(replaceTabs(agent)));
+		for (const [agent, selector] of entries) {
+			const liveRaw = this.#normalizeSelector(current[agent]);
+			const live = replaceTabs(liveRaw);
+			const matches = liveRaw === selector;
+			const marker = matches ? theme.fg("dim", "=") : liveRaw ? theme.fg("warning", "≠") : theme.fg("success", "+");
+			const label = replaceTabs(agent).padEnd(nameWidth);
+			const nameStyled = matches ? theme.fg("muted", label) : theme.fg("accent", label);
+			const missingSuffix = !defined.has(agent) ? theme.fg("error", "  (missing)") : "";
+			const liveSuffix =
+				!matches && liveRaw
+					? theme.fg("dim", projectOwned.has(agent) ? `  (project: ${live})` : `  (now ${live})`)
+					: "";
+			lines.push(
+				truncateToWidth(
+					`  ${marker} ${nameStyled}  ${theme.fg("muted", replaceTabs(selector))}${missingSuffix}${liveSuffix}`,
+					width,
+				),
+			);
+		}
+		const drops = this.#presetDropNames(name);
+		if (drops.length > 0) {
+			lines.push("");
+			lines.push(
+				truncateToWidth(
+					theme.fg("warning", ` apply(replace) would drop: ${drops.map(replaceTabs).join(", ")}`),
+					width,
+				),
+			);
+		}
+		while (lines.length < rows) lines.push("");
+		return lines.slice(0, rows);
+	}
+
 	#renderCreate(width: number, rows: number): string[] {
 		const lines: string[] = [];
 		lines.push("");
@@ -1380,7 +1859,17 @@ export class AgentsHubComponent implements Component {
 	}
 
 	#footerHint(): string {
+		if (this.#presetInputMode) {
+			return this.#presetInputMode === "create"
+				? "Enter create preset from current overrides · Esc cancel"
+				: "Enter rename preset · Esc cancel";
+		}
 		if (this.#strip) {
+			if (this.#strip.kind === "preset") {
+				return this.#presetConfirmDrop > 0
+					? "←/→ choose · Enter run · Esc cancel replace"
+					: "←/→ choose · Enter run · Esc back";
+			}
 			if (this.#strip.kind === "pattern") {
 				const property = this.#strip.property;
 				const values = property === "model" ? "a model pattern" : '"on", "off", or a model pattern';
@@ -1396,6 +1885,9 @@ export class AgentsHubComponent implements Component {
 			if (this.#createGenerating) return "Generating…";
 			return "Ctrl+Q/Ctrl+Enter generate · Enter newline · Tab scope · Esc cancel";
 		}
+		if (this.#presetDetail) {
+			return "Enter configure preset · Esc back";
+		}
 		if (this.#focus === "scope") {
 			return "↑/↓ scopes · →/Enter agents · Esc close";
 		}
@@ -1404,6 +1896,12 @@ export class AgentsHubComponent implements Component {
 
 	#renderFooter(width: number): string {
 		this.#chipRanges = [];
+		if (this.#presetInputMode) {
+			const labelText = this.#presetInputMode === "create" ? "New preset:" : `Rename ${this.#presetDetail}:`;
+			const inputWidth = Math.max(8, Math.min(40, width - visibleWidth(labelText) - 4));
+			const inputLine = this.#presetInput?.render(inputWidth)[0] ?? "";
+			return truncateToWidth(`${theme.fg("accent", labelText)} ${inputLine}`, width);
+		}
 		const strip = this.#strip;
 		if (!strip) {
 			return truncateToWidth(theme.fg("dim", this.#footerHint()), width);
@@ -1415,9 +1913,12 @@ export class AgentsHubComponent implements Component {
 			const inputLine = strip.input.render(inputWidth)[0] ?? "";
 			return truncateToWidth(`${label} ${inputLine}`, width);
 		}
-		const prefix = strip.property
-			? `${theme.fg("accent", strip.agent.name)}${theme.fg("dim", ` · ${strip.property} →`)} `
-			: `${theme.fg("accent", strip.agent.name)}${theme.fg("dim", " →")} `;
+		const prefix =
+			strip.kind === "preset"
+				? `${theme.fg("accent", `preset ${replaceTabs(strip.preset)}`)}${theme.fg("dim", " →")} `
+				: strip.property
+					? `${theme.fg("accent", strip.agent.name)}${theme.fg("dim", ` · ${strip.property} →`)} `
+					: `${theme.fg("accent", strip.agent.name)}${theme.fg("dim", " →")} `;
 		let line = prefix;
 		let col = 2 + visibleWidth(prefix);
 		for (let i = 0; i < strip.chips.length; i++) {
@@ -1449,6 +1950,8 @@ export class AgentsHubComponent implements Component {
 		const bodyLines: string[] = [this.#statusRow(bodyWidth)];
 		if (this.#createActive) {
 			bodyLines.push(...this.#renderCreate(bodyWidth, contentRows - 1));
+		} else if (this.#presetDetail) {
+			bodyLines.push(...this.#renderPreset(bodyWidth, contentRows - 1));
 		} else if (this.#assigning) {
 			this.#browser.setMaxVisible(contentRows - 1 - 5);
 			this.#browser.setFocused(true);

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -254,6 +254,7 @@ describe("ACP lazy startup", () => {
 			"task.disabledAgents": ["scout"],
 			"task.agentModelOverrides": { task: "claude-sonnet-4-20250514" },
 			"task.agentAdvisor": { task: "on" },
+			"task.agentPresets": { peak: { scout: "anthropic/claude-sonnet-4-5" } },
 			"memory.backend": "local",
 			"memories.enabled": true,
 			"advisor.enabled": true,

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -16,10 +16,13 @@ import { AgentsHubComponent } from "@oh-my-pi/pi-coding-agent/modes/components/a
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import * as discovery from "@oh-my-pi/pi-coding-agent/task/discovery";
 import type { TUI } from "@oh-my-pi/pi-tui";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { isRecord, removeWithRetries } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
 
 const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 let tempCwd: string;
+/** Temp project roots created by {@link projectSettings}, cleaned up in `afterAll`. */
+const projectDirs: string[] = [];
 
 // Narrow TUI stub: the hub only reads terminal rows and requests renders.
 const tuiStub = { requestRender: () => {}, terminal: { rows: 30 } } as unknown as TUI;
@@ -83,6 +86,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
 	await removeWithRetries(tempCwd);
+	for (const dir of projectDirs) await removeWithRetries(dir);
 });
 
 afterEach(() => {
@@ -219,5 +223,370 @@ describe("AgentsHub configuration strips", () => {
 		hub.handleInput("\x1b"); // close strip
 		expect(strip()).not.toContain("dev →");
 		expect(cancelled()).toBe(false);
+	});
+});
+
+describe("AgentsHub presets", () => {
+	/** Scope focus → the first preset row (skips separators and source scopes). */
+	function focusPreset(hub: AgentsHubComponent, index = 0): void {
+		hub.handleInput("\x1b[D"); // scope focus
+		hub.handleInput("\x1b[B"); // Project
+		hub.handleInput("\x1b[B"); // Bundled
+		for (let i = 0; i <= index; i++) hub.handleInput("\x1b[B");
+	}
+
+	function focusNewPreset(hub: AgentsHubComponent, presetCount: number): void {
+		hub.handleInput("\x1b[D");
+		hub.handleInput("\x1b[B"); // Project
+		hub.handleInput("\x1b[B"); // Bundled
+		for (let i = 0; i <= presetCount; i++) hub.handleInput("\x1b[B");
+	}
+
+	test("renders the presets sidebar section and the preset detail body", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { peak: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip } = await createHub(settings);
+		expect(strip()).toContain("+ New preset");
+		focusPreset(hub);
+		hub.handleInput("\r");
+		const rendered = strip();
+		expect(rendered).toContain("Preset peak");
+		expect(rendered).toContain("scout");
+		expect(rendered).toContain("deepseek/deepseek-chat");
+		expect(rendered).toContain("preset peak →");
+	});
+
+	test("apply (replace) swaps the whole override record after confirming dropped entries", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		settings.set("task.agentPresets", {
+			offpeak: { scout: "deepseek/deepseek-chat", task: "deepseek/deepseek-chat" },
+		});
+		const { hub, strip } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\r"); // apply → confirm drop
+		expect(strip()).toContain("replace — drop 1");
+		hub.handleInput("\r"); // confirm replace
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			scout: "deepseek/deepseek-chat",
+			task: "deepseek/deepseek-chat",
+		});
+	});
+
+	test("apply (merge) keeps overrides the preset does not mention", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		settings.set("task.agentPresets", { offpeak: { scout: "deepseek/deepseek-chat" } });
+		const { hub } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // apply → merge
+		hub.handleInput("\r");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			dev: "anthropic/claude-sonnet-4-5",
+			scout: "deepseek/deepseek-chat",
+		});
+	});
+
+	test("active preset is derived from the live override record", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { scout: "deepseek/deepseek-chat" });
+		settings.set("task.agentPresets", { offpeak: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip } = await createHub(settings);
+		expect(strip()).toContain("active");
+		focusPreset(hub);
+		hub.handleInput("\r");
+		expect(strip()).toContain("(active)");
+	});
+
+	test("New preset snapshots the live overrides", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		const { hub, strip, type } = await createHub(settings);
+		focusNewPreset(hub, 0);
+		hub.handleInput("\r");
+		expect(strip()).toContain("New preset:");
+		type("day");
+		hub.handleInput("\r");
+		expect(settings.get("task.agentPresets")).toEqual({ day: { dev: "anthropic/claude-sonnet-4-5" } });
+	});
+
+	test("New preset rejects a duplicate name", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		settings.set("task.agentPresets", { day: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip, type } = await createHub(settings);
+		focusNewPreset(hub, 1);
+		hub.handleInput("\r");
+		type("day");
+		hub.handleInput("\r");
+		expect(settings.get("task.agentPresets")).toEqual({ day: { scout: "deepseek/deepseek-chat" } });
+		expect(strip()).toContain("already exists");
+	});
+
+	test("rename moves the preset to the new name", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { day: { scout: "deepseek/deepseek-chat" }, night: { task: "x" } });
+		const { hub, type } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // apply → merge
+		hub.handleInput("\x1b[C"); // merge → rename
+		hub.handleInput("\r"); // rename input prefilled "day"
+		for (let i = 0; i < 3; i++) hub.handleInput("\x7f");
+		type("peak");
+		hub.handleInput("\r");
+		expect(Object.keys(settings.get("task.agentPresets"))).toEqual(["peak", "night"]);
+	});
+
+	test("delete removes the preset", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { day: { scout: "deepseek/deepseek-chat" }, night: { task: "x" } });
+		const { hub } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // apply → merge
+		hub.handleInput("\x1b[C"); // merge → rename
+		hub.handleInput("\x1b[C"); // rename → delete
+		hub.handleInput("\r");
+		expect(Object.keys(settings.get("task.agentPresets"))).toEqual(["night"]);
+	});
+
+	test("Esc steps back from preset strip → detail → panel close cleanly", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { peak: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip, cancelled } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // opens detail + strip
+		expect(strip()).toContain("preset peak →");
+		expect(strip()).toContain("Preset peak");
+		expect(cancelled()).toBe(false);
+
+		hub.handleInput("\x1b"); // closes strip
+		expect(strip()).not.toContain("preset peak →");
+		expect(strip()).toContain("Preset peak");
+		expect(cancelled()).toBe(false);
+
+		hub.handleInput("\x1b"); // closes detail
+		expect(strip()).not.toContain("Preset peak");
+		expect(cancelled()).toBe(false);
+
+		hub.handleInput("\x1b"); // closes hub
+		expect(cancelled()).toBe(true);
+	});
+
+	test("keyboard isolation in preset detail blocks space and list mutations", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { peak: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // open detail + strip
+		hub.handleInput("\x1b"); // close strip, detail remains
+		expect(strip()).toContain("Preset peak");
+
+		// Space should not toggle any hidden agent
+		hub.handleInput(" ");
+		expect(settings.get("task.disabledAgents")).toEqual([]);
+
+		// Tab and Right should not leak focus into the list
+		hub.handleInput("\x1b[C"); // Right
+		hub.handleInput("\t"); // Tab
+
+		// Enter should re-open the preset strip rather than activating a list row
+		hub.handleInput("\r");
+		expect(strip()).toContain("preset peak →");
+	});
+
+	test("rejects preset names containing spaces", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		const { hub, strip, type } = await createHub(settings);
+		focusNewPreset(hub, 0);
+		hub.handleInput("\r");
+		type("my peak preset");
+		hub.handleInput("\r");
+		expect(strip()).toContain("≤32 chars without spaces");
+		expect(settings.get("task.agentPresets")).toEqual({});
+	});
+
+	test("rejects preset names exceeding 32 characters", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { dev: "anthropic/claude-sonnet-4-5" });
+		const { hub, strip, type } = await createHub(settings);
+		focusNewPreset(hub, 0);
+		hub.handleInput("\r");
+		type("a".repeat(33));
+		hub.handleInput("\r");
+		expect(strip()).toContain("≤32 chars without spaces");
+		expect(settings.get("task.agentPresets")).toEqual({});
+	});
+
+	test("preset referencing nonexistent agent displays missing annotation", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { peak: { ghost: "deepseek/deepseek-chat" } });
+		const { hub, strip } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r");
+		expect(strip()).toContain("ghost");
+		expect(strip()).toContain("(missing)");
+	});
+
+	test("project-layer preset is protected from rename and delete", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		vi.spyOn(settings, "getProjectSettings").mockReturnValue({
+			task: { agentPresets: { shared: { dev: "anthropic/claude-sonnet-4-5" } } },
+		});
+		settings.set("task.agentPresets", { shared: { dev: "anthropic/claude-sonnet-4-5" } });
+		const { hub, strip, type } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // merge
+		hub.handleInput("\x1b[C"); // rename
+		hub.handleInput("\r"); // try rename
+		type("custom");
+		hub.handleInput("\r");
+		expect(strip()).toContain("read-only in the UI");
+		expect(settings.get("task.agentPresets")).toEqual({ shared: { dev: "anthropic/claude-sonnet-4-5" } });
+
+		hub.handleInput("\x1b[C"); // delete
+		hub.handleInput("\r"); // try delete
+		expect(strip()).toContain("read-only in the UI");
+		expect(settings.get("task.agentPresets")).toEqual({ shared: { dev: "anthropic/claude-sonnet-4-5" } });
+	});
+
+	test("navigating to a preset clears existing search query", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { peak: { scout: "deepseek/deepseek-chat" } });
+		const { hub, strip, type } = await createHub(settings);
+		type("dev"); // filter query
+		expect(strip()).toContain("dev");
+		focusPreset(hub); // move to preset row
+		expect(strip()).toContain("Preset peak");
+	});
+
+	/** The global layer's own preset record, without the project merge. */
+	function globalPresets(settings: Settings): unknown {
+		const task = settings.getGlobalSettings().task;
+		return isRecord(task) ? task.agentPresets : undefined;
+	}
+
+	/** The global layer's own override record, without the project merge. */
+	function globalOverrides(settings: Settings): unknown {
+		const task = settings.getGlobalSettings().task;
+		return isRecord(task) ? task.agentModelOverrides : undefined;
+	}
+
+	/**
+	 * Settings with a real `<cwd>/.omp/config.yml` project layer, so the merge behaves
+	 * exactly as it does for a user who defines overrides or presets in a repository.
+	 */
+	async function projectSettings(layer: {
+		overrides?: Record<string, string>;
+		presets?: Record<string, Record<string, string>>;
+	}): Promise<Settings> {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agents-hub-proj-"));
+		projectDirs.push(cwd);
+		const agentDir = path.join(cwd, "agent");
+		const task: Record<string, unknown> = {};
+		if (layer.overrides) task.agentModelOverrides = layer.overrides;
+		if (layer.presets) task.agentPresets = layer.presets;
+		await fs.mkdir(path.join(cwd, ".omp"), { recursive: true });
+		await fs.writeFile(path.join(cwd, ".omp", "config.yml"), YAML.stringify({ task }));
+		return Settings.loadReadOnly({ cwd, agentDir, inMemory: true });
+	}
+
+	test("editing one preset keeps a global preset whose name the project also defines", async () => {
+		mockAgents();
+		const settings = await projectSettings({ presets: { day: { scout: "anthropic/claude-sonnet-4-5" } } });
+		settings.set("task.agentPresets", {
+			day: { scout: "deepseek/deepseek-chat" },
+			night: { task: "qwen-local/Qwen" },
+		});
+		const { hub } = await createHub(settings);
+		focusPreset(hub, 1); // night — day collides with the project layer
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // merge
+		hub.handleInput("\x1b[C"); // rename
+		hub.handleInput("\x1b[C"); // delete
+		hub.handleInput("\r");
+		expect(globalPresets(settings)).toEqual({ day: { scout: "deepseek/deepseek-chat" } });
+	});
+
+	test("apply (merge) leaves project-owned overrides out of global config", async () => {
+		mockAgents();
+		const settings = await projectSettings({
+			overrides: { dev: "anthropic/claude-sonnet-4-5" },
+			presets: { offpeak: { task: "qwen-local/Qwen" } },
+		});
+		settings.set("task.agentModelOverrides", { scout: "deepseek/deepseek-chat" });
+		const { hub } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r"); // detail + strip
+		hub.handleInput("\x1b[C"); // apply → merge
+		hub.handleInput("\r");
+		// The effective record keeps the project override, which outranks this layer.
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			dev: "anthropic/claude-sonnet-4-5",
+			scout: "deepseek/deepseek-chat",
+			task: "qwen-local/Qwen",
+		});
+		expect(globalOverrides(settings)).toEqual({
+			scout: "deepseek/deepseek-chat",
+			task: "qwen-local/Qwen",
+		});
+	});
+
+	test("a preset is active when only project-owned overrides sit outside it", async () => {
+		mockAgents();
+		const settings = await projectSettings({
+			overrides: { dev: "anthropic/claude-sonnet-4-5" },
+			presets: { offpeak: { scout: "deepseek/deepseek-chat" } },
+		});
+		settings.set("task.agentModelOverrides", { scout: "deepseek/deepseek-chat" });
+		const { hub, strip } = await createHub(settings);
+		expect(strip()).toMatch(/offpeak\s+active/);
+		focusPreset(hub);
+		hub.handleInput("\r");
+		expect(strip()).toContain("(active)");
+	});
+
+	test("a preset entry the project layer outranks is labelled as project-forced", async () => {
+		mockAgents();
+		const settings = await projectSettings({
+			overrides: { scout: "anthropic/claude-sonnet-4-5" },
+			presets: { offpeak: { scout: "deepseek/deepseek-chat" } },
+		});
+		const { hub, strip } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r");
+		expect(strip()).toContain("(project: anthropic/claude-sonnet-4-5)");
+		expect(strip()).not.toContain("(active)");
+	});
+
+	test("preset values containing tabs render without control characters", async () => {
+		mockAgents();
+		const settings = Settings.isolated();
+		settings.set("task.agentPresets", { "peak\ttab": { "sco\tut": "deepseek/deepseek-\tchat" } });
+		const { hub, strip } = await createHub(settings);
+		focusPreset(hub);
+		hub.handleInput("\r");
+		expect(strip()).toContain("peak");
+		expect(strip()).not.toContain("\t");
 	});
 });


### PR DESCRIPTION
My pain point is cost and workflow: I run subagents on DeepSeek during the day, where peak-hour rates are **2x off-peak**, so with a cheap flash model pinned as the subagent model the daytime bill doubles while omp fans out across several agents at once. I want to swap the whole subagent group to a peak-hour preset and back to an off-peak preset, and I also want different agent line-ups for different kinds of work. This PR is what I built to fix that, and I verified it by running the UI myself.

### Problem & Motivation

Today the only ways to change subagent models are clicking through each agent one at a time in `/agents`, or hand-editing `~/.omp/agent/config.yml`. Two concrete pain points:

1. **Peak vs. off-peak pricing (the main one).** DeepSeek charges roughly **2x during peak daytime hours**. Because a single turn fans out across several subagents (`scout`, `reviewer`, `task`, `security-reviewer`, `sonic`), daytime runs compound that multiplier fast. During peak hours I want the whole set on a cheap/local model; off-peak I want the flagship models back. Doing that by hand twice a day means 20+ clicks across submenus, and it is easy to leave one agent behind on the expensive model.

2. **Different work needs different agent line-ups.** A deep review wants reasoning-heavy models for `reviewer` / `security-reviewer`; fast triage wants cheap, low-latency models for `scout` / `task` / `sonic`. There is currently no way to keep those line-ups around and swap between them as a unit.

### Solution

A **Presets** section in the fullscreen `/agents` hub:

- **Snapshot & save**: store the current live `task.agentModelOverrides` under a name (`+ New preset…`).
- **One-click apply**: `apply` (replace, with a confirmation that previews which overrides would be dropped) or `merge` (only overwrite the agents the preset names).
- **Live diff preview**: the detail view marks every entry against the current overrides — `=` same, `≠` will be overwritten (showing the live value), `+` not currently set, `(missing)` for agents that no longer exist.
- **Manage**: rename and delete in place. Presets defined in project config are read-only in the UI, and UI edits persist to the global layer only.

Presets are deliberately just a named snapshot of `task.agentModelOverrides` — no new state, no timers, no change to spawn-time precedence.

### Changes

- `packages/coding-agent/src/config/settings-schema.ts`: register `task.agentPresets` (`Record<string, Record<string, string>>`).
- `packages/coding-agent/src/main.ts`: add `task.agentPresets` to `HOST_DEFAULTED_SETTING_PATHS`.
- `packages/coding-agent/src/modes/components/agents-hub.ts`: Presets sidebar group with active-preset derivation, detail view with diff markers and drop warning, `apply` / `merge` / `rename…` / `delete` strip actions, snapshot creation, project-layer read-only protection, and keyboard/mouse isolation while a preset detail is shown.
- `packages/coding-agent/test/agents-hub.test.ts`: 15 new contract tests (CRUD, apply replace/merge, Esc unwinding, input isolation, project-layer guards).
- `docs/settings.md`, `docs/task-agent-discovery.md`, `packages/coding-agent/CHANGELOG.md`.

### Verification

- `bun run check` (oxlint, oxfmt, tsgo) — clean, 0 errors.
- `bun test test/agents-hub.test.ts test/acp-lazy-startup.test.ts` — 28/28 passing.
- Interactive run of the built binary with an isolated agent dir (`PI_CODING_AGENT_DIR`), exercising the full flow:
  1. `/agents` rendered `↻ peak active`, `↻ offpeak`, `+ New preset`.
  2. Selected `offpeak`; the detail showed `≠ task  qwen-local/Qwen  (now deepseek/deepseek-chat)` before applying.
  3. `+ New preset` → `night` snapshot created from the live overrides; the sidebar selection stayed on the new preset.
  4. Applied `offpeak` → on disk `agentModelOverrides` became `scout: deepseek/deepseek-chat`, `task: deepseek/deepseek-chat`, all presets intact, and the sidebar then showed `↻ offpeak active`.
  5. Deleted `night` → removed from disk, footer strip closed cleanly, and the hub stayed navigable.
