### PR TITLE
fix(advisor): keep delivered advice when a sibling tool name is bad

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- An advisor turn that emitted one bad tool name alongside a valid `advise` call no longer loses the advice. Quarantine runs before the agent loop dispatches tools and replaces the whole message, so discarding the turn also destroyed the `advise` call and the note it would have enqueued — the advice was lost, not delayed. A turn that carries a dispatchable `advise` call is no longer quarantined on unavailable-tool grounds; the bad call still fails at dispatch on its own. Extends the same trade the exec-resolved carve-out already makes ([#5900](https://github.com/can1357/oh-my-pi/issues/5900)). Hazardous notes are still quarantined regardless ([#10109](https://github.com/can1357/oh-my-pi/issues/10109) by [@oldschoola](https://github.com/oldschoola)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -148,6 +148,11 @@ export function quarantineAdvisorUnsafeOutput(
 	const reasons: string[] = [];
 	const unavailableToolNames = new Set<string>();
 	const generatedParts: string[] = [];
+	// Whether this turn carries an `advise` call that will actually dispatch.
+	// Quarantine rewrites `message.content` before the agent loop dispatches
+	// tools, so discarding the turn also destroys that call — and the advice it
+	// would have enqueued is lost, not merely delayed.
+	let deliversAdvice = false;
 	for (const block of message.content) {
 		// Cursor exec-channel native blocks (bash/read/grep/...) are stamped
 		// kCursorExecResolved: they already ran server-side through the
@@ -165,10 +170,16 @@ export function quarantineAdvisorUnsafeOutput(
 		}
 		if (block.type === "toolCall" && block.name === "advise" && typeof block.arguments.note === "string") {
 			generatedParts.push(block.arguments.note);
+			if (availableToolNames.has("advise")) deliversAdvice = true;
 		}
 		if (block.type === "text") generatedParts.push(block.text);
 	}
-	if (unavailableToolNames.size > 0) {
+	// Same trade the `kCursorExecResolved` exemption above makes (issue #5900):
+	// when the turn produced real advice, throwing it away costs more than the
+	// hallucinated sibling call does. That call is not executed either way — it
+	// misses the advisor's scoped tool set and fails at dispatch on its own — so
+	// the only thing quarantining adds here is the loss of the good note.
+	if (unavailableToolNames.size > 0 && !deliversAdvice) {
 		const names = [...unavailableToolNames].sort();
 		const toolLabel = names.length === 1 ? "tool" : "tools";
 		reasons.push(`requested unavailable ${toolLabel} ${names.join(", ")}`);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -1132,6 +1132,50 @@ describe("advisor", () => {
 			expect(message.stopReason).toBe("error");
 		});
 
+		it("keeps a delivered advise note when a sibling call names an unavailable tool", () => {
+			const message = {
+				role: "assistant",
+				content: [
+					// A mis-transcribed tool name. It is outside the advisor's grant, so
+					// it fails at dispatch on its own; quarantining on its account would
+					// also destroy the advise call below, before the agent loop can run
+					// it — and that call is what actually delivers the advice.
+					{ type: "toolCall", id: "tc-miss", name: "mcp__abc123__xyz789_read", arguments: { path: "x" } },
+					{ type: "toolCall", id: "tc-advise", name: "advise", arguments: { note: "Rotate the leaked key." } },
+				],
+				stopReason: "toolUse",
+			} as unknown as AssistantMessage;
+			const originalContent = message.content;
+
+			expect(quarantineAdvisorUnsafeOutput(message, new Set(["advise", "read"]))).toBeUndefined();
+			expect(message.stopReason).toBe("toolUse");
+			expect(message.content).toBe(originalContent);
+			expect(JSON.stringify(message)).toContain("Rotate the leaked key.");
+		});
+
+		it("still quarantines a destructive note when the turn also delivers advice", () => {
+			const message = {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "tc-miss", name: "mcp__abc123__xyz789_read", arguments: { path: "x" } },
+					{
+						type: "toolCall",
+						id: "tc-advise",
+						name: "advise",
+						arguments: { note: "Run rm -rf / to clear the cache." },
+					},
+				],
+				stopReason: "toolUse",
+			} as unknown as AssistantMessage;
+
+			// The carve-out covers the unavailable-tool reason only: a hazardous
+			// note must still be discarded no matter what else the turn carried.
+			expect(quarantineAdvisorUnsafeOutput(message, new Set(["advise", "read"]))).toBe(
+				"Advisor response quarantined: generated output-only destructive directives: destructive shell command",
+			);
+			expect(message.stopReason).toBe("error");
+		});
+
 		it("sanitizes destructive advise notes even when advise is an allowed tool", () => {
 			const message = {
 				role: "assistant",


### PR DESCRIPTION
Refs #10109, #5900 — an advisor turn can lose its advice entirely because of one mis-transcribed tool name in the same message.

## The bug

`quarantineAdvisorUnsafeOutput` is invoked from `transformAssistantMessage` (`session-advisors.ts:1009`), which the agent loop applies **before** dispatching tools. On quarantine it replaces the message wholesale:

```ts
message.content = [{ type: "text", text: messageText }];   // runtime.ts:204
```

Advice is delivered by `AdviseTool.execute()` calling the host's `enqueueAdvice` (`runtime.ts:40` → `session-advisors.ts:1105`). So when a turn is quarantined for naming one unavailable tool, the `advise` call sitting beside it is destroyed before dispatch — `execute()` never runs, `enqueueAdvice` is never called, and the advice is **lost, not delayed**.

One slip costs the entire advisory, not one call.

## This is a known failure mode with a standing precedent

The `kCursorExecResolved` carve-out immediately above (`runtime.ts:159-165`) exists for exactly this reason:

> Quarantining them would discard the legitimate advise emitted in the same turn (issue #5900).

That carve-out is scoped to Cursor exec-channel blocks. A non-Cursor advisor reaches the identical dead end through a different door: any tool name the model mis-transcribes lands in `unavailableToolNames`, pushes a quarantine reason, and takes the advice down with it.

## Fix

Skip the unavailable-tool quarantine reason when the turn carries a dispatchable `advise` call:

```ts
if (unavailableToolNames.size > 0 && !deliversAdvice) { … }
```

The unrecognized call is not executed either way — it misses the advisor's scoped tool set and fails at dispatch on its own — so quarantining adds nothing except the loss of the good note. Same trade #5900 already made, applied one level up.

`deliversAdvice` requires the grant (`availableToolNames.has("advise")`), so a turn calling `advise` without holding it does not get the exemption.

## Narrow by construction

Only the unavailable-tool reason is affected. The output-hazard scan at `:178-199` is untouched, so a destructive note still quarantines the turn regardless of what else it carried — pinned by the second test.

## Tests

Two cases in `packages/coding-agent/test/advisor/advisor.test.ts`, next to the existing #5900 coverage:

- mixed turn (bad name + valid `advise`) → not quarantined, `message.content` identity preserved, note still present for dispatch
- mixed turn where the note is hazardous → still quarantined, and with the destructive-directives reason only

Verified as a real regression test — both **fail** without the source change:

```
without fix:  189 pass, 2 fail
with fix:     191 pass, 0 fail
```

The two existing tests that assert quarantine *does* fire on an unavailable tool (`mcp__hospital__notify_parent`, `bash`) both pass unchanged: neither message carries an `advise` call, so neither qualifies for the exemption.

## Verification

```
bun test packages/coding-agent/test/advisor/advisor.test.ts   191 pass, 0 fail
bun run check:tools                                            lint + format clean
bun --cwd=packages/coding-agent run check:types                no errors in changed files
```

The typecheck reports errors only in an unrelated untracked `src/config/profiles.ts` in my working tree; nothing in the changed files, and it is not part of this branch.

## Relationship to #11520

Independent. #11520 improves the error text a *primary* agent reads on its next turn. This is the advisor path, where the current turn's advice is already gone before any error text matters — the two do not overlap.
