### PR TITLE
feat(coding-agent): recall drafts cleared with Ctrl+C

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -49,6 +49,16 @@ app.history.search: []
 | `app.live.toggle`            | `Ctrl+L`                                                              | Start or stop live voice mode (same as `/live`)                                                                                                                                      |
 | `app.agents.hub`             | `Alt+A`                                                               | [Open the Agent Hub](./agent-hub.md)                                                                                                                                                 |
 
+## Recover a cleared prompt
+
+Press `Ctrl+C` to clear an unsent composer draft, then `Up` to recall it. Older drafts and submitted prompts share the existing Up/Down navigation. Recalled drafts remain editable and are never sent until you submit them.
+
+Cleared drafts preserve whitespace, collapsed pastes, and image attachments in the current editor's bounded history (100 entries). They are not written to persistent prompt history and do not appear in `Ctrl+R` search. Closing the process discards these canceled drafts; the separate save-on-exit behavior still applies to text currently in the composer. This is not a per-agent stash: history follows the editor, including when Agent Hub changes focus.
+
+The existing double-`Ctrl+C` exit behavior is unchanged. Empty clears do not add history entries.
+
+Recovery is on by default. Turn off **Recall Cleared Drafts** in `/settings` under Interaction > Composer, or set `composer.recallClearedDrafts: false`. This takes effect on the next clear without restarting; previously retained drafts remain in history until evicted or the editor closes.
+
 On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. When the clipboard holds no image, `app.clipboard.pasteImage` pastes the clipboard text instead, so hosts that deliver only this chord (VS Code's integrated terminal when configured to forward `Ctrl+V`, Windows clipboard history via `Win+V`) work for both payload kinds. Windows Terminal also swallows `Ctrl+Enter`, so the `app.message.followUp` chord also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses — and the same chord submits the agent dashboard's new-agent description and hook-editor prompts. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 
 Terminals that implement OSC 5522 enhanced paste can send clipboard MIME data directly to `omp`; image pastes are attached as `[Image #N]`, while text/plain paste events keep normal paste behavior. When OSC 5522 is unavailable, bracketed paste still handles text, and a pasted single image-file path is loaded as an image when the file is readable from the `omp` host.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -57,7 +57,7 @@ Cleared drafts preserve whitespace, collapsed pastes, and image attachments in t
 
 The existing double-`Ctrl+C` exit behavior is unchanged. Empty clears do not add history entries.
 
-Recovery is on by default. Turn off **Recall Cleared Drafts** in `/settings` under Interaction > Composer, or set `composer.recallClearedDrafts: false`. This takes effect on the next clear without restarting; previously retained drafts remain in history until evicted or the editor closes.
+Recovery is on by default. Turn off **Recall Cleared Drafts** in `/settings` under Interaction > Input, or set `composer.recallClearedDrafts: false`. This takes effect on the next clear without restarting; previously retained drafts remain in history until evicted or the editor closes.
 
 On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. When the clipboard holds no image, `app.clipboard.pasteImage` pastes the clipboard text instead, so hosts that deliver only this chord (VS Code's integrated terminal when configured to forward `Ctrl+V`, Windows clipboard history via `Win+V`) work for both payload kinds. Windows Terminal also swallows `Ctrl+Enter`, so the `app.message.followUp` chord also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses — and the same chord submits the agent dashboard's new-agent description and hook-editor prompts. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,9 @@
 ### Fixed
 
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
+### Fixed
+
+- Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead.
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).
 - Added `tui.vimMode`, an opt-in modal editing layer for the prompt, off by default ([#3299](https://github.com/can1357/oh-my-pi/issues/3299)). Escape leaves Insert; Normal mode has `hjkl`, `0`, `^`, `$`, `w`, `b`, `e`, `gg`, `G`, count prefixes, `x`/`D`/`C`, `dd`/`yy`, `p`/`P` and `u`; `v`/`V` start a Visual selection that `y` copies and `d` deletes.
 - Added a `vim` status-line segment showing the current Vim mode (`NORMAL`/`INSERT`/`VISUAL`/`V-LINE`), the half-typed command beside it (Vim's `showcmd`, e.g. `2d`), and the Visual selection height (`V-LINE 4L`). Included in every built-in preset and hidden entirely unless `tui.vimMode` is on; `custom` preset users can add `"vim"` to `statusLine.leftSegments`.
 - The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.
@@ -17,9 +18,6 @@
 ### Fixed
 
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
-### Fixed
-
-- Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead.
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -766,17 +766,6 @@ export const SETTINGS_SCHEMA = {
 			options: "runtime",
 		},
 	},
-	"composer.recallClearedDrafts": {
-		type: "boolean",
-		default: true,
-		ui: {
-			tab: "interaction",
-			group: "Composer",
-			label: "Recall Cleared Drafts",
-			description:
-				"Keep drafts cleared with Ctrl+C in local Up/Down history until exit; disabling affects future clears",
-		},
-	},
 
 	// Status line
 	"statusLine.preset": {
@@ -2107,6 +2096,18 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Input and startup
+	"composer.recallClearedDrafts": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Recall Cleared Drafts",
+			description:
+				"Keep drafts cleared with Ctrl+C in local Up/Down history until exit; disabling affects future clears",
+		},
+	},
+
 	doubleEscapeAction: {
 		type: "enum",
 		values: ["rewind", "tree", "none"] as const,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -766,6 +766,17 @@ export const SETTINGS_SCHEMA = {
 			options: "runtime",
 		},
 	},
+	"composer.recallClearedDrafts": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Composer",
+			label: "Recall Cleared Drafts",
+			description:
+				"Keep drafts cleared with Ctrl+C in local Up/Down history until exit; disabling affects future clears",
+		},
+	},
 
 	// Status line
 	"statusLine.preset": {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -470,12 +470,45 @@ export class CustomEditor extends Editor {
 	clearDraft(historyText?: string): void {
 		if (historyText !== undefined) this.addToHistory(historyText);
 		this.setText("");
-		this.clearAtoms();
+		this.clearPasteState();
 		this.imageLinks = undefined;
 		this.pendingImages = [];
 		this.pendingImageLinks = [];
 		this.pendingTexts = [];
 		this.#textAttachmentCounter = 0;
+	}
+
+	/** Preserve a canceled draft in local navigation, then clear the composer. */
+	clearDraftForRecall(): void {
+		if (!this.getText().trim()) {
+			this.clearDraft();
+			return;
+		}
+		const images = [...this.pendingImages];
+		const links = [...this.pendingImageLinks];
+		const imageLinks = this.imageLinks;
+		const texts = [...this.pendingTexts];
+		const counter = this.#textAttachmentCounter;
+		this.rememberDraft(() => {
+			this.pendingImages = [...images];
+			this.pendingImageLinks = [...links];
+			this.imageLinks = imageLinks;
+			this.pendingTexts = [...texts];
+			this.#textAttachmentCounter = counter;
+			if (this.pendingImages.length > 0 && this.pendingImageLinks.some(link => link === undefined)) {
+				void this.#materializeDraftLinks();
+			}
+		});
+		this.clearDraft();
+	}
+
+	override restoreHistoryState(restore?: () => void): void {
+		this.imageLinks = undefined;
+		this.pendingImages = [];
+		this.pendingImageLinks = [];
+		this.pendingTexts = [];
+		this.#textAttachmentCounter = 0;
+		super.restoreHistoryState(restore);
 	}
 
 	/** Replace the composer draft with a restored historical prompt: re-attaches the message's

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -516,7 +516,7 @@ export class CustomEditor extends Editor {
 	 *  chips band and atomic deletion return), and re-materializes `file://` links so the tokens
 	 *  are clickable again instead of degrading to dead text (esc-esc branch, `/tree`). */
 	setDraft(text: string, images?: readonly ImageContent[]): void {
-		this.clearAtoms();
+		this.clearPasteState();
 		this.pendingTexts = [];
 		this.#textAttachmentCounter = 0;
 		this.imageLinks = undefined;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -1034,7 +1034,8 @@ export class UiHelpers {
 	}
 
 	clearEditor(): void {
-		this.ctx.editor.clearDraft();
+		if (this.ctx.settings.get("composer.recallClearedDrafts")) this.ctx.editor.clearDraftForRecall();
+		else this.ctx.editor.clearDraft();
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/input-controller-large-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-large-paste.test.ts
@@ -143,6 +143,20 @@ describe("InputController.presentLargePasteMenu actions", () => {
 		expect(spies.insertTextAttachment).toHaveBeenCalledWith("payload", "<attachment>\npayload\n</attachment>");
 	});
 
+	it("recalls and submits the wrapped expansion rather than only the chip preview", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const { controller } = createContext({ choice: "Attach as a wrapped block", editor });
+		await controller.presentLargePasteMenu("line one\nline two", 2);
+		editor.clearDraftForRecall();
+		editor.addToHistory("intervening prompt");
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[A");
+		const submitted = vi.fn();
+		editor.onSubmit = submitted;
+		editor.handleInput("\r");
+		expect(submitted).toHaveBeenCalledWith("<attachment>\nline one\nline two\n</attachment>");
+	});
+
 	it("pastes inline when explicitly selected", async () => {
 		const { controller, spies } = createContext({ choice: "Paste inline" });
 
@@ -199,5 +213,23 @@ describe("InputController.presentLargePasteMenu file attachment", () => {
 		expect(spies.insertText).toHaveBeenCalledWith("local://paste-2.md ");
 		expect(await Bun.file(path.join(dir, "local", "paste-1.md")).text()).toBe("previous");
 		expect(await Bun.file(path.join(dir, "local", "paste-2.md")).text()).toBe("fresh");
+	});
+
+	it("recalls a paste-file reference without deleting or overwriting its content", async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-paste-recall-"));
+		const editor = new CustomEditor(getEditorTheme());
+		const { controller } = createContext({ choice: "Attach as local file", artifactsDir: dir, editor });
+		await controller.presentLargePasteMenu("first file\nsecond line", 2);
+		editor.clearDraftForRecall();
+		await controller.presentLargePasteMenu("another paste", 1);
+		editor.clearDraftForRecall();
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[A");
+		const submitted = vi.fn();
+		editor.onSubmit = submitted;
+		editor.handleInput("\r");
+		expect(submitted).toHaveBeenCalledWith("local://paste-1.md");
+		expect(await Bun.file(path.join(dir, "local", "paste-1.md")).text()).toBe("first file\nsecond line");
+		expect(await Bun.file(path.join(dir, "local", "paste-2.md")).text()).toBe("another paste");
 	});
 });

--- a/packages/coding-agent/test/modes/components/custom-editor-draft.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor-draft.test.ts
@@ -3,6 +3,9 @@ import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { chipLabel } from "@oh-my-pi/pi-coding-agent/modes/composer-attachments";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
 const image: ImageContent = { type: "image", data: "aGVsbG8=", mimeType: "image/png" };
 
@@ -72,5 +75,161 @@ describe("CustomEditor draft restore", () => {
 		const chips = editor.composerChips();
 		expect(chips).toHaveLength(1);
 		expect(chips[0]).toMatchObject({ kind: "paste", n: 2 });
+	});
+});
+
+describe("cleared draft recall", () => {
+	it("recalls an image-only draft as a live, atomically deletable chip", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.addToHistory("earlier prompt");
+		editor.setDraft("[Image #1]", [image]);
+		editor.clearDraftForRecall();
+		expect(editor.pendingImages).toEqual([]);
+
+		editor.handleInput("\x1b[A");
+		expect(editor.getExpandedText()).toBe("[Image #1]");
+		expect(editor.composerChips()).toEqual([{ kind: "image", n: 1, image, link: undefined }]);
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("earlier prompt");
+		expect(editor.pendingImages).toEqual([]);
+		editor.handleInput("\x1b[B");
+		expect(editor.getExpandedText()).toBe("[Image #1]");
+		expect(editor.pendingImages).toEqual([image]);
+		editor.handleInput("\x7f"); // Down recalls at the end, after the chip.
+		expect(editor.getExpandedText()).toBe("");
+		expect(editor.composerChips()).toEqual([]);
+	});
+
+	it("keeps the saved attachment snapshot intact across repeated recall and mutation", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.insertTextAttachment("original payload");
+		editor.clearDraftForRecall();
+
+		for (const addition of ["first edit", "second edit"]) {
+			editor.handleInput("\x1b[A");
+			expect(editor.getExpandedText()).toBe("original payload ");
+			editor.handleInput("\x05");
+			editor.insertTextAttachment(addition);
+			expect(editor.getExpandedText()).toBe("original payload " + addition + " ");
+			expect(editor.composerChips().map(chip => chip.n)).toEqual([1, 2]);
+			editor.clearDraft();
+		}
+		editor.handleInput("\x1b[A");
+		expect(editor.getExpandedText()).toBe("original payload ");
+		expect(editor.pendingTexts.map(text => text.content)).toEqual(["original payload"]);
+	});
+
+	it("recalls an unsent multiline draft without trimming it or submitting it", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const submitted: string[] = [];
+		editor.onSubmit = text => {
+			submitted.push(text);
+		};
+		editor.setText("  first line\nsecond line  ");
+		editor.clearDraftForRecall();
+		expect(editor.getText()).toBe("");
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("  first line\nsecond line  ");
+		expect(submitted).toEqual([]);
+	});
+
+	it("restores image and paste payloads without leaking them into other history entries", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setDraft("inspect [Image #1] ", [image]);
+		editor.insertTextAttachment("first\nsecond");
+		const expanded = editor.getExpandedText();
+		editor.clearDraftForRecall();
+		editor.setText("unrelated prompt");
+		editor.clearDraftForRecall();
+		editor.handleInput("\x1b[A");
+		expect(editor.getExpandedText()).toBe("unrelated prompt");
+		expect(editor.pendingImages).toEqual([]);
+		editor.handleInput("\x1b[A");
+		expect(editor.getExpandedText()).toBe(expanded);
+		expect(editor.pendingImages).toEqual([image]);
+		expect(editor.composerChips().map(chip => chip.kind)).toEqual(["image", "paste"]);
+		editor.handleInput("\x1b[B");
+		expect(editor.getText()).toBe("unrelated prompt");
+		expect(editor.pendingImages).toEqual([]);
+		expect(editor.pendingTexts).toEqual([]);
+	});
+
+	it("does not persist canceled drafts or hide prior history behind empty clears", () => {
+		const written: string[] = [];
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setHistoryStorage({
+			add: async text => {
+				written.push(text);
+			},
+			getRecent: () => [{ prompt: "submitted earlier" }],
+		});
+		editor.setText("unsent private draft");
+		editor.clearDraftForRecall();
+		editor.clearDraftForRecall();
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("unsent private draft");
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("submitted earlier");
+		expect(written).toEqual([]);
+	});
+
+	it("does not retain evicted legacy pastes in newer drafts", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.insertPaste("old payload");
+		const marker = editor.getText();
+		editor.clearDraftForRecall();
+		for (let index = 0; index < 100; index++) {
+			editor.setText("draft " + index);
+			editor.clearDraftForRecall();
+		}
+		editor.handleInput("\x1b[A");
+		editor.setText(marker);
+		expect(editor.getExpandedText()).toBe(marker);
+	});
+
+	it("rematerializes missing attachment links after a canceled restore", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const first = Promise.withResolvers<(string | undefined)[]>();
+		const second = Promise.withResolvers<(string | undefined)[]>();
+		let calls = 0;
+		editor.draftImageLinkMaterializer = () => (++calls === 1 ? first.promise : second.promise);
+		editor.setDraft("[Image #1]", [image]);
+		editor.clearDraftForRecall();
+		first.resolve(["file:///tmp/image.png"]);
+		await first.promise;
+		editor.handleInput("\x1b[A");
+		second.resolve(["file:///tmp/image.png"]);
+		await second.promise;
+		expect(editor.composerChips()).toEqual([{ kind: "image", n: 1, image, link: "file:///tmp/image.png" }]);
+	});
+});
+
+describe("cleared draft recovery preference", () => {
+	it("respects disabling and re-enabling recovery without replacing the editor", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const settings = Settings.isolated();
+		const helpers = new UiHelpers({
+			editor,
+			settings,
+			ui: { requestRender() {} },
+		} as unknown as InteractiveModeContext);
+		editor.addToHistory("submitted earlier");
+		editor.setText("recovered by default");
+		helpers.clearEditor();
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("recovered by default");
+		settings.set("composer.recallClearedDrafts", false);
+		editor.setDraft("discard [Image #1]", [image]);
+		helpers.clearEditor();
+		expect(editor.getText()).toBe("");
+		expect(editor.pendingImages).toEqual([]);
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("recovered by default");
+		expect(editor.pendingImages).toEqual([]);
+		settings.set("composer.recallClearedDrafts", true);
+		editor.setText("recovered again");
+		helpers.clearEditor();
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("recovered again");
 	});
 });

--- a/packages/coding-agent/test/modes/components/custom-editor-draft.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor-draft.test.ts
@@ -154,6 +154,78 @@ describe("cleared draft recall", () => {
 		expect(editor.pendingTexts).toEqual([]);
 	});
 
+	it("does not submit a canceled image with another history entry after editing the recalled draft", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setDraft("canceled [Image #1]", [image]);
+		editor.clearDraftForRecall();
+		editor.addToHistory("different [Image #1]");
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[A");
+		expect(editor.pendingImages).toEqual([image]);
+		editor.handleInput("\x05");
+		editor.handleInput("\x15"); // Delete the recalled text without clearing its attachment state.
+		expect(editor.getText()).toBe("");
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("different [Image #1]");
+		const submitted: { text: string; images: ImageContent[] }[] = [];
+		editor.onSubmit = text => {
+			submitted.push({ text, images: [...editor.pendingImages] });
+		};
+		editor.handleInput("\r");
+		expect(submitted).toEqual([{ text: "different [Image #1]", images: [] }]);
+	});
+
+	it("does not expand another history entry with paste payloads from an edited recalled draft", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.insertTextAttachment("canceled text attachment");
+		editor.insertPaste("canceled legacy paste");
+		const otherPrompt = `different ${editor.getText()}`.trim();
+		editor.clearDraftForRecall();
+		editor.addToHistory(otherPrompt);
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x05");
+		editor.handleInput("\x15");
+		expect(editor.getText()).toBe("");
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe(otherPrompt);
+		const submitted: string[] = [];
+		editor.onSubmit = text => {
+			submitted.push(text);
+		};
+		editor.handleInput("\r");
+		expect(submitted).toEqual([otherPrompt]);
+		expect(editor.pendingTexts).toEqual([]);
+	});
+
+	for (const transition of ["discard", "submit", "replace"] as const) {
+		it(`preserves a fresh image during normal history recall after ${transition} of a recalled draft`, () => {
+			const editor = new CustomEditor(getEditorTheme());
+			editor.setDraft("canceled [Image #1]", [image]);
+			editor.clearDraftForRecall();
+			editor.handleInput("\x1b[A");
+			if (transition === "discard") editor.clearDraft();
+			if (transition === "submit") editor.handleInput("\r");
+			const freshImage: ImageContent = { ...image, data: "ZnJlc2g=" };
+			if (transition === "replace") {
+				editor.setDraft("fresh [Image #1]", [freshImage]);
+			} else {
+				editor.pendingImages = [freshImage];
+				editor.setCollapsedText("fresh [Image #1]");
+			}
+			editor.addToHistory("submitted [Image #1]");
+			editor.handleInput("\x05");
+			editor.handleInput("\x15");
+			editor.handleInput("\x1b[A");
+			const submitted: { text: string; images: ImageContent[] }[] = [];
+			editor.onSubmit = text => {
+				submitted.push({ text, images: [...editor.pendingImages] });
+			};
+			editor.handleInput("\r");
+			expect(submitted).toEqual([{ text: "submitted [Image #1]", images: [freshImage] }]);
+		});
+	}
+
 	it("does not persist canceled drafts or hide prior history behind empty clears", () => {
 		const written: string[] = [];
 		const editor = new CustomEditor(getEditorTheme());

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - The software cursor now reflects the Vim mode: a reverse-video block in Normal/Visual and an underline in Insert. Both occupy one cell, so layout is unchanged, and non-modal editors keep the reverse-video block they always had.
+- Editor history can retain local draft snapshots with their paste expansions and host-owned attachment restoration, without writing them to persistent history.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Editor history can retain local draft snapshots with their paste expansions and host-owned attachment restoration, without writing them to persistent history ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).
 - Added an optional Vim-style modal editing layer to `Editor`, off unless `setVimMode(true)` is called: Insert, Normal, and Visual/Visual-Line with motions, count prefixes, and operators. `j`/`k` keep Vim's desired column, so passing over a shorter line does not collapse it, and `$` sticks to end-of-line. `p`/`P` paste from an internal register; yanks are surfaced to the host through `onYank` so it can route them to the system clipboard.
 - Vim mode now exposes its chrome to hosts: `Editor.vimEnabled`, `Editor.vimPending` (the half-typed command, e.g. `2d`), and `Editor.vimSelectedLines` (Visual selection height). `onVimModeChange` additionally fires when the pending command or selection size changes, not only on mode switches.
 - Vim mode now understands text objects: `iw`/`aw` (and `W`), quotes `i"`/`a'`/`` a` ``, bracket pairs `i(`/`a{`/`i[`/`a<` (nesting-aware and multi-line), and paragraphs `ip`/`ap`. They work under an operator (`diw`, `ca(`) and in Visual mode (`viw`), with counts (`d2aw`). Previously `i` after an operator fell through to Insert mode, so `diw` typed text instead of deleting a word.
@@ -13,7 +14,6 @@
 ### Changed
 
 - The software cursor now reflects the Vim mode: a reverse-video block in Normal/Visual and an underline in Insert. Both occupy one cell, so layout is unchanged, and non-modal editors keep the reverse-video block they always had.
-- Editor history can retain local draft snapshots with their paste expansions and host-owned attachment restoration, without writing them to persistent history.
 
 ## [18.1.15] - 2026-09-08
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -447,6 +447,16 @@ interface HistoryStorage {
 	getRecent(limit: number): HistoryEntry[];
 }
 
+interface LocalHistoryEntry {
+	text: string;
+	draft?: {
+		pastes: Map<number, string>;
+		atoms: Map<string, string>;
+		pasteCounter: number;
+		restore?: () => void;
+	};
+}
+
 /** A synchronous replacement immediately before the editor cursor. */
 export interface EditorInlineReplacement {
 	/** UTF-16 code units to remove immediately before the cursor. */
@@ -604,7 +614,7 @@ export class Editor implements Component, Focusable {
 	#pasteHandler = new BracketedPasteHandler();
 
 	// Prompt history for up/down navigation
-	#history: string[] = [];
+	#history: LocalHistoryEntry[] = [];
 	#historyIndex: number = -1; // -1 = not browsing, 0 = most recent, 1 = older, etc.
 	#historyStorage?: HistoryStorage;
 
@@ -841,7 +851,7 @@ export class Editor implements Component, Focusable {
 	setHistoryStorage(storage: HistoryStorage): void {
 		this.#historyStorage = storage;
 		const recent = storage.getRecent(100);
-		this.#history = recent.map(entry => entry.prompt);
+		this.#history = recent.map(entry => ({ text: entry.prompt }));
 		this.#historyIndex = -1;
 	}
 
@@ -860,13 +870,48 @@ export class Editor implements Component, Focusable {
 			});
 		}
 
-		// Don't add consecutive duplicates
-		if (this.#history.length > 0 && this.#history[0] === trimmed) return;
-		this.#history.unshift(trimmed);
-		// Limit history size
-		if (this.#history.length > 100) {
-			this.#history.pop();
+		// Don't add consecutive submitted duplicates; a draft owns separate state.
+		const previous = this.#history[0];
+		if (previous?.text === trimmed && !previous.draft) return;
+		this.#pushHistory({ text: trimmed });
+	}
+
+	/** Retain the current draft for local recall only, never persistent history. */
+	rememberDraft(restore?: () => void): void {
+		const text = this.getText();
+		if (!text.trim()) return;
+		const pastes = new Map<number, string>();
+		for (const match of text.matchAll(/\[Paste #(\d+)(?:, (?:\+\d+ lines|\d+ chars))?\]/g)) {
+			const id = Number(match[1]);
+			const value = this.#pastes.get(id);
+			if (value !== undefined) pastes.set(id, value);
 		}
+		this.#pushHistory({
+			text,
+			draft: {
+				pastes,
+				atoms: new Map([...this.#atoms].filter(([label]) => text.includes(label))),
+				pasteCounter: this.#pasteCounter,
+				restore,
+			},
+		});
+	}
+
+	/** Release the current draft's expansion payloads without touching history. */
+	clearPasteState(): void {
+		this.#pastes.clear();
+		this.#pasteCounter = 0;
+		this.#atoms.clear();
+	}
+
+	/** Restore host-owned draft state before history text triggers onChange. */
+	restoreHistoryState(restore?: () => void): void {
+		restore?.();
+	}
+
+	#pushHistory(entry: LocalHistoryEntry): void {
+		this.#history.unshift(entry);
+		if (this.#history.length > 100) this.#history.pop();
 	}
 
 	#isEditorEmpty(): boolean {
@@ -890,14 +935,17 @@ export class Editor implements Component, Focusable {
 		if (this.#history.length === 0) return;
 		const newIndex = this.#historyIndex - direction; // Up(-1) increases index, Down(1) decreases
 		if (newIndex < -1 || newIndex >= this.#history.length) return;
+		const previousHadDraft = this.#history[this.#historyIndex]?.draft !== undefined;
 		this.#historyIndex = newIndex;
-		if (this.#historyIndex === -1) {
-			// Returned to "current" state - clear editor
-			this.#setTextInternal("", "end");
-		} else {
-			const cursorAnchor: HistoryCursorAnchor = direction === -1 ? "start" : "end";
-			this.#setTextInternal(this.#history[this.#historyIndex] || "", cursorAnchor);
+		const entry = this.#history[this.#historyIndex];
+		if (entry?.draft || previousHadDraft) {
+			this.#pastes = new Map(entry?.draft?.pastes);
+			this.#atoms = new Map(entry?.draft?.atoms);
+			this.#pasteCounter = entry?.draft?.pasteCounter ?? 0;
+			this.restoreHistoryState(entry?.draft?.restore);
 		}
+		const cursorAnchor: HistoryCursorAnchor = direction === -1 ? "start" : "end";
+		this.#setTextInternal(entry?.text ?? "", cursorAnchor);
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -617,6 +617,8 @@ export class Editor implements Component, Focusable {
 	#history: LocalHistoryEntry[] = [];
 	#historyIndex: number = -1; // -1 = not browsing, 0 = most recent, 1 = older, etc.
 	#historyStorage?: HistoryStorage;
+	// Recalled payloads outlive browsing when an edit resets #historyIndex.
+	#historyDraftActive = false;
 
 	// Undo stack for editor state changes
 	#undoStack: EditorState[] = [];
@@ -902,6 +904,7 @@ export class Editor implements Component, Focusable {
 		this.#pastes.clear();
 		this.#pasteCounter = 0;
 		this.#atoms.clear();
+		this.#historyDraftActive = false;
 	}
 
 	/** Restore host-owned draft state before history text triggers onChange. */
@@ -935,14 +938,14 @@ export class Editor implements Component, Focusable {
 		if (this.#history.length === 0) return;
 		const newIndex = this.#historyIndex - direction; // Up(-1) increases index, Down(1) decreases
 		if (newIndex < -1 || newIndex >= this.#history.length) return;
-		const previousHadDraft = this.#history[this.#historyIndex]?.draft !== undefined;
 		this.#historyIndex = newIndex;
 		const entry = this.#history[this.#historyIndex];
-		if (entry?.draft || previousHadDraft) {
+		if (entry?.draft || this.#historyDraftActive) {
 			this.#pastes = new Map(entry?.draft?.pastes);
 			this.#atoms = new Map(entry?.draft?.atoms);
 			this.#pasteCounter = entry?.draft?.pasteCounter ?? 0;
 			this.restoreHistoryState(entry?.draft?.restore);
+			this.#historyDraftActive = entry?.draft !== undefined;
 		}
 		const cursorAnchor: HistoryCursorAnchor = direction === -1 ? "start" : "end";
 		this.#setTextInternal(entry?.text ?? "", cursorAnchor);
@@ -2918,9 +2921,7 @@ export class Editor implements Component, Focusable {
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();
 
 		this.#state = { lines: [""], cursorLine: 0, cursorCol: 0 };
-		this.#pastes.clear();
-		this.#pasteCounter = 0;
-		this.#atoms.clear();
+		this.clearPasteState();
 		this.#historyIndex = -1;
 		this.#scrollOffset = 0;
 		this.#undoStack.length = 0;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -95,6 +95,68 @@ describe("Editor component", () => {
 	});
 
 	describe("Prompt history navigation", () => {
+		it("recalls each large paste after another draft and a submission without overwriting payloads", () => {
+			const editor = new Editor(defaultEditorTheme);
+			const first = "first payload ".repeat(120).trim();
+			const second = "second payload ".repeat(120).trim();
+			const addition = "added payload ".repeat(120).trim();
+			const submitted: string[] = [];
+			editor.onSubmit = text => {
+				submitted.push(text);
+			};
+			editor.handleInput("\x1b[200~" + first + "\x1b[201~");
+			editor.rememberDraft();
+			editor.setText("");
+			editor.handleInput("\x1b[200~" + second + "\x1b[201~");
+			editor.rememberDraft();
+			editor.handleInput("\r");
+			expect(submitted).toEqual([second]);
+
+			editor.handleInput("\x1b[A");
+			expect(editor.getExpandedText()).toBe(second);
+			editor.handleInput("\x1b[A");
+			expect(editor.getExpandedText()).toBe(first);
+			editor.handleInput("\x05");
+			editor.handleInput("\x1b[200~" + addition + "\x1b[201~");
+			editor.handleInput("\r");
+			expect(submitted).toEqual([second, first + addition]);
+			editor.handleInput("\x1b[A");
+			expect(editor.getExpandedText()).toBe(second);
+			editor.handleInput("\x1b[A");
+			expect(editor.getExpandedText()).toBe(first);
+		});
+
+		it("retains only the newest 100 drafts locally and never reloads them from storage", () => {
+			const persisted = [{ prompt: "submitted earlier" }];
+			const storage = {
+				add: async (prompt: string) => {
+					persisted.unshift({ prompt });
+				},
+				getRecent: () => persisted,
+			};
+			const editor = new Editor(defaultEditorTheme);
+			editor.setHistoryStorage(storage);
+			for (let i = 0; i < 101; i++) {
+				editor.setText("draft " + i);
+				editor.rememberDraft();
+				editor.setText("");
+			}
+			for (let i = 100; i >= 1; i--) {
+				editor.handleInput("\x1b[A");
+				expect(editor.getText()).toBe("draft " + i);
+			}
+			editor.handleInput("\x1b[A");
+			expect(editor.getText()).toBe("draft 1");
+			expect(persisted).toEqual([{ prompt: "submitted earlier" }]);
+
+			const reopened = new Editor(defaultEditorTheme);
+			reopened.setHistoryStorage(storage);
+			reopened.handleInput("\x1b[A");
+			expect(reopened.getText()).toBe("submitted earlier");
+			reopened.handleInput("\x1b[A");
+			expect(reopened.getText()).toBe("submitted earlier");
+		});
+
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);
 


### PR DESCRIPTION
## What

This adds recall of unsent prompts through history after pressing Ctrl+C to clear them. I missed having this when moving to OMP. I prefer it to a single-slot stash because I can recover several drafts from history instead of keeping only one aside.

Cleared drafts preserve whitespace, collapsed pastes and image attachments in the editor's existing 100-entry Up/Down history. Wrapped-block pastes keep their `<attachment>` expansion. Pastes saved as files keep their `local://` reference; clearing the draft leaves the file intact.

The new Recall Cleared Drafts setting is on by default under Settings > Interaction > Input (`composer.recallClearedDrafts`). Turning it off restores discard-on-clear for future clears without restarting. Drafts already retained remain available until evicted or the editor closes.

Canceled drafts stay in memory. They aren't written to persistent prompt history, don't appear in Ctrl+R search, and don't survive a process restart. Existing exit and interrupt shortcuts are unchanged.

## Why

OMP currently has no dedicated prompt stash, and Ctrl+C clears unsent work without a history-recall path. This lets users clear the composer, send something else, then return to an earlier draft without submitting it accidentally.

Related to #7162. This does not add its proposed stash stack or the per-agent draft storage in #10080. History belongs to the current editor.

## Testing

I attached a screenshot and entered a multiline prompt, cleared it with Ctrl+C, sent another message, then pressed Up twice and submitted the recovered draft. The response understood both the image and prompt.

- Actual source CLI in a PTY: with recovery on, Ctrl+C then Up cleared and restored an unsent prompt. With recovery off, Up did not recover it. Neither smoke test sent a model request.
- A regression test covers changing the setting off and on without replacing the editor.
- Final focused run across eight draft, editor, keybinding and paste suites: 311 passed, 0 failed, 979 assertions. Includes recall and submission of wrapped blocks and local-file references, with file contents checked after recall.
- `bun check` passed, with an unrelated unused-variable warning in `executor-subagent-reminders.test.ts`.
- An earlier broader UI run had 2,056 passes and one failure: a status-line placeholder test expects a folder icon in a linked worktree. It also fails with unchanged upstream production modules. A separate broader-runner attempt encountered six localhost HTTP fixture connection failures in packages/utils. A clean full-repository test run is not claimed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)

