### PR TITLE
fix(catalog): preserve metadata during model discovery

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed model discovery losing catalog thinking controls and ignoring provider-reported token limits for newly discovered models.
+
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed model discovery losing catalog thinking controls and ignoring provider-reported token limits for newly discovered models.
+- Fixed model discovery losing catalog thinking controls and ignoring provider-reported token limits for newly discovered models ([#11529](https://github.com/can1357/oh-my-pi/pull/11529) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -213,6 +213,7 @@ export function buildModel<TApi extends Api>(spec: ModelSpec<TApi>): Model<TApi>
 		requiresGlyphTokenization: policy.identity.class === "anthropic",
 		tokenizer: spec.tokenizer ?? resolveModelTokenizer(spec.requestModelId ?? spec.id),
 		thinking: policy.thinking,
+		thinkingConfig: spec.thinking,
 		supportsComputerUse: supportsOpenAIGAComputerUse(spec, policy.identity, supportsComputerUseConfig),
 		supportsComputerUseConfig,
 		compat: policy.compat,

--- a/packages/catalog/src/compat/collapse.ts
+++ b/packages/catalog/src/compat/collapse.ts
@@ -1010,8 +1010,8 @@ export function collapseVariants<TSpec extends VariantSpecLike>(
  * Runtime entry point for already-built `Model` lists (the model-manager
  * merge point, coding-agent registry custom providers): collapses hand
  * tables plus derived pairs, then re-runs `buildModel` on freshly created
- * logical specs so thinking wire defaults stay resolved. Untouched entries
- * pass through by reference.
+ * logical specs. Ordinary projections retain only authored controls; a newly
+ * collapsed logical model promotes its calculated routing to authored metadata.
  */
 export function collapseBuiltVariants<TApi extends Api>(models: readonly Model<TApi>[]): Model<TApi>[] {
 	const collapsed = collapseVariants(models);
@@ -1026,9 +1026,15 @@ function projectModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TApi>
 		identity: _identity,
 		requiresGlyphTokenization: _requiresGlyphTokenization,
 		supportsComputerUseConfig: _supportsComputerUseConfig,
+		thinking: transformedThinking,
+		thinkingConfig: _thinkingConfig,
 		...spec
 	} = model;
-	return { ...spec, compat: compatConfig };
+	return {
+		...spec,
+		...(transformedThinking !== undefined ? { thinking: transformedThinking } : {}),
+		compat: compatConfig,
+	};
 }
 
 /**

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -10,7 +10,9 @@ import type { Api, Model, ModelSpec } from "./types";
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
 // the model manager rebuilds via `buildModel` on load. Request headers are
 // intentionally omitted: arbitrary provider-defined header names can carry
-// credentials. v12 invalidates Kimi Code rows carrying the blanket
+// credentials. v13 invalidates rows that can persist `buildModel`-derived
+// thinking controls without provenance; new rows project only authored
+// `thinkingConfig`. v12 invalidates Kimi Code rows carrying the blanket
 // maxTokens: 32000 that predate per-family output caps (k3/k3-256k -> 131072,
 // kimi-for-coding[-highspeed] -> 32768, #6711); v11 invalidates rows that may
 // persist derived computer-use
@@ -23,7 +25,7 @@ import type { Api, Model, ModelSpec } from "./types";
 // retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 12;
+const CACHE_SCHEMA_VERSION = 13;
 const HEADER_RESTORE_VERSION = 1;
 
 interface CacheRow {
@@ -259,16 +261,31 @@ function hasModelHeaders(model: Model<Api>): boolean {
 }
 
 /**
- * Project a live model to cache-safe metadata.
+ * Project a live model to cache-safe authored metadata.
  *
  * Headers are never persisted: custom/runtime providers may use arbitrary
  * credential header names, so no name-based filter can be complete. The
  * separately persisted model-id list lets the manager restore matching static
  * headers and reject/refetch dynamic-only cached models that need live headers.
+ * `thinkingConfig` distinguishes builder-derived controls from authored ones;
+ * generated bundled rows without that field retain their direct thinking data.
  */
 function toCachedModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TApi> {
-	const { headers: _headers, compatConfig, supportsComputerUseConfig, ...rest } = model;
-	return { ...rest, supportsComputerUse: supportsComputerUseConfig, compat: compatConfig };
+	const {
+		headers: _headers,
+		compatConfig,
+		supportsComputerUseConfig,
+		thinking: _derivedThinking,
+		thinkingConfig,
+		...rest
+	} = model;
+	const thinking = Object.hasOwn(model, "thinkingConfig") ? thinkingConfig : _derivedThinking;
+	return {
+		...rest,
+		supportsComputerUse: supportsComputerUseConfig,
+		...(thinking !== undefined ? { thinking } : {}),
+		compat: compatConfig,
+	};
 }
 
 /** Whether two in-memory header records are byte-for-byte equivalent. */

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -580,6 +580,13 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 		...dynamicModel,
 		name: preferDiscoveryName(dynamicModel.name, existingModel.name, dynamicModel.id),
 		reasoning,
+		// ID-only discovery has no effort metadata. Retain the catalog controls
+		// only for the same transport and non-authoritative reasoning sources.
+		thinking:
+			dynamicModel.thinking ??
+			(!endpointChanged && existingModel.api === dynamicModel.api && !dynamicReasoningAuthoritative
+				? existingModel.thinking
+				: undefined),
 		input: supportsImage ? ["text", "image"] : ["text"],
 		cost: {
 			input: preferDiscoveryCost(dynamicModel.cost.input, existingModel.cost.input),

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -273,7 +273,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		? await Promise.all([fetchModelsDev(options), dynamicFetcher ? fetchDynamicModels(dynamicFetcher) : null])
 		: [null, null];
 	const modelsDevFetchSucceeded = fetchedModelsDevModels !== null;
-	const normalizedModelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
+	const normalizedModelsDevModels = fetchedModelsDevModels ?? [];
 	const modelsDevModels = additiveStaticModelIds
 		? normalizedModelsDevModels.filter(model => !additiveStaticModelIds.has(model.id))
 		: normalizedModelsDevModels;
@@ -573,6 +573,12 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 		? dynamicModel.reasoning
 		: existingModel.reasoning || dynamicModel.reasoning;
 	const longContextCost = dynamicModel.cost.longContext ?? existingModel.cost.longContext;
+	const dynamicThinkingConfig = Object.hasOwn(dynamicModel, "thinkingConfig")
+		? dynamicModel.thinkingConfig
+		: dynamicModel.thinking;
+	const existingThinkingConfig = Object.hasOwn(existingModel, "thinkingConfig")
+		? existingModel.thinkingConfig
+		: existingModel.thinking;
 	// Re-build from spec stage: sparse compat comes from `compatConfig` (the
 	// verbatim override vocabulary), never the resolved `compat` record.
 	return buildModel({
@@ -580,12 +586,13 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 		...dynamicModel,
 		name: preferDiscoveryName(dynamicModel.name, existingModel.name, dynamicModel.id),
 		reasoning,
-		// ID-only discovery has no effort metadata. Retain the catalog controls
-		// only for the same transport and non-authoritative reasoning sources.
+		// Discovery controls win when explicitly advertised. Otherwise retain
+		// catalog controls only when their endpoint/API is still the wire route;
+		// never mistake buildModel-derived metadata for upstream controls.
 		thinking:
-			dynamicModel.thinking ??
+			dynamicThinkingConfig ??
 			(!endpointChanged && existingModel.api === dynamicModel.api && !dynamicReasoningAuthoritative
-				? existingModel.thinking
+				? existingThinkingConfig
 				: undefined),
 		input: supportsImage ? ["text", "image"] : ["text"],
 		cost: {

--- a/packages/catalog/src/provider-models/bundled-references.ts
+++ b/packages/catalog/src/provider-models/bundled-references.ts
@@ -4,9 +4,10 @@ import type { Api, Model, ModelSpec } from "../types";
 
 /**
  * Project a built `Model` back to spec stage: `compat` becomes the verbatim
- * sparse override record (`compatConfig`), never the resolved view. Discovery
- * mappers spread these references into the specs they hand to the model
- * manager, which rebuilds via `buildModel`.
+ * sparse override record (`compatConfig`) and only authored
+ * `thinkingConfig` becomes `thinking`; resolved views never re-enter
+ * discovery. Generated bundled rows predate provenance, so their direct
+ * `thinking` remains authored.
  */
 export function toModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TApi> {
 	const {
@@ -14,11 +15,15 @@ export function toModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TAp
 		compatConfig,
 		supportsComputerUse: _derivedComputerUse,
 		supportsComputerUseConfig,
+		thinking: derivedThinking,
+		thinkingConfig,
 		...rest
 	} = model;
+	const thinking = Object.hasOwn(model, "thinkingConfig") ? thinkingConfig : derivedThinking;
 	return {
 		...rest,
 		...(supportsComputerUseConfig !== undefined ? { supportsComputerUse: supportsComputerUseConfig } : {}),
+		...(thinking !== undefined ? { thinking } : {}),
 		compat: compatConfig,
 	} as ModelSpec<TApi>;
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -373,6 +373,8 @@ function mapWithBundledReference<TApi extends Api>(
 		return {
 			...defaults,
 			name,
+			contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
+			maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
 		};
 	}
 	return {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1111,6 +1111,8 @@ export interface Model<TApi extends Api = Api> {
 	supportsTools?: boolean;
 	/** Whether this model accepts the GA OpenAI Responses `{ type: "computer" }` native tool. */
 	supportsComputerUse?: boolean;
+	/** Verbatim authored thinking controls; undefined when `buildModel` derived the runtime metadata. */
+	thinkingConfig?: ThinkingConfig;
 	/** Verbatim explicit computer-use support from the spec; undefined when `buildModel` inferred the runtime value. */
 	supportsComputerUseConfig?: boolean;
 	/** GitLab Duo Workflow root namespace selected during catalog discovery. */
@@ -1250,6 +1252,7 @@ export interface ModelSpec<TApi extends Api = Api> extends Omit<
 	| "compatConfig"
 	| "requiresGlyphTokenization"
 	| "requiresCursorToolSchemaProjection"
+	| "thinkingConfig"
 	| "supportsComputerUseConfig"
 > {
 	/** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -939,6 +939,80 @@ describe("model cache spec round trip", () => {
 		}
 	});
 
+	it.each(["bundled", "shared catalog"])(
+		"preserves %s thinking controls through ID-only discovery and offline restore",
+		async source => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-merge-"));
+			const catalogModel = completionsSpec({
+				provider: "thinking-merge-test",
+				reasoning: true,
+				thinking: { mode: "effort", efforts: [Effort.Low, Effort.High], defaultLevel: Effort.High },
+			});
+			const discoveredModel = completionsSpec({
+				provider: catalogModel.provider,
+				contextWindow: null,
+				maxTokens: null,
+			});
+			const options = {
+				providerId: catalogModel.provider,
+				staticModels: source === "bundled" ? [catalogModel] : [],
+				cacheDbPath: path.join(tempDir, "models.db"),
+				...(source === "shared catalog"
+					? { modelsDev: { fetch: async () => [catalogModel], map: () => [catalogModel] } }
+					: {}),
+			};
+			try {
+				const online = await resolveProviderModels(
+					{ ...options, fetchDynamicModels: async () => [discoveredModel] },
+					"online",
+				);
+				expect(online.models[0]?.thinking).toEqual(catalogModel.thinking);
+				const offline = await resolveProviderModels(options, "offline");
+				expect(offline.models[0]?.thinking).toEqual(catalogModel.thinking);
+
+				const updatedThinking = { mode: "effort", efforts: [Effort.Low], defaultLevel: Effort.Low } as const;
+				const refreshed = await resolveProviderModels(
+					{
+						...options,
+						fetchDynamicModels: async () => [{ ...discoveredModel, reasoning: true, thinking: updatedThinking }],
+					},
+					"online",
+				);
+				expect(refreshed.models[0]?.thinking).toEqual(updatedThinking);
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	it("does not copy thinking controls to a different discovery endpoint", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-endpoint-"));
+		const catalogModel = completionsSpec({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.High],
+				effortMap: { [Effort.High]: "endpoint-specific-high" },
+			},
+		});
+		const discoveredModel = completionsSpec({ baseUrl: "https://other.example.com/v1" });
+		try {
+			const result = await resolveProviderModels(
+				{
+					providerId: "thinking-endpoint-test",
+					staticModels: [catalogModel],
+					cacheDbPath: path.join(tempDir, "models.db"),
+					fetchDynamicModels: async () => [discoveredModel],
+				},
+				"online",
+			);
+			expect(result.models[0]?.baseUrl).toBe(discoveredModel.baseUrl);
+			expect(result.models[0]?.thinking?.effortMap).toBeUndefined();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves static long-context pricing through dynamic refresh and cache restore", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-tiered-cost-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -8,9 +8,10 @@ import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic
 import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
-import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import { fingerprintStaticModels, resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { openrouterModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import { toModelSpec } from "@oh-my-pi/pi-catalog/provider-models/bundled-references";
 import type { Api, Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 function completionsSpec(overrides: Partial<ModelSpec<"openai-completions">> = {}): ModelSpec<"openai-completions"> {
@@ -84,6 +85,26 @@ describe("buildModel", () => {
 		}
 	});
 
+	it("records authored thinking controls separately from derived metadata", () => {
+		const authored = { mode: "effort", efforts: [Effort.Low], defaultLevel: Effort.Low } as const;
+		const inferred = buildModel(completionsSpec({ id: "gpt-5.6", reasoning: true }));
+		const configured = buildModel(completionsSpec({ reasoning: true, thinking: authored }));
+
+		expect(inferred.thinking).toBeDefined();
+		expect(inferred.thinkingConfig).toBeUndefined();
+		expect(configured.thinkingConfig).toBe(authored);
+		expect(configured.thinking).toEqual(authored);
+	});
+
+	it("projects only authored thinking from built models while retaining legacy bundled controls", () => {
+		const authored = { mode: "effort", efforts: [Effort.Low], defaultLevel: Effort.Low } as const;
+		const inferred = buildModel(completionsSpec({ id: "gpt-5.6", reasoning: true }));
+		const explicit = buildModel(completionsSpec({ reasoning: true, thinking: authored }));
+		const { thinkingConfig: _thinkingConfig, ...legacyBundledRow } = explicit;
+
+		expect(toModelSpec(inferred)).not.toHaveProperty("thinking");
+		expect(toModelSpec(legacyBundledRow).thinking).toEqual(authored);
+	});
 	it("lets sparse overrides win over detection and keeps the verbatim config", () => {
 		const sparse = { supportsDeveloperRole: true } as const;
 		const model = buildModel(
@@ -939,9 +960,14 @@ describe("model cache spec round trip", () => {
 		}
 	});
 
-	it.each(["bundled", "shared catalog"])(
-		"preserves %s thinking controls through ID-only discovery and offline restore",
-		async source => {
+	it.each([
+		["bundled", false],
+		["bundled", true],
+		["shared catalog", false],
+		["shared catalog", true],
+	])(
+		"preserves %s thinking controls through reasoning:%s ID-only discovery and offline restore",
+		async (source, discoveredReasoning) => {
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-merge-"));
 			const catalogModel = completionsSpec({
 				provider: "thinking-merge-test",
@@ -950,6 +976,7 @@ describe("model cache spec round trip", () => {
 			});
 			const discoveredModel = completionsSpec({
 				provider: catalogModel.provider,
+				reasoning: discoveredReasoning,
 				contextWindow: null,
 				maxTokens: null,
 			});
@@ -985,6 +1012,91 @@ describe("model cache spec round trip", () => {
 		},
 	);
 
+	it("does not persist derived discovery thinking over later static controls", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-provenance-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const dynamicModel = completionsSpec({
+			id: "gpt-5.6",
+			provider: "thinking-provenance-test",
+			reasoning: true,
+		});
+		const staticThinking = {
+			mode: "effort",
+			efforts: [Effort.Low],
+			defaultLevel: Effort.Low,
+			effortMap: { [Effort.Low]: "catalog-low" },
+		} as const;
+		const staticModel = completionsSpec({ ...dynamicModel, thinking: staticThinking });
+		try {
+			const online = await resolveProviderModels<"openai-completions">(
+				{
+					providerId: dynamicModel.provider,
+					staticModels: [],
+					cacheDbPath: dbPath,
+					fetchDynamicModels: async () => [dynamicModel],
+				},
+				"online",
+			);
+			expect(online.models[0]?.thinking).toBeDefined();
+			expect(online.models[0]?.thinkingConfig).toBeUndefined();
+
+			const db = new Database(dbPath, { readonly: true });
+			const row = db
+				.query<{ models: string }, [string]>("SELECT models FROM model_cache WHERE provider_id = ?")
+				.get(dynamicModel.provider);
+			db.close();
+			const persisted = JSON.parse(row?.models ?? "[]") as Array<Record<string, unknown>>;
+			expect(persisted[0]).not.toHaveProperty("thinking");
+			expect(persisted[0]).not.toHaveProperty("thinkingConfig");
+
+			const offline = await resolveProviderModels<"openai-completions">(
+				{
+					providerId: dynamicModel.provider,
+					staticModels: [staticModel],
+					cacheDbPath: dbPath,
+				},
+				"offline",
+			);
+			expect(offline.models[0]?.thinking).toEqual(staticThinking);
+			expect(offline.models[0]?.thinkingConfig).toEqual(staticThinking);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	it("persists legacy bundled thinking controls through an offline cache restore", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-bundled-thinking-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const thinking = { mode: "effort", efforts: [Effort.Low], defaultLevel: Effort.Low } as const;
+		const built = buildModel(
+			completionsSpec({
+				id: "legacy-bundled-thinking",
+				provider: "bundled-thinking-cache-test",
+				reasoning: true,
+				thinking,
+			}),
+		);
+		const { thinkingConfig: _thinkingConfig, ...legacyBundledRow } = built;
+		try {
+			writeModelCache(legacyBundledRow.provider, Date.now(), [legacyBundledRow], true, "", dbPath);
+			const db = new Database(dbPath, { readonly: true });
+			const row = db
+				.query<{ models: string }, [string]>("SELECT models FROM model_cache WHERE provider_id = ?")
+				.get(legacyBundledRow.provider);
+			db.close();
+			const persisted = JSON.parse(row?.models ?? "[]") as Array<Record<string, unknown>>;
+			expect(persisted[0]?.thinking).toEqual(legacyBundledRow.thinking);
+
+			const offline = await resolveProviderModels<"openai-completions">(
+				{ providerId: legacyBundledRow.provider, staticModels: [], cacheDbPath: dbPath },
+				"offline",
+			);
+			expect(offline.models[0]?.thinking).toEqual(legacyBundledRow.thinking);
+			expect(offline.models[0]?.thinkingConfig).toEqual(legacyBundledRow.thinking);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("does not copy thinking controls to a different discovery endpoint", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-endpoint-"));
 		const catalogModel = completionsSpec({
@@ -995,7 +1107,7 @@ describe("model cache spec round trip", () => {
 				effortMap: { [Effort.High]: "endpoint-specific-high" },
 			},
 		});
-		const discoveredModel = completionsSpec({ baseUrl: "https://other.example.com/v1" });
+		const discoveredModel = completionsSpec({ baseUrl: "https://other.example.com/v1", reasoning: true });
 		try {
 			const result = await resolveProviderModels(
 				{
@@ -1007,6 +1119,41 @@ describe("model cache spec round trip", () => {
 				"online",
 			);
 			expect(result.models[0]?.baseUrl).toBe(discoveredModel.baseUrl);
+			expect(result.models[0]?.thinking?.effortMap).toBeUndefined();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not copy thinking controls across discovery API surfaces", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-thinking-api-"));
+		const catalogModel = completionsSpec({
+			id: "gpt-5.6",
+			provider: "thinking-api-test",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.High],
+				effortMap: { [Effort.High]: "completions-high" },
+			},
+		});
+		const discoveredModel = responsesSpec({
+			id: catalogModel.id,
+			provider: catalogModel.provider,
+			baseUrl: catalogModel.baseUrl,
+			reasoning: true,
+		});
+		try {
+			const result = await resolveProviderModels<Api>(
+				{
+					providerId: catalogModel.provider,
+					staticModels: [catalogModel],
+					cacheDbPath: path.join(tempDir, "models.db"),
+					fetchDynamicModels: async () => [discoveredModel],
+				},
+				"online",
+			);
+			expect(result.models[0]?.api).toBe("openai-responses");
 			expect(result.models[0]?.thinking?.effortMap).toBeUndefined();
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
@@ -1089,6 +1236,56 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it.each(["offline", "online-if-uncached"] as const)(
+		"rejects schema-v12 cache rows before %s resolution can reuse matching authoritative metadata",
+		async strategy => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-legacy-thinking-cache-"));
+			const dbPath = path.join(tempDir, "models.db");
+			const discoveredModel = completionsSpec({
+				id: "gpt-5.6",
+				provider: "legacy-thinking-cache-test",
+				reasoning: true,
+			});
+			const staticThinking = {
+				mode: "effort",
+				efforts: [Effort.Low],
+				defaultLevel: Effort.Low,
+				effortMap: { [Effort.Low]: "catalog-low" },
+			} as const;
+			const staticModel = completionsSpec({ ...discoveredModel, thinking: staticThinking });
+			const legacyModel = buildModel(discoveredModel);
+			const staticFingerprint = fingerprintStaticModels([buildModel(staticModel)]);
+			let fetches = 0;
+			try {
+				writeModelCache(discoveredModel.provider, Date.now(), [legacyModel], true, staticFingerprint, dbPath);
+				const db = new Database(dbPath);
+				db.run("UPDATE model_cache SET version = ?, models = ? WHERE provider_id = ?", [
+					12,
+					JSON.stringify([legacyModel]),
+					discoveredModel.provider,
+				]);
+				db.close();
+
+				const result = await resolveProviderModels<"openai-completions">(
+					{
+						providerId: discoveredModel.provider,
+						staticModels: [staticModel],
+						cacheDbPath: dbPath,
+						fetchDynamicModels: async () => {
+							fetches++;
+							return [discoveredModel];
+						},
+					},
+					strategy,
+				);
+				expect(fetches).toBe(strategy === "offline" ? 0 : 1);
+				expect(result.models[0]?.thinking).toEqual(staticThinking);
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("preserves computer-use provenance across cache restarts and endpoint reroutes", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-computer-use-cache-"));

--- a/packages/catalog/test/cerebras-provider.test.ts
+++ b/packages/catalog/test/cerebras-provider.test.ts
@@ -3,7 +3,7 @@ import { cerebrasModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-model
 import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 
 describe("Cerebras provider discovery", () => {
-	test("discovers gemma-4-31b as image-capable", async () => {
+	test("maps live limits while retaining reference fallbacks", async () => {
 		const calls: Array<{ url: string; authorization: string | null }> = [];
 		const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
 			const headers = new Headers(init?.headers);
@@ -14,8 +14,31 @@ describe("Cerebras provider discovery", () => {
 			return new Response(
 				JSON.stringify({
 					data: [
-						{ id: "gemma-4-31b", object: "model" },
-						{ id: "llama3.1-8b", object: "model" },
+						{
+							id: "gemma-4-31b",
+							object: "model",
+							context_length: 0,
+							max_completion_tokens: "not-a-number",
+						},
+						{
+							id: "llama3.1-8b",
+							object: "model",
+							context_length: 64_000,
+							max_completion_tokens: 16_000,
+						},
+						{
+							id: "cerebras-future",
+							object: "model",
+							context_length: "262144",
+							max_completion_tokens: 65_536,
+						},
+						{ id: "cerebras-id-only", object: "model" },
+						{
+							id: "cerebras-invalid-limits",
+							object: "model",
+							context_length: -1,
+							max_completion_tokens: "not-a-number",
+						},
 					],
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
@@ -35,7 +58,25 @@ describe("Cerebras provider discovery", () => {
 			provider: "cerebras",
 			api: "openai-completions",
 			input: ["text", "image"],
+			contextWindow: 131_072,
+			maxTokens: 40_960,
 		});
-		expect(models?.find(model => model.id === "llama3.1-8b")?.input).toEqual(["text"]);
+		expect(models?.find(model => model.id === "llama3.1-8b")).toMatchObject({
+			input: ["text"],
+			contextWindow: 64_000,
+			maxTokens: 16_000,
+		});
+		expect(models?.find(model => model.id === "cerebras-future")).toMatchObject({
+			provider: "cerebras",
+			api: "openai-completions",
+			contextWindow: 262_144,
+			maxTokens: 65_536,
+		});
+		for (const id of ["cerebras-id-only", "cerebras-invalid-limits"]) {
+			expect(models?.find(model => model.id === id)).toMatchObject({
+				contextWindow: null,
+				maxTokens: null,
+			});
+		}
 	});
 });


### PR DESCRIPTION
## What

Preserve model metadata during discovery:

- Retain catalog thinking controls when discovery omits them, including reasoning-enabled responses and offline cache reloads. Track authored controls separately from builder-derived defaults.
- Read provider-reported context and output limits for IDs that are not in the bundled catalog yet.
- Preserve explicit discovery thinking overrides and existing authoritative reasoning behavior. Do not copy catalog thinking controls across different endpoints or APIs.
- Invalidate pre-fix model-cache rows with schema v13. Offline startup falls back to bundled metadata; online discovery refreshes the cache. Dynamic-only models need a successful refresh after upgrade.

## Why

Newly discovered models can lose usable metadata even when the provider or shared catalog supplies it. An ID-only response currently replaces catalog thinking settings with a generic effort range, while token-limit parsing only runs for already-bundled IDs.

This is a focused discovery-enrichment change. It does not add DeepSeek model entries or compatibility rules, infer capabilities from model names, change refresh behavior, or copy metadata between providers. The DeepSeek release and tool-choice changes remain separate in #11509 and #11506.

## Testing

- `bun --cwd=packages/catalog run check` passed: lint, formatting, and type checks.
- `bun test packages/catalog/test/build.test.ts packages/catalog/test/cerebras-provider.test.ts packages/catalog/test/synthetic-provider.test.ts packages/catalog/test/opencode-provider.test.ts packages/catalog/test/codex-discovery.test.ts packages/catalog/test/compat-collapse.test.ts` passed.
- `bun --cwd=packages/ai run check:types` and `bun --cwd=packages/coding-agent run check:types` passed.
- Before the fix, the new bundled/shared-catalog regression cases failed because the declared `low/high` effort range and default were replaced by a generic range. After the fix, both passed, including explicit live overrides and offline restore.
- A production-API smoke with an injected `/models` response returned unknown limits before the mapper fix and `200000` context / `32000` output afterward. A combined resolver smoke retained those limits plus shared-catalog `low/high` thinking controls after an offline cache reload. No external provider requests were made.
- Covered reasoning-enabled discovery without authored thinking, explicit-control precedence, cache provenance roundtrips, same-fingerprint schema-v12 caches in offline and online-if-uncached modes, endpoint/API isolation, and collapsed variant wire routing. A production resolver smoke retained shared-catalog `low/high` controls with a reasoning-enabled sparse discovery response and after offline restore.
- Local checks reused an existing macOS native addon. No Rust code changed; no native rebuild or workspace-wide suite was run.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
