### PR TITLE
docs: update Windows PowerShell install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Flake consumers can use `packages.<system>.omp`, `overlays.default`, `nixosModul
 **Windows (PowerShell)**
 
 ```powershell
-irm https://omp.sh/install.ps1 | iex
+powershell -c "irm https://omp.sh/install.ps1|iex"
 ```
 
 **Pinned versions (mise)**

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,5 +1,5 @@
 # OMP Coding Agent Installer for Windows
-# Usage: irm https://raw.githubusercontent.com/can1357/oh-my-pi/main/scripts/install.ps1 | iex
+# Usage: powershell -c "https://raw.githubusercontent.com/can1357/oh-my-pi/main/scripts/install.ps1|iex"
 #
 # Or with options:
 #   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/can1357/oh-my-pi/main/scripts/install.ps1))) -Source


### PR DESCRIPTION
## What

Use `powershell -c "irm https://omp.sh/install.ps1|iex"` for Windows PowerShell.

## Why

The command `irm https://omp.sh/install.ps1 | iex` fails in the current session with "Cannot call a method on a null-valued expression". The pipeline execution context in the current session causes `irm` to pass null to `iex`. Using `powershell -c "irm https://omp.sh/install.ps1|iex"` starts a new PowerShell process, which provides a clean execution environment and avoids the issue.

This aligns with the install command style used by Bun.

## Testing

Verified manually on Windows PowerShell: `irm https://omp.sh/install.ps1 | iex` fails, while `powershell -c "irm https://omp.sh/install.ps1|iex"` installs successfully.

Windows 11 25H2 powershell 5.1
<img width="1734" height="927" alt="Windows powershell" src="https://github.com/user-attachments/assets/a2a09956-c1fe-45fd-a2ec-00d38b4d6081" />

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
