### PR TITLE
fix(coding-agent): report wire image support in `omp models`

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -466,6 +466,10 @@ Both surfaces keep provider-prefixed concrete models visible and selectable.
 
 Selecting a provider row stores its explicit `provider/modelId`.
 
+The table's `images` column reports what the transport will actually send, so a model whose images are
+stripped (`compat.stripImageInput`, see [Image handling](#compatibility-and-routing-fields)) shows `no`
+even when its spec declares `input: [text, image]`; `--json` keeps the declared `input`.
+
 ## Context promotion (model-level fallback chains)
 
 Context promotion is an overflow recovery mechanism for small-context variants (for example `*-spark`) that automatically promotes to a larger-context sibling when the API rejects a request with a context length error.
@@ -545,6 +549,15 @@ Request shaping:
 - `supportsImageDetailOriginal` — allow the Responses API's nonstandard `detail: "original"` image
   mode where the endpoint supports it.
 - `extraBody` — extra top-level fields merged into every request body (gateway hints, controller selectors, etc.).
+
+Image handling:
+
+- `stripImageInput` — drop image parts before an `openai-completions` request is encoded. The catalog's
+  class rules set it for model lines that endpoints commonly serve as text-only (e.g. the DeepSeek class),
+  independently of the provider's own `input` declaration, so a model can declare `input: [text, image]`
+  and still send no image. Per-model `compat` is deep-merged over those rules and wins: set
+  `stripImageInput: false` for an id whose endpoint really accepts `image_url` — a vision-augmenting
+  proxy, for example. Default: auto (catalog class and provider rules).
 
 Reasoning / thinking:
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -558,7 +558,9 @@ Image handling:
   and still send no image. Per-model `compat` is deep-merged over those rules and wins: set
   `stripImageInput: false` for an id whose endpoint really accepts `image_url` — a vision-augmenting
   proxy, for example. Default: auto (catalog class and provider rules). The Responses and Anthropic/Google
-  encoders ship the modalities the model declares.
+  encoders ship the modalities the model declares, as does the `pi-native` transport (it forwards the
+  original context to the gateway, so the guard never runs client-side and the `images` column reports
+  the declared `input`).
 
 Reasoning / thinking:
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -552,7 +552,7 @@ Request shaping:
 
 Image handling:
 
-- `stripImageInput` — drop image parts before an `openai-completions` request is encoded. The catalog's
+- `stripImageInput` — drop image parts before an `openai-completions` request is encoded (including the OpenRouter chat fallback, `PI_OPENROUTER_RESPONSES=0`). The catalog's
   class rules set it for model lines that endpoints commonly serve as text-only (e.g. the DeepSeek class),
   independently of the provider's own `input` declaration, so a model can declare `input: [text, image]`
   and still send no image. Per-model `compat` is deep-merged over those rules and wins: set

--- a/docs/models.md
+++ b/docs/models.md
@@ -557,7 +557,8 @@ Image handling:
   independently of the provider's own `input` declaration, so a model can declare `input: [text, image]`
   and still send no image. Per-model `compat` is deep-merged over those rules and wins: set
   `stripImageInput: false` for an id whose endpoint really accepts `image_url` — a vision-augmenting
-  proxy, for example. Default: auto (catalog class and provider rules).
+  proxy, for example. Default: auto (catalog class and provider rules). The Responses and Anthropic/Google
+  encoders ship the modalities the model declares.
 
 Reasoning / thinking:
 

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -45,14 +45,18 @@ export function isOpenAICompletionsVisionSupported(model: Model<"openai-completi
 /**
  * Whether the transport that will carry `model` sends image content on the wire.
  *
- * The OpenAI Chat Completions path applies the text-only guard, as does the
- * OpenRouter chat fallback (`PI_OPENROUTER_RESPONSES=0`, which dispatches
- * `openrouter` models through `streamOpenAICompletions`); every other API
- * ships the modalities the model declares. Callers that report or gate on
- * the wire (for example the `omp models` table) read this predicate; declared
- * capability reads `model.input`.
+ * The `pi-native` transport forwards the original context (images included) to
+ * the gateway, which resolves its own model server-side, so the Chat
+ * Completions guard below never runs client-side and the declared input
+ * applies. Otherwise the OpenAI Chat Completions path applies the text-only
+ * guard, as does the OpenRouter chat fallback (`PI_OPENROUTER_RESPONSES=0`,
+ * which dispatches `openrouter` models through `streamOpenAICompletions`);
+ * every other API ships the modalities the model declares. Callers that report
+ * or gate on the wire (for example the `omp models` table) read this
+ * predicate; declared capability reads `model.input`.
  */
 export function sendsImageInputOnWire(model: Model<Api>): boolean {
+	if (model.transport === "pi-native") return model.input.includes("image");
 	if (isGuardedCompletionsTransport(model)) return isOpenAICompletionsVisionSupported(model);
 	return model.input.includes("image");
 }

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -49,10 +49,10 @@ export function isOpenAICompletionsVisionSupported(model: Model<"openai-completi
  * OpenRouter chat fallback (`PI_OPENROUTER_RESPONSES=0`, which dispatches
  * `openrouter` models through `streamOpenAICompletions`); every other API
  * ships the modalities the model declares. Callers that report or gate on
- * image capability (e.g. the `omp models` table) must read this instead of
- * `model.input` alone, or they advertise support the wire silently strips.
+ * the wire (for example the `omp models` table) read this predicate; declared
+ * capability reads `model.input`.
  */
-export function supportsImageInput(model: Model<Api>): boolean {
+export function sendsImageInputOnWire(model: Model<Api>): boolean {
 	if (isGuardedCompletionsTransport(model)) return isOpenAICompletionsVisionSupported(model);
 	return model.input.includes("image");
 }

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -1,3 +1,4 @@
+import { $env } from "@oh-my-pi/pi-utils";
 import type { Api, ImageContent, Model, TextContent } from "../types";
 
 export const NON_VISION_IMAGE_PLACEHOLDER = "[image omitted: model does not support vision]";
@@ -35,7 +36,7 @@ export function joinTextWithImagePlaceholder(text: string, omittedImages: boolea
  * misconfigured provider descriptors or user model entries (e.g. text-only
  * DashScope Qwen SKUs, DeepSeek models) whose endpoints reject `image_url`.
  */
-export function isOpenAICompletionsVisionSupported(model: Model<"openai-completions">): boolean {
+export function isOpenAICompletionsVisionSupported(model: Model<"openai-completions" | "openrouter">): boolean {
 	if (!model.input.includes("image")) return false;
 	if (model.compat.stripImageInput) return false;
 	return true;
@@ -44,17 +45,20 @@ export function isOpenAICompletionsVisionSupported(model: Model<"openai-completi
 /**
  * Whether the transport that will carry `model` sends image content on the wire.
  *
- * Only the OpenAI Chat Completions path applies the text-only guard; every other
- * API ships the modalities the model declares. Callers that report or gate on
+ * The OpenAI Chat Completions path applies the text-only guard, as does the
+ * OpenRouter chat fallback (`PI_OPENROUTER_RESPONSES=0`, which dispatches
+ * `openrouter` models through `streamOpenAICompletions`); every other API
+ * ships the modalities the model declares. Callers that report or gate on
  * image capability (e.g. the `omp models` table) must read this instead of
  * `model.input` alone, or they advertise support the wire silently strips.
  */
 export function supportsImageInput(model: Model<Api>): boolean {
-	if (!isOpenAICompletionsModel(model)) return model.input.includes("image");
-	return isOpenAICompletionsVisionSupported(model);
+	if (isGuardedCompletionsTransport(model)) return isOpenAICompletionsVisionSupported(model);
+	return model.input.includes("image");
 }
 
-/** Narrows the model union to the one API the text-only guard belongs to. */
-function isOpenAICompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
-	return model.api === "openai-completions";
+/** True for the transports that encode through the Chat Completions guard. */
+function isGuardedCompletionsTransport(model: Model<Api>): model is Model<"openai-completions" | "openrouter"> {
+	if (model.api === "openai-completions") return true;
+	return model.api === "openrouter" && $env.PI_OPENROUTER_RESPONSES === "0";
 }

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -1,4 +1,4 @@
-import type { ImageContent, Model, TextContent } from "../types";
+import type { Api, ImageContent, Model, TextContent } from "../types";
 
 export const NON_VISION_IMAGE_PLACEHOLDER = "[image omitted: model does not support vision]";
 export function partitionVisionContent(
@@ -39,4 +39,22 @@ export function isOpenAICompletionsVisionSupported(model: Model<"openai-completi
 	if (!model.input.includes("image")) return false;
 	if (model.compat.stripImageInput) return false;
 	return true;
+}
+
+/**
+ * Whether the transport that will carry `model` sends image content on the wire.
+ *
+ * Only the OpenAI Chat Completions path applies the text-only guard; every other
+ * API ships the modalities the model declares. Callers that report or gate on
+ * image capability (e.g. the `omp models` table) must read this instead of
+ * `model.input` alone, or they advertise support the wire silently strips.
+ */
+export function supportsImageInput(model: Model<Api>): boolean {
+	if (!isOpenAICompletionsModel(model)) return model.input.includes("image");
+	return isOpenAICompletionsVisionSupported(model);
+}
+
+/** Narrows the model union to the one API the text-only guard belongs to. */
+function isOpenAICompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
+	return model.api === "openai-completions";
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
+- `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -16,7 +16,7 @@ import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import { ConfigError } from "../config/config-file";
+import type { ConfigError } from "../config/config-file";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
 import { discoverAndLoadExtensions, ExtensionRunner, emitSessionShutdownEvent } from "../extensibility/extensions";

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -12,9 +12,11 @@
  * forces the network (`online`).
  */
 import type { Api, Effort, Model } from "@oh-my-pi/pi-ai";
+import { supportsImageInput } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { ConfigError } from "../config/config-file";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
 import { discoverAndLoadExtensions, ExtensionRunner, emitSessionShutdownEvent } from "../extensibility/extensions";
@@ -165,14 +167,23 @@ function boxTable(columns: BoxColumn[], rows: string[][]): string[] {
 	return lines;
 }
 
+/**
+ * The two registry reads the listing performs. Structural so the renderer can be
+ * exercised without booting a full {@link ModelRegistry}.
+ */
+export interface ModelsListingSource {
+	getAvailable(): Model<Api>[];
+	getError(): ConfigError | undefined;
+}
+
 /** `omp models ls`/`find`: provider-grouped listing (one box table per provider). */
-function renderProviderModels(
-	modelRegistry: ModelRegistry,
+export function renderProviderModels(
+	source: ModelsListingSource,
 	action: ModelsAction,
 	pattern: string | undefined,
 	json: boolean,
 ): void {
-	const available = modelRegistry.getAvailable();
+	const available = source.getAvailable();
 	const needle = pattern?.toLowerCase();
 	let filtered = available;
 
@@ -196,7 +207,7 @@ function renderProviderModels(
 		}
 	}
 
-	const configError = modelRegistry.getError();
+	const configError = source.getError();
 
 	if (json) {
 		if (configError) {
@@ -243,7 +254,9 @@ function renderProviderModels(
 			formatLimit(model.contextWindow),
 			formatLimit(model.maxTokens),
 			model.thinking ? getSupportedEfforts(model).join(",") : model.reasoning ? "yes" : "-",
-			model.input.includes("image") ? "yes" : "no",
+			// Wire truth, not the declared `input`: the transport drops image parts for
+			// models the catalog marks text-only (`compat.stripImageInput`, #9697).
+			supportsImageInput(model) ? "yes" : "no",
 		]);
 		for (const line of boxTable(
 			[

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -12,7 +12,7 @@
  * forces the network (`online`).
  */
 import type { Api, Effort, Model } from "@oh-my-pi/pi-ai";
-import { supportsImageInput } from "@oh-my-pi/pi-ai/providers/vision-guard";
+import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -256,7 +256,7 @@ export function renderProviderModels(
 			model.thinking ? getSupportedEfforts(model).join(",") : model.reasoning ? "yes" : "-",
 			// Wire truth, not the declared `input`: the transport drops image parts for
 			// models the catalog marks text-only (`compat.stripImageInput`, #9697).
-			supportsImageInput(model) ? "yes" : "no",
+			sendsImageInputOnWire(model) ? "yes" : "no",
 		]);
 		for (const line of boxTable(
 			[

--- a/packages/coding-agent/test/models-cli-image-support.test.ts
+++ b/packages/coding-agent/test/models-cli-image-support.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import type { Api, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { renderProviderModels } from "@oh-my-pi/pi-coding-agent/cli/models-cli";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function stripAnsi(value: string): string {
+	return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function makeModel(spec: {
+	id: string;
+	api: Api;
+	compat?: ModelSpec["compat"];
+	input?: readonly ("text" | "image")[];
+}) {
+	return buildModel({
+		id: spec.id,
+		name: spec.id,
+		api: spec.api,
+		provider: "myproxy",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: false,
+		input: (spec.input ?? ["text", "image"]) as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		compat: spec.compat,
+	} as ModelSpec);
+}
+
+/** Render one model through `omp models ls` and return its `images` cell. */
+function imagesCell(model: Model<Api>): string {
+	const output: string[] = [];
+	spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+		output.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+		return true;
+	});
+	renderProviderModels({ getAvailable: () => [model], getError: () => undefined }, "ls", undefined, false);
+	vi.restoreAllMocks();
+
+	const row = stripAnsi(output.join(""))
+		.split("\n")
+		.find(line => line.includes(model.id));
+	if (!row) throw new Error(`no listing row rendered for ${model.id}`);
+	const cells = row
+		.split("│")
+		.map(cell => cell.trim())
+		.filter(cell => cell.length > 0);
+	return cells.at(-1) ?? "";
+}
+
+describe("omp models image support column", () => {
+	it("reports wire truth for a DeepSeek-class id served by a proxy that accepts images", () => {
+		// The catalog strips images for the DeepSeek class on any provider, so the
+		// listing must not advertise the declared `input: [text, image]`.
+		expect(imagesCell(makeModel({ id: "deepseek-v4-flash", api: "openai-completions" }))).toBe("no");
+	});
+
+	it("reports images once the model opts out with compat.stripImageInput", () => {
+		expect(
+			imagesCell(
+				makeModel({
+					id: "deepseek-v4-flash",
+					api: "openai-completions",
+					compat: { stripImageInput: false },
+				}),
+			),
+		).toBe("yes");
+	});
+
+	it("keeps the declared modalities on APIs without the text-only guard", () => {
+		expect(imagesCell(makeModel({ id: "claude-sonnet-4-6", api: "anthropic-messages" }))).toBe("yes");
+	});
+
+	it("keeps declared text-only models at no", () => {
+		expect(imagesCell(makeModel({ id: "text-only-model", api: "openai-completions", input: ["text"] }))).toBe("no");
+	});
+});

--- a/packages/coding-agent/test/models-cli-image-support.test.ts
+++ b/packages/coding-agent/test/models-cli-image-support.test.ts
@@ -16,6 +16,7 @@ function makeModel(spec: {
 	api: Api;
 	compat?: ModelSpec["compat"];
 	input?: readonly ("text" | "image")[];
+	transport?: ModelSpec["transport"];
 }) {
 	return buildModel({
 		id: spec.id,
@@ -29,6 +30,7 @@ function makeModel(spec: {
 		contextWindow: 128_000,
 		maxTokens: 8_192,
 		compat: spec.compat,
+		transport: spec.transport,
 	} as ModelSpec);
 }
 
@@ -123,5 +125,20 @@ describe("omp models image support column", () => {
 			if (previous === undefined) delete Bun.env.PI_OPENROUTER_RESPONSES;
 			else Bun.env.PI_OPENROUTER_RESPONSES = previous;
 		}
+	});
+	it("forwards declared images on the pi-native transport despite the strip rule", () => {
+		// pi-native short-circuits to streamPiNative before the Chat Completions
+		// encoder, so compat.stripImageInput never runs client-side.
+		expect(
+			imagesCell(makeModel({ id: "deepseek-v4-flash", api: "openai-completions", transport: "pi-native" })),
+		).toBe("yes");
+	});
+
+	it("keeps declared text-only pi-native models at no", () => {
+		expect(
+			imagesCell(
+				makeModel({ id: "text-only-model", api: "openai-completions", input: ["text"], transport: "pi-native" }),
+			),
+		).toBe("no");
 	});
 });

--- a/packages/coding-agent/test/models-cli-image-support.test.ts
+++ b/packages/coding-agent/test/models-cli-image-support.test.ts
@@ -79,4 +79,49 @@ describe("omp models image support column", () => {
 	it("keeps declared text-only models at no", () => {
 		expect(imagesCell(makeModel({ id: "text-only-model", api: "openai-completions", input: ["text"] }))).toBe("no");
 	});
+
+	it("strips images on the OpenRouter chat fallback", () => {
+		// PI_OPENROUTER_RESPONSES=0 dispatches openrouter models through
+		// streamOpenAICompletions, so the Chat Completions guard applies.
+		const previous = Bun.env.PI_OPENROUTER_RESPONSES;
+		Bun.env.PI_OPENROUTER_RESPONSES = "0";
+		try {
+			expect(imagesCell(makeModel({ id: "deepseek-v4-flash", api: "openrouter" }))).toBe("no");
+		} finally {
+			if (previous === undefined) delete Bun.env.PI_OPENROUTER_RESPONSES;
+			else Bun.env.PI_OPENROUTER_RESPONSES = previous;
+		}
+	});
+
+	it("honours the strip opt-out on the OpenRouter chat fallback", () => {
+		const previous = Bun.env.PI_OPENROUTER_RESPONSES;
+		Bun.env.PI_OPENROUTER_RESPONSES = "0";
+		try {
+			expect(
+				imagesCell(
+					makeModel({
+						id: "deepseek-v4-flash",
+						api: "openrouter",
+						compat: { stripImageInput: false },
+					}),
+				),
+			).toBe("yes");
+		} finally {
+			if (previous === undefined) delete Bun.env.PI_OPENROUTER_RESPONSES;
+			else Bun.env.PI_OPENROUTER_RESPONSES = previous;
+		}
+	});
+
+	it("reports declared input on the OpenRouter Responses path", () => {
+		// The default Responses transport ignores stripImageInput (openai-shared
+		// derives supportsImages from the declared input), so the column must too.
+		const previous = Bun.env.PI_OPENROUTER_RESPONSES;
+		delete Bun.env.PI_OPENROUTER_RESPONSES;
+		try {
+			expect(imagesCell(makeModel({ id: "deepseek-v4-flash", api: "openrouter" }))).toBe("yes");
+		} finally {
+			if (previous === undefined) delete Bun.env.PI_OPENROUTER_RESPONSES;
+			else Bun.env.PI_OPENROUTER_RESPONSES = previous;
+		}
+	});
 });


### PR DESCRIPTION
## What changes

`omp models` reads the wire, not the declaration, for the `images` column.

- `packages/ai/src/providers/vision-guard.ts` exports `sendsImageInputOnWire(model)`. The predicate returns the Chat Completions guard result for the transports that encode through it, and the declared modalities for every other API.
- `packages/coding-agent/src/cli/models-cli.ts` computes the column with that predicate. `renderProviderModels` takes the two registry reads it performs (`ModelsListingSource`), so the table renders without a registry.
- `docs/models.md` documents `stripImageInput`: the default from the catalog class rules, the per-model opt-out, and the encoders that read it.
- `packages/coding-agent/CHANGELOG.md` gains one `[Unreleased] → Fixed` entry.

Request payloads do not change. The change lands in the listing column, the docs, and one exported predicate.

## Why

`renderProviderModels` computed the column from `model.input`. That field states the modality a spec declares, not the modality the encoder sends. The Chat Completions encoder replaces image parts with `[image omitted: model does not support vision]` when the catalog marks the model text-only: `compat.stripImageInput`, which the DeepSeek class rule sets for every provider, or `input` without `image`. The table advertised image support the wire stripped.

Only the Chat Completions encoder reads the guard. `streamSimple` dispatches `openrouter` models through it when `PI_OPENROUTER_RESPONSES=0`, and the predicate mirrors that route.

Continues the follow-ups in #9697.

## Workaround we run today

Our gateway serves `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` under the id `deepseek-v4-flash`. The id matches the DeepSeek class rule, so the catalog strips its images on Chat Completions. Two configurations work:

1. Keep the provider on the Responses route. That encoder never applies the guard, and the request carries `input_image`.
2. Stay on Chat Completions and opt out per model — the option this PR documents:

```yaml
providers:
  nan:
    api: openai-completions
    models:
      - id: deepseek-v4-flash
    modelOverrides:
      deepseek-v4-flash:
        input: [text, image]
        compat:
          stripImageInput: false
```

Both payloads were checked against the real encoders on this branch: the opt-out carries `image_url`, the default carries the placeholder.

not-covered: how the gateway or the served model treats the image parts.

## Verify

```
bun test packages/coding-agent/test/models-cli-image-support.test.ts packages/ai/test/issue-967-vision-guard.test.ts
bun run check:tools
```

Both commands pass on this branch (12 tests, 0 fail). `tsgo -p` passes for `packages/ai` and `packages/coding-agent`.

## Follow-up

The guard is a wire rule, and the app-level gates still read `model.input`. `session-provider-boundary.buildImageDescriptionNotice()` (`packages/coding-agent/src/session/session-provider-boundary.ts:231`) never fires the `images.describeForTextModels` fallback for a stripped model, so an attached image becomes a placeholder instead of a description. Adopting `sendsImageInputOnWire()` there is a behaviour change and belongs in its own PR.
