### PR TITLE
feat(extensions): add assistant text decorators

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -114,7 +114,7 @@ Core methods:
 
 - `on(event, handler)`
 - `registerTool`, `registerCommand`, `registerShortcut`, `registerFlag`
-- `registerMessageRenderer`, `registerAssistantThinkingRenderer`
+- `registerMessageRenderer`, `registerAssistantThinkingRenderer`, `registerAssistantTextDecorator`
 - `registerComposerShape`
 - `setLabel`, `getFlag`
 - `sendMessage`, `sendUserMessage`, `appendEntry`, `exec`
@@ -724,6 +724,20 @@ pi.registerAssistantThinkingRenderer((context, theme) => {
 ```
 
 Used by interactive rendering to add display-only supplemental UI below each visible assistant thinking block. The renderer receives the already-visible thinking text, content/thinking indexes, theme, and a `requestRender()` callback for async renderers. All registered renderers that return a component are appended in registration order. Renderers must not mutate messages; the original thinking block remains the provider/session source of truth.
+
+## Assistant prose decorator
+
+`registerAssistantTextDecorator` changes only how assistant prose is painted in the TUI. Stored messages and model context remain untouched. Decorators receive plain Markdown text tokens, so inline code and fenced code blocks retain their original rendering.
+
+```ts
+pi.registerAssistantTextDecorator({
+  decorate(text, { transient }, theme) {
+    return transient ? text : theme.bold(text);
+  },
+});
+```
+
+Decorators may expose `onDidChange(listener)` when their presentation state changes at runtime. Mounted assistant messages subscribe to that signal and repaint without rewriting session history.
 
 ## Tool call/result renderer
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -731,13 +731,15 @@ Used by interactive rendering to add display-only supplemental UI below each vis
 
 ```ts
 pi.registerAssistantTextDecorator({
-  decorate(text, { transient }, theme) {
+  decorate(text, { contentIndex, transient }, theme) {
     return transient ? text : theme.bold(text);
   },
 });
 ```
 
-Decorators may expose `onDidChange(listener)` when their presentation state changes at runtime. Mounted assistant messages subscribe to that signal and repaint without rewriting session history.
+The `text` argument is always plain prose — no escape sequences, even in the live transcript where assistant text is painted in a session color; that color is applied to whatever the decorator returns. Tabs in the returned string are normalized to spaces before layout. `contentIndex` is the block's index in the assistant message's `content` array and stays stable when a turn's text is split around tool calls. A decorator that throws is skipped and its block renders as the model wrote it.
+
+Decorators may expose `onDidChange(listener)` when their presentation state changes at runtime. Mounted assistant messages subscribe to that signal and repaint without rewriting session history; a subscription that throws only costs that decorator its repaints.
 
 ## Tool call/result renderer
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Extensions can register `registerAssistantTextDecorator` to restyle assistant prose in the transcript — display only, leaving the stored message, model context, and code blocks untouched.
 - Added `tui.vimMode`, an opt-in modal editing layer for the prompt, off by default ([#3299](https://github.com/can1357/oh-my-pi/issues/3299)). Escape leaves Insert; Normal mode has `hjkl`, `0`, `^`, `$`, `w`, `b`, `e`, `gg`, `G`, count prefixes, `x`/`D`/`C`, `dd`/`yy`, `p`/`P` and `u`; `v`/`V` start a Visual selection that `y` copies and `d` deletes.
 - Added a `vim` status-line segment showing the current Vim mode (`NORMAL`/`INSERT`/`VISUAL`/`V-LINE`), the half-typed command beside it (Vim's `showcmd`, e.g. `2d`), and the Visual selection height (`V-LINE 4L`). Included in every built-in preset and hidden entirely unless `tui.vimMode` is on; `custom` preset users can add `"vim"` to `statusLine.leftSegments`.
 - The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -37,6 +37,7 @@ import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath, withHostGuard } from "../utils";
 import type {
 	AssistantThinkingRenderer,
+	AssistantTextDecorator,
 	ComposerShapeDefinition,
 	Extension,
 	ExtensionAPI,
@@ -237,6 +238,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		this.extension.assistantThinkingRenderers.push(renderer);
 	}
 
+	registerAssistantTextDecorator(decorator: AssistantTextDecorator): void {
+		this.extension.assistantTextDecorators.push(decorator);
+	}
+
 	registerComposerShape(definition: ComposerShapeDefinition): void {
 		const id = definition.style.id;
 		if (id.length === 0 || id !== id.trim()) {
@@ -345,6 +350,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		tools: new Map(),
 		toolRegistrationListeners: new Set(),
 		assistantThinkingRenderers: [],
+		assistantTextDecorators: [],
 		fileWriteFallbackHandlers: [],
 		fileDeleteFallbackHandlers: [],
 		messageRenderers: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -25,6 +25,7 @@ import { ManagedTimers } from "./managed-timers";
 import { createExtensionModelQuery } from "./model-api";
 import type {
 	AfterProviderResponseEvent,
+	AssistantTextDecorator,
 	AssistantThinkingRenderer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
@@ -1097,6 +1098,10 @@ export class ExtensionRunner {
 
 	getAssistantThinkingRenderers(): AssistantThinkingRenderer[] {
 		return this.extensions.flatMap(ext => ext.assistantThinkingRenderers);
+	}
+
+	getAssistantTextDecorators(): AssistantTextDecorator[] {
+		return this.extensions.flatMap(ext => ext.assistantTextDecorators);
 	}
 
 	getRegisteredCommands(reserved?: ReadonlySet<string>): RegisteredCommand[] {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1174,6 +1174,24 @@ export type MessageRenderer<T = unknown> = (
 	theme: Theme,
 ) => Component | undefined;
 
+export interface AssistantTextDecoratorContext {
+	/** Index of the text content block in the assistant message. */
+	contentIndex: number;
+	/** Whether the message is still streaming. */
+	transient: boolean;
+}
+
+/**
+ * Decorates rendered assistant prose without modifying the stored message.
+ * The callback receives plain text tokens only; Markdown code spans and fenced
+ * code blocks keep their original rendering.
+ */
+export interface AssistantTextDecorator {
+	decorate(text: string, context: AssistantTextDecoratorContext, theme: Theme): string;
+	/** Notify mounted transcript components when decorator state changes. */
+	onDidChange?(listener: () => void): () => void;
+}
+
 export interface AssistantThinkingRenderContext {
 	contentIndex: number;
 	thinkingIndex: number;
@@ -1411,6 +1429,9 @@ export interface ExtensionAPI {
 
 	/** Register a renderer for assistant thinking blocks. Rendered after the original thinking text. */
 	registerAssistantThinkingRenderer(renderer: AssistantThinkingRenderer): void;
+
+	/** Register a presentation-only decorator for assistant prose text tokens. */
+	registerAssistantTextDecorator(decorator: AssistantTextDecorator): void;
 
 	/**
 	 * Register a composer shape for the interactive editor.
@@ -1762,6 +1783,7 @@ export interface Extension {
 	tools: Map<string, RegisteredTool<any, any>>;
 	toolRegistrationListeners?: Set<ToolRegistrationListener>;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
+	assistantTextDecorators: AssistantTextDecorator[];
 	fileWriteFallbackHandlers: FileWriteFallbackHandler[];
 	fileDeleteFallbackHandlers: FileDeleteFallbackHandler[];
 	messageRenderers: Map<string, MessageRenderer>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1175,7 +1175,12 @@ export type MessageRenderer<T = unknown> = (
 ) => Component | undefined;
 
 export interface AssistantTextDecoratorContext {
-	/** Index of the text content block in the assistant message. */
+	/**
+	 * Index of the text block in the assistant message's `content` array. Stable
+	 * across the turn: a turn whose text is split around tool calls still reports
+	 * each block's index in the original message, not its position within the
+	 * rendered segment.
+	 */
 	contentIndex: number;
 	/** Whether the message is still streaming. */
 	transient: boolean;
@@ -1187,8 +1192,21 @@ export interface AssistantTextDecoratorContext {
  * code blocks keep their original rendering.
  */
 export interface AssistantTextDecorator {
+	/**
+	 * Return the presentation form of one prose token.
+	 *
+	 * `text` is the author's text: never a code span or fenced block, and free of
+	 * escape sequences even when the transcript paints assistant prose in a color
+	 * — that paint is layered onto the returned string afterwards. Tabs in the
+	 * result are normalized to spaces before layout. A throwing decorator is
+	 * skipped and the original prose renders unchanged.
+	 */
 	decorate(text: string, context: AssistantTextDecoratorContext, theme: Theme): string;
-	/** Notify mounted transcript components when decorator state changes. */
+	/**
+	 * Notify mounted transcript components when decorator state changes.
+	 * Returns an unsubscribe function. Subscription failures are isolated: a
+	 * throwing implementation only forfeits repaints for its own decorator.
+	 */
 	onDidChange?(listener: () => void): () => void;
 }
 

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -35,7 +35,7 @@ import {
 } from "../../activity";
 import type { KeyId } from "../../config/keybindings";
 import type { Settings } from "../../config/settings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextDecorator, MessageRenderer } from "../../extensibility/extensions/types";
 import { IrcBus } from "../../irc/bus";
 import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry, type AgentStatus, MAIN_AGENT_ID } from "../../registry/agent-registry";
@@ -167,6 +167,7 @@ export interface AgentHubDeps {
 	isBuiltInTool?: (name: string) => boolean;
 	/** Extension message renderers for custom messages in the transcript. */
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextDecorators?: () => readonly AssistantTextDecorator[];
 	/** Cwd used by tool renderers for path shortening; defaults to the project dir. */
 	cwd?: string;
 	/** Mirrors the main transcript's thinking-block visibility. */
@@ -272,6 +273,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#getTool: ((name: string) => AgentTool | undefined) | undefined;
 	#isBuiltInTool: ((name: string) => boolean) | undefined;
 	#getMessageRenderer: ((customType: string) => MessageRenderer | undefined) | undefined;
+	#getAssistantTextDecorators: (() => readonly AssistantTextDecorator[]) | undefined;
 	#cwd: string;
 	#hideThinkingBlock: (() => boolean) | undefined;
 	#proseOnlyThinking: (() => boolean) | undefined;
@@ -308,6 +310,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#getTool = deps.getTool;
 		this.#isBuiltInTool = deps.isBuiltInTool;
 		this.#getMessageRenderer = deps.getMessageRenderer;
+		this.#getAssistantTextDecorators = deps.getAssistantTextDecorators;
 		this.#cwd = deps.cwd ?? getProjectDir();
 		this.#hideThinkingBlock = deps.hideThinkingBlock;
 		this.#proseOnlyThinking = deps.proseOnlyThinking;
@@ -454,6 +457,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			getTool: this.#getTool,
 			isBuiltInTool: this.#isBuiltInTool,
 			getMessageRenderer: this.#getMessageRenderer,
+			getAssistantTextDecorators: this.#getAssistantTextDecorators,
 			cwd: this.#cwd,
 			hideThinkingBlock: this.#hideThinkingBlock,
 			proseOnlyThinking: this.#proseOnlyThinking,

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -18,7 +18,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { type Component, Editor, matchesKey, routeSgrMouseInput, ScrollView, type TUI } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextDecorator, MessageRenderer } from "../../extensibility/extensions/types";
 import type { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import type { AgentRegistry, AgentStatus } from "../../registry/agent-registry";
 import type { FileEntry, SessionMessageEntry } from "../../session/session-entries";
@@ -48,6 +48,7 @@ export interface AgentTranscriptViewerDeps {
 	/** Whether the active registry entry came from a built-in factory. */
 	isBuiltInTool?: (name: string) => boolean;
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextDecorators?: () => readonly AssistantTextDecorator[];
 	cwd: string;
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
@@ -169,6 +170,7 @@ export class AgentTranscriptViewer implements Component {
 			getTool: deps.getTool,
 			isBuiltInTool: deps.isBuiltInTool,
 			getMessageRenderer: deps.getMessageRenderer,
+			getAssistantTextDecorators: deps.getAssistantTextDecorators,
 			cwd: deps.cwd,
 			hideThinkingBlock: deps.hideThinkingBlock,
 			proseOnlyThinking: deps.proseOnlyThinking,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -13,7 +13,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextDecorator, AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { resolveImageOptions } from "../../tools/render-utils";
 import { WidthAwareText } from "../../tui";
@@ -261,6 +261,7 @@ export class AssistantMessageComponent extends Container {
 
 	#textColorTransform?: (text: string) => string;
 	#linkTargets: ReadonlyMap<string, string> = EMPTY_LINK_TARGETS;
+	#decoratorUnsubscribers: Array<() => void> = [];
 	#markdownTheme: MarkdownTheme | undefined;
 	/** Block this reply reacts to; undefined when the preceding block takes no reactions. */
 	#reactionTarget: ReactionTarget | undefined;
@@ -269,6 +270,18 @@ export class AssistantMessageComponent extends Container {
 
 	setTextColorTransform(transform?: (text: string) => string): void {
 		this.#textColorTransform = transform;
+	}
+
+	#decorateText(text: string, contentIndex: number): string {
+		let decorated = text;
+		for (const decorator of this.textDecorators) {
+			try {
+				decorated = decorator.decorate(decorated, { contentIndex, transient: this.#lastUpdateTransient }, theme);
+			} catch {
+				// A presentation extension must never hide the original assistant prose.
+			}
+		}
+		return decorated;
 	}
 
 	#getProseTheme(): MarkdownTheme {
@@ -369,10 +382,20 @@ export class AssistantMessageComponent extends Container {
 		private readonly imageBudget?: ImageBudget,
 		private proseOnlyThinking = true,
 		linkTargets?: ReadonlyMap<string, string>,
+		private readonly textDecorators: readonly AssistantTextDecorator[] = [],
 	) {
 		super();
 		this.#transcriptBlockFinalized = message !== undefined;
 		if (linkTargets?.size) this.#linkTargets = linkTargets;
+		for (const decorator of this.textDecorators) {
+			const unsubscribe = decorator.onDidChange?.(() => {
+				this.#fastPathKey = undefined;
+				this.#fastPathItems = undefined;
+				if (this.#lastMessage) this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+				this.onImageUpdate?.();
+			});
+			if (unsubscribe) this.#decoratorUnsubscribers.push(unsubscribe);
+		}
 
 		// Container for text/thinking content.
 		this.#contentContainer = new Container();
@@ -426,6 +449,8 @@ export class AssistantMessageComponent extends Container {
 
 	override dispose(): void {
 		this.#stopThinkingAnimation();
+		for (const unsubscribe of this.#decoratorUnsubscribers) unsubscribe();
+		this.#decoratorUnsubscribers = [];
 		super.dispose();
 	}
 
@@ -1038,7 +1063,12 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
-				const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
+				const decorate = (text: string) => {
+					const colored = this.#textColorTransform ? this.#textColorTransform(text) : text;
+					return this.#decorateText(colored, i);
+				};
+				const mdOptions =
+					this.#textColorTransform || this.textDecorators.length > 0 ? { color: decorate } : undefined;
 				const md = new Markdown(trimmed, 1, 0, this.#getProseTheme(), mdOptions, 0);
 				this.#contentContainer.addChild(md);
 				this.#emergencyText = md;

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-a
 import {
 	type Component,
 	Container,
+	type DefaultTextStyle,
 	Image,
 	type ImageBudget,
 	ImageProtocol,
@@ -262,6 +263,9 @@ export class AssistantMessageComponent extends Container {
 	#textColorTransform?: (text: string) => string;
 	#linkTargets: ReadonlyMap<string, string> = EMPTY_LINK_TARGETS;
 	#decoratorUnsubscribers: Array<() => void> = [];
+	/** Streaming state the mounted Markdown children were built for; decorators
+	 *  read it through {@link AssistantTextDecoratorContext.transient}. */
+	#decoratedTransient = false;
 	#markdownTheme: MarkdownTheme | undefined;
 	/** Block this reply reacts to; undefined when the preceding block takes no reactions. */
 	#reactionTarget: ReactionTarget | undefined;
@@ -272,6 +276,11 @@ export class AssistantMessageComponent extends Container {
 		this.#textColorTransform = transform;
 	}
 
+	/**
+	 * Compose the registered decorators over one plain prose token. Called from
+	 * Markdown's text-token seam, so `text` is the author's prose: no SGR runs,
+	 * no style sentinel, never a code span or fenced block.
+	 */
 	#decorateText(text: string, contentIndex: number): string {
 		let decorated = text;
 		for (const decorator of this.textDecorators) {
@@ -383,18 +392,31 @@ export class AssistantMessageComponent extends Container {
 		private proseOnlyThinking = true,
 		linkTargets?: ReadonlyMap<string, string>,
 		private readonly textDecorators: readonly AssistantTextDecorator[] = [],
+		/**
+		 * Index in the *original* assistant message of this component's first
+		 * content block. Post-tool timeline segments carry a fresh content array,
+		 * so without this the decorator context would report a segment-local index.
+		 */
+		private readonly contentIndexOffset = 0,
 	) {
 		super();
 		this.#transcriptBlockFinalized = message !== undefined;
 		if (linkTargets?.size) this.#linkTargets = linkTargets;
 		for (const decorator of this.textDecorators) {
-			const unsubscribe = decorator.onDidChange?.(() => {
-				this.#fastPathKey = undefined;
-				this.#fastPathItems = undefined;
-				if (this.#lastMessage) this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
-				this.onImageUpdate?.();
-			});
-			if (unsubscribe) this.#decoratorUnsubscribers.push(unsubscribe);
+			// Subscribing is extension code like decorate() is, and it runs during
+			// transcript construction: an unguarded throw here would take down every
+			// assistant message instead of just this decorator's repaint signal.
+			try {
+				const unsubscribe = decorator.onDidChange?.(() => {
+					this.#fastPathKey = undefined;
+					this.#fastPathItems = undefined;
+					if (this.#lastMessage) this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+					this.onImageUpdate?.();
+				});
+				if (unsubscribe) this.#decoratorUnsubscribers.push(unsubscribe);
+			} catch {
+				// Decoration stays live; only this decorator loses runtime repaints.
+			}
 		}
 
 		// Container for text/thinking content.
@@ -449,7 +471,15 @@ export class AssistantMessageComponent extends Container {
 
 	override dispose(): void {
 		this.#stopThinkingAnimation();
-		for (const unsubscribe of this.#decoratorUnsubscribers) unsubscribe();
+		for (const unsubscribe of this.#decoratorUnsubscribers) {
+			// One throwing unsubscriber must not strand the rest, nor skip the
+			// base dispose that releases this component's render resources.
+			try {
+				unsubscribe();
+			} catch {
+				// Best-effort cleanup; the component is going away regardless.
+			}
+		}
 		this.#decoratorUnsubscribers = [];
 		super.dispose();
 	}
@@ -946,6 +976,15 @@ export class AssistantMessageComponent extends Container {
 			return false;
 		}
 		const transient = opts?.transient === true;
+		// Decorators may present streaming prose differently from settled prose
+		// (the documented `transient ? … : …` pattern). Reused Markdown children
+		// only repaint the block whose source text changed, so every earlier block
+		// would keep its streaming look once the turn settles. Rebuild instead.
+		if (this.textDecorators.length > 0 && transient !== this.#decoratedTransient) {
+			this.#fastPathKey = undefined;
+			this.#fastPathItems = undefined;
+			return false;
+		}
 		// Shape is identical — setText only on Markdown children whose source changed.
 		this.#applyItemTransience(transient);
 		for (let i = 0; i < this.#fastPathItems.length; i++) {
@@ -1034,6 +1073,9 @@ export class AssistantMessageComponent extends Container {
 		// Fast path: reuse Markdown children when shape is stable during streaming
 		if (this.#tryFastPathUpdate(message, opts)) return;
 
+		// Children rebuilt below decorate against the current streaming state.
+		this.#decoratedTransient = this.#lastUpdateTransient;
+
 		// Clear content container
 		this.#contentContainer.clear();
 		this.#emergencyText = undefined;
@@ -1063,12 +1105,20 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
-				const decorate = (text: string) => {
-					const colored = this.#textColorTransform ? this.#textColorTransform(text) : text;
-					return this.#decorateText(colored, i);
-				};
-				const mdOptions =
-					this.#textColorTransform || this.textDecorators.length > 0 ? { color: decorate } : undefined;
+				// Decoration runs on Markdown's prose-token seam, ahead of the color
+				// hook: a decorator sees the author's words, and the live transcript's
+				// SGR transform paints whatever it returns.
+				const contentIndex = this.contentIndexOffset + i;
+				const mdOptions: DefaultTextStyle | undefined =
+					this.#textColorTransform || this.textDecorators.length > 0
+						? {
+								color: this.#textColorTransform,
+								transformText:
+									this.textDecorators.length > 0
+										? (text: string) => this.#decorateText(text, contentIndex)
+										: undefined,
+							}
+						: undefined;
 				const md = new Markdown(trimmed, 1, 0, this.#getProseTheme(), mdOptions, 0);
 				this.#contentContainer.addChild(md);
 				this.#emergencyText = md;

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -17,7 +17,7 @@ import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
 import { settings } from "../../config/settings";
-import type { MessageRenderer } from "../../extensibility/extensions/types";
+import type { AssistantTextDecorator, MessageRenderer } from "../../extensibility/extensions/types";
 import { LAUNCH_COMPLETION_MESSAGE_TYPE } from "../../session/launch-completion";
 import {
 	BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE,
@@ -67,6 +67,7 @@ export interface ChatTranscriptBuilderDeps {
 	/** Whether the active registry entry came from a built-in factory. */
 	isBuiltInTool?: (name: string) => boolean;
 	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getAssistantTextDecorators?: () => readonly AssistantTextDecorator[];
 	cwd: string;
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
@@ -385,6 +386,7 @@ export class ChatTranscriptBuilder {
 			this.deps.ui.imageBudget,
 			proseOnlyThinking,
 			this.deps.linkTargets,
+			this.deps.getAssistantTextDecorators?.(),
 		);
 		assistantComponent.setImagesVisible(settings.get("terminal.showImages"));
 		assistantComponent.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));
@@ -420,6 +422,7 @@ export class ChatTranscriptBuilder {
 				undefined,
 				proseOnlyThinking,
 				this.deps.linkTargets,
+				this.deps.getAssistantTextDecorators?.(),
 			);
 			component.setImagesVisible(settings.get("terminal.showImages"));
 			component.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -32,6 +32,7 @@ import { theme } from "../theme/theme";
 import {
 	assistantHasVisibleContent,
 	assistantUsageIsBilled,
+	type AssistantToolTimelineSegment,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -412,10 +413,10 @@ export class ChatTranscriptBuilder {
 		const errorPresentation = resolveAssistantErrorPresentation(message);
 		const hasErrorStop = errorPresentation.kind === "full";
 		const errorMessage = hasErrorStop ? errorPresentation.text : null;
-		const appendAssistantSegment = (segment: Extract<AgentMessage, { role: "assistant" }> | undefined) => {
-			if (!segment || !assistantHasVisibleContent(segment)) return;
+		const appendAssistantSegment = (segment: AssistantToolTimelineSegment | undefined) => {
+			if (!segment || !assistantHasVisibleContent(segment.message)) return;
 			const component = new AssistantMessageComponent(
-				segment,
+				segment.message,
 				hideThinkingBlock,
 				() => this.deps.requestRender(),
 				this.deps.getMessageRenderer ? undefined : [],
@@ -423,6 +424,7 @@ export class ChatTranscriptBuilder {
 				proseOnlyThinking,
 				this.deps.linkTargets,
 				this.deps.getAssistantTextDecorators?.(),
+				segment.contentOffset,
 			);
 			component.setImagesVisible(settings.get("terminal.showImages"));
 			component.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -48,6 +48,7 @@ import {
 } from "../utils/interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
+	type AssistantToolTimelineSegment,
 	assistantUsageIsBilled,
 	splitAssistantMessageToolTimeline,
 } from "../utils/transcript-render-helpers";
@@ -549,18 +550,18 @@ export class EventController {
 
 	#upsertPostToolAssistantSegment(
 		toolCallId: string,
-		segment: AssistantMessage | undefined,
+		segment: AssistantToolTimelineSegment | undefined,
 		linkTargets?: ReadonlyMap<string, string>,
 	): AssistantMessageComponent | undefined {
-		if (!segment || !assistantHasVisibleContent(segment)) return undefined;
+		if (!segment || !assistantHasVisibleContent(segment.message)) return undefined;
 		const existing = this.#postToolAssistantComponents.get(toolCallId);
 		if (existing) {
 			if (linkTargets) existing.setLinkTargets(linkTargets);
-			existing.updateContent(segment);
+			existing.updateContent(segment.message);
 			return existing;
 		}
-		const component = createAssistantMessageComponent(this.ctx, undefined, linkTargets);
-		component.updateContent(segment);
+		const component = createAssistantMessageComponent(this.ctx, undefined, linkTargets, segment.contentOffset);
+		component.updateContent(segment.message);
 		this.#postToolAssistantComponents.set(toolCallId, component);
 		if (!this.#insertAfterTranscriptComponent(this.#toolTimelineComponents.get(toolCallId), component)) {
 			this.ctx.chatContainer.addChild(component);
@@ -1476,7 +1477,7 @@ export class EventController {
 				const component = this.#upsertPostToolAssistantSegment(
 					toolCallId,
 					segment,
-					assistantMessageLinkTargets(segment, linkTargets),
+					assistantMessageLinkTargets(segment.message, linkTargets),
 				);
 				component?.markTranscriptBlockFinalized();
 				if (component) lastPostToolAssistantComponent = component;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2371,6 +2371,7 @@ export class SelectorController {
 			getTool: name => this.ctx.session.getToolByName(name),
 			isBuiltInTool: name => this.ctx.session.hasBuiltInTool(name),
 			getMessageRenderer: type => this.ctx.session.extensionRunner?.getMessageRenderer(type),
+			getAssistantTextDecorators: () => this.ctx.session.extensionRunner?.getAssistantTextDecorators() ?? [],
 			cwd: this.ctx.sessionManager.getCwd(),
 			hideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			proseOnlyThinking: () => this.ctx.proseOnlyThinking,

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -95,12 +95,15 @@ export function assistantMessageLinkTargets(
 /**
  * Construct an {@link AssistantMessageComponent} wired to the live context's
  * thinking/image settings. `message` is omitted for the streaming placeholder
- * component and supplied when rendering a persisted turn.
+ * component and supplied when rendering a persisted turn. `contentIndexOffset`
+ * rebases extension-facing content indexes when `message` is a post-tool
+ * timeline segment rather than a whole turn.
  */
 export function createAssistantMessageComponent(
 	ctx: InteractiveModeContext,
 	message?: AssistantMessage,
 	linkTargets: ReadonlyMap<string, string> = getAssistantMessageLinkTargets(ctx),
+	contentIndexOffset = 0,
 ): AssistantMessageComponent {
 	const component = new AssistantMessageComponent(
 		message,
@@ -111,6 +114,7 @@ export function createAssistantMessageComponent(
 		ctx.proseOnlyThinking,
 		linkTargets,
 		ctx.viewSession.extensionRunner?.getAssistantTextDecorators(),
+		contentIndexOffset,
 	);
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
 	component.setToolResultImagesVisible(!ctx.hideToolActivity);

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -110,6 +110,7 @@ export function createAssistantMessageComponent(
 		ctx.ui.imageBudget,
 		ctx.proseOnlyThinking,
 		linkTargets,
+		ctx.viewSession.extensionRunner?.getAssistantTextDecorators(),
 	);
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
 	component.setToolResultImagesVisible(!ctx.hideToolActivity);

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -186,6 +186,19 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
 }
 
 /**
+ * A post-tool slice of an assistant turn, plus where it began in the original
+ * message. Extension-facing content indexes are reported against the original
+ * message, so a rebased segment must carry its offset rather than let consumers
+ * assume the segment-local loop index.
+ */
+export interface AssistantToolTimelineSegment {
+	/** Display-only message holding just this segment's content blocks. */
+	message: AssistantAgentMessage;
+	/** Index of this segment's first block in the original message's content. */
+	contentOffset: number;
+}
+
+/**
  * Split mixed assistant turns into visible text before tool execution and
  * visible text segments that must render immediately after the preceding tool.
  * Cursor can return intro text, tool calls, progress text, and the final answer
@@ -194,12 +207,13 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
  */
 export function splitAssistantMessageToolTimeline(message: AssistantAgentMessage): {
 	beforeTools: AssistantAgentMessage;
-	afterToolCalls: ReadonlyMap<string, AssistantAgentMessage>;
+	afterToolCalls: ReadonlyMap<string, AssistantToolTimelineSegment>;
 	hasToolCalls: boolean;
 } {
 	const beforeTools: AssistantAgentMessage["content"] = [];
-	const afterToolCalls = new Map<string, AssistantAgentMessage>();
+	const afterToolCalls = new Map<string, AssistantToolTimelineSegment>();
 	let pendingAfterTool: AssistantAgentMessage["content"] = [];
+	let pendingContentOffset = 0;
 	let lastToolCallId: string | undefined;
 	let sawToolCall = false;
 
@@ -213,11 +227,15 @@ export function splitAssistantMessageToolTimeline(message: AssistantAgentMessage
 
 	const flushPendingAfterTool = () => {
 		if (!lastToolCallId || pendingAfterTool.length === 0) return;
-		afterToolCalls.set(lastToolCallId, displaySegment(pendingAfterTool));
+		afterToolCalls.set(lastToolCallId, {
+			message: displaySegment(pendingAfterTool),
+			contentOffset: pendingContentOffset,
+		});
 		pendingAfterTool = [];
 	};
 
-	for (const content of message.content) {
+	for (let index = 0; index < message.content.length; index++) {
+		const content = message.content[index]!;
 		if (content.type === "toolCall") {
 			flushPendingAfterTool();
 			sawToolCall = true;
@@ -225,6 +243,10 @@ export function splitAssistantMessageToolTimeline(message: AssistantAgentMessage
 			continue;
 		}
 		if (sawToolCall) {
+			// Segments are contiguous runs of the original array (only toolCall
+			// blocks are dropped, and one always ends the preceding run), so the
+			// first block's index rebases the whole segment.
+			if (pendingAfterTool.length === 0) pendingContentOffset = index;
 			pendingAfterTool.push(content);
 		} else {
 			beforeTools.push(content);

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -65,6 +65,7 @@ import {
 import {
 	assistantHasVisibleContent,
 	assistantUsageIsBilled,
+	type AssistantToolTimelineSegment,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -517,12 +518,13 @@ export class UiHelpers {
 				const errorPresentation = resolveAssistantErrorPresentation(message, this.ctx.viewSession.retryAttempt);
 				const hasErrorStop = errorPresentation.kind === "full";
 				const errorMessage = hasErrorStop ? errorPresentation.text : null;
-				const appendAssistantSegment = (segment: AssistantMessage | undefined) => {
-					if (!segment || !assistantHasVisibleContent(segment)) return;
+				const appendAssistantSegment = (segment: AssistantToolTimelineSegment | undefined) => {
+					if (!segment || !assistantHasVisibleContent(segment.message)) return;
 					const component = createAssistantMessageComponent(
 						this.ctx,
-						segment,
+						segment.message,
 						getAssistantMessageLinkTargets(this.ctx),
+						segment.contentOffset,
 					);
 					this.ctx.chatContainer.addChild(component);
 				};

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -535,6 +535,26 @@ describe("ExtensionRunner", () => {
 
 			expect(runner.getAssistantThinkingRenderers().length).toBe(1);
 		});
+
+		it("collects assistant text decorators", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerAssistantTextDecorator({ decorate: text => text });
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "text-decorator.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			expect(runner.getAssistantTextDecorators()).toHaveLength(1);
+		});
 	});
 
 	describe("composer shapes", () => {
@@ -3925,6 +3945,7 @@ describe("ExtensionRunner", () => {
 				handlers: new Map([["input", [async (...args: unknown[]) => handler(args[0] as InputEvent)]]]),
 				tools: new Map(),
 				assistantThinkingRenderers: [],
+				assistantTextDecorators: [],
 				fileWriteFallbackHandlers: [],
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
@@ -97,6 +97,32 @@ describe("AssistantMessageComponent streaming fast path", () => {
 		}
 	});
 
+	it("decorates prose tokens without changing code spans or stored text", () => {
+		const listeners = new Set<() => void>();
+		let enabled = true;
+		const message = msg([{ type: "text", text: "read `const value = 1` safely" }]);
+		const component = new AssistantMessageComponent(message, false, undefined, [], undefined, true, undefined, [
+			{
+				decorate: (text, _context, theme) => (enabled ? theme.bold(text.toUpperCase()) : text),
+				onDidChange(listener) {
+					listeners.add(listener);
+					return () => listeners.delete(listener);
+				},
+			},
+		]);
+
+		const decorated = Bun.stripANSI(component.render(W).join("\n"));
+		expect(decorated).toContain("READ");
+		expect(decorated).toContain("const value = 1");
+		expect(message.content[0]).toEqual({ type: "text", text: "read `const value = 1` safely" });
+
+		enabled = false;
+		for (const listener of listeners) listener();
+		expect(Bun.stripANSI(component.render(W).join("\n"))).toContain("read");
+		component.dispose();
+		expect(listeners.size).toBe(0);
+	});
+
 	it("repairs Gemini's lone closing fence when the streamed turn becomes final", () => {
 		const text = `=== PACED IP ROTATION SOAK RESULTS ===
 Average Latency: 1,240 ms

--- a/packages/coding-agent/test/modes/components/assistant-text-decorator.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-text-decorator.test.ts
@@ -1,0 +1,270 @@
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { AssistantTextDecorator } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { splitAssistantMessageToolTimeline } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
+
+const W = 100;
+const ESC = "\u001b";
+const NUL = "\u0000";
+const TAB = "\t";
+
+function msg(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "m",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+/** Record every token handed to `decorate`, passing the prose through unchanged. */
+function recordingDecorator(): { decorator: AssistantTextDecorator; seen: Array<{ text: string; index: number }> } {
+	const seen: Array<{ text: string; index: number }> = [];
+	return {
+		seen,
+		decorator: {
+			decorate(text, context) {
+				seen.push({ text, index: context.contentIndex });
+				return text;
+			},
+		},
+	};
+}
+
+function component(
+	message: AssistantMessage | undefined,
+	decorators: AssistantTextDecorator[],
+	contentIndexOffset = 0,
+): AssistantMessageComponent {
+	return new AssistantMessageComponent(
+		message,
+		false,
+		undefined,
+		[],
+		undefined,
+		true,
+		undefined,
+		decorators,
+		contentIndexOffset,
+	);
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+describe("assistant text decorators", () => {
+	describe("input contract", () => {
+		it("passes plain prose even when the live transcript paints assistant text", () => {
+			const { decorator, seen } = recordingDecorator();
+			const comp = component(undefined, [decorator]);
+			// The live transcript installs an SGR foreground transform on the same
+			// Markdown; decoration must still see the author's words, and Markdown's
+			// own style probe (a NUL sentinel) must never reach a decorator either.
+			comp.setTextColorTransform(text => `${ESC}[38;5;42m${text}${ESC}[39m`);
+			comp.updateContent(msg([{ type: "text", text: "read this safely" }]));
+			const rendered = comp.render(W).join("\n");
+
+			expect(seen.length).toBeGreaterThan(0);
+			for (const { text } of seen) {
+				expect(text).not.toContain(ESC);
+				expect(text).not.toContain(NUL);
+			}
+			expect(seen.some(entry => entry.text.includes("read this safely"))).toBe(true);
+			// The color transform still paints the decorated result.
+			expect(rendered).toContain(`${ESC}[38;5;42m`);
+		});
+
+		it("never hands code spans or fenced code to a decorator", () => {
+			const { decorator, seen } = recordingDecorator();
+			const text = "call `configure(x)` first\n\n```ts\nconst secret = 1;\n```\n\nthen ship";
+			const comp = component(msg([{ type: "text", text }]), [decorator]);
+			const rendered = Bun.stripANSI(comp.render(W).join("\n"));
+
+			const inputs = seen.map(entry => entry.text).join("");
+			expect(inputs).not.toContain("configure(x)");
+			expect(inputs).not.toContain("const secret = 1;");
+			expect(inputs).toContain("call ");
+			// Code survives verbatim in the output.
+			expect(rendered).toContain("configure(x)");
+			expect(rendered).toContain("const secret = 1;");
+		});
+
+		it("reports the original content index for post-tool segments", () => {
+			const message = msg([
+				{ type: "text", text: "starting now" },
+				{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+				{ type: "text", text: "finished cleanly" },
+			]);
+			const timeline = splitAssistantMessageToolTimeline(message);
+			const segment = timeline.afterToolCalls.get("call_1");
+			expect(segment?.contentOffset).toBe(2);
+
+			const before = recordingDecorator();
+			component(timeline.beforeTools, [before.decorator]).render(W);
+			expect(before.seen.length).toBeGreaterThan(0);
+			expect(before.seen.every(entry => entry.index === 0)).toBe(true);
+
+			const after = recordingDecorator();
+			component(segment?.message, [after.decorator], segment?.contentOffset).render(W);
+			expect(after.seen.length).toBeGreaterThan(0);
+			expect(after.seen.every(entry => entry.index === 2)).toBe(true);
+		});
+
+		it("keeps offsets stable across back-to-back tool calls", () => {
+			const message = msg([
+				{ type: "toolCall", id: "a", name: "bash", arguments: {} },
+				{ type: "toolCall", id: "b", name: "bash", arguments: {} },
+				{ type: "text", text: "tail text" },
+			]);
+			const timeline = splitAssistantMessageToolTimeline(message);
+			expect(timeline.afterToolCalls.get("a")).toBeUndefined();
+			expect(timeline.afterToolCalls.get("b")?.contentOffset).toBe(2);
+		});
+	});
+
+	describe("output sanitization", () => {
+		it("normalizes tabs a decorator introduces", () => {
+			const comp = component(msg([{ type: "text", text: "before after" }]), [
+				{ decorate: text => text.replace(" ", `${TAB}gap${TAB}`) },
+			]);
+			const rendered = comp.render(W).join("\n");
+
+			expect(rendered).not.toContain(TAB);
+			expect(Bun.stripANSI(rendered)).toContain("gap");
+		});
+
+		it("survives hostile decorator output", () => {
+			const cases: Array<(text: string) => string> = [
+				() => "",
+				text => text.repeat(200),
+				() => "unicode: \u{1F642}́ ünïcödé",
+				text => `${text}\n\ninjected`,
+				() => NUL,
+			];
+			for (const decorate of cases) {
+				const comp = component(msg([{ type: "text", text: "stay alive" }]), [{ decorate }]);
+				expect(() => comp.render(W)).not.toThrow();
+			}
+		});
+	});
+
+	describe("failure isolation", () => {
+		it("renders the original prose when decorate throws", () => {
+			const comp = component(msg([{ type: "text", text: "original prose" }]), [
+				{
+					decorate() {
+						throw new Error("extension bug");
+					},
+				},
+			]);
+
+			expect(Bun.stripANSI(comp.render(W).join("\n"))).toContain("original prose");
+		});
+
+		it("keeps the surviving links when one decorator throws mid-chain", () => {
+			const comp = component(msg([{ type: "text", text: "chain" }]), [
+				{ decorate: text => `[${text}]` },
+				{
+					decorate() {
+						throw new Error("second decorator bug");
+					},
+				},
+				{ decorate: text => `${text}!` },
+			]);
+
+			expect(Bun.stripANSI(comp.render(W).join("\n"))).toContain("[chain]!");
+		});
+
+		it("does not abort construction when onDidChange throws", () => {
+			let healthyListenerRegistered = false;
+			let comp: AssistantMessageComponent | undefined;
+
+			expect(() => {
+				comp = component(msg([{ type: "text", text: "still visible" }]), [
+					{
+						decorate: text => text,
+						onDidChange() {
+							throw new Error("subscription bug");
+						},
+					},
+					{
+						decorate: text => text,
+						onDidChange() {
+							healthyListenerRegistered = true;
+							return () => {};
+						},
+					},
+				]);
+			}).not.toThrow();
+
+			expect(healthyListenerRegistered).toBe(true);
+			expect(Bun.stripANSI(comp?.render(W).join("\n") ?? "")).toContain("still visible");
+		});
+
+		it("runs every unsubscriber even when one throws", () => {
+			let secondUnsubscribed = false;
+			const comp = component(msg([{ type: "text", text: "disposable" }]), [
+				{
+					decorate: text => text,
+					onDidChange: () => () => {
+						throw new Error("unsubscribe bug");
+					},
+				},
+				{
+					decorate: text => text,
+					onDidChange: () => () => {
+						secondUnsubscribed = true;
+					},
+				},
+			]);
+
+			expect(() => comp.dispose()).not.toThrow();
+			expect(secondUnsubscribed).toBe(true);
+		});
+	});
+
+	describe("streaming state", () => {
+		it("repaints every prose block when the turn stops streaming", () => {
+			const content: AssistantMessage["content"] = [
+				{ type: "text", text: "first block" },
+				{ type: "text", text: "second block" },
+			];
+			const comp = component(undefined, [
+				{ decorate: (text, { transient }) => (transient ? `~${text}~` : `=${text}=`) },
+			]);
+
+			comp.updateContent(msg(content), { transient: true });
+			const streaming = Bun.stripANSI(comp.render(W).join("\n"));
+			expect(streaming).toContain("~first block~");
+			expect(streaming).toContain("~second block~");
+
+			// Source text is unchanged at finalize — only the transient flag flips,
+			// so a cached earlier block would keep its streaming presentation.
+			comp.updateContent(msg(content), { transient: false });
+			const settled = Bun.stripANSI(comp.render(W).join("\n"));
+			expect(settled).toContain("=first block=");
+			expect(settled).toContain("=second block=");
+			expect(settled).not.toContain("~");
+		});
+	});
+});

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -506,6 +506,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 				]),
 				tools: new Map(),
 				assistantThinkingRenderers: [],
+				assistantTextDecorators: [],
 				fileWriteFallbackHandlers: [],
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1321,6 +1321,18 @@ function objectId(o: object): number {
  * Applied to all text unless overridden by markdown formatting.
  */
 export interface DefaultTextStyle {
+	/**
+	 * Rewrite plain prose runs before any styling is applied.
+	 *
+	 * Unlike {@link DefaultTextStyle.color}, which is a paint hook — it is probed
+	 * with a `\0` sentinel to derive an SGR prefix and receives already-assembled
+	 * runs — this is a *semantic* seam: it sees the raw text of a prose token with
+	 * no escape sequences or sentinels, and only for tokens the reader sees as
+	 * prose. Code spans, fenced code, and link targets never reach it. The result
+	 * is tab-normalized (a literal tab would punch a hole in the layout) and then
+	 * handed to the style hooks, so a caller can layer color on top of a rewrite.
+	 */
+	transformText?: (text: string) => string;
 	/** Foreground color function */
 	color?: (text: string) => string;
 	/** Background color function */
@@ -2267,6 +2279,10 @@ export class Markdown implements Component {
 			// Run-level default styling (color/bold/italic/strikethrough/
 			// underline) disarms: the splice yields two ANSI runs where a cold
 			// render yields one; bgColor is line-level and stays eligible.
+			// transformText disarms for the same reason and one more: it rewrites
+			// whole prose tokens, so a spliced tail can differ from a cold render
+			// wherever the transform's output depends on the surrounding word.
+			!this.#defaultTextStyle?.transformText &&
 			!this.#defaultTextStyle?.color &&
 			!this.#defaultTextStyle?.bold &&
 			!this.#defaultTextStyle?.italic &&
@@ -3159,6 +3175,14 @@ export class Markdown implements Component {
 			const segments: string[] = text.split("\n");
 			return segments.map((segment: string) => (segment === "" ? "" : applyText(segment))).join("\n");
 		};
+		// Prose runs pass through the semantic transform first, so its input is the
+		// author's text rather than a styled run, and `applyText` layers color over
+		// whatever it returns. replaceTabs re-runs here because the input pass ran
+		// before the transform existed.
+		const transformProse = this.#defaultTextStyle?.transformText;
+		const applyProseRun = transformProse
+			? (text: string): string => applyTextWithNewlines(replaceTabs(transformProse(text)))
+			: applyTextWithNewlines;
 		const swatchGlyph = this.#theme.symbols.colorSwatch || DEFAULT_COLOR_SWATCH_GLYPH;
 		let trimLeadingWhitespace = false;
 		const htmlState = createHtmlNormalizationState();
@@ -3183,7 +3207,7 @@ export class Markdown implements Component {
 					if (token.tokens && token.tokens.length > 0) {
 						result += this.#renderInlineTokens(token.tokens, resolvedStyleContext);
 					} else {
-						result += renderTextWithSwatches(text, applyTextWithNewlines, swatchGlyph);
+						result += renderTextWithSwatches(text, applyProseRun, swatchGlyph);
 					}
 					break;
 				}
@@ -3270,7 +3294,7 @@ export class Markdown implements Component {
 						const text = normalizeHtmlEntitiesForTerminal(rawText);
 						trimLeadingWhitespace = false;
 						markHtmlItemWhenContent(text);
-						result += applyTextWithNewlines(text);
+						result += applyProseRun(text);
 					}
 			}
 		}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -75,6 +75,83 @@ describe("extractMarkdownLinks", () => {
 });
 
 describe("Markdown component", () => {
+	describe("defaultTextStyle.transformText", () => {
+		/** Collect what the semantic seam is handed, passing prose through unchanged. */
+		function recorder(): { seen: string[]; transformText: (text: string) => string } {
+			const seen: string[] = [];
+			return { seen, transformText: (text: string) => (seen.push(text), text) };
+		}
+
+		it("sees author prose, never a styled run or the style sentinel", () => {
+			const { seen, transformText } = recorder();
+			const markdown = new Markdown("stay **bold** and plain", 0, 0, defaultMarkdownTheme, {
+				transformText,
+				color: text => chalk.magenta(text),
+				bold: true,
+			});
+
+			const rendered = markdown.render(80).join("\n");
+
+			expect(seen.length).toBeGreaterThan(0);
+			for (const text of seen) {
+				expect(text).not.toContain("\x1b");
+				expect(text).not.toContain("\u0000");
+			}
+			expect(seen.join("|")).toContain("stay ");
+			// Color still paints the transformed prose.
+			expect(rendered).toContain("\x1b[");
+		});
+
+		it("applies to prose in paragraphs, headings, lists, quotes and tables", () => {
+			const doc = [
+				"# Title",
+				"",
+				"para text",
+				"",
+				"- item text",
+				"",
+				"> quoted text",
+				"",
+				"| head |",
+				"| --- |",
+				"| cell |",
+			].join("\n");
+			const { seen, transformText } = recorder();
+			new Markdown(doc, 0, 0, defaultMarkdownTheme, { transformText }).render(60);
+
+			const joined = seen.join("|");
+			for (const fragment of ["Title", "para text", "item text", "quoted text", "head", "cell"]) {
+				expect(joined).toContain(fragment);
+			}
+		});
+
+		it("skips code spans, fenced code, and link targets", () => {
+			const doc = "run `inline code` here\n\n```ts\nconst fenced = 1;\n```\n\n[label](https://example.com/path)";
+			const { seen, transformText } = recorder();
+			const rendered = stripVTControlCharacters(
+				new Markdown(doc, 0, 0, defaultMarkdownTheme, { transformText }).render(80).join("\n"),
+			);
+
+			const joined = seen.join("|");
+			expect(joined).not.toContain("inline code");
+			expect(joined).not.toContain("const fenced = 1;");
+			expect(joined).not.toContain("https://example.com/path");
+			expect(joined).toContain("run ");
+			// Untouched content still renders.
+			expect(rendered).toContain("inline code");
+			expect(rendered).toContain("const fenced = 1;");
+		});
+
+		it("normalizes tabs the transform introduces", () => {
+			const rendered = new Markdown("before after", 0, 0, defaultMarkdownTheme, {
+				transformText: text => text.replace(" ", "\tgap\t"),
+			}).render(80);
+
+			expect(rendered.join("\n")).not.toContain("\t");
+			expect(stripVTControlCharacters(rendered.join("\n"))).toContain("gap");
+		});
+	});
+
 	describe("Nested lists", () => {
 		it("should render simple nested list", () => {
 			const markdown = new Markdown(


### PR DESCRIPTION
## Summary

Add a presentation-only extension API for decorating assistant prose while preserving the original message, Markdown structure, session history, and model context.

The motivating use case is Bionic Reading: emphasizing the beginning of words to create visual fixation points. Some readers with ADHD, dyslexia, or attention-related reading friction find this easier to scan, although benefit varies by person. Implementing it in the renderer avoids prompt instructions, extra model calls, and token cost.


## Changes

### Extension API
- Add `registerAssistantTextDecorator`.
- Provide each decorator with plain prose text, content index, streaming state, and the active theme.
- Support optional `onDidChange` subscriptions so extension toggles can repaint mounted messages.
- Compose multiple decorators in extension load order and fail open to the original prose if one throws.

### Rendering
- Apply decorators through Markdown's plain-text styling path.
- Leave inline code and fenced code blocks untouched.
- Wire the same decorators into the live transcript and Agent Hub transcript viewer.
- Keep persisted assistant messages unchanged.

### Documentation and coverage
- Document the new API and its presentation-only contract.
- Cover registration, prose decoration, code exclusion, runtime repaint, cleanup, and message immutability.

## How It Works

`AssistantMessageComponent` receives the registered decorators from `ExtensionRunner`. Markdown invokes them only for ordinary text tokens. A stateful extension can call listeners returned through `onDidChange`; mounted messages rebuild their local rendered content and request a repaint without rewriting the underlying `AssistantMessage`.

This PR intentionally adds only the generic rendering seam. A Bionic Reading extension, shortcut, intensity settings, and persistence can live outside core.

## Testing

- `bun run check` in `packages/coding-agent` — passed (one pre-existing unused-variable warning).
- `bun test test/extensions-runner.test.ts` — 85 passed.
- `bun test test/modes/components/assistant-message-streaming-fastpath.test.ts` — 10 passed.
- Exercised the renderer contract in the focused component test: prose changes, inline code remains unchanged, the stored message stays byte-for-byte original, a runtime state signal restores normal rendering, and disposal removes the listener.

## Notes

- No provider request or model prompt changes.
- No additional tokens or API cost.
- No Bionic Reading behavior is hard-coded into OMP.