### PR TITLE
Deliver misfiled yield payloads instead of aborting the task envelope

### DIFF
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -720,8 +720,13 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 			const delivered = recoverDeliveredPayload(lastYield.error);
 			if (delivered !== undefined) {
 				rawOutput = delivered;
-				exitCode = 0;
-				stderr = "";
+				// Mirror the sibling delivered-yield contract below: a run that already
+				// failed before the yield keeps its non-zero exit code and stderr
+				// rather than being reset to a completed status.
+				if (!hadFailureBeforeYield) {
+					exitCode = 0;
+					stderr = "";
+				}
 			} else {
 				abortedViaYield = true;
 				exitCode = 0;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -691,14 +691,9 @@ function recoverDeliveredPayload(error: unknown): string | undefined {
 	// be a success token. A single ISSUES/BLOCKED/FAIL/ERROR on the resolution chain — the
 	// PASS/ISSUES contradiction, a top-level ISSUES beside a nested child PASS — keeps the payload
 	// on the abort path; so does the absence of any success token (a genuine cancel, a plain error).
-	const tokens = [
-		data?.status,
-		data?.verdict,
-		result?.status,
-		result?.verdict,
-		parsed.status,
-		parsed.verdict,
-	].filter((token): token is string => typeof token === "string");
+	const tokens = [data?.status, data?.verdict, result?.status, result?.verdict, parsed.status, parsed.verdict].filter(
+		(token): token is string => typeof token === "string",
+	);
 	if (tokens.length === 0) return undefined;
 	return tokens.every(token => Object.hasOwn(SUCCESS_OUTCOME_TOKENS, token.toLowerCase())) ? text : undefined;
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -663,6 +663,46 @@ function buildSchemaViolationOutcome(
 	return { rawOutput, stderr: headline, exitCode: 1 };
 }
 
+/**
+ * A terminal yield whose `error` channel carries a full delivery payload is a misfiled
+ * delivery, not an abort. Returning the payload keeps it in the subagent output instead of
+ * wrapping it into an abort-reason envelope, where callers recovered it by hand from `agent://`.
+ * The delivery record sits at `result.data`, at a top-level `data` object, or at the root, and
+ * carries its outcome in `status` or `verdict`. Delivery requires every resolved token to be a
+ * success: an explicit non-success or a contradiction between tokens — a genuine cancel, an ISSUES
+ * report, a PASS/ISSUES mix, a plain error — stays on the abort path.
+ */
+const SUCCESS_OUTCOME_TOKENS: Record<string, true> = { pass: true, success: true };
+
+function recoverDeliveredPayload(error: unknown): string | undefined {
+	if (typeof error !== "string") return undefined;
+	const text = error.trim();
+	if (!text.startsWith("{")) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+	if (!isRecord(parsed)) return undefined;
+	const result = isRecord(parsed.result) ? parsed.result : undefined;
+	const data = isRecord(result?.data) ? result.data : isRecord(parsed.data) ? parsed.data : undefined;
+	// Only the resolved record's own `status`/`verdict` tokens count, and every present token must
+	// be a success token. A single ISSUES/BLOCKED/FAIL/ERROR on the resolution chain — the
+	// PASS/ISSUES contradiction, a top-level ISSUES beside a nested child PASS — keeps the payload
+	// on the abort path; so does the absence of any success token (a genuine cancel, a plain error).
+	const tokens = [
+		data?.status,
+		data?.verdict,
+		result?.status,
+		result?.verdict,
+		parsed.status,
+		parsed.verdict,
+	].filter((token): token is string => typeof token === "string");
+	if (tokens.length === 0) return undefined;
+	return tokens.every(token => Object.hasOwn(SUCCESS_OUTCOME_TOKENS, token.toLowerCase())) ? text : undefined;
+}
+
 export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): FinalizeSubprocessOutputResult {
 	let { rawOutput, exitCode, stderr } = args;
 	const { yieldItems, doneAborted, signalAborted, outputSchema, lastAssistantText } = args;
@@ -677,13 +717,20 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 	if (hasYield) {
 		const lastYield = yieldItems[yieldItems.length - 1];
 		if (lastYield?.status === "aborted") {
-			abortedViaYield = true;
-			exitCode = 0;
-			stderr = lastYield.error || "Subagent aborted task";
-			try {
-				rawOutput = JSON.stringify({ aborted: true, error: lastYield.error }, null, 2);
-			} catch {
-				rawOutput = `{"aborted":true,"error":"${lastYield.error || "Unknown error"}"}`;
+			const delivered = recoverDeliveredPayload(lastYield.error);
+			if (delivered !== undefined) {
+				rawOutput = delivered;
+				exitCode = 0;
+				stderr = "";
+			} else {
+				abortedViaYield = true;
+				exitCode = 0;
+				stderr = lastYield.error || "Subagent aborted task";
+				try {
+					rawOutput = JSON.stringify({ aborted: true, error: lastYield.error }, null, 2);
+				} catch {
+					rawOutput = `{"aborted":true,"error":"${lastYield.error || "Unknown error"}"}`;
+				}
 			}
 		} else {
 			const assembled = assembleYieldResult(yieldItems, lastAssistantText, arrayValuedLabels(outputSchema));

--- a/packages/coding-agent/test/task/pass-payload-abort-envelope.test.ts
+++ b/packages/coding-agent/test/task/pass-payload-abort-envelope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { finalizeSubprocessOutput } from "../../src/task/executor";
+
+const PASS_DELIVERY = JSON.stringify({
+	status: "PASS",
+	details: "guard wired",
+	artifacts: [{ locator: "reviews/orchestrate/x/report.md" }],
+});
+
+const WRAPPED_PASS_DELIVERY = JSON.stringify({
+	result: { data: { status: "PASS", details: "guard wired" } },
+});
+
+describe("terminal yield with a PASS payload on the error channel", () => {
+	it("delivers the payload instead of wrapping it into an abort-reason envelope", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "aborted", error: PASS_DELIVERY }],
+			outputSchema: undefined,
+		});
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.rawOutput).toBe(PASS_DELIVERY);
+	});
+
+	it("delivers a result.data-wrapped PASS payload on the error channel", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "aborted", error: WRAPPED_PASS_DELIVERY }],
+			outputSchema: undefined,
+		});
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.rawOutput).toBe(WRAPPED_PASS_DELIVERY);
+	});
+
+	it("still aborts on a genuine caller cancel", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: true,
+			signalAborted: true,
+			yieldItems: [{ status: "aborted", error: "Cancelled by caller" }],
+			outputSchema: undefined,
+		});
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("Cancelled by caller");
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: "Cancelled by caller" }, null, 2));
+	});
+
+	it("still aborts when the error payload carries no success status", () => {
+		const issues = JSON.stringify({ status: "ISSUES", details: "lane found defects" });
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "aborted", error: issues }],
+			outputSchema: undefined,
+		});
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(issues);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: issues }, null, 2));
+	});
+});

--- a/packages/coding-agent/test/task/pass-payload-abort-envelope.test.ts
+++ b/packages/coding-agent/test/task/pass-payload-abort-envelope.test.ts
@@ -77,4 +77,21 @@ describe("terminal yield with a PASS payload on the error channel", () => {
 		expect(result.stderr).toBe(issues);
 		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: issues }, null, 2));
 	});
+
+	it("keeps a pre-yield failure exit code while still delivering the PASS payload", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 1,
+			stderr: "stream error: ECONNRESET",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "aborted", error: PASS_DELIVERY }],
+			outputSchema: undefined,
+		});
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe("stream error: ECONNRESET");
+		expect(result.rawOutput).toBe(PASS_DELIVERY);
+	});
 });

--- a/packages/coding-agent/test/task/verdict-payload-v3.test.ts
+++ b/packages/coding-agent/test/task/verdict-payload-v3.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import { finalizeSubprocessOutput } from "../../src/task/executor";
+
+// G062: verbatim abort-reason from the live RecursionCorrection lane
+// (DeepEnvWave3.RecursionCorrection, status=cancelled, output {aborted:true,error:<this>}).
+// The terminal yield put the real deliverable on the `error` channel. Shape: a top-level `data`
+// object carrying `verdict: "PASS"`, no `status` field anywhere, and nested `childReports[].verdict`
+// PASS entries that must NOT count as the resolved record's token.
+const RECURSION_CORRECTION_ABORT_REASON = `{"data": {"brief": "RecursionCorrection (G085 + SH-08): correct report timestamps/routing gaps and confounded matched plan; preserve ten feeder units + referee + four valid artifacts", "children": 3, "taskCalls": 1, "childReports": [{"id": "DeepEnvWave3.RecursionCorrection.RecurseAudit", "verdict": "PASS", "artifact": "reviews/orchestrate/2026-09-10-phase2/env-wave/recursion/correction-audit/audit.md (184 lines)", "routing": "deepseek/deepseek-v4-flash, resolvedModelIsFallback false, own jsonl:3", "finding": "Lead start 08:41:43.524Z PRESERVED; '48 seconds' respawn false (actual 238.49s); 08:50Z-vs-mtime-08:52:23Z unresolved; BakeoffPlan 'nothing on disk' partial (50-byte file); routing = Muse lead/watcher/report vs DeepSeek owner cohort, all fallback false"}, {"id": "DeepEnvWave3.RecursionCorrection.MatchedPlanFix", "verdict": "PASS", "artifact": "reviews/orchestrate/2026-09-10-phase2/env-wave/recursion/bakeoff-plan/bakeoff-plan-corrected.md (267 lines, sha256 36c1346c6a8474cfc559b49a97f6afebf1a8eca3660fbb2498fb16e17ccea986)", "routing": "deepseek/deepseek-v4-flash, resolvedModelIsFallback false, own jsonl:3", "finding": "Same-model rule + retained void-on-fallback + pre-dispatch jsonl:3 receipt check; model-vs-delegation separation paragraph; roster diff exit 0, referee diff exit 0, gate diff exit 1 (one declared voided-pair sentence); original 173-line plan untouched"}, {"id": "DeepEnvWave3.RecursionCorrection.RecurseReportFix", "verdict": "PASS", "artifact": "reviews/orchestrate/2026-09-10-phase2/env-wave/recursion/report-corrected.md (191 lines)", "routing": "deepseek/deepseek-v4-flash, resolvedModelIsFallback false, own jsonl:3", "finding": "Eight-seat accounting with audit-verified stamps; chronology without causal claim; original 61-line report.md mtime unchanged"}], "ownRouting": "openrouter/meta/muse-spark-1.3-contributor, resolvedModelIsFallback false, agent/sessions/-.omp/2026-09-10T03-53-28-158Z_01a08972-f75e-724a-a2cb-0ab46606b80c/DeepEnvWave3/DeepEnvWave3.RecursionCorrection.jsonl:3 (bash EXIT:0)", "verification": ["wc -l audit.md/report-corrected.md/bakeoff-plan-corrected.md/report.md/bakeoff-plan.md = 184/191/267/61/173, EXIT:0", "Read audit.md fully (184 lines), report-corrected.md:1-63 + :64-191, bakeoff-plan-corrected.md:1-80 + :84-180 + :184-267 — all end END, ten-unit table + referee preserved, no causal allegation", "No DB query rerun; originals untouched"], "deviations": ["PlanFix added two metric fields (model_id, model_fallback) + one gate-analysis sentence on voided pairs counting as undecided — both declared in its yield, accepted as required for auditability", "Report-corrected.md cites bakeoff-plan-corrected.md at 17446 bytes/263 lines from a mid-write read; landed file is 17912 bytes/267 lines after final receipt-table edit — content verified identical in scope, size drift only"], "remainingLimits": ["Bakeoff not executed: zero pairs run; same-model control is a design rule realized only on execution", "Original report write time (08:50Z vs 08:52:23Z mtime) unresolved by line-2/line-3 receipts alone", "'48 seconds' figure unsourcable from receipts", "Sample is ten pairs; cannot generalize thresholds"], "ledgerRows": ["- 2026-09-10 09:0x UTC · DeepEnvWave2.RecursionGates correction-audit · PASS — 8/8 seat receipts verified from raw jsonl:2/:3; G085-a start stamp 08:41:43.524Z PRESERVED; GAPS: '48 seconds' false (238.49 s), 08:50Z vs 08:52:23Z unresolved, 'nothing on disk' partial (50-byte file); Muse lead/watcher/report vs DeepSeek owner cohort, all fallback false.", "- 2026-09-10 09:0x UTC · DeepEnvWave2.RecursionGates correction · PASS — corrected report report-corrected.md preserves G085/SH-08 start stamp 08:41:43Z, corrects '48 seconds' to 238.49 s, marks 08:50Z-vs-08:52:23Z unresolved, corrects 'nothing on disk' to 50-byte partial, accounts all eight seats, routes Muse lead/watcher/report versus DeepSeek owner cohort all fallback false."], "verdict": "PASS"}}`;
+
+function runWith(payload: string) {
+	return finalizeSubprocessOutput({
+		rawOutput: "",
+		exitCode: 0,
+		stderr: "",
+		doneAborted: false,
+		signalAborted: false,
+		yieldItems: [{ status: "aborted", error: payload }],
+		outputSchema: undefined,
+	});
+}
+
+describe("terminal yield abort envelope (G062/G138 v3)", () => {
+	// ---- valid terminal deliveries that must survive the v3 correction ----
+	it("delivers the live RecursionCorrection abort reason instead of wrapping it", () => {
+		const parsed = JSON.parse(RECURSION_CORRECTION_ABORT_REASON);
+		expect(parsed.data.verdict).toBe("PASS");
+		expect(JSON.stringify(parsed)).not.toContain('"status"');
+
+		const result = runWith(RECURSION_CORRECTION_ABORT_REASON);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.rawOutput).toBe(RECURSION_CORRECTION_ABORT_REASON);
+	});
+
+	it("delivers a bare data.verdict PASS payload", () => {
+		const payload = JSON.stringify({ data: { verdict: "PASS", details: "guard wired" } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.rawOutput).toBe(payload);
+	});
+
+	it("delivers a result.data-wrapped verdict PASS payload", () => {
+		const payload = JSON.stringify({ result: { data: { verdict: "PASS", details: "guard wired" } } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.rawOutput).toBe(payload);
+	});
+
+	it("delivers a root verdict PASS payload", () => {
+		const payload = JSON.stringify({ verdict: "PASS", details: "root-level terminal result" });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.rawOutput).toBe(payload);
+	});
+
+	it("delivers a root status PASS payload", () => {
+		const payload = JSON.stringify({ status: "PASS", details: "status token" });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.rawOutput).toBe(payload);
+	});
+
+	it("delivers a root status success payload", () => {
+		const payload = JSON.stringify({ status: "success", details: "success token" });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(false);
+		expect(result.exitCode).toBe(0);
+		expect(result.rawOutput).toBe(payload);
+	});
+
+	// ---- the v2 hole: a PASS alongside an explicit non-success must not win ----
+	it("still aborts a data.verdict ISSUES payload", () => {
+		const payload = JSON.stringify({ data: { verdict: "ISSUES", details: "lane found defects" } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+
+	it("aborts a PASS/ISSUES contradiction inside one resolved record", () => {
+		const payload = JSON.stringify({ data: { status: "PASS", verdict: "ISSUES" } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+
+	it("aborts when any explicit failure token sits beside a PASS", () => {
+		for (const token of ["ISSUES", "BLOCKED", "FAIL", "ERROR"]) {
+			const payload = JSON.stringify({ data: { verdict: "PASS", status: token } });
+			const result = runWith(payload);
+
+			expect(result.abortedViaYield).toBe(true);
+			expect(result.stderr).toBe(payload);
+			expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+		}
+	});
+
+	it("aborts a nested child PASS under a top-level ISSUES", () => {
+		const payload = JSON.stringify({ status: "ISSUES", data: { verdict: "PASS" } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+
+	it("does not let a child-array PASS override a top-level ISSUES", () => {
+		const payload = JSON.stringify({
+			data: { verdict: "ISSUES", children: [{ verdict: "PASS" }, { verdict: "PASS" }] },
+		});
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+
+	it("aborts a success-word announcement with no resolved outcome token", () => {
+		const payload = JSON.stringify({ data: { summary: "22 pass, 0 fail", counts: { pass: 22, fail: 0 } } });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+
+	it("aborts a near-token substring that is not an exact success token", () => {
+		for (const payload of [
+			JSON.stringify({ data: { verdict: "passed" } }),
+			JSON.stringify({ data: { status: "in-progress", note: "verification passed" } }),
+		]) {
+			const result = runWith(payload);
+
+			expect(result.abortedViaYield).toBe(true);
+			expect(result.stderr).toBe(payload);
+			expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+		}
+	});
+
+	// ---- intentional cancel stays on the abort path ----
+	it("still aborts on a genuine caller cancel", () => {
+		const result = runWith("Cancelled by caller");
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe("Cancelled by caller");
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: "Cancelled by caller" }, null, 2));
+	});
+
+	it("still aborts a JSON error payload with no success token", () => {
+		const payload = JSON.stringify({ error: "boom", message: "subagent crashed" });
+		const result = runWith(payload);
+
+		expect(result.abortedViaYield).toBe(true);
+		expect(result.stderr).toBe(payload);
+		expect(result.rawOutput).toBe(JSON.stringify({ aborted: true, error: payload }, null, 2));
+	});
+});


### PR DESCRIPTION
## What
`finalizeSubprocessOutput` wrapped any `aborted`-status yield into `{"aborted":true,"error":<payload>}`, so a report submitted through `yield result.error` reached the caller as a cancelled envelope with the deliverable buried in the abort reason (callers recovered it by hand from `agent://`).

`recoverDeliveredPayload` now returns the payload when every present `status`/`verdict` token on the resolution chain (`data`, `result.data`, root) is an exact pass/success. The delivered short-circuit keeps `exitCode 0`, empty `stderr`, and clears `abortedViaYield` so `progress.status` resolves to `completed`. A cancel, an ISSUES report, a PASS/ISSUES contradiction, a nested child PASS under a top-level ISSUES, or an unrecognized token stays on the abort path.

## Provenance
- Hand-port onto upstream main, base `678bba44926c04d805581115baaf88bd26ea04e6`.
- Ported from `guard/yield-envelope-v3` head `9995f14e` (executor.ts hunks at the abort branch plus the two v3 tests). Hand-port, not `git apply`; executor.ts had drifted.

## Related
- Related: #10645 (deliberately **not** `Fixes:`).
- #10646: file set has empty intersection with this change.
- #11214: proposes no diff.

## Status: UNREVIEWED DRAFT — tests blocked
This is an unreviewed draft; do not treat it as reviewed. The ported source tests (tree-run, not a fresh-process verify) are blocked by a native addon load stall in the review environment, unrelated to this change. The executor module graph imports `@oh-my-pi/pi-natives`; on this host the addon `require` hangs:

    $ timeout 120 bun -e 'const m = require("./packages/natives/native/pi_natives.darwin-arm64.node"); require("fs").writeFileSync("node_modules/.probe.txt","keys="+Object.keys(m).length+"\n"); process.exit(0)'
    PROBE-EXIT=124
    cat: node_modules/.probe.txt: No such file or directory

With no `.node` staged, the suites fail fast at import with `Failed to load pi_natives native addon for darwin-arm64`. So the suites could not be run to completion here.

## Base..head
- base: `678bba44926c04d805581115baaf88bd26ea04e6`
- head: `b31569794a1a82c37e5afa51afee7a611fb398f4`
- diffstat: `executor.ts +54/-7`, `pass-payload-abort-envelope.test.ts +80`, `verdict-payload-v3.test.ts +174` (3 files, 308 insertions, 7 deletions)


## Update 2026-09-11 (owner lane, append-only; earlier sections preserved verbatim)
- CI GREEN terminal on head `453bb5d561af5e121660f6f09f5b003fe5ebd0c5`: `Lint, type check & web build` pass, 0 failing of 21 checks, MERGEABLE/CLEAN, zero review threads. The tests-blocked claim in the `Status` section above is stale (suites ran green in CI on the current head); unreviewed still holds.
- Current `Base..head`: base `425f510e8d2fa645a1a10d2a99e3e6c4e69cefb0`, head `453bb5d561af5e121660f6f09f5b003fe5ebd0c5`, 3 commits, `executor.ts +54/-7`, `pass-payload-abort-envelope.test.ts +97`, `verdict-payload-v3.test.ts +174` (325 insertions, 7 deletions). The `Base..head` section above predates the oxfmt fix commit and current main.
- Handover: green CI plus clean mergeability plus zero threads — awaiting upstream review; no merge from this side (pull-only).

Co-authored-by: Jo Hughes <284454611+JamieJ5926@users.noreply.github.com>
