### PR TITLE
fix(desktop): map wayland captures through logical monitor geometry

### DIFF
--- a/crates/pi-natives/src/desktop/linux/wayland/capture.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/capture.rs
@@ -13,7 +13,8 @@ use crate::desktop::error::{CoreResult, DesktopError};
 
 const SCREENCAST_TOKEN: &str = "screencast-token";
 
-async fn open_screencast() -> Result<(u32, OwnedFd), String> {
+async fn open_screencast() -> Result<(u32, OwnedFd, Option<(i32, i32)>, Option<(i32, i32)>), String>
+{
 	let portal = Screencast::new()
 		.await
 		.map_err(|err| format!("ScreenCast portal: {err}"))?;
@@ -45,11 +46,13 @@ async fn open_screencast() -> Result<(u32, OwnedFd), String> {
 		.first()
 		.ok_or_else(|| "ScreenCast returned no monitor stream".to_string())?;
 	let node = stream.pipe_wire_node_id();
+	let position = stream.position();
+	let size = stream.size();
 	let fd = portal
 		.open_pipe_wire_remote(&session)
 		.await
 		.map_err(|err| format!("ScreenCast OpenPipeWireRemote: {err}"))?;
-	Ok((node, fd))
+	Ok((node, fd, position, size))
 }
 
 struct UserData {
@@ -244,11 +247,13 @@ fn grab_pipewire_frame(node: u32, fd: OwnedFd) -> Result<RgbaImage, String> {
 		.unwrap_or_else(|| Err("PipeWire stream ended before producing a frame".to_string()))
 }
 
-pub(super) fn capture() -> CoreResult<RgbaImage> {
+pub(super) fn capture() -> CoreResult<(RgbaImage, super::PortalGeometry)> {
 	let runtime = super::portal::portal_runtime()?;
-	let (node, fd) = runtime.block_on(open_screencast()).map_err(|err| {
+	let (node, fd, position, size) = runtime.block_on(open_screencast()).map_err(|err| {
 		DesktopError::capture_failed(format!("wayland screencast unavailable: {err}"))
 	})?;
-	grab_pipewire_frame(node, fd)
-		.map_err(|err| DesktopError::capture_failed(format!("wayland screencast failed: {err}")))
+	let image = grab_pipewire_frame(node, fd)
+		.map_err(|err| DesktopError::capture_failed(format!("wayland screencast failed: {err}")))?;
+	let geometry = super::PortalGeometry::new(position, size, image.width(), image.height());
+	Ok((image, geometry))
 }

--- a/crates/pi-natives/src/desktop/linux/wayland/mod.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/mod.rs
@@ -16,6 +16,92 @@ use crate::desktop::{
 	},
 };
 
+/// Logical monitor geometry from the portal ScreenCast stream, paired with the
+/// physical PipeWire buffer size.
+///
+/// The captured buffer is in physical pixels, while libei and AT-SPI address
+/// the monitor in the compositor's logical coordinate space. On a scaled
+/// monitor the two differ (e.g. a 2560×2880 buffer for a 1280×1440 logical
+/// region at scale 2), so clicks must be mapped through the logical geometry
+/// instead of treating buffer pixels as logical coordinates.
+#[cfg(any(feature = "wayland-pipewire", test))]
+#[derive(Debug, Clone, Copy)]
+struct PortalGeometry {
+	logical_x:      i32,
+	logical_y:      i32,
+	logical_width:  u32,
+	logical_height: u32,
+	pixel_width:    u32,
+	pixel_height:   u32,
+}
+
+#[cfg(any(feature = "wayland-pipewire", test))]
+impl PortalGeometry {
+	/// Build from the portal stream's `position`/`size` and the captured buffer
+	/// dimensions. A missing or degenerate logical size falls back to the buffer
+	/// size (scale 1), preserving behaviour on compositors that omit the
+	/// mapping.
+	fn new(
+		position: Option<(i32, i32)>,
+		size: Option<(i32, i32)>,
+		pixel_width: u32,
+		pixel_height: u32,
+	) -> Self {
+		let (logical_x, logical_y) = position.unwrap_or((0, 0));
+		let (logical_width, logical_height) = match size {
+			Some((w, h)) if w > 0 && h > 0 => (w as u32, h as u32),
+			_ => (pixel_width, pixel_height),
+		};
+		Self { logical_x, logical_y, logical_width, logical_height, pixel_width, pixel_height }
+	}
+
+	/// Synthetic single-monitor display describing the captured buffer, with
+	/// logical bounds and scale derived from the portal geometry.
+	fn display(&self) -> DesktopDisplay {
+		let scale = f64::from(self.pixel_width) / f64::from(self.logical_width.max(1));
+		DesktopDisplay {
+			id: "wayland-portal-0".to_string(),
+			name: "Wayland portal monitor".to_string(),
+			x: self.logical_x,
+			y: self.logical_y,
+			width: self.logical_width.max(1),
+			height: self.logical_height.max(1),
+			scale,
+			pixel_x: 0,
+			pixel_y: 0,
+			pixel_width: self.pixel_width,
+			pixel_height: self.pixel_height,
+			is_primary: true,
+		}
+	}
+
+	/// Convert a window's logical bounds (global compositor coordinates) into a
+	/// pixel crop rectangle within the captured buffer. Returns `None` when the
+	/// window lies outside the captured monitor.
+	fn window_crop(&self, window: &DesktopWindow) -> Option<(u32, u32, u32, u32)> {
+		let scale_x = f64::from(self.pixel_width) / f64::from(self.logical_width.max(1));
+		let scale_y = f64::from(self.pixel_height) / f64::from(self.logical_height.max(1));
+		let rel_x = window.x - self.logical_x;
+		let rel_y = window.y - self.logical_y;
+		if rel_x < 0 || rel_y < 0 {
+			return None;
+		}
+		let px_x = (f64::from(rel_x) * scale_x).round() as u32;
+		let px_y = (f64::from(rel_y) * scale_y).round() as u32;
+		if px_x >= self.pixel_width || px_y >= self.pixel_height {
+			return None;
+		}
+		let px_width = (f64::from(window.width) * scale_x).round().max(1.0) as u32;
+		let px_height = (f64::from(window.height) * scale_y).round().max(1.0) as u32;
+		let width = px_width.min(self.pixel_width - px_x);
+		let height = px_height.min(self.pixel_height - px_y);
+		if width == 0 || height == 0 {
+			return None;
+		}
+		Some((px_x, px_y, width, height))
+	}
+}
+
 pub struct WaylandBackend {
 	#[cfg_attr(
 		not(feature = "wayland-pipewire"),
@@ -68,24 +154,6 @@ impl WaylandBackend {
 				"RemoteDesktop portal or LIBEI_SOCKET is required for Wayland input",
 			)
 		}))
-	}
-
-	#[cfg(feature = "wayland-pipewire")]
-	fn synthetic_display(image: &RgbaImage) -> DesktopDisplay {
-		DesktopDisplay {
-			id:           "wayland-portal-0".to_string(),
-			name:         "Wayland portal monitor".to_string(),
-			x:            0,
-			y:            0,
-			width:        image.width(),
-			height:       image.height(),
-			scale:        1.0,
-			pixel_x:      0,
-			pixel_y:      0,
-			pixel_width:  image.width(),
-			pixel_height: image.height(),
-			is_primary:   true,
-		}
 	}
 
 	#[cfg(feature = "wayland-pipewire")]
@@ -165,14 +233,10 @@ impl Backend for WaylandBackend {
 		#[cfg(feature = "wayland-pipewire")]
 		{
 			self.selected_display_allowed()?;
-			let image = capture::capture()?;
-			let display = Self::synthetic_display(&image);
-			self.displays = vec![display.clone()];
+			let (image, geometry) = capture::capture()?;
+			self.displays = vec![geometry.display()];
 			match target {
-				Target::Desktop => {
-					let geometry = FrameGeometry::for_displays(&self.displays);
-					Ok((image, geometry))
-				},
+				Target::Desktop => Ok((image, FrameGeometry::for_displays(&self.displays))),
 				Target::Window(id) => {
 					let window = self
 						.windows()?
@@ -181,24 +245,14 @@ impl Backend for WaylandBackend {
 						.ok_or_else(|| {
 							DesktopError::window_not_found(format!("Wayland window {id} not found"))
 						})?;
-					if window.x < 0 || window.y < 0 {
-						return Err(DesktopError::capture_failed(
-							"Wayland portal monitor stream cannot crop a window outside the selected \
-							 monitor",
-						));
-					}
-					let x = window.x as u32;
-					let y = window.y as u32;
-					let width = window.width.min(image.width().saturating_sub(x));
-					let height = window.height.min(image.height().saturating_sub(y));
-					if width == 0 || height == 0 {
-						return Err(DesktopError::capture_failed(format!(
+					let (x, y, width, height) = geometry.window_crop(&window).ok_or_else(|| {
+						DesktopError::capture_failed(format!(
 							"Wayland window {id} is outside the selected portal monitor"
-						)));
-					}
+						))
+					})?;
 					let cropped = image::imageops::crop_imm(&image, x, y, width, height).to_image();
-					let geometry = FrameGeometry::for_window(&window, cropped.width(), cropped.height());
-					Ok((cropped, geometry))
+					let frame = FrameGeometry::for_window(&window, cropped.width(), cropped.height());
+					Ok((cropped, frame))
 				},
 			}
 		}
@@ -380,5 +434,78 @@ mod tests {
 			.capture(&Target::Desktop, &CaptureCaps::default())
 			.expect_err("capture must fail without the pipewire feature");
 		assert_eq!(err.code.as_str(), "CaptureFailed");
+	}
+
+	fn portal_window(id: &str, x: i32, y: i32, width: u32, height: u32) -> DesktopWindow {
+		DesktopWindow {
+			id: id.into(),
+			title: "T".into(),
+			app: "A".into(),
+			pid: None,
+			x,
+			y,
+			width,
+			height,
+			focused: false,
+		}
+	}
+
+	#[test]
+	fn scaled_monitor_maps_screenshot_pixel_to_logical_point() {
+		// 2560x2880 buffer for a 1280x1440 logical region at scale 2 (issue #11540).
+		let geometry = PortalGeometry::new(Some((0, 0)), Some((1280, 1440)), 2560, 2880);
+		let display = geometry.display();
+		assert_eq!((display.width, display.height), (1280, 1440));
+		assert!((display.scale - 2.0).abs() < f64::EPSILON);
+		let frame = FrameGeometry::for_displays(&[display]);
+		// A lower-half click that the old identity mapping pushed outside the
+		// 1280x1440 input region now lands inside it.
+		let (lx, ly) = frame.map_point(1066.0, 1867.0, None).unwrap();
+		assert!((lx - 533.0).abs() < 1e-6, "logical x {lx}");
+		assert!((ly - 933.5).abs() < 1e-6, "logical y {ly}");
+		assert!(lx < 1280.0 && ly < 1440.0, "mapped point must stay inside the logical region");
+	}
+
+	#[test]
+	fn monitor_offset_is_added_to_logical_point() {
+		let geometry = PortalGeometry::new(Some((100, 50)), Some((1280, 1440)), 2560, 2880);
+		let frame = FrameGeometry::for_displays(&[geometry.display()]);
+		assert_eq!(frame.map_point(1280.0, 1440.0, None).unwrap(), (740.0, 770.0));
+	}
+
+	#[test]
+	fn missing_portal_size_falls_back_to_buffer_scale_one() {
+		let geometry = PortalGeometry::new(None, None, 1920, 1080);
+		let display = geometry.display();
+		assert_eq!((display.x, display.y), (0, 0));
+		assert_eq!((display.width, display.height), (1920, 1080));
+		assert!((display.scale - 1.0).abs() < f64::EPSILON);
+		// Degenerate (zero) portal dimensions take the same fallback.
+		let degenerate = PortalGeometry::new(Some((0, 0)), Some((0, 0)), 1920, 1080);
+		assert_eq!(degenerate.display().width, 1920);
+	}
+
+	#[test]
+	fn window_crop_scales_logical_bounds_to_buffer_pixels() {
+		let geometry = PortalGeometry::new(Some((0, 0)), Some((1280, 1440)), 2560, 2880);
+		let crop = geometry
+			.window_crop(&portal_window("w", 100, 200, 300, 400))
+			.expect("window inside monitor");
+		assert_eq!(crop, (200, 400, 600, 800));
+	}
+
+	#[test]
+	fn window_crop_rejects_window_outside_monitor() {
+		let geometry = PortalGeometry::new(Some((0, 0)), Some((1280, 1440)), 2560, 2880);
+		assert!(
+			geometry
+				.window_crop(&portal_window("w", 2000, 0, 100, 100))
+				.is_none()
+		);
+		assert!(
+			geometry
+				.window_crop(&portal_window("w", -10, 0, 100, 100))
+				.is_none()
+		);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Wayland computer-use clicks landing in the wrong place on scaled monitors by mapping captures through the portal's logical monitor geometry ([#11540](https://github.com/can1357/oh-my-pi/issues/11540)).
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed


### PR DESCRIPTION
## Repro
On a Wayland monitor at scale 2 (2560×2880 physical buffer, 1280×1440 logical input region) with computer use enabled, a screenshot click misses its target. OMP caps the screenshot to 2133×2400, and a click at screenshot point `(1066, 1867)` is delivered to logical point `(1279.3999, 2240.4)` — the y coordinate lands far outside the 1440px logical input region, so the click misses. Reproduced deterministically:

```
cargo nextest run -p pi-natives -E 'test(/repro_issue_11540/)' --no-capture
REPRO click (1066,1867) -> logical (1279.3999, 2240.4000); input region 1280x1440
```

## Cause
`WaylandBackend::synthetic_display` (`crates/pi-natives/src/desktop/linux/wayland/mod.rs`) built a `DesktopDisplay` at `(0,0)` using the physical PipeWire buffer dimensions as the display's *logical* bounds with `scale: 1.0`, discarding the ScreenCast stream's logical `position`/`size`. `FrameGeometry::map_point` (`crates/pi-natives/src/desktop/frame.rs`) then scales a screenshot pixel by `width/pixel_width` — which, with `width == pixel_width`, is identity, so physical buffer pixels reach libei as logical coordinates. After the capture cap, `map_point` scales `(1066,1867)` by `2560/2133` and `2880/2400`, yielding `(1279.4, 2240.4)`. The `Target::Window` crop compounded this by using AT-SPI logical window bounds (`window.x/y/width/height`) directly as buffer-pixel offsets. X11's identical `scale: 1.0` shortcut is correct only because X11 reports native-pixel geometry.

## Fix
- `capture.rs`: read the ScreenCast stream's `position()`/`size()` in `open_screencast` and return them alongside the frame; `capture()` now yields `(RgbaImage, PortalGeometry)`.
- `mod.rs`: new `PortalGeometry` carrying logical position/size plus the physical buffer size. `display()` derives the display's logical bounds and scale (`pixel_width / logical_width`); `window_crop()` converts logical window bounds into a buffer-pixel crop rectangle and rejects windows outside the captured monitor.
- `mod.rs::capture` uses `PortalGeometry::display()` for the synthetic display and `window_crop()` for window targets, replacing the removed `synthetic_display` and the logical-as-pixel crop math.
- Missing or degenerate portal geometry falls back to the buffer size (scale 1), preserving prior behaviour on compositors that omit the mapping.
- `PortalGeometry` is gated `#[cfg(any(feature = "wayland-pipewire", test))]` so the default (feature-off) build carries no dead code.

## Verification
`cargo nextest run -p pi-natives -E 'test(/wayland::tests/)'` — 11 passed, including new coverage: `scaled_monitor_maps_screenshot_pixel_to_logical_point` (the reporter's `(1066,1867)` now maps inside the logical region), `monitor_offset_is_added_to_logical_point`, `missing_portal_size_falls_back_to_buffer_scale_one`, `window_crop_scales_logical_bounds_to_buffer_pixels`, `window_crop_rejects_window_outside_monitor`. `cargo clippy -p pi-natives --no-deps -- -D warnings` and `cargo fmt -p pi-natives -- --check` clean. The `--features wayland-pipewire` build could not be compiled in this environment (system `libpipewire-0.3` is not installed — the reason the feature is off by default and CI never builds it); the feature-gated capture wiring was reviewed for type/signature correctness. Fixes #11540