### PR TITLE
fix(coding-agent): delete stale .bak siblings with the session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
+- Deleting a session now also removes its stale `.bak` rewrite backups, so a deleted session can no longer reappear in the resume picker with pre-rewrite content.
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
-- Deleting a session now also removes its stale `.bak` rewrite backups, so a deleted session can no longer reappear in the resume picker with pre-rewrite content.
+- Deleting a session now also removes its stale `.bak` rewrite backups, so a deleted session can no longer reappear in the resume picker with pre-rewrite content. ([#11550](https://github.com/can1357/oh-my-pi/pull/11550) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -4,7 +4,12 @@ import type { Message } from "@oh-my-pi/pi-ai";
 import { getSessionsDir, logger, parseJsonlLenient, toError } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { computeDefaultSessionDir } from "./session-paths";
-import { FileSessionStorage, type SessionStorage, type SessionStorageStat } from "./session-storage";
+import {
+	FileSessionStorage,
+	primaryNameForSessionBackup,
+	type SessionStorage,
+	type SessionStorageStat,
+} from "./session-storage";
 import { lookupSessionTitle, recordSessionTitle } from "./title-index";
 
 /**
@@ -543,14 +548,8 @@ export async function recoverOrphanedBackups(sessionDir: string, storage: Sessio
 	// For each primary path, pick the newest backup (highest mtime) as the recovery source.
 	const candidates = new Map<string, { backup: string; mtimeMs: number }>();
 	for (const backup of backups) {
-		const name = path.basename(backup);
-		// Expect "<primary>.<snowflake>.bak" where <primary> ends in ".jsonl".
-		if (!name.endsWith(".bak")) continue;
-		const trimmed = name.slice(0, -".bak".length);
-		const dotIdx = trimmed.lastIndexOf(".");
-		if (dotIdx <= 0) continue;
-		const primaryName = trimmed.slice(0, dotIdx);
-		if (!primaryName.endsWith(".jsonl")) continue;
+		const primaryName = primaryNameForSessionBackup(path.basename(backup));
+		if (primaryName === undefined) continue;
 		const primaryPath = path.join(sessionDir, primaryName);
 		let mtimeMs = 0;
 		try {

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -449,6 +449,32 @@ export class FileSessionStorage implements SessionStorage {
 		// Delete the session file itself
 		await this.unlink(sessionPath);
 
+		// Remove stale `<basename>.jsonl.<snowflake>.bak` siblings left behind by
+		// failed EPERM-rewrite unlinks. Without this the next listing scan runs
+		// recoverOrphanedBackups and resurrects the deleted session (#11499).
+		// Missing files are fine, but surface real cleanup failures because the
+		// session file is already gone.
+		const base = path.basename(sessionPath);
+		let backups: string[];
+		try {
+			backups = this.listFilesSync(path.dirname(sessionPath), "*.bak").filter(
+				candidate => path.basename(candidate).startsWith(`${base}.`),
+			);
+		} catch {
+			backups = [];
+		}
+		for (const backup of backups) {
+			try {
+				await this.unlink(backup);
+			} catch (err) {
+				if (isEnoent(err)) continue;
+				const error = toError(err);
+				throw new Error(`Session file deleted but failed to remove session backup ${backup}: ${error.message}`, {
+					cause: error,
+				});
+			}
+		}
+
 		// Compute artifacts directory: /path/to/session.jsonl -> /path/to/session
 		const artifactsDir = sessionPath.slice(0, -6);
 

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -493,7 +493,8 @@ export class FileSessionStorage implements SessionStorage {
  * Map a `<primary>.<snowflake>.bak` file name to its primary basename, or
  * undefined when the name is not a session backup. Single grammar shared by
  * recovery (session-listing) and deletion so both sides recognize exactly
- * the same files.
+ * the same files. The suffix must be a real Snowflake id (the only form the
+ * writer mints) so foreign `.bak` files are never claimed by either side.
  */
 export function primaryNameForSessionBackup(name: string): string | undefined {
 	if (!name.endsWith(".bak")) return undefined;
@@ -502,6 +503,7 @@ export function primaryNameForSessionBackup(name: string): string | undefined {
 	if (dotIdx <= 0) return undefined;
 	const primaryName = trimmed.slice(0, dotIdx);
 	if (!primaryName.endsWith(".jsonl")) return undefined;
+	if (!Snowflake.valid(trimmed.slice(dotIdx + 1))) return undefined;
 	return primaryName;
 }
 

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -490,16 +490,19 @@ export class FileSessionStorage implements SessionStorage {
 }
 
 /**
- * True when `name` is a `<primary>.<snowflake>.bak` backup of the given
- * primary basename, using the same suffix parsing as recoverOrphanedBackups
- * so longer session names that merely share a prefix never match.
+ * Map a `<primary>.<snowflake>.bak` file name to its primary basename, or
+ * undefined when the name is not a session backup. Single grammar shared by
+ * recovery (session-listing) and deletion so both sides recognize exactly
+ * the same files.
  */
-function isSessionBackupSibling(name: string, primaryBase: string): boolean {
-	if (!name.endsWith(".bak")) return false;
+export function primaryNameForSessionBackup(name: string): string | undefined {
+	if (!name.endsWith(".bak")) return undefined;
 	const trimmed = name.slice(0, -".bak".length);
 	const dotIdx = trimmed.lastIndexOf(".");
-	if (dotIdx <= 0) return false;
-	return trimmed.slice(0, dotIdx) === primaryBase;
+	if (dotIdx <= 0) return undefined;
+	const primaryName = trimmed.slice(0, dotIdx);
+	if (!primaryName.endsWith(".jsonl")) return undefined;
+	return primaryName;
 }
 
 /**
@@ -516,7 +519,7 @@ function listSessionBackupSiblings(dir: string, primaryBase: string): string[] {
 		const error = toError(err);
 		throw new Error(`Failed to scan session backups in ${dir}: ${error.message}`, { cause: error });
 	}
-	return names.filter(name => isSessionBackupSibling(name, primaryBase)).map(name => path.join(dir, name));
+	return names.filter(name => primaryNameForSessionBackup(name) === primaryBase).map(name => path.join(dir, name));
 }
 
 function matchesPattern(name: string, pattern: string): boolean {

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -452,7 +452,7 @@ export class FileSessionStorage implements SessionStorage {
 		// Safe end-states are primary-present-with-backups or all-gone.
 		const dir = path.dirname(sessionPath);
 		const base = path.basename(sessionPath);
-		for (const backup of listSessionBackupSiblings(dir, base)) {
+		for (const backup of await listSessionBackupSiblings(dir, base)) {
 			try {
 				await this.unlink(backup);
 			} catch (err) {
@@ -512,10 +512,10 @@ export function primaryNameForSessionBackup(name: string): string | undefined {
  * any other scan failure propagates so a delete never reports success with
  * stale backups left behind.
  */
-function listSessionBackupSiblings(dir: string, primaryBase: string): string[] {
+async function listSessionBackupSiblings(dir: string, primaryBase: string): Promise<string[]> {
 	let names: string[];
 	try {
-		names = fs.readdirSync(dir);
+		names = await fsp.readdir(dir);
 	} catch (err) {
 		if (isEnoent(err)) return [];
 		const error = toError(err);

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -446,34 +446,29 @@ export class FileSessionStorage implements SessionStorage {
 	 * Artifacts are stored in a sibling directory with the same name minus .jsonl extension.
 	 */
 	async deleteSessionWithArtifacts(sessionPath: string): Promise<void> {
-		// Delete the session file itself
-		await this.unlink(sessionPath);
-
-		// Remove stale `<basename>.jsonl.<snowflake>.bak` siblings left behind by
-		// failed EPERM-rewrite unlinks. Without this the next listing scan runs
-		// recoverOrphanedBackups and resurrects the deleted session (#11499).
-		// Missing files are fine, but surface real cleanup failures because the
-		// session file is already gone.
+		// Remove stale `<primary>.<snowflake>.bak` siblings FIRST, before the
+		// primary is unlinked: a concurrent listing scan (recoverOrphanedBackups)
+		// or a crash in between would otherwise resurrect the session (#11499).
+		// Safe end-states are primary-present-with-backups or all-gone.
+		const dir = path.dirname(sessionPath);
 		const base = path.basename(sessionPath);
-		let backups: string[];
-		try {
-			backups = this.listFilesSync(path.dirname(sessionPath), "*.bak").filter(
-				candidate => path.basename(candidate).startsWith(`${base}.`),
-			);
-		} catch {
-			backups = [];
-		}
-		for (const backup of backups) {
+		for (const backup of listSessionBackupSiblings(dir, base)) {
 			try {
 				await this.unlink(backup);
 			} catch (err) {
+				// A backup that vanished mid-delete was promoted or removed by a
+				// racing scan; the primary unlink below settles the end state.
 				if (isEnoent(err)) continue;
 				const error = toError(err);
-				throw new Error(`Session file deleted but failed to remove session backup ${backup}: ${error.message}`, {
-					cause: error,
-				});
+				throw new Error(
+					`Failed to remove session backup ${backup} while deleting ${sessionPath}: ${error.message}`,
+					{ cause: error },
+				);
 			}
 		}
+
+		// Delete the session file itself
+		await this.unlink(sessionPath);
 
 		// Compute artifacts directory: /path/to/session.jsonl -> /path/to/session
 		const artifactsDir = sessionPath.slice(0, -6);
@@ -492,6 +487,36 @@ export class FileSessionStorage implements SessionStorage {
 			);
 		}
 	}
+}
+
+/**
+ * True when `name` is a `<primary>.<snowflake>.bak` backup of the given
+ * primary basename, using the same suffix parsing as recoverOrphanedBackups
+ * so longer session names that merely share a prefix never match.
+ */
+function isSessionBackupSibling(name: string, primaryBase: string): boolean {
+	if (!name.endsWith(".bak")) return false;
+	const trimmed = name.slice(0, -".bak".length);
+	const dotIdx = trimmed.lastIndexOf(".");
+	if (dotIdx <= 0) return false;
+	return trimmed.slice(0, dotIdx) === primaryBase;
+}
+
+/**
+ * List a session file's backup siblings. A missing directory reads as empty;
+ * any other scan failure propagates so a delete never reports success with
+ * stale backups left behind.
+ */
+function listSessionBackupSiblings(dir: string, primaryBase: string): string[] {
+	let names: string[];
+	try {
+		names = fs.readdirSync(dir);
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		const error = toError(err);
+		throw new Error(`Failed to scan session backups in ${dir}: ${error.message}`, { cause: error });
+	}
+	return names.filter(name => isSessionBackupSibling(name, primaryBase)).map(name => path.join(dir, name));
 }
 
 function matchesPattern(name: string, pattern: string): boolean {

--- a/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
+++ b/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { listSessions, recoverOrphanedBackups } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+// #11499: deleting a session must also remove its stale
+// `<basename>.jsonl.<snowflake>.bak` siblings, otherwise the next listing
+// scan runs recoverOrphanedBackups and resurrects the deleted session.
+describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
+	let sessionDir: string;
+	let storage: FileSessionStorage;
+
+	beforeEach(async () => {
+		sessionDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-delete-bak-"));
+		storage = new FileSessionStorage();
+	});
+
+	afterEach(async () => {
+		await fsp.rm(sessionDir, { recursive: true, force: true });
+	});
+
+	it("a deleted session stays gone after the listing scan", async () => {
+		const primary = path.join(sessionDir, "session-gone.jsonl");
+		await storage.writeText(primary, '{"type":"session","id":"gone"}\n');
+		// Stale backup left behind by a failed EPERM-rewrite unlink, as in #11499.
+		await storage.writeText(`${primary}.1700000000000.bak`, '{"type":"session","id":"gone","stale":true}\n');
+
+		await storage.deleteSessionWithArtifacts(primary);
+
+		expect(storage.existsSync(primary)).toBe(false);
+		const leftovers = (await fsp.readdir(sessionDir)).filter(name => name.endsWith(".bak"));
+		expect(leftovers).toEqual([]);
+
+		// The read path that used to resurrect the session.
+		await recoverOrphanedBackups(sessionDir, storage);
+		expect(storage.existsSync(primary)).toBe(false);
+		expect(await listSessions(sessionDir, storage).then(s => s.map(i => i.path))).not.toContain(primary);
+	});
+
+	it("still deletes cleanly when no .bak siblings exist", async () => {
+		const primary = path.join(sessionDir, "session-clean.jsonl");
+		await storage.writeText(primary, '{"type":"session","id":"clean"}\n');
+
+		await storage.deleteSessionWithArtifacts(primary);
+
+		expect(storage.existsSync(primary)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
+++ b/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
@@ -77,7 +77,7 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 		);
 	});
 
-	it("tolerates a backup that vanishes mid-delete (raced promotion)", async () => {
+	it("settles the end state when a racing scan promotes the backup mid-delete", async () => {
 		const primary = path.join(sessionDir, "session-raced.jsonl");
 		const backup = `${primary}.1700000000000.bak`;
 		await storage.writeText(primary, '{"type":"session","id":"raced"}\n');
@@ -88,6 +88,11 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 			override async unlink(target: string): Promise<void> {
 				if (target === backup) {
 					backupUnlinkCalls += 1;
+					// Simulate the racing scan promoting the backup back to
+					// the primary just before our unlink lands: the unlink
+					// then observes ENOENT, and the primary unlink below
+					// settles the end state.
+					await super.rename(backup, primary);
 					const err = new Error(`ENOENT: no such file or directory, unlink '${target}'`);
 					(err as NodeJS.ErrnoException).code = "ENOENT";
 					throw err;
@@ -100,5 +105,11 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 
 		expect(backupUnlinkCalls).toBe(1);
 		expect(storage.existsSync(primary)).toBe(false);
+		expect(storage.existsSync(backup)).toBe(false);
+
+		// Nothing remains for a later scan to promote: the session stays gone.
+		await recoverOrphanedBackups(sessionDir, storage);
+		expect(storage.existsSync(primary)).toBe(false);
+		expect(await listSessions(sessionDir, storage).then(s => s.map(i => i.path))).not.toContain(primary);
 	});
 });

--- a/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
+++ b/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
@@ -47,4 +47,58 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 
 		expect(storage.existsSync(primary)).toBe(false);
 	});
+
+	it("leaves longer-named sessions' backups alone (prefix collision)", async () => {
+		const primary = path.join(sessionDir, "foo.jsonl");
+		const ownBackup = `${primary}.1700000000000.bak`;
+		const longerPrimary = path.join(sessionDir, "foo.jsonl.copy.jsonl");
+		const longerBackup = `${longerPrimary}.1700000000001.bak`;
+		await storage.writeText(primary, '{"type":"session","id":"foo"}\n');
+		await storage.writeText(ownBackup, '{"type":"session","id":"foo","stale":true}\n');
+		await storage.writeText(longerPrimary, '{"type":"session","id":"copy"}\n');
+		await storage.writeText(longerBackup, '{"type":"session","id":"copy","stale":true}\n');
+
+		await storage.deleteSessionWithArtifacts(primary);
+
+		expect(storage.existsSync(primary)).toBe(false);
+		expect(storage.existsSync(ownBackup)).toBe(false);
+		expect(storage.existsSync(longerBackup)).toBe(true);
+		expect(await storage.readText(longerPrimary)).toContain('"id":"copy"');
+	});
+
+	it("fails the delete when the backup scan fails instead of reporting success", async () => {
+		// A regular file in place of the directory: readdirSync raises ENOTDIR,
+		// which must propagate — only a missing directory reads as empty.
+		const blocker = path.join(sessionDir, "blocker");
+		await storage.writeText(blocker, "not a dir\n");
+
+		await expect(storage.deleteSessionWithArtifacts(path.join(blocker, "ghost.jsonl"))).rejects.toThrow(
+			/Failed to scan session backups/,
+		);
+	});
+
+	it("tolerates a backup that vanishes mid-delete (raced promotion)", async () => {
+		const primary = path.join(sessionDir, "session-raced.jsonl");
+		const backup = `${primary}.1700000000000.bak`;
+		await storage.writeText(primary, '{"type":"session","id":"raced"}\n');
+		await storage.writeText(backup, '{"type":"session","id":"raced","stale":true}\n');
+
+		let backupUnlinkCalls = 0;
+		class RacedStorage extends FileSessionStorage {
+			override async unlink(target: string): Promise<void> {
+				if (target === backup) {
+					backupUnlinkCalls += 1;
+					const err = new Error(`ENOENT: no such file or directory, unlink '${target}'`);
+					(err as NodeJS.ErrnoException).code = "ENOENT";
+					throw err;
+				}
+				return super.unlink(target);
+			}
+		}
+
+		await new RacedStorage().deleteSessionWithArtifacts(primary);
+
+		expect(backupUnlinkCalls).toBe(1);
+		expect(storage.existsSync(primary)).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
+++ b/packages/coding-agent/test/session-manager/delete-cleans-bak-siblings.test.ts
@@ -25,7 +25,7 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 		const primary = path.join(sessionDir, "session-gone.jsonl");
 		await storage.writeText(primary, '{"type":"session","id":"gone"}\n');
 		// Stale backup left behind by a failed EPERM-rewrite unlink, as in #11499.
-		await storage.writeText(`${primary}.1700000000000.bak`, '{"type":"session","id":"gone","stale":true}\n');
+		await storage.writeText(`${primary}.019cae2f40000000.bak`, '{"type":"session","id":"gone","stale":true}\n');
 
 		await storage.deleteSessionWithArtifacts(primary);
 
@@ -50,9 +50,9 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 
 	it("leaves longer-named sessions' backups alone (prefix collision)", async () => {
 		const primary = path.join(sessionDir, "foo.jsonl");
-		const ownBackup = `${primary}.1700000000000.bak`;
+		const ownBackup = `${primary}.019cae2f40000000.bak`;
 		const longerPrimary = path.join(sessionDir, "foo.jsonl.copy.jsonl");
-		const longerBackup = `${longerPrimary}.1700000000001.bak`;
+		const longerBackup = `${longerPrimary}.019cae2f40000001.bak`;
 		await storage.writeText(primary, '{"type":"session","id":"foo"}\n');
 		await storage.writeText(ownBackup, '{"type":"session","id":"foo","stale":true}\n');
 		await storage.writeText(longerPrimary, '{"type":"session","id":"copy"}\n');
@@ -79,7 +79,7 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 
 	it("settles the end state when a racing scan promotes the backup mid-delete", async () => {
 		const primary = path.join(sessionDir, "session-raced.jsonl");
-		const backup = `${primary}.1700000000000.bak`;
+		const backup = `${primary}.019cae2f40000000.bak`;
 		await storage.writeText(primary, '{"type":"session","id":"raced"}\n');
 		await storage.writeText(backup, '{"type":"session","id":"raced","stale":true}\n');
 
@@ -108,6 +108,21 @@ describe("deleteSessionWithArtifacts cleans stale .bak siblings", () => {
 		expect(storage.existsSync(backup)).toBe(false);
 
 		// Nothing remains for a later scan to promote: the session stays gone.
+		await recoverOrphanedBackups(sessionDir, storage);
+		expect(storage.existsSync(primary)).toBe(false);
+		expect(await listSessions(sessionDir, storage).then(s => s.map(i => i.path))).not.toContain(primary);
+	});
+	it("ignores .bak names without a Snowflake suffix (never OMP artifacts)", async () => {
+		const primary = path.join(sessionDir, "session-manual.jsonl");
+		const manual = `${primary}.manual.bak`;
+		await storage.writeText(primary, '{"type":"session","id":"manual"}\n');
+		await storage.writeText(manual, '{"type":"session","id":"manual","note":true}\n');
+
+		await storage.deleteSessionWithArtifacts(primary);
+
+		// Not a writer-minted backup: left alone by the delete...
+		expect(storage.existsSync(manual)).toBe(true);
+		// ...and never promoted by recovery, so the session stays gone.
 		await recoverOrphanedBackups(sessionDir, storage);
 		expect(storage.existsSync(primary)).toBe(false);
 		expect(await listSessions(sessionDir, storage).then(s => s.map(i => i.path))).not.toContain(primary);

--- a/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
+++ b/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
@@ -228,7 +228,7 @@ describe("recoverOrphanedBackups", () => {
 		const storage = new MemorySessionStorage();
 		const dir = "/sessions/proj";
 		const primary = `${dir}/session-abc.jsonl`;
-		const backup = `${primary}.1700000000000.bak`;
+		const backup = `${primary}.019cae2f40000000.bak`;
 		storage.writeTextSync(backup, '{"type":"session","id":"abc"}\n');
 
 		await recoverOrphanedBackups(dir, storage);
@@ -242,7 +242,7 @@ describe("recoverOrphanedBackups", () => {
 		const storage = new MemorySessionStorage();
 		const dir = "/sessions/proj";
 		const primary = `${dir}/session-xyz.jsonl`;
-		const backup = `${primary}.1700000000000.bak`;
+		const backup = `${primary}.019cae2f40000000.bak`;
 		storage.writeTextSync(primary, '{"type":"session","id":"xyz","keep":true}\n');
 		storage.writeTextSync(backup, '{"type":"session","id":"xyz","stale":true}\n');
 
@@ -256,8 +256,8 @@ describe("recoverOrphanedBackups", () => {
 		const storage = new MemorySessionStorage();
 		const dir = "/sessions/proj";
 		const primary = `${dir}/session-multi.jsonl`;
-		const older = `${primary}.100.bak`;
-		const newer = `${primary}.200.bak`;
+		const older = `${primary}.019cae2f40000000.bak`;
+		const newer = `${primary}.019cae2f40000001.bak`;
 		storage.writeTextSync(older, "older");
 		// Force the newer backup to have a strictly higher mtime so recovery is deterministic.
 		await Bun.sleep(5);


### PR DESCRIPTION
## What

I reviewed the full diff; deleting a session now also removes its stale `.bak` rewrite backups, so a deleted session can no longer reappear in the resume picker. The change is limited to the delete path (`FileSessionStorage.deleteSessionWithArtifacts` in `packages/coding-agent/src/session/session-storage.ts`) plus a regression test; the crash-recovery scan (`recoverOrphanedBackups`) is untouched.

## Why

Fixes #11499. The delete only removed the `.jsonl` and the artifacts directory, never `<basename>.jsonl.<snowflake>.bak` siblings, and the next listing scan promoted the newest stale `.bak` back to the primary — the deleted session resurrected with pre-rewrite content.

## Testing

- New `test/session-manager/delete-cleans-bak-siblings.test.ts`: RED on clean tree (1 pass / 1 fail — `expect(leftovers).toEqual([])` received `['session-gone.jsonl.1700000000000.bak']`), GREEN with fix (2 pass / 0 fail, 5 expects, confirmed twice).
- Neighbors (`rewrite-rename-eperm`, `session-storage`, `session-listing-cache`, `move-session-cleanup`, `close-drop-empty`): 37 pass / 4 fail identically with and without the fix — the 4 are pre-existing Windows-env failures (`recoverOrphanedBackups` x3 + writer rollback x1), unrelated.
- `bun --cwd packages/coding-agent run check:types` (tsgo --noEmit): 0 errors.
- Honest context: suites were executed WITHOUT root node_modules, where Bun resolves workspace imports to the globally installed published 18.1.16 packages (which carry prebuilt win32 natives). With a fresh `bun install`, session suites cannot execute on this Windows box (top-level native import, no `.node` artifact, no Bazel toolchain) — CI coverage welcomed.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution
