### PR TITLE
fix(cli): reject missing --fork session paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
+- `omp --fork` with a missing session path now fails with `Session "<path>" not found.` instead of silently opening an empty parentless session ([#11491](https://github.com/can1357/oh-my-pi/issues/11491)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
-- `omp --fork` with a missing session path now fails with `Session "<path>" not found.` instead of silently opening an empty parentless session ([#11491](https://github.com/can1357/oh-my-pi/issues/11491)).
+- `omp --fork` with a missing session path now fails with `Session "<path>" not found.` instead of silently opening an empty parentless session ([#11556](https://github.com/can1357/oh-my-pi/pull/11556) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -99,7 +99,6 @@ import {
 import type { ForeignSessionInfo, ForeignSessionSource, ForeignSessionStore } from "./session/foreign-session-store";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
 import { ForkSourceNotFoundError, SessionManager } from "./session/session-manager";
-import { FileSessionStorage } from "./session/session-storage";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
@@ -967,9 +966,10 @@ export async function createSessionManager(
 		}
 		const forkSource = parsed.fork;
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
-			if (!(await new FileSessionStorage().exists(forkSource))) {
-				throw new SessionResolutionError(`Session "${forkSource}" not found.`, FORK_NOT_FOUND_HINT);
-			}
+			// No exists() preflight: forkFrom performs the authoritative
+			// throwIfMissing load and the catch below maps its typed
+			// missing-source error, so path-form forks use a single read
+			// and never depend on a stale preflight snapshot.
 			try {
 				return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
 			} catch (err) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -99,6 +99,7 @@ import {
 import type { ForeignSessionInfo, ForeignSessionSource, ForeignSessionStore } from "./session/foreign-session-store";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
 import { SessionManager } from "./session/session-manager";
+import { FileSessionStorage } from "./session/session-storage";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
@@ -963,6 +964,12 @@ export async function createSessionManager(
 		}
 		const forkSource = parsed.fork;
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
+			if (!(await new FileSessionStorage().exists(forkSource))) {
+				throw new SessionResolutionError(
+					`Session "${forkSource}" not found.`,
+					"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
+				);
+			}
 			return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
 		}
 		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -98,7 +98,7 @@ import {
 } from "./session/foreign-session-import";
 import type { ForeignSessionInfo, ForeignSessionSource, ForeignSessionStore } from "./session/foreign-session-store";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
-import { SessionManager } from "./session/session-manager";
+import { ForkSourceNotFoundError, SessionManager } from "./session/session-manager";
 import { FileSessionStorage } from "./session/session-storage";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { shouldShowStartupSplash } from "./startup-splash";
@@ -951,6 +951,9 @@ export function normalizeContinueSessionArgs(parsed: Args, rawArgs?: readonly st
 	parsed.messages.splice(messageIndex, 1);
 }
 
+const FORK_NOT_FOUND_HINT =
+	"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.";
+
 /** Resolves CLI session flags into an existing, forked, in-memory, or cancelled session manager. */
 export async function createSessionManager(
 	parsed: Args,
@@ -965,21 +968,29 @@ export async function createSessionManager(
 		const forkSource = parsed.fork;
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
 			if (!(await new FileSessionStorage().exists(forkSource))) {
-				throw new SessionResolutionError(
-					`Session "${forkSource}" not found.`,
-					"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
-				);
+				throw new SessionResolutionError(`Session "${forkSource}" not found.`, FORK_NOT_FOUND_HINT);
 			}
-			return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
+			try {
+				return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
+			} catch (err) {
+				if (err instanceof ForkSourceNotFoundError) {
+					throw new SessionResolutionError(err.message, FORK_NOT_FOUND_HINT);
+				}
+				throw err;
+			}
 		}
 		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);
 		if (!match) {
-			throw new SessionResolutionError(
-				`Session "${forkSource}" not found.`,
-				"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
-			);
+			throw new SessionResolutionError(`Session "${forkSource}" not found.`, FORK_NOT_FOUND_HINT);
 		}
-		return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
+		try {
+			return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
+		} catch (err) {
+			if (err instanceof ForkSourceNotFoundError) {
+				throw new SessionResolutionError(err.message, FORK_NOT_FOUND_HINT);
+			}
+			throw err;
+		}
 	}
 
 	if (parsed.noSession) {

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -31,6 +31,8 @@ export interface VisitEntriesFromFileStreamOptions {
 	yieldEveryEntries?: number;
 	/** Called once for every malformed JSONL record skipped by the stream. */
 	onMalformedRecord?: () => void;
+	/** Rethrow a missing source instead of visiting nothing (fork backstop). */
+	throwIfMissing?: boolean;
 }
 
 /** Parsed session entries plus corruption metadata needed by writable loaders. */
@@ -229,7 +231,10 @@ export async function visitEntriesFromFileStream(
 		}
 	} catch (err) {
 		if (visitorThrew) throw err;
-		if (isEnoent(err)) return undefined;
+		if (isEnoent(err)) {
+			if (options.throwIfMissing) throw err;
+			return undefined;
+		}
 		throw err;
 	}
 
@@ -237,7 +242,10 @@ export async function visitEntriesFromFileStream(
 }
 
 /** Exported for testing — the ≥8MiB streaming path (works on any file size). */
-export async function loadEntriesFromFileStream(filePath: string): Promise<SessionLoadResult> {
+export async function loadEntriesFromFileStream(
+	filePath: string,
+	options?: Pick<VisitEntriesFromFileStreamOptions, "throwIfMissing">,
+): Promise<SessionLoadResult> {
 	const entries: FileEntry[] = [];
 	let malformedRecords = 0;
 	const titleSlot = await visitEntriesFromFileStream(
@@ -249,6 +257,7 @@ export async function loadEntriesFromFileStream(filePath: string): Promise<Sessi
 			onMalformedRecord: () => {
 				malformedRecords++;
 			},
+			throwIfMissing: options?.throwIfMissing,
 		},
 	);
 	return {
@@ -268,9 +277,14 @@ function shouldStreamEntries(storage: SessionStorage, size: number): boolean {
 	return storage instanceof FileSessionStorage && size >= STREAM_LOAD_THRESHOLD_BYTES;
 }
 
-async function loadWithKnownSize(filePath: string, storage: SessionStorage, size: number): Promise<SessionLoadResult> {
+async function loadWithKnownSize(
+	filePath: string,
+	storage: SessionStorage,
+	size: number,
+	options?: { throwIfMissing?: boolean },
+): Promise<SessionLoadResult> {
 	const loaded = shouldStreamEntries(storage, size)
-		? await loadEntriesFromFileStream(filePath)
+		? await loadEntriesFromFileStream(filePath, options)
 		: parseSessionContent(await storage.readText(filePath));
 	return loaded.invalidHeader ? { ...loaded, entries: [] } : loaded;
 }
@@ -282,7 +296,7 @@ export async function loadSessionFile(
 	options?: { throwIfMissing?: boolean },
 ): Promise<SessionLoadResult> {
 	try {
-		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
+		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size, options);
 	} catch (err) {
 		if (isEnoent(err)) {
 			if (options?.throwIfMissing) throw err;

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -279,11 +279,15 @@ async function loadWithKnownSize(filePath: string, storage: SessionStorage, size
 export async function loadSessionFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	options?: { throwIfMissing?: boolean },
 ): Promise<SessionLoadResult> {
 	try {
 		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
 	} catch (err) {
-		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		if (isEnoent(err)) {
+			if (options?.throwIfMissing) throw err;
+			return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
+		}
 		throw err;
 	}
 }
@@ -292,8 +296,9 @@ export async function loadSessionFile(
 export async function loadEntriesFromFile(
 	filePath: string,
 	storage: SessionStorage = new FileSessionStorage(),
+	options?: { throwIfMissing?: boolean },
 ): Promise<FileEntry[]> {
-	return (await loadSessionFile(filePath, storage)).entries;
+	return (await loadSessionFile(filePath, storage, options)).entries;
 }
 
 /**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2868,7 +2868,18 @@ export class SessionManager {
 		const manager = new SessionManager(cwd, dir, true, storage);
 		manager.#suppressBreadcrumb = options?.suppressBreadcrumb === true;
 
-		const sourceEntries = structuredClone(await loadEntriesFromFile(sourcePath, storage)) as FileEntry[];
+		// A source deleted after the caller's existence check must still fail
+		// instead of forking an empty parentless session: the loader swallows
+		// ENOENT by default for fresh-session opens, so fork opts out.
+		let sourceEntries: FileEntry[];
+		try {
+			sourceEntries = structuredClone(
+				await loadEntriesFromFile(sourcePath, storage, { throwIfMissing: true }),
+			) as FileEntry[];
+		} catch (err) {
+			if (isEnoent(err)) throw new Error(`Session "${sourcePath}" not found.`);
+			throw err;
+		}
 		migrateToCurrentVersion(sourceEntries);
 		await resolveBlobRefsInEntries(sourceEntries, manager.#blobs);
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -451,6 +451,19 @@ export class SessionPersistenceIndeterminateError extends AggregateError {
 }
 
 /**
+ * Thrown by {@link SessionManager.forkFrom} when the fork source disappears
+ * between the caller's existence check and the load. The CLI maps this to a
+ * clean session-resolution failure at its own boundary (this module must not
+ * import `main.ts`, where `SessionResolutionError` lives).
+ */
+export class ForkSourceNotFoundError extends Error {
+	constructor(sourcePath: string) {
+		super(`Session "${sourcePath}" not found.`);
+		this.name = "ForkSourceNotFoundError";
+	}
+}
+
+/**
  * Stores and navigates an append-only conversation journal.
  *
  * A session is a JSONL file: one header line followed by entries. Entries form a
@@ -2877,7 +2890,7 @@ export class SessionManager {
 				await loadEntriesFromFile(sourcePath, storage, { throwIfMissing: true }),
 			) as FileEntry[];
 		} catch (err) {
-			if (isEnoent(err)) throw new Error(`Session "${sourcePath}" not found.`);
+			if (isEnoent(err)) throw new ForkSourceNotFoundError(sourcePath);
 			throw err;
 		}
 		migrateToCurrentVersion(sourceEntries);

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -254,4 +254,28 @@ describe("createSessionManager — missing session (#2084)", () => {
 			await fsp.rm(cwd, { recursive: true, force: true });
 		}
 	});
+	it("forkFrom rejects a large vanished source taken by the streaming path (#11491)", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-fork-vanished-stream-"));
+		const sessionDir = path.join(cwd, "sessions");
+		await fsp.mkdir(sessionDir, { recursive: true });
+		const missingPath = path.join(cwd, "ghost-big-zz9q.jsonl");
+		const storage = new FileSessionStorage();
+		const realStatSync = storage.statSync.bind(storage);
+		// Report a stream-sized file that is already gone when the stream
+		// opens: statSync succeeds, Bun.file(...).stream() raises ENOENT.
+		vi.spyOn(storage, "statSync").mockImplementation((target: string) =>
+			target === missingPath
+				? { size: 8 * 1024 * 1024, mtimeMs: Date.now(), mtime: new Date() }
+				: realStatSync(target),
+		);
+		try {
+			await expect(SessionManager.forkFrom(missingPath, cwd, sessionDir, storage)).rejects.toThrowError(
+				ForkSourceNotFoundError,
+			);
+			expect(await fsp.readdir(sessionDir)).toEqual([]);
+		} finally {
+			vi.restoreAllMocks();
+			await fsp.rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -196,4 +196,19 @@ describe("createSessionManager — missing session (#2084)", () => {
 			hint: undefined,
 		});
 	});
+
+	it("rejects --fork with a missing path before materializing anything (#11491)", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-fork-missing-path-"));
+		const missingPath = path.join(cwd, "ghost-zz9q.jsonl");
+		try {
+			await expect(createSessionManager(buildForkArgs(missingPath), cwd, stubSettings)).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: `Session "${missingPath}" not found.`,
+			});
+			const entries = await fsp.readdir(cwd, { recursive: true });
+			expect(entries.filter(name => name.endsWith(".jsonl"))).toEqual([]);
+		} finally {
+			await fsp.rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -13,7 +13,8 @@ import type { Args } from "@oh-my-pi/pi-coding-agent/cli/args";
 import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createSessionManager, SessionResolutionError, writeStartupNotice } from "@oh-my-pi/pi-coding-agent/main";
 import * as sessionListingModule from "@oh-my-pi/pi-coding-agent/session/session-listing";
-import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { ForkSourceNotFoundError, SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 
 function buildResumeArgs(resume: string, sessionDir?: string): Args {
 	return {
@@ -225,8 +226,31 @@ describe("createSessionManager — missing session (#2084)", () => {
 			await expect(SessionManager.forkFrom(missingPath, cwd, sessionDir)).rejects.toThrow(
 				`Session "${missingPath}" not found.`,
 			);
+			// Typed so the CLI boundary can map it to the clean stderr failure.
+			const caught = await SessionManager.forkFrom(missingPath, cwd, sessionDir).catch((err: unknown) => err);
+			expect(caught).toBeInstanceOf(ForkSourceNotFoundError);
 			expect(await fsp.readdir(sessionDir)).toEqual([]);
 		} finally {
+			await fsp.rm(cwd, { recursive: true, force: true });
+		}
+	});
+	it("maps a source that vanishes after the preflight to SessionResolutionError (#11491)", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-fork-vanished-cli-"));
+		const sessionDir = path.join(cwd, "sessions");
+		await fsp.mkdir(sessionDir, { recursive: true });
+		const missingPath = path.join(cwd, "ghost-zz9q.jsonl");
+		vi.spyOn(FileSessionStorage.prototype, "exists").mockResolvedValue(true);
+		try {
+			await expect(
+				createSessionManager(buildForkArgs(missingPath, false, sessionDir), cwd, stubSettings),
+			).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: `Session "${missingPath}" not found.`,
+				hint: expect.stringContaining("omp --resume"),
+			});
+			expect(await fsp.readdir(sessionDir)).toEqual([]);
+		} finally {
+			vi.restoreAllMocks();
 			await fsp.rm(cwd, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -37,10 +37,11 @@ function buildContinueArgs(message: string, sessionDir?: string): Args {
 	};
 }
 
-function buildForkArgs(fork: string, noSession = false): Args {
+function buildForkArgs(fork: string, noSession = false, sessionDir?: string): Args {
 	return {
 		fork,
 		noSession: noSession || undefined,
+		sessionDir,
 		messages: [],
 		fileArgs: [],
 		unknownFlags: new Map(),
@@ -199,14 +200,32 @@ describe("createSessionManager — missing session (#2084)", () => {
 
 	it("rejects --fork with a missing path before materializing anything (#11491)", async () => {
 		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-fork-missing-path-"));
+		const sessionDir = path.join(cwd, "sessions");
+		await fsp.mkdir(sessionDir, { recursive: true });
 		const missingPath = path.join(cwd, "ghost-zz9q.jsonl");
 		try {
-			await expect(createSessionManager(buildForkArgs(missingPath), cwd, stubSettings)).rejects.toMatchObject({
+			await expect(
+				createSessionManager(buildForkArgs(missingPath, false, sessionDir), cwd, stubSettings),
+			).rejects.toMatchObject({
 				name: "SessionResolutionError",
 				message: `Session "${missingPath}" not found.`,
 			});
-			const entries = await fsp.readdir(cwd, { recursive: true });
-			expect(entries.filter(name => name.endsWith(".jsonl"))).toEqual([]);
+			expect(await fsp.readdir(sessionDir)).toEqual([]);
+		} finally {
+			await fsp.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("forkFrom rejects a vanished source without materializing (race backstop, #11491)", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-fork-vanished-"));
+		const sessionDir = path.join(cwd, "sessions");
+		await fsp.mkdir(sessionDir, { recursive: true });
+		const missingPath = path.join(cwd, "ghost-zz9q.jsonl");
+		try {
+			await expect(SessionManager.forkFrom(missingPath, cwd, sessionDir)).rejects.toThrow(
+				`Session "${missingPath}" not found.`,
+			);
+			expect(await fsp.readdir(sessionDir)).toEqual([]);
 		} finally {
 			await fsp.rm(cwd, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## What

I made the path form of `--fork` fail fast on a missing file instead of silently opening an empty session. `createSessionManager` now checks the fork source exists before calling `forkFrom`, throwing the same `Session "<source>" not found.` error (with the same usage hint) that the id form already throws — so both spellings of one flag finally agree, and nothing is materialized in the session store on a miss. As a backstop for the check-then-load race, `forkFrom` itself loads with an opt-in throw-if-missing mode and maps a vanished source to the same not-found error before writing anything.

## Why

Fixes #11491

#11553 reports the same trap from a second reporter (same missing-path mechanism, same silent empty session), which corroborates the fix; closing #11491 covers it. Sibling guards #11484 (export) and #11490 (share) cover the other two mint-on-missing callers with their own `throwIfMissing`/path-guard approach — this PR mirrors that direction for the remaining caller, fork, at the CLI layer (fork's choke point writes into the store, and `SessionResolutionError` must stay in `main.ts` to avoid a session-manager→main import cycle).

## Testing

- RED (fix reverted, new test only): `bun test test/main-session-resolution-error.test.ts` → 7 pass / 1 fail: `Expected promise that rejects / Received promise that resolved` — the missing-path fork resolved into a phantom session instead of rejecting.
- GREEN (with fix): same file → 8 pass / 0 fail (12 expects).
- Rework (review round 2): fork tests now target an explicit temporary session directory; new `forkFrom`-vanished-source regression test covers the TOCTOU backstop → file now 9 pass / 0 fail (14 expects). Neighbor sets re-run, all failures byte-identical to clean-tree baselines; `bun run check` still green (oxfmt clean, `tsgo --noEmit` 0 errors).
- Neighbors (`session-manager-fork`, `main-cross-project-resume`, `close-drop-empty`, `move-session-cleanup`): 26 pass / 1 fail with fix; `git stash` baseline on clean tree gives the identical 26 pass / 1 fail (the failure is a pre-existing Windows cross-project resume environment issue, unrelated).
- `bun run check` in `packages/coding-agent`: oxlint 1 pre-existing warning in unrelated `executor-subagent-reminders.test.ts`, oxfmt clean (2896 files), `tsgo --noEmit` 0 errors.
- Session suites were run with root `node_modules` held aside per the Windows import quirk, restored afterwards (`git status` clean apart from the change).

---

- [ ] `bun check` passes (repo-wide gate not run; per-package `bun run check` green — see above)
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution ([#11556](https://github.com/can1357/oh-my-pi/pull/11556) by [@nikkoxgonzales](https://github.com/nikkoxgonzales))


