### PR TITLE
fix(gc): scan breadcrumbed session dirs before sweeping blobs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
+- `omp gc --blobs` no longer deletes image blobs still referenced by a session stored via `--session-dir`/`--session`; the blob reachability scan now also covers transcript directories recorded in terminal breadcrumbs ([#11551](https://github.com/can1357/oh-my-pi/issues/11551)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
-- `omp gc --blobs` no longer deletes image blobs still referenced by a session stored via `--session-dir`/`--session`; the blob reachability scan now also covers transcript directories recorded in terminal breadcrumbs ([#11551](https://github.com/can1357/oh-my-pi/issues/11551)).
+- `omp gc --blobs` no longer deletes image blobs still referenced by a session stored via `--session-dir`/`--session`; every relocated transcript directory is now recorded in a persistent registry the blob reachability scan reads (issue [#11551](https://github.com/can1357/oh-my-pi/issues/11551)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
-- `omp gc --blobs` no longer deletes image blobs still referenced by a session stored via `--session-dir`/`--session`; every relocated transcript directory is now recorded in a persistent registry the blob reachability scan reads (issue [#11551](https://github.com/can1357/oh-my-pi/issues/11551)).
+- `omp gc --blobs` no longer deletes image blobs still referenced by a session stored via `--session-dir`/`--session`, including exact paths without a `.jsonl` suffix; relocated transcript files are now recorded in a persistent registry the blob reachability scan reads (issue [#11551](https://github.com/can1357/oh-my-pi/issues/11551)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -6,6 +6,7 @@ import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import {
 	getAgentDir,
 	getBlobsDir,
+	getCustomSessionRootsDir,
 	getHistoryDbPath,
 	getModelDbPath,
 	getSessionsDir,
@@ -299,14 +300,42 @@ async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<
 }
 
 /**
+ * Custom session-storage roots recorded in the persistent registry
+ * (`<agentDir>/custom-session-roots/*`, one marker file per relocated
+ * directory whose content is its absolute path). A `--session-dir`/`--session`
+ * transcript stores its `blob:sha256:` references outside `<agentDir>/sessions`
+ * yet externalizes images into the shared agent-global blob store, so the mark
+ * phase must widen its reachability roots here or the sweep unlinks blobs a
+ * live transcript still references (issue #11551). The registry retains every
+ * relocated root across sessions and terminals; vanished directories are
+ * skipped since blobs they uniquely referenced are already unreachable.
+ */
+async function collectRegisteredSessionRoots(registryDir: string, defaultRoots: string[]): Promise<string[]> {
+	let entries: string[];
+	try {
+		entries = await fs.readdir(registryDir);
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return [];
+		throw error;
+	}
+	const roots = new Map<string, string>();
+	for (const entry of entries) {
+		const recorded = (await readTextIfPresent(path.join(registryDir, entry))).trim();
+		if (!recorded) continue;
+		const sessionRoot = path.resolve(recorded);
+		if (!(await pathExists(sessionRoot))) continue;
+		if (defaultRoots.some(root => pathIsWithin(root, sessionRoot))) continue;
+		roots.set(normalizePathForComparison(sessionRoot), sessionRoot);
+	}
+	return [...roots.values()];
+}
+
+/**
  * Session directories recorded in terminal breadcrumbs that live outside the
- * default scan roots. A `--session-dir`/`--session` transcript stores its
- * `blob:sha256:` references outside `<agentDir>/sessions`, yet externalizes
- * images into the shared agent-global blob store, so the mark phase must widen
- * its reachability roots to these locations or the sweep unlinks blobs a live
- * transcript still references (issue #11551). Breadcrumbs
- * (`<agentDir>/terminal-sessions/*`, `cwd\nsessionFile` per terminal) are the
- * durable record of relocated transcripts GC cannot otherwise enumerate.
+ * default scan roots. Supplements {@link collectRegisteredSessionRoots}: a
+ * breadcrumb (`<agentDir>/terminal-sessions/*`, `cwd\nsessionFile` per
+ * terminal) holds only that terminal's last session, but still catches a
+ * current relocated transcript even if its registry marker write failed.
  */
 async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots: string[]): Promise<string[]> {
 	let entries: string[];
@@ -362,8 +391,14 @@ async function runBlobGc(options: ResolvedGcOptions, archiveSessionsRoot: string
 	const blobDir = getBlobsDir(options.agentDir);
 	const sessionsRoot = getSessionsDir(options.agentDir);
 	const defaultRoots = [sessionsRoot, archiveSessionsRoot];
-	const breadcrumbRoots = await collectBreadcrumbSessionRoots(getTerminalSessionsDir(options.agentDir), defaultRoots);
-	const referenced = await collectReferencedBlobHashes([...defaultRoots, ...breadcrumbRoots]);
+	const extraRoots = new Map<string, string>();
+	for (const root of await collectRegisteredSessionRoots(getCustomSessionRootsDir(options.agentDir), defaultRoots)) {
+		extraRoots.set(normalizePathForComparison(root), root);
+	}
+	for (const root of await collectBreadcrumbSessionRoots(getTerminalSessionsDir(options.agentDir), defaultRoots)) {
+		extraRoots.set(normalizePathForComparison(root), root);
+	}
+	const referenced = await collectReferencedBlobHashes([...defaultRoots, ...extraRoots.values()]);
 	const candidates = await collectBlobCandidates(blobDir);
 	const result: BlobGcResult = {
 		referenced: referenced.size,

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -319,9 +319,12 @@ async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots
 	const roots = new Map<string, string>();
 	for (const entry of entries) {
 		const text = await readTextIfPresent(path.join(breadcrumbDir, entry));
-		const sessionFile = text.split("\n")[1]?.trim();
-		if (!sessionFile) continue;
-		const sessionRoot = path.dirname(path.resolve(sessionFile));
+		const lines = text.split("\n");
+		const breadcrumbCwd = lines[0]?.trim();
+		const recordedSessionFile = lines[1]?.trim();
+		if (!breadcrumbCwd || !recordedSessionFile) continue;
+		const sessionFile = path.resolve(breadcrumbCwd, recordedSessionFile);
+		const sessionRoot = path.dirname(sessionFile);
 		if (defaultRoots.some(root => pathIsWithin(root, sessionRoot))) continue;
 		roots.set(normalizePathForComparison(sessionRoot), sessionRoot);
 	}

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -10,6 +10,9 @@ import {
 	getModelDbPath,
 	getSessionsDir,
 	getStatsDbPath,
+	getTerminalSessionsDir,
+	normalizePathForComparison,
+	pathIsWithin,
 	readLines,
 } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
@@ -295,6 +298,36 @@ async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<
 	return hashes;
 }
 
+/**
+ * Session directories recorded in terminal breadcrumbs that live outside the
+ * default scan roots. A `--session-dir`/`--session` transcript stores its
+ * `blob:sha256:` references outside `<agentDir>/sessions`, yet externalizes
+ * images into the shared agent-global blob store, so the mark phase must widen
+ * its reachability roots to these locations or the sweep unlinks blobs a live
+ * transcript still references (issue #11551). Breadcrumbs
+ * (`<agentDir>/terminal-sessions/*`, `cwd\nsessionFile` per terminal) are the
+ * durable record of relocated transcripts GC cannot otherwise enumerate.
+ */
+async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots: string[]): Promise<string[]> {
+	let entries: string[];
+	try {
+		entries = await fs.readdir(breadcrumbDir);
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return [];
+		throw error;
+	}
+	const roots = new Map<string, string>();
+	for (const entry of entries) {
+		const text = await readTextIfPresent(path.join(breadcrumbDir, entry));
+		const sessionFile = text.split("\n")[1]?.trim();
+		if (!sessionFile) continue;
+		const sessionRoot = path.dirname(path.resolve(sessionFile));
+		if (defaultRoots.some(root => pathIsWithin(root, sessionRoot))) continue;
+		roots.set(normalizePathForComparison(sessionRoot), sessionRoot);
+	}
+	return [...roots.values()];
+}
+
 async function collectBlobCandidates(blobDir: string): Promise<BlobCandidate[]> {
 	let entries: string[];
 	try {
@@ -325,7 +358,9 @@ async function collectBlobCandidates(blobDir: string): Promise<BlobCandidate[]> 
 async function runBlobGc(options: ResolvedGcOptions, archiveSessionsRoot: string): Promise<BlobGcResult> {
 	const blobDir = getBlobsDir(options.agentDir);
 	const sessionsRoot = getSessionsDir(options.agentDir);
-	const referenced = await collectReferencedBlobHashes([sessionsRoot, archiveSessionsRoot]);
+	const defaultRoots = [sessionsRoot, archiveSessionsRoot];
+	const breadcrumbRoots = await collectBreadcrumbSessionRoots(getTerminalSessionsDir(options.agentDir), defaultRoots);
+	const referenced = await collectReferencedBlobHashes([...defaultRoots, ...breadcrumbRoots]);
 	const candidates = await collectBlobCandidates(blobDir);
 	const result: BlobGcResult = {
 		referenced: referenced.size,

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -6,14 +6,13 @@ import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import {
 	getAgentDir,
 	getBlobsDir,
-	getCustomSessionRootsDir,
+	getCustomSessionFilesDir,
 	getHistoryDbPath,
 	getModelDbPath,
 	getSessionsDir,
 	getStatsDbPath,
 	getTerminalSessionsDir,
 	normalizePathForComparison,
-	pathIsWithin,
 	readLines,
 } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
@@ -280,37 +279,40 @@ async function collectBackupJsonlFiles(root: string): Promise<string[]> {
 	}
 }
 
-async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<string>> {
-	const hashes = new Set<string>();
+async function collectReferencedBlobHashes(sessionRoots: string[], exactSessionFiles: string[]): Promise<Set<string>> {
+	const files = new Map<string, string>();
 	for (const root of sessionRoots) {
-		const files = [
+		for (const file of [
 			...(await collectJsonlFiles(root)),
 			...(await collectCompressedJsonlFiles(root)),
 			...(await collectBackupJsonlFiles(root)),
-		];
-		for (const file of files) {
-			const text = await readTextIfPresent(file);
-			for (const match of text.matchAll(BLOB_REF_RE)) {
-				const hash = match[1]?.toLowerCase();
-				if (hash && BLOB_HASH_RE.test(hash)) hashes.add(hash);
-			}
+		]) {
+			files.set(normalizePathForComparison(file), file);
+		}
+	}
+	for (const file of exactSessionFiles) {
+		files.set(normalizePathForComparison(file), file);
+	}
+
+	const hashes = new Set<string>();
+	for (const file of files.values()) {
+		const text = await readTextIfPresent(file);
+		for (const match of text.matchAll(BLOB_REF_RE)) {
+			const hash = match[1]?.toLowerCase();
+			if (hash && BLOB_HASH_RE.test(hash)) hashes.add(hash);
 		}
 	}
 	return hashes;
 }
 
 /**
- * Custom session-storage roots recorded in the persistent registry
- * (`<agentDir>/custom-session-roots/*`, one marker file per relocated
- * directory whose content is its absolute path). A `--session-dir`/`--session`
- * transcript stores its `blob:sha256:` references outside `<agentDir>/sessions`
- * yet externalizes images into the shared agent-global blob store, so the mark
- * phase must widen its reachability roots here or the sweep unlinks blobs a
- * live transcript still references (issue #11551). The registry retains every
- * relocated root across sessions and terminals; vanished directories are
- * skipped since blobs they uniquely referenced are already unreachable.
+ * Exact session files recorded in the persistent registry
+ * (`<agentDir>/custom-session-files/*`, one marker per transcript whose
+ * content is its absolute path). Recording files rather than parent
+ * directories preserves `--session` paths outside the root-scan globs,
+ * including names without a `.jsonl` suffix.
  */
-async function collectRegisteredSessionRoots(registryDir: string, defaultRoots: string[]): Promise<string[]> {
+async function collectRegisteredSessionFiles(registryDir: string): Promise<string[]> {
 	let entries: string[];
 	try {
 		entries = await fs.readdir(registryDir);
@@ -318,26 +320,25 @@ async function collectRegisteredSessionRoots(registryDir: string, defaultRoots: 
 		if (codeOf(error) === "ENOENT") return [];
 		throw error;
 	}
-	const roots = new Map<string, string>();
+	const files = new Map<string, string>();
 	for (const entry of entries) {
 		const recorded = (await readTextIfPresent(path.join(registryDir, entry))).trim();
 		if (!recorded) continue;
-		const sessionRoot = path.resolve(recorded);
-		if (!(await pathExists(sessionRoot))) continue;
-		if (defaultRoots.some(root => pathIsWithin(root, sessionRoot))) continue;
-		roots.set(normalizePathForComparison(sessionRoot), sessionRoot);
+		const sessionFile = path.resolve(recorded);
+		const stat = await statIfPresent(sessionFile);
+		if (!stat?.isFile()) continue;
+		files.set(normalizePathForComparison(sessionFile), sessionFile);
 	}
-	return [...roots.values()];
+	return [...files.values()];
 }
 
 /**
- * Session directories recorded in terminal breadcrumbs that live outside the
- * default scan roots. Supplements {@link collectRegisteredSessionRoots}: a
- * breadcrumb (`<agentDir>/terminal-sessions/*`, `cwd\nsessionFile` per
- * terminal) holds only that terminal's last session, but still catches a
- * current relocated transcript even if its registry marker write failed.
+ * Exact session files recorded in terminal breadcrumbs. Supplements
+ * {@link collectRegisteredSessionFiles}: a breadcrumb holds only that
+ * terminal's last session, but catches the current transcript even if its
+ * persistent marker write failed.
  */
-async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots: string[]): Promise<string[]> {
+async function collectBreadcrumbSessionFiles(breadcrumbDir: string): Promise<string[]> {
 	let entries: string[];
 	try {
 		entries = await fs.readdir(breadcrumbDir);
@@ -345,7 +346,7 @@ async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots
 		if (codeOf(error) === "ENOENT") return [];
 		throw error;
 	}
-	const roots = new Map<string, string>();
+	const files = new Map<string, string>();
 	for (const entry of entries) {
 		const text = await readTextIfPresent(path.join(breadcrumbDir, entry));
 		const lines = text.split("\n");
@@ -353,11 +354,9 @@ async function collectBreadcrumbSessionRoots(breadcrumbDir: string, defaultRoots
 		const recordedSessionFile = lines[1]?.trim();
 		if (!breadcrumbCwd || !recordedSessionFile) continue;
 		const sessionFile = path.resolve(breadcrumbCwd, recordedSessionFile);
-		const sessionRoot = path.dirname(sessionFile);
-		if (defaultRoots.some(root => pathIsWithin(root, sessionRoot))) continue;
-		roots.set(normalizePathForComparison(sessionRoot), sessionRoot);
+		files.set(normalizePathForComparison(sessionFile), sessionFile);
 	}
-	return [...roots.values()];
+	return [...files.values()];
 }
 
 async function collectBlobCandidates(blobDir: string): Promise<BlobCandidate[]> {
@@ -391,14 +390,14 @@ async function runBlobGc(options: ResolvedGcOptions, archiveSessionsRoot: string
 	const blobDir = getBlobsDir(options.agentDir);
 	const sessionsRoot = getSessionsDir(options.agentDir);
 	const defaultRoots = [sessionsRoot, archiveSessionsRoot];
-	const extraRoots = new Map<string, string>();
-	for (const root of await collectRegisteredSessionRoots(getCustomSessionRootsDir(options.agentDir), defaultRoots)) {
-		extraRoots.set(normalizePathForComparison(root), root);
+	const exactSessionFiles = new Map<string, string>();
+	for (const file of await collectRegisteredSessionFiles(getCustomSessionFilesDir(options.agentDir))) {
+		exactSessionFiles.set(normalizePathForComparison(file), file);
 	}
-	for (const root of await collectBreadcrumbSessionRoots(getTerminalSessionsDir(options.agentDir), defaultRoots)) {
-		extraRoots.set(normalizePathForComparison(root), root);
+	for (const file of await collectBreadcrumbSessionFiles(getTerminalSessionsDir(options.agentDir))) {
+		exactSessionFiles.set(normalizePathForComparison(file), file);
 	}
-	const referenced = await collectReferencedBlobHashes([...defaultRoots, ...extraRoots.values()]);
+	const referenced = await collectReferencedBlobHashes(defaultRoots, [...exactSessionFiles.values()]);
 	const candidates = await collectBlobCandidates(blobDir);
 	const result: BlobGcResult = {
 		referenced: referenced.size,

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -2,7 +2,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
-import { getSessionsDir, getTerminalSessionsDir, isEnoent, logger, resolveEquivalentPath } from "@oh-my-pi/pi-utils";
+import {
+	getCustomSessionRootsDir,
+	getSessionsDir,
+	getTerminalSessionsDir,
+	hashPath,
+	isEnoent,
+	logger,
+	pathIsWithin,
+	resolveEquivalentPath,
+} from "@oh-my-pi/pi-utils";
 import type { SessionStorage } from "./session-storage";
 
 const migratedSessionRoots = new Set<string>();
@@ -201,6 +210,26 @@ export function computeDefaultSessionDir(
 // =============================================================================
 
 /**
+ * Record a session's storage directory in the persistent custom-roots registry
+ * when it lives outside the managed sessions root. Idempotent: the marker file
+ * is keyed by a hash of the resolved directory, its content is the absolute
+ * path. Best-effort — a failure here must never break session creation.
+ *
+ * `sessionFile` may be relative (e.g. `--session-dir .omp-sessions`); it is
+ * resolved against the recorded `cwd`, matching how the breadcrumb stores it.
+ */
+function recordCustomSessionRoot(cwd: string, sessionFile: string): void {
+	try {
+		const sessionRoot = path.dirname(path.resolve(cwd, sessionFile));
+		if (pathIsWithin(getSessionsDir(), sessionRoot)) return;
+		const registryDir = getCustomSessionRootsDir();
+		fs.mkdirSync(registryDir, { recursive: true });
+		fs.writeFileSync(path.join(registryDir, hashPath(sessionRoot)), sessionRoot);
+	} catch (err) {
+		if (!isEnoent(err)) logger.debug("Custom session root record failed", { err });
+	}
+}
+/**
  * Write a breadcrumb linking the current terminal to a session file.
  * The breadcrumb contains the cwd and session path so --continue can
  * find "this terminal's last session" even when running concurrent instances.
@@ -215,6 +244,12 @@ export function computeDefaultSessionDir(
  * external delete is still treated as a genuinely stale crumb.
  */
 export function writeTerminalBreadcrumb(cwd: string, sessionFile: string, fresh = false): void {
+	// Persist non-default session roots regardless of terminal identity: a
+	// `--session-dir`/`--session` transcript stores blob references outside the
+	// managed sessions root, and storage GC needs this registry to reach them
+	// after the per-terminal breadcrumb is overwritten by a later session.
+	recordCustomSessionRoot(cwd, sessionFile);
+
 	const terminalId = getTerminalId();
 	if (!terminalId) return;
 

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
 import {
-	getCustomSessionRootsDir,
+	getCustomSessionFilesDir,
 	getSessionsDir,
 	getTerminalSessionsDir,
 	hashPath,
@@ -210,23 +210,24 @@ export function computeDefaultSessionDir(
 // =============================================================================
 
 /**
- * Record a session's storage directory in the persistent custom-roots registry
- * when it lives outside the managed sessions root. Idempotent: the marker file
- * is keyed by a hash of the resolved directory, its content is the absolute
- * path. Best-effort — a failure here must never break session creation.
+ * Record a session's exact file in the persistent custom-files registry when
+ * the managed-root glob scan cannot fully account for it. Idempotent: the
+ * marker is keyed by a hash of the resolved file, and its content is the
+ * absolute path. Best-effort — a failure here must never break session
+ * creation.
  *
- * `sessionFile` may be relative (e.g. `--session-dir .omp-sessions`); it is
+ * `sessionFile` may be relative (e.g. `--session .omp-sessions/work`); it is
  * resolved against the recorded `cwd`, matching how the breadcrumb stores it.
  */
-function recordCustomSessionRoot(cwd: string, sessionFile: string): void {
+function recordCustomSessionFile(cwd: string, sessionFile: string): void {
 	try {
-		const sessionRoot = path.dirname(path.resolve(cwd, sessionFile));
-		if (pathIsWithin(getSessionsDir(), sessionRoot)) return;
-		const registryDir = getCustomSessionRootsDir();
+		const resolvedSessionFile = path.resolve(cwd, sessionFile);
+		if (pathIsWithin(getSessionsDir(), resolvedSessionFile) && resolvedSessionFile.endsWith(".jsonl")) return;
+		const registryDir = getCustomSessionFilesDir();
 		fs.mkdirSync(registryDir, { recursive: true });
-		fs.writeFileSync(path.join(registryDir, hashPath(sessionRoot)), sessionRoot);
+		fs.writeFileSync(path.join(registryDir, hashPath(resolvedSessionFile)), resolvedSessionFile);
 	} catch (err) {
-		if (!isEnoent(err)) logger.debug("Custom session root record failed", { err });
+		if (!isEnoent(err)) logger.debug("Custom session file record failed", { err });
 	}
 }
 /**
@@ -244,11 +245,10 @@ function recordCustomSessionRoot(cwd: string, sessionFile: string): void {
  * external delete is still treated as a genuinely stale crumb.
  */
 export function writeTerminalBreadcrumb(cwd: string, sessionFile: string, fresh = false): void {
-	// Persist non-default session roots regardless of terminal identity: a
-	// `--session-dir`/`--session` transcript stores blob references outside the
-	// managed sessions root, and storage GC needs this registry to reach them
-	// after the per-terminal breadcrumb is overwritten by a later session.
-	recordCustomSessionRoot(cwd, sessionFile);
+	// Persist session files the managed-root glob scan cannot fully account for,
+	// regardless of terminal identity. Storage GC needs the exact path after the
+	// per-terminal breadcrumb is overwritten by a later session.
+	recordCustomSessionFile(cwd, sessionFile);
 
 	const terminalId = getTerminalId();
 	if (!terminalId) return;

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -10,6 +10,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	getAgentDir,
 	getBlobsDir,
+	getCustomSessionRootsDir,
 	getHistoryDbPath,
 	getSessionsDir,
 	getTerminalSessionsDir,
@@ -223,6 +224,38 @@ describe("runGcCommand blob sweep", () => {
 		const crumbDir = getTerminalSessionsDir(root);
 		await fs.mkdir(crumbDir, { recursive: true });
 		await Bun.write(path.join(crumbDir, "tty-1"), `${projectDir}\n.omp-sessions/work.jsonl\n`);
+
+		const result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
+
+		expect(result.blobs?.referenced).toBe(1);
+		expect(result.blobs?.deleted).toBe(1);
+		expect(await Bun.file(referenced).exists()).toBe(true);
+		expect(await Bun.file(orphan).exists()).toBe(false);
+	});
+
+	test("--apply scans the persistent custom-session-root registry without a breadcrumb", async () => {
+		const referencedHash = hashFor("registry-reference");
+		const orphanHash = hashFor("registry-orphan");
+		const referenced = await writeBlob(root, referencedHash, "referenced");
+		const orphan = await writeBlob(root, orphanHash, "orphan");
+		await agePath(referenced);
+		await agePath(orphan);
+
+		// A relocated transcript whose terminal breadcrumb was overwritten by a later session.
+		const externalDir = path.join(root, "external-sessions");
+		await fs.mkdir(externalDir, { recursive: true });
+		await Bun.write(
+			path.join(externalDir, "work.jsonl"),
+			[
+				JSON.stringify({ type: "session", version: 3, id: "work", timestamp: "2026-01-01T00:00:00.000Z" }),
+				JSON.stringify({ type: "message", message: { role: "user", content: `blob:sha256:${referencedHash}` } }),
+				"",
+			].join("\n"),
+		);
+		// Only the persistent registry records the root — no terminal breadcrumb exists.
+		const registryDir = getCustomSessionRootsDir(root);
+		await fs.mkdir(registryDir, { recursive: true });
+		await Bun.write(path.join(registryDir, "root-1"), externalDir);
 
 		const result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
 

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -12,6 +12,7 @@ import {
 	getBlobsDir,
 	getHistoryDbPath,
 	getSessionsDir,
+	getTerminalSessionsDir,
 	setAgentDir,
 	setProjectDir,
 } from "@oh-my-pi/pi-utils";
@@ -194,6 +195,39 @@ describe("runGcCommand blob sweep", () => {
 		expect(result.blobs?.wouldDelete).toBe(0);
 		expect(result.blobs?.deleted).toBe(0);
 		expect(await Bun.file(referenced).exists()).toBe(true);
+	});
+
+	test("--apply keeps blobs referenced by a breadcrumbed session outside the scan roots", async () => {
+		const referencedHash = hashFor("custom-dir-reference");
+		const orphanHash = hashFor("custom-dir-orphan");
+		const referenced = await writeBlob(root, referencedHash, "referenced");
+		const orphan = await writeBlob(root, orphanHash, "orphan");
+		await agePath(referenced);
+		await agePath(orphan);
+
+		// A --session-dir transcript stored outside <agentDir>/sessions and archive.
+		const externalDir = path.join(root, "external-sessions");
+		await fs.mkdir(externalDir, { recursive: true });
+		const externalFile = path.join(externalDir, "work.jsonl");
+		await Bun.write(
+			externalFile,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "work", timestamp: "2026-01-01T00:00:00.000Z" }),
+				JSON.stringify({ type: "message", message: { role: "user", content: `blob:sha256:${referencedHash}` } }),
+				"",
+			].join("\n"),
+		);
+		// The session's terminal breadcrumb records the relocated transcript.
+		const crumbDir = getTerminalSessionsDir(root);
+		await fs.mkdir(crumbDir, { recursive: true });
+		await Bun.write(path.join(crumbDir, "tty-1"), `/tmp/project\n${externalFile}\n`);
+
+		const result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
+
+		expect(result.blobs?.referenced).toBe(1);
+		expect(result.blobs?.deleted).toBe(1);
+		expect(await Bun.file(referenced).exists()).toBe(true);
+		expect(await Bun.file(orphan).exists()).toBe(false);
 	});
 
 	test("uses configured gc selectors and retention defaults", async () => {

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -197,7 +197,7 @@ describe("runGcCommand blob sweep", () => {
 		expect(await Bun.file(referenced).exists()).toBe(true);
 	});
 
-	test("--apply keeps blobs referenced by a breadcrumbed session outside the scan roots", async () => {
+	test("--apply resolves breadcrumbed relative session paths from their recorded cwd", async () => {
 		const referencedHash = hashFor("custom-dir-reference");
 		const orphanHash = hashFor("custom-dir-orphan");
 		const referenced = await writeBlob(root, referencedHash, "referenced");
@@ -205,8 +205,9 @@ describe("runGcCommand blob sweep", () => {
 		await agePath(referenced);
 		await agePath(orphan);
 
-		// A --session-dir transcript stored outside <agentDir>/sessions and archive.
-		const externalDir = path.join(root, "external-sessions");
+		// A relative --session-dir transcript stored outside the managed roots.
+		const projectDir = path.join(root, "project");
+		const externalDir = path.join(projectDir, ".omp-sessions");
 		await fs.mkdir(externalDir, { recursive: true });
 		const externalFile = path.join(externalDir, "work.jsonl");
 		await Bun.write(
@@ -217,10 +218,11 @@ describe("runGcCommand blob sweep", () => {
 				"",
 			].join("\n"),
 		);
-		// The session's terminal breadcrumb records the relocated transcript.
+		// GC runs from another cwd, so resolving the relative path from process.cwd()
+		// would miss this transcript and delete its blob.
 		const crumbDir = getTerminalSessionsDir(root);
 		await fs.mkdir(crumbDir, { recursive: true });
-		await Bun.write(path.join(crumbDir, "tty-1"), `/tmp/project\n${externalFile}\n`);
+		await Bun.write(path.join(crumbDir, "tty-1"), `${projectDir}\n.omp-sessions/work.jsonl\n`);
 
 		const result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
 

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -10,7 +10,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	getAgentDir,
 	getBlobsDir,
-	getCustomSessionRootsDir,
+	getCustomSessionFilesDir,
 	getHistoryDbPath,
 	getSessionsDir,
 	getTerminalSessionsDir,
@@ -233,7 +233,7 @@ describe("runGcCommand blob sweep", () => {
 		expect(await Bun.file(orphan).exists()).toBe(false);
 	});
 
-	test("--apply scans the persistent custom-session-root registry without a breadcrumb", async () => {
+	test("--apply scans an exact extensionless session file after its breadcrumb is overwritten", async () => {
 		const referencedHash = hashFor("registry-reference");
 		const orphanHash = hashFor("registry-orphan");
 		const referenced = await writeBlob(root, referencedHash, "referenced");
@@ -241,21 +241,23 @@ describe("runGcCommand blob sweep", () => {
 		await agePath(referenced);
 		await agePath(orphan);
 
-		// A relocated transcript whose terminal breadcrumb was overwritten by a later session.
+		// An extensionless --session transcript whose terminal breadcrumb was
+		// overwritten by a later session is invisible to the root-scan globs.
 		const externalDir = path.join(root, "external-sessions");
 		await fs.mkdir(externalDir, { recursive: true });
+		const externalFile = path.join(externalDir, "work");
 		await Bun.write(
-			path.join(externalDir, "work.jsonl"),
+			externalFile,
 			[
 				JSON.stringify({ type: "session", version: 3, id: "work", timestamp: "2026-01-01T00:00:00.000Z" }),
 				JSON.stringify({ type: "message", message: { role: "user", content: `blob:sha256:${referencedHash}` } }),
 				"",
 			].join("\n"),
 		);
-		// Only the persistent registry records the root — no terminal breadcrumb exists.
-		const registryDir = getCustomSessionRootsDir(root);
+		// Only the persistent registry records the exact file — no terminal breadcrumb exists.
+		const registryDir = getCustomSessionFilesDir(root);
 		await fs.mkdir(registryDir, { recursive: true });
-		await Bun.write(path.join(registryDir, "root-1"), externalDir);
+		await Bun.write(path.join(registryDir, "session-1"), externalFile);
 
 		const result = await runGcCommand({ flags: { agentDir: root, blobs: true, apply: true } });
 

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { computeDefaultSessionDir, writeTerminalBreadcrumb } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
-import { getAgentDir, getCustomSessionRootsDir, getSessionsDir, hashPath, setAgentDir } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getCustomSessionFilesDir, getSessionsDir, hashPath, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const cleanup: string[] = [];
 
@@ -67,23 +67,25 @@ describe("legacy session directory migration", () => {
 	});
 });
 
-describe("custom session-root registry", () => {
-	test("records a relocated session root and skips managed ones", () => {
+describe("custom session-file registry", () => {
+	test("records an exact relocated session file and skips managed JSONL files", () => {
 		const agentDir = makeTempDir("omp-agent-");
 		const cwd = makeTempDir("omp-cwd-");
 		const originalAgentDir = getAgentDir();
 		setAgentDir(agentDir);
 		try {
-			// A relative --session-dir resolves against cwd and lands in the registry.
-			writeTerminalBreadcrumb(cwd, path.join(".omp-sessions", "work.jsonl"));
-			const expectedRoot = path.join(cwd, ".omp-sessions");
-			const marker = path.join(getCustomSessionRootsDir(agentDir), hashPath(expectedRoot));
-			expect(fs.readFileSync(marker, "utf8")).toBe(expectedRoot);
+			// A relative extensionless --session path resolves against cwd and
+			// lands in the registry as the exact file, not its parent directory.
+			writeTerminalBreadcrumb(cwd, path.join(".omp-sessions", "work"));
+			const expectedFile = path.join(cwd, ".omp-sessions", "work");
+			const marker = path.join(getCustomSessionFilesDir(agentDir), hashPath(expectedFile));
+			expect(fs.readFileSync(marker, "utf8")).toBe(expectedFile);
 
-			// A transcript under the managed sessions root is never registered.
+			// A JSONL transcript under the managed sessions root is covered by
+			// the root glob scan and never registered individually.
 			const managedFile = path.join(getSessionsDir(agentDir), "project", "s.jsonl");
 			writeTerminalBreadcrumb(cwd, managedFile);
-			const managedMarker = path.join(getCustomSessionRootsDir(agentDir), hashPath(path.dirname(managedFile)));
+			const managedMarker = path.join(getCustomSessionFilesDir(agentDir), hashPath(managedFile));
 			expect(fs.existsSync(managedMarker)).toBe(false);
 		} finally {
 			setAgentDir(originalAgentDir);

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import { computeDefaultSessionDir, writeTerminalBreadcrumb } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+import { getAgentDir, getCustomSessionRootsDir, getSessionsDir, hashPath, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const cleanup: string[] = [];
 
@@ -63,5 +64,29 @@ describe("legacy session directory migration", () => {
 
 		expect(fs.readFileSync(recreated, "utf8")).toBe("older-process-write\n");
 		expect(fs.readFileSync(destination, "utf8")).toBe("canonical\n");
+	});
+});
+
+describe("custom session-root registry", () => {
+	test("records a relocated session root and skips managed ones", () => {
+		const agentDir = makeTempDir("omp-agent-");
+		const cwd = makeTempDir("omp-cwd-");
+		const originalAgentDir = getAgentDir();
+		setAgentDir(agentDir);
+		try {
+			// A relative --session-dir resolves against cwd and lands in the registry.
+			writeTerminalBreadcrumb(cwd, path.join(".omp-sessions", "work.jsonl"));
+			const expectedRoot = path.join(cwd, ".omp-sessions");
+			const marker = path.join(getCustomSessionRootsDir(agentDir), hashPath(expectedRoot));
+			expect(fs.readFileSync(marker, "utf8")).toBe(expectedRoot);
+
+			// A transcript under the managed sessions root is never registered.
+			const managedFile = path.join(getSessionsDir(agentDir), "project", "s.jsonl");
+			writeTerminalBreadcrumb(cwd, managedFile);
+			const managedMarker = path.join(getCustomSessionRootsDir(agentDir), hashPath(path.dirname(managedFile)));
+			expect(fs.existsSync(managedMarker)).toBe(false);
+		} finally {
+			setAgentDir(originalAgentDir);
+		}
 	});
 });

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -914,14 +914,13 @@ export function getTerminalSessionsDir(agentDir?: string): string {
 }
 
 /**
- * Get the persistent registry of custom (non-default) session-storage roots
- * (~/.omp/agent/custom-session-roots). Each `--session-dir`/`--session`
- * transcript directory is recorded here as one marker file so storage GC can
- * reach blobs a relocated transcript still references even after its terminal
- * breadcrumb is overwritten by a later session.
+ * Get the persistent registry of custom session files
+ * (~/.omp/agent/custom-session-files). Each `--session-dir`/`--session`
+ * transcript is recorded here as one marker file so storage GC can scan its
+ * exact path after its terminal breadcrumb is overwritten by a later session.
  */
-export function getCustomSessionRootsDir(agentDir?: string): string {
-	return dirs.agentSubdir(agentDir, "custom-session-roots", "state");
+export function getCustomSessionFilesDir(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, "custom-session-files", "state");
 }
 
 /** Get the crash log path (~/.omp/agent/omp-crash.log). */

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -913,6 +913,17 @@ export function getTerminalSessionsDir(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "terminal-sessions", "state");
 }
 
+/**
+ * Get the persistent registry of custom (non-default) session-storage roots
+ * (~/.omp/agent/custom-session-roots). Each `--session-dir`/`--session`
+ * transcript directory is recorded here as one marker file so storage GC can
+ * reach blobs a relocated transcript still references even after its terminal
+ * breadcrumb is overwritten by a later session.
+ */
+export function getCustomSessionRootsDir(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, "custom-session-roots", "state");
+}
+
 /** Get the crash log path (~/.omp/agent/omp-crash.log). */
 export function getCrashLogPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "omp-crash.log", "state");


### PR DESCRIPTION
## Repro
`omp gc --blobs --apply` (blobs default on, so a bare `omp gc --apply` too) permanently unlinks image blobs still referenced by a session stored via the documented `--session-dir`/`--session` flag. The transcript lives outside `<agentDir>/sessions`, but its externalized images go to the shared agent-global blob store, so its `blob:sha256:` references are never scanned; on resume `resolveImageData` returns the literal ref and the model silently receives no image. Reproduced with a temp agent dir holding an aged blob referenced only by a transcript in a custom dir outside the scan roots, plus a default-located session as a negative control: `runGcCommand({ flags: { agentDir, blobs: true, apply: true } })` returned `{referenced:1,candidates:2,wouldDelete:1,deleted:1}` — the custom-dir blob deleted, the default-located control surviving.

## Cause
`runBlobGc` (`packages/coding-agent/src/cli/gc-cli.ts`) built its reachable-hash set from only `[getSessionsDir(agentDir), getArchivedSessionsDir(agentDir)]` via `collectReferencedBlobHashes`, while the blob store is agent-global (`getBlobsDir`, no session-dir parameter). Any transcript outside those two roots was never opened, so its blobs looked unreferenced and — once past the 5-minute `GC_WRITE_GRACE_MS` window — were unlinked. The reachability set had already been widened twice (archive root, `.jsonl.<ts>.bak` backups); relocated transcripts were the remaining gap.

## Fix
- Add `collectBreadcrumbSessionRoots(breadcrumbDir, defaultRoots)`: reads the terminal breadcrumb files under `<agentDir>/terminal-sessions/*` (the durable `cwd\nsessionFile` record of the last session per terminal), extracts each recorded transcript's directory, and returns those that fall outside the default roots (deduped via `normalizePathForComparison`, filtered with `pathIsWithin`).
- `runBlobGc` now unions those breadcrumb roots into the roots passed to `collectReferencedBlobHashes`, so a relocated transcript's `blob:sha256:` references are scanned before the sweep. The union only ever adds to the reachable set, so genuine orphans are still collected. This runs for both the dry run and `--apply`, so the preview no longer lists a live blob as deletable.

## Verification
`bun test test/gc-cli.test.ts` — 42 pass. Added `--apply keeps blobs referenced by a breadcrumbed session outside the scan roots`, which stores a transcript outside the scan roots, records its breadcrumb, and asserts the referenced blob survives (`referenced:1`) while a genuine orphan is still deleted (`deleted:1`). Note the fix covers transcripts recorded in breadcrumbs; a standalone `omp gc` cannot enumerate arbitrary custom dirs that left no durable pointer. Fixes #11551