### PR TITLE
fix(ai): force SSE in codex retry tests via preferWebsockets

### DIFF
--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -2373,6 +2373,7 @@ describe("openai-codex streaming", () => {
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
 			reasoning: true,
+			preferWebsockets: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 400000,
@@ -2387,7 +2388,6 @@ describe("openai-codex streaming", () => {
 		const result = await completeSimple(model, context, {
 			apiKey: token,
 			fetch: fetchMock as FetchImpl,
-			transport: "sse",
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(result.stopReason).toBe("stop");


### PR DESCRIPTION
Fixes the deterministic CI break from #11160: the new retry tests passed a nonexistent `transport: "sse"` option to `completeSimple()` (TS2353, red `Type check workspace` on main).

Uses the file's established convention instead — `preferWebsockets: false` on the model, same as every other SSE-path test in this file. `shouldUseCodexWebSocket` short-circuits on `model.preferWebsockets === false`, so the mocked-fetch SSE path is forced exactly as the test intends.

Verification: `bun run ci:check:full` green; the 3 retry tests pass.

Note: the same #11160 run also failed `interactive-mode-working-accent.test.ts` (`titleSignal.aborted` on undefined). That file is untouched by #11160 and passes 5/5 locally — looks like a parallel-bucket timing flake, left alone.