### PR TITLE
fix(collab): acknowledge responses to settled host UI requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay only to writable guests, and already-aborted asks no longer consume request IDs ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
+- Collab hosts now acknowledge a writable guest's `ui-response` for an already-settled request with a targeted `ui-request-end`, so a guest that reconnected after the broadcast and resent its answer no longer waits forever ([#11561](https://github.com/can1357/oh-my-pi/pull/11561) by [@alphastorm](https://github.com/alphastorm)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.
 - Repeated soft compaction now includes messages retained by the previous pass instead of silently dropping them from model context.

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -463,7 +463,15 @@ export class CollabHost {
 			this.#rejectReadOnly("responding to ask", fromPeer);
 			return;
 		}
-		this.#pendingUi.get(reqId)?.settle({ kind: "answered", value });
+		const pending = this.#pendingUi.get(reqId);
+		if (pending) {
+			pending.settle({ kind: "answered", value });
+			return;
+		}
+		// The request already settled (or never existed for this peer). A writer that
+		// reconnected after the broadcast `ui-request-end` resends its answer and would
+		// otherwise wait forever, so acknowledge it directly.
+		this.#socket?.send({ t: "ui-request-end", reqId }, fromPeer);
 	}
 
 	#handlePrompt(text: string, images: ImageContent[] | undefined, fromPeer: number): void {

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -390,6 +390,41 @@ describe("collab read-only links", () => {
 		expect(end).toEqual({ t: "ui-request-end", reqId: request.request.reqId });
 	});
 
+	it("acknowledges a late or duplicate writable response after the request settled", async () => {
+		const answerer = await joinAsGuest(host.link, "writer-answer");
+		guestCleanups.push(() => answerer.socket.close());
+		const answererWelcome = await answerer.nextFrame();
+		if (answererWelcome.t !== "welcome") throw new Error(`expected welcome, got ${answererWelcome.t}`);
+
+		const pending = host.requestGuestUi({ kind: "select", title: "Settle once?", options: ["Yes"] });
+		if (!pending) throw new Error("expected writable guest UI request");
+		const request = await answerer.nextFrame();
+		if (request.t !== "ui-request") throw new Error(`expected ui-request, got ${request.t}`);
+		const reqId = request.request.reqId;
+
+		answerer.socket.send({ t: "ui-response", reqId, value: "Yes" });
+		expect(await pending).toEqual({ kind: "answered", value: "Yes" });
+		expect(await answerer.nextFrame()).toEqual({ t: "ui-request-end", reqId });
+
+		// A writer that reconnects after settlement never saw the broadcast end frame
+		// and resends its answer. The barrier orders the reply: before the fix, the
+		// resend was dropped and the barrier error arrived first.
+		const late = await joinAsGuest(host.link, "writer-late");
+		guestCleanups.push(() => late.socket.close());
+		const lateWelcome = await late.nextFrame();
+		if (lateWelcome.t !== "welcome") throw new Error(`expected welcome, got ${lateWelcome.t}`);
+		late.socket.send({ t: "ui-response", reqId, value: "Yes" });
+		late.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+		expect(await late.nextFrame()).toEqual({ t: "ui-request-end", reqId });
+		const lateBarrier = await late.nextFrame();
+		if (lateBarrier.t !== "error") throw new Error(`expected error, got ${lateBarrier.t}`);
+
+		// The acknowledgement is targeted: the original writer sees only its own barrier reply.
+		answerer.socket.send({ t: "agent-cmd", cmd: "chat", agentId: "barrier", text: "" });
+		const answererBarrier = await answerer.nextFrame();
+		if (answererBarrier.t !== "error") throw new Error(`expected error, got ${answererBarrier.t}`);
+	});
+
 	it("treats a forged write token as read-only", async () => {
 		const { prompts } = harness;
 


### PR DESCRIPTION
## What

`CollabHost.#handleUiResponse` settled the pending entry for a `ui-response` and did nothing when there was no such entry. The host now sends a targeted `ui-request-end` to the responding writable guest in that case.

## Why

When a host UI request settles, `ui-request-end` is broadcast once to the writable peers connected at that moment. A writer whose relay connection dropped in between misses it; on reconnect it is a new peer, resends its answer, and previously got nothing back, so its pending state never converged. Follow-up to #9031 (which retains the request until a writer joins); this covers the other half of a reconnecting writer's lifecycle. Context: https://github.com/can1357/oh-my-pi/discussions/6460#discussioncomment-18387101

The acknowledgement is peer-targeted, mirrors how `#handleFetchTranscript` replies to its requester, and adds no wire grammar: `ui-request-end` already exists in `COLLAB_PROTO` 3. Read-only peers are rejected before this path exactly as before.

## Testing

The new test in `read-only.test.ts` has a first writer answer a `select`, then a second writer (the reconnected client) resend the same `ui-response` followed by a barrier frame. Before the fix the barrier error arrives first (`1 fail`); after the fix the targeted `ui-request-end` precedes it, and the original writer's barrier shows it received nothing extra.

Based on upstream `c5ae5cb14f9ed6b1d98c0677e43d4bface7ab7c0`.

```sh
bun test packages/coding-agent/test/collab/read-only.test.ts \
  packages/coding-agent/test/collab/guest-ui-request.test.ts
# 24 pass, 0 fail, 81 expect() calls

bun --cwd=packages/coding-agent run check
# oxlint, oxfmt --check, check:types: clean
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
