### PR TITLE
fix(collab-web): resolve link schemes the way the browser does

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Transcript links are now allowed by the scheme the browser will actually resolve, so a destination that only becomes `javascript:` after URL normalization is dropped like any other unsafe scheme ([#11562](https://github.com/can1357/oh-my-pi/pull/11562) by [@alphastorm](https://github.com/alphastorm)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Fixed

--- a/packages/collab-web/src/components/transcript/Markdown.tsx
+++ b/packages/collab-web/src/components/transcript/Markdown.tsx
@@ -43,9 +43,16 @@ function unescapeHtml(raw: string): string {
 }
 function safeHref(href: string): string | null {
 	const trimmed = href.trim();
-	if (/^(?:https?:|mailto:)/i.test(trimmed)) return trimmed;
-	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null; // unknown scheme (javascript:, data:, …)
-	return trimmed; // relative / fragment
+	let protocol: string;
+	try {
+		// Resolve the scheme exactly as the browser will: the URL parser strips leading
+		// C0 controls and embedded tab/newline that a text check would carry through.
+		({ protocol } = new URL(trimmed, "https://relative.invalid/"));
+	} catch {
+		return null;
+	}
+	if (protocol === "https:" || protocol === "http:" || protocol === "mailto:") return trimmed;
+	return null; // unknown scheme (javascript:, data:, …)
 }
 
 const md = new Marked({

--- a/packages/collab-web/test/markdown.test.tsx
+++ b/packages/collab-web/test/markdown.test.tsx
@@ -51,6 +51,19 @@ describe("Transcript Markdown", () => {
 		expect(html).not.toContain("&lt;/advisory&gt;");
 	});
 
+	it("drops links whose scheme is unsafe only after browser URL normalization", () => {
+		// Browsers strip leading C0 controls before parsing the scheme, so a text
+		// check that only trims whitespace lets this through as a "relative" link.
+		const html = renderMarkdown(
+			"[ctl](\u0001javascript:alert(1)) [plain](javascript:alert(1)) [ok](https://example.com) [mail](mailto:a@b.test) [rel](#anchor)",
+		);
+
+		expect(html).not.toContain("javascript:alert(1)");
+		expect(html).toContain('href="https://example.com"');
+		expect(html).toContain('href="mailto:a@b.test"');
+		expect(html).toContain('href="#anchor"');
+	});
+
 	it("typesets every delimiter form and marks display math", () => {
 		const inline = renderMarkdown("energy $E=mc^2$ and \\(x^2\\) here");
 		expect(inline).toContain('encoding="application/x-tex">E=mc^2</annotation>');


### PR DESCRIPTION
## What

`safeHref` in `collab-web`'s transcript Markdown renderer decided a link's scheme with a regex over a `trim()`ed string. It now resolves the destination with the `URL` parser against a placeholder base and allows only `http:`, `https:`, and `mailto:`, dropping everything else as before.

## Why

The check and the browser disagreed about what the scheme is. Browsers strip leading C0 control characters and embedded tab/newline before parsing a URL; `String.prototype.trim()` strips neither, and `/^[a-z][a-z0-9+.-]*:/` then sees no scheme at all. Such a destination classified as "relative" and was emitted into `href`, where the browser resolves it to a scheme the renderer meant to reject. Using the parser the browser uses removes the disagreement instead of enumerating characters.

Relative and fragment links resolve against the placeholder base to `https:` and are kept unchanged; protocol-relative links behave as before. A destination the parser rejects outright is dropped, which is stricter than before only for links a browser could not have followed anyway.

## Testing

The added `markdown.test.tsx` case renders a control-prefixed `javascript:` link beside plain `javascript:`, `https:`, `mailto:`, and fragment links through the real component. Against the unchanged renderer it fails with the control-prefixed destination present in `href`; with the change only the `https:`, `mailto:`, and fragment anchors remain.

Based on upstream `c5ae5cb14f9ed6b1d98c0677e43d4bface7ab7c0`.

```sh
bun --cwd=packages/collab-web test test/markdown.test.tsx
# 20 pass, 0 fail, 52 expect() calls

bun --cwd=packages/collab-web run check
# oxlint, oxfmt --check, check:types: clean
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
