### PR TITLE
fix(coding-agent): hide web URL reads from tool prompts when fetch is disabled

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
 ### Fixed
 
+- Disabling "Read URLs" (`fetch.enabled=false`) no longer advertises web URL reads the runtime gate would reject: the `read` description and `path` schema drop their URL copy (internal URIs, `ssh://`, and `host:port` are still advertised), and the `read` cross-reference is removed from the browser prompt ([#11573](https://github.com/can1357/oh-my-pi/pull/11573) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 - Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay only to writable guests, and already-aborted asks no longer consume request IDs ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
 - Streaming edit guard (`edit.streamingAbort`) no longer aborts on no-op preview results when replacement content produces no file changes, and carries the native patch diagnostic through the abort reason on genuine preview failures.

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -1,7 +1,7 @@
 Drive real Chromium tabs from JavaScript or Python Eval with the global `browser` object.
 
 <instruction>
-- Static content? Use `read`. Use `browser` for JavaScript execution, authenticated sessions, and interactive actions.
+- Use `browser` for JavaScript execution, authenticated sessions, and interactive actions.
 - JavaScript: `await browser.open(options)` returns a `BrowserTab`; `browser.tab(name)` returns an existing handle; `await browser.close(options)` releases tabs.
 - Python: `await browser.open(name=…, url=…)`, synchronous `browser.tab(name)`, and `await browser.close(name=…)`. Python methods accept keyword arguments.
 - `open` options: `name`, `url`, `app`, `viewport`, `wait_until`, `dialogs`, `timeout`, `persist`.

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -1,8 +1,8 @@
-Read files, directories, archives, SQLite, images, documents, internal resources, and web URLs via `path`.
+Read files, directories, archives, SQLite, images, documents, and internal resources{{#if FETCH_ENABLED}}, and web URLs{{/if}} via `path`.
 
 <instruction>
 - SHOULD parallelize independent reads.
-- SHOULD use `read` (not browser) for web content; browser only when `read` can't deliver.
+{{#if FETCH_ENABLED}}- SHOULD use `read` (not browser) for web content; browser only when `read` can't deliver.{{/if}}
 </instruction>
 
 ## Selectors — append `:<sel>` to `path` (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`)
@@ -23,7 +23,7 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 - SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`): `file.db` (tables), `file.db:table` (schema+rows), `file.db:table:key` (by PK), `?limit=`/`?where=`/`?q=SELECT`.
 - Archives (`.zip` family incl. `.jar`/`.apk`/`.whl`, `.tar` incl. `.tar.{gz,bz2,xz,zst}`, `.rar`, `.7z`, `.iso`, `.cab`, `.deb`/`.rpm`/`.cpio`/`.ar`/`.a`, `.lzh`/`.arj`, `.asar`; single-stream `.gz`/`.bz2`/`.xz`/`.zst`): `archive.ext:path/inside/archive` reads a member.
 - Documents → extracted text. Notebooks → editable cells. Images → decoded inline for vision-capable models (prefer bare image path); `img.png?q=<question>` asks a vision model and returns text (spares context; works on any model). Videos → preview grid plus metadata. SVGs read as text unless `:img` is specified; `:raw` bypasses converters.
-- URLs → reader-mode clean text/markdown; `:raw` → untouched HTML. Bare `host:port` needs trailing slash.
+- {{#if FETCH_ENABLED}}URLs → reader-mode clean text/markdown; `:raw` → untouched HTML. {{/if}}Bare `host:port` needs trailing slash.
 - Internal URIs — all schemes take selectors. `artifact://<id>` recovers spilled output; page with `:N-M`/`:raw:N-M`.
 - `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts; writable with `write` and searchable with `grep`.
   Literal `:`, `?`, `#` → percent-encode (`%3A`/`%3F`/`%23`). Requires a verified POSIX shell on the remote host. For Windows or other unsupported hosts, use `bash` with a remote SSH command or mount with `sshfs`.

--- a/packages/coding-agent/src/prompts/tools/web-search.md
+++ b/packages/coding-agent/src/prompts/tools/web-search.md
@@ -3,6 +3,6 @@ Web search: current information beyond knowledge cutoff.
 <instruction>
 - SHOULD prefer primary sources (papers, official docs); corroborate key claims with multiple sources.
 - MUST link cited sources in final response.
-- NEVER use for programmatically accessible content or known URLs (GitHub repos/issues, known arXiv papers, Wikipedia pages, official docs) — `read` URL directly.
+- NEVER use for programmatically accessible content or known URLs (GitHub repos/issues, known arXiv papers, Wikipedia pages, official docs){{#if FETCH_ENABLED}} — `read` URL directly{{/if}}.
 - `query`: every provider supports Google-style `site:`/`-site:`, `after:`/`before:` (`YYYY-MM-DD`), `inurl:`, `intitle:`, `filetype:`, `"exact phrase"`, `-term`, `OR`. Map constraints to native filters when available; otherwise filter results leniently. If a constraint matches nothing, relax and report it; do not return zero results.
 </instruction>

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -627,6 +627,16 @@ const readSchemaWithoutMemory = type({
 	path: type("string").describe("Local path, internal URI (e.g. skill://), or URL. Inline selectors are supported."),
 });
 
+const readSchemaWithoutUrl = type({
+	path: type("string").describe(
+		"Local path, internal URI (e.g. memory://, skill://). Inline selectors are supported.",
+	),
+});
+
+const readSchemaWithoutMemoryWithoutUrl = type({
+	path: type("string").describe("Local path, internal URI (e.g. skill://). Inline selectors are supported."),
+});
+
 export type ReadToolInput = typeof readSchema.infer;
 
 export interface ReadToolDetails {
@@ -717,9 +727,16 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	};
 	readonly label = "Read";
 	readonly loadMode = "essential";
-	description: string;
+	/** Rendered live so a fetch.enabled flip is reflected at the next prompt rebuild (see TaskTool). */
+	get description(): string {
+		return this.#renderDescription();
+	}
 	get parameters(): typeof readSchema {
-		return this.session.settings.get("memory.backend") === "off" ? readSchemaWithoutMemory : readSchema;
+		const memoryOff = this.session.settings.get("memory.backend") === "off";
+		if (!this.session.settings.get("fetch.enabled")) {
+			return memoryOff ? readSchemaWithoutMemoryWithoutUrl : readSchemaWithoutUrl;
+		}
+		return memoryOff ? readSchemaWithoutMemory : readSchema;
 	}
 	readonly strict = true;
 
@@ -735,7 +752,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			1,
 			Math.min(session.settings.get("read.defaultLimit") ?? DEFAULT_MAX_LINES, DEFAULT_MAX_LINES),
 		);
-		this.description = this.#renderDescription();
 	}
 
 	/** Render the description for the current file display mode. */
@@ -746,6 +762,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			DEFAULT_MAX_LINES: String(DEFAULT_MAX_LINES),
 			IS_HL_MODE: displayMode.hashLines,
 			IS_LINE_NUMBER_MODE: !displayMode.hashLines && displayMode.lineNumbers,
+			FETCH_ENABLED: this.session.settings.get("fetch.enabled"),
 		});
 	}
 

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -359,7 +359,14 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	name: "web_search",
 	label: "Web Search",
 	get description() {
-		return prompt.render(webSearchDescription, { FETCH_ENABLED: settings.get("fetch.enabled") });
+		let fetchEnabled = true;
+		try {
+			fetchEnabled = settings.get("fetch.enabled");
+		} catch {
+			// No global store (isolated SDK embedder without Settings.init):
+			// keep the historical advertising instead of breaking creation.
+		}
+		return prompt.render(webSearchDescription, { FETCH_ENABLED: fetchEnabled });
 	},
 	parameters: webSearchSchema,
 

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -319,7 +319,12 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 	readonly name = "web_search";
 	readonly approval = "read" as const;
 	readonly label = "Web Search";
-	readonly description: string;
+	/** Rendered live so a fetch.enabled flip is reflected at the next prompt rebuild (see ReadTool). */
+	get description(): string {
+		return prompt.render(webSearchDescription, {
+			FETCH_ENABLED: this.#session.settings.get("fetch.enabled"),
+		});
+	}
 	readonly parameters = webSearchSchema;
 	readonly strict = true;
 	readonly loadMode = "discoverable";
@@ -329,7 +334,6 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 
 	constructor(session: ToolSession) {
 		this.#session = session;
-		this.description = prompt.render(webSearchDescription);
 	}
 
 	async execute(
@@ -354,7 +358,9 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRenderDetails> = {
 	name: "web_search",
 	label: "Web Search",
-	description: prompt.render(webSearchDescription),
+	get description() {
+		return prompt.render(webSearchDescription, { FETCH_ENABLED: settings.get("fetch.enabled") });
+	},
 	parameters: webSearchSchema,
 
 	approval: "read",

--- a/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
+++ b/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
-import { WebSearchTool } from "@oh-my-pi/pi-coding-agent/web/search";
+import { WebSearchTool, webSearchCustomTool } from "@oh-my-pi/pi-coding-agent/web/search";
 
 function createSession(fetchEnabled: boolean): ToolSession {
 	return {
@@ -45,5 +45,14 @@ describe("web_search read-URL handoff follows fetch.enabled", () => {
 	test("enabled: description keeps the read-URL handoff", () => {
 		const tool = new WebSearchTool(createSession(true));
 		expect(tool.description).toContain("`read` URL directly");
+	});
+});
+
+describe("web_search custom-tool copy without a global store", () => {
+	test("renders without throwing when Settings.init() never ran", () => {
+		// The global settings proxy throws outside a session; the singleton
+		// copy must fall back instead of breaking embedder session creation.
+		const description: string = webSearchCustomTool.description;
+		expect(description).toContain("Web search");
 	});
 });

--- a/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
+++ b/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
@@ -1,0 +1,36 @@
+// Issue #11347: with fetch.enabled=false the runtime gates reject URL reads,
+// but the model-facing copy still advertises them. When disabled, the read
+// description and path schema must not mention web URL reads.
+import { describe, expect, test } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+
+function createSession(fetchEnabled: boolean): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated({ "fetch.enabled": fetchEnabled, "images.autoResize": false }),
+		getImageAttachments: () => [],
+	} as unknown as ToolSession;
+}
+
+describe("read URL copy follows fetch.enabled", () => {
+	test("disabled: description does not advertise web URL reads", () => {
+		const tool = new ReadTool(createSession(false));
+		expect(tool.description).not.toContain("web URLs");
+		expect(tool.description).not.toContain("for web content");
+	});
+
+	test("disabled: path schema does not advertise URL input", () => {
+		const tool = new ReadTool(createSession(false));
+		expect(JSON.stringify(tool.parameters.toJsonSchema())).not.toContain("or URL");
+	});
+
+	test("enabled: description still advertises web URL reads", () => {
+		const tool = new ReadTool(createSession(true));
+		expect(tool.description).toContain("web URLs");
+	});
+});

--- a/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
+++ b/packages/coding-agent/test/read-fetch-disabled-copy.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { WebSearchTool } from "@oh-my-pi/pi-coding-agent/web/search";
 
 function createSession(fetchEnabled: boolean): ToolSession {
 	return {
@@ -32,5 +33,17 @@ describe("read URL copy follows fetch.enabled", () => {
 	test("enabled: description still advertises web URL reads", () => {
 		const tool = new ReadTool(createSession(true));
 		expect(tool.description).toContain("web URLs");
+	});
+});
+
+describe("web_search read-URL handoff follows fetch.enabled", () => {
+	test("disabled: description does not steer into the blocked read-URL route", () => {
+		const tool = new WebSearchTool(createSession(false));
+		expect(tool.description).not.toContain("`read` URL directly");
+	});
+
+	test("enabled: description keeps the read-URL handoff", () => {
+		const tool = new WebSearchTool(createSession(true));
+		expect(tool.description).toContain("`read` URL directly");
 	});
 });


### PR DESCRIPTION
## What

I was bothered that turning off "Read URLs" (`fetch.enabled=false`) still steered the model straight into the error it was meant to avoid, so I made the advertising copy follow the switch: with fetch disabled, the `read` description drops its web-URL fragments, the `path` schema no longer says "or URL", and the `read`-over-browser steering line is gone. Only `http(s)` copy is gated — internal URIs, `ssh://`, and `host:port` are still advertised — and I removed the `read` cross-reference from `browser.md` outright instead of conditioning it. The description renders live from settings (the same getter pattern `TaskTool` uses, which the prompt signature already tracks), so a settings flip takes effect at the next prompt rebuild with no re-instantiation plumbing. Runtime behavior is unchanged: the gate already threw, it just stopped being advertised.

## Why

Fixes #11347

## Testing

- RED: new `test/read-fetch-disabled-copy.test.ts` fails on clean tree — disabled description still contains "web URLs", disabled schema JSON still contains "or URL".
- GREEN with fix: 5 pass / 0 fail (new test + existing `read-tool.test.ts`).
- Neighbors: 66 pass / 0 fail (`read-tool-group`, `read-single-pass`, `read-summary`, `model-browser`); no test or source pins the removed `browser.md` line (verified by grep).
- `bun run check:types` (tsgo) in `packages/coding-agent`: exit 0, no errors.
- Note: suite runs were done with the repo-root `node_modules` held aside per this box's procedure (restored after each run; `git status` identical); type check ran with it in place since it needs the toolchain.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)