### PR TITLE
feat(coding-agent): add discoverable /continue command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.
 - Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
 - Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
+- Added `/continue`: submits the same hidden continue prompt as typing `.` or `c`, resuming the agent's most recent intent when there was no failure to retry.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 - The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.
 - Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
 - Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
-- Added `/continue`: submits the same hidden continue prompt as typing `.` or `c`, resuming the agent's most recent intent when there was no failure to retry.
+- Added `/continue`: submits the same hidden continue prompt as typing `.` or `c`, resuming the agent's most recent intent when there was no failure to retry ([#11575](https://github.com/can1357/oh-my-pi/pull/11575) by [@brunowowk](https://github.com/brunowowk)).
 
 ### Changed
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -711,6 +711,22 @@ export class InputController {
 		return compacted.text.trim();
 	}
 
+	/** Submit the manual-continue developer directive (the `.` / `c` shortcuts, also `/continue`):
+	 *  resumes the agent toward its most recent intent without a visible user message.
+	 *  Returns false when the main loop has no input waiter (agent busy). */
+	submitManualContinue(): boolean {
+		if (!this.ctx.onInputCallback) return false;
+		this.ctx.editor.clearDraft();
+		this.ctx.onInputCallback({
+			text: manualContinuePrompt,
+			cancelled: false,
+			started: true,
+			synthetic: true,
+			userInitiated: true,
+		});
+		return true;
+	}
+
 	setupEditorSubmitHandler(): void {
 		this.ctx.editor.onSubmit = async (text: string) => {
 			text = this.#compactDraftImages(text.trim());
@@ -742,17 +758,9 @@ export class InputController {
 			// Continue shortcuts: "." or "c" resume the agent with a hidden agent-authored
 			// developer directive (no visible user message) instead of an empty turn, so the
 			// model continues the prior intent rather than second-guessing the interrupt.
+			// Also exposed as the /continue slash command.
 			if (text === "." || text === "c") {
-				if (this.ctx.onInputCallback) {
-					this.ctx.editor.clearDraft();
-					this.ctx.onInputCallback({
-						text: manualContinuePrompt,
-						cancelled: false,
-						started: true,
-						synthetic: true,
-						userInitiated: true,
-					});
-				}
+				this.submitManualContinue();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6168,6 +6168,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#inputController.handleQueueCommand(message);
 	}
 
+	/** Submit the manual-continue directive (the `.` / `c` shortcut, exposed as `/continue`). */
+	submitManualContinue(): boolean {
+		return this.#inputController.submitManualContinue();
+	}
+
 	handleBtwCommand(question: string): Promise<void> {
 		return this.#btwController.start(question);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -478,6 +478,8 @@ export interface InteractiveModeContext {
 	handleImagePaste(): Promise<boolean>;
 	/** Queue a message for delivery only after the active agent turn would stop. */
 	handleQueueCommand(message: string): Promise<void>;
+	/** Submit the manual-continue directive (the `.` / `c` shortcut, exposed as `/continue`); false when the agent is busy. */
+	submitManualContinue(): boolean;
 	handleBtwCommand(question: string): Promise<void>;
 	handleTanCommand(work: string): Promise<void>;
 	hasActiveBtw(): boolean;

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -515,6 +515,17 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		},
 	},
 	{
+		name: "continue",
+		icon: "prompt",
+		description: "Continue the agent's most recent intent (same as typing . or c)",
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			if (!runtime.ctx.submitManualContinue()) {
+				runtime.ctx.showStatus("Agent is busy — wait for the current response to finish or abort it");
+			}
+		},
+	},
+	{
 		name: "retry",
 		icon: "redo",
 		description: "Retry the last failed agent turn",

--- a/packages/coding-agent/test/slash-commands/continue.test.ts
+++ b/packages/coding-agent/test/slash-commands/continue.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import {
+	executeBuiltinSlashCommand,
+	lookupBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntime(submitManualContinue: () => boolean) {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	return {
+		setText,
+		showStatus,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				submitManualContinue,
+				showStatus,
+			} as unknown as InteractiveModeContext,
+		},
+	};
+}
+
+describe("/continue slash command", () => {
+	it("is registered for autocomplete and routes through the shared continue path", async () => {
+		expect(lookupBuiltinSlashCommand("continue")?.name).toBe("continue");
+
+		const submitManualContinue = vi.fn(() => true);
+		const harness = createRuntime(submitManualContinue);
+
+		const handled = await executeBuiltinSlashCommand("/continue", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(submitManualContinue).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("reports a status instead of a silent no-op when the agent has no idle input waiter", async () => {
+		const harness = createRuntime(() => false);
+
+		const handled = await executeBuiltinSlashCommand("/continue", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.showStatus).toHaveBeenCalledWith(expect.stringContaining("busy"));
+	});
+});


### PR DESCRIPTION
<!-- Suggested title: feat(coding-agent): add discoverable /continue command -->

## What

- Adds a discoverable `/continue` built-in slash command (TUI) that submits the same hidden continue directive as the existing `.` and `c` editor prompts — no new turn semantics, no visible user message.
- The command delegates to the extracted `submitManualContinue()` on the input controller; when the agent is busy it shows a status instead of a silent no-op.

This is a narrower version of #10709, reduced to just exposing the `/continue` command for discoverability.

## Why

When I rewind to an agent turn when it fails to run something and I fix it outside the session (e.g. it tries to run an unavailable command, then I install it myself), I want the agent to continue its turns as if it had not been interrupted without polluting the context with a trivial user turn asking the agent to continue.

Turns out all that was needed was to expose the `/continue` command for discoverability and reusing the existing `.` and `c` plumbing, which I didn't know existed.

Unlike #10709, this version touches no session internals: it adds no scheduling path, so the swallowed-failure concern from the #10709 review does not apply — `/continue` reaches the model through the same awaited `session.prompt()` path as `.` and `c`. Collab guests keep the default host-only gate, and the `.`/`c` behavior itself is unchanged.

## Testing

Automated:

- `bun check` passes (oxlint, oxfmt, tsgo) in `packages/coding-agent`.
- `bun test test/slash-commands/continue.test.ts test/input-controller-keybindings.test.ts` — 34 passed: new `/continue` dispatch tests plus the existing `.`/`c` shortcut tests, which now exercise the extracted shared path.
- `bun test test/slash-commands/` — 195 passed across 30 files.

Manual:

- Idle TUI: submit `/continue` → agent resumes its most recent intent with no visible user message, same as typing `c`; the input history records `/continue`.
- While streaming: `/continue` → `Agent is busy — wait for the current response to finish or abort it` status, no turn scheduled.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (PR link + `[@brunowowk]` credit added immediately after the PR number is assigned)
