### PR TITLE
fix(catalog): make LiteLLM discovery timeout configurable

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- LiteLLM model discovery no longer gives up after a hardcoded 10s on slow `/model/info` payloads: the budget is configurable via `discoveryTimeoutMs` or `LITELLM_DISCOVERY_TIMEOUT_MS` (default unchanged), so large proxies keep their reasoning metadata instead of silently falling back ([#11355](https://github.com/can1357/oh-my-pi/issues/11355)).
+
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- LiteLLM model discovery no longer gives up after a hardcoded 10s on slow `/model/info` payloads: the budget is configurable via `discoveryTimeoutMs` or `LITELLM_DISCOVERY_TIMEOUT_MS` (default unchanged), so large proxies keep their reasoning metadata instead of silently falling back ([#11355](https://github.com/can1357/oh-my-pi/issues/11355)).
+- LiteLLM model discovery no longer gives up after a hardcoded 10s on slow `/model/info` payloads: the budget is configurable via `discoveryTimeoutMs` or `LITELLM_DISCOVERY_TIMEOUT_MS` (default unchanged), so large proxies keep their reasoning metadata instead of silently falling back ([#11576](https://github.com/can1357/oh-my-pi/pull/11576) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -54,6 +54,12 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	restorableHeaderFallback?: Record<string, string>;
 	/** Optional dynamic endpoint fetcher. */
 	fetchDynamicModels?: () => Promise<readonly ModelSpec<TApi>[] | null>;
+	/**
+	 * Total inner discovery budget (rich phase + fallback) the runtime outer
+	 * timeout must accommodate. Omit when the provider fits the default outer
+	 * guard; the registry then applies its unchanged default timeout.
+	 */
+	discoveryBudgetMs?: number;
 	/** Optional stencil.so fallback hook. */
 	modelsDev?: ModelsDevFallback<TApi, TModelsDevPayload>;
 	/** Clock override for deterministic tests. */

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5366,6 +5366,13 @@ export function xiaomiModelManagerOptions(
 // ---------------------------------------------------------------------------
 
 const LITELLM_DISCOVERY_TIMEOUT_MS = DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS;
+/**
+ * Headroom past the summed phase bounds in the stretched outer budget: the
+ * outer timer starts before cache work and each phase hands off to the next,
+ * so an exact rich + prefetch + fallback sum can expire before the fallback
+ * completes under ordinary timer/processing jitter.
+ */
+const LITELLM_DISCOVERY_OUTER_HEADROOM_MS = 5_000;
 
 export interface LiteLLMModelManagerConfig {
 	apiKey?: string;
@@ -5958,11 +5965,14 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 		providerId: "litellm",
 		// Stretch the runtime outer guard past its default only when the
 		// configured rich budget exceeds the default it was sized for. Budget
-		// all three sequential phases: the models.dev prefetch and the
-		// /v1/models fallback are each bounded by the shared default.
+		// all three sequential phases — the models.dev prefetch and the
+		// /v1/models fallback are each bounded by the shared default — plus
+		// headroom for the outer timer's start offset and per-phase handoff.
 		discoveryBudgetMs:
 			discoveryTimeoutMs > DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
-				? discoveryTimeoutMs + 2 * DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
+				? discoveryTimeoutMs +
+					2 * DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS +
+					LITELLM_DISCOVERY_OUTER_HEADROOM_MS
 				: undefined,
 		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
 		// bundled model's provider-specific transport (e.g. Fireworks

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -26,7 +26,15 @@ import { resolveModelReference } from "../identity/reference";
 import type { ModelManagerOptions, ModelsDevFallback } from "../model-manager";
 import { type GeneratedProvider, getBundledModels } from "../models";
 import type { Api, FetchImpl, Model, ModelSpec, OpenAICompat, Provider, ThinkingConfig, TokenCost } from "../types";
-import { discoveryFetch, isAnthropicOAuthToken, isRecord, toBoolean, toNumber, toPositiveNumber } from "../utils";
+import {
+	discoveryFetch,
+	isAnthropicOAuthToken,
+	isRecord,
+	toBoolean,
+	toNumber,
+	toPositiveNumber,
+	toPositiveNumberOrNull,
+} from "../utils";
 import { ALIBABA_TOKEN_PLAN_BASE_URL, parseAlibabaTokenPlanCredential } from "../wire/alibaba-token-plan";
 import { CLINEPASS_API_BASE_URL, clinePassClientHeaders } from "../wire/cline-pass";
 import { CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL } from "../wire/cloudflare-ai-gateway";
@@ -5957,23 +5965,27 @@ export async function fetchLiteLLMRichModels<TApi extends Api>(
 export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): ModelManagerOptions<Api> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
-	const discoveryTimeoutMs = toPositiveNumber(
+	const configuredTimeoutMs = toPositiveNumberOrNull(
 		config?.discoveryTimeoutMs ?? Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS,
-		LITELLM_DISCOVERY_TIMEOUT_MS,
 	);
+	const discoveryTimeoutMs = configuredTimeoutMs ?? LITELLM_DISCOVERY_TIMEOUT_MS;
 	return {
 		providerId: "litellm",
-		// Stretch the runtime outer guard past its default only when the
-		// configured rich budget exceeds the default it was sized for. Budget
-		// all three sequential phases — the models.dev prefetch and the
-		// /v1/models fallback are each bounded by the shared default — plus
-		// headroom for the outer timer's start offset and per-phase handoff.
+		// Declare the full sequential pipeline whenever a rich budget is
+		// explicitly configured: the runtime outer guard defaults to 15s,
+		// but discovery can spend the models.dev prefetch plus the
+		// configured rich phase plus the /v1/models fallback — the latter
+		// two each bounded by the shared default — so a short setting
+		// would otherwise exhaust the guard before the fallback answers.
+		// Unset means the default path, which keeps no declared budget and
+		// resolves to the byte-identical 15s guard. Headroom covers the
+		// outer timer's start offset and per-phase handoff jitter.
 		discoveryBudgetMs:
-			discoveryTimeoutMs > DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
-				? discoveryTimeoutMs +
+			configuredTimeoutMs === null
+				? undefined
+				: configuredTimeoutMs +
 					2 * DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS +
-					LITELLM_DISCOVERY_OUTER_HEADROOM_MS
-				: undefined,
+					LITELLM_DISCOVERY_OUTER_HEADROOM_MS,
 		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
 		// bundled model's provider-specific transport (e.g. Fireworks
 		// `wireModelIdMode`) before that leak was fixed. Earlier versions added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5956,6 +5956,13 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 	);
 	return {
 		providerId: "litellm",
+		// Stretch the runtime outer guard past its default only when the
+		// configured rich budget exceeds the default it was sized for; the
+		// /v1/models fallback is bounded by the shared default, so budget both.
+		discoveryBudgetMs:
+			discoveryTimeoutMs > DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
+				? discoveryTimeoutMs + DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
+				: undefined,
 		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
 		// bundled model's provider-specific transport (e.g. Fireworks
 		// `wireModelIdMode`) before that leak was fixed. Earlier versions added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5957,11 +5957,12 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 	return {
 		providerId: "litellm",
 		// Stretch the runtime outer guard past its default only when the
-		// configured rich budget exceeds the default it was sized for; the
-		// /v1/models fallback is bounded by the shared default, so budget both.
+		// configured rich budget exceeds the default it was sized for. Budget
+		// all three sequential phases: the models.dev prefetch and the
+		// /v1/models fallback are each bounded by the shared default.
 		discoveryBudgetMs:
 			discoveryTimeoutMs > DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
-				? discoveryTimeoutMs + DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
+				? discoveryTimeoutMs + 2 * DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS
 				: undefined,
 		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
 		// bundled model's provider-specific transport (e.g. Fireworks

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5365,7 +5365,7 @@ export function xiaomiModelManagerOptions(
 // 21. LiteLLM
 // ---------------------------------------------------------------------------
 
-const LITELLM_DISCOVERY_TIMEOUT_MS = 10_000;
+const LITELLM_DISCOVERY_TIMEOUT_MS = DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS;
 
 export interface LiteLLMModelManagerConfig {
 	apiKey?: string;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5365,10 +5365,13 @@ export function xiaomiModelManagerOptions(
 // 21. LiteLLM
 // ---------------------------------------------------------------------------
 
+const LITELLM_DISCOVERY_TIMEOUT_MS = 10_000;
+
 export interface LiteLLMModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
 	fetch?: FetchImpl;
+	discoveryTimeoutMs?: number;
 }
 
 export interface FetchLiteLLMRichModelsOptions<TApi extends Api> {
@@ -5947,6 +5950,10 @@ export async function fetchLiteLLMRichModels<TApi extends Api>(
 export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): ModelManagerOptions<Api> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
+	const discoveryTimeoutMs = toPositiveNumber(
+		config?.discoveryTimeoutMs ?? Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS,
+		LITELLM_DISCOVERY_TIMEOUT_MS,
+	);
 	return {
 		providerId: "litellm",
 		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
@@ -5973,7 +5980,7 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 				fetch: config?.fetch,
 				referenceResolver: resolveReference,
 				resolveApi: resolveLiteLLMApi,
-				timeoutMs: 10_000,
+				timeoutMs: discoveryTimeoutMs,
 			});
 			if (richModels && richModels.length > 0) {
 				return richModels;

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1333,12 +1333,34 @@ describe("LiteLLM discovery timeout (#11355)", () => {
 });
 
 describe("litellm discoveryBudgetMs (#11576)", () => {
-	test("omits the key when the inner budget fits the default outer", () => {
+	test("omits the key only when no explicit budget is configured", () => {
 		const original = Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
 		delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
 		try {
 			expect(litellmModelManagerOptions({}).discoveryBudgetMs).toBeUndefined();
-			expect(litellmModelManagerOptions({ discoveryTimeoutMs: 10_000 }).discoveryBudgetMs).toBeUndefined();
+		} finally {
+			if (original === undefined) delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+			else Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = original;
+		}
+	});
+	test("budgets an explicitly short branch past its summed phase bounds", () => {
+		// An explicitly short rich budget still pays the full sequential
+		// pipeline: models.dev prefetch + rich + /v1/models fallback. The
+		// outer must clear that exact sum plus handoff headroom, else the
+		// guard fires before the fallback answers (Codex P1 3986054005).
+		const budget = litellmModelManagerOptions({ discoveryTimeoutMs: 5_000 }).discoveryBudgetMs;
+		expect(budget).toBeGreaterThan(5_000 + 2 * 10_000);
+	});
+	test("an explicit default-sized budget still declares the full pipeline", () => {
+		expect(litellmModelManagerOptions({ discoveryTimeoutMs: 10_000 }).discoveryBudgetMs).toBeGreaterThan(
+			10_000 + 2 * 10_000,
+		);
+	});
+	test("an explicit env budget is honored the same way", () => {
+		const original = Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = "5000";
+		try {
+			expect(litellmModelManagerOptions({}).discoveryBudgetMs).toBeGreaterThan(5_000 + 2 * 10_000);
 		} finally {
 			if (original === undefined) delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
 			else Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = original;

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1331,3 +1331,20 @@ describe("LiteLLM discovery timeout (#11355)", () => {
 		expect(models?.[0]).toMatchObject({ id: "slow-reasoner" });
 	});
 });
+
+describe("litellm discoveryBudgetMs (#11576)", () => {
+	test("omits the key when the inner budget fits the default outer", () => {
+		const original = Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		try {
+			expect(litellmModelManagerOptions({}).discoveryBudgetMs).toBeUndefined();
+			expect(litellmModelManagerOptions({ discoveryTimeoutMs: 10_000 }).discoveryBudgetMs).toBeUndefined();
+		} finally {
+			if (original === undefined) delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+			else Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = original;
+		}
+	});
+	test("budgets rich plus prefetch and fallback bounds when configured above default", () => {
+		expect(litellmModelManagerOptions({ discoveryTimeoutMs: 30_000 }).discoveryBudgetMs).toBe(50_000);
+	});
+});

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1344,7 +1344,13 @@ describe("litellm discoveryBudgetMs (#11576)", () => {
 			else Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = original;
 		}
 	});
-	test("budgets rich plus prefetch and fallback bounds when configured above default", () => {
-		expect(litellmModelManagerOptions({ discoveryTimeoutMs: 30_000 }).discoveryBudgetMs).toBe(50_000);
+	test("leaves headroom past the summed phase bounds when stretched", () => {
+		// Pins the margin, not the literal: the stretched outer must clear
+		// the exact rich + prefetch + fallback sum, else a deadline-edge
+		// pipeline loses the fallback to timer/processing jitter. The
+		// deadline-edge outcome itself is covered at the registry level in
+		// litellm-discovery-outer-timeout.test.ts.
+		const budget = litellmModelManagerOptions({ discoveryTimeoutMs: 30_000 }).discoveryBudgetMs;
+		expect(budget).toBeGreaterThan(30_000 + 2 * 10_000);
 	});
 });

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1251,3 +1251,83 @@ describe("LiteLLM provider discovery", () => {
 		});
 	});
 });
+
+describe("LiteLLM discovery timeout (#11355)", () => {
+	const ORIGINAL_TIMEOUT = Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+
+	afterEach(() => {
+		if (ORIGINAL_TIMEOUT === undefined) {
+			delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+			return;
+		}
+		Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = ORIGINAL_TIMEOUT;
+	});
+
+	function delayedRichFetchMock(richDelayMs: number): FetchImpl {
+		return (async (input: string | URL | Request, init?: RequestInit) => {
+			const url = inputUrl(input);
+			if (url === MODELS_DEV_URL) {
+				return new Response("{}", { status: 500 });
+			}
+			if (url === "http://slow-proxy:4000/v1/models") {
+				return Response.json({ data: [{ id: "openai/gpt-5" }] });
+			}
+			if (url === "http://slow-proxy:4000/model_group/info") {
+				// Real delays are load-bearing here: the discovery budget is a
+				// wall-clock AbortSignal timeout, so fake timers cannot drive it.
+				if (richDelayMs === Number.POSITIVE_INFINITY) {
+					const { promise, reject } = Promise.withResolvers<never>();
+					init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+					await promise;
+				} else {
+					await Bun.sleep(richDelayMs);
+				}
+				return Response.json({ data: [{ model_group: "slow-reasoner", supports_reasoning: true }] });
+			}
+			return new Response("{}", { status: 404 });
+		}) as FetchImpl;
+	}
+
+	test("honors discoveryTimeoutMs instead of the hardcoded budget", async () => {
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-litellm-test",
+			baseUrl: "http://slow-proxy:4000/v1",
+			fetch: delayedRichFetchMock(Number.POSITIVE_INFINITY),
+			discoveryTimeoutMs: 50,
+		});
+		const started = Date.now();
+		const models = await options.fetchDynamicModels?.();
+		// A hanging rich phase must abort on the configured budget and fall
+		// back to /v1/models instead of stalling for the 10s default.
+		expect(Date.now() - started).toBeLessThan(2000);
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({ id: "openai/gpt-5" });
+	}, 15_000);
+
+	test("honors LITELLM_DISCOVERY_TIMEOUT_MS when no option is set", async () => {
+		Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = "50";
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-litellm-test",
+			baseUrl: "http://slow-proxy:4000/v1",
+			fetch: delayedRichFetchMock(Number.POSITIVE_INFINITY),
+		});
+		const started = Date.now();
+		const models = await options.fetchDynamicModels?.();
+		expect(Date.now() - started).toBeLessThan(2000);
+		expect(models?.[0]).toMatchObject({ id: "openai/gpt-5" });
+	}, 15_000);
+
+	test("keeps the 10s default when neither option nor env is set", async () => {
+		delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-litellm-test",
+			baseUrl: "http://slow-proxy:4000/v1",
+			fetch: delayedRichFetchMock(150),
+		});
+		const models = await options.fetchDynamicModels?.();
+		// A rich phase slower than any collapsed default still wins: the
+		// default budget must remain large enough to let it through.
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({ id: "slow-reasoner" });
+	});
+});

--- a/packages/coding-agent/src/config/model-provider-discovery.ts
+++ b/packages/coding-agent/src/config/model-provider-discovery.ts
@@ -73,6 +73,19 @@ export async function withModelDiscoveryTimeout<T>(timeoutMs: number, run: () =>
 	}
 }
 
+/**
+ * Outer budget for one provider's `manager.refresh()`: the default guard,
+ * stretched only when the provider declares a larger inner
+ * (`ModelManagerOptions.discoveryBudgetMs`) budget. Providers that omit the
+ * key keep the byte-identical default timeout; non-finite values fall back
+ * to it rather than arming a degenerate timer.
+ */
+export function resolveModelDiscoveryTimeoutMs(options: { discoveryBudgetMs?: number }): number {
+	const budget = options.discoveryBudgetMs;
+	if (typeof budget !== "number" || !Number.isFinite(budget)) return RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS;
+	return Math.max(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, budget);
+}
+
 export interface BuiltInDiscoveryResult {
 	models: Model<Api>[];
 	authoritativeProviders: Set<string>;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -108,6 +108,7 @@ import {
 	type ProviderDiscoveryState,
 	RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS,
 	resolveCodexDiscoveryAccounts,
+	resolveModelDiscoveryTimeoutMs,
 	SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
 	STARTUP_MODEL_CACHE_PROVIDER_IDS,
 	withModelDiscoveryTimeout,
@@ -1947,7 +1948,7 @@ export class ModelRegistry {
 	): Promise<BuiltInDiscoveryResult> {
 		try {
 			const manager = createModelManager({ ...options, cacheDbPath: this.#cacheDbPath });
-			const result = await withModelDiscoveryTimeout(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, () =>
+			const result = await withModelDiscoveryTimeout(resolveModelDiscoveryTimeoutMs(options), () =>
 				manager.refresh(strategy),
 			);
 			const models = result.models.map(model =>

--- a/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
+++ b/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
@@ -59,6 +59,33 @@ function pressuredFetchMock(): FetchImpl {
 		return new Response("", { status: 404 });
 	}) as FetchImpl;
 }
+function shortTimeoutFetchMock(): FetchImpl {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("models.json.zstd")) {
+			// Prefetch burns nearly its whole 10s transport bound before
+			// failing, so the pipeline starts the rich phase ~9s in.
+			// Load-bearing wall clock like the mocks above: the outer
+			// guard and phase budgets are real AbortSignal timers.
+			await Bun.sleep(9_000);
+			return new Response("", { status: 404 });
+		}
+		if (url.endsWith("/model_group/info")) {
+			// Never answers: the 5s inner budget aborts this, and the
+			// fallback must still fit inside the short-branch outer.
+			const { promise, reject } = Promise.withResolvers<never>();
+			init?.signal?.addEventListener("abort", () => reject(new Error("rich fetch aborted")), { once: true });
+			await promise;
+		}
+		if (url.endsWith("/v1/models")) {
+			await Bun.sleep(9_000);
+			if (init?.signal?.aborted) throw new Error("fallback fetch aborted");
+			return Response.json({ data: [{ id: "openai/gpt-5" }] });
+		}
+		return new Response("", { status: 404 });
+	}) as FetchImpl;
+}
+
 function deadlineEdgeFetchMock(): FetchImpl {
 	return (async (input: string | URL | Request, init?: RequestInit) => {
 		const url = String(input);
@@ -148,6 +175,19 @@ describe("litellm discovery outer timeout (#11576)", () => {
 		// what makes this edge robust rather than luck. This is the
 		// observable outcome that replaces the old internal
 		// discoveryBudgetMs literal assertion.
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: deadlineEdgeFetchMock() });
+		await registry.refreshDiscoverableProviders(["litellm"], "online");
+		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
+	}, 120_000);
+
+	test("a short configured budget still reaches the fallback after a slow prefetch", async () => {
+		// ~9s prefetch + 5s rich abort + ~9s fallback ≈ 23s: inside the
+		// 30s short-branch outer (5s rich + 2x10s phase bounds + 5s
+		// headroom), past the 15s default guard the undeclared branch
+		// resolves to (Codex P1 3986054005).
+		Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = "5000";
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: shortTimeoutFetchMock() });
+		await registry.refreshDiscoverableProviders(["litellm"], "online");
 		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
 	}, 120_000);
 });

--- a/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
+++ b/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
@@ -59,6 +59,31 @@ function pressuredFetchMock(): FetchImpl {
 		return new Response("", { status: 404 });
 	}) as FetchImpl;
 }
+function deadlineEdgeFetchMock(): FetchImpl {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("models.json.zstd")) {
+			// Prefetch burns nearly its whole 10s transport bound before
+			// failing, so the pipeline starts the rich phase ~9s into the
+			// outer budget.
+			await Bun.sleep(9_000);
+			return new Response("", { status: 404 });
+		}
+		if (url.endsWith("/model_group/info")) {
+			// Never answers: the inner 30s budget aborts this, and the
+			// fallback must still fit inside the stretched outer.
+			const { promise, reject } = Promise.withResolvers<never>();
+			init?.signal?.addEventListener("abort", () => reject(new Error("rich fetch aborted")), { once: true });
+			await promise;
+		}
+		if (url.endsWith("/v1/models")) {
+			await Bun.sleep(9_000);
+			if (init?.signal?.aborted) throw new Error("fallback fetch aborted");
+			return Response.json({ data: [{ id: "openai/gpt-5" }] });
+		}
+		return new Response("", { status: 404 });
+	}) as FetchImpl;
+}
 
 describe("litellm discovery outer timeout (#11576)", () => {
 	let tempDir: string;
@@ -109,6 +134,20 @@ describe("litellm discovery outer timeout (#11576)", () => {
 		// 50s budget, past the 40s the old arithmetic allowed.
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: pressuredFetchMock() });
 		await registry.refreshDiscoverableProviders(["litellm"], "online");
+		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
+	}, 120_000);
+
+	test("a deadline-edge pipeline still reaches the fallback", async () => {
+		// ~9s prefetch + 30s rich abort + ~9s fallback ≈ 48s of wall clock
+		// (load-bearing: outer and phase budgets are real AbortSignal
+		// timers, as the mocks above document). Past the 44s the pressured
+		// test covers and comfortable inside the 55s stretched outer — but
+		// only ~1s inside an exact-sum 50s outer, with no room left for the
+		// outer timer's start offset or per-phase handoff jitter (measured
+		// 48.9s against the exact sum locally). The explicit headroom is
+		// what makes this edge robust rather than luck. This is the
+		// observable outcome that replaces the old internal
+		// discoveryBudgetMs literal assertion.
 		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
 	}, 120_000);
 });

--- a/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
+++ b/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
@@ -1,0 +1,105 @@
+// #11576 follow-up (Codex P1): the runtime outer guard must accommodate a
+// configured inner discovery budget larger than its 15s default. A rich
+// /model/info response arriving after 15s must still yield models instead of
+// an empty registry result.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import {
+	RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS,
+	resolveModelDiscoveryTimeoutMs,
+} from "@oh-my-pi/pi-coding-agent/config/model-provider-discovery";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+const RICH_DELAY_MS = 16_000;
+
+function slowRichFetchMock(): FetchImpl {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("/model_group/info")) {
+			// Load-bearing wall clock: the outer guard and the inner rich
+			// budget are real setTimeout/AbortSignal timers around a real
+			// fetch pipeline, so fake timers cannot drive this path.
+			await Bun.sleep(RICH_DELAY_MS);
+			if (init?.signal?.aborted) throw new Error("rich fetch aborted");
+			return Response.json({ data: [{ model_group: "slow-reasoner", supports_reasoning: true }] });
+		}
+		if (url.endsWith("/v1/models")) {
+			return Response.json({ data: [{ id: "openai/gpt-5" }] });
+		}
+		return new Response("", { status: 404 });
+	}) as FetchImpl;
+}
+
+describe("litellm discovery outer timeout (#11576)", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+	let originalApiKey: string | undefined;
+	let originalEnvTimeout: string | undefined;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		originalEnvTimeout = Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = "30000";
+		originalApiKey = Bun.env.LITELLM_API_KEY;
+		Bun.env.LITELLM_API_KEY = "sk-test";
+		tempDir = path.join(os.tmpdir(), `pi-test-litellm-outer-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		fs.writeFileSync(modelsJsonPath, JSON.stringify({ providers: {} }));
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+		if (originalEnvTimeout === undefined) {
+			delete Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+		} else {
+			Bun.env.LITELLM_DISCOVERY_TIMEOUT_MS = originalEnvTimeout;
+		}
+		if (originalApiKey === undefined) {
+			delete Bun.env.LITELLM_API_KEY;
+		} else {
+			Bun.env.LITELLM_API_KEY = originalApiKey;
+		}
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+	});
+
+	test("a rich response slower than the default outer still yields models", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: slowRichFetchMock() });
+		await registry.refreshDiscoverableProviders(["litellm"], "online");
+		expect(registry.find("litellm", "slow-reasoner")).toBeDefined();
+	}, 120_000);
+});
+
+describe("resolveModelDiscoveryTimeoutMs", () => {
+	test("keeps the default guard when no inner budget is declared", () => {
+		expect(resolveModelDiscoveryTimeoutMs({})).toBe(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS);
+		expect(resolveModelDiscoveryTimeoutMs({ discoveryBudgetMs: undefined })).toBe(
+			RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS,
+		);
+	});
+
+	test("never shrinks the guard below its default", () => {
+		expect(resolveModelDiscoveryTimeoutMs({ discoveryBudgetMs: 5_000 })).toBe(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS);
+	});
+
+	test("stretches past the default for a larger declared budget", () => {
+		expect(resolveModelDiscoveryTimeoutMs({ discoveryBudgetMs: 40_000 })).toBe(40_000);
+	});
+
+	test("falls back to the default guard on a non-finite budget", () => {
+		expect(resolveModelDiscoveryTimeoutMs({ discoveryBudgetMs: Number.NaN })).toBe(
+			RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS,
+		);
+	});
+});

--- a/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
+++ b/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
@@ -35,6 +35,30 @@ function slowRichFetchMock(): FetchImpl {
 		return new Response("", { status: 404 });
 	}) as FetchImpl;
 }
+function pressuredFetchMock(): FetchImpl {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("models.json.zstd")) {
+			// A struggling catalog mirror: burns part of the outer budget
+			// before the transport deadline would fire.
+			await Bun.sleep(5_000);
+			return new Response("", { status: 404 });
+		}
+		if (url.endsWith("/model_group/info")) {
+			// Never answers: the inner rich budget aborts this at 30s, and
+			// discovery must still reach the fallback inside the outer.
+			const { promise, reject } = Promise.withResolvers<never>();
+			init?.signal?.addEventListener("abort", () => reject(new Error("rich fetch aborted")), { once: true });
+			await promise;
+		}
+		if (url.endsWith("/v1/models")) {
+			await Bun.sleep(9_000);
+			if (init?.signal?.aborted) throw new Error("fallback fetch aborted");
+			return Response.json({ data: [{ id: "openai/gpt-5" }] });
+		}
+		return new Response("", { status: 404 });
+	}) as FetchImpl;
+}
 
 describe("litellm discovery outer timeout (#11576)", () => {
 	let tempDir: string;
@@ -78,6 +102,14 @@ describe("litellm discovery outer timeout (#11576)", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: slowRichFetchMock() });
 		await registry.refreshDiscoverableProviders(["litellm"], "online");
 		expect(registry.find("litellm", "slow-reasoner")).toBeDefined();
+	}, 120_000);
+
+	test("a pressured prefetch plus rich abort still reaches the fallback", async () => {
+		// ~5s prefetch + 30s rich abort + ~9s fallback ≈ 44s: inside the
+		// 50s budget, past the 40s the old arithmetic allowed.
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: pressuredFetchMock() });
+		await registry.refreshDiscoverableProviders(["litellm"], "online");
+		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
 	}, 120_000);
 });
 

--- a/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
+++ b/packages/coding-agent/test/litellm-discovery-outer-timeout.test.ts
@@ -91,9 +91,9 @@ function deadlineEdgeFetchMock(): FetchImpl {
 		const url = String(input);
 		if (url.endsWith("models.json.zstd")) {
 			// Prefetch burns nearly its whole 10s transport bound before
-			// failing, so the pipeline starts the rich phase ~9s into the
-			// outer budget.
-			await Bun.sleep(9_000);
+			// failing, so the pipeline starts the rich phase ~10s into the
+			// outer budget. 9.9s (not 10s) keeps clear of the bound itself.
+			await Bun.sleep(9_900);
 			return new Response("", { status: 404 });
 		}
 		if (url.endsWith("/model_group/info")) {
@@ -104,7 +104,8 @@ function deadlineEdgeFetchMock(): FetchImpl {
 			await promise;
 		}
 		if (url.endsWith("/v1/models")) {
-			await Bun.sleep(9_000);
+			// 9.9s (not 10s) keeps clear of the default phase bound itself.
+			await Bun.sleep(9_900);
 			if (init?.signal?.aborted) throw new Error("fallback fetch aborted");
 			return Response.json({ data: [{ id: "openai/gpt-5" }] });
 		}
@@ -163,18 +164,22 @@ describe("litellm discovery outer timeout (#11576)", () => {
 		await registry.refreshDiscoverableProviders(["litellm"], "online");
 		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();
 	}, 120_000);
-
 	test("a deadline-edge pipeline still reaches the fallback", async () => {
-		// ~9s prefetch + 30s rich abort + ~9s fallback ≈ 48s of wall clock
-		// (load-bearing: outer and phase budgets are real AbortSignal
-		// timers, as the mocks above document). Past the 44s the pressured
-		// test covers and comfortable inside the 55s stretched outer — but
-		// only ~1s inside an exact-sum 50s outer, with no room left for the
-		// outer timer's start offset or per-phase handoff jitter (measured
-		// 48.9s against the exact sum locally). The explicit headroom is
-		// what makes this edge robust rather than luck. This is the
-		// observable outcome that replaces the old internal
-		// discoveryBudgetMs literal assertion.
+		// ~9.9s prefetch + 30s rich abort + ~9.9s fallback ≈ 49.8s nominal,
+		// the most any completable pipeline can schedule: prefetch and
+		// fallback are hard-capped at the 10s shared default and rich
+		// aborts at its 30s inner, so the caps sum to exactly the old
+		// exact-sum 50s arithmetic. Measured against a zeroed headroom,
+		// this pipeline still completes (~50.7s wall, models found) —
+		// the old budget absorbs the worst case within ordinary
+		// handoff variance, so an outcome test that fails without the
+		// headroom is unconstructible without racing sub-0.2s timer
+		// margins (Codex P1 3986541327). The headroom margin itself is
+		// pinned deterministically by the margin unit in
+		// litellm-provider.test.ts (stretched budget must clear the exact
+		// phase sum — fails without headroom); this test pins end-to-end
+		// delivery at the nearest constructible edge, inside the 55s
+		// stretched outer.
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: deadlineEdgeFetchMock() });
 		await registry.refreshDiscoverableProviders(["litellm"], "online");
 		expect(registry.find("litellm", "openai/gpt-5")).toBeDefined();


### PR DESCRIPTION
## What

I made LiteLLM's model-discovery budget configurable instead of hardcoded at 10 seconds. `litellmModelManagerOptions` now accepts a `discoveryTimeoutMs` option with a `LITELLM_DISCOVERY_TIMEOUT_MS` env fallback (both sanitized to positive numbers), defaulting to the previous 10s — so slow `/model/info` payloads on large proxies no longer silently fall back to `/v1/models` and lose their reasoning metadata, while anyone happy with the default sees zero behavior change.

## Why

Fixes #11355

The existing plumbing already accepted `timeoutMs`; only the LiteLLM call site hardcoded it. The naming and shape mirror the in-repo `VLLM_DISCOVERY_TIMEOUT_MS` precedent.

## Testing

- RED (source reverted, new tests only): the `discoveryTimeoutMs` test fails — the hanging rich phase stalls for the hardcoded 10s budget instead of aborting on the configured 50ms.
- GREEN (with fix): `bun test test/litellm-provider.test.ts` → 32 pass / 0 fail (29 existing + 3 new: config key, env var, 10s default intact).
- Neighbors (full `packages/catalog` suite): 868 pass / 4 fail / 2 errors with fix vs 865 pass / identical 4 fail / 2 errors on the clean-tree `git stash` baseline (missing `@bgotink/kdl` module + 2 sqlite-cache self-heal env failures, all pre-existing and unrelated).
- `bun run check` in `packages/catalog`: oxlint clean, oxfmt clean (185 files), `tsgo --noEmit` 0 errors.
- Suites run with root `node_modules` held aside per the Windows import quirk, restored afterwards.

---

- [ ] `bun check` passes (repo-wide gate not run; per-package `bun run check` green — see above)
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution ([#11576](https://github.com/can1357/oh-my-pi/pull/11576) by [@nikkoxgonzales](https://github.com/nikkoxgonzales))

