### PR TITLE
fix(coding-agent): log successful settings persists at debug level

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
 ### Fixed
 
+- Successful settings persists now emit a debug-level log line with the config path, so machine-global mutations are attributable instead of only failures leaving a record ([#11581](https://github.com/can1357/oh-my-pi/pull/11581) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 - Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay only to writable guests, and already-aborted asks no longer consume request IDs ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
 - Collab hosts now acknowledge a writable guest's `ui-response` for an already-settled request with a targeted `ui-request-end`, so a guest that reconnected after the broadcast and resent its answer no longer waits forever ([#11561](https://github.com/can1357/oh-my-pi/pull/11561) by [@alphastorm](https://github.com/alphastorm)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -2673,6 +2673,7 @@ export class Settings {
 				await handle.close();
 			}
 			await replaceFileAtomically(tempPath, filePath);
+			logger.debug("Settings: saved", { path: filePath });
 			removeTemp = false;
 		} finally {
 			if (removeTemp) {

--- a/packages/coding-agent/test/config/settings-save-log.test.ts
+++ b/packages/coding-agent/test/config/settings-save-log.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { logger, removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -38,6 +39,7 @@ describe("settings persist logging", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		AgentStorage.close();
 		await removeWithRetries(agentDir).catch(() => {});
 	});
 
@@ -46,7 +48,10 @@ describe("settings persist logging", () => {
 		const settings = await Settings.loadIsolated({ agentDir, cwd: agentDir });
 		settings.set("fetch.enabled", false);
 		await waitForFile(path.join(agentDir, "config.yml"));
-		expect(debugSpy).toHaveBeenCalledWith("Settings: saved", expect.objectContaining({ path: expect.any(String) }));
+		expect(debugSpy).toHaveBeenCalledWith(
+			"Settings: saved",
+			expect.objectContaining({ path: path.join(agentDir, "config.yml") }),
+		);
 	});
 
 	test("a failed save emits no success line", async () => {

--- a/packages/coding-agent/test/config/settings-save-log.test.ts
+++ b/packages/coding-agent/test/config/settings-save-log.test.ts
@@ -1,0 +1,69 @@
+// Issue #11475: a successful settings write leaves no record — only failure
+// lines exist. Success must emit one debug-level log line with the path;
+// failure paths must stay silent on success logging.
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { logger, removeWithRetries } from "@oh-my-pi/pi-utils";
+
+// Exception to no-real-timers: the debounced background save and the durable
+// write run on the real platform clock and real filesystem — fake timers
+// cannot advance fsync or file visibility. Poll for the real outcome instead.
+async function waitForFile(file: string, timeoutMs = 5000): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (await Bun.file(file).exists()) return;
+		await Bun.sleep(50);
+	}
+	throw new Error(`timed out waiting for ${file}`);
+}
+
+async function waitForWarn(spy: { mock: { calls: unknown[][] } }, timeoutMs = 5000): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (spy.mock.calls.length > 0) return;
+		await Bun.sleep(50);
+	}
+	throw new Error("timed out waiting for warn call");
+}
+
+describe("settings persist logging", () => {
+	let agentDir!: string;
+
+	beforeEach(async () => {
+		agentDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pi-settings-save-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await removeWithRetries(agentDir).catch(() => {});
+	});
+
+	test("a successful save emits one debug line with the config path", async () => {
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const settings = await Settings.loadIsolated({ agentDir, cwd: agentDir });
+		settings.set("fetch.enabled", false);
+		await waitForFile(path.join(agentDir, "config.yml"));
+		expect(debugSpy).toHaveBeenCalledWith("Settings: saved", expect.objectContaining({ path: expect.any(String) }));
+	});
+
+	test("a failed save emits no success line", async () => {
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const settings = await Settings.loadIsolated({ agentDir, cwd: agentDir });
+		// Fail the atomic write's temp-file creation deterministically: every
+		// open under the agent dir throws, so the queued save cannot persist.
+		const realOpen = fs.promises.open.bind(fs.promises);
+		vi.spyOn(fs.promises, "open").mockImplementation(async (target, flags, mode) => {
+			if (typeof target === "string" && target.startsWith(agentDir)) {
+				throw Object.assign(new Error("injected write failure"), { code: "ENOSPC" });
+			}
+			return realOpen(target, flags, mode);
+		});
+		settings.set("fetch.enabled", false);
+		await waitForWarn(warnSpy);
+		expect(debugSpy).not.toHaveBeenCalledWith("Settings: saved", expect.anything());
+	});
+});


### PR DESCRIPTION
## What

I was annoyed that a settings write succeeding left no trace while every failure got a log line, so I added the missing half: one debug-level line after the atomic write lands on disk. I put it in `#writeYamlAtomically` (right after the durable rename) so every persist path — global saves, project saves, migrations — is covered by a single line, and I kept it at debug because settings writes are frequent. The line mirrors the existing style (`Settings: save failed` → `Settings: saved`, same `{ path }` shape as the migration line). This was split out of #11431 at maintainer request. Runtime behavior is otherwise unchanged.

## Why

Fixes #11475

## Testing

- RED: new `test/config/settings-save-log.test.ts` fails on clean tree — the save lands on disk (file appears) but `"Settings: saved"` is never logged (`Expected: ["Settings: saved", ObjectContaining {path: Any<String>}] / But it was not called`).
- GREEN with fix: 2 pass / 0 fail (success emits the line; sabotaged save emits the existing failure warn and no success line).
- Neighbors: `test/config/` 15 pass / 0 fail; `agent-session-model-persistence` + `advisor-tool-call-loop-guard` (both assert on `Settings: ` log lines) 24 pass / 0 fail.
- `bun run check` (oxlint + oxfmt + tsgo) in `packages/coding-agent`: exit 0 (one pre-existing unused-var warning in untouched `test/task/executor-subagent-reminders.test.ts`).
- Note: suite runs were done with the repo-root `node_modules` held aside per this box's procedure (restored after each run; `git status` identical); lint/types ran with it in place since they need the toolchain.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)