### PR TITLE
fix(tui): restore custom status line defaults

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Selecting the Custom status line preset now starts from its built-in segment layout when no segment lists are configured, while explicit empty lists still hide either side ([#11577](https://github.com/can1357/oh-my-pi/issues/11577)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -265,6 +265,15 @@ export type StatusLineSegmentId =
 	| "collab"
 	| "vim";
 
+/** Baseline segments used when Custom is selected without segment overrides. */
+export const CUSTOM_STATUS_LINE_DEFAULTS: {
+	readonly left: StatusLineSegmentId[];
+	readonly right: StatusLineSegmentId[];
+} = {
+	left: ["vim", "model", "mode", "path", "git", "pr"],
+	right: ["session_name", "token_total", "cost", "context_pct"],
+};
+
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {
 	value: V;
@@ -990,9 +999,9 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentId[] },
+	"statusLine.leftSegments": { type: "array", default: CUSTOM_STATUS_LINE_DEFAULTS.left },
 
-	"statusLine.rightSegments": { type: "array", default: [] as StatusLineSegmentId[] },
+	"statusLine.rightSegments": { type: "array", default: CUSTOM_STATUS_LINE_DEFAULTS.right },
 
 	"statusLine.segmentOptions": { type: "record", default: {} as Record<string, unknown> },
 

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_STATUS_LINE_DEFAULTS } from "../../../config/settings-schema";
 import type { PresetDef, StatusLinePreset } from "./types";
 
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
@@ -94,8 +95,8 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	custom: {
 		// User-defined - these are just defaults that get overridden
-		leftSegments: ["vim", "model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
+		leftSegments: [...CUSTOM_STATUS_LINE_DEFAULTS.left],
+		rightSegments: [...CUSTOM_STATUS_LINE_DEFAULTS.right],
 		separator: "powerline-thin",
 		segmentOptions: {},
 	},

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -164,6 +164,24 @@ describe("StatusLineComponent effective settings cache", () => {
 		expect(customComponent.getTopBorder(120)).toEqual({ content: "", width: 0, revision: 0 });
 	});
 
+	it("renders custom preset defaults when segment arrays are unconfigured", () => {
+		Settings.instance.override("statusLine.preset", "custom");
+		const component = makeComponent({
+			preset: Settings.instance.get("statusLine.preset"),
+			leftSegments: Settings.instance.get("statusLine.leftSegments"),
+			rightSegments: Settings.instance.get("statusLine.rightSegments"),
+			sessionAccent: false,
+		});
+
+		const effective = component.getEffectiveSettingsForTest();
+		expect(effective.leftSegments).toEqual(STATUS_LINE_PRESETS.custom.leftSegments);
+		expect(effective.rightSegments).toEqual(STATUS_LINE_PRESETS.custom.rightSegments);
+
+		const content = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(content).toContain("Test Model");
+		expect(content).toContain("Cache Session");
+	});
+
 	it("surfaces active subagents even when custom segments omit subagents", () => {
 		const component = makeComponent({ preset: "custom", leftSegments: [], rightSegments: [] });
 


### PR DESCRIPTION
## Repro

With no `statusLine.leftSegments` or `statusLine.rightSegments` configured, select Custom in `/settings` → Appearance → Status Line Preset. `bun test packages/coding-agent/test/status-line-settings-cache.test.ts --test-name-pattern "renders custom preset defaults"` reproduced the failure: the effective left segment list was `[]` instead of the Custom preset baseline.

## Cause

`SETTINGS_SCHEMA` in `packages/coding-agent/src/config/settings-schema.ts` supplied empty arrays as the resolved defaults. `StatusLineComponent.#computeEffectiveSettings()` in `packages/coding-agent/src/modes/components/status-line/component.ts` therefore treated those arrays as configured Custom overrides and never reached the fallback lists from `STATUS_LINE_PRESETS.custom`.

## Fix

- Define the Custom baseline once in `settings-schema.ts` and use it for unconfigured segment-list defaults.
- Reuse the same baseline in `presets.ts`, while preserving explicitly configured empty arrays.
- Add a rendering regression test and an Unreleased changelog entry.

## Verification

`bun test packages/coding-agent/test/status-line-settings-cache.test.ts` passes: 13 tests, 58 assertions. `bun check` passes. In an isolated live TUI, selecting Custom changed the preview and saved status line to a non-empty model/path/git and session/token layout.

Fixes #11577