### PR TITLE
fix(status-line): rejected unknown segment ids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Unknown custom status-line segment ids now produce a config warning and are rejected by `omp config set` instead of silently disappearing ([#11579](https://github.com/can1357/oh-my-pi/issues/11579)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -236,34 +236,38 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 	providers: ["Services", "Fireworks", "Tiny Model", "Protocol", "Timeouts", "Privacy"],
 };
 
-/** Status line segment identifiers */
-export type StatusLineSegmentId =
-	| "pi"
-	| "status"
-	| "model"
-	| "mode"
-	| "path"
-	| "git"
-	| "pr"
-	| "subagents"
-	| "token_in"
-	| "token_out"
-	| "token_total"
-	| "token_rate"
-	| "cost"
-	| "context_pct"
-	| "context_total"
-	| "time_spent"
-	| "time"
-	| "session"
-	| "hostname"
-	| "cache_read"
-	| "cache_write"
-	| "cache_hit"
-	| "session_name"
-	| "usage"
-	| "collab"
-	| "vim";
+/** Status line segment identifiers accepted by custom status-line settings. */
+export const STATUS_LINE_SEGMENT_IDS = [
+	"pi",
+	"status",
+	"model",
+	"mode",
+	"path",
+	"git",
+	"pr",
+	"subagents",
+	"token_in",
+	"token_out",
+	"token_total",
+	"token_rate",
+	"cost",
+	"context_pct",
+	"context_total",
+	"time_spent",
+	"time",
+	"session",
+	"hostname",
+	"cache_read",
+	"cache_write",
+	"cache_hit",
+	"session_name",
+	"usage",
+	"collab",
+	"vim",
+] as const;
+
+/** One identifier from the supported status-line segment catalog. */
+export type StatusLineSegmentId = (typeof STATUS_LINE_SEGMENT_IDS)[number];
 
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -51,6 +51,7 @@ import {
 	type GroupTypeMap,
 	getDefault,
 	SETTINGS_SCHEMA,
+	STATUS_LINE_SEGMENT_IDS,
 	type SettingPath,
 	type SettingValue,
 } from "./settings-schema";
@@ -58,6 +59,30 @@ import {
 // Re-export types that callers need
 export type * from "./settings-schema";
 export * from "./settings-schema";
+
+const STATUS_LINE_SEGMENT_PATHS = ["statusLine.leftSegments", "statusLine.rightSegments"] as const;
+const warnedUnknownStatusLineSegments = new Set<string>();
+
+function getUnknownStatusLineSegments(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const unknown = new Set<string>();
+	for (const segment of value) {
+		if (!STATUS_LINE_SEGMENT_IDS.some(id => id === segment)) {
+			unknown.add(typeof segment === "string" ? JSON.stringify(segment) : String(segment));
+		}
+	}
+	return [...unknown];
+}
+
+function assertKnownStatusLineSegments(path: SettingPath, value: unknown): void {
+	if (path !== "statusLine.leftSegments" && path !== "statusLine.rightSegments") return;
+	const unknown = getUnknownStatusLineSegments(value);
+	if (unknown.length === 0) return;
+	const noun = unknown.length === 1 ? "segment" : "segments";
+	throw new Error(
+		`Unknown status line ${noun}: ${unknown.join(", ")}. Valid segments: ${STATUS_LINE_SEGMENT_IDS.join(", ")}`,
+	);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Types
@@ -661,6 +686,7 @@ export class Settings {
 	 * Triggers hooks for settings that have side effects.
 	 */
 	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+		assertKnownStatusLineSegments(path, value);
 		const prev = this.get(path);
 		const segments = path.split(".");
 		this.#captureGlobalMutation(path, this.#modifiedPathMutations, getByPath(this.#global, segments));
@@ -2959,12 +2985,24 @@ export class Settings {
 		return filteredRoles ? { ...this.#project, modelRoles: filteredRoles } : this.#project;
 	}
 
+	#warnUnknownStatusLineSegments(): void {
+		for (const path of STATUS_LINE_SEGMENT_PATHS) {
+			const value = getByPath(this.#merged, SETTING_PATH_SEGMENTS[path]);
+			for (const segment of getUnknownStatusLineSegments(value)) {
+				if (warnedUnknownStatusLineSegments.has(segment)) continue;
+				warnedUnknownStatusLineSegments.add(segment);
+				logger.warn(`Settings: unknown status line segment ${segment}`, { setting: path });
+			}
+		}
+	}
+
 	#rebuildMerged(): void {
 		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#projectSettingsForMerge());
 		this.#merged = this.#deepMerge(this.#merged, this.#configOverlay);
 		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
 		this.#resolvedCache.clear();
 		this.#editVariantCache = undefined;
+		this.#warnUnknownStatusLineSegments();
 	}
 
 	#fireAllHooks(): void {
@@ -3256,6 +3294,7 @@ export function resetSettingsForTest(): void {
 		ref.deref()?.cancelPendingSaves();
 	}
 	liveSettingsInstances.clear();
+	warnedUnknownStatusLineSegments.clear();
 	globalInstance = null;
 	globalInstancePromise = null;
 	clearBoundSettingsMethods();

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -139,6 +139,27 @@ describe("config CLI schema coverage", () => {
 		expect(parsed.type).toBe("array");
 		expect(parsed.value).toEqual(["claude-opus-4-6", "gpt-5.3-codex"]);
 	});
+
+	it("rejects unknown status line segment ids", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as typeof process.exit);
+
+		await expect(
+			runConfigCommand({
+				action: "set",
+				key: "statusLine.leftSegments",
+				value: '["modle","git"]',
+				flags: { json: true },
+			}),
+		).rejects.toThrow("process.exit");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringContaining('Unknown status line segment: "modle". Valid segments: pi, status, model'),
+		);
+	});
 	it("sets numeric idle compaction settings from CLI values", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		await runConfigCommand({

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -21,7 +21,7 @@ import * as discovery from "@oh-my-pi/pi-coding-agent/discovery";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/tools/image-providers";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
-import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
 import * as fileLock from "@oh-my-pi/pi-utils/file-lock";
 import { YAML } from "bun";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -149,6 +149,29 @@ describe("Settings", () => {
 			const content = await Bun.file(getConfigPath()).text();
 			expect(content).not.toMatch(/: +$/m);
 			expect(YAML.parse(content)).toEqual({ custom, theme: { dark: "titanium" } });
+		});
+	});
+
+	describe("status line segment validation", () => {
+		it("logs each unknown configured segment once while preserving the config", async () => {
+			await writeSettings({
+				statusLine: {
+					preset: "custom",
+					leftSegments: ["modle", "git", "modle"],
+					rightSegments: ["usage", "sesion", "modle"],
+				},
+			});
+			const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(JSON.stringify(settings.get("statusLine.leftSegments"))).toBe('["modle","git","modle"]');
+			expect(
+				warn.mock.calls.filter(([message]) => String(message).startsWith("Settings: unknown status line segment")),
+			).toEqual([
+				['Settings: unknown status line segment "modle"', { setting: "statusLine.leftSegments" }],
+				['Settings: unknown status line segment "sesion"', { setting: "statusLine.rightSegments" }],
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Repro

With an isolated config home, `bun run dev -- config set statusLine.leftSegments '["modle"]'` previously exited 0 and persisted `["modle"]`; rendering then treated the unknown segment as hidden.

## Cause

`packages/coding-agent/src/config/settings-schema.ts` expressed `StatusLineSegmentId` only as a compile-time union, while `Settings.set` accepted runtime array contents without checking them and `renderSegment` converted missing registry entries into invisible segments.

## Fix

- Define the runtime status-line segment catalog beside the derived `StatusLineSegmentId` type.
- Reject unknown segment ids on settings updates and log each unknown id once when loading existing configuration.
- Cover config CLI rejection and load-time warning/deduplication, and add the user-facing changelog entry.

## Verification

`bun test packages/coding-agent/test/config-cli.test.ts packages/coding-agent/test/settings-manager.test.ts` passed 130 tests. `bun run check` passed for `packages/coding-agent` (with one pre-existing unused-variable warning). Re-running the original isolated `config set` command now exits 1 with `Unknown status line segment: "modle"` and lists valid segments.

Fixes #11579