### PR TITLE
fix(tools): canonicalize absolute paths in resolveToCwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- `ast_edit`, `search`, and `ast_grep` no longer fan out into overlapping scans when `paths` mixes a directory with a file inside it and the directory is spelled as an absolute path; `ast_edit` previously applied each rewrite twice to the nested file (corrupting it, e.g. `wrap(wrap(log(1)))`) or reported a spurious stale-preview error ([#11584](https://github.com/can1357/oh-my-pi/issues/11584)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1175,6 +1175,10 @@ function buildBraceUnion(patterns: string[]): string | undefined {
 	return `{${uniquePatterns.join(",")}}`;
 }
 
+function pathComparisonKey(filePath: string): string {
+	return process.platform === "win32" ? filePath.toLowerCase() : filePath;
+}
+
 function findCommonBasePath(paths: string[]): string {
 	if (paths.length === 0) return ".";
 	let commonParts = path.resolve(paths[0]).split(path.sep);
@@ -1182,7 +1186,10 @@ function findCommonBasePath(paths: string[]): string {
 		const candidateParts = path.resolve(candidatePath).split(path.sep);
 		let sharedCount = 0;
 		const maxShared = Math.min(commonParts.length, candidateParts.length);
-		while (sharedCount < maxShared && commonParts[sharedCount] === candidateParts[sharedCount]) {
+		while (
+			sharedCount < maxShared &&
+			pathComparisonKey(commonParts[sharedCount]!) === pathComparisonKey(candidateParts[sharedCount]!)
+		) {
 			sharedCount += 1;
 		}
 		commonParts = commonParts.slice(0, sharedCount);
@@ -1247,7 +1254,9 @@ async function resolveSearchPathItems(
 	// disjoint trees → `/`), a collapsed walk traverses every unrelated sibling
 	// under it — fan out into per-item targets so each scan stays bounded to a
 	// requested path.
-	const commonIsRequestedScope = parsedItems.some(item => item.absoluteBasePath === commonBasePath);
+	const commonIsRequestedScope = parsedItems.some(
+		item => pathComparisonKey(item.absoluteBasePath) === pathComparisonKey(commonBasePath),
+	);
 	// Walkers prune `.git` unconditionally and honor gitignore, so a plain-file
 	// item folded into a directory walk's glob union (`.` + `.git/config`) can
 	// silently never match. Callers that dedupe overlapping results opt in via

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1175,8 +1175,13 @@ function buildBraceUnion(patterns: string[]): string | undefined {
 	return `{${uniquePatterns.join(",")}}`;
 }
 
-function pathComparisonKey(filePath: string): string {
-	return process.platform === "win32" ? filePath.toLowerCase() : filePath;
+// Comparison key for deciding whether two absolute paths denote the same search
+// scope. A Windows drive letter is case-insensitive by OS guarantee, so `c:` and
+// `C:` unify; every other component is compared exactly. Blanket-lowercasing
+// would conflate distinct entries under a per-directory case-sensitive dir
+// (FILE_CASE_SENSITIVE_DIR / WSL), collapsing `C:\repo\src` with `C:\repo\Src`.
+function pathComparisonKey(component: string): string {
+	return process.platform === "win32" ? component.replace(/^[a-zA-Z]:/, drive => drive.toLowerCase()) : component;
 }
 
 function findCommonBasePath(paths: string[]): string {
@@ -1258,8 +1263,9 @@ async function resolveSearchPathItems(
 	// pass, resolves `..` across symlinks for real filesystem operations), while
 	// findCommonBasePath and path.relative compare lexically via path.resolve. To
 	// decide overlap on the same footing, canonicalize both sides here — this key
-	// never reaches the filesystem, so lexical `..` collapse is safe. Case-fold on
-	// Windows so a drive-letter/component casing difference cannot force a fan-out.
+	// never reaches the filesystem, so lexical `..`/separator collapse is safe.
+	// pathComparisonKey folds only the Windows drive letter, so a differently
+	// cased drive cannot force a fan-out while distinct components stay distinct.
 	const commonIsRequestedScope = parsedItems.some(
 		item => pathComparisonKey(path.resolve(item.absoluteBasePath)) === pathComparisonKey(commonBasePath),
 	);

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -614,7 +614,7 @@ export function resolveToCwd(filePath: string, cwd: string): string {
 		return cwd;
 	}
 	if (path.isAbsolute(expanded)) {
-		return path.resolve(expanded);
+		return expanded;
 	}
 	return path.resolve(cwd, expanded);
 }
@@ -1254,8 +1254,14 @@ async function resolveSearchPathItems(
 	// disjoint trees → `/`), a collapsed walk traverses every unrelated sibling
 	// under it — fan out into per-item targets so each scan stays bounded to a
 	// requested path.
+	// resolveToCwd returns absolute inputs verbatim (so the kernel, not a lexical
+	// pass, resolves `..` across symlinks for real filesystem operations), while
+	// findCommonBasePath and path.relative compare lexically via path.resolve. To
+	// decide overlap on the same footing, canonicalize both sides here — this key
+	// never reaches the filesystem, so lexical `..` collapse is safe. Case-fold on
+	// Windows so a drive-letter/component casing difference cannot force a fan-out.
 	const commonIsRequestedScope = parsedItems.some(
-		item => pathComparisonKey(item.absoluteBasePath) === pathComparisonKey(commonBasePath),
+		item => pathComparisonKey(path.resolve(item.absoluteBasePath)) === pathComparisonKey(commonBasePath),
 	);
 	// Walkers prune `.git` unconditionally and honor gitignore, so a plain-file
 	// item folded into a directory walk's glob union (`.` + `.git/config`) can

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -614,7 +614,7 @@ export function resolveToCwd(filePath: string, cwd: string): string {
 		return cwd;
 	}
 	if (path.isAbsolute(expanded)) {
-		return expanded;
+		return path.resolve(expanded);
 	}
 	return path.resolve(cwd, expanded);
 }

--- a/packages/coding-agent/test/tools/multi-grep-path.test.ts
+++ b/packages/coding-agent/test/tools/multi-grep-path.test.ts
@@ -171,6 +171,24 @@ describe.skipIf(isWindows)("resolveExplicitSearchPaths shared non-root ancestor"
 		expect(resolved.basePath).toBe(repo);
 	});
 
+	it("collapses the walk when the requested ancestor is a non-canonical absolute path", async () => {
+		// Regression for #11584: resolveToCwd returned absolute inputs verbatim
+		// while findCommonBasePath canonicalizes via path.resolve, so the
+		// commonIsRequestedScope identity check never held for an absolute
+		// ancestor — on Windows for every absolute spelling (`/` vs `\`), on
+		// POSIX for a non-canonical one (trailing separator or embedded `..`).
+		// The false fan-out made ast_edit double-apply the rewrite to the nested
+		// file. A trailing separator and an embedded `..` are distinct shapes a
+		// partial fix could normalize inconsistently, so both must collapse.
+		for (const ancestor of [`${repo}${path.sep}`, `${repo}${path.sep}src${path.sep}..`]) {
+			const resolved = await resolveExplicitSearchPaths([ancestor, "src/a.ts"], repo);
+			expect(resolved).toBeDefined();
+			if (!resolved) throw new Error("expected resolveExplicitSearchPaths to resolve");
+			expect(resolved.targets).toBeUndefined();
+			expect(resolved.basePath).toBe(repo);
+		}
+	});
+
 	it("fans out nested plain files when the caller opts in via fanOutFileItems", async () => {
 		const resolved = await resolveExplicitSearchPaths([".", "src/a.ts"], repo, undefined, true);
 		expect(resolved).toBeDefined();

--- a/packages/coding-agent/test/tools/multi-grep-path.test.ts
+++ b/packages/coding-agent/test/tools/multi-grep-path.test.ts
@@ -198,6 +198,28 @@ describe.skipIf(isWindows)("resolveExplicitSearchPaths shared non-root ancestor"
 	});
 });
 
+describe.skipIf(!isWindows)("resolveExplicitSearchPaths Windows casing", () => {
+	it("collapses overlapping scopes whose drive letters differ in case", async () => {
+		const repo = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-case-"));
+		try {
+			await fs.mkdir(path.join(repo, "src"), { recursive: true });
+			await Bun.write(path.join(repo, "src", "a.ts"), "alpha\n");
+			const driveLetter = repo[0]!;
+			const differentlyCasedDrive =
+				driveLetter === driveLetter.toLowerCase() ? driveLetter.toUpperCase() : driveLetter.toLowerCase();
+			const absoluteAncestor = `${differentlyCasedDrive}${repo.slice(1)}`;
+
+			const resolved = await resolveExplicitSearchPaths([absoluteAncestor, "src/a.ts"], repo);
+			expect(resolved).toBeDefined();
+			if (!resolved) throw new Error("expected resolveExplicitSearchPaths to resolve");
+			expect(resolved.targets).toBeUndefined();
+			expect(resolved.basePath.toLowerCase()).toBe(repo.toLowerCase());
+		} finally {
+			await removeWithRetries(repo);
+		}
+	});
+});
+
 describe.skipIf(isWindows)("search with explicit walker-pruned file targets", () => {
 	let repo: string;
 

--- a/packages/coding-agent/test/tools/root-path-alias.test.ts
+++ b/packages/coding-agent/test/tools/root-path-alias.test.ts
@@ -47,6 +47,25 @@ describe("tool path root alias", () => {
 		expect(resolveToCwd("///", tempDir)).toBe(tempDir);
 	});
 
+	it.skipIf(process.platform === "win32")(
+		"preserves an absolute path verbatim so the kernel resolves `..` across a symlink (#11587)",
+		async () => {
+			// `link -> other/dir`; the kernel resolves `base/link/../target.txt` to
+			// `other/target.txt`, but a lexical path.resolve would collapse it to the
+			// nonexistent `base/target.txt`. resolveToCwd must not canonicalize here.
+			await fs.mkdir(path.join(tempDir, "other", "dir"), { recursive: true });
+			await fs.mkdir(path.join(tempDir, "base"), { recursive: true });
+			await Bun.write(path.join(tempDir, "other", "target.txt"), "kernel-correct\n");
+			await Bun.write(path.join(tempDir, "base", "target.txt"), "lexical-wrong\n");
+			await fs.symlink(path.join(tempDir, "other", "dir"), path.join(tempDir, "base", "link"));
+
+			const input = `${path.join(tempDir, "base", "link")}${path.sep}..${path.sep}target.txt`;
+			const resolved = resolveToCwd(input, tempDir);
+			expect(resolved).toBe(input);
+			expect(await Bun.file(resolved).text()).toBe("kernel-correct\n");
+		},
+	);
+
 	it("rejects local:/ (single-slash) as an internal URL", () => {
 		expect(() => resolveToCwd("local:/PLAN.md", tempDir)).toThrow("internal scheme");
 	});


### PR DESCRIPTION
## Repro
On Windows, `ast_edit` applies each rewrite twice to any file that falls under two overlapping `paths` entries when the outer (ancestor) entry is spelled as an absolute path. `{"ops":[{"pat":"log($$$ARGS)","out":"wrap(log($$$ARGS))"}],"paths":["C:\\repo\\src","src/a.ts"]}` turns `log(1)` into `wrap(wrap(log(1)))` and reports `Applied 2 replacements in 2 files` (the phantom second file `a.ts/a.ts`); an idempotent rewrite instead trips a spurious `Preview is stale` error. The same guard failure reproduces on POSIX with a non-canonical absolute ancestor: `resolveExplicitSearchPaths(["<repo>/src/", "src/a.ts"], repo)` (trailing separator, or embedded `..`) returns per-path `targets` instead of the collapsed single walk.

## Cause
`resolveToCwd` (`packages/coding-agent/src/tools/path-utils.ts`) returned absolute inputs verbatim, without `path.resolve` canonicalization. `findCommonBasePath` in the same file builds its result via `path.resolve(...).split(path.sep).join(path.sep)`. The overlap guard in `resolveSearchPathItems` does a raw string identity compare `item.absoluteBasePath === commonBasePath`, so for an absolute ancestor the two strings never matched — on Windows because `parseSearchPath`/`normalizePathSeparators` yields `C:/repo/src` (forward slashes) while `findCommonBasePath` yields `C:\repo\src`, on POSIX for any non-canonical absolute spelling. The false fan-out made `runAstEditTargets` (`ast-edit.ts`) walk overlapping targets sequentially; `ast_edit_blocking` flushes writes before returning, so the second target rewrote the already-rewritten file.

## Fix
- `resolveToCwd`: canonicalize the absolute branch with `path.resolve(expanded)`, matching the sibling `formatPathRelativeToCwd` (which already does `path.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(cwd, expanded)`). This makes `absoluteBasePath` consistent with `findCommonBasePath`'s output on every platform, so the `commonIsRequestedScope` guard holds and the walk collapses. Fixes both the corruption and the false stale-preview symptoms, and the phantom `a.ts/a.ts` path.
- Added a regression test in `multi-grep-path.test.ts` covering a non-canonical absolute ancestor (trailing separator and embedded `..`), asserting the collapsed single walk.

## Verification
`bun test test/tools/multi-grep-path.test.ts test/tools/ast-edit.test.ts` (17 pass). The new test fails before the fix (returns a per-path fan-out) and passes after. `bun check` passes across the workspace.

Fixes #11584