### PR TITLE
fix(agent): preserve non-throwing tool errors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Non-throwing tool failures now retain their error status through extension result rewrites and eval-defined subagent tools ([#11585](https://github.com/can1357/oh-my-pi/issues/11585)).
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
 ### Added
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -380,7 +380,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				),
 				content: result.content,
 				details: result.details,
-				isError: !!executionError,
+				isError: !!executionError || result.isError === true,
 			});
 
 			if (resultResult) {

--- a/packages/coding-agent/src/task/eval-tools.ts
+++ b/packages/coding-agent/src/task/eval-tools.ts
@@ -138,6 +138,7 @@ function errorResult(
 	return {
 		content: [{ type: "text", text: error }],
 		details: { evalTool: name, language, isError: true },
+		isError: true,
 	};
 }
 

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -5,7 +5,7 @@ import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { disposeAllVmContexts, invokeJsTool } from "@oh-my-pi/pi-coding-agent/eval/js/context-manager";
 import { executeJs, type JsResult } from "@oh-my-pi/pi-coding-agent/eval/js/executor";
-import { describeEvalTools } from "@oh-my-pi/pi-coding-agent/task/eval-tools";
+import { createEvalCustomTools, describeEvalTools } from "@oh-my-pi/pi-coding-agent/task/eval-tools";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -157,6 +157,14 @@ describe("executeJs", () => {
 			{ sessionKey: toolSessionId, session: evalSession },
 		);
 		expect(failed).toEqual({ ok: false, error: "kaboom" });
+		const [boomTool] = createEvalCustomTools(evalSession, await describeEvalTools(evalSession, ["boom"]));
+		if (!boomTool) throw new Error("Expected the defined eval tool");
+		const bridgedFailure = await Reflect.apply(boomTool.execute, boomTool, ["call-boom", {}, undefined, undefined]);
+		expect(bridgedFailure).toMatchObject({
+			content: [{ type: "text", text: "kaboom" }],
+			details: { evalTool: "boom", language: "js", isError: true },
+			isError: true,
+		});
 		const alive = await executeJs("return 'still here';", {
 			sessionId: toolSessionId,
 			session: evalSession,

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1327,6 +1327,17 @@ describe("ExtensionRunner", () => {
 			execute: async () => ({ content: [{ type: "text" as const, text: "success" }] }),
 		};
 
+		const flaggedTool: AgentTool = {
+			name: "flagged",
+			label: "Flagged",
+			description: "returns a non-throwing failure",
+			parameters: {} as never,
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "reported failure" }],
+				isError: true,
+			}),
+		};
+
 		const firstText = (result: { content: readonly (TextContent | ImageContent)[] }): string | undefined => {
 			const block = result.content[0];
 			return block?.type === "text" ? block.text : undefined;
@@ -1397,6 +1408,20 @@ describe("ExtensionRunner", () => {
 			const wrapper = new ExtensionToolWrapper(okTool, runner);
 			const res = await wrapper.execute("call-flagged", {} as never, undefined, undefined, undefined);
 			expect(firstText(res)).toBe("now failing");
+			expect(res.isError).toBe(true);
+		});
+
+		it("preserves a tool-reported error through extension rewrites", async () => {
+			const runner = await runnerFor(`
+				export default function(pi) {
+					pi.on("tool_result", (event) => ({
+						content: [{ type: "text", text: event.isError ? "observed failure" : "observed success" }],
+					}));
+				}
+			`);
+			const wrapper = new ExtensionToolWrapper(flaggedTool, runner);
+			const res = await wrapper.execute("call-reported-failure", {} as never, undefined, undefined, undefined);
+			expect(firstText(res)).toBe("observed failure");
 			expect(res.isError).toBe(true);
 		});
 	});


### PR DESCRIPTION
## Repro
A tool returning `{ isError: true }` was wrapped by an extension that rewrote its result, while a throwing eval-defined JavaScript tool was materialized for child-agent use. `bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/core/js-executor.test.ts` reproduced both failures: the extension observed success and the eval bridge omitted the top-level error flag.

## Cause
`AgentToolResult.isError` is the documented way for a tool to report a failure **without throwing**. `ExtensionToolWrapper.execute` in `packages/coding-agent/src/extensibility/extensions/wrapper.ts` initialized `tool_result.isError` only from a caught exception, while `errorResult` in `packages/coding-agent/src/task/eval-tools.ts` stored the flag only inside `details`; both discarded a valid non-throwing failure state before downstream consumers saw it.

## Fix
- Seed extension `tool_result` events from either a caught exception or the wrapped result's top-level `isError` flag.
- Mark eval-defined tool failures with top-level `isError: true` while retaining their existing details metadata.
- Cover both model-visible failure paths and document the user-facing correction.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/core/js-executor.test.ts` passes: 109 tests, 0 failures, 306 assertions. The same two regression assertions failed before the fix. The pre-publish `bun run fix` and `bun check` gate passed while publishing the branch.

Fixes #11585