### PR TITLE
fix(coding-agent): steer sqlite3 shell-outs to read in bash prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
 ### Fixed
 
+- The `bash` tool prompt now steers SQLite queries to `read` (`db.sqlite:table`, `?q=SELECT`) instead of shelling out to `sqlite3` ([#11591](https://github.com/can1357/oh-my-pi/pull/11591) by [@nikkoxgonzales](https://github.com/nikkoxgonzales)).
 - Fixed collab host UI requests raised before a writable guest joins being lost; up to 64 pending asks now replay only to writable guests, and already-aborted asks no longer consume request IDs ([#9031](https://github.com/can1357/oh-my-pi/pull/9031) by [@alphastorm](https://github.com/alphastorm)).
 - Collab hosts now acknowledge a writable guest's `ui-response` for an already-settled request with a targeted `ui-request-end`, so a guest that reconnected after the broadcast and resent its answer no longer waits forever ([#11561](https://github.com/can1357/oh-my-pi/pull/11561) by [@alphastorm](https://github.com/alphastorm)).
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -231,6 +231,12 @@ function createRegistryTool(
 	settingOverrides?: LegacySettingOverrides,
 ): Tool {
 	const session = legacyToolSession(cwd, settingOverrides);
+	// The factory creates exactly this one tool, so it is the only
+	// availability the session can assert. Without this, tool prompts fall
+	// back to the main agent's defaults and steer the model toward siblings
+	// the extension may never have registered (e.g. bash-only setups told
+	// to query SQLite via an unregistered `read` — Codex P2 3986069142).
+	session.isToolActive = toolName => toolName === name;
 	switch (name) {
 		case "bash":
 			return new BashTool(session);

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -229,14 +229,19 @@ function createRegistryTool(
 	cwd: string,
 	name: LegacyRegistryToolName,
 	settingOverrides?: LegacySettingOverrides,
+	activeNames?: ReadonlySet<string>,
 ): Tool {
 	const session = legacyToolSession(cwd, settingOverrides);
 	// The factory creates exactly this one tool, so it is the only
-	// availability the session can assert. Without this, tool prompts fall
-	// back to the main agent's defaults and steer the model toward siblings
-	// the extension may never have registered (e.g. bash-only setups told
-	// to query SQLite via an unregistered `read` — Codex P2 3986069142).
-	session.isToolActive = toolName => toolName === name;
+	// availability the session can assert — unless the caller passes the
+	// bundle's full name set (createCodingTools below), mirroring the
+	// main agent's setActiveToolNames precedent (tools/index.ts). Without
+	// this, tool prompts fall back to the main agent's defaults and steer
+	// the model toward siblings the extension may never have registered
+	// (e.g. bash-only setups told to query SQLite via an unregistered
+	// `read` — Codex P2 3986069142).
+	const names = activeNames ?? new Set([name]);
+	session.isToolActive = toolName => names.has(toolName);
 	switch (name) {
 		case "bash":
 			return new BashTool(session);
@@ -265,8 +270,8 @@ async function executeBuiltinTool(
 	return tool.execute(toolCallId, params, signal, onUpdate);
 }
 
-function legacyBuiltinTool(cwd: string, name: LegacyCodingToolName): ToolDefinition {
-	const tool = createRegistryTool(cwd, name);
+function legacyBuiltinTool(cwd: string, name: LegacyCodingToolName, activeNames?: ReadonlySet<string>): ToolDefinition {
+	const tool = createRegistryTool(cwd, name, undefined, activeNames);
 	const definition: LegacyBuiltinToolDefinition = {
 		name: tool.name,
 		label: tool.label,
@@ -750,7 +755,11 @@ export function createWriteTool(cwd: string, options?: WriteToolOptions): ToolDe
 
 /** Create legacy read, bash, edit, and write tools. */
 export function createCodingTools(cwd: string): ToolDefinition[] {
-	return LEGACY_CODING_TOOL_NAMES.map(name => legacyBuiltinTool(cwd, name));
+	// The bundle always registers every name, so each definition's session
+	// reports the full set — otherwise bundled bash would lose read-gated
+	// guidance it legitimately has (Codex P2 3986602647).
+	const activeNames = new Set<string>(LEGACY_CODING_TOOL_NAMES);
+	return LEGACY_CODING_TOOL_NAMES.map(name => legacyBuiltinTool(cwd, name, activeNames));
 }
 
 /** Create legacy read, grep, find, and ls tools. */

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -15,6 +15,7 @@ Use ONLY for one binary or a short pipeline that computes a fact (`wc -l`, `sort
 <critical>
 {{#if hasGrep}}- NEVER use shell `grep`/`rg`; use built-in `grep`.{{/if}}
 {{#if hasRead}}{{#if hasGlob}}- List directories with `read` and find paths with `glob`; NEVER use `ls`/`find`.{{/if}}{{/if}}
+{{#if hasRead}}- Query SQLite databases with `read` (`db.sqlite:table`, `?q=SELECT`); NEVER shell out to `sqlite3`.{{/if}}
 - Avoid `head`, `tail`, and redirection: output is captured, truncated, and linked as `artifact://<id>`.
 {{#if hasLaunch}}- Services, watchers, debuggers, and REPLs MUST use `hub` (`op:"start"`).{{/if}}
 </critical>

--- a/packages/coding-agent/test/extensibility/legacy-tool-availability.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-tool-availability.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import * as os from "node:os";
+import { createBashToolDefinition } from "../../src/extensibility/legacy-pi-coding-agent-shim";
+
+describe("legacy tool availability (#11591)", () => {
+	test("a standalone legacy bash definition omits the sqlite3-to-read steer", () => {
+		// A legacy extension registering only bash supplies no `read` tool.
+		// The factory session reports exactly the tool it created, so the
+		// read-gated steer must stay silent instead of naming an
+		// unregistered tool (Codex P2 3986069142).
+		const bash = createBashToolDefinition(os.tmpdir());
+		expect(bash.description).not.toContain("sqlite3");
+	});
+});

--- a/packages/coding-agent/test/extensibility/legacy-tool-availability.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-tool-availability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import * as os from "node:os";
-import { createBashToolDefinition } from "../../src/extensibility/legacy-pi-coding-agent-shim";
+import { createBashToolDefinition, createCodingTools } from "../../src/extensibility/legacy-pi-coding-agent-shim";
 
 describe("legacy tool availability (#11591)", () => {
 	test("a standalone legacy bash definition omits the sqlite3-to-read steer", () => {
@@ -10,5 +10,13 @@ describe("legacy tool availability (#11591)", () => {
 		// unregistered tool (Codex P2 3986069142).
 		const bash = createBashToolDefinition(os.tmpdir());
 		expect(bash.description).not.toContain("sqlite3");
+	});
+	test("a bundled legacy bash definition keeps the sqlite3-to-read steer", () => {
+		// createCodingTools always registers read alongside bash, so the
+		// bundle session must report read active and the read-gated steer
+		// must render (Codex P2 3986602647).
+		const tools = createCodingTools(os.tmpdir());
+		const bash = tools.find(tool => tool.name === "bash");
+		expect(bash?.description).toContain("sqlite3");
 	});
 });

--- a/packages/coding-agent/test/tool-guidance-efficiency.test.ts
+++ b/packages/coding-agent/test/tool-guidance-efficiency.test.ts
@@ -4,7 +4,7 @@ import bashPrompt from "../src/prompts/tools/bash.md" with { type: "text" };
 import globPrompt from "../src/prompts/tools/glob.md" with { type: "text" };
 import grepPrompt from "../src/prompts/tools/grep.md" with { type: "text" };
 
-const bash = prompt.render(bashPrompt, {
+const baseFlags = {
 	asyncEnabled: true,
 	autoBackgroundEnabled: true,
 	autoBackgroundThresholdSeconds: 60,
@@ -17,12 +17,18 @@ const bash = prompt.render(bashPrompt, {
 	hasRead: true,
 	hasShellBuiltins: true,
 	isWindows: false,
-});
+};
+const bash = prompt.render(bashPrompt, baseFlags);
 const glob = prompt.render(globPrompt);
 const grep = prompt.render(grepPrompt);
 
 describe("tool guidance efficiency", () => {
 	test("keeps the corrected guidance smaller than the previous prompt set", () => {
 		expect(bash.length + grep.length + glob.length).toBeLessThan(3_050);
+	});
+	test("steers sqlite3 shell-outs to read when the read tool is active", () => {
+		expect(bash).toContain("sqlite3");
+		const withoutRead = prompt.render(bashPrompt, { ...baseFlags, hasRead: false });
+		expect(withoutRead).not.toContain("sqlite3");
 	});
 });

--- a/packages/coding-agent/test/tool-guidance-efficiency.test.ts
+++ b/packages/coding-agent/test/tool-guidance-efficiency.test.ts
@@ -27,7 +27,15 @@ describe("tool guidance efficiency", () => {
 		expect(bash.length + grep.length + glob.length).toBeLessThan(3_050);
 	});
 	test("steers sqlite3 shell-outs to read when the read tool is active", () => {
-		expect(bash).toContain("sqlite3");
+		// Routing contract, not a token literal: every sqlite3 mention must
+		// prohibit the shell-out and redirect to read, so an inverted
+		// "use sqlite3" guidance fails instead of passing.
+		const mentions = bash.split("\n").filter(line => line.includes("sqlite3"));
+		expect(mentions.length).toBeGreaterThan(0);
+		for (const line of mentions) {
+			expect(line).toMatch(/NEVER/);
+			expect(line).toMatch(/`read`/);
+		}
 		const withoutRead = prompt.render(bashPrompt, { ...baseFlags, hasRead: false });
 		expect(withoutRead).not.toContain("sqlite3");
 	});


### PR DESCRIPTION
## What

I kept seeing the model shell out to `sqlite3` for database reads the `read` tool already owns, so I added the missing steer to the `bash` prompt's `<critical>` block: one `hasRead`-guarded line sending SQLite queries to `read` (`db.sqlite:table`, `?q=SELECT`) instead of the shell, shaped exactly like its sibling lines. I know this spends a little of the scarce `<critical>` budget and overlaps capability routing — I kept it to a single conditional line and touched nothing else, since the observed miss (about 15 `sqlite3` shell-outs in one session, never touching `read`'s SQLite selectors) seemed worth exactly that much.

## Why

Fixes #11319

## Testing

- RED: extended `test/tool-guidance-efficiency.test.ts` fails on clean tree — rendered prompt does not contain `sqlite3`.
- GREEN with fix: 2 pass / 0 fail (steer present with `hasRead`, absent without; length budget still holds).
- Neighbors: `bash-acp-terminal` + `bash-autobg-timer` 11 pass / 0 fail.
- `bun run check` (oxlint + oxfmt + tsgo) in `packages/coding-agent`: exit 0.
- Note: suite runs were done with the repo-root `node_modules` held aside per this box's procedure (restored after each run; `git status` identical); lint/types ran with it in place since they need the toolchain.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)