### PR TITLE
fix(tui): allow disabling background usage refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
 - Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
 - Added peak `↑` / off-peak `↓` indicators to the cost display for models with scheduled pricing (DeepSeek), refreshed automatically when the tariff changes.
+- Added `usage.backgroundRefresh`, allowing automatic provider-usage requests at startup and every five minutes to be disabled ([#11589](https://github.com/can1357/oh-my-pi/issues/11589)).
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5938,6 +5938,17 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
+	"usage.backgroundRefresh": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Background Usage Refresh",
+			description: "Fetch provider usage at startup and every five minutes for status and account automation",
+		},
+	},
+
 	// Codex saved rate-limit resets (auto-redeem)
 	"codexResets.autoRedeem": {
 		type: "enum",

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1441,6 +1441,7 @@ export class StatusLineComponent implements Component {
 	 * cadence while a late successful fetch can still refresh the cached segment.
 	 */
 	refreshUsageInBackground(): void {
+		if (!settings.get("usage.backgroundRefresh")) return;
 		const now = Date.now();
 		const session = this.session;
 		const usageContextKey = this.#getUsageContextKey(session);

--- a/packages/coding-agent/test/status-line-usage-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-usage-refresh.test.ts
@@ -170,6 +170,23 @@ describe("StatusLineComponent usage refresh", () => {
 		expect(calls).toBe(1);
 	});
 
+	it("does not poll provider usage when background refresh is disabled", async () => {
+		Settings.instance.set("usage.backgroundRefresh", false);
+		let calls = 0;
+		const component = new StatusLineComponent(
+			makeSession(async () => {
+				calls++;
+				return [];
+			}),
+		);
+
+		component.refreshUsageInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(calls).toBe(0);
+	});
+
 	it("passes a startup timeout signal to the background usage fetch", async () => {
 		let signal: AbortSignal | undefined;
 		const component = new StatusLineComponent(


### PR DESCRIPTION
## Repro
A minimal status-line harness configured `preset: custom` with only the `subagents` segment, then rendered once while `fetchUsageReports()` performed 750 ms of synchronous setup. Running `bun /tmp/issue-11589-repro.ts` on `main` produced `{"fetches":1,"loopLagMs":743}`, proving that the unused automatic poll still starved an independent event-loop timer.

## Cause
`StatusLineComponent.#buildSegmentContext()` calls `refreshUsageInBackground()` on every render, and `packages/coding-agent/src/modes/components/status-line/component.ts` previously had no opt-out before arming its five-minute poll. The existing zero-delay timer removed usage fetching from the render stack but still ran provider fan-out on the UI event loop.

## Fix
- Add the `usage.backgroundRefresh` setting, enabled by default, to the provider Services configuration.
- Return before scheduling automatic usage work when the setting is disabled.
- Cover the disabled polling contract and document the setting in the coding-agent changelog.

## Verification
The same harness with `usage.backgroundRefresh: false` produced `{"fetches":0,"loopLagMs":6}`. `bun --cwd=packages/coding-agent test test/status-line-usage-refresh.test.ts` passed 15 tests; `bun --cwd=packages/coding-agent run check:types` passed; the publish gate's `bun check` passed. Fixes #11589