### PR TITLE
feat(ai): report Command Code quota in omp usage

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -53,6 +53,8 @@ When a model has no credentials, `omp` tells you to run `/login` or set the prov
 
 For ClinePass, set `CLINE_API_KEY` or run `/login cline-pass` to open the Cline dashboard and validate a newly created API key. OMP refreshes membership from Cline's public recommended-models endpoint and bundles the current sixteen-model roster with Cline-authored limits, subscription pricing, modalities, and per-model reasoning controls for offline startup. New live ids remain selectable before regeneration, using conservative metadata rather than guessed controls. `omp usage` reports five-hour, weekly, and monthly quota windows. Free-tier models are marked `(free)` and work with the same key on any Cline account; subscription models show API-equivalent reference pricing, while streamed gateway cost remains authoritative for actual billed or discounted usage. Requests mirror Cline CLI client headers and a stable per-session task id, Qwen routes use Cline's prompt-cache shape, and Qwen3.7 Plus maps thinking levels to the gateway's token-budget field.
 
+For Command Code, set `COMMAND_CODE_API_KEY` (`COMMANDCODE_API_KEY` is accepted as a legacy alias) or run `/login commandcode` to validate the same `/login` Command Code API key. `omp usage` reports the 5-hour and weekly credit windows plus remaining dollar credits from the alpha billing endpoints (`whoami`, `billing/credits`, `billing/subscriptions`, `usage/summary`).
+
 ### Pinning a key in `models.yml`
 
 A custom provider's `apiKey` is resolved as **environment-variable-name-or-literal**: if the value names an existing environment variable, that variable's value is used; otherwise the string itself is the key. Prefixing the value with `!` runs it as a shell command and uses the trimmed stdout (see [Model and Provider Configuration](./models.md) for the full value syntax).
@@ -141,6 +143,7 @@ Each provider has one or more environment variables that supply a key when no st
 | `gitlab-duo`, `gitlab-duo-agent` | `GITLAB_TOKEN`                                                                |
 | `opencode-zen`, `opencode-go`    | `OPENCODE_API_KEY`                                                            |
 | `cline-pass`                     | `CLINE_API_KEY`                                                               |
+| `commandcode`                    | `COMMAND_CODE_API_KEY` (also `COMMANDCODE_API_KEY` as a legacy alias)         |
 | `firepass`                       | `FIREPASS_API_KEY`                                                            |
 | `wafer-serverless`               | `WAFER_SERVERLESS_API_KEY`                                                    |
 | `xiaomi`                         | `XIAOMI_API_KEY`                                                              |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Command Code `omp usage` reports 5-hour and weekly credit windows plus remaining credits via the alpha billing endpoints.
+
 ### Fixed
 
 - Fixed transient Python HTTP/2 stream resets and HTTP/1.1 chunked response interruptions being treated as terminal errors when forwarded by a proxy ([#11160](https://github.com/can1357/oh-my-pi/pull/11160) by [@cyriusweng](https://github.com/cyriusweng)).

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -53,6 +53,7 @@ import { resolveUsedFraction } from "./usage";
 import { alibabaTokenPlanRankingStrategy, alibabaTokenPlanUsageProvider } from "./usage/alibaba-token-plan";
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { clinePassUsageProvider } from "./usage/cline-pass";
+import { commandcodeRankingStrategy, commandcodeUsageProvider } from "./usage/commandcode";
 import { cursorUsageProvider } from "./usage/cursor";
 import { devinUsageProvider } from "./usage/devin";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
@@ -669,6 +670,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	ollamaCloudUsageProvider,
 	claudeUsageProvider,
 	clinePassUsageProvider,
+	commandcodeUsageProvider,
 	zaiUsageProvider,
 	umansUsageProvider,
 	opencodeGoUsageProvider,
@@ -1144,6 +1146,7 @@ const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>(
 	["alibaba-token-plan", alibabaTokenPlanRankingStrategy],
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
+	["commandcode", commandcodeRankingStrategy],
 	["google-antigravity", antigravityRankingStrategy],
 	["kimi-code", kimiRankingStrategy],
 	["zai", zaiRankingStrategy],

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -29,6 +29,7 @@ export * from "./stream";
 export * from "./types";
 export * from "./usage";
 export * from "./usage/claude";
+export * from "./usage/commandcode";
 export * from "./usage/cursor";
 export * from "./usage/gemini";
 export * from "./usage/github-copilot";

--- a/packages/ai/src/usage/commandcode.ts
+++ b/packages/ai/src/usage/commandcode.ts
@@ -1,0 +1,465 @@
+import { toNumber } from "@oh-my-pi/pi-catalog/utils";
+import { ProviderHttpError } from "../error";
+import type {
+	CredentialRankingStrategy,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+} from "../usage";
+import { isRecord } from "../utils";
+import { DAY_MS, HOUR_MS, parseIsoTimestamp, parsePositiveTimestamp, usageStatus, WEEK_MS } from "./shared";
+
+const COMMANDCODE_PROVIDER = "commandcode";
+const DEFAULT_ENDPOINT = "https://api.commandcode.ai";
+const WHOAMI_PATH = "/alpha/whoami";
+const CREDITS_PATH = "/alpha/billing/credits";
+const SUBSCRIPTIONS_PATH = "/alpha/billing/subscriptions";
+const SUMMARY_PATH = "/alpha/usage/summary";
+
+function normalizeCommandCodeBaseUrl(baseUrl?: string): string {
+	if (!baseUrl?.trim()) return DEFAULT_ENDPOINT;
+	try {
+		// The catalog discovery base is `${origin}/provider` (optionally with
+		// `/v1`); usage lives at `${origin}/alpha/*`, so only the origin survives.
+		return new URL(baseUrl.trim()).origin;
+	} catch {
+		return DEFAULT_ENDPOINT;
+	}
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Unwrap a `{ data: ... }` envelope; tolerates a top-level payload. */
+function unwrapData(payload: unknown): unknown {
+	if (isRecord(payload) && payload.data !== undefined) return payload.data;
+	return payload;
+}
+
+/** Unwrap `{ data: ... }`, tolerating a single-element list envelope. */
+function firstNode(payload: unknown): unknown {
+	const node = unwrapData(payload);
+	return Array.isArray(node) ? node[0] : node;
+}
+
+interface CommandCodeIdentity {
+	orgId?: string;
+	login?: string;
+	keyName?: string;
+}
+
+function parseWhoami(payload: unknown): CommandCodeIdentity {
+	const root = unwrapData(payload);
+	if (!isRecord(root)) return {};
+	const org = isRecord(root.org) ? root.org : undefined;
+	const user = isRecord(root.user) ? root.user : undefined;
+	const rawOrgId = org?.id;
+	const orgId =
+		nonEmptyString(rawOrgId) ??
+		(typeof rawOrgId === "number" && Number.isFinite(rawOrgId) ? String(rawOrgId) : undefined);
+	const login =
+		nonEmptyString(org?.login) ?? nonEmptyString(user?.userName) ?? nonEmptyString(user?.name);
+	const keyName = nonEmptyString(user?.keyName) ?? nonEmptyString(user?.displayName);
+	return {
+		...(orgId ? { orgId } : {}),
+		...(login ? { login } : {}),
+		...(keyName ? { keyName } : {}),
+	};
+}
+
+interface CommandCodeWindowState {
+	used?: number;
+	cap?: number;
+	resetsAt?: number;
+}
+
+function parseWindowState(value: unknown): CommandCodeWindowState | null {
+	if (!isRecord(value)) return null;
+	const used = toNumber(value.used);
+	const cap = toNumber(value.cap);
+	// An untouched window reports 0/0 (or omits both); surfacing it would read
+	// as an exhausted quota, so skip it.
+	if (!used && !cap) return null;
+	const resetsAt = parsePositiveTimestamp(value.resetAt);
+	return {
+		...(used !== undefined ? { used } : {}),
+		...(cap !== undefined ? { cap } : {}),
+		...(resetsAt !== undefined ? { resetsAt } : {}),
+	};
+}
+
+interface CommandCodeCredits {
+	remainingCredits?: number;
+	fiveHour?: CommandCodeWindowState;
+	weekly?: CommandCodeWindowState;
+}
+
+function parseCredits(payload: unknown): CommandCodeCredits {
+	const root = unwrapData(payload);
+	if (!isRecord(root)) return {};
+	const credits = isRecord(root.credits) ? root.credits : undefined;
+	const parts = [
+		toNumber(credits?.monthlyCredits),
+		toNumber(credits?.purchasedCredits),
+		toNumber(credits?.freeCredits),
+	].filter((value): value is number => value !== undefined);
+	const windowLimits = isRecord(root.windowLimits) ? root.windowLimits : undefined;
+	const fiveHour = parseWindowState(windowLimits?.fiveHour);
+	const weekly = parseWindowState(windowLimits?.weekly);
+	return {
+		...(parts.length > 0 ? { remainingCredits: parts.reduce((total, part) => total + part, 0) } : {}),
+		...(fiveHour ? { fiveHour } : {}),
+		...(weekly ? { weekly } : {}),
+	};
+}
+
+interface CommandCodeSubscription {
+	planId?: string;
+	status?: string;
+	/** Raw period start, passed through as the usage-summary `since` cursor. */
+	startRaw?: string;
+	startMs?: number;
+	endMs?: number;
+}
+
+function parsePeriodTimestamp(value: unknown): number | undefined {
+	return parsePositiveTimestamp(value) ?? parseIsoTimestamp(value);
+}
+
+function parseSubscription(payload: unknown): CommandCodeSubscription {
+	const node = firstNode(payload);
+	if (!isRecord(node)) return {};
+	const planId = nonEmptyString(node.planId);
+	const status = nonEmptyString(node.status);
+	const rawStart = node.currentPeriodStart;
+	const startRaw =
+		typeof rawStart === "string" && rawStart
+			? rawStart
+			: typeof rawStart === "number" && Number.isFinite(rawStart)
+				? String(rawStart)
+				: undefined;
+	const startMs = parsePeriodTimestamp(node.currentPeriodStart);
+	const endMs = parsePeriodTimestamp(node.currentPeriodEnd);
+	return {
+		...(planId ? { planId } : {}),
+		...(status ? { status } : {}),
+		...(startRaw ? { startRaw } : {}),
+		...(startMs !== undefined ? { startMs } : {}),
+		...(endMs !== undefined ? { endMs } : {}),
+	};
+}
+
+interface CommandCodeSummary {
+	totalCost?: number;
+	totalCount?: number;
+	totalTokens?: number;
+}
+
+function parseSummary(payload: unknown): CommandCodeSummary {
+	const node = firstNode(payload);
+	if (!isRecord(node)) return {};
+	const totalCost = toNumber(node.totalCost);
+	const totalCount = toNumber(node.totalCount);
+	const totalTokens = toNumber(node.totalTokens) ?? toNumber(node.tokens);
+	return {
+		...(totalCost !== undefined ? { totalCost } : {}),
+		...(totalCount !== undefined ? { totalCount } : {}),
+		...(totalTokens !== undefined ? { totalTokens } : {}),
+	};
+}
+
+function buildCreditWindowLimit(args: {
+	provider: UsageFetchParams["provider"];
+	id: string;
+	label: string;
+	windowId: string;
+	durationMs: number;
+	state: CommandCodeWindowState;
+}): UsageLimit {
+	const { used, cap, resetsAt } = args.state;
+	const remaining = used !== undefined && cap !== undefined ? cap - used : undefined;
+	const usedFraction =
+		used !== undefined && cap !== undefined && cap > 0 ? Math.min(used / cap, 1) : undefined;
+	const remainingFraction = usedFraction !== undefined ? Math.max(1 - usedFraction, 0) : undefined;
+	return {
+		id: args.id,
+		label: args.label,
+		scope: { provider: args.provider, windowId: args.windowId, shared: true },
+		window: {
+			id: args.windowId,
+			label: args.windowId,
+			durationMs: args.durationMs,
+			...(resetsAt !== undefined ? { resetsAt } : {}),
+		},
+		amount: {
+			...(used !== undefined ? { used } : {}),
+			...(cap !== undefined ? { limit: cap } : {}),
+			...(remaining !== undefined ? { remaining } : {}),
+			...(usedFraction !== undefined ? { usedFraction } : {}),
+			...(remainingFraction !== undefined ? { remainingFraction } : {}),
+			unit: "credits",
+		},
+		status: usageStatus(usedFraction),
+	};
+}
+
+function buildRemainingLimit(args: {
+	provider: UsageFetchParams["provider"];
+	remainingCredits: number;
+	totalCost?: number;
+	periodStartMs?: number;
+	periodEndMs?: number;
+}): UsageLimit {
+	const used = args.totalCost;
+	const limit = used !== undefined ? args.remainingCredits + used : undefined;
+	const usedFraction =
+		used !== undefined && limit !== undefined && limit > 0 ? Math.min(used / limit, 1) : undefined;
+	const remainingFraction = usedFraction !== undefined ? Math.max(1 - usedFraction, 0) : undefined;
+	const durationMs =
+		args.periodStartMs !== undefined &&
+		args.periodEndMs !== undefined &&
+		args.periodEndMs > args.periodStartMs
+			? args.periodEndMs - args.periodStartMs
+			: undefined;
+	return {
+		id: "commandcode:credits:remaining",
+		label: "Command Code Credits",
+		scope: {
+			provider: args.provider,
+			shared: true,
+			...(args.periodEndMs !== undefined ? { windowId: "billing-period" } : {}),
+		},
+		...(args.periodEndMs !== undefined
+			? {
+					window: {
+						id: "billing-period",
+						label: "Billing period",
+						...(durationMs !== undefined ? { durationMs } : {}),
+						resetsAt: args.periodEndMs,
+					},
+				}
+			: {}),
+		amount: {
+			...(used !== undefined ? { used } : {}),
+			...(limit !== undefined ? { limit } : {}),
+			remaining: args.remainingCredits,
+			...(usedFraction !== undefined ? { usedFraction } : {}),
+			...(remainingFraction !== undefined ? { remainingFraction } : {}),
+			// The credits balance is dollar-denominated, so the pool meters spend in USD.
+			unit: "usd",
+		},
+		status: usageStatus(usedFraction),
+	};
+}
+
+function authError(label: string, response: Response): ProviderHttpError {
+	return new ProviderHttpError(
+		`Command Code ${label} endpoint returned ${response.status} ${response.statusText}`.trim(),
+		response.status,
+	);
+}
+
+async function fetchOptionalPayload(
+	url: string,
+	label: string,
+	headers: Record<string, string>,
+	params: UsageFetchParams,
+	ctx: UsageFetchContext,
+): Promise<unknown> {
+	try {
+		const response = await ctx.fetch(url, { headers, signal: params.signal });
+		if (!response.ok) {
+			// Auth failures are fatal even on optional endpoints: a rotated key
+			// must surface as bad credentials, not as silently missing quotas.
+			if (response.status === 401 || response.status === 403) throw authError(label, response);
+			ctx.logger?.warn(`Command Code ${label} fetch failed`, {
+				status: response.status,
+				statusText: response.statusText,
+			});
+			return undefined;
+		}
+		return (await response.json()) as unknown;
+	} catch (error) {
+		if (error instanceof ProviderHttpError) throw error;
+		ctx.logger?.warn(`Command Code ${label} fetch error`, { error: String(error) });
+		return undefined;
+	}
+}
+
+async function fetchCommandCodeUsage(
+	params: UsageFetchParams,
+	ctx: UsageFetchContext,
+): Promise<UsageReport | null> {
+	if (params.provider !== COMMANDCODE_PROVIDER) return null;
+	const credential = params.credential;
+	const token = credential.type === "oauth" ? credential.accessToken : credential.apiKey;
+	if (!token) return null;
+
+	const origin = normalizeCommandCodeBaseUrl(params.baseUrl);
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+		accept: "application/json",
+	};
+
+	let whoamiPayload: unknown;
+	try {
+		const response = await ctx.fetch(`${origin}${WHOAMI_PATH}`, { headers, signal: params.signal });
+		if (!response.ok) {
+			// Auth failures must throw so checkCredentials flags the bad key as
+			// ok:false rather than ok:null (unknown). Other non-ok statuses are
+			// transient — return null so the probe reports "no data".
+			if (response.status === 401 || response.status === 403) throw authError("whoami", response);
+			ctx.logger?.warn("Command Code whoami fetch failed", {
+				status: response.status,
+				statusText: response.statusText,
+			});
+			return null;
+		}
+		whoamiPayload = (await response.json()) as unknown;
+	} catch (error) {
+		// Re-throw auth errors so the credential-health probe can surface them.
+		if (error instanceof ProviderHttpError) throw error;
+		ctx.logger?.warn("Command Code whoami fetch error", { error: String(error) });
+		return null;
+	}
+
+	const identity = parseWhoami(whoamiPayload);
+
+	const withQuery = (path: string, extra?: Record<string, string | undefined>): string => {
+		const search = new URLSearchParams();
+		if (identity.orgId) search.set("orgId", identity.orgId);
+		for (const [key, value] of Object.entries(extra ?? {})) {
+			if (value) search.set(key, value);
+		}
+		const query = search.toString();
+		return `${origin}${path}${query ? `?${query}` : ""}`;
+	};
+
+	const creditsPayload = await fetchOptionalPayload(
+		withQuery(CREDITS_PATH),
+		"credits",
+		headers,
+		params,
+		ctx,
+	);
+	const subscriptionsPayload = await fetchOptionalPayload(
+		withQuery(SUBSCRIPTIONS_PATH),
+		"subscriptions",
+		headers,
+		params,
+		ctx,
+	);
+
+	const credits: CommandCodeCredits =
+		creditsPayload === undefined ? {} : parseCredits(creditsPayload);
+	const subscription: CommandCodeSubscription =
+		subscriptionsPayload === undefined ? {} : parseSubscription(subscriptionsPayload);
+
+	// Spend should cover the current billing period when the subscription tells
+	// us where it started; otherwise fall back to trailing 30 days.
+	const since = subscription.startRaw ?? new Date(Date.now() - 30 * DAY_MS).toISOString();
+	const summaryPayload = await fetchOptionalPayload(
+		withQuery(SUMMARY_PATH, { since }),
+		"usage summary",
+		headers,
+		params,
+		ctx,
+	);
+	const summary: CommandCodeSummary =
+		summaryPayload === undefined ? {} : parseSummary(summaryPayload);
+
+	const limits: UsageLimit[] = [];
+	if (credits.fiveHour) {
+		limits.push(
+			buildCreditWindowLimit({
+				provider: params.provider,
+				id: "commandcode:credits:5h",
+				label: "Command Code 5h Credit Quota",
+				windowId: "5h",
+				durationMs: 5 * HOUR_MS,
+				state: credits.fiveHour,
+			}),
+		);
+	}
+	if (credits.weekly) {
+		limits.push(
+			buildCreditWindowLimit({
+				provider: params.provider,
+				id: "commandcode:credits:7d",
+				label: "Command Code Weekly Credit Quota",
+				windowId: "7d",
+				durationMs: WEEK_MS,
+				state: credits.weekly,
+			}),
+		);
+	}
+	if (credits.remainingCredits !== undefined) {
+		limits.push(
+			buildRemainingLimit({
+				provider: params.provider,
+				remainingCredits: credits.remainingCredits,
+				...(summary.totalCost !== undefined ? { totalCost: summary.totalCost } : {}),
+				...(subscription.startMs !== undefined ? { periodStartMs: subscription.startMs } : {}),
+				...(subscription.endMs !== undefined ? { periodEndMs: subscription.endMs } : {}),
+			}),
+		);
+	}
+
+	if (limits.length === 0) return null;
+
+	return {
+		provider: params.provider,
+		fetchedAt: Date.now(),
+		limits,
+		metadata: {
+			endpoint: origin,
+			...(credential.accountId ? { accountId: credential.accountId } : {}),
+			...(credential.email ? { email: credential.email } : {}),
+			...(identity.login ? { login: identity.login } : {}),
+			...(identity.orgId ? { orgId: identity.orgId } : {}),
+			...(identity.keyName ? { keyName: identity.keyName } : {}),
+			...(subscription.planId ? { planType: subscription.planId } : {}),
+		},
+		raw: {
+			whoami: whoamiPayload,
+			...(creditsPayload !== undefined ? { credits: creditsPayload } : {}),
+			...(subscriptionsPayload !== undefined ? { subscriptions: subscriptionsPayload } : {}),
+			...(summaryPayload !== undefined ? { summary: summaryPayload } : {}),
+		},
+	};
+}
+
+function commandCodeCreditLimits(report: UsageReport): UsageLimit[] {
+	return report.limits.filter(limit => limit.id.startsWith("commandcode:credits:"));
+}
+
+export const commandcodeUsageProvider: UsageProvider = {
+	id: COMMANDCODE_PROVIDER,
+	fetchUsage: fetchCommandCodeUsage,
+	supports: params =>
+		params.provider === COMMANDCODE_PROVIDER &&
+		(params.credential.type === "oauth"
+			? Boolean(params.credential.accessToken)
+			: Boolean(params.credential.apiKey)),
+	validatesCredentials: true,
+};
+
+export const commandcodeRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		const windows = commandCodeCreditLimits(report);
+		return {
+			primary: windows.find(limit => limit.id === "commandcode:credits:5h"),
+			secondary: windows.find(limit => limit.id === "commandcode:credits:7d"),
+		};
+	},
+	scopeLimits(report) {
+		return commandCodeCreditLimits(report);
+	},
+	windowDefaults: {
+		primaryMs: 5 * HOUR_MS,
+		secondaryMs: WEEK_MS,
+	},
+};

--- a/packages/ai/test/commandcode-usage.test.ts
+++ b/packages/ai/test/commandcode-usage.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "bun:test";
+
+import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import type { UsageFetchContext, UsageFetchParams } from "@oh-my-pi/pi-ai/usage";
+import { commandcodeUsageProvider } from "@oh-my-pi/pi-ai/usage/commandcode";
+
+const FULL_WHOAMI = {
+	org: { id: "org_123", login: "acme" },
+	user: { userName: "jdoe", keyName: "my-key" },
+};
+
+const FULL_CREDITS = {
+	credits: { monthlyCredits: 100, purchasedCredits: 25, freeCredits: 5 },
+	windowLimits: {
+		// Seconds on purpose: the provider must normalize to epoch milliseconds.
+		fiveHour: { used: 30, cap: 100, resetAt: 1780000000 },
+		weekly: { used: 200, cap: 500, resetAt: 1780000000000 },
+	},
+};
+
+const FULL_SUBSCRIPTIONS = {
+	data: {
+		planId: "pro",
+		status: "active",
+		currentPeriodStart: "2026-08-10T00:00:00.000Z",
+		currentPeriodEnd: "2026-09-10T00:00:00.000Z",
+	},
+};
+
+const FULL_SUMMARY = {
+	data: { totalCost: 42.5, totalCount: 1000, totalTokens: 123456 },
+};
+
+interface RouteConfig {
+	whoami?: unknown;
+	credits?: unknown;
+	subscriptions?: unknown;
+	summary?: unknown;
+	whoamiStatus?: number;
+	creditsStatus?: number;
+	subscriptionsStatus?: number;
+	summaryStatus?: number;
+}
+
+interface SeenRequest {
+	url: string;
+	authorization: string | null;
+}
+
+function makeCredential(): UsageFetchParams["credential"] {
+	return {
+		type: "api_key",
+		apiKey: "commandcode-test-key",
+	};
+}
+
+function makeCtx(routes: RouteConfig = {}): { ctx: UsageFetchContext; seen: SeenRequest[] } {
+	const seen: SeenRequest[] = [];
+	const pick = (url: string): { payload: unknown; status: number } => {
+		if (url.includes("/alpha/whoami")) {
+			return { payload: routes.whoami ?? FULL_WHOAMI, status: routes.whoamiStatus ?? 200 };
+		}
+		if (url.includes("/alpha/billing/credits")) {
+			return { payload: routes.credits ?? FULL_CREDITS, status: routes.creditsStatus ?? 200 };
+		}
+		if (url.includes("/alpha/billing/subscriptions")) {
+			return {
+				payload: routes.subscriptions ?? FULL_SUBSCRIPTIONS,
+				status: routes.subscriptionsStatus ?? 200,
+			};
+		}
+		if (url.includes("/alpha/usage/summary")) {
+			return { payload: routes.summary ?? FULL_SUMMARY, status: routes.summaryStatus ?? 200 };
+		}
+		return { payload: { message: "not found" }, status: 404 };
+	};
+	const fetch: FetchImpl = async (input, init) => {
+		const url = String(input);
+		const headers = new Headers(init?.headers as HeadersInit | undefined);
+		seen.push({ url, authorization: headers.get("authorization") });
+		const { payload, status } = pick(url);
+		return new Response(JSON.stringify(payload), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	return { ctx: { fetch }, seen };
+}
+
+function makeCtxThrow(): UsageFetchContext {
+	const fetch: FetchImpl = async () => {
+		throw new Error("Network error");
+	};
+	return { fetch };
+}
+
+function fetchUsage(params: UsageFetchParams, ctx: UsageFetchContext) {
+	return commandcodeUsageProvider.fetchUsage!(
+		params,
+		ctx,
+	);
+}
+
+describe("commandcode usage provider", () => {
+	it("happy path: full fixture returns 5h + 7d + remaining limits", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(l => l.id)).toEqual([
+			"commandcode:credits:5h",
+			"commandcode:credits:7d",
+			"commandcode:credits:remaining",
+		]);
+		expect(report!.limits.map(l => l.label)).toEqual([
+			"Command Code 5h Credit Quota",
+			"Command Code Weekly Credit Quota",
+			"Command Code Credits",
+		]);
+		expect(report!.limits.map(l => l.scope.windowId)).toEqual(["5h", "7d", "billing-period"]);
+		expect(report!.limits.map(l => l.window?.durationMs)).toEqual([
+			5 * 60 * 60 * 1000,
+			7 * 24 * 60 * 60 * 1000,
+			31 * 24 * 60 * 60 * 1000,
+		]);
+	});
+
+	it("5h window: used/limit math, seconds resetAt normalized to ms", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		const fiveHour = report!.limits.find(l => l.id === "commandcode:credits:5h")!;
+		expect(fiveHour.amount.used).toBe(30);
+		expect(fiveHour.amount.limit).toBe(100);
+		expect(fiveHour.amount.remaining).toBe(70);
+		expect(fiveHour.amount.usedFraction).toBeCloseTo(0.3, 10);
+		expect(fiveHour.amount.remainingFraction).toBeCloseTo(0.7, 10);
+		expect(fiveHour.amount.unit).toBe("credits");
+		expect(fiveHour.status).toBe("ok");
+		// resetAt arrived in seconds; OMP windows use epoch milliseconds.
+		expect(fiveHour.window?.resetsAt).toBe(1780000000000);
+	});
+
+	it("7d window: used/limit math, millisecond resetAt passes through", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		const weekly = report!.limits.find(l => l.id === "commandcode:credits:7d")!;
+		expect(weekly.amount.used).toBe(200);
+		expect(weekly.amount.limit).toBe(500);
+		expect(weekly.amount.remaining).toBe(300);
+		expect(weekly.amount.usedFraction).toBeCloseTo(0.4, 10);
+		expect(weekly.amount.unit).toBe("credits");
+		expect(weekly.status).toBe("ok");
+		expect(weekly.window?.resetsAt).toBe(1780000000000);
+	});
+
+	it("remaining pool: dollar balance + summary spend, windowed by the billing period", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		const remaining = report!.limits.find(l => l.id === "commandcode:credits:remaining")!;
+		// 100 monthly + 25 purchased + 5 free = 130 remaining; 42.5 spent.
+		expect(remaining.amount.remaining).toBe(130);
+		expect(remaining.amount.used).toBe(42.5);
+		expect(remaining.amount.limit).toBe(172.5);
+		expect(remaining.amount.usedFraction).toBeCloseTo(42.5 / 172.5, 10);
+		expect(remaining.amount.unit).toBe("usd");
+		expect(remaining.status).toBe("ok");
+		expect(remaining.window?.resetsAt).toBe(Date.parse("2026-09-10T00:00:00.000Z"));
+	});
+
+	it("metadata carries endpoint, credential identity, and org/plan details", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{
+				provider: "commandcode",
+				credential: { type: "api_key", apiKey: "k", accountId: "acc-1", email: "jdoe@acme.test" },
+				signal: undefined,
+			},
+			ctx,
+		);
+
+		expect(report!.metadata).toMatchObject({
+			endpoint: "https://api.commandcode.ai",
+			accountId: "acc-1",
+			email: "jdoe@acme.test",
+			login: "acme",
+			orgId: "org_123",
+			keyName: "my-key",
+			planType: "pro",
+		});
+	});
+
+	it("orgId and billing-period start ride the downstream queries", async () => {
+		const { ctx, seen } = makeCtx();
+		await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		const credits = seen.find(r => r.url.includes("/alpha/billing/credits"))!;
+		expect(credits.url).toContain("orgId=org_123");
+		const summary = seen.find(r => r.url.includes("/alpha/usage/summary"))!;
+		expect(summary.url).toContain("orgId=org_123");
+		expect(summary.url).toContain("since=2026-08-10T00%3A00%3A00.000Z");
+	});
+	it("whoami without orgId still fetches billing endpoints", async () => {
+		const { ctx, seen } = makeCtx({
+			whoami: { user: { userName: "solo" }, org: null },
+		});
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		expect(seen.some(r => r.url.includes("/alpha/billing/credits"))).toBe(true);
+		expect(seen.find(r => r.url.includes("/alpha/billing/credits"))!.url).not.toContain("orgId=");
+		expect(report!.metadata?.login).toBe("solo");
+	});
+
+
+
+	it("whoami 401 throws ProviderHttpError so bad keys flag as invalid", async () => {
+		const { ctx } = makeCtx({ whoamiStatus: 401 });
+		const error = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		).then(
+			() => null,
+			(caught: unknown) => caught,
+		);
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).status).toBe(401);
+	});
+
+	it("credits 403 is fatal like whoami", async () => {
+		const { ctx } = makeCtx({ creditsStatus: 403 });
+		const error = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		).then(
+			() => null,
+			(caught: unknown) => caught,
+		);
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).status).toBe(403);
+	});
+
+	it("non-commandcode provider → returns null", async () => {
+		const { ctx } = makeCtx();
+		const report = await fetchUsage(
+			{ provider: "openai", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+		expect(report).toBeNull();
+	});
+
+	it("missing token → returns null", async () => {
+		const { ctx } = makeCtx();
+		const noKey = await fetchUsage(
+			{
+				provider: "commandcode",
+				credential: { type: "api_key" } as UsageFetchParams["credential"],
+				signal: undefined,
+			},
+			ctx,
+		);
+		expect(noKey).toBeNull();
+
+		const noBearer = await fetchUsage(
+			{
+				provider: "commandcode",
+				credential: { type: "oauth" } as UsageFetchParams["credential"],
+				signal: undefined,
+			},
+			ctx,
+		);
+		expect(noBearer).toBeNull();
+	});
+
+	it("network error / thrown fetch → returns null", async () => {
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			makeCtxThrow(),
+		);
+		expect(report).toBeNull();
+	});
+
+	it("credits 500 but summary ok → null when nothing surfaceable remains", async () => {
+		const { ctx, seen } = makeCtx({ creditsStatus: 500 });
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		// The credits outage skips windows and the remaining pool; the summary
+		// fetch still ran rather than aborting the report.
+		expect(seen.some(r => r.url.includes("/alpha/usage/summary"))).toBe(true);
+		expect(report).toBeNull();
+	});
+
+	it("empty windows (used=0 cap=0) are skipped but the remaining pool survives", async () => {
+		const { ctx } = makeCtx({
+			credits: {
+				credits: { monthlyCredits: 50 },
+				windowLimits: { fiveHour: { used: 0, cap: 0 }, weekly: {} },
+			},
+		});
+		const report = await fetchUsage(
+			{ provider: "commandcode", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(l => l.id)).toEqual(["commandcode:credits:remaining"]);
+		expect(report!.limits[0].amount.remaining).toBe(50);
+		expect(report!.limits[0].amount.used).toBe(42.5);
+		expect(report!.limits[0].amount.limit).toBe(92.5);
+	});
+
+	it("oauth accessToken is used as the Bearer token", async () => {
+		const { ctx, seen } = makeCtx();
+		const report = await fetchUsage(
+			{
+				provider: "commandcode",
+				credential: { type: "oauth", accessToken: "oauth-token" },
+				signal: undefined,
+			},
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		expect(seen.length).toBeGreaterThan(0);
+		for (const request of seen) {
+			expect(request.authorization).toBe("Bearer oauth-token");
+		}
+	});
+
+	it("baseUrl with /provider/v1 still hits the origin /alpha endpoints", async () => {
+		const { ctx, seen } = makeCtx();
+		const report = await fetchUsage(
+			{
+				provider: "commandcode",
+				credential: makeCredential(),
+				baseUrl: "https://api.commandcode.ai/provider/v1",
+				signal: undefined,
+			},
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		expect(seen[0].url).toBe("https://api.commandcode.ai/alpha/whoami");
+	});
+
+	it("supports() gates on provider plus a usable token", async () => {
+		expect(
+			commandcodeUsageProvider.supports!({
+				provider: "commandcode",
+				credential: makeCredential(),
+			}),
+		).toBe(true);
+		expect(
+			commandcodeUsageProvider.supports!({
+				provider: "commandcode",
+				credential: { type: "oauth", accessToken: "oauth-token" },
+			}),
+		).toBe(true);
+		expect(
+			commandcodeUsageProvider.supports!({
+				provider: "commandcode",
+				credential: { type: "oauth" } as UsageFetchParams["credential"],
+			}),
+		).toBe(false);
+		expect(
+			commandcodeUsageProvider.supports!({
+				provider: "openai",
+				credential: makeCredential(),
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
`omp usage` already reports Z.AI and Synthetic quotas. Command Code is now a first-class catalog provider (`commandcode`) but had no usage probe, so authenticated Command Code accounts were missing from `omp usage`.

This adds `packages/ai/src/usage/commandcode.ts` and registers it next to the other usage providers.

**What `omp usage` shows**
- 5-hour credit window
- Weekly credit window
- Remaining dollar credits for the billing period

**How it fetches**
Bearer token from the stored `/login` API key or OAuth access token against `https://api.commandcode.ai`:
- `GET /alpha/whoami` (401/403 fail the credential probe)
- `GET /alpha/billing/credits`
- `GET /alpha/billing/subscriptions`
- `GET /alpha/usage/summary`

Catalog `baseUrl` values such as `https://api.commandcode.ai/provider/v1` are normalized to the origin so usage still hits `/alpha/*`.

**Tests**
`packages/ai/test/commandcode-usage.test.ts` covers the happy path, 401/403, missing tokens, oauth bearer, and baseUrl normalization.