### PR TITLE
fix(catalog,stats): follow up DeepSeek pricing nits from #11542

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added dated, announced price changes to the catalog, so rates switch on their effective date (e.g. DeepSeek Pro moving to Flash rates).
 
 - Added Command Code as a built-in provider with API-key login, live model discovery, per-model pricing, native OpenAI/Anthropic-compatible routing, cache-aware token usage, and TTFT metrics ([#11391](https://github.com/can1357/oh-my-pi/pull/11391) by [@CherkaSSH](https://github.com/CherkaSSH)).
+
+### Fixed
+
+- Fixed the bundled `deepseek-flash` row shipping without context limits: it now carries its documented 1M context / 384K output so offline context accounting enforces the real window.
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -70199,8 +70199,8 @@
 					]
 				}
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
 			"identity": {
 				"class": "deepseek"
 			},

--- a/packages/catalog/test/time-based-pricing.test.ts
+++ b/packages/catalog/test/time-based-pricing.test.ts
@@ -419,4 +419,12 @@ describe("deepseek provider metadata corrections", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it("materializes the bare Flash alias limits in the bundled row for offline startup", () => {
+		// The registry serves committed rows verbatim on the cacheless,
+		// pre-discovery path, so the documented 1M/384K limits must live in
+		// models.json itself — not only in the live KDL rule.
+		const bundled = getBundledModels("deepseek").find(model => model.id === "deepseek-flash");
+		expect(bundled?.contextWindow).toBe(1_000_000);
+		expect(bundled?.maxTokens).toBe(384_000);
+	});
 });

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed legacy requests that recorded no cost at all being stored as free usage: they are estimated at their request timestamp, and requests without a recoverable timestamp stay unpriced instead of being billed as 1970.
 - Fixed a legacy entry whose malformed token counter was summed into an inflated request total; counters that are not finite numbers now count as absent.
 - Fixed requests whose timestamp could not be recovered being reported as free usage: they now count as unpriced (`N/A`) rather than `$0`, in both the aggregates and the per-request list, and an existing database re-parses its sessions once so rows stored before this change are repaired.
+- Fixed the trace summary showing `$0` instead of `N/A` for legacy scheduled requests that omit their token total: the total is derived from the token buckets before classifying unpriced usage.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -168,12 +168,32 @@ function finiteTokenCount(value: unknown): number {
 }
 
 /**
- * `Usage.totalTokens` per the documented contract: the conversation buckets plus
- * provider-reported orchestration tokens. Used when a legacy entry omits the
- * total, which would otherwise persist a zero total next to real token counts.
+ * Token-bucket view for total derivation. Persisted session payloads are
+ * outside-controlled (old versions, foreign producers), so every counter is
+ * `unknown` and validated at read time.
  */
-function sumReportedTokens(usage: Partial<Usage>): number {
-	const orchestration = usage.orchestration;
+export interface UsageBucketView {
+	totalTokens?: unknown;
+	input?: unknown;
+	output?: unknown;
+	cacheRead?: unknown;
+	cacheWrite?: unknown;
+	orchestration?: { input?: unknown; output?: unknown; cacheRead?: unknown } | null;
+}
+
+/**
+ * Total tokens for one usage payload, per the documented contract: the
+ * conversation buckets plus provider-reported orchestration tokens. A present
+ * finite provider total stays authoritative; a missing or malformed one
+ * (absent, string, NaN) is derived from the buckets, which would otherwise
+ * persist a zero total next to real token counts. Shared by ingest and the
+ * trace builder so stored and displayed totals cannot disagree.
+ */
+export function resolveUsageTotal(usage: UsageBucketView | null | undefined): number {
+	if (typeof usage?.totalTokens === "number" && Number.isFinite(usage.totalTokens)) return usage.totalTokens;
+	if (!usage || typeof usage !== "object") return 0;
+	const orchestration =
+		usage.orchestration && typeof usage.orchestration === "object" ? usage.orchestration : undefined;
 	return (
 		finiteTokenCount(usage.input) +
 		finiteTokenCount(usage.output) +
@@ -239,11 +259,8 @@ function extractStats(
 					cacheRead: finiteTokenCount(rawUsage.cacheRead),
 					cacheWrite: finiteTokenCount(rawUsage.cacheWrite),
 					// A present finite provider total stays authoritative; a missing
-					// or malformed one (absent, string, NaN) is derived below.
-					totalTokens:
-						typeof rawUsage.totalTokens === "number" && Number.isFinite(rawUsage.totalTokens)
-							? rawUsage.totalTokens
-							: sumReportedTokens(rawUsage),
+					// or malformed one (absent, string, NaN) is derived from the buckets.
+					totalTokens: resolveUsageTotal(rawUsage),
 					// An omitted `cost` must stay omitted: `resolveStoredCost` reads
 					// absence as "no recorded price" and estimates the request, while
 					// a zero would read as an explicitly free request.

--- a/packages/stats/src/trace.ts
+++ b/packages/stats/src/trace.ts
@@ -85,11 +85,46 @@ interface MessageView {
 	completedAt?: number;
 	duration?: number;
 	ttft?: number;
-	usage?: { totalTokens?: number; cost?: { total?: number } };
+	usage?: {
+		input?: unknown;
+		output?: unknown;
+		cacheRead?: unknown;
+		cacheWrite?: unknown;
+		totalTokens?: unknown;
+		orchestration?: { input?: unknown; output?: unknown; cacheRead?: unknown };
+		cost?: { total?: unknown };
+	};
 	model?: string;
 	provider?: string;
 	stopReason?: string;
 	errorMessage?: string;
+}
+
+/** Session JSONL token buckets are outside-controlled; malformed counts as absent. */
+function finiteCount(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Total tokens for trace classification, mirroring the parser's derivation:
+ * a present finite provider total stays authoritative; a missing or malformed
+ * one is derived from the component buckets so a legacy entry still surfaces
+ * as unpriced rather than free.
+ */
+function traceTotalTokens(usage: MessageView["usage"]): number {
+	if (typeof usage?.totalTokens === "number" && Number.isFinite(usage.totalTokens)) return usage.totalTokens;
+	if (!usage || typeof usage !== "object") return 0;
+	const orchestration =
+		usage.orchestration && typeof usage.orchestration === "object" ? usage.orchestration : undefined;
+	return (
+		finiteCount(usage.input) +
+		finiteCount(usage.output) +
+		finiteCount(usage.cacheRead) +
+		finiteCount(usage.cacheWrite) +
+		finiteCount(orchestration?.input) +
+		finiteCount(orchestration?.output) +
+		finiteCount(orchestration?.cacheRead)
+	);
 }
 
 /** `tool_execution_start` marker facts joined to tool spans by call id. */
@@ -365,9 +400,12 @@ function scanTranscript(
 			// with Costs/Recent Requests: a zero that is unknown spend, not free.
 			// Counted before the span-timing `continue` below so a fully
 			// dateless entry still surfaces as N/A rather than vanishing.
-			const totalTokens = typeof msg.usage?.totalTokens === "number" ? msg.usage.totalTokens : 0;
+			// Derive a missing total from the buckets like the parser does, so a
+			// legacy entry with tokens but no total still classifies as unpriced.
+			const totalTokens = traceTotalTokens(msg.usage);
 			const costObj = msg.usage?.cost;
-			const costTotal = typeof costObj?.total === "number" ? costObj.total : undefined;
+			const costTotal =
+				typeof costObj?.total === "number" && Number.isFinite(costObj.total) ? costObj.total : undefined;
 			if (totalTokens > 0 && (costTotal === undefined || costTotal === 0)) {
 				const provider = typeof msg.provider === "string" ? msg.provider : "";
 				const model = typeof msg.model === "string" ? msg.model : "";
@@ -411,8 +449,10 @@ function scanTranscript(
 			if (detail) span.detail = detail;
 			if (entry.id) span.entryId = entry.id;
 			if (typeof msg.model === "string") span.model = msg.model;
-			if (typeof msg.usage?.totalTokens === "number") span.tokens = msg.usage.totalTokens;
-			if (typeof msg.usage?.cost?.total === "number") span.cost = msg.usage.cost.total;
+			if (totalTokens > 0) span.tokens = totalTokens;
+			else if (typeof msg.usage?.totalTokens === "number" && Number.isFinite(msg.usage.totalTokens))
+				span.tokens = msg.usage.totalTokens;
+			if (costTotal !== undefined) span.cost = costTotal;
 			if (typeof msg.ttft === "number") span.ttft = msg.ttft;
 			if (msg.stopReason === "error" || msg.errorMessage) span.isError = true;
 			spans.push(span);

--- a/packages/stats/src/trace.ts
+++ b/packages/stats/src/trace.ts
@@ -14,7 +14,7 @@ import * as path from "node:path";
 import { getBundledModel, type GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
 import { getSessionsDir, isEnoent } from "@oh-my-pi/pi-utils";
 import { getSessionRollups, getToolCallCountsBySession, isScheduledCatalogModel } from "./db";
-import { extractFolderFromPath, parseAllSessionEntries } from "./parser";
+import { extractFolderFromPath, parseAllSessionEntries, resolveUsageTotal } from "./parser";
 import type {
 	SessionEntry,
 	SessionSummary,
@@ -98,33 +98,6 @@ interface MessageView {
 	provider?: string;
 	stopReason?: string;
 	errorMessage?: string;
-}
-
-/** Session JSONL token buckets are outside-controlled; malformed counts as absent. */
-function finiteCount(value: unknown): number {
-	return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-/**
- * Total tokens for trace classification, mirroring the parser's derivation:
- * a present finite provider total stays authoritative; a missing or malformed
- * one is derived from the component buckets so a legacy entry still surfaces
- * as unpriced rather than free.
- */
-function traceTotalTokens(usage: MessageView["usage"]): number {
-	if (typeof usage?.totalTokens === "number" && Number.isFinite(usage.totalTokens)) return usage.totalTokens;
-	if (!usage || typeof usage !== "object") return 0;
-	const orchestration =
-		usage.orchestration && typeof usage.orchestration === "object" ? usage.orchestration : undefined;
-	return (
-		finiteCount(usage.input) +
-		finiteCount(usage.output) +
-		finiteCount(usage.cacheRead) +
-		finiteCount(usage.cacheWrite) +
-		finiteCount(orchestration?.input) +
-		finiteCount(orchestration?.output) +
-		finiteCount(orchestration?.cacheRead)
-	);
 }
 
 /** `tool_execution_start` marker facts joined to tool spans by call id. */
@@ -400,9 +373,10 @@ function scanTranscript(
 			// with Costs/Recent Requests: a zero that is unknown spend, not free.
 			// Counted before the span-timing `continue` below so a fully
 			// dateless entry still surfaces as N/A rather than vanishing.
-			// Derive a missing total from the buckets like the parser does, so a
-			// legacy entry with tokens but no total still classifies as unpriced.
-			const totalTokens = traceTotalTokens(msg.usage);
+			// Derive a missing total from the buckets via the shared ingest
+			// helper, so a legacy entry with tokens but no total still
+			// classifies as unpriced.
+			const totalTokens = resolveUsageTotal(msg.usage);
 			const costObj = msg.usage?.cost;
 			const costTotal =
 				typeof costObj?.total === "number" && Number.isFinite(costObj.total) ? costObj.total : undefined;
@@ -450,8 +424,7 @@ function scanTranscript(
 			if (entry.id) span.entryId = entry.id;
 			if (typeof msg.model === "string") span.model = msg.model;
 			if (totalTokens > 0) span.tokens = totalTokens;
-			else if (typeof msg.usage?.totalTokens === "number" && Number.isFinite(msg.usage.totalTokens))
-				span.tokens = msg.usage.totalTokens;
+
 			if (costTotal !== undefined) span.cost = costTotal;
 			if (typeof msg.ttft === "number") span.ttft = msg.ttft;
 			if (msg.stopReason === "error" || msg.errorMessage) span.isError = true;

--- a/packages/stats/src/trace.ts
+++ b/packages/stats/src/trace.ts
@@ -33,7 +33,7 @@ export class TracePathError extends Error {}
  * span assembly changes so browsers don't revalidate stale cached bodies
  * against an unchanged transcript mtime.
  */
-export const TRACE_ETAG_VERSION = 2;
+export const TRACE_ETAG_VERSION = 3;
 
 const MAX_TRACK_DEPTH = 6;
 const LABEL_MAX = 80;

--- a/packages/stats/test/trace-builder.test.ts
+++ b/packages/stats/test/trace-builder.test.ts
@@ -456,6 +456,56 @@ describe("buildSessionTrace", () => {
 		expect(summary.unpricedRequests).toBe(1);
 	});
 
+	it("derives a missing total from buckets before classifying trace costs", async () => {
+		// Legacy entries can omit totalTokens while carrying real buckets; the
+		// parser derives the total and the db marks the request unpriced, so the
+		// trace headline must agree instead of reporting the zero as free. A
+		// malformed bucket counts as absent and stays free at zero tokens.
+		const projectDir = path.join(getSessionsDir(), PROJECT);
+		await fs.mkdir(projectDir, { recursive: true });
+		const file = path.join(projectDir, "1700000000002_derived-unpriced.jsonl");
+		const entries: unknown[] = [
+			{ type: "title", v: 1, title: "Derived" },
+			{ type: "session", version: 3, id: "s", timestamp: iso(T), cwd: "/tmp/proj" },
+			{
+				type: "message",
+				id: "a1",
+				parentId: null,
+				message: {
+					role: "assistant",
+					model: "deepseek-v4-flash",
+					provider: "deepseek",
+					api: "openai-completions",
+					timestamp: 0,
+					stopReason: "stop",
+					content: [],
+					usage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0 },
+				},
+			},
+			{
+				type: "message",
+				id: "a2",
+				parentId: "a1",
+				message: {
+					role: "assistant",
+					model: "deepseek-v4-flash",
+					provider: "deepseek",
+					api: "openai-completions",
+					timestamp: 0,
+					stopReason: "stop",
+					content: [],
+					usage: { input: "10", output: 0, cacheRead: 0, cacheWrite: 0 },
+				},
+			},
+		];
+		await Bun.write(file, entries.map(entry => JSON.stringify(entry)).join("\n"));
+		const { summary } = await buildSessionTrace(file);
+		expect(summary.requests).toBe(2);
+		expect(summary.totalTokens).toBe(100);
+		expect(summary.costTotal).toBe(0);
+		expect(summary.unpricedRequests).toBe(1);
+	});
+
 	it("rejects paths outside the sessions root", async () => {
 		await writeFixture();
 		expect(buildSessionTrace("/etc/passwd.jsonl")).rejects.toThrow(TracePathError);


### PR DESCRIPTION
## What

This follow-up addresses the two post-merge review nits on #11542.

- `packages/catalog/src/models.json`: the bundled `deepseek-flash` row now carries its documented 1M context / 384K output (was `null`/`null`), matching the `limits-patch` already in `providers/deepseek.kdl`. No KDL change; this is the materialization Codex asked for. Full `gen:models` deliberately not run (live sweep churns ~57 unrelated blocks; same reason #11542 left the row stale).
- `packages/stats/src/trace.ts` + `parser.ts`: the trace unpriced classifier derives a missing `totalTokens` via the shared `resolveUsageTotal` helper in `parser.ts` (single implementation for ingest + trace, per round-2 review), so a legacy scheduled request with tokens but no total shows `N/A` instead of `$0`. Malformed buckets count as absent; span tokens/cost use the derived/finite values. `TRACE_ETAG_VERSION` bumped 2→3 so previously cached trace payloads revalidate instead of serving stale summaries.

## Why

Follow-up to #11542 review nits: offline startup serves bundled rows verbatim, so the bare Flash alias had a zero effective context window (no over-context compaction); and the trace headline disagreed with Costs/Recent Requests for repaired legacy rows.

## Testing

| Check | Result |
|---|---|
| `bun test packages/catalog/test/time-based-pricing.test.ts packages/catalog/test/long-context-pricing.test.ts packages/catalog/test/compat-compile.test.ts` | 38 pass / 0 fail |
| `bun --cwd=packages/stats test test/trace-builder.test.ts` | 7 pass, 1 pre-existing Windows `EBUSY` teardown flake (identical on clean tree) |
| New regression tests fail without the fixes, pass with them | verified both directions via stash |
| `bun --cwd=packages/stats run check` (oxlint + oxfmt + both tsconfigs) | pass |
| `bun --cwd=packages/catalog run check` | pass |
| `db-cost` / `parser-malformed` suites | unrunnable in this Windows env — `EBUSY` temp-cleanup fails 13/13 on the clean tree too; bodies unaffected by this change |

---

- [x] `bun check` passes (both touched packages green; workspace `check:ts` still stops on the unrelated upstream `openai-codex-stream.test.ts` type error noted in #11542)
- [x] Tested locally (incl. a throwaway trace repro: derived-total entry → `unpricedRequests: 1`, malformed-bucket entry stays free at 0 tokens; repro file removed)
- [x] CHANGELOG updated (`catalog`, `stats`, under `[Unreleased]`)