### PR TITLE
feat(coding-agent): autosave approved plans to .omp/plans

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
 - Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
 - Added peak `↑` / off-peak `↓` indicators to the cost display for models with scheduled pricing (DeepSeek), refreshed automatically when the tariff changes.
+- Added plan autosave: enable `plan.autosave` to automatically save approved plans to `<project>/.omp/plans/` when plan mode completes (customize with `plan.autosaveDir`, which accepts `~`, absolute, and cwd-relative paths).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
 - Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
 - Added peak `↑` / off-peak `↓` indicators to the cost display for models with scheduled pricing (DeepSeek), refreshed automatically when the tariff changes.
-- Added plan autosave: enable `plan.autosave` to automatically save approved plans to `<project>/.omp/plans/` when plan mode completes (customize with `plan.autosaveDir`, which accepts `~`, absolute, and cwd-relative paths).
+- Added plan autosave: enable `plan.autosave` to automatically save approved plans to `<project>/.omp/plans/` when plan mode completes (customize with `plan.autosaveDir`, which accepts `~`, absolute, and cwd-relative paths) ([#11599](https://github.com/can1357/oh-my-pi/pull/11599) by [@H4vC](https://github.com/H4vC)).
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4924,6 +4924,31 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"plan.autosave": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Autosave Plans",
+			description: "Automatically save approved plans to disk when plan mode completes",
+			condition: "planModeEnabled",
+		},
+	},
+
+	"plan.autosaveDir": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Autosave Directory",
+			description:
+				"Directory for autosaved plans. Supports ~, absolute, and cwd-relative paths. Empty uses <project>/.omp/plans/.",
+			condition: "planAutosaveEnabled",
+		},
+	},
+
 	"goal.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -1,5 +1,11 @@
 import { sanitizeText } from "@oh-my-pi/pi-utils";
-import { replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
+import {
+	replaceTabs,
+	shortenEmbeddedPaths,
+	shortenPath,
+	TRUNCATE_LENGTHS,
+	truncateToWidth,
+} from "../tools/render-utils";
 
 export const MCP_CONNECTION_STATUS_EVENT_CHANNEL = "mcp:connection-status";
 
@@ -43,19 +49,6 @@ function formatServerCount(count: number): string {
 }
 function sanitizeMcpStatusError(error: string): string {
 	return sanitizeMcpStatusText(error, TRUNCATE_LENGTHS.CONTENT);
-}
-
-function shortenEmbeddedPaths(text: string): string {
-	return text
-		.split(" ")
-		.map(segment => {
-			const leading = segment.match(/^[("'`[]*/)?.[0] ?? "";
-			const trailing = segment.match(/[)"'`,.;:\]]*$/)?.[0] ?? "";
-			const end = segment.length - trailing.length;
-			if (leading.length >= end) return segment;
-			return `${leading}${shortenPath(segment.slice(leading.length, end))}${trailing}`;
-		})
-		.join(" ");
 }
 
 export function formatMCPConnectingMessage(serverNames: readonly string[]): string {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -76,7 +76,6 @@ import { refreshAgentDiscovery } from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { OTHER_OPTION } from "../../tools/ask";
 import { normalizeLocalScheme } from "../../tools/path-utils";
-import { shortenPath } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
@@ -1927,9 +1926,9 @@ export class AcpAgent implements Agent {
 		session.setPlanReferencePath(planFilePath);
 		session.setPlanProposalHandler?.(null);
 		session.setPlanModeState(undefined);
-		let autosavedPlan: string | null = null;
+		let autosaveFailed = false;
 		try {
-			autosavedPlan = await autosaveApprovedPlan({
+			await autosaveApprovedPlan({
 				settings: session.settings,
 				cwd: session.sessionManager.getCwd(),
 				title: resolvedTitle,
@@ -1940,6 +1939,7 @@ export class AcpAgent implements Agent {
 				sessionId: session.sessionId,
 				error,
 			});
+			autosaveFailed = true;
 		}
 		try {
 			await this.#connection.sessionUpdate({
@@ -1957,8 +1957,8 @@ export class AcpAgent implements Agent {
 			content: [
 				{
 					type: "text" as const,
-					text: autosavedPlan
-						? `Plan approved at ${planFilePath} (autosaved to ${shortenPath(autosavedPlan)}). Plan mode exited; proceed with the implementation.`
+					text: autosaveFailed
+						? `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation. (Plan autosave failed; continuing.)`
 						: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
 				},
 			],

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -76,6 +76,7 @@ import { refreshAgentDiscovery } from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { OTHER_OPTION } from "../../tools/ask";
 import { normalizeLocalScheme } from "../../tools/path-utils";
+import { shortenPath } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
@@ -1957,7 +1958,7 @@ export class AcpAgent implements Agent {
 				{
 					type: "text" as const,
 					text: autosavedPlan
-						? `Plan approved at ${planFilePath} (autosaved to ${autosavedPlan}). Plan mode exited; proceed with the implementation.`
+						? `Plan approved at ${planFilePath} (autosaved to ${shortenPath(autosavedPlan)}). Plan mode exited; proceed with the implementation.`
 						: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
 				},
 			],

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -62,6 +62,7 @@ import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
 import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
+import { autosaveApprovedPlan } from "../../plan-mode/plan-autosave";
 import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
 import { BlobStore, resolveImageDataSync } from "../../session/blob-store";
 import { isSilentAbort, SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -1922,10 +1923,23 @@ export class AcpAgent implements Agent {
 		}
 		// Approved. Set the plan reference so the next turn injects the plan
 		// content as context (the file keeps its agent-chosen name — no rename),
-		// then exit plan mode so the agent regains full tools.
 		session.setPlanReferencePath(planFilePath);
 		session.setPlanProposalHandler?.(null);
 		session.setPlanModeState(undefined);
+		let autosavedPlan: string | null = null;
+		try {
+			autosavedPlan = await autosaveApprovedPlan({
+				settings: session.settings,
+				cwd: session.sessionManager.getCwd(),
+				title: resolvedTitle,
+				planContent,
+			});
+		} catch (error) {
+			logger.warn("Failed to autosave approved plan", {
+				sessionId: session.sessionId,
+				error,
+			});
+		}
 		try {
 			await this.#connection.sessionUpdate({
 				sessionId: session.sessionId,
@@ -1942,7 +1956,9 @@ export class AcpAgent implements Agent {
 			content: [
 				{
 					type: "text" as const,
-					text: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
+					text: autosavedPlan
+						? `Plan approved at ${planFilePath} (autosaved to ${autosavedPlan}). Plan mode exited; proceed with the implementation.`
+						: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
 				},
 			],
 			details,

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -154,6 +154,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	planAutosaveEnabled: () => {
+		try {
+			return Settings.instance.get("plan.enabled") && Settings.instance.get("plan.autosave");
+		} catch {
+			return false;
+		}
+	},
 	unexpectedStopSmart: () => {
 		try {
 			return Settings.instance.get("features.unexpectedStopDetection") === "smart";

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -9,3 +9,7 @@ export * from "./composer";
 export * from "./interactive-mode";
 export * from "./rpc/rpc-client";
 export * from "./rpc/rpc-types";
+
+// planSaveFileName moved to plan-mode/plan-autosave; preserved here so its
+// pre-existing barrel reachability survives the move.
+export { planSaveFileName } from "../plan-mode/plan-autosave";

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -94,6 +94,7 @@ import {
 	type McpConnectionStatusEvent,
 } from "../mcp/startup-events";
 import { humanizePlanTitle, type PlanApprovalDetails, resolvePlanTitle } from "../plan-mode/approved-plan";
+import { autosaveApprovedPlan, planSaveFileName } from "../plan-mode/plan-autosave";
 import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import guidedGoalInterviewPrompt from "../prompts/goals/guided-goal-interview.md" with { type: "text" };
 import planFilenamePrompt from "../prompts/system/plan-filename.md" with { type: "text" };
@@ -341,25 +342,9 @@ const PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT = 95;
 const PLAN_SAVE_AND_QUIT_OPTION = "Save and quit";
 const PLAN_SAVE_TITLE_LINE_LIMIT = 6;
 
-const PLAN_SAVE_STEM_MAX_LENGTH = 32;
 const PLAN_FILENAME_SYSTEM_PROMPT = prompt.render(planFilenamePrompt);
-/** Suggested save filename for an approved plan: `<TOPIC>_PLAN.md` from the
- *  tiny-model topic (e.g. `PYO3_METHODS_PLAN.md`), trimmed to a word boundary
- *  when a verbose fallback title sneaks through. */
-export function planSaveFileName(title: string): string {
-	let stem = title
-		.normalize("NFC")
-		.replace(/[^\p{L}\p{N}]+/gu, "_")
-		.replace(/_+/g, "_")
-		.replace(/^_+|_+$/g, "")
-		.toUpperCase();
-	if (stem.length > PLAN_SAVE_STEM_MAX_LENGTH) {
-		const cut = stem.lastIndexOf("_", PLAN_SAVE_STEM_MAX_LENGTH);
-		stem = cut > 0 ? stem.slice(0, cut) : stem.slice(0, PLAN_SAVE_STEM_MAX_LENGTH);
-	}
-	if (!stem || stem === "PLAN") return "PLAN.md";
-	return `${stem.endsWith("_PLAN") ? stem : `${stem}_PLAN`}.md`;
-}
+/** Re-exported for tests and external importers; canonical implementation lives in plan-mode/plan-autosave. */
+export { planSaveFileName };
 
 function planSaveTitleExcerpt(planContent: string): string {
 	return planContent
@@ -4103,6 +4088,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			: [...previousPresentation.enabled, "read"];
 		await this.session.restoreNonMCPToolPresentation(executionTools, previousPresentation.mounted);
 		this.session.setPlanReferencePath(options.planFilePath);
+		try {
+			const autosaved = await autosaveApprovedPlan({
+				settings: this.session.settings,
+				cwd: this.sessionManager.getCwd(),
+				title: options.title,
+				planContent,
+			});
+			if (autosaved) this.showStatus(`Saved plan to ${shortenPath(autosaved)}.`);
+		} catch (error) {
+			this.showWarning(`Failed to autosave plan: ${error instanceof Error ? error.message : String(error)}`);
+		}
 
 		// Resolve the deferred plan-approval model transition. On the compact path
 		// the before-flush hook passed to handleCompactCommand already ran this (so

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -134,6 +134,7 @@ import {
 	formatMoreItems,
 	isFeedModelBadgeEnabled,
 	replaceTabs,
+	shortenEmbeddedPaths,
 	shortenPath,
 	TRUNCATE_LENGTHS,
 	truncateToWidth,
@@ -343,8 +344,6 @@ const PLAN_SAVE_AND_QUIT_OPTION = "Save and quit";
 const PLAN_SAVE_TITLE_LINE_LIMIT = 6;
 
 const PLAN_FILENAME_SYSTEM_PROMPT = prompt.render(planFilenamePrompt);
-/** Re-exported for tests and external importers; canonical implementation lives in plan-mode/plan-autosave. */
-export { planSaveFileName };
 
 function planSaveTitleExcerpt(planContent: string): string {
 	return planContent
@@ -4095,9 +4094,20 @@ export class InteractiveMode implements InteractiveModeContext {
 				title: options.title,
 				planContent,
 			});
-			if (autosaved) this.showStatus(`Saved plan to ${shortenPath(autosaved)}.`);
+			if (autosaved) {
+				const displayPath = truncateToWidth(replaceTabs(shortenPath(autosaved)), TRUNCATE_LENGTHS.CONTENT);
+				this.showStatus(`Saved plan to ${displayPath}.`);
+			}
 		} catch (error) {
-			this.showWarning(`Failed to autosave plan: ${error instanceof Error ? error.message : String(error)}`);
+			const detail = truncateToWidth(
+				shortenEmbeddedPaths(
+					replaceTabs(error instanceof Error ? error.message : String(error))
+						.replace(/[\r\n]+/g, " ")
+						.trim(),
+				),
+				TRUNCATE_LENGTHS.CONTENT,
+			);
+			this.showWarning(`Failed to autosave plan: ${detail}`);
 		}
 
 		// Resolve the deferred plan-approval model transition. On the compact path

--- a/packages/coding-agent/src/plan-mode/plan-autosave.ts
+++ b/packages/coding-agent/src/plan-mode/plan-autosave.ts
@@ -1,0 +1,93 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getProjectAgentDir } from "@oh-my-pi/pi-utils";
+import type { Settings } from "../config/settings";
+import { expandTilde } from "../tools/path-utils";
+
+const PLAN_SAVE_STEM_MAX_LENGTH = 32;
+const MAX_AUTOSAVE_CANDIDATES = 1000;
+
+type PlanAutosaveSettings = Pick<Settings, "get">;
+
+/** Suggested save filename for an approved plan: `<TOPIC>_PLAN.md` from the
+ *  tiny-model topic (e.g. `PYO3_METHODS_PLAN.md`), trimmed to a word boundary
+ *  when a verbose fallback title sneaks through. */
+export function planSaveFileName(title: string): string {
+	let stem = title
+		.normalize("NFC")
+		.replace(/[^\p{L}\p{N}]+/gu, "_")
+		.replace(/_+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.toUpperCase();
+	if (stem.length > PLAN_SAVE_STEM_MAX_LENGTH) {
+		const cut = stem.lastIndexOf("_", PLAN_SAVE_STEM_MAX_LENGTH);
+		stem = cut > 0 ? stem.slice(0, cut) : stem.slice(0, PLAN_SAVE_STEM_MAX_LENGTH);
+	}
+	if (!stem || stem === "PLAN") return "PLAN.md";
+	return `${stem.endsWith("_PLAN") ? stem : `${stem}_PLAN`}.md`;
+}
+
+/** Default autosave location: `<project>/.omp/plans/`. */
+export function defaultPlanAutosaveDir(cwd: string): string {
+	return path.join(getProjectAgentDir(cwd), "plans");
+}
+
+/** Resolve the autosave directory: `plan.autosaveDir` (`~`/absolute/cwd-relative)
+ *  or the project-local default when unset/blank. */
+export function resolvePlanAutosaveDir(settings: PlanAutosaveSettings, cwd: string): string {
+	const raw = settings.get("plan.autosaveDir");
+	if (typeof raw !== "string" || raw.trim() === "") return defaultPlanAutosaveDir(cwd);
+	const expanded = expandTilde(raw.trim());
+	if (path.isAbsolute(expanded)) return path.normalize(expanded);
+	return path.resolve(cwd, expanded);
+}
+
+export function isPlanAutosaveEnabled(settings: PlanAutosaveSettings): boolean {
+	try {
+		return settings.get("plan.autosave") === true;
+	} catch {
+		return false;
+	}
+}
+
+function autosaveCandidate(dir: string, filename: string, index: number): string {
+	if (index === 0) return path.join(dir, filename);
+	const ext = path.extname(filename);
+	const stem = filename.slice(0, filename.length - ext.length);
+	return path.join(dir, `${stem}-${index}${ext}`);
+}
+
+async function autosavePathExists(candidate: string): Promise<boolean> {
+	try {
+		await fs.stat(candidate);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** First non-colliding `<dir>/<filename>` (`<stem>-<n><ext>` on collision). */
+export async function resolveUniqueAutosavePath(dir: string, filename: string): Promise<string> {
+	for (let index = 0; index < MAX_AUTOSAVE_CANDIDATES; index += 1) {
+		const candidate = autosaveCandidate(dir, filename, index);
+		if (!(await autosavePathExists(candidate))) return candidate;
+	}
+	return path.join(dir, `${Date.now()}-${filename}`);
+}
+
+/** Best-effort copy of an approved plan into the autosave dir.
+ *  Returns the destination path, or null when autosave is disabled/empty. */
+export async function autosaveApprovedPlan(input: {
+	settings: PlanAutosaveSettings;
+	cwd: string;
+	title: string;
+	planContent: string;
+}): Promise<string | null> {
+	if (!isPlanAutosaveEnabled(input.settings)) return null;
+	if (input.planContent.trim() === "") return null;
+	const dir = resolvePlanAutosaveDir(input.settings, input.cwd);
+	const destination = await resolveUniqueAutosavePath(dir, planSaveFileName(input.title));
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	await Bun.write(destination, input.planContent);
+	return destination;
+}

--- a/packages/coding-agent/src/plan-mode/plan-autosave.ts
+++ b/packages/coding-agent/src/plan-mode/plan-autosave.ts
@@ -57,22 +57,23 @@ function autosaveCandidate(dir: string, filename: string, index: number): string
 	return path.join(dir, `${stem}-${index}${ext}`);
 }
 
-async function autosavePathExists(candidate: string): Promise<boolean> {
-	try {
-		await fs.stat(candidate);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/** First non-colliding `<dir>/<filename>` (`<stem>-<n><ext>` on collision). */
-export async function resolveUniqueAutosavePath(dir: string, filename: string): Promise<string> {
+/** Claim the first free `<dir>/<filename>` with an exclusive create, so two
+ *  sessions approving same-titled plans at once can't settle on the same
+ *  candidate (`<stem>-<n><ext>` on collision). `wx` (O_CREAT|O_EXCL) makes the
+ *  check-and-claim a single syscall; EEXIST advances to the next candidate. */
+async function claimAutosavePath(dir: string, filename: string, planContent: string): Promise<string> {
 	for (let index = 0; index < MAX_AUTOSAVE_CANDIDATES; index += 1) {
 		const candidate = autosaveCandidate(dir, filename, index);
-		if (!(await autosavePathExists(candidate))) return candidate;
+		try {
+			await fs.writeFile(candidate, planContent, { flag: "wx" });
+			return candidate;
+		} catch (error) {
+			if ((error as { code?: string }).code !== "EEXIST") throw error;
+		}
 	}
-	return path.join(dir, `${Date.now()}-${filename}`);
+	const fallback = path.join(dir, `${Date.now()}-${filename}`);
+	await fs.writeFile(fallback, planContent, { flag: "wx" });
+	return fallback;
 }
 
 /** Best-effort copy of an approved plan into the autosave dir.
@@ -86,8 +87,8 @@ export async function autosaveApprovedPlan(input: {
 	if (!isPlanAutosaveEnabled(input.settings)) return null;
 	if (input.planContent.trim() === "") return null;
 	const dir = resolvePlanAutosaveDir(input.settings, input.cwd);
-	const destination = await resolveUniqueAutosavePath(dir, planSaveFileName(input.title));
-	await fs.mkdir(path.dirname(destination), { recursive: true });
-	await Bun.write(destination, input.planContent);
-	return destination;
+	// fs.writeFile (unlike Bun.write) leaves parent creation to us; one mkdir
+	// up front covers every candidate the claim loop below may create.
+	await fs.mkdir(dir, { recursive: true });
+	return claimAutosavePath(dir, planSaveFileName(input.title), input.planContent);
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1276,6 +1276,7 @@ export class AgentSession {
 		const prewalkHost: PrewalkCoordinatorHost = {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
+			settings: this.settings,
 			model: () => this.model,
 			configuredThinkingLevel: () => this.configuredThinkingLevel(),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -14,7 +14,13 @@ import prewalkContinuePrompt from "../prompts/system/prewalk-continue.md" with {
 import prewalkPlanPrompt from "../prompts/system/prewalk-plan.md" with { type: "text" };
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop } from "../thinking";
 import { isMCPToolName } from "../tools/builtin-names";
-import { shortenPath } from "../tools/render-utils";
+import {
+	replaceTabs,
+	shortenEmbeddedPaths,
+	shortenPath,
+	TRUNCATE_LENGTHS,
+	truncateToWidth,
+} from "../tools/render-utils";
 import type { PlanProposalHandler } from "../tools/resolve";
 import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
@@ -325,8 +331,25 @@ export class PrewalkCoordinator {
 				title: resolvedTitle,
 				planContent,
 			});
+			if (autosavedPlan) {
+				const displayPath = truncateToWidth(replaceTabs(shortenPath(autosavedPlan)), TRUNCATE_LENGTHS.CONTENT);
+				this.#host.emitNotice("info", `Plan autosaved to ${displayPath}.`, "plan-yolo");
+			}
 		} catch (error) {
 			logger.warn("Failed to autosave approved plan", { error });
+			const detail = truncateToWidth(
+				shortenEmbeddedPaths(
+					replaceTabs(error instanceof Error ? error.message : String(error))
+						.replace(/[\r\n]+/g, " ")
+						.trim(),
+				),
+				TRUNCATE_LENGTHS.CONTENT,
+			);
+			this.#host.emitNotice(
+				"warning",
+				`Plan autosave failed: ${detail} Continuing with implementation.`,
+				"plan-yolo",
+			);
 		}
 		this.#host.setPlanModeState(undefined);
 		const previousPresentation = this.#planYoloPreviousNonMCPPresentation;
@@ -356,14 +379,7 @@ export class PrewalkCoordinator {
 			timestamp: Date.now(),
 		});
 		return {
-			content: [
-				{
-					type: "text",
-					text: autosavedPlan
-						? `Plan approved. Implementing now with ${planYolo.target.id} (autosaved to ${shortenPath(autosavedPlan)}).`
-						: `Plan approved. Implementing now with ${planYolo.target.id}.`,
-				},
-			],
+			content: [{ type: "text", text: `Plan approved. Implementing now with ${planYolo.target.id}.` }],
 			details: { planFilePath, title: resolvedTitle, planExists: true },
 		};
 	}

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -1,9 +1,11 @@
 import type { Agent, AgentMessage, AgentToolResult, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
 import { invalidateMessageCache } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { logger, prompt } from "@oh-my-pi/pi-utils";
+import type { Settings } from "../config/settings";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { resolveApprovedPlan } from "../plan-mode/approved-plan";
+import { autosaveApprovedPlan } from "../plan-mode/plan-autosave";
 import { listPlanFiles, readPlanFile } from "../plan-mode/plan-files";
 import type { PlanModeState } from "../plan-mode/state";
 import planYoloHandoffPrompt from "../prompts/system/plan-yolo-handoff.md" with { type: "text" };
@@ -17,7 +19,6 @@ import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
 import { PREWALK_PLAN_MESSAGE_TYPE } from "./messages";
 import type { SessionManager } from "./session-manager";
-
 const PREWALK_CONTINUE_MESSAGE_TYPE = "prewalk-continue";
 const PREWALK_CHECKLIST_MESSAGE_TYPE = "prewalk-checklist";
 
@@ -57,6 +58,7 @@ function isPrewalkImplementationAction(result: ToolResultMessage): boolean {
 export interface PrewalkCoordinatorHost {
 	agent: Agent;
 	sessionManager: SessionManager;
+	settings: Pick<Settings, "get">;
 	model(): Model | undefined;
 	configuredThinkingLevel(): ConfiguredThinkingLevel | undefined;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
@@ -300,7 +302,11 @@ export class PrewalkCoordinator {
 		const planYolo = this.#planYolo;
 		const state = this.#host.getPlanModeState();
 		if (!planYolo || !state?.enabled) throw new ToolError("Plan mode is not active.");
-		const { planFilePath, title: resolvedTitle } = await resolveApprovedPlan({
+		const {
+			planFilePath,
+			planContent,
+			title: resolvedTitle,
+		} = await resolveApprovedPlan({
 			suppliedTitle: title,
 			statePlanFilePath: state.planFilePath,
 			readPlan: url =>
@@ -310,6 +316,17 @@ export class PrewalkCoordinator {
 				}),
 			listPlanFiles: () => listPlanFiles({ localProtocolOptions: this.#host.localProtocolOptions() }),
 		});
+		let autosavedPlan: string | null = null;
+		try {
+			autosavedPlan = await autosaveApprovedPlan({
+				settings: this.#host.settings,
+				cwd: this.#host.sessionManager.getCwd(),
+				title: resolvedTitle,
+				planContent,
+			});
+		} catch (error) {
+			logger.warn("Failed to autosave approved plan", { error });
+		}
 		this.#host.setPlanModeState(undefined);
 		const previousPresentation = this.#planYoloPreviousNonMCPPresentation;
 		try {
@@ -338,7 +355,14 @@ export class PrewalkCoordinator {
 			timestamp: Date.now(),
 		});
 		return {
-			content: [{ type: "text", text: `Plan approved. Implementing now with ${planYolo.target.id}.` }],
+			content: [
+				{
+					type: "text",
+					text: autosavedPlan
+						? `Plan approved. Implementing now with ${planYolo.target.id} (autosaved to ${autosavedPlan}).`
+						: `Plan approved. Implementing now with ${planYolo.target.id}.`,
+				},
+			],
 			details: { planFilePath, title: resolvedTitle, planExists: true },
 		};
 	}

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -14,6 +14,7 @@ import prewalkContinuePrompt from "../prompts/system/prewalk-continue.md" with {
 import prewalkPlanPrompt from "../prompts/system/prewalk-plan.md" with { type: "text" };
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop } from "../thinking";
 import { isMCPToolName } from "../tools/builtin-names";
+import { shortenPath } from "../tools/render-utils";
 import type { PlanProposalHandler } from "../tools/resolve";
 import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
@@ -359,7 +360,7 @@ export class PrewalkCoordinator {
 				{
 					type: "text",
 					text: autosavedPlan
-						? `Plan approved. Implementing now with ${planYolo.target.id} (autosaved to ${autosavedPlan}).`
+						? `Plan approved. Implementing now with ${planYolo.target.id} (autosaved to ${shortenPath(autosavedPlan)}).`
 						: `Plan approved. Implementing now with ${planYolo.target.id}.`,
 				},
 			],

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -836,6 +836,21 @@ export function shortenPath(filePath: unknown, homeDir?: string): string {
 	return filePath;
 }
 
+/** Shorten any home-prefixed segments inside free text, preserving surrounding
+ *  punctuation so error strings with embedded paths stay readable. */
+export function shortenEmbeddedPaths(text: string): string {
+	return text
+		.split(" ")
+		.map(segment => {
+			const leading = segment.match(/^[("'`[]*/)?.[0] ?? "";
+			const trailing = segment.match(/[)"'`,.;:\]]*$/)?.[0] ?? "";
+			const end = segment.length - trailing.length;
+			if (leading.length >= end) return segment;
+			return `${leading}${shortenPath(segment.slice(leading.length, end))}${trailing}`;
+		})
+		.join(" ");
+}
+
 export function formatToolWorkingDirectory(workdir: string | undefined, projectDir: string): string | undefined {
 	if (!workdir) return undefined;
 	const resolvedProjectDir = path.resolve(projectDir);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -760,6 +760,76 @@ describe("ACP agent", () => {
 		harness.abortController.abort();
 		await Bun.sleep(0);
 	});
+	it("plan-proposal handler autosaves the approved plan without leaking the path", async () => {
+		const harness = await createHarness();
+		Settings.instance.set("plan.enabled", true);
+		Settings.instance.set("plan.autosave", true);
+
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+
+		const localOptions = {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		};
+		cleanupRoots.push(resolveLocalUrlToPath("local://", localOptions));
+		const planPath = resolveLocalUrlToPath("local://words-counter-plan.md", localOptions);
+		await Bun.write(planPath, "# Words Counter\n\nFile contents.");
+
+		const handler = session.planProposalHandler!;
+		const result = (await handler("words-counter")) as {
+			content: Array<{ type: string; text: string }>;
+			details: { planFilePath: string; title: string; planExists: boolean };
+		};
+
+		expect(result.details.planExists).toBe(true);
+		expect(result.content[0]?.text).toMatch(/Plan approved/);
+		expect(result.content[0]?.text).not.toContain(harness.cwdA);
+		expect(result.content[0]?.text).not.toContain("autosaved to");
+		const saved = path.join(harness.cwdA, ".omp", "plans", "WORDS_COUNTER_PLAN.md");
+		expect(await Bun.file(saved).text()).toBe("# Words Counter\n\nFile contents.");
+		expect(session.planModeState).toBeUndefined();
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("plan-proposal handler approves and notes autosave failure without the path", async () => {
+		const harness = await createHarness();
+		Settings.instance.set("plan.enabled", true);
+		const blocker = path.join(harness.cwdA, "blocker");
+		await Bun.write(blocker, "x");
+		Settings.instance.set("plan.autosave", true);
+		Settings.instance.set("plan.autosaveDir", path.join(blocker, "sub"));
+
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+
+		const localOptions = {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		};
+		cleanupRoots.push(resolveLocalUrlToPath("local://", localOptions));
+		const planPath = resolveLocalUrlToPath("local://words-counter-plan.md", localOptions);
+		await Bun.write(planPath, "# Words Counter\n\nFile contents.");
+
+		const handler = session.planProposalHandler!;
+		const result = (await handler("words-counter")) as {
+			content: Array<{ type: string; text: string }>;
+		};
+		const text = result.content[0]?.text ?? "";
+
+		expect(text).toMatch(/Plan approved/);
+		expect(text).toMatch(/autosave failed/);
+		expect(text).not.toContain(harness.cwdA);
+		expect(session.planModeState).toBeUndefined();
+		expect(session.planReferencePath).toBe("local://words-counter-plan.md");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
 
 	it("plan-proposal handler treats dismissed elicitation as refine, never approves", async () => {
 		// Regression for the P1 review finding on #1870: when a form-capable

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -14,7 +14,8 @@ import {
 	type PlanReviewAnnotationState,
 	PlanReviewOverlay,
 } from "@oh-my-pi/pi-coding-agent/modes/components/plan-review-overlay";
-import { InteractiveMode, planSaveFileName } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { planSaveFileName } from "@oh-my-pi/pi-coding-agent/plan-mode/plan-autosave";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -1643,6 +1644,61 @@ describe("InteractiveMode plan review rendering", () => {
 			planFilePath,
 			reentry: true,
 		});
+	});
+	it("autosaves the approved plan when plan.autosave is enabled", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nAutosave me.");
+
+		await mode.handlePlanModeCommand();
+		session.settings.set("plan.autosave", true);
+
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+		const status = vi.spyOn(mode, "showStatus");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "AUTOSAVE",
+		});
+
+		const saved = path.join(tempDir.path(), ".omp", "plans", "AUTOSAVE_PLAN.md");
+		expect(await Bun.file(saved).text()).toBe("# Plan\n\nAutosave me.");
+		expect(status).toHaveBeenCalledWith(expect.stringContaining("Saved plan to"));
+	});
+
+	it("continues approval with a warning when autosave fails", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nAutosave me.");
+
+		await mode.handlePlanModeCommand();
+		session.settings.set("plan.autosave", true);
+		const blocker = path.join(tempDir.path(), "blocker");
+		await Bun.write(blocker, "x");
+		session.settings.set("plan.autosaveDir", path.join(blocker, "sub"));
+
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+		const warning = vi.spyOn(mode, "showWarning");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "AUTOSAVE",
+		});
+
+		expect(promptSpy.mock.calls.some(isPlanApprovedCall)).toBe(true);
+		expect(warning).toHaveBeenCalledWith(expect.stringContaining("Failed to autosave plan"));
 	});
 
 	it("Approve and compact context: ok outcome dispatches plan-approved after compaction", async () => {

--- a/packages/coding-agent/test/plan-autosave.test.ts
+++ b/packages/coding-agent/test/plan-autosave.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { SETTINGS_SCHEMA } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
 import {
 	autosaveApprovedPlan,
 	defaultPlanAutosaveDir,
@@ -12,9 +12,15 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 
 let tempDir: TempDir | undefined;
 
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
 afterEach(() => {
 	tempDir?.removeSync();
 	tempDir = undefined;
+	resetSettingsForTest();
 });
 
 function makeCwd(): string {
@@ -22,20 +28,24 @@ function makeCwd(): string {
 	return tempDir.path();
 }
 
-describe("plan autosave settings", () => {
-	it("registers autosave under Tasks > Modes, gated on plan mode", () => {
-		expect(SETTINGS_SCHEMA["plan.autosave"].default).toBe(false);
-		expect(SETTINGS_SCHEMA["plan.autosave"].ui).toMatchObject({
-			tab: "tasks",
-			group: "Modes",
-			condition: "planModeEnabled",
-		});
-		expect(SETTINGS_SCHEMA["plan.autosaveDir"].default).toBeUndefined();
-		expect(SETTINGS_SCHEMA["plan.autosaveDir"].ui).toMatchObject({
-			tab: "tasks",
-			group: "Modes",
-			condition: "planAutosaveEnabled",
-		});
+describe("plan autosave settings UI", () => {
+	it("gates the autosave directory on plan.autosave", () => {
+		const defs = getSettingsForTab("tasks");
+		const autosave = defs.find(def => def.path === "plan.autosave");
+		const autosaveDir = defs.find(def => def.path === "plan.autosaveDir");
+		if (!autosave?.condition || !autosaveDir?.condition) {
+			throw new Error("plan autosave settings should be gated on plan mode");
+		}
+		// Fresh defaults: plan mode on, autosave off.
+		expect(autosave.condition()).toBe(true);
+		expect(autosaveDir.condition()).toBe(false);
+
+		Settings.instance.set("plan.autosave", true);
+		expect(autosaveDir.condition()).toBe(true);
+
+		Settings.instance.set("plan.enabled", false);
+		expect(autosave.condition()).toBe(false);
+		expect(autosaveDir.condition()).toBe(false);
 	});
 });
 
@@ -100,6 +110,18 @@ describe("autosaveApprovedPlan", () => {
 		expect(second).toBe(path.join(cwd, ".omp", "plans", "AUTH_PLAN-1.md"));
 		expect(await Bun.file(first!).text()).toBe("# v1\n");
 		expect(await Bun.file(second!).text()).toBe("# v2\n");
+	});
+	it("keeps both plans when same-titled approvals race", async () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated({ "plan.autosave": true });
+		const [first, second] = await Promise.all([
+			autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "# v1\n" }),
+			autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "# v2\n" }),
+		]);
+		expect(new Set([first, second]).size).toBe(2);
+		expect(new Set([await Bun.file(first!).text(), await Bun.file(second!).text()])).toEqual(
+			new Set(["# v1\n", "# v2\n"]),
+		);
 	});
 
 	it("skips empty plans", async () => {

--- a/packages/coding-agent/test/plan-autosave.test.ts
+++ b/packages/coding-agent/test/plan-autosave.test.ts
@@ -4,10 +4,12 @@ import * as path from "node:path";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import * as modes from "@oh-my-pi/pi-coding-agent/modes";
 import { getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
 import {
 	autosaveApprovedPlan,
 	defaultPlanAutosaveDir,
+	planSaveFileName,
 	resolvePlanAutosaveDir,
 } from "@oh-my-pi/pi-coding-agent/plan-mode/plan-autosave";
 import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
@@ -52,6 +54,9 @@ describe("plan autosave settings UI", () => {
 		Settings.instance.set("plan.enabled", false);
 		expect(autosave.condition()).toBe(false);
 		expect(autosaveDir.condition()).toBe(false);
+	});
+	it("stays reachable from the public modes barrel", () => {
+		expect(modes.planSaveFileName).toBe(planSaveFileName);
 	});
 });
 

--- a/packages/coding-agent/test/plan-autosave.test.ts
+++ b/packages/coding-agent/test/plan-autosave.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
 import {
 	autosaveApprovedPlan,
 	defaultPlanAutosaveDir,
 	resolvePlanAutosaveDir,
 } from "@oh-my-pi/pi-coding-agent/plan-mode/plan-autosave";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
+import type { PlanYolo } from "@oh-my-pi/pi-coding-agent/session/agent-session-types";
+import { PrewalkCoordinator, type PrewalkCoordinatorHost } from "@oh-my-pi/pi-coding-agent/session/prewalk";
+import type { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 let tempDir: TempDir | undefined;
@@ -129,5 +135,108 @@ describe("autosaveApprovedPlan", () => {
 		const settings = Settings.isolated({ "plan.autosave": true });
 		const result = await autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "  \n" });
 		expect(result).toBeNull();
+	});
+});
+
+describe("plan-yolo approval autosave", () => {
+	const target = buildModel({
+		id: "test-plan-target",
+		name: "Test Plan Target",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	});
+
+	function setupPlanYolo(cwd: string, artifactsDir: string, settings: Settings) {
+		const notices: Array<{ level: "info" | "warning" | "error"; message: string; source?: string }> = [];
+		const modelTemporaryCalls: unknown[][] = [];
+		let capturedHandler: ((title: string) => Promise<unknown>) | undefined;
+		let planModeState: PlanModeState | undefined;
+		const localOptions = { getArtifactsDir: () => artifactsDir, getSessionId: () => "test-session" };
+		const host: PrewalkCoordinatorHost = {
+			agent: { steer: () => {} } as unknown as PrewalkCoordinatorHost["agent"],
+			sessionManager: { getCwd: () => cwd } as unknown as SessionManager,
+			settings,
+			model: () => undefined,
+			configuredThinkingLevel: () => undefined,
+			emitNotice: (level, message, source) => {
+				notices.push({ level, message, source });
+			},
+			setModelTemporary: async (...args: unknown[]) => {
+				modelTemporaryCalls.push(args);
+			},
+			setActiveToolsByName: async () => {},
+			restoreNonMCPToolPresentation: async () => {},
+			getActiveToolNames: () => [],
+			getEnabledToolNames: () => [],
+			getMountedXdevToolNames: () => [],
+			hasBuiltInTool: () => false,
+			getPlanModeState: () => planModeState,
+			setPlanModeState: state => {
+				planModeState = state;
+			},
+			getPlanReferencePath: () => "",
+			setPlanProposalHandler: handler => {
+				capturedHandler = handler ?? undefined;
+			},
+			waitForSessionMessagePersistence: async () => {},
+			localProtocolOptions: () => localOptions,
+		};
+		return { host, notices, modelTemporaryCalls, localOptions, getHandler: () => capturedHandler };
+	}
+
+	it("autosaves the approved plan and preserves the plan-yolo transition", async () => {
+		const cwd = makeCwd();
+		const artifactsDir = path.join(cwd, "artifacts");
+		const settings = Settings.isolated({ "plan.autosave": true });
+		const t = setupPlanYolo(cwd, artifactsDir, settings);
+		const coordinator = new PrewalkCoordinator(t.host, { planYolo: { target } satisfies PlanYolo });
+		await coordinator.armPlanYoloIfNeeded();
+		const planPath = resolveLocalUrlToPath("local://auth-plan.md", t.localOptions);
+		await Bun.write(planPath, "# Plan\n\nYolo.\n");
+		const handler = t.getHandler();
+		if (!handler) throw new Error("expected a plan proposal handler");
+		const result = (await handler("auth")) as {
+			content: Array<{ type: string; text: string }>;
+			details: { planFilePath: string; title: string; planExists: boolean };
+		};
+		expect(result.details).toMatchObject({ planFilePath: "local://auth-plan.md", title: "auth", planExists: true });
+		expect(result.content[0]?.text).toBe(`Plan approved. Implementing now with ${target.id}.`);
+		expect(result.content[0]?.text).not.toContain(cwd);
+		expect(await Bun.file(path.join(cwd, ".omp", "plans", "AUTH_PLAN.md")).text()).toBe("# Plan\n\nYolo.\n");
+		expect(t.notices).toContainEqual({
+			level: "info",
+			message: expect.stringContaining("Plan autosaved to"),
+			source: "plan-yolo",
+		});
+		expect(t.modelTemporaryCalls.length).toBe(1);
+	});
+
+	it("warns the operator but still implements when autosave fails", async () => {
+		const cwd = makeCwd();
+		const artifactsDir = path.join(cwd, "artifacts");
+		const blocker = path.join(cwd, "blocker");
+		await Bun.write(blocker, "x");
+		const settings = Settings.isolated({ "plan.autosave": true, "plan.autosaveDir": path.join(blocker, "sub") });
+		const t = setupPlanYolo(cwd, artifactsDir, settings);
+		const coordinator = new PrewalkCoordinator(t.host, { planYolo: { target } satisfies PlanYolo });
+		await coordinator.armPlanYoloIfNeeded();
+		const planPath = resolveLocalUrlToPath("local://auth-plan.md", t.localOptions);
+		await Bun.write(planPath, "# Plan\n\nYolo.\n");
+		const handler = t.getHandler();
+		if (!handler) throw new Error("expected a plan proposal handler");
+		const result = (await handler("auth")) as { content: Array<{ type: string; text: string }> };
+		expect(result.content[0]?.text).toBe(`Plan approved. Implementing now with ${target.id}.`);
+		expect(t.modelTemporaryCalls.length).toBe(1);
+		expect(t.notices).toContainEqual({
+			level: "warning",
+			message: expect.stringContaining("Plan autosave failed"),
+			source: "plan-yolo",
+		});
 	});
 });

--- a/packages/coding-agent/test/plan-autosave.test.ts
+++ b/packages/coding-agent/test/plan-autosave.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SETTINGS_SCHEMA } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import {
+	autosaveApprovedPlan,
+	defaultPlanAutosaveDir,
+	resolvePlanAutosaveDir,
+} from "@oh-my-pi/pi-coding-agent/plan-mode/plan-autosave";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+let tempDir: TempDir | undefined;
+
+afterEach(() => {
+	tempDir?.removeSync();
+	tempDir = undefined;
+});
+
+function makeCwd(): string {
+	tempDir = TempDir.createSync("@pi-plan-autosave-");
+	return tempDir.path();
+}
+
+describe("plan autosave settings", () => {
+	it("registers autosave under Tasks > Modes, gated on plan mode", () => {
+		expect(SETTINGS_SCHEMA["plan.autosave"].default).toBe(false);
+		expect(SETTINGS_SCHEMA["plan.autosave"].ui).toMatchObject({
+			tab: "tasks",
+			group: "Modes",
+			condition: "planModeEnabled",
+		});
+		expect(SETTINGS_SCHEMA["plan.autosaveDir"].default).toBeUndefined();
+		expect(SETTINGS_SCHEMA["plan.autosaveDir"].ui).toMatchObject({
+			tab: "tasks",
+			group: "Modes",
+			condition: "planAutosaveEnabled",
+		});
+	});
+});
+
+describe("resolvePlanAutosaveDir", () => {
+	it("defaults to <project>/.omp/plans when unset", () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated();
+		expect(resolvePlanAutosaveDir(settings, cwd)).toBe(path.join(cwd, ".omp", "plans"));
+		expect(defaultPlanAutosaveDir(cwd)).toBe(path.join(cwd, ".omp", "plans"));
+	});
+
+	it("resolves absolute, tilde, and cwd-relative custom dirs", () => {
+		const cwd = makeCwd();
+		expect(resolvePlanAutosaveDir(Settings.isolated({ "plan.autosaveDir": path.join(cwd, "custom") }), cwd)).toBe(
+			path.join(cwd, "custom"),
+		);
+		expect(resolvePlanAutosaveDir(Settings.isolated({ "plan.autosaveDir": "~/my-plans" }), cwd)).toBe(
+			path.join(os.homedir(), "my-plans"),
+		);
+		expect(resolvePlanAutosaveDir(Settings.isolated({ "plan.autosaveDir": "docs/plans" }), cwd)).toBe(
+			path.join(cwd, "docs", "plans"),
+		);
+		expect(resolvePlanAutosaveDir(Settings.isolated({ "plan.autosaveDir": "   " }), cwd)).toBe(
+			path.join(cwd, ".omp", "plans"),
+		);
+	});
+});
+
+describe("autosaveApprovedPlan", () => {
+	it("writes nothing when autosave is disabled", async () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated();
+		const result = await autosaveApprovedPlan({
+			settings,
+			cwd,
+			title: "Auth",
+			planContent: "# Plan\n",
+		});
+		expect(result).toBeNull();
+		expect(await Bun.file(path.join(cwd, ".omp", "plans", "AUTH_PLAN.md")).exists()).toBe(false);
+	});
+
+	it("saves the approved plan under the default dir", async () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated({ "plan.autosave": true });
+		const result = await autosaveApprovedPlan({
+			settings,
+			cwd,
+			title: "Auth storage",
+			planContent: "# Plan\n\nShip it.\n",
+		});
+		expect(result).toBe(path.join(cwd, ".omp", "plans", "AUTH_STORAGE_PLAN.md"));
+		expect(await Bun.file(result!).text()).toBe("# Plan\n\nShip it.\n");
+	});
+
+	it("suffices colliding filenames instead of overwriting", async () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated({ "plan.autosave": true });
+		const first = await autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "# v1\n" });
+		const second = await autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "# v2\n" });
+		expect(first).toBe(path.join(cwd, ".omp", "plans", "AUTH_PLAN.md"));
+		expect(second).toBe(path.join(cwd, ".omp", "plans", "AUTH_PLAN-1.md"));
+		expect(await Bun.file(first!).text()).toBe("# v1\n");
+		expect(await Bun.file(second!).text()).toBe("# v2\n");
+	});
+
+	it("skips empty plans", async () => {
+		const cwd = makeCwd();
+		const settings = Settings.isolated({ "plan.autosave": true });
+		const result = await autosaveApprovedPlan({ settings, cwd, title: "Auth", planContent: "  \n" });
+		expect(result).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

A few users asked for a way to keep their plan-mode plans, so this adds an opt-in setting that automatically saves approved plans to disk.

Adds `plan.autosave` (default off) and `plan.autosaveDir` settings; when enabled, approving a plan saves a copy to `<project>/.omp/plans/` (or the custom dir — `~`/absolute/cwd-relative supported, filename collisions suffixed). Wired into interactive, ACP, and plan-yolo approval paths; autosave failures warn without blocking approval.

## Why

Plans previously lived only in session artifacts and were lost on clear/compact; autosave keeps finished plans on disk automatically, with a user-configurable location.

## Testing

- `bun run check:ts` passes on the PR branch (lint + format + typecheck).
- New `test/plan-autosave.test.ts`: 7 pass (schema placement/gating, dir-resolution branches, disabled-writes-nothing, default-dir save, collision suffix, empty-plan skip).
- Regression on the PR branch: prewalk suites 21 pass; `planSaveFileName` 3 pass; settings-layout 10 pass; plan-review 59/60 (one pre-existing Windows-only `#!/bin/sh` $EDITOR timeout, untouched by this change); acp-agent 76/77 (one pre-existing Windows EBUSY temp-cleanup flake).
- Not exercised end-to-end in a live TUI session.

---

- [x] `bun check` passes (TS half; Rust half not run — no Rust code touched)
- [ ] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
