### PR TITLE
fix(catalog): stopped serving deepseek v4.1 flash as text-only

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Added dated, announced price changes to the catalog, so rates switch on their effective date (e.g. DeepSeek Pro moving to Flash rates).
 
 - Added Command Code as a built-in provider with API-key login, live model discovery, per-model pricing, native OpenAI/Anthropic-compatible routing, cache-aware token usage, and TTFT metrics ([#11391](https://github.com/can1357/oh-my-pi/pull/11391) by [@CherkaSSH](https://github.com/CherkaSSH)).
+
+### Fixed
+
+- Fixed DeepSeek V4.1 Flash (`deepseek-flash`, and the `deepseek-v4-flash`/`-free` ids routed to it on DeepSeek and the OpenCode Zen/Go gateways) being served as text-only; its native image input is now accepted instead of stripped to a separate vision model ([#11602](https://github.com/can1357/oh-my-pi/issues/11602)).
+
 ## [18.1.16] - 2026-09-09
 
 - Updated Fire Pass (`firepass`) login validation probe to `accounts/fireworks/routers/glm-5p2-fast` and bundled `glm-5.2-fast` and `kimi-k3-fast` models in place of decommissioned `kimi-k2.6-turbo` ([#10859](https://github.com/can1357/oh-my-pi/pull/10859) by [@olegpulatov](https://github.com/olegpulatov)).

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4575,7 +4575,50 @@
 				}
 			},
 			{
-				"source": "classes/deepseek.kdl:76",
+				"source": "classes/deepseek.kdl:82",
+				"class": "deepseek",
+				"providers": [
+					"deepseek",
+					"opencode-go",
+					"opencode-zen"
+				],
+				"family": "flash",
+				"wire": {
+					"stripImageInput": false
+				},
+				"catalog": {
+					"inputModalities": [
+						"text",
+						"image"
+					]
+				}
+			},
+			{
+				"source": "classes/deepseek.kdl:86",
+				"class": "deepseek",
+				"providers": [
+					"deepseek",
+					"opencode-go",
+					"opencode-zen"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "deepseek-flash"
+					}
+				],
+				"wire": {
+					"stripImageInput": false
+				},
+				"catalog": {
+					"inputModalities": [
+						"text",
+						"image"
+					]
+				}
+			},
+			{
+				"source": "classes/deepseek.kdl:91",
 				"class": "deepseek",
 				"providers": [
 					"ollama-cloud",

--- a/packages/catalog/src/compat/rules/classes/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/classes/deepseek.kdl
@@ -73,6 +73,21 @@ class "deepseek" {
 	models token="vision" {
 		strip-image-input #false
 	}
+	// DeepSeek V4.1 Flash (2026-09-10) is natively multimodal. It serves as
+	// `deepseek-flash`, and the retired `deepseek-v4-flash*` ids are routed to
+	// it on the first-party API and the OpenCode partner gateways. Upstream
+	// discovery still reports these SKUs as text-only, so opt image input back
+	// in and clear the class-wide text-only strip for those hosts.
+	on "deepseek" "opencode-go" "opencode-zen" {
+		family "flash" {
+			input-modalities "text" "image"
+			strip-image-input #false
+		}
+		models "deepseek-flash" {
+			input-modalities "text" "image"
+			strip-image-input #false
+		}
+	}
 	on "ollama-cloud" "nvidia" "deepseek" "fireworks" "nanogpt" "opencode-go" "openrouter" {
 		stream-markup-healing-pattern "dsml"
 	}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -70164,7 +70164,8 @@
 			"baseUrl": "https://api.deepseek.com",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.3,
@@ -70260,7 +70261,7 @@
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
@@ -70276,7 +70277,8 @@
 			"baseUrl": "https://api.deepseek.com",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.3,
@@ -70365,7 +70367,7 @@
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
@@ -261875,7 +261877,8 @@
 			"baseUrl": "https://opencode.ai/zen/go/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.22,
@@ -261914,7 +261917,7 @@
 				"supportsAllTurnsReasoningContext": false,
 				"supportsConfigurationUpdate": false,
 				"requiresReasoningOffJuiceInstruction": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"reasoningEffortMap": {},
 				"supportsReasoningParams": true,
@@ -267410,7 +267413,8 @@
 			"baseUrl": "https://opencode.ai/zen/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.14,
@@ -267486,7 +267490,7 @@
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
@@ -267556,7 +267560,8 @@
 			"baseUrl": "https://opencode.ai/zen/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -267629,7 +267634,7 @@
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -449,6 +449,40 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("restores native image input for DeepSeek V4.1 Flash SKUs on first-party and OpenCode hosts", () => {
+		// V4.1 Flash (served as `deepseek-flash`, with the retired
+		// `deepseek-v4-flash*` ids routed to it) is natively multimodal; upstream
+		// discovery still reports these SKUs as text-only, and the DeepSeek class
+		// otherwise strips image input class-wide. Rule-owned
+		// (`classes/deepseek.kdl` input-modalities + strip-image-input).
+		const visionModels = (
+			[
+				["deepseek", "deepseek-flash"],
+				["deepseek", "deepseek-v4-flash"],
+				["opencode-go", "deepseek-v4-flash"],
+				["opencode-zen", "deepseek-v4-flash"],
+				["opencode-zen", "deepseek-v4-flash-free"],
+			] as const
+		).map(([provider, id]) => buildGenerated(createSpec({ id, api: "openai-completions", provider })));
+		for (const model of visionModels) {
+			expect(model.input).toEqual(["text", "image"]);
+			expect(model.compat.stripImageInput).toBe(false);
+		}
+
+		// Non-flash DeepSeek SKUs (and flash on unlisted resellers) keep the
+		// class-wide text-only strip.
+		const textOnlyModels = (
+			[
+				["deepseek", "deepseek-v4-pro"],
+				["fireworks", "deepseek-v4-flash"],
+			] as const
+		).map(([provider, id]) => buildGenerated(createSpec({ id, api: "openai-completions", provider })));
+		for (const model of textOnlyModels) {
+			expect(model.input).toEqual(["text"]);
+			expect(model.compat.stripImageInput).toBe(true);
+		}
+	});
+
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {
 		const models = [
 			createSpec({


### PR DESCRIPTION
## Repro
`deepseek-flash` / `deepseek-v4-flash` on the `deepseek`, `opencode-zen`, and `opencode-go` providers are cataloged as text-only, so `isOpenAICompletionsVisionSupported` returns false, images are stripped, and the agent hands off to a separate vision model. Reproduced against the bundled catalog:

```
bun -e "import { getBundledModel } from './src/models.ts'; import { isOpenAICompletionsVisionSupported } from '../ai/src/providers/vision-guard.ts'; for (const [p,id] of [['deepseek','deepseek-flash'],['opencode-zen','deepseek-v4-flash'],['opencode-go','deepseek-v4-flash']]) { const m=getBundledModel(p,id); console.log(p+'/'+id+': input='+JSON.stringify(m.input)+' strip='+m.compat?.stripImageInput+' native='+isOpenAICompletionsVisionSupported(m)); }"
# deepseek/deepseek-flash:        input=["text"] strip=true native=false
# opencode-zen/deepseek-v4-flash: input=["text"] strip=true native=false
# opencode-go/deepseek-v4-flash:  input=["text"] strip=true native=false
```

## Cause
The `deepseek` class rule in `packages/catalog/src/compat/rules/classes/deepseek.kdl` sets `strip-image-input #true` for the whole class and only exempts ids tokened `vision`/`ocr`, while upstream discovery reports these SKUs as text-only. That was correct for the V4 era where Flash was text-only and vision was the separate `-vision-exp` SKU. DeepSeek's [2026-09-10 release](https://www.deepseek.com/news/deepseek-v4-1-flash/) makes V4.1 Flash natively multimodal — served as `deepseek-flash`, with the retired `deepseek-v4-flash`/`-vision-exp` ids routed to it, and OpenCode named an official partner — so the guard now overreaches. The pricing/limits half of the V4.1 Flash catalog update already landed; only the modality was missed.

## Fix
- `classes/deepseek.kdl`: on `deepseek`, `opencode-go`, and `opencode-zen`, opt the `flash` family and the bare `deepseek-flash` alias back into image input via `input-modalities "text" "image"` and `strip-image-input #false`. Non-flash DeepSeek SKUs and flash on unlisted resellers keep the class-wide text-only strip.
- Regenerated `compat/rules.json` (`bun run gen:compat`).
- Applied the resulting `input`/`stripImageInput` deltas to the five affected `models.json` entries (`deepseek-flash`, `deepseek-v4-flash` on deepseek/opencode-go/opencode-zen, `deepseek-v4-flash-free` on opencode-zen).
- Added a regression test asserting the flash SKUs are multimodal while `deepseek-v4-pro` and reseller flash stay text-only.

## Verification
`cd packages/catalog && bun test` → 920 pass, 0 fail (includes the new `generated-policies` case). Post-fix repro shows `native=true` for the flash SKUs and `native=false` for `deepseek-v4-pro`. `bun run fix` + `bun check` ran clean via the pre-publish gate.

Fixes #11602