### PR TITLE
fix(coding-agent): preserve mixed provider model routes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Built-in models now retain their catalog endpoint when a custom model under the same provider uses another API, preventing provider-level URLs from routing mixed models incorrectly ([#11608](https://github.com/can1357/oh-my-pi/pull/11608) by [@danilouchoa](https://github.com/danilouchoa)).
+- Provider `baseUrl` overrides now scope by API: custom models inheriting the provider URL define which APIs it covers (a provider-level `api` covers override-only providers), `transport: pi-native` keeps its gateway `baseUrl` provider-wide, and a bundled model no longer routes to another API's endpoint ([#11608](https://github.com/can1357/oh-my-pi/pull/11608) by [@danilouchoa](https://github.com/danilouchoa)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Built-in models now retain their catalog endpoint when a custom model under the same provider uses another API, preventing provider-level URLs from routing mixed models incorrectly ([#11608](https://github.com/can1357/oh-my-pi/pull/11608) by [@danilouchoa](https://github.com/danilouchoa)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -9,8 +9,10 @@ import type { ModelOverride } from "./models-config-schema";
 /** Provider override config (baseUrl, headers, apiKey, compat, transport). */
 export interface ProviderOverride {
 	baseUrl?: string;
-	/** Restricts a provider baseUrl to one custom model API; null means multiple APIs are configured. */
-	api?: Api | null;
+	/** APIs covered by the provider `baseUrl`: effective APIs of custom models
+	 * inheriting that URL, plus a provider-level `api` for override-only
+	 * configs. `undefined` preserves the historical provider-wide override. */
+	baseUrlApis?: readonly Api[];
 	headers?: Record<string, string>;
 	apiKey?: string;
 	authHeader?: boolean;
@@ -21,6 +23,28 @@ export interface ProviderOverride {
 	guardrailVersion?: Model<Api>["guardrailVersion"];
 	guardrailTrace?: Model<Api>["guardrailTrace"];
 	requestMetadata?: Model<Api>["requestMetadata"];
+}
+
+/**
+ * Single decision point for provider `baseUrl` application, shared by every
+ * composition path (built-in load, cached load, discovery merge, runtime
+ * overrides). `undefined` `baseUrlApis` keeps the historical provider-wide
+ * override; an explicit scope applies only to models whose API it covers.
+ * `transport: "pi-native"` is provider-wide by documented contract
+ * (docs/models.md): every model under the provider rides the auth-gateway,
+ * so the gateway `baseUrl` follows the transport regardless of the model's
+ * own API — a model must never end up pi-native on a catalog upstream host
+ * (#2555).
+ */
+export function resolveProviderBaseUrl<TApi extends Api>(
+	modelApi: TApi,
+	modelBaseUrl: string | undefined,
+	override: Pick<ProviderOverride, "baseUrl" | "baseUrlApis" | "transport"> | undefined,
+): string | undefined {
+	if (override?.baseUrl === undefined) return modelBaseUrl;
+	if (override.transport === "pi-native") return override.baseUrl;
+	if (override.baseUrlApis !== undefined && !override.baseUrlApis.includes(modelApi)) return modelBaseUrl;
+	return override.baseUrl;
 }
 
 /**
@@ -64,18 +88,14 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	existing: Model<Api> | undefined,
 	providerOverride?: Pick<
 		ProviderOverride,
-		"baseUrl" | "api" | "compat" | "headers" | "remoteCompaction" | "transport" | "authHeader" | "apiKey"
+		"baseUrl" | "baseUrlApis" | "compat" | "headers" | "remoteCompaction" | "transport" | "authHeader" | "apiKey"
 	>,
 ): Model<TApi> {
-	const matchesConfiguredApi = providerOverride?.api === undefined || providerOverride.api === model.api;
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
 		return buildModel({
 			...toModelSpec(model),
-			baseUrl:
-				providerOverride?.baseUrl !== undefined && matchesConfiguredApi
-					? providerOverride.baseUrl
-					: (model.baseUrl ?? existing.baseUrl),
+			baseUrl: resolveProviderBaseUrl(model.api, model.baseUrl ?? existing.baseUrl, providerOverride),
 			// providerOverride.headers (raw `!command`) must be the last live
 			// source: `model.headers` is a discovery-time resolved snapshot, so
 			// without this a rotated credential (401 → cache invalidation) would
@@ -96,8 +116,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	if (providerOverride) {
 		return buildModel({
 			...toModelSpec(model),
-			baseUrl:
-				providerOverride.baseUrl !== undefined && matchesConfiguredApi ? providerOverride.baseUrl : model.baseUrl,
+			baseUrl: resolveProviderBaseUrl(model.api, model.baseUrl, providerOverride),
 			headers: createLiveConfigHeaders([model.headers, providerOverride.headers], {
 				authHeader: providerOverride.authHeader,
 				apiKeyConfig: providerOverride.apiKey,

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -6,11 +6,11 @@ import { toModelSpec } from "@oh-my-pi/pi-catalog/provider-models/bundled-refere
 import { isRecord } from "@oh-my-pi/pi-utils";
 import { createLiveConfigHeaders } from "./model-config-values";
 import type { ModelOverride } from "./models-config-schema";
-/** Provider override config (baseUrl, headers, apiKey, compat, transport) without custom models */
+/** Provider override config (baseUrl, headers, apiKey, compat, transport). */
 export interface ProviderOverride {
 	baseUrl?: string;
-	/** Restricts a provider baseUrl inferred from a single custom model API. */
-	api?: Api;
+	/** Restricts a provider baseUrl to one custom model API; null means multiple APIs are configured. */
+	api?: Api | null;
 	headers?: Record<string, string>;
 	apiKey?: string;
 	authHeader?: boolean;

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -9,6 +9,8 @@ import type { ModelOverride } from "./models-config-schema";
 /** Provider override config (baseUrl, headers, apiKey, compat, transport) without custom models */
 export interface ProviderOverride {
 	baseUrl?: string;
+	/** Restricts a provider baseUrl inferred from a single custom model API. */
+	api?: Api;
 	headers?: Record<string, string>;
 	apiKey?: string;
 	authHeader?: boolean;
@@ -62,14 +64,18 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	existing: Model<Api> | undefined,
 	providerOverride?: Pick<
 		ProviderOverride,
-		"baseUrl" | "compat" | "headers" | "remoteCompaction" | "transport" | "authHeader" | "apiKey"
+		"baseUrl" | "api" | "compat" | "headers" | "remoteCompaction" | "transport" | "authHeader" | "apiKey"
 	>,
 ): Model<TApi> {
+	const matchesConfiguredApi = providerOverride?.api === undefined || providerOverride.api === model.api;
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
 		return buildModel({
 			...toModelSpec(model),
-			baseUrl: providerOverride?.baseUrl ?? model.baseUrl ?? existing.baseUrl,
+			baseUrl:
+				providerOverride?.baseUrl !== undefined && matchesConfiguredApi
+					? providerOverride.baseUrl
+					: (model.baseUrl ?? existing.baseUrl),
 			// providerOverride.headers (raw `!command`) must be the last live
 			// source: `model.headers` is a discovery-time resolved snapshot, so
 			// without this a rotated credential (401 → cache invalidation) would
@@ -90,7 +96,8 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	if (providerOverride) {
 		return buildModel({
 			...toModelSpec(model),
-			baseUrl: providerOverride.baseUrl ?? model.baseUrl,
+			baseUrl:
+				providerOverride.baseUrl !== undefined && matchesConfiguredApi ? providerOverride.baseUrl : model.baseUrl,
 			headers: createLiveConfigHeaders([model.headers, providerOverride.headers], {
 				authHeader: providerOverride.authHeader,
 				apiKeyConfig: providerOverride.apiKey,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1357,6 +1357,8 @@ export class ModelRegistry {
 				if (modelApi) configuredApis.add(modelApi);
 			}
 			const [configuredApi] = [...configuredApis];
+			const providerOverrideApi =
+				configuredApis.size === 1 ? configuredApi : configuredApis.size > 1 ? null : undefined;
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/guardrail*/transport are present
 			if (
 				providerConfig.baseUrl ||
@@ -1372,7 +1374,7 @@ export class ModelRegistry {
 			) {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
-					api: configuredApis.size === 1 ? configuredApi : undefined,
+					api: providerOverrideApi,
 					baseUrl:
 						providerConfig.discovery?.type === "litellm"
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
@@ -2037,7 +2039,7 @@ export class ModelRegistry {
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
 		return {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
-			api: override.api ?? baseOverride?.api,
+			api: override.api !== undefined ? override.api : baseOverride?.api,
 			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
 			headers: override.headers

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1351,6 +1351,12 @@ export class ModelRegistry {
 			for (const modelDef of providerConfig.models ?? []) {
 				this.#collectCommandConfigValues(commandConfigs, undefined, modelDef.headers);
 			}
+			const configuredApis = new Set<Api>();
+			for (const modelDef of providerConfig.models ?? []) {
+				const modelApi = modelDef.api ?? providerConfig.api;
+				if (modelApi) configuredApis.add(modelApi);
+			}
+			const [configuredApi] = [...configuredApis];
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/guardrail*/transport are present
 			if (
 				providerConfig.baseUrl ||
@@ -1366,6 +1372,7 @@ export class ModelRegistry {
 			) {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
+					api: configuredApis.size === 1 ? configuredApi : undefined,
 					baseUrl:
 						providerConfig.discovery?.type === "litellm"
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
@@ -2030,6 +2037,7 @@ export class ModelRegistry {
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
 		return {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
+			api: override.api ?? baseOverride?.api,
 			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
 			headers: override.headers
@@ -2041,12 +2049,17 @@ export class ModelRegistry {
 		};
 	}
 	#applyProviderTransportOverride<
-		T extends { baseUrl?: string; headers?: Record<string, string>; remoteCompaction?: RemoteCompactionConfig<Api> },
+		T extends {
+			api: Api;
+			baseUrl?: string;
+			headers?: Record<string, string>;
+			remoteCompaction?: RemoteCompactionConfig<Api>;
+		},
 	>(
 		entry: T,
 		override: Pick<
 			ProviderOverride,
-			"baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
+			"api" | "baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
 		>,
 	): T {
 		const headers = mergeAuthHeaderSources(
@@ -2056,7 +2069,10 @@ export class ModelRegistry {
 		);
 		return {
 			...entry,
-			baseUrl: override.baseUrl ?? entry.baseUrl,
+			baseUrl:
+				override.baseUrl !== undefined && (override.api === undefined || override.api === entry.api)
+					? override.baseUrl
+					: entry.baseUrl,
 			headers,
 			// Preserve the model's existing transport when the override omits one;
 			// providers without a `transport` field keep the default per-API dispatch.
@@ -2068,7 +2084,7 @@ export class ModelRegistry {
 		model: Model<Api>,
 		override: Pick<
 			ProviderOverride,
-			"baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
+			"api" | "baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
 		>,
 	): Model<Api> {
 		return buildModel(this.#applyProviderTransportOverride(toModelSpec(model), override));

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -92,6 +92,7 @@ import {
 	mergeDiscoveredModel,
 	mergeProviderRemoteCompactionConfig,
 	mergeRemoteCompactionConfig,
+	resolveProviderBaseUrl,
 	type ProviderOverride,
 	providersWithAuthoritativeProjectCatalog,
 } from "./model-patch";
@@ -1351,14 +1352,18 @@ export class ModelRegistry {
 			for (const modelDef of providerConfig.models ?? []) {
 				this.#collectCommandConfigValues(commandConfigs, undefined, modelDef.headers);
 			}
-			const configuredApis = new Set<Api>();
+			// Scope: effective APIs of models inheriting the provider URL; a
+			// provider-level api covers the override-only case; none is wide.
+			const baseUrlApis = new Set<Api>();
 			for (const modelDef of providerConfig.models ?? []) {
+				if (modelDef.baseUrl) continue;
 				const modelApi = modelDef.api ?? providerConfig.api;
-				if (modelApi) configuredApis.add(modelApi);
+				if (modelApi) baseUrlApis.add(modelApi);
 			}
-			const [configuredApi] = [...configuredApis];
-			const providerOverrideApi =
-				configuredApis.size === 1 ? configuredApi : configuredApis.size > 1 ? null : undefined;
+			if (providerConfig.api && (providerConfig.models?.length ?? 0) === 0) {
+				baseUrlApis.add(providerConfig.api);
+			}
+			const baseUrlScope = baseUrlApis.size > 0 ? [...baseUrlApis] : undefined;
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/guardrail*/transport are present
 			if (
 				providerConfig.baseUrl ||
@@ -1374,7 +1379,7 @@ export class ModelRegistry {
 			) {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
-					api: providerOverrideApi,
+					baseUrlApis: baseUrlScope,
 					baseUrl:
 						providerConfig.discovery?.type === "litellm"
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
@@ -2039,7 +2044,7 @@ export class ModelRegistry {
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
 		return {
 			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
-			api: override.api !== undefined ? override.api : baseOverride?.api,
+			baseUrlApis: override.baseUrlApis ?? baseOverride?.baseUrlApis,
 			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			authHeader: override.authHeader ?? baseOverride?.authHeader,
 			headers: override.headers
@@ -2061,7 +2066,7 @@ export class ModelRegistry {
 		entry: T,
 		override: Pick<
 			ProviderOverride,
-			"api" | "baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
+			"baseUrl" | "baseUrlApis" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
 		>,
 	): T {
 		const headers = mergeAuthHeaderSources(
@@ -2071,10 +2076,7 @@ export class ModelRegistry {
 		);
 		return {
 			...entry,
-			baseUrl:
-				override.baseUrl !== undefined && (override.api === undefined || override.api === entry.api)
-					? override.baseUrl
-					: entry.baseUrl,
+			baseUrl: resolveProviderBaseUrl(entry.api, entry.baseUrl, override),
 			headers,
 			// Preserve the model's existing transport when the override omits one;
 			// providers without a `transport` field keep the default per-API dispatch.
@@ -2086,7 +2088,7 @@ export class ModelRegistry {
 		model: Model<Api>,
 		override: Pick<
 			ProviderOverride,
-			"api" | "baseUrl" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
+			"baseUrl" | "baseUrlApis" | "headers" | "authHeader" | "apiKey" | "remoteCompaction" | "transport"
 		>,
 	): Model<Api> {
 		return buildModel(this.#applyProviderTransportOverride(toModelSpec(model), override));

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -9,7 +9,7 @@ import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { fingerprintStaticModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { calculateUsageCost, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { finalizeCustomModel } from "@oh-my-pi/pi-coding-agent/config/custom-models";
-import { applyModelPatch } from "@oh-my-pi/pi-coding-agent/config/model-patch";
+import { applyModelPatch, mergeDiscoveredModel } from "@oh-my-pi/pi-coding-agent/config/model-patch";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -808,6 +808,69 @@ describe("ModelRegistry", () => {
 			const compat = getOpenAICompat(model);
 			expect(compat?.supportsUsageInStreaming).toBe(true);
 			expect(compat?.maxTokensField).toBe("max_completion_tokens");
+		});
+	});
+
+	describe("mixed provider routes", () => {
+		let registry: ModelRegistry;
+
+		beforeAll(() => {
+			registry = readonlyRegistry({
+				providers: {
+					zai: {
+						baseUrl: "https://api.z.ai/api/anthropic",
+						apiKey: "TEST_KEY",
+						models: [
+							{
+								id: "glm-5.3",
+								api: "anthropic-messages",
+								name: "GLM-5.3",
+								reasoning: true,
+								input: ["text"],
+								cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+								contextWindow: 1_000_000,
+								maxTokens: 131_072,
+							},
+						],
+					},
+				},
+			});
+		});
+
+		test("keeps a built-in model route when a custom model uses another API", () => {
+			const flash = registry.find("zai", "glm-5.3-flash");
+			const glm53 = registry.find("zai", "glm-5.3");
+			expect(flash).toMatchObject({
+				api: "openai-completions",
+				baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			});
+			expect(glm53).toMatchObject({
+				api: "anthropic-messages",
+				baseUrl: "https://api.z.ai/api/anthropic",
+			});
+		});
+
+		test("keeps a discovered model route when the provider override uses another API", () => {
+			const model = buildModel({
+				id: "glm-5.3-flash",
+				name: "GLM-5.3 Flash",
+				api: "openai-completions",
+				provider: "zai",
+				baseUrl: "https://api.z.ai/api/coding/paas/v4",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+			});
+			const merged = mergeDiscoveredModel(model, model, {
+				api: "anthropic-messages",
+				baseUrl: "https://api.z.ai/api/anthropic",
+			});
+			expect(merged).toMatchObject({
+				api: "openai-completions",
+				baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			});
 		});
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -872,6 +872,44 @@ describe("ModelRegistry", () => {
 				baseUrl: "https://api.z.ai/api/coding/paas/v4",
 			});
 		});
+
+		test("does not apply an ambiguous provider route to built-in models", () => {
+			const multiApiRegistry = readonlyRegistry({
+				providers: {
+					zai: {
+						baseUrl: "https://api.z.ai/api/anthropic",
+						apiKey: "TEST_KEY",
+						models: [
+							{
+								id: "glm-anthropic",
+								api: "anthropic-messages",
+								name: "GLM Anthropic",
+								reasoning: true,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 1_000_000,
+								maxTokens: 131_072,
+							},
+							{
+								id: "glm-openai",
+								api: "openai-completions",
+								name: "GLM OpenAI",
+								reasoning: true,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 1_000_000,
+								maxTokens: 131_072,
+							},
+						],
+					},
+				},
+			});
+			const flash = multiApiRegistry.find("zai", "glm-5.3-flash");
+			expect(flash).toMatchObject({
+				api: "openai-completions",
+				baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			});
+		});
 	});
 
 	describe("custom models merge behavior", () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { fingerprintStaticModels } from "@oh-my-pi/pi-catalog/model-manager";
@@ -848,6 +849,60 @@ describe("ModelRegistry", () => {
 				api: "anthropic-messages",
 				baseUrl: "https://api.z.ai/api/anthropic",
 			});
+		});
+
+		test("preserves Z.AI streamed content through the final assistant message", async () => {
+			const flash = registry.find("zai", "glm-5.3-flash");
+			if (!flash || flash.api !== "openai-completions") {
+				throw new Error("expected the bundled Z.AI flash model to use OpenAI Completions");
+			}
+			const openAIFlash = flash as Model<"openai-completions">;
+			let requestUrl: string | undefined;
+			const fetchMock: FetchImpl = input => {
+				requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+				if (requestUrl !== "https://api.z.ai/api/coding/paas/v4/chat/completions") {
+					return Promise.resolve(
+						new Response(JSON.stringify({ code: 500, msg: "404_NOT_FOUND", success: false }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+					);
+				}
+				const events = [
+					{
+						id: "chatcmpl-zai-fixture",
+						choices: [{ index: 0, delta: { role: "assistant", reasoning_content: "thinking..." } }],
+					},
+					{
+						id: "chatcmpl-zai-fixture",
+						choices: [{ index: 0, delta: { role: "assistant", content: "OK" } }],
+					},
+					{
+						id: "chatcmpl-zai-fixture",
+						choices: [{ index: 0, finish_reason: "stop", delta: { role: "assistant", content: "" } }],
+						usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+					},
+				];
+				const payload = `${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+				return Promise.resolve(
+					new Response(payload, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+				);
+			};
+
+			const result = await streamOpenAICompletions(
+				openAIFlash,
+				{
+					messages: [{ role: "user", content: "Reply with exactly OK.", timestamp: Date.now() }],
+				},
+				{ apiKey: "TEST_KEY", fetch: fetchMock },
+			).result();
+
+			expect(requestUrl).toBe("https://api.z.ai/api/coding/paas/v4/chat/completions");
+			expect(result.content).toEqual(expect.arrayContaining([{ type: "text", text: "OK" }]));
+			expect(result.stopReason).toBe("stop");
 		});
 
 		test("keeps a discovered model route when the provider override uses another API", () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -838,25 +838,13 @@ describe("ModelRegistry", () => {
 			});
 		});
 
-		test("keeps a built-in model route when a custom model uses another API", () => {
-			const flash = registry.find("zai", "glm-5.3-flash");
-			const glm53 = registry.find("zai", "glm-5.3");
-			expect(flash).toMatchObject({
-				api: "openai-completions",
-				baseUrl: "https://api.z.ai/api/coding/paas/v4",
-			});
-			expect(glm53).toMatchObject({
-				api: "anthropic-messages",
-				baseUrl: "https://api.z.ai/api/anthropic",
-			});
-		});
-
 		test("preserves Z.AI streamed content through the final assistant message", async () => {
 			const flash = registry.find("zai", "glm-5.3-flash");
 			if (!flash || flash.api !== "openai-completions") {
 				throw new Error("expected the bundled Z.AI flash model to use OpenAI Completions");
 			}
 			const openAIFlash = flash as Model<"openai-completions">;
+			expect(openAIFlash.baseUrl).toBe("https://api.z.ai/api/coding/paas/v4");
 			let requestUrl: string | undefined;
 			const fetchMock: FetchImpl = input => {
 				requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -903,6 +891,10 @@ describe("ModelRegistry", () => {
 			expect(requestUrl).toBe("https://api.z.ai/api/coding/paas/v4/chat/completions");
 			expect(result.content).toEqual(expect.arrayContaining([{ type: "text", text: "OK" }]));
 			expect(result.stopReason).toBe("stop");
+			expect(registry.find("zai", "glm-5.3")).toMatchObject({
+				api: "anthropic-messages",
+				baseUrl: "https://api.z.ai/api/anthropic",
+			});
 		});
 
 		test("keeps a discovered model route when the provider override uses another API", () => {
@@ -919,7 +911,7 @@ describe("ModelRegistry", () => {
 				maxTokens: 131_072,
 			});
 			const merged = mergeDiscoveredModel(model, model, {
-				api: "anthropic-messages",
+				baseUrlApis: ["anthropic-messages"],
 				baseUrl: "https://api.z.ai/api/anthropic",
 			});
 			expect(merged).toMatchObject({
@@ -928,7 +920,7 @@ describe("ModelRegistry", () => {
 			});
 		});
 
-		test("does not apply an ambiguous provider route to built-in models", () => {
+		test("scopes multiple custom APIs sharing the provider baseUrl", () => {
 			const multiApiRegistry = readonlyRegistry({
 				providers: {
 					zai: {
@@ -960,9 +952,92 @@ describe("ModelRegistry", () => {
 				},
 			});
 			const flash = multiApiRegistry.find("zai", "glm-5.3-flash");
+			const glmAnthropic = multiApiRegistry.find("zai", "glm-anthropic");
+			const glmOpenai = multiApiRegistry.find("zai", "glm-openai");
+			expect(flash).toMatchObject({ api: "openai-completions", baseUrl: "https://api.z.ai/api/anthropic" });
+			expect(glmAnthropic).toMatchObject({ baseUrl: "https://api.z.ai/api/anthropic" });
+			expect(glmOpenai).toMatchObject({ baseUrl: "https://api.z.ai/api/anthropic" });
+		});
+
+		test("override-only provider api keeps a bundled model on its catalog route", () => {
+			const apiOnlyRegistry = readonlyRegistry({
+				providers: {
+					zai: {
+						baseUrl: "https://api.z.ai/api/anthropic",
+						apiKey: "TEST_KEY",
+						api: "anthropic-messages",
+					},
+				},
+			});
+			const flash = apiOnlyRegistry.find("zai", "glm-5.3-flash");
 			expect(flash).toMatchObject({
 				api: "openai-completions",
 				baseUrl: "https://api.z.ai/api/coding/paas/v4",
+			});
+		});
+
+		test("a custom model baseUrl keeps its own host and does not scope the provider", () => {
+			const directHostRegistry = readonlyRegistry({
+				providers: {
+					zai: {
+						baseUrl: "https://api.z.ai/api/anthropic",
+						apiKey: "TEST_KEY",
+						models: [
+							{
+								id: "glm-direct",
+								api: "anthropic-messages",
+								name: "GLM Direct",
+								baseUrl: "https://direct.example.com",
+								reasoning: true,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 1_000_000,
+								maxTokens: 131_072,
+							},
+						],
+					},
+				},
+			});
+			const direct = directHostRegistry.find("zai", "glm-direct");
+			const flash = directHostRegistry.find("zai", "glm-5.3-flash");
+			expect(direct).toMatchObject({ baseUrl: "https://direct.example.com" });
+			expect(flash).toMatchObject({ baseUrl: "https://api.z.ai/api/anthropic" });
+		});
+
+		test("refresh keeps pi-native gateway baseUrl across APIs", async () => {
+			writeRawModelsJson({
+				zai: {
+					baseUrl: "http://localhost:4000",
+					apiKey: "gateway-token",
+					api: "anthropic-messages",
+					transport: "pi-native",
+					models: [
+						{
+							id: "glm-anthropic",
+							api: "anthropic-messages",
+							name: "GLM Anthropic",
+							reasoning: true,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 1_000_000,
+							maxTokens: 131_072,
+						},
+					],
+				},
+			});
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refreshProvider("zai", "offline");
+
+			const flash = registry.find("zai", "glm-5.3-flash");
+			expect(flash).toMatchObject({
+				api: "openai-completions",
+				baseUrl: "http://localhost:4000",
+				transport: "pi-native",
+			});
+			const glmAnthropic = registry.find("zai", "glm-anthropic");
+			expect(glmAnthropic).toMatchObject({
+				api: "anthropic-messages",
+				baseUrl: "http://localhost:4000",
 			});
 		});
 	});


### PR DESCRIPTION
## What

> [!NOTE]
> The opening sentence is the author's own words, as CONTRIBUTING.md requires.

**Hello people, i`m glad to help the community! - duchoa**

In this PR i'm trying to fix GLM 5.3 Flash error.

| What changed | Why it matters |
|---|---|
| `ProviderOverride.baseUrlApis?: readonly Api[]` replaces the `api: Api \| null` tri-state | Multi-API is explicit: both APIs stay covered instead of encoding "multi-API ⇒ apply nowhere" |
| Scope is derived from custom models that inherit the provider `baseUrl` | A model with its own model-level `baseUrl` keeps its host and does not shape the scope |
| `providerConfig.api` seeds the scope for override-only providers | `zai` + Anthropic `baseUrl` with no `models:` can no longer hijack the bundled `glm-5.3-flash` route |
| `transport: "pi-native"` keeps its gateway `baseUrl` provider-wide | No model ends up pi-native against a catalog upstream host (`docs/models.md`, #2555) |
| One helper decides: `resolveProviderBaseUrl()` in `model-patch.ts` | Built-in, cached, discovery-merge, and runtime paths stay consistent by construction |

`baseUrlApis` left `undefined` preserves the historical provider-wide override for configs with no API evidence (plain proxies).

## Why

A provider-level Anthropic `baseUrl` was applied to the bundled `openai-completions` `zai/glm-5.3-flash`: requests went to `https://api.z.ai/api/anthropic/chat/completions` and came back HTTP 200 with an application-JSON `404_NOT_FOUND` body instead of SSE — an empty assistant message with `stopReason: "stop"`.

- #10539 reported the same 404 through the Anthropic route; #10541 corrected the bundled catalog entry to the Coding Plan endpoint. This PR closes the remaining path: personal `models.yml` overriding that corrected route.
- Review also flagged the inverse hazard: a `pi-native` provider must carry its gateway `baseUrl` to every model, otherwise a model goes pi-native against the wrong host.

## Testing

**Regression proof (mutation):** with the previous implementation checked out, all four new boundary tests fail; with this patch, all four pass.

| Boundary test | Pre-fix | Post-fix |
|---|---|---|
| `scopes multiple custom APIs sharing the provider baseUrl` | fail | pass |
| `override-only provider api keeps a bundled model on its catalog route` | fail | pass |
| `a custom model baseUrl keeps its own host and does not scope the provider` | fail | pass |
| `refresh keeps pi-native gateway baseUrl across APIs` | fail | pass |

**End-to-end (kept regression):** `ModelRegistry` → bundled `zai/glm-5.3-flash` → `openai-completions` → `https://api.z.ai/api/coding/paas/v4/chat/completions` → Z.AI SSE `delta.content = "OK"` → assistant text `OK`, `stopReason: "stop"`.

**Commands:**

```shell
bun --cwd=packages/coding-agent run fix
bun --cwd=packages/coding-agent run check
bun test packages/coding-agent/test/model-registry.test.ts \
  packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts \
  packages/coding-agent/test/model-registry-runtime-provider.test.ts \
  packages/coding-agent/test/model-registry-command-values.test.ts   # 200 passed
```

**Authenticated source CLI:** `--model zai/glm-5.3-flash --mode json` returned `api: "openai-completions"`, `provider: "zai"`, text `OK`, `text_delta: "OK"`, `stopReason: "stop"`.

<sub>📎 Source: local runs only — upstream CI has not executed on this fork PR yet (no checks reported), so no CI claim is made.</sub>

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution

