### PR TITLE
fix(windows): resolve /tmp through system temp

### DIFF
--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -40,6 +40,10 @@ use std::{
 		atomic::{AtomicBool, Ordering},
 	},
 };
+#[cfg(windows)]
+use std::env;
+#[cfg(any(windows, test))]
+use std::{ffi::OsStr, path::Component};
 
 use parking_lot::Mutex;
 
@@ -224,6 +228,20 @@ impl Drop for CancelOnDrop {
 	}
 }
 
+#[cfg(any(windows, test))]
+fn resolve_windows_tmp_alias(path: &Path, temp_dir: impl FnOnce() -> PathBuf) -> Option<PathBuf> {
+	let mut components = path.components();
+	if components.next() != Some(Component::RootDir)
+		|| components.next() != Some(Component::Normal(OsStr::new("tmp")))
+	{
+		return None;
+	}
+
+	let mut native = temp_dir();
+	native.push(components.as_path());
+	Some(native)
+}
+
 impl Host {
 	/// The name the utility was invoked as. Differs from [`Utility::NAME`] when
 	/// one implementation backs several builtins (`grep` and `rg`).
@@ -236,7 +254,9 @@ impl Host {
 		&self.cwd
 	}
 
-	/// Resolves `path` against [`Host::cwd`]; absolute paths pass through.
+	/// Resolves `path` against [`Host::cwd`]; absolute paths pass through except
+	/// for the POSIX `/tmp` alias, which maps to the system temporary directory
+	/// on Windows.
 	///
 	/// Every path argument must go through this before touching the
 	/// filesystem: the host process's current directory is unrelated to the
@@ -244,6 +264,10 @@ impl Host {
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
 		let normalized_path = brush_core::sys::fs::normalize_shell_path(path.as_ref());
 		let path = normalized_path.as_ref();
+		#[cfg(windows)]
+		if let Some(temp_path) = resolve_windows_tmp_alias(path, env::temp_dir) {
+			return temp_path;
+		}
 		if path.is_absolute() {
 			path.to_path_buf()
 		} else {
@@ -1140,9 +1164,12 @@ mod testing {
 	use parking_lot::Mutex;
 
 	use super::{
-		Arc, AtomicBool, GuardedStream, HashMap, Host, OpenFile, OsString, PathBuf, Read, Sigpipe,
-		SigpipeGuard, Stdin, StreamWriter, Utility, Write, io, openfiles, run_caught,
+		Arc, AtomicBool, GuardedStream, HashMap, Host, OpenFile, OsString, Path, PathBuf, Read, Sigpipe,
+		SigpipeGuard, Stdin, StreamWriter, Utility, Write, io, openfiles, resolve_windows_tmp_alias,
+		run_caught,
 	};
+	#[cfg(windows)]
+	use super::env;
 
 	/// Captured in-memory output from [`Host::for_test`].
 	pub(crate) struct Capture {
@@ -1251,12 +1278,32 @@ mod testing {
 		}
 	}
 
+	#[test]
+	fn windows_tmp_alias_preserves_suffix_under_system_temp() {
+		let temp = PathBuf::from(r"C:\Users\Adam\AppData\Local\Temp");
+		let probe = temp.join("probe");
+
+		assert_eq!(
+			resolve_windows_tmp_alias(Path::new("/tmp"), || temp.clone()).as_deref(),
+			Some(temp.as_path()),
+		);
+		assert_eq!(
+			resolve_windows_tmp_alias(Path::new("/tmp/probe"), || temp.clone()).as_deref(),
+			Some(probe.as_path()),
+		);
+		assert_eq!(
+			resolve_windows_tmp_alias(Path::new("/tmpfile"), || temp.clone()),
+			None,
+		);
+	}
+
 	#[cfg(windows)]
 	#[test]
-	fn resolves_msys_drive_aliases_to_native_drive() {
+	fn resolves_msys_aliases_to_native_locations() {
 		let (host, _) = Host::for_test("test", "", r"C:\workspace");
 
 		assert_eq!(host.resolve("/c/Users/Adam/file.txt"), PathBuf::from(r"C:\Users\Adam\file.txt"));
+		assert_eq!(host.resolve("/tmp/probe"), env::temp_dir().join("probe"));
 	}
 
 	/// Parses `argv` and runs `U` against an in-memory host, mirroring what the

--- a/crates/pi-builtins/src/host.rs
+++ b/crates/pi-builtins/src/host.rs
@@ -40,10 +40,6 @@ use std::{
 		atomic::{AtomicBool, Ordering},
 	},
 };
-#[cfg(windows)]
-use std::env;
-#[cfg(any(windows, test))]
-use std::{ffi::OsStr, path::Component};
 
 use parking_lot::Mutex;
 
@@ -228,20 +224,6 @@ impl Drop for CancelOnDrop {
 	}
 }
 
-#[cfg(any(windows, test))]
-fn resolve_windows_tmp_alias(path: &Path, temp_dir: impl FnOnce() -> PathBuf) -> Option<PathBuf> {
-	let mut components = path.components();
-	if components.next() != Some(Component::RootDir)
-		|| components.next() != Some(Component::Normal(OsStr::new("tmp")))
-	{
-		return None;
-	}
-
-	let mut native = temp_dir();
-	native.push(components.as_path());
-	Some(native)
-}
-
 impl Host {
 	/// The name the utility was invoked as. Differs from [`Utility::NAME`] when
 	/// one implementation backs several builtins (`grep` and `rg`).
@@ -254,20 +236,15 @@ impl Host {
 		&self.cwd
 	}
 
-	/// Resolves `path` against [`Host::cwd`]; absolute paths pass through except
-	/// for the POSIX `/tmp` alias, which maps to the system temporary directory
-	/// on Windows.
+	/// Resolves `path` against [`Host::cwd`]; absolute paths pass through.
 	///
 	/// Every path argument must go through this before touching the
 	/// filesystem: the host process's current directory is unrelated to the
-	/// shell's.
+	/// shell's. Windows aliases (`/c/...`, `/tmp`) are rewritten to native
+	/// paths by `brush_core::sys::fs::normalize_shell_path`.
 	pub fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
 		let normalized_path = brush_core::sys::fs::normalize_shell_path(path.as_ref());
 		let path = normalized_path.as_ref();
-		#[cfg(windows)]
-		if let Some(temp_path) = resolve_windows_tmp_alias(path, env::temp_dir) {
-			return temp_path;
-		}
 		if path.is_absolute() {
 			path.to_path_buf()
 		} else {
@@ -1164,12 +1141,9 @@ mod testing {
 	use parking_lot::Mutex;
 
 	use super::{
-		Arc, AtomicBool, GuardedStream, HashMap, Host, OpenFile, OsString, Path, PathBuf, Read, Sigpipe,
-		SigpipeGuard, Stdin, StreamWriter, Utility, Write, io, openfiles, resolve_windows_tmp_alias,
-		run_caught,
+		Arc, AtomicBool, GuardedStream, HashMap, Host, OpenFile, OsString, PathBuf, Read, Sigpipe,
+		SigpipeGuard, Stdin, StreamWriter, Utility, Write, io, openfiles, run_caught,
 	};
-	#[cfg(windows)]
-	use super::env;
 
 	/// Captured in-memory output from [`Host::for_test`].
 	pub(crate) struct Capture {
@@ -1278,32 +1252,13 @@ mod testing {
 		}
 	}
 
-	#[test]
-	fn windows_tmp_alias_preserves_suffix_under_system_temp() {
-		let temp = PathBuf::from(r"C:\Users\Adam\AppData\Local\Temp");
-		let probe = temp.join("probe");
-
-		assert_eq!(
-			resolve_windows_tmp_alias(Path::new("/tmp"), || temp.clone()).as_deref(),
-			Some(temp.as_path()),
-		);
-		assert_eq!(
-			resolve_windows_tmp_alias(Path::new("/tmp/probe"), || temp.clone()).as_deref(),
-			Some(probe.as_path()),
-		);
-		assert_eq!(
-			resolve_windows_tmp_alias(Path::new("/tmpfile"), || temp.clone()),
-			None,
-		);
-	}
-
 	#[cfg(windows)]
 	#[test]
-	fn resolves_msys_aliases_to_native_locations() {
+	fn resolves_msys_and_tmp_aliases_to_native_locations() {
 		let (host, _) = Host::for_test("test", "", r"C:\workspace");
 
 		assert_eq!(host.resolve("/c/Users/Adam/file.txt"), PathBuf::from(r"C:\Users\Adam\file.txt"));
-		assert_eq!(host.resolve("/tmp/probe"), env::temp_dir().join("probe"));
+		assert_eq!(host.resolve("/tmp/probe"), std::env::temp_dir().join("probe"));
 	}
 
 	/// Parses `argv` and runs `U` against an in-memory host, mirroring what the

--- a/crates/vendor/brush-core/src/sys/fs.rs
+++ b/crates/vendor/brush-core/src/sys/fs.rs
@@ -34,7 +34,7 @@ pub fn pattern_drive_alias_root(
 ) -> Option<(PathBuf, usize)> {
 	#[cfg(windows)]
 	{
-		pattern_drive_alias_root_impl(starts_with_forward_slash, first, second, third)
+		pattern_drive_alias_root_impl(starts_with_forward_slash, first, second, third, env::temp_dir)
 	}
 	#[cfg(not(windows))]
 	{
@@ -49,9 +49,16 @@ fn pattern_drive_alias_root_impl(
 	first: &str,
 	second: Option<&str>,
 	third: Option<&str>,
+	temp_dir: impl FnOnce() -> PathBuf,
 ) -> Option<(PathBuf, usize)> {
 	if !starts_with_forward_slash || !first.is_empty() {
 		return None;
+	}
+
+	// A bare `/tmp` glob root maps to the system temp dir, matching the
+	// non-pattern rewrite in `normalize_shell_path`.
+	if second == Some("tmp") {
+		return Some((temp_dir(), 2));
 	}
 
 	if let Some(drive) = second
@@ -246,23 +253,41 @@ mod tests {
 	#[test]
 	fn pattern_drive_alias_roots_report_consumed_components() {
 		assert_eq!(
-			pattern_drive_alias_root_impl(true, "", Some("d"), Some("project")),
+			pattern_drive_alias_root_impl(true, "", Some("d"), Some("project"), || PathBuf::from(r"C:\Temp")),
 			Some((PathBuf::from("D:/"), 2)),
 		);
 		assert_eq!(
-			pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("d")),
+			pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("d"), || PathBuf::from(r"C:\Temp")),
 			Some((PathBuf::from("D:/"), 3)),
 		);
 	}
 
 	#[test]
 	fn pattern_drive_alias_roots_require_forward_slash_prefix() {
-		assert_eq!(pattern_drive_alias_root_impl(false, "", Some("d"), Some("logs")), None);
+		let tmp = || PathBuf::from(r"C:\Temp");
+		assert_eq!(pattern_drive_alias_root_impl(false, "", Some("d"), Some("logs"), tmp), None);
 		assert_eq!(
-			pattern_drive_alias_root_impl(false, "", Some("mnt"), Some("d")),
+			pattern_drive_alias_root_impl(false, "", Some("mnt"), Some("d"), || PathBuf::from(r"C:\Temp")),
 			None,
 		);
-		assert_eq!(pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("data")), None);
+		assert_eq!(
+			pattern_drive_alias_root_impl(true, "", Some("mnt"), Some("data"), || PathBuf::from(r"C:\Temp")),
+			None,
+		);
+	}
+
+	#[test]
+	fn pattern_tmp_root_maps_to_system_temp() {
+		let temp = PathBuf::from(r"C:\Users\Adam\AppData\Local\Temp");
+		assert_eq!(
+			pattern_drive_alias_root_impl(true, "", Some("tmp"), Some("a"), || temp.clone()),
+			Some((temp.clone(), 2)),
+		);
+		// `/tmpfile` is not the tmp alias; it falls through to plain root handling.
+		assert_eq!(
+			pattern_drive_alias_root_impl(true, "", Some("tmpfile"), None, || temp.clone()),
+			None,
+		);
 	}
 
 	#[test]

--- a/crates/vendor/brush-core/src/sys/fs.rs
+++ b/crates/vendor/brush-core/src/sys/fs.rs
@@ -4,13 +4,19 @@ use std::{
 	borrow::Cow,
 	path::{Path, PathBuf},
 };
+#[cfg(windows)]
+use std::env;
+#[cfg(any(windows, test))]
+use std::{ffi::OsStr, path::Component};
 
 /// Normalizes shell-facing path aliases before `std::fs` sees them.
 #[allow(clippy::missing_const_for_fn, reason = "Windows implementation allocates")]
 pub fn normalize_shell_path(path: &Path) -> Cow<'_, Path> {
 	#[cfg(windows)]
 	{
-		translate_unix_drive_path(path).map_or(Cow::Borrowed(path), Cow::Owned)
+		translate_unix_drive_path(path)
+			.or_else(|| translate_unix_tmp_path(path, env::temp_dir))
+			.map_or(Cow::Borrowed(path), Cow::Owned)
 	}
 	#[cfg(not(windows))]
 	{
@@ -96,6 +102,27 @@ fn translate_unix_drive_path(path: &Path) -> Option<PathBuf> {
 		native.push(if ch == '/' || ch == '\\' { '\\' } else { ch });
 	}
 	Some(PathBuf::from(native))
+}
+
+/// Maps the POSIX `/tmp` tree onto the Windows system temporary directory.
+///
+/// A bare `/tmp` under Win32 is drive-relative (`<cwd-drive>:\tmp`), not a
+/// scratch root; MSYS/Cygwin tools instead mount it at `%TEMP%`. Rewriting it
+/// here — the single boundary every shell path passes through — keeps the
+/// in-process builtins, `ls`, and redirections agreeing with those external
+/// tools instead of scattering files across a drive-root `tmp`.
+#[cfg(any(windows, test))]
+fn translate_unix_tmp_path(path: &Path, temp_dir: impl FnOnce() -> PathBuf) -> Option<PathBuf> {
+	let mut components = path.components();
+	if components.next() != Some(Component::RootDir)
+		|| components.next() != Some(Component::Normal(OsStr::new("tmp")))
+	{
+		return None;
+	}
+
+	let mut native = temp_dir();
+	native.push(components.as_path());
+	Some(native)
 }
 
 #[cfg(any(windows, test))]
@@ -198,6 +225,22 @@ mod tests {
 			translate_unix_drive_path(Path::new("/mnt/d/项目/データ")).as_deref(),
 			Some(Path::new("D:\\项目\\データ")),
 		);
+	}
+
+	#[test]
+	fn unix_tmp_alias_maps_onto_system_temp_dir() {
+		let temp = PathBuf::from(r"C:\Users\Adam\AppData\Local\Temp");
+		assert_eq!(
+			translate_unix_tmp_path(Path::new("/tmp"), || temp.clone()).as_deref(),
+			Some(temp.as_path()),
+		);
+		assert_eq!(
+			translate_unix_tmp_path(Path::new("/tmp/probe/sub"), || temp.clone()).as_deref(),
+			Some(temp.join("probe").join("sub").as_path()),
+		);
+		// Only the `/tmp` component aliases; `/tmpfile` and `/var/tmp` do not.
+		assert_eq!(translate_unix_tmp_path(Path::new("/tmpfile"), || temp.clone()), None);
+		assert_eq!(translate_unix_tmp_path(Path::new("/var/tmp"), || temp.clone()), None);
 	}
 
 	#[test]

--- a/crates/vendor/brush-core/src/sys/fs.rs
+++ b/crates/vendor/brush-core/src/sys/fs.rs
@@ -118,17 +118,38 @@ fn translate_unix_drive_path(path: &Path) -> Option<PathBuf> {
 /// here — the single boundary every shell path passes through — keeps the
 /// in-process builtins, `ls`, and redirections agreeing with those external
 /// tools instead of scattering files across a drive-root `tmp`.
+///
+/// `.`/`..` are collapsed against the logical POSIX path first, clamping at the
+/// root, so `/tmp/../tmp/f` resolves like `/tmp/f` instead of appending the raw
+/// remainder onto the nested `%TEMP%` (which would escape into a sibling dir).
+/// A `..` that climbs out of `/tmp` yields a non-`/tmp` path, i.e. no rewrite.
 #[cfg(any(windows, test))]
 fn translate_unix_tmp_path(path: &Path, temp_dir: impl FnOnce() -> PathBuf) -> Option<PathBuf> {
 	let mut components = path.components();
-	if components.next() != Some(Component::RootDir)
-		|| components.next() != Some(Component::Normal(OsStr::new("tmp")))
-	{
+	if components.next() != Some(Component::RootDir) {
+		return None;
+	}
+
+	let mut logical: Vec<&OsStr> = Vec::new();
+	for component in components {
+		match component {
+			Component::CurDir => {}
+			Component::ParentDir => {
+				logical.pop();
+			},
+			Component::Normal(part) => logical.push(part),
+			// A second root or a drive prefix cannot appear in a POSIX operand.
+			Component::RootDir | Component::Prefix(_) => return None,
+		}
+	}
+
+	let mut tail = logical.into_iter();
+	if tail.next() != Some(OsStr::new("tmp")) {
 		return None;
 	}
 
 	let mut native = temp_dir();
-	native.push(components.as_path());
+	native.extend(tail);
 	Some(native)
 }
 
@@ -248,6 +269,18 @@ mod tests {
 		// Only the `/tmp` component aliases; `/tmpfile` and `/var/tmp` do not.
 		assert_eq!(translate_unix_tmp_path(Path::new("/tmpfile"), || temp.clone()), None);
 		assert_eq!(translate_unix_tmp_path(Path::new("/var/tmp"), || temp.clone()), None);
+		// `.`/`..` collapse against the logical root before substitution.
+		assert_eq!(
+			translate_unix_tmp_path(Path::new("/tmp/../tmp/f"), || temp.clone()).as_deref(),
+			Some(temp.join("f").as_path()),
+		);
+		assert_eq!(
+			translate_unix_tmp_path(Path::new("/tmp/probe/../sub"), || temp.clone()).as_deref(),
+			Some(temp.join("sub").as_path()),
+		);
+		// A `..` that climbs out of `/tmp` is no longer a tmp path.
+		assert_eq!(translate_unix_tmp_path(Path::new("/tmp/.."), || temp.clone()), None);
+		assert_eq!(translate_unix_tmp_path(Path::new("/tmp/../var/f"), || temp.clone()), None);
 	}
 
 	#[test]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Windows home launches and the in-process `mkdir` builtin now resolve `/tmp` to the system temporary directory instead of a drive-root `tmp` directory ([#11603](https://github.com/can1357/oh-my-pi/issues/11603)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
-- Windows home launches and the in-process `mkdir` builtin now resolve `/tmp` to the system temporary directory instead of a drive-root `tmp` directory ([#11603](https://github.com/can1357/oh-my-pi/issues/11603)).
+- Windows home launches and in-process shell paths (builtins, `ls`, and redirections) now resolve `/tmp` to the system temporary directory instead of a drive-root `tmp` directory ([#11603](https://github.com/can1357/oh-my-pi/issues/11603)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/cli/startup-cwd.ts
+++ b/packages/coding-agent/src/cli/startup-cwd.ts
@@ -21,7 +21,8 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 		return;
 	}
 
-	const candidates = [path.join(home, "tmp"), "/tmp", "/var/tmp"];
+	const candidates =
+		process.platform === "win32" ? [path.join(home, "tmp")] : [path.join(home, "tmp"), "/tmp", "/var/tmp"];
 	for (const candidate of candidates) {
 		try {
 			if (!(await directoryExists(candidate))) {

--- a/packages/coding-agent/test/cli-cwd-flag.test.ts
+++ b/packages/coding-agent/test/cli-cwd-flag.test.ts
@@ -4,12 +4,15 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { applyStartupCwd } from "@oh-my-pi/pi-coding-agent/cli/startup-cwd";
-import { getProjectDir, normalizePathForComparison, setProjectDir } from "@oh-my-pi/pi-utils";
+import * as utils from "@oh-my-pi/pi-utils";
 
-const originalProjectDir = getProjectDir();
+const originalProjectDir = utils.getProjectDir();
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
 afterEach(() => {
-	setProjectDir(originalProjectDir);
+	vi.restoreAllMocks();
+	if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+	utils.setProjectDir(originalProjectDir);
 });
 describe("parseArgs — --cwd flag", () => {
 	it("parses --cwd with a space-separated directory", () => {
@@ -35,14 +38,14 @@ describe("parseArgs — --cwd flag", () => {
 	it("applies --cwd before session lookup callers read the project directory", async () => {
 		const launchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-launch-"));
 		const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-target-"));
-		setProjectDir(launchDir);
+		utils.setProjectDir(launchDir);
 
 		const parsed = parseArgs(["--cwd", targetDir, "--continue"]);
 		await applyStartupCwd(parsed);
 
 		expect(parsed.continue).toBe(true);
-		expect(getProjectDir()).toBe(targetDir);
-		expect(normalizePathForComparison(process.cwd())).toBe(normalizePathForComparison(targetDir));
+		expect(utils.getProjectDir()).toBe(targetDir);
+		expect(utils.normalizePathForComparison(process.cwd())).toBe(utils.normalizePathForComparison(targetDir));
 	});
 
 	it("normalizes a relative --cwd target to the resolved absolute path", async () => {
@@ -50,7 +53,7 @@ describe("parseArgs — --cwd flag", () => {
 		const childName = "repo";
 		const childDir = path.join(launchDir, childName);
 		fs.mkdirSync(childDir);
-		setProjectDir(launchDir);
+		utils.setProjectDir(launchDir);
 
 		const parsed = parseArgs(["--cwd", childName]);
 		await applyStartupCwd(parsed);
@@ -58,17 +61,17 @@ describe("parseArgs — --cwd flag", () => {
 		// parsed.cwd must be the resolved absolute target, not the raw relative
 		// string that would re-resolve against the new cwd (e.g. repo/repo).
 		expect(path.isAbsolute(parsed.cwd ?? "")).toBe(true);
-		expect(parsed.cwd).toBe(getProjectDir());
-		expect(getProjectDir()).toBe(childDir);
+		expect(parsed.cwd).toBe(utils.getProjectDir());
+		expect(utils.getProjectDir()).toBe(childDir);
 		// Re-resolving the normalized value against the (now changed) process cwd
 		// is idempotent — no doubled "repo/repo" segment.
-		expect(path.resolve(parsed.cwd ?? "")).toBe(getProjectDir());
+		expect(path.resolve(parsed.cwd ?? "")).toBe(utils.getProjectDir());
 		expect(parsed.cwd?.endsWith(`${childName}${path.sep}${childName}`)).toBe(false);
 	});
 
 	it("reports a clean error when the cwd change is denied", async () => {
 		const launchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-denied-launch-"));
-		setProjectDir(launchDir);
+		utils.setProjectDir(launchDir);
 		const targetDir = path.join(launchDir, "blocked");
 		const parsed = parseArgs(["--cwd", targetDir]);
 		const chdir = vi.spyOn(process, "chdir").mockImplementation(() => {
@@ -82,12 +85,12 @@ describe("parseArgs — --cwd flag", () => {
 		} finally {
 			chdir.mockRestore();
 		}
-		expect(getProjectDir()).toBe(launchDir);
+		expect(utils.getProjectDir()).toBe(launchDir);
 	});
 
 	it("appends the macOS permission hint only for permission errors", async () => {
 		const launchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-hint-launch-"));
-		setProjectDir(launchDir);
+		utils.setProjectDir(launchDir);
 		const targetDir = path.join(launchDir, "blocked");
 		const parsed = parseArgs(["--cwd", targetDir]);
 		const chdir = vi.spyOn(process, "chdir").mockImplementation(() => {
@@ -101,5 +104,24 @@ describe("parseArgs — --cwd flag", () => {
 		} finally {
 			chdir.mockRestore();
 		}
+	});
+
+	it("uses the system temporary directory for Windows home launches", async () => {
+		const home = String.raw`C:\Users\reporter`;
+		const fallback = String.raw`C:\Users\reporter\AppData\Local\Temp`;
+		if (!platformDescriptor) throw new Error("process.platform descriptor is unavailable");
+		Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		vi.spyOn(os, "tmpdir").mockReturnValue(fallback);
+		vi.spyOn(utils, "getProjectDir").mockReturnValue(home);
+		vi.spyOn(utils, "directoryExists").mockImplementation(async candidate => {
+			return candidate === "/tmp" || candidate === fallback;
+		});
+		const setProjectDir = vi.spyOn(utils, "setProjectDir").mockImplementation(() => {});
+
+		await applyStartupCwd(parseArgs([]));
+
+		expect(setProjectDir).toHaveBeenCalledTimes(1);
+		expect(setProjectDir).toHaveBeenCalledWith(fallback);
 	});
 });


### PR DESCRIPTION
## Repro
From a simulated Windows home directory, `bun -e 'import * as path from \"node:path\"; const cwd=\"C:\\\\Users\\\\reporter\"; for (const candidate of [\"/tmp\", \"/var/tmp\"]) console.log(candidate, path.win32.resolve(cwd, candidate))'` resolves the current startup candidates to `C:\\tmp` and `C:\\var\\tmp`, confirming that an existing drive-root directory can win before `os.tmpdir()`.

## Cause
`maybeAutoChdir` in `packages/coding-agent/src/cli/startup-cwd.ts` included POSIX-only `/tmp` and `/var/tmp` candidates on every platform. Separately, `Host::resolve` in `crates/pi-builtins/src/host.rs` passed `/tmp` through to Rust’s Windows path handling, so in-process utilities such as `mkdir` targeted the current drive root rather than the system temporary directory.

## Fix
- Keep only the opt-in `~/tmp` startup candidate on Windows, then use the existing `os.tmpdir()` fallback.
- Resolve `/tmp` and its descendants through `std::env::temp_dir()` for in-process shell utilities on Windows.
- Cover Windows startup selection, `/tmp` suffix preservation, the native Windows resolver wiring, and the non-alias `/tmpfile` boundary.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/cli-cwd-flag.test.ts` passes 8 tests. `bun run test:rs` passes 2,771 tests with 6 skipped and all doctest commands successful. `bun check` passes. The startup regression test models an existing drive-root `/tmp` and confirms the selected directory is the Windows system temp fallback; the Rust regression maps `/tmp/probe` under the supplied system temp root without matching `/tmpfile`.

Fixes #11603