### PR TITLE
fix(session): suppress duplicate snapcompact rescue dividers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Snapcompact frame-overflow rescue now replaces its superseded divider instead of rendering two contradictory before→after badges ([#11607](https://github.com/can1357/oh-my-pi/issues/11607)).
 ### Added
 
 - Unsent prompts cleared with Ctrl+C can now be recalled with Up, including pastes and images; disable Recall Cleared Drafts in settings to discard future clears instead ([#11524](https://github.com/can1357/oh-my-pi/pull/11524) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -412,10 +412,23 @@ export function buildSessionContext(
 		// Display transcript: every entry in chronological order. Compactions do
 		// not erase prior history here — each renders inline (as a divider in the
 		// TUI) at the point it fired, with any snapcompact frames re-attached so
-		// the component can report them.
-		for (const entry of path) {
+		// the component can report them. An immediate frame-rescue replacement is
+		// the same compaction point and supersedes its source entry below.
+		for (let index = 0; index < path.length; index++) {
+			const entry = path[index];
 			handleEntryResetTracking(entry);
 			if (entry.type === "compaction") {
+				const replacement = path[index + 1];
+				if (
+					replacement?.type === "compaction" &&
+					entry.method === "snapcompact" &&
+					replacement.method === "snapcompact" &&
+					replacement.parentId === entry.id &&
+					replacement.firstKeptEntryId === entry.firstKeptEntryId &&
+					replacement.tokensBefore === entry.tokensBefore
+				) {
+					continue;
+				}
 				const active = entry.id === compaction?.id;
 				const snapcompactArchive = active ? snapcompact.getPreservedArchive(entry.preserveData) : undefined;
 				pushMessage(

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -1493,6 +1493,29 @@ describe("buildSessionContext", () => {
 		expect(llm.messages.map(m => m.role)).toEqual(["compactionSummary", "user", "user"]);
 	});
 
+	it("renders a snapcompact frame rescue as one replacement divider", () => {
+		const u1 = createMessageEntry(createUserMessage("1"));
+		const a1 = createMessageEntry(createAssistantMessage("a"));
+		const stale = createCompactionEntry("Oversized archive", u1.id);
+		stale.method = "snapcompact";
+		stale.tokensBefore = 188_789;
+		stale.tokensAfter = 168_131;
+		const rebuilt = createCompactionEntry("Rebuilt archive", u1.id);
+		rebuilt.method = "snapcompact";
+		rebuilt.tokensBefore = stale.tokensBefore;
+		rebuilt.tokensAfter = 163_107;
+
+		const transcript = buildSessionContext([u1, a1, stale, rebuilt], undefined, undefined, { transcript: true });
+		const dividers = transcript.messages.filter(message => message.role === "compactionSummary");
+
+		expect(dividers).toHaveLength(1);
+		expect(dividers[0]).toMatchObject({
+			summary: "Rebuilt archive",
+			tokensBefore: 188_789,
+			tokensAfter: 163_107,
+		});
+	});
+
 	it("transcript collapse option elides compacted display history", () => {
 		const u1 = createMessageEntry(createUserMessage("1"));
 		const a1 = createMessageEntry(createAssistantMessage("a"));


### PR DESCRIPTION
## Repro

With an uncollapsed transcript, two adjacent snapcompact entries sharing `firstKeptEntryId` and `tokensBefore` reproduce the frame-rescue sequence. `bun test packages/coding-agent/test/compaction.test.ts --test-name-pattern "renders a snapcompact frame rescue as one replacement divider"` failed on `main` with 2 dividers where 1 was expected.

## Cause

`SessionMaintenance.#rescueSnapcompactFrameOverflow()` appends the rebuilt archive as an immediate child compaction entry, while the uncollapsed branch in `packages/coding-agent/src/session/session-context.ts` rendered every persisted compaction entry. The superseded source archive therefore remained visible as a second, contradictory divider at the same compaction point.

## Fix

- Skip an immediate snapcompact source entry only when its child replacement has the same archive boundary and before-token count.
- Preserve separately fired compactions and render the rebuilt entry's summary and token badge.
- Add a focused transcript regression and an Unreleased changelog entry.

## Verification

`bun test packages/coding-agent/test/compaction.test.ts packages/coding-agent/test/agent-session-snapcompact-frame-dead-end.test.ts` passes: 63 passed, 1 skipped, 0 failed. The focused reproduction now emits one divider with `188789→163107`; the pre-publish `bun run fix` and `bun check` gate passed.

Fixes #11607