### PR TITLE
feat(ai,catalog): adopt Cursor's native agent surface (rich catalog, paired routing, honest pricing)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Cursor streams now use the official RunSSE/BidiAppend HTTP/1 fallback, decode structured service errors, report final token usage, and resume from safe server checkpoints ([#11613](https://github.com/can1357/oh-my-pi/pull/11613) by [@will-bogusz](https://github.com/will-bogusz)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import http2 from "node:http2";
+import { scheduler } from "node:timers/promises";
 import { classifyModel, collapseVariantId } from "@oh-my-pi/pi-catalog/compat/taxonomy";
 import type {
 	ConversationStep,
@@ -8,6 +9,14 @@ import type {
 	McpToolDefinition,
 	RequestedModel_ModelParameterbytes,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import {
+	CURSOR_BIDI_APPEND_PATH,
+	CURSOR_CLIENT_VERSION,
+	CURSOR_DEFAULT_BASE_URL,
+	CURSOR_RUN_PATH,
+	CURSOR_RUN_SSE_PATH,
+	cursorClientHeaders,
+} from "@oh-my-pi/pi-catalog/wire/cursor";
 import {
 	AgentClientMessageSchema,
 	AgentConversationTurnStructureSchema,
@@ -17,6 +26,8 @@ import {
 	AgentStoreConflictErrorSchema,
 	AgentStoreConflictResultSchema,
 	AssistantMessageSchema,
+	BidiAppendRequestSchema,
+	BidiRequestIdSchema,
 	BackgroundShellSpawnResultSchema,
 	CanvasDiagnosticsErrorSchema,
 	CanvasDiagnosticsResultSchema,
@@ -42,6 +53,7 @@ import {
 	DiagnosticsRejectedSchema,
 	DiagnosticsResultSchema,
 	DiagnosticsSuccessSchema,
+	ErrorDetailsSchema,
 	ExecClientControlMessageSchema,
 	type ExecClientMessage,
 	ExecClientMessageSchema,
@@ -207,7 +219,7 @@ import {
 } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { connectProxiedSocket, getProxyForUrl } from "../utils/proxy";
+import { connectProxiedSocket, getProxyForUrl, wrapFetchForProxy } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { sanitizeSchemaForCursor, toolWireSchema } from "../utils/schema";
 import { formatConnectEndStreamError } from "./connect-error-detail";
@@ -244,8 +256,8 @@ import {
 } from "./cursor/exec-modern";
 import { handleInteractionQuery } from "./cursor/interaction-query";
 
-export const CURSOR_API_URL = "https://api2.cursor.sh";
-export const CURSOR_CLIENT_VERSION = "cli-2026.07.23-e383d2b";
+export const CURSOR_API_URL = CURSOR_DEFAULT_BASE_URL;
+export { CURSOR_CLIENT_VERSION };
 
 /**
  * HTTP/1 connection-specific headers that HTTP/2 forbids. Node's `http2.request()`
@@ -320,6 +332,15 @@ const NOT_IMPLEMENTED_SUFFIX = "not implemented by this client";
 const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
 /** Model-resolution failures that can safely retry the exact discovery id before any server output. */
 const CURSOR_MODEL_NOT_FOUND_PATTERN = /^(?:Connect error not_found:|gRPC error 5:)/i;
+function isCursorModelNotFound(error: unknown): boolean {
+	return (
+		(error instanceof AIError.ProviderHttpError && error.code === "BAD_MODEL_NAME") ||
+		(error instanceof Error && CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message))
+	);
+}
+
+const CURSOR_MAX_STREAM_RETRIES = 5;
+const CURSOR_RETRY_BASE_DELAY_MS = 500;
 const NOT_IMPLEMENTED = `Not implemented by this client`;
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
@@ -347,13 +368,32 @@ export interface CursorOptions extends StreamOptions {
 	externalToolExecutor?: boolean;
 	/** Wire model id selected after thinking-effort routing (`resolveWireModelId`). */
 	wireModelId?: string;
+	/** Run transport. `auto` starts with HTTP/2 and falls back on failed ALPN negotiation. */
+	transport?: "auto" | "http2" | "http1";
 }
 
 type CursorWireMode = "normalized" | "discovered";
 
+interface CursorRetryContext {
+	attempt: number;
+	originalRequestId: string;
+	checkpoint?: ConversationStateStructure;
+	checkpointHash?: string;
+	noProgressResumes: number;
+	output: AssistantMessage;
+	blockState: BlockState;
+	usageState: UsageState;
+	baseConversationId: string;
+	conversationId: string;
+	blobStore: Map<string, Uint8Array>;
+	firstTokenTime?: number;
+}
+
 interface CursorStreamTiming {
 	startTime: number;
 	timestamp: number;
+	retry?: CursorRetryContext;
+	transport?: "http2" | "http1";
 }
 
 interface CursorRequestState {
@@ -361,6 +401,7 @@ interface CursorRequestState {
 	blobStore: Map<string, Uint8Array>;
 	conversationState?: ConversationStateStructure;
 	rotatedFresh?: boolean;
+	resume?: boolean;
 }
 
 interface CursorGrpcRequest {
@@ -398,8 +439,9 @@ function log(type: string, subtype?: string, data?: unknown): void {
 	const normalizedData = data ? decodeLogData(data) : data;
 	const entry: CursorLogEntry = { ts: Date.now(), type, subtype, data: normalizedData };
 	const verbose = $env.DEBUG_CURSOR === "2" || $env.DEBUG_CURSOR === "verbose";
-	const dataStr = verbose && normalizedData ? ` ${JSON.stringify(normalizedData, debugReplacer)?.slice(0, 500)}` : "";
-	console.error(`[CURSOR] ${type}${subtype ? `: ${subtype}` : ""}${dataStr}`);
+	logger.debug(`cursor: ${type}${subtype ? `: ${subtype}` : ""}`, {
+		...(verbose && normalizedData ? { data: normalizedData } : undefined),
+	});
 	void appendCursorDebugLog(entry);
 }
 
@@ -420,32 +462,412 @@ class ConnectEndStreamError extends AIError.ProviderResponseError {
 	}
 }
 
+const CURSOR_ERROR_NAMES: Readonly<Record<number, string>> = {
+	0: "UNSPECIFIED",
+	1: "BAD_API_KEY",
+	2: "NOT_LOGGED_IN",
+	3: "INVALID_AUTH_ID",
+	4: "NOT_HIGH_ENOUGH_PERMISSIONS",
+	5: "BAD_MODEL_NAME",
+	6: "USER_NOT_FOUND",
+	7: "FREE_USER_RATE_LIMIT_EXCEEDED",
+	8: "PRO_USER_RATE_LIMIT_EXCEEDED",
+	9: "FREE_USER_USAGE_LIMIT",
+	10: "PRO_USER_USAGE_LIMIT",
+	11: "AUTH_TOKEN_NOT_FOUND",
+	12: "AUTH_TOKEN_EXPIRED",
+	13: "OPENAI",
+	14: "OPENAI_RATE_LIMIT_EXCEEDED",
+	18: "AGENT_REQUIRES_LOGIN",
+	20: "MAX_TOKENS",
+	21: "USER_ABORTED_REQUEST",
+	22: "GENERIC_RATE_LIMIT_EXCEEDED",
+	23: "PRO_USER_ONLY",
+	25: "TIMEOUT",
+	28: "GPT_4_VISION_PREVIEW_RATE_LIMIT",
+	29: "CUSTOM_MESSAGE",
+	30: "OUTDATED_CLIENT",
+	31: "CLAUDE_IMAGE_TOO_LARGE",
+	33: "FILE_NOT_FOUND",
+	34: "API_KEY_RATE_LIMIT",
+	35: "DEBOUNCED",
+	36: "BAD_REQUEST",
+	37: "REPOSITORY_SERVICE_REPOSITORY_IS_NOT_INITIALIZED",
+	38: "UNAUTHORIZED",
+	39: "NOT_FOUND",
+	40: "DEPRECATED",
+	41: "RESOURCE_EXHAUSTED",
+	42: "BAD_USER_API_KEY",
+	43: "CONVERSATION_TOO_LONG",
+	44: "USAGE_PRICING_REQUIRED",
+	45: "USAGE_PRICING_REQUIRED_CHANGEABLE",
+	46: "GITHUB_NO_USER_CREDENTIALS",
+	47: "GITHUB_USER_NO_ACCESS",
+	48: "GITHUB_APP_NO_ACCESS",
+	49: "GITHUB_MULTIPLE_OWNERS",
+	50: "RATE_LIMITED",
+	51: "RATE_LIMITED_CHANGEABLE",
+	52: "CUSTOM",
+	53: "HOOKS_BLOCKED",
+	54: "SUSPICIOUS_USAGE_BLOCKED",
+	55: "EXTENSION_HOST_TIMEOUT",
+	56: "NETWORK_ERROR",
+	57: "PROVIDER_ERROR",
+	58: "MODEL_BLOCKED",
+	59: "INTERNAL",
+	60: "MAX_MODE_REQUIRED",
+	61: "MODEL_NO_LONGER_SUPPORTED",
+	62: "PRICING_WARNING",
+	63: "SLOW_POOL",
+	64: "UNSUPPORTED_REGION",
+	65: "ACCOUNT_CLOSED",
+};
+
+const CURSOR_ERROR_STATUS: Readonly<Record<number, number>> = {
+	1: 401,
+	2: 401,
+	3: 401,
+	4: 403,
+	5: 404,
+	6: 404,
+	7: 429,
+	8: 429,
+	9: 429,
+	10: 429,
+	11: 401,
+	12: 401,
+	14: 429,
+	18: 401,
+	20: 413,
+	22: 429,
+	23: 403,
+	28: 429,
+	33: 404,
+	34: 429,
+	35: 429,
+	38: 401,
+	39: 404,
+	41: 429,
+	42: 401,
+	43: 413,
+	44: 429,
+	45: 429,
+	46: 403,
+	47: 403,
+	48: 403,
+	49: 403,
+	50: 429,
+	51: 429,
+	54: 403,
+	58: 403,
+	61: 404,
+	64: 403,
+	65: 401,
+};
+
+const CURSOR_RETRYABLE_ERROR_CODES = new Set([13, 25, 55, 56, 57, 59, 63]);
+
+interface CursorStructuredError {
+	code: number;
+	name: string;
+	message: string;
+	retryable: boolean | undefined;
+}
+
+function decodeCursorStructuredError(error: unknown): CursorStructuredError | undefined {
+	if (!isRecord(error) || !Array.isArray(error.details)) return undefined;
+	for (const entry of error.details) {
+		if (!isRecord(entry) || typeof entry.type !== "string") continue;
+		if (entry.type !== "aiserver.v1.ErrorDetails" && entry.type !== "type.googleapis.com/aiserver.v1.ErrorDetails") {
+			continue;
+		}
+		const encoded = entry.value;
+		if (typeof encoded !== "string" || encoded.length === 0) continue;
+		try {
+			const detail = fromBinary(ErrorDetailsSchema, Uint8Array.from(Buffer.from(encoded, "base64")));
+			const code = detail.error;
+			const name = CURSOR_ERROR_NAMES[code] ?? `ERROR_${code}`;
+			const title = detail.details?.title.trim();
+			const body = detail.details?.detail.trim();
+			const message = [title, body].filter((part): part is string => Boolean(part)).join(": ") || name;
+			return { code, name, message, retryable: detail.details?.isRetryable };
+		} catch {
+			continue;
+		}
+	}
+	return undefined;
+}
+
+function classifyCursorStructuredError(structured: CursorStructuredError): Error {
+	const { code, name, message, retryable } = structured;
+	const fullMessage = `Cursor ${name}: ${message}`;
+	if (code === 21) return new AIError.AbortError(fullMessage);
+	const status = CURSOR_ERROR_STATUS[code];
+	if (status !== undefined) return new AIError.ProviderHttpError(fullMessage, status, { code: name });
+	if (retryable === true || CURSOR_RETRYABLE_ERROR_CODES.has(code)) {
+		return new AIError.ProviderHttpError(fullMessage, 503, { code: name });
+	}
+	return new AIError.ProviderHttpError(fullMessage, 400, { code: name });
+}
+
 function parseConnectEndStream(data: Uint8Array): Error | null {
 	try {
 		const payload = JSON.parse(new TextDecoder().decode(data));
 		const error = payload?.error;
-		if (error) {
-			const code = typeof error.code === "string" ? error.code : "unknown";
-			const message = typeof error.message === "string" ? error.message : "Unknown error";
-			const classificationMessage = `Connect error ${code}: ${message}`;
-			return new ConnectEndStreamError(classificationMessage, formatConnectEndStreamError(error));
-		}
-		return null;
+		if (!error) return null;
+		const structured = decodeCursorStructuredError(error);
+		if (structured) return classifyCursorStructuredError(structured);
+		const code = typeof error.code === "string" ? error.code : "unknown";
+		const message = typeof error.message === "string" ? error.message : "Unknown error";
+		const classificationMessage = `Connect error ${code}: ${message}`;
+		return new ConnectEndStreamError(classificationMessage, formatConnectEndStreamError(error));
 	} catch {
 		return new AIError.ProviderResponseError("Failed to parse Connect end stream", { kind: "envelope" });
 	}
 }
 
+interface CursorMessageWriter {
+	write(frame: Uint8Array): void;
+}
+
+interface CursorRunTransport extends CursorMessageWriter {
+	readonly closed: boolean;
+	close(): void;
+	onResponse(listener: (headers: http2.IncomingHttpHeaders) => void): void;
+	onData(listener: (chunk: Buffer) => void): void;
+	onTrailers(listener: (trailers: http2.IncomingHttpHeaders) => void): void;
+	onEnd(listener: () => void): void;
+	onError(listener: (error: unknown) => void): void;
+}
+
+function wrapHttp2RunTransport(request: http2.ClientHttp2Stream): CursorRunTransport {
+	return {
+		get closed() {
+			return request.closed;
+		},
+		write(frame) {
+			request.write(frame);
+		},
+		close() {
+			request.close();
+		},
+		onResponse(listener) {
+			request.on("response", listener);
+		},
+		onData(listener) {
+			request.on("data", listener);
+		},
+		onTrailers(listener) {
+			request.on("trailers", listener);
+		},
+		onEnd(listener) {
+			request.on("end", listener);
+		},
+		onError(listener) {
+			request.on("error", listener);
+		},
+	};
+}
+
+interface CursorHttp1RunTransportOptions {
+	baseUrl: string;
+	headers: Record<string, string>;
+	requestId: string;
+	signal?: AbortSignal;
+}
+
+interface CursorPendingAppend {
+	seqno: bigint;
+	data: Uint8Array;
+}
+
+const CURSOR_HTTP1_APPEND_CONCURRENCY = 16;
+const CURSOR_HTTP1_APPEND_BASE_TIMEOUT_MS = 60_000;
+const CURSOR_HTTP1_APPEND_BYTES_PER_SECOND = 128 * 1024;
+
+function readConnectFrameMessage(frame: Uint8Array): Uint8Array {
+	if (frame.length < 5) {
+		throw new AIError.ProviderResponseError("Cursor emitted an invalid Connect request frame", {
+			kind: "envelope",
+		});
+	}
+	const length = new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(1, false);
+	if (length !== frame.length - 5 || (frame[0] & CONNECT_END_STREAM_FLAG) !== 0) {
+		throw new AIError.ProviderResponseError("Cursor emitted an invalid Connect request frame", {
+			kind: "envelope",
+		});
+	}
+	return frame.subarray(5);
+}
+
+function getConnectResponseError(payload: Uint8Array): Error | null {
+	let offset = 0;
+	while (offset + 5 <= payload.length) {
+		const length = new DataView(payload.buffer, payload.byteOffset + offset, payload.byteLength - offset).getUint32(
+			1,
+			false,
+		);
+		const end = offset + 5 + length;
+		if (end > payload.length) {
+			return new AIError.ProviderResponseError("Cursor returned a truncated Connect response", {
+				kind: "incomplete-stream",
+			});
+		}
+		if ((payload[offset] & CONNECT_END_STREAM_FLAG) !== 0) {
+			return parseConnectEndStream(payload.subarray(offset + 5, end));
+		}
+		offset = end;
+	}
+	return offset === payload.length
+		? null
+		: new AIError.ProviderResponseError("Cursor returned a truncated Connect response", {
+				kind: "incomplete-stream",
+			});
+}
+
+function createHttp1RunTransport(options: CursorHttp1RunTransportOptions): CursorRunTransport {
+	const abortController = new AbortController();
+	const signal = options.signal ? AbortSignal.any([options.signal, abortController.signal]) : abortController.signal;
+	const fetchImpl = wrapFetchForProxy(globalThis.fetch, "cursor");
+	const requestId = create(BidiRequestIdSchema, { requestId: options.requestId });
+	const pendingAppends: CursorPendingAppend[] = [];
+	let appendSeqno = 0n;
+	let activeAppends = 0;
+	let closed = false;
+	let responseListener: (headers: http2.IncomingHttpHeaders) => void = () => {};
+	let dataListener: (chunk: Buffer) => void = () => {};
+	let endListener: () => void = () => {};
+	let errorListener: (error: unknown) => void = () => {};
+
+	const fail = (error: unknown): void => {
+		if (closed) return;
+		closed = true;
+		pendingAppends.length = 0;
+		abortController.abort(error);
+		errorListener(error);
+	};
+
+	const sendAppend = async (append: CursorPendingAppend): Promise<void> => {
+		const body = create(BidiAppendRequestSchema, {
+			requestId,
+			appendSeqno: append.seqno,
+			dataBinary: append.data,
+		});
+		const timeoutMs =
+			CURSOR_HTTP1_APPEND_BASE_TIMEOUT_MS +
+			Math.ceil(append.data.byteLength / CURSOR_HTTP1_APPEND_BYTES_PER_SECOND) * 1_000;
+		const response = await fetchImpl(new URL(CURSOR_BIDI_APPEND_PATH, options.baseUrl), {
+			method: "POST",
+			headers: options.headers,
+			body: frameConnectMessage(toBinary(BidiAppendRequestSchema, body)),
+			signal: AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]),
+		});
+		const payload = new Uint8Array(await response.arrayBuffer());
+		if (!response.ok) {
+			throw new AIError.ProviderHttpError(`Cursor BidiAppend failed with HTTP ${response.status}`, response.status);
+		}
+		const responseError = getConnectResponseError(payload);
+		if (responseError) throw responseError;
+	};
+
+	const pumpAppends = (): void => {
+		while (!closed && activeAppends < CURSOR_HTTP1_APPEND_CONCURRENCY) {
+			const append = pendingAppends.shift();
+			if (!append) return;
+			activeAppends++;
+			void sendAppend(append)
+				.catch(fail)
+				.finally(() => {
+					activeAppends--;
+					pumpAppends();
+				});
+		}
+	};
+
+	const run = async (): Promise<void> => {
+		try {
+			const response = await fetchImpl(new URL(CURSOR_RUN_SSE_PATH, options.baseUrl), {
+				method: "POST",
+				headers: options.headers,
+				body: frameConnectMessage(toBinary(BidiRequestIdSchema, requestId)),
+				signal,
+			});
+			const responseHeaders: http2.IncomingHttpHeaders = { ":status": String(response.status) };
+			response.headers.forEach((value, name) => {
+				responseHeaders[name] = value;
+			});
+			responseListener(responseHeaders);
+			if (!response.ok) {
+				throw new AIError.ProviderHttpError(`Cursor RunSSE failed with HTTP ${response.status}`, response.status);
+			}
+			if (!response.body) {
+				throw new AIError.ProviderResponseError("Cursor RunSSE returned no response body", {
+					kind: "incomplete-stream",
+				});
+			}
+			for await (const chunk of response.body) {
+				if (closed) return;
+				dataListener(Buffer.from(chunk));
+			}
+			if (closed) return;
+			closed = true;
+			endListener();
+		} catch (error) {
+			if (!closed) fail(error);
+		}
+	};
+	void run();
+	return {
+		get closed() {
+			return closed;
+		},
+		write(frame) {
+			if (closed) return;
+			pendingAppends.push({
+				seqno: appendSeqno++,
+				data: readConnectFrameMessage(frame),
+			});
+			pumpAppends();
+		},
+		close() {
+			if (closed) return;
+			closed = true;
+			pendingAppends.length = 0;
+			abortController.abort();
+		},
+		onResponse(listener) {
+			responseListener = listener;
+		},
+		onData(listener) {
+			dataListener = listener;
+		},
+		onTrailers(_listener) {},
+		onEnd(listener) {
+			endListener = listener;
+		},
+		onError(listener) {
+			errorListener = listener;
+		},
+	};
+}
+
+function isHttp2Unavailable(error: unknown): boolean {
+	const code = (error as { code?: unknown } | null)?.code;
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		(code === "ERR_HTTP2_ERROR" && /h2 is not supported/i.test(message)) ||
+		/Cursor run transport could not negotiate HTTP\/2/i.test(message)
+	);
+}
+
 /**
  * Maps an opaque HTTP/2 negotiation failure into an actionable error.
  *
- * bun only opens an HTTP/2 session when TLS-ALPN negotiates `h2`. Behind a
- * TLS-intercepting proxy that strips ALPN (e.g. Zscaler), the handshake yields
- * no `h2` protocol and bun throws `ERR_HTTP2_ERROR: h2 is not supported`. The
- * Cursor run RPC is HTTP/2-only (the ALB rejects HTTP/1.1 with 464), so there
- * is no h1 fallback the way model discovery has one — the run simply cannot
- * proceed. Replace the opaque message with one that names the cause and points
- * at the `providers.cursor.baseUrl` workaround.
+ * Bun only opens an HTTP/2 session when TLS-ALPN negotiates `h2`. Behind a
+ * TLS-intercepting proxy that strips ALPN, the handshake can fail with
+ * `ERR_HTTP2_ERROR: h2 is not supported`. Automatic transport retries the
+ * official RunSSE/BidiAppend HTTP/1 path; this mapped error remains observable
+ * when a caller explicitly forces HTTP/2.
  *
  * Non-ALPN errors pass through untouched.
  */
@@ -455,9 +877,8 @@ export function mapH2TransportError(error: unknown, baseUrl: string): unknown {
 	if (code === "ERR_HTTP2_ERROR" && /h2 is not supported/i.test(message)) {
 		return new AIError.ProviderResponseError(
 			`Cursor run transport could not negotiate HTTP/2 with ${baseUrl}: "h2 is not supported". ` +
-				"This host serves the run RPC over HTTP/2 only, and the TLS handshake did not negotiate " +
-				"h2 via ALPN — typically an ALPN-stripping TLS-intercepting proxy (e.g. Zscaler). " +
-				"Front the provider with a local HTTP/2 bridge and set providers.cursor.baseUrl to it.",
+				"The TLS handshake did not negotiate h2 via ALPN, typically because a TLS-intercepting proxy " +
+				"stripped ALPN. Use Cursor transport mode auto or http1 so the official RunSSE/BidiAppend path can run.",
 			{ provider: "cursor", kind: "runtime", cause: error },
 		);
 	}
@@ -561,9 +982,8 @@ function decodeLogData(value: unknown): unknown {
 			mutated = true;
 		}
 	}
-	return mutated ? decoded : record;
+	return mutated ? decoded : value;
 }
-
 function omitTypeName(record: Record<string, unknown>): Record<string, unknown> {
 	const { $typeName: _, ...rest } = record;
 	return rest;
@@ -579,26 +999,30 @@ function streamCursorWithWireMode(
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {
+		const retryContext = timing?.retry;
+		const transportMode = timing?.transport ?? (options?.transport === "http1" ? "http1" : "http2");
 		const startTime = timing?.startTime ?? performance.now();
-		let firstTokenTime: number | undefined;
+		let firstTokenTime = retryContext?.firstTokenTime;
 
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "cursor-agent" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: timing?.timestamp ?? Date.now(),
-		};
+		const output: AssistantMessage =
+			retryContext?.output ??
+			({
+				role: "assistant",
+				content: [],
+				api: "cursor-agent" as Api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: timing?.timestamp ?? Date.now(),
+			} satisfies AssistantMessage);
 
 		// Declared outside the `try` because BOTH exits must drain it: an exec
 		// handler decoded from the last chunk can still be running when the
@@ -634,13 +1058,17 @@ function streamCursorWithWireMode(
 		};
 
 		let h2Client: http2.ClientHttp2Session | null = null;
-		let h2Request: http2.ClientHttp2Stream | null = null;
+		let runTransport: CursorRunTransport | null = null;
 		let heartbeatTimer: NodeJS.Timeout | null = null;
 		let debugResponseLogPromise: Promise<RequestDebugResponseLog | undefined> | undefined;
 		const h2Completion = Promise.withResolvers<void>();
 		let h2Settled = false;
 		let sawTurnEnded = false;
 		let endStreamError: Error | null = null;
+		let progressVersion = 0;
+		let latestCheckpointProgressVersion = -1;
+		let latestCheckpoint: ConversationStateStructure | undefined;
+		let latestCheckpointTerminal = false;
 		// Blocks the discovered-id retry once the turn produced observable output or
 		// ran a side effect (streamed content/tool call, exec bridge, permission
 		// reply). Pure keepalive heartbeats never set it, so a `not_found` that
@@ -653,12 +1081,12 @@ function streamCursorWithWireMode(
 		const settleH2 = (error?: unknown): void => {
 			if (h2Settled) return;
 			h2Settled = true;
-			if (error !== undefined) {
-				h2Completion.reject(error);
-				return;
-			}
-			if (endStreamError) {
-				h2Completion.reject(endStreamError);
+			if (error !== undefined || endStreamError) {
+				if (sawTurnEnded && latestCheckpointTerminal) {
+					h2Completion.resolve();
+				} else {
+					h2Completion.reject(error ?? endStreamError);
+				}
 				return;
 			}
 			if (!sawTurnEnded) {
@@ -678,18 +1106,25 @@ function streamCursorWithWireMode(
 		let conversationId: string | undefined;
 		let usageState: UsageState | undefined;
 		let serializedFallbackWireModelId: string | undefined;
+		let activeBlobStore: Map<string, Uint8Array> | undefined;
+		let originalRequestId: string | undefined;
 		try {
 			const apiKey = options?.apiKey;
 			if (!apiKey) {
 				throw new AIError.MissingApiKeyError(undefined, "Cursor API key (access token) is required");
 			}
 
-			baseConversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
-			conversationId = rotatedConversationIds.get(baseConversationId) ?? baseConversationId;
-			const rotatedFresh = freshRotatedConversationIds.has(conversationId);
-			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
+			baseConversationId =
+				retryContext?.baseConversationId ?? options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
+			conversationId =
+				retryContext?.conversationId ?? rotatedConversationIds.get(baseConversationId) ?? baseConversationId;
+			const rotatedFresh = retryContext ? false : freshRotatedConversationIds.has(conversationId);
+			activeBlobStore =
+				retryContext?.blobStore ?? conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
+			const blobStore = activeBlobStore;
 			conversationBlobStores.set(conversationId, blobStore);
-			const cachedState = rotatedFresh ? undefined : conversationStateCache.get(conversationId);
+			const cachedState =
+				retryContext?.checkpoint ?? (rotatedFresh ? undefined : conversationStateCache.get(conversationId));
 			const builtRequest = await buildGrpcRequestForWireMode(
 				model,
 				context,
@@ -699,6 +1134,7 @@ function streamCursorWithWireMode(
 					blobStore,
 					conversationState: cachedState,
 					rotatedFresh,
+					resume: retryContext?.checkpoint !== undefined,
 				},
 				wireMode,
 			);
@@ -712,37 +1148,35 @@ function streamCursorWithWireMode(
 			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
-			const requestPath = "/agent.v1.AgentService/Run";
-			// Caller headers are additive, and are spread FIRST so the protocol
-			// framing, auth, and request id below always win. Cursor built this map
-			// from scratch and never read `options.headers`, so tracing/attribution
-			// headers set by a caller (or a `before_provider_headers` extension) were
-			// silently dropped here while working on other providers.
-			//
-			// Two classes are stripped because node's http2 client THROWS on them
-			// rather than ignoring them, which would turn a harmless header into a
-			// dead request: pseudo-headers, which belong to the transport, and the
-			// HTTP/1 connection-specific headers HTTP/2 forbids outright
-			// (ERR_HTTP2_INVALID_CONNECTION_HEADERS). `te` needs no filtering here —
-			// HTTP/2 allows it only as `trailers`, which is exactly what the fixed
-			// set below re-applies over anything a caller sent.
+			const requestPath = transportMode === "http2" ? CURSOR_RUN_PATH : CURSOR_RUN_SSE_PATH;
+			const requestId = crypto.randomUUID();
+			originalRequestId = retryContext?.originalRequestId ?? requestId;
 			const callerHeaders = sanitizeCursorCallerHeaders(options?.headers);
-			const requestHeaders = {
+			const sharedRequestHeaders = {
 				...callerHeaders,
-				":method": "POST",
-				":path": requestPath,
-				"content-type": "application/connect+proto",
+				...cursorClientHeaders(apiKey, {
+					clientVersion: CURSOR_CLIENT_VERSION,
+					contentType: "application/connect+proto",
+				}),
 				"connect-protocol-version": "1",
-				te: "trailers",
-				authorization: `Bearer ${apiKey}`,
-				"x-ghost-mode": "true",
-				"x-cursor-client-version": CURSOR_CLIENT_VERSION,
-				"x-cursor-client-type": "cli",
-				"x-request-id": crypto.randomUUID(),
+				"x-request-id": requestId,
+				...(retryContext ? { "x-original-request-id": originalRequestId } : undefined),
 			};
+			const requestHeaders =
+				transportMode === "http2"
+					? {
+							":method": "POST",
+							":path": requestPath,
+							...sharedRequestHeaders,
+							te: "trailers",
+						}
+					: {
+							...sharedRequestHeaders,
+							"x-cursor-streaming": "true",
+						};
 			const debugSession = isRequestDebugEnabled()
 				? await createRequestDebugSession({
-						protocol: "http2",
+						protocol: transportMode,
 						method: "POST",
 						url: new URL(requestPath, baseUrl).toString(),
 						headers: requestHeaders,
@@ -750,30 +1184,41 @@ function streamCursorWithWireMode(
 					})
 				: undefined;
 
-			const proxyUrl = getProxyForUrl(model.provider, new URL(baseUrl));
-			if (proxyUrl) {
-				const tlsSocket = await connectProxiedSocket(proxyUrl, baseUrl, {
-					signal: options?.signal,
-					timeoutMs: CURSOR_PROXY_TUNNEL_TIMEOUT_MS,
-				});
-				h2Client = http2.connect(baseUrl, {
-					createConnection: () => tlsSocket,
-				});
+			if (transportMode === "http2") {
+				const proxyUrl = getProxyForUrl(model.provider, new URL(baseUrl));
+				let client: http2.ClientHttp2Session;
+				if (proxyUrl) {
+					const tlsSocket = await connectProxiedSocket(proxyUrl, baseUrl, {
+						signal: options?.signal,
+						timeoutMs: CURSOR_PROXY_TUNNEL_TIMEOUT_MS,
+					});
+					client = http2.connect(baseUrl, {
+						createConnection: () => tlsSocket,
+					});
+				} else {
+					client = http2.connect(baseUrl);
+				}
+				h2Client = client;
+				client.on("error", error => settleH2(mapH2TransportError(error, baseUrl)));
+				runTransport = wrapHttp2RunTransport(client.request(requestHeaders));
 			} else {
-				h2Client = http2.connect(baseUrl);
+				runTransport = createHttp1RunTransport({
+					baseUrl,
+					headers: requestHeaders,
+					requestId,
+					signal: options?.signal,
+				});
 			}
-			h2Client.on("error", error => settleH2(mapH2TransportError(error, baseUrl)));
 
-			h2Request = h2Client.request(requestHeaders);
-
-			stream.push({ type: "start", partial: output });
+			if (!retryContext) stream.push({ type: "start", partial: output });
 
 			let pendingBuffer: Buffer = Buffer.alloc(0);
-			let currentTextBlock: (TextContent & { [kStreamingBlockIndex]: number }) | null = null;
-			let currentThinkingBlock: (ThinkingContent & { [kStreamingBlockIndex]: number }) | null = null;
-			let currentToolCall: ToolCallState | null = null;
-			const resolvedMcpToolCallIds = new Set<string>();
-			usageState = { sawTokenDelta: false };
+			const previousState = retryContext?.blockState;
+			let currentTextBlock = previousState?.currentTextBlock ?? null;
+			let currentThinkingBlock = previousState?.currentThinkingBlock ?? null;
+			let currentToolCall = previousState?.currentToolCall ?? null;
+			const resolvedMcpToolCallIds = previousState?.resolvedMcpToolCallIds ?? new Set<string>();
+			usageState = retryContext?.usageState ?? { sawTokenDelta: false };
 
 			const state: BlockState = {
 				get currentTextBlock() {
@@ -785,7 +1230,7 @@ function streamCursorWithWireMode(
 				get currentToolCall() {
 					return currentToolCall;
 				},
-				openToolCalls: new Map<string, ToolCallState>(),
+				openToolCalls: previousState?.openToolCalls ?? new Map<string, ToolCallState>(),
 				resolvedMcpToolCallIds,
 				get firstTokenTime() {
 					return firstTokenTime;
@@ -811,21 +1256,22 @@ function streamCursorWithWireMode(
 				conversationStateCache.set(conversationId!, checkpoint);
 			};
 
-			h2Request.on("response", headers => {
+			runTransport.onResponse(headers => {
+				const protocol = transportMode === "http2" ? "HTTP/2" : "HTTP/1.1";
 				debugResponseLogPromise = debugSession?.openResponseLog(
-					`HTTP/2 ${headers[":status"] ?? ""}`.trim(),
+					`${protocol} ${headers[":status"] ?? ""}`.trim(),
 					headers,
 				);
 			});
 
-			h2Request.on("data", (chunk: Buffer) => {
+			runTransport.onData((chunk: Buffer) => {
 				if (debugResponseLogPromise) {
 					void debugResponseLogPromise.then(log => {
 						log?.write(chunk);
 					});
 				}
-				// Steady state drains fully per chunk; alias the fresh h2 chunk instead
-				// of copying it through Buffer.concat (see aws-eventstream.ts).
+				// Steady state drains fully per chunk; alias a fresh transport chunk
+				// instead of copying it through Buffer.concat (see aws-eventstream.ts).
 				pendingBuffer = pendingBuffer.length === 0 ? chunk : Buffer.concat([pendingBuffer, chunk]);
 
 				while (pendingBuffer.length >= 5) {
@@ -840,7 +1286,7 @@ function streamCursorWithWireMode(
 						const endError = parseConnectEndStream(messageBytes);
 						if (endError) {
 							endStreamError = endError;
-							h2Request?.close();
+							runTransport?.close();
 						}
 						continue;
 					}
@@ -853,7 +1299,16 @@ function streamCursorWithWireMode(
 						// A heartbeat is a pure keepalive `processInteractionUpdate` ignores;
 						// every other frame is progress or a side effect that must block the
 						// discovered-id retry.
-						if (interactionCase !== "heartbeat") sawProgressOrSideEffect = true;
+						if (interactionCase !== "heartbeat") {
+							sawProgressOrSideEffect = true;
+							progressVersion++;
+						}
+						if (serverMessage.message.case === "conversationCheckpointUpdate") {
+							latestCheckpoint = serverMessage.message.value;
+							latestCheckpointProgressVersion = progressVersion;
+							latestCheckpointTerminal = sawTurnEnded;
+							conversationStateCache.set(conversationId!, latestCheckpoint);
+						}
 						const isTurnEnded = interactionCase === "turnEnded";
 						// Dispatch is fire-and-forget so the socket keeps draining while a
 						// handler runs, but the promise is tracked: `done` must not be
@@ -867,7 +1322,7 @@ function streamCursorWithWireMode(
 							stream,
 							state,
 							blobStore,
-							h2Request!,
+							runTransport!,
 							options?.execHandlers,
 							options?.onToolResult,
 							usageState!,
@@ -881,7 +1336,7 @@ function streamCursorWithWireMode(
 						inFlightDispatches.add(dispatch);
 						void dispatch.finally(() => inFlightDispatches.delete(dispatch));
 
-						// Application completion is not protocol success; wait for a clean HTTP/2 end.
+						// Application completion is not protocol success; wait for a clean transport end.
 						if (isTurnEnded) {
 							sawTurnEnded = true;
 						}
@@ -892,14 +1347,14 @@ function streamCursorWithWireMode(
 			});
 
 			const sendHeartbeat = () => {
-				if (!h2Request || h2Request.closed) {
+				if (!runTransport || runTransport.closed) {
 					return;
 				}
 				const heartbeatMessage = create(AgentClientMessageSchema, {
 					message: { case: "clientHeartbeat", value: create(ClientHeartbeatSchema, {}) },
 				});
 				const heartbeatBytes = toBinary(AgentClientMessageSchema, heartbeatMessage);
-				h2Request.write(frameConnectMessage(heartbeatBytes));
+				runTransport.write(frameConnectMessage(heartbeatBytes));
 			};
 
 			const closeDebugLog = async (): Promise<void> => {
@@ -907,7 +1362,7 @@ function streamCursorWithWireMode(
 				await log?.close();
 			};
 
-			h2Request.on("trailers", trailers => {
+			runTransport.onTrailers(trailers => {
 				const status = trailers["grpc-status"];
 				const msg = trailers["grpc-message"];
 				if (status && status !== "0" && !endStreamError) {
@@ -918,27 +1373,27 @@ function streamCursorWithWireMode(
 				}
 			});
 
-			h2Request.on("end", () => {
+			runTransport.onEnd(() => {
 				void closeDebugLog()
 					.then(() => settleH2())
 					.catch(error => settleH2(error));
 			});
 
-			h2Request.on("error", error => {
-				const mapped = mapH2TransportError(error, baseUrl);
+			runTransport.onError(error => {
+				const mapped = transportMode === "http2" ? mapH2TransportError(error, baseUrl) : error;
 				void closeDebugLog().finally(() => settleH2(mapped));
 			});
 
 			if (options?.signal) {
 				options.signal.addEventListener("abort", () => {
-					h2Request?.close();
+					runTransport?.close();
 					void closeDebugLog().finally(() => {
 						settleH2(new AIError.AbortError());
 					});
 				});
 			}
 
-			h2Request.write(frameConnectMessage(requestBytes));
+			runTransport.write(frameConnectMessage(requestBytes));
 			heartbeatTimer = setInterval(sendHeartbeat, 5000);
 			await h2Completion.promise;
 			if (conversationId && baseConversationId && conversationId !== baseConversationId) {
@@ -967,13 +1422,65 @@ function streamCursorWithWireMode(
 				message: output,
 			});
 			stream.end();
-		} catch (error) {
+		} catch (caughtError) {
+			let error = caughtError;
+			const h2Unavailable = transportMode === "http2" && isHttp2Unavailable(error);
+			if (
+				h2Unavailable &&
+				options?.transport !== "http2" &&
+				!sawProgressOrSideEffect &&
+				!options?.signal?.aborted &&
+				openBlockState !== undefined &&
+				usageState !== undefined &&
+				baseConversationId !== undefined &&
+				conversationId !== undefined &&
+				activeBlobStore !== undefined &&
+				originalRequestId !== undefined
+			) {
+				clearInterval(heartbeatTimer ?? undefined);
+				heartbeatTimer = null;
+				runTransport?.close();
+				h2Client?.close();
+				logger.debug("cursor transport falling back to RunSSE", { baseUrl: model.baseUrl || CURSOR_API_URL });
+
+				const http1Stream = streamCursorWithWireMode(model, context, options, wireMode, {
+					startTime,
+					timestamp: output.timestamp,
+					transport: "http1",
+					retry: {
+						attempt: retryContext?.attempt ?? 0,
+						originalRequestId,
+						checkpoint: retryContext?.checkpoint,
+						checkpointHash: retryContext?.checkpointHash,
+						noProgressResumes: retryContext?.noProgressResumes ?? 0,
+						output,
+						blockState: openBlockState,
+						usageState,
+						baseConversationId,
+						conversationId,
+						blobStore: activeBlobStore,
+						firstTokenTime,
+					},
+				});
+				stream.forwardLocalWorkFrom(http1Stream);
+				try {
+					for await (const event of http1Stream) {
+						if (event.type === "start") continue;
+						stream.push(event);
+					}
+					const http1Result = await http1Stream.result();
+					if (!stream.resultSettled) stream.end(http1Result);
+				} finally {
+					stream.forwardLocalWorkFrom(undefined);
+				}
+				return;
+			}
+			if (h2Unavailable) error = mapH2TransportError(error, model.baseUrl || CURSOR_API_URL);
 			const fallbackWireModelId =
 				wireMode === "normalized" &&
 				!sawProgressOrSideEffect &&
 				!options?.signal?.aborted &&
-				error instanceof Error &&
-				CURSOR_MODEL_NOT_FOUND_PATTERN.test(error.message)
+				isCursorModelNotFound(error)
 					? serializedFallbackWireModelId
 					: undefined;
 			if (fallbackWireModelId !== undefined) {
@@ -981,12 +1488,13 @@ function streamCursorWithWireMode(
 					clearInterval(heartbeatTimer);
 					heartbeatTimer = null;
 				}
-				h2Request?.close();
+				runTransport?.close();
 				h2Client?.close();
 
 				const fallbackStream = streamCursorWithWireMode(model, context, options, "discovered", {
 					startTime,
 					timestamp: output.timestamp,
+					transport: transportMode,
 				});
 				// The lazy watchdog observes THIS outer stream; the fallback's exec
 				// bridge marks the inner stream busy via `trackLocalWork`. Forward
@@ -1005,13 +1513,105 @@ function streamCursorWithWireMode(
 				}
 				return;
 			}
-			// Same reason as the success path: the Agent finalizes the synthesized
-			// call from this terminal error and clears its Cursor result buffer, so
-			// a handler still running would land its real result after `agent_end`
-			// and be discarded — even though the tool may already have run side
-			// effects. Wait for it first; on abort the drain returns immediately
-			// (handlers have no cancellation contract and must not delay the
-			// terminal error the user asked for).
+			// Resume only from a checkpoint that followed every decoded side effect.
+			// Without one, replay is safe solely before the provider emitted work.
+			const retryAttempt = retryContext?.attempt ?? 0;
+			const hasFreshCheckpoint =
+				latestCheckpoint !== undefined &&
+				latestCheckpointProgressVersion === progressVersion &&
+				!latestCheckpointTerminal;
+			const replaySafe = hasFreshCheckpoint || !sawProgressOrSideEffect;
+			const retryCheckpoint = hasFreshCheckpoint ? latestCheckpoint : retryContext?.checkpoint;
+			const checkpointHash =
+				retryCheckpoint === undefined
+					? undefined
+					: Bun.hash(toBinary(ConversationStateStructureSchema, retryCheckpoint)).toString(36);
+			const repeatedCheckpoint = checkpointHash !== undefined && checkpointHash === retryContext?.checkpointHash;
+			const noProgressResumes = repeatedCheckpoint ? (retryContext?.noProgressResumes ?? 0) + 1 : 0;
+			const canRetryFromCheckpoint =
+				replaySafe &&
+				!options?.signal?.aborted &&
+				retryAttempt < CURSOR_MAX_STREAM_RETRIES &&
+				noProgressResumes <= 2 &&
+				(AIError.isProviderRetryableError(error) ||
+					(error instanceof AIError.ProviderResponseError && error.kind === "incomplete-stream"));
+			if (
+				canRetryFromCheckpoint &&
+				openBlockState !== undefined &&
+				usageState !== undefined &&
+				baseConversationId !== undefined &&
+				conversationId !== undefined &&
+				activeBlobStore !== undefined &&
+				originalRequestId !== undefined
+			) {
+				const retryOriginalRequestId = originalRequestId;
+				const retryBlockState = openBlockState;
+				const retryUsageState = usageState;
+				const retryBaseConversationId = baseConversationId;
+				const retryConversationId = conversationId;
+				const retryBlobStore = activeBlobStore;
+				await drainInFlightDispatches();
+				if (heartbeatTimer) {
+					clearInterval(heartbeatTimer);
+					heartbeatTimer = null;
+				}
+				runTransport?.close();
+				h2Client?.close();
+
+				const uncappedDelayMs = CURSOR_RETRY_BASE_DELAY_MS * 2 ** retryAttempt;
+				const maxRetryDelayMs = options?.maxRetryDelayMs ?? 60_000;
+				const delayMs = maxRetryDelayMs > 0 ? Math.min(uncappedDelayMs, maxRetryDelayMs) : uncappedDelayMs;
+				logger.debug("cursor stream retrying", {
+					attempt: retryAttempt + 1,
+					checkpoint: checkpointHash,
+					delayMs,
+				});
+				let retryDelayCompleted = false;
+				try {
+					if (options?.providerRetryWait) {
+						await options.providerRetryWait(delayMs, options.signal);
+					} else {
+						await scheduler.wait(delayMs, { signal: options?.signal });
+					}
+					retryDelayCompleted = !options?.signal?.aborted;
+				} catch (waitError) {
+					error = waitError;
+				}
+				if (retryDelayCompleted) {
+					const retryStream = streamCursorWithWireMode(model, context, options, wireMode, {
+						startTime,
+						timestamp: output.timestamp,
+						transport: transportMode,
+						retry: {
+							attempt: retryAttempt + 1,
+							originalRequestId: retryOriginalRequestId,
+							checkpoint: retryCheckpoint,
+							checkpointHash,
+							noProgressResumes,
+							output,
+							blockState: retryBlockState,
+							usageState: retryUsageState,
+							baseConversationId: retryBaseConversationId,
+							conversationId: retryConversationId,
+							blobStore: retryBlobStore,
+							firstTokenTime,
+						},
+					});
+					stream.forwardLocalWorkFrom(retryStream);
+					try {
+						for await (const event of retryStream) {
+							if (event.type === "start") continue;
+							stream.push(event);
+						}
+						const retryResult = await retryStream.result();
+						if (!stream.resultSettled) stream.end(retryResult);
+					} finally {
+						stream.forwardLocalWorkFrom(undefined);
+					}
+					return;
+				}
+			}
+			// Terminal failure: wait for handlers before finalizing their synthesized calls.
 			await drainInFlightDispatches();
 			// A stream that dies mid-turn leaves blocks open, and this is the path
 			// it takes: `settleH2` rejects when the transport closes without
@@ -1075,7 +1675,7 @@ function streamCursorWithWireMode(
 				clearInterval(heartbeatTimer);
 				heartbeatTimer = null;
 			}
-			h2Request?.close();
+			runTransport?.close();
 			h2Client?.close();
 		}
 	})();
@@ -1145,6 +1745,8 @@ function markCursorExecResolved(block: CursorExecResolvedCarrier): void {
 
 export interface UsageState {
 	sawTokenDelta: boolean;
+	/** `TurnEndedUpdate` supplied exact final usage, superseding token deltas. */
+	sawAuthoritativeUsage?: boolean;
 }
 
 /** Exported for tests: drives one Cursor server message through the stream (exec waits mark the stream busy). */
@@ -1154,7 +1756,7 @@ export async function handleServerMessage(
 	stream: AssistantMessageEventStream,
 	state: BlockState,
 	blobStore: Map<string, Uint8Array>,
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execHandlers: CursorExecHandlers | undefined,
 	onToolResult: CursorToolResultHandler | undefined,
 	usageState: UsageState,
@@ -1170,7 +1772,7 @@ export async function handleServerMessage(
 	if (msgCase === "interactionUpdate") {
 		processInteractionUpdate(msg.message.value, output, stream, state, usageState);
 	} else if (msgCase === "kvServerMessage") {
-		handleKvServerMessage(msg.message.value as KvServerMessage, blobStore, h2Request);
+		handleKvServerMessage(msg.message.value as KvServerMessage, blobStore, runTransport);
 	} else if (msgCase === "execServerMessage") {
 		// The server is waiting on OUR local tool result during this window — no
 		// AssistantMessageEvent flows until the handler finishes. Mark the wait
@@ -1179,7 +1781,7 @@ export async function handleServerMessage(
 		await stream.trackLocalWork(
 			handleExecServerMessage(
 				msg.message.value as ExecServerMessage,
-				h2Request,
+				runTransport,
 				execHandlers,
 				onToolResult,
 				requestContextTools,
@@ -1197,7 +1799,7 @@ export async function handleServerMessage(
 		// aborts a live stream with "Provider stream stalled while waiting for
 		// the next event" (cursor-grok-4.6-xhigh after a WebFetch/WebSearch
 		// permission prompt).
-		handleInteractionQuery(msg.message.value, h2Request);
+		handleInteractionQuery(msg.message.value, runTransport);
 	} else if (msgCase === "conversationCheckpointUpdate") {
 		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
 	}
@@ -1254,7 +1856,7 @@ function protoUnknownFields(message: object): ProtoUnknownField[] {
 function handleKvServerMessage(
 	kvMsg: KvServerMessage,
 	blobStore: Map<string, Uint8Array>,
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 ): void {
 	const kvCase = kvMsg.message.case;
 
@@ -1277,7 +1879,7 @@ function handleKvServerMessage(
 		});
 
 		const responseBytes = toBinary(AgentClientMessageSchema, kvClientMessage);
-		h2Request.write(frameConnectMessage(responseBytes));
+		runTransport.write(frameConnectMessage(responseBytes));
 
 		log("kvClient", "getBlobResult", { blobId: blobIdKey.slice(0, 40) });
 	} else if (kvCase === "setBlobArgs") {
@@ -1298,18 +1900,18 @@ function handleKvServerMessage(
 		});
 
 		const responseBytes = toBinary(AgentClientMessageSchema, kvClientMessage);
-		h2Request.write(frameConnectMessage(responseBytes));
+		runTransport.write(frameConnectMessage(responseBytes));
 
 		log("kvClient", "setBlobResult", { blobId: blobIdKey.slice(0, 40) });
 	}
 }
 
 function sendShellStreamEvent(
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execMsg: ExecServerMessage,
 	event: ShellStream["event"],
 ): void {
-	sendExecClientMessage(h2Request, execMsg, "shellStream", create(ShellStreamSchema, { event }));
+	sendExecClientMessage(runTransport, execMsg, "shellStream", create(ShellStreamSchema, { event }));
 }
 
 function sanitizeShellExecResult(execResult: ShellResult): ShellResult {
@@ -1340,7 +1942,7 @@ function sanitizeShellExecResult(execResult: ShellResult): ShellResult {
 async function handleShellStreamArgs(
 	args: ShellArgs,
 	execMsg: ExecServerMessage,
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execHandlers: CursorExecHandlers | undefined,
 	onToolResult: CursorToolResultHandler | undefined,
 ): Promise<void> {
@@ -1356,7 +1958,7 @@ async function handleShellStreamArgs(
 		hasShellStream: !!execHandlers?.shellStream,
 	});
 
-	sendShellStreamEvent(h2Request, execMsg, { case: "start", value: create(ShellStreamStartSchema, {}) });
+	sendShellStreamEvent(runTransport, execMsg, { case: "start", value: create(ShellStreamStartSchema, {}) });
 
 	// Buffer for incomplete ANSI sequences across chunks
 	let stdoutBuffer = "";
@@ -1374,7 +1976,7 @@ async function handleShellStreamArgs(
 			const toSend = stdoutBuffer.slice(0, safeEnd);
 			const remaining = stdoutBuffer.slice(safeEnd);
 			if (toSend) {
-				sendShellStreamEvent(h2Request, execMsg, {
+				sendShellStreamEvent(runTransport, execMsg, {
 					case: "stdout",
 					value: create(ShellStreamStdoutSchema, { data: sanitizeText(toSend) }),
 				});
@@ -1393,7 +1995,7 @@ async function handleShellStreamArgs(
 			const toSend = stderrBuffer.slice(0, safeEnd);
 			const remaining = stderrBuffer.slice(safeEnd);
 			if (toSend) {
-				sendShellStreamEvent(h2Request, execMsg, {
+				sendShellStreamEvent(runTransport, execMsg, {
 					case: "stderr",
 					value: create(ShellStreamStderrSchema, { data: sanitizeText(toSend) }),
 				});
@@ -1479,17 +2081,17 @@ async function handleShellStreamArgs(
 	flushStdout();
 	flushStderr();
 
-	sendShellStreamExitFromResult(h2Request, execMsg, sanitizedExecResult, sendBufferedOutput);
+	sendShellStreamExitFromResult(runTransport, execMsg, sanitizedExecResult, sendBufferedOutput);
 	// Cursor can keep the turn pending when it receives only stream deltas.
 	// Send the final structured shellResult as completion acknowledgement.
-	sendExecClientMessage(h2Request, execMsg, "shellResult", sanitizedExecResult);
-	sendExecClientStreamClose(h2Request, execMsg);
+	sendExecClientMessage(runTransport, execMsg, "shellResult", sanitizedExecResult);
+	sendExecClientStreamClose(runTransport, execMsg);
 
 	log("shellStream", "done", { elapsed: performance.now() - startTs });
 }
 
 function sendShellStreamExitFromResult(
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execMsg: ExecServerMessage,
 	execResult: ShellResult,
 	sendBufferedOutput: boolean,
@@ -1500,19 +2102,19 @@ function sendShellStreamExitFromResult(
 			const value = result.value;
 			if (sendBufferedOutput) {
 				if (value.stdout) {
-					sendShellStreamEvent(h2Request, execMsg, {
+					sendShellStreamEvent(runTransport, execMsg, {
 						case: "stdout",
 						value: create(ShellStreamStdoutSchema, { data: sanitizeText(value.stdout) }),
 					});
 				}
 				if (value.stderr) {
-					sendShellStreamEvent(h2Request, execMsg, {
+					sendShellStreamEvent(runTransport, execMsg, {
 						case: "stderr",
 						value: create(ShellStreamStderrSchema, { data: sanitizeText(value.stderr) }),
 					});
 				}
 			}
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "exit",
 				value: create(ShellStreamExitSchema, {
 					code: value.exitCode,
@@ -1526,19 +2128,19 @@ function sendShellStreamExitFromResult(
 			const value = result.value;
 			if (sendBufferedOutput) {
 				if (value.stdout) {
-					sendShellStreamEvent(h2Request, execMsg, {
+					sendShellStreamEvent(runTransport, execMsg, {
 						case: "stdout",
 						value: create(ShellStreamStdoutSchema, { data: sanitizeText(value.stdout) }),
 					});
 				}
 				if (value.stderr) {
-					sendShellStreamEvent(h2Request, execMsg, {
+					sendShellStreamEvent(runTransport, execMsg, {
 						case: "stderr",
 						value: create(ShellStreamStderrSchema, { data: sanitizeText(value.stderr) }),
 					});
 				}
 			}
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "exit",
 				value: create(ShellStreamExitSchema, {
 					code: value.exitCode,
@@ -1550,8 +2152,8 @@ function sendShellStreamExitFromResult(
 			return;
 		}
 		case "rejected": {
-			sendShellStreamEvent(h2Request, execMsg, { case: "rejected", value: result.value });
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, { case: "rejected", value: result.value });
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "exit",
 				value: create(ShellStreamExitSchema, {
 					code: 1,
@@ -1563,13 +2165,13 @@ function sendShellStreamExitFromResult(
 		}
 		case "timeout": {
 			const value = result.value;
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "stderr",
 				value: create(ShellStreamStderrSchema, {
 					data: `Command timed out after ${value.timeoutMs}ms`,
 				}),
 			});
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "exit",
 				value: create(ShellStreamExitSchema, {
 					code: 1,
@@ -1580,8 +2182,8 @@ function sendShellStreamExitFromResult(
 			return;
 		}
 		case "permissionDenied": {
-			sendShellStreamEvent(h2Request, execMsg, { case: "permissionDenied", value: result.value });
-			sendShellStreamEvent(h2Request, execMsg, {
+			sendShellStreamEvent(runTransport, execMsg, { case: "permissionDenied", value: result.value });
+			sendShellStreamEvent(runTransport, execMsg, {
 				case: "exit",
 				value: create(ShellStreamExitSchema, {
 					code: 1,
@@ -1598,7 +2200,7 @@ function sendShellStreamExitFromResult(
 
 async function handleExecServerMessage(
 	execMsg: ExecServerMessage,
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execHandlers: CursorExecHandlers | undefined,
 	onToolResult: CursorToolResultHandler | undefined,
 	requestContextTools: McpToolDefinition[],
@@ -1629,7 +2231,7 @@ async function handleExecServerMessage(
 			},
 		});
 
-		sendExecClientMessage(h2Request, execMsg, "requestContextResult", requestContextResult);
+		sendExecClientMessage(runTransport, execMsg, "requestContextResult", requestContextResult);
 		log("execClient", "requestContextResult");
 		return;
 	}
@@ -1642,7 +2244,7 @@ async function handleExecServerMessage(
 		// that never comes. Distinct from the `default:` branch below, which
 		// names a frame it recognises but cannot serve.
 		log("warn", "unknownExecVariant", { id: execMsg.id, execId: execMsg.execId });
-		sendExecClientThrow(h2Request, execMsg, "Unknown exec message variant", "unknown_exec_variant");
+		sendExecClientThrow(runTransport, execMsg, "Unknown exec message variant", "unknown_exec_variant");
 		return;
 	}
 
@@ -1684,7 +2286,7 @@ async function handleExecServerMessage(
 				error => buildReadErrorResult(args.path, error),
 				editOwned ? null : { toolCallId: args.toolCallId, toolName: "read" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "readResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "readResult", execResult);
 			return;
 		}
 		case "lsArgs": {
@@ -1703,7 +2305,7 @@ async function handleExecServerMessage(
 				error => buildLsErrorResult(args.path, error),
 				{ toolCallId: args.toolCallId, toolName: "read" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "lsResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "lsResult", execResult);
 			return;
 		}
 		case "grepArgs": {
@@ -1717,7 +2319,7 @@ async function handleExecServerMessage(
 			// synthesized block has already been persisted with a placeholder pattern.
 			const emptyPatternError = emptyGrepPatternRejection(args.pattern, args.glob);
 			if (emptyPatternError !== null) {
-				sendExecClientMessage(h2Request, execMsg, "grepResult", buildGrepErrorResult(emptyPatternError));
+				sendExecClientMessage(runTransport, execMsg, "grepResult", buildGrepErrorResult(emptyPatternError));
 				return;
 			}
 			// Mirror the coding-agent bridge's arg mapping so live UI (from
@@ -1739,7 +2341,7 @@ async function handleExecServerMessage(
 				error => buildGrepErrorResult(error),
 				{ toolCallId: args.toolCallId, toolName: "grep" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "grepResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "grepResult", execResult);
 			return;
 		}
 		case "writeArgs": {
@@ -1780,7 +2382,7 @@ async function handleExecServerMessage(
 				{ toolCallId: args.toolCallId, toolName: editOwned ? "edit" : "write" },
 			);
 			if (editOwned) markEditToolCallPaired(state, args.toolCallId);
-			sendExecClientMessage(h2Request, execMsg, "writeResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "writeResult", execResult);
 			return;
 		}
 		case "deleteArgs": {
@@ -1796,7 +2398,7 @@ async function handleExecServerMessage(
 				error => buildDeleteErrorResult(args.path, error),
 				{ toolCallId: args.toolCallId, toolName: "delete" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "deleteResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "deleteResult", execResult);
 			return;
 		}
 		case "shellArgs": {
@@ -1821,7 +2423,7 @@ async function handleExecServerMessage(
 				{ toolCallId: args.toolCallId, toolName: "bash" },
 			);
 			const sanitizedExecResult = sanitizeShellExecResult(execResult);
-			sendExecClientMessage(h2Request, execMsg, "shellResult", sanitizedExecResult);
+			sendExecClientMessage(runTransport, execMsg, "shellResult", sanitizedExecResult);
 			return;
 		}
 		case "shellStreamArgs": {
@@ -1833,7 +2435,7 @@ async function handleExecServerMessage(
 				cwd: args.workingDirectory || undefined,
 				timeout: shellStreamTimeout,
 			});
-			await handleShellStreamArgs(args, execMsg, h2Request, execHandlers, onToolResult);
+			await handleShellStreamArgs(args, execMsg, runTransport, execHandlers, onToolResult);
 			return;
 		}
 		case "backgroundShellSpawnArgs": {
@@ -1849,7 +2451,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "backgroundShellSpawnResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "backgroundShellSpawnResult", execResult);
 			return;
 		}
 		case "writeShellStdinArgs": {
@@ -1861,7 +2463,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "writeShellStdinResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "writeShellStdinResult", execResult);
 			return;
 		}
 		case "fetchArgs": {
@@ -1875,7 +2477,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "fetchResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "fetchResult", execResult);
 			return;
 		}
 		case "diagnosticsArgs": {
@@ -1896,7 +2498,7 @@ async function handleExecServerMessage(
 				error => buildDiagnosticsErrorResult(args.path, error),
 				{ toolCallId: args.toolCallId, toolName: "lsp" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "diagnosticsResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "diagnosticsResult", execResult);
 			return;
 		}
 		case "mcpArgs": {
@@ -1916,7 +2518,7 @@ async function handleExecServerMessage(
 			if (mcpCall.approvalOnly) {
 				const approved = (await execHandlers?.mcpApprovalPreflight?.(mcpCall)) === true;
 				sendExecClientMessage(
-					h2Request,
+					runTransport,
 					execMsg,
 					"mcpResult",
 					create(McpResultSchema, {
@@ -1962,7 +2564,7 @@ async function handleExecServerMessage(
 				error => buildMcpErrorResult(error),
 				execHandlers?.mcp ? { toolCallId: mcpCall.toolCallId, toolName: mcpCall.toolName } : null,
 			);
-			sendExecClientMessage(h2Request, execMsg, "mcpResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "mcpResult", execResult);
 			return;
 		}
 		case "listMcpResourcesExecArgs": {
@@ -2028,7 +2630,7 @@ async function handleExecServerMessage(
 					settled.case !== "success",
 				);
 			}
-			sendExecClientMessage(h2Request, execMsg, "listMcpResourcesExecResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "listMcpResourcesExecResult", execResult);
 			return;
 		}
 		case "readMcpResourceExecArgs": {
@@ -2129,21 +2731,21 @@ async function handleExecServerMessage(
 					settled.case !== "success",
 				);
 			}
-			sendExecClientMessage(h2Request, execMsg, "readMcpResourceExecResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "readMcpResourceExecResult", execResult);
 			return;
 		}
 		case "recordScreenArgs": {
 			const execResult = create(RecordScreenResultSchema, {
 				result: { case: "failure", value: create(RecordScreenFailureSchema, { error: NOT_IMPLEMENTED }) },
 			});
-			sendExecClientMessage(h2Request, execMsg, "recordScreenResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "recordScreenResult", execResult);
 			return;
 		}
 		case "computerUseArgs": {
 			const execResult = create(ComputerUseResultSchema, {
 				result: { case: "error", value: create(ComputerUseErrorSchema, { error: NOT_IMPLEMENTED }) },
 			});
-			sendExecClientMessage(h2Request, execMsg, "computerUseResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "computerUseResult", execResult);
 			return;
 		}
 		case "piReadArgs": {
@@ -2163,7 +2765,7 @@ async function handleExecServerMessage(
 				buildPiReadError,
 				{ toolCallId, toolName: "read" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piReadResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piReadResult", execResult);
 			return;
 		}
 		case "piBashArgs": {
@@ -2182,7 +2784,7 @@ async function handleExecServerMessage(
 				buildPiBashError,
 				{ toolCallId, toolName: "bash" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piBashResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piBashResult", execResult);
 			return;
 		}
 		case "piEditArgs": {
@@ -2206,7 +2808,7 @@ async function handleExecServerMessage(
 				buildPiEditError,
 				{ toolCallId, toolName: "edit" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piEditResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piEditResult", execResult);
 			return;
 		}
 		case "piWriteArgs": {
@@ -2225,7 +2827,7 @@ async function handleExecServerMessage(
 				buildPiWriteError,
 				{ toolCallId, toolName: "write" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piWriteResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piWriteResult", execResult);
 			return;
 		}
 		case "piGrepArgs": {
@@ -2252,7 +2854,7 @@ async function handleExecServerMessage(
 				buildPiGrepError,
 				{ toolCallId, toolName: "grep" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piGrepResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piGrepResult", execResult);
 			return;
 		}
 		case "piFindArgs": {
@@ -2271,7 +2873,7 @@ async function handleExecServerMessage(
 				buildPiFindError,
 				{ toolCallId, toolName: "glob" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piFindResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piFindResult", execResult);
 			return;
 		}
 		case "piLsArgs": {
@@ -2290,7 +2892,7 @@ async function handleExecServerMessage(
 				buildPiLsError,
 				{ toolCallId, toolName: "read" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "piLsResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "piLsResult", execResult);
 			return;
 		}
 		case "miniSweAgentBashArgs": {
@@ -2313,7 +2915,7 @@ async function handleExecServerMessage(
 				error => buildShellFailureResult(normalizedArgs.command, normalizedArgs.workingDirectory, error),
 				{ toolCallId: args.toolCallId, toolName: "bash" },
 			);
-			sendExecClientMessage(h2Request, execMsg, "miniSweAgentBashResult", sanitizeShellExecResult(execResult));
+			sendExecClientMessage(runTransport, execMsg, "miniSweAgentBashResult", sanitizeShellExecResult(execResult));
 			return;
 		}
 		case "redactedReadArgs": {
@@ -2323,7 +2925,7 @@ async function handleExecServerMessage(
 			// unredacted bytes the frame exists to withhold.
 			const args = execMsg.message.value;
 			sendExecClientMessage(
-				h2Request,
+				runTransport,
 				execMsg,
 				"redactedReadResult",
 				buildReadErrorResult(args.path, "Secret redaction is not implemented by this client"),
@@ -2333,7 +2935,7 @@ async function handleExecServerMessage(
 		case "mcpStateExecArgs": {
 			const args = execMsg.message.value;
 			sendExecClientMessage(
-				h2Request,
+				runTransport,
 				execMsg,
 				"mcpStateExecResult",
 				buildMcpStateResult(requestContextTools, args.serverIdentifiers),
@@ -2345,14 +2947,14 @@ async function handleExecServerMessage(
 			const execResult = buildNeutralHookResult(args.request);
 			if (!execResult) {
 				sendExecClientThrow(
-					h2Request,
+					runTransport,
 					execMsg,
 					`Unsupported hook request: ${args.request?.request.case ?? "unset"}`,
 					"unknown_hook_request",
 				);
 				return;
 			}
-			sendExecClientMessage(h2Request, execMsg, "executeHookResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "executeHookResult", execResult);
 			return;
 		}
 		case "subagentArgs": {
@@ -2364,7 +2966,7 @@ async function handleExecServerMessage(
 				},
 			});
 			log("exec", "subagentRejected", { subagentType: args.subagentType });
-			sendExecClientMessage(h2Request, execMsg, "subagentResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "subagentResult", execResult);
 			return;
 		}
 		case "subagentAwaitArgs": {
@@ -2376,7 +2978,7 @@ async function handleExecServerMessage(
 					value: create(SubagentAwaitNotFoundSchema, { agentId: args.agentId }),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "subagentAwaitResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "subagentAwaitResult", execResult);
 			return;
 		}
 		case "forceBackgroundShellArgs": {
@@ -2385,14 +2987,14 @@ async function handleExecServerMessage(
 			const execResult = create(ForceBackgroundShellResultSchema, {
 				status: ForceBackgroundShellStatus.NOT_FOUND,
 			});
-			sendExecClientMessage(h2Request, execMsg, "forceBackgroundShellResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "forceBackgroundShellResult", execResult);
 			return;
 		}
 		case "forceBackgroundSubagentArgs": {
 			const execResult = create(ForceBackgroundSubagentResultSchema, {
 				status: ForceBackgroundSubagentStatus.NOT_FOUND,
 			});
-			sendExecClientMessage(h2Request, execMsg, "forceBackgroundSubagentResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "forceBackgroundSubagentResult", execResult);
 			return;
 		}
 		case "smartModeClassifierArgs": {
@@ -2407,7 +3009,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "smartModeClassifierResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "smartModeClassifierResult", execResult);
 			return;
 		}
 		case "canvasDiagnosticsArgs": {
@@ -2421,7 +3023,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "canvasDiagnosticsResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "canvasDiagnosticsResult", execResult);
 			return;
 		}
 		case "shellAllowlistPrecheckArgs": {
@@ -2430,7 +3032,7 @@ async function handleExecServerMessage(
 			// `false` costs an approval round-trip, `true` would grant one that was
 			// never configured.
 			sendExecClientMessage(
-				h2Request,
+				runTransport,
 				execMsg,
 				"shellAllowlistPrecheckResult",
 				create(ShellAllowlistPrecheckResultSchema, { allowlisted: false }),
@@ -2439,7 +3041,7 @@ async function handleExecServerMessage(
 		}
 		case "mcpAllowlistPrecheckArgs": {
 			sendExecClientMessage(
-				h2Request,
+				runTransport,
 				execMsg,
 				"mcpAllowlistPrecheckResult",
 				create(McpAllowlistPrecheckResultSchema, { allowlisted: false }),
@@ -2448,7 +3050,7 @@ async function handleExecServerMessage(
 		}
 		case "webFetchAllowlistPrecheckArgs": {
 			sendExecClientMessage(
-				h2Request,
+				runTransport,
 				execMsg,
 				"webFetchAllowlistPrecheckResult",
 				create(WebFetchAllowlistPrecheckResultSchema, { allowlisted: false }),
@@ -2476,7 +3078,7 @@ async function handleExecServerMessage(
 			const execResult = create(ConversationSearchResultSchema, {
 				result: { case: "error", value: create(ConversationSearchErrorSchema, { error }) },
 			});
-			sendExecClientMessage(h2Request, execMsg, "conversationSearchResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "conversationSearchResult", execResult);
 			return;
 		}
 		case "agentStoreConflictArgs": {
@@ -2490,7 +3092,7 @@ async function handleExecServerMessage(
 					}),
 				},
 			});
-			sendExecClientMessage(h2Request, execMsg, "agentStoreConflictResult", execResult);
+			sendExecClientMessage(runTransport, execMsg, "agentStoreConflictResult", execResult);
 			return;
 		}
 		case "gitDiffRequest": {
@@ -2498,7 +3100,12 @@ async function handleExecServerMessage(
 			// plus before/after file contents and nothing else. Any in-band answer is
 			// therefore a claim that a diff was computed, so a `throw` is the only
 			// truthful reply.
-			sendExecClientThrow(h2Request, execMsg, `Git diff is ${NOT_IMPLEMENTED_SUFFIX}`, "exec_variant_unsupported");
+			sendExecClientThrow(
+				runTransport,
+				execMsg,
+				`Git diff is ${NOT_IMPLEMENTED_SUFFIX}`,
+				"exec_variant_unsupported",
+			);
 			return;
 		}
 		default: {
@@ -2507,7 +3114,7 @@ async function handleExecServerMessage(
 			// even name the frame.
 			log("warn", "unhandledExecMessage", { execCase });
 			sendExecClientThrow(
-				h2Request,
+				runTransport,
 				execMsg,
 				`No handler for exec message of type ${execCase}`,
 				"exec_variant_unsupported",
@@ -2525,7 +3132,7 @@ async function handleExecServerMessage(
  * message the server rejects at runtime.
  */
 function sendExecClientMessage<TCase extends NonNullable<ExecClientMessage["message"]["case"]>>(
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execMsg: ExecServerMessage,
 	messageCase: TCase,
 	value: Extract<ExecClientMessage["message"], { case: TCase }>["value"],
@@ -2541,7 +3148,7 @@ function sendExecClientMessage<TCase extends NonNullable<ExecClientMessage["mess
 	});
 
 	const responseBytes = toBinary(AgentClientMessageSchema, clientMessage);
-	h2Request.write(frameConnectMessage(responseBytes));
+	runTransport.write(frameConnectMessage(responseBytes));
 
 	log("execClientMessage", messageCase, value);
 }
@@ -2563,7 +3170,7 @@ function sendExecClientMessage<TCase extends NonNullable<ExecClientMessage["mess
  * result and cannot tell it apart from a malformed frame.
  */
 function sendExecClientThrow(
-	h2Request: http2.ClientHttp2Stream,
+	runTransport: CursorMessageWriter,
 	execMsg: ExecServerMessage,
 	error: string,
 	errorCode?: string,
@@ -2577,12 +3184,12 @@ function sendExecClientThrow(
 	const clientMessage = create(AgentClientMessageSchema, {
 		message: { case: "execClientControlMessage", value: controlMessage },
 	});
-	h2Request.write(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
+	runTransport.write(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
 	log("execClientControl", "throw", { id: execMsg.id, execId: execMsg.execId, error, errorCode });
-	sendExecClientStreamClose(h2Request, execMsg);
+	sendExecClientStreamClose(runTransport, execMsg);
 }
 
-function sendExecClientStreamClose(h2Request: http2.ClientHttp2Stream, execMsg: ExecServerMessage): void {
+function sendExecClientStreamClose(runTransport: CursorMessageWriter, execMsg: ExecServerMessage): void {
 	const closeMessage = create(ExecClientControlMessageSchema, {
 		message: {
 			case: "streamClose",
@@ -2595,7 +3202,7 @@ function sendExecClientStreamClose(h2Request: http2.ClientHttp2Stream, execMsg: 
 		message: { case: "execClientControlMessage", value: closeMessage },
 	});
 	const responseBytes = toBinary(AgentClientMessageSchema, clientMessage);
-	h2Request.write(frameConnectMessage(responseBytes));
+	runTransport.write(frameConnectMessage(responseBytes));
 	log("execClientControl", "streamClose", { id: execMsg.id, execId: execMsg.execId });
 }
 
@@ -4543,6 +5150,24 @@ export function processInteractionUpdate(
 		}
 	} else if (updateCase === "turnEnded") {
 		output.stopReason = "stop";
+		const usage = update.message.value;
+		const hasAuthoritativeUsage =
+			usage.inputTokens !== undefined ||
+			usage.outputTokens !== undefined ||
+			usage.cachedInputTokens !== undefined ||
+			usage.cacheWriteTokens !== undefined ||
+			usage.reasoningOutputTokens !== undefined;
+		if (hasAuthoritativeUsage) {
+			output.usage.input = Number(usage.inputTokens ?? 0);
+			output.usage.output = Number(usage.outputTokens ?? 0);
+			output.usage.cacheRead = Number(usage.cachedInputTokens ?? 0);
+			output.usage.cacheWrite = Number(usage.cacheWriteTokens ?? 0);
+			output.usage.reasoningTokens =
+				usage.reasoningOutputTokens === undefined ? undefined : Number(usage.reasoningOutputTokens);
+			output.usage.totalTokens =
+				output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+			usageState.sawAuthoritativeUsage = true;
+		}
 		if (
 			classifyModel("cursor", output.model).family === "k3" &&
 			!output.content.some(item => item.type === "thinking" && item.thinking.length > 0)
@@ -4552,7 +5177,7 @@ export function processInteractionUpdate(
 				{ model: output.model, messageTimestamp: output.timestamp },
 			);
 		}
-	} else if (updateCase === "tokenDelta") {
+	} else if (updateCase === "tokenDelta" && !usageState.sawAuthoritativeUsage) {
 		const tokenDelta = update.message.value;
 		usageState.sawTokenDelta = true;
 		output.usage.output += tokenDelta.tokens || 0;
@@ -5229,24 +5854,19 @@ function extractImages(content: (TextContent | ImageContent)[]) {
 }
 
 /**
- * Resolve the Cursor Run wire model id and its parameter list.
+ * Resolve Cursor's paired model identities and rich parameter list.
  *
- * Cursor's `GetUsableModels` lists reasoning models as per-effort sibling
- * slugs (`gpt-5.4-mini-low`, `gpt-5.6-sol-high`), and OMP copies those ids 1:1.
- * The Run endpoint rejects a sibling slug as the wire `model_id` with
- * `resource_exhausted` (errorId 528384); the official `cursor-agent` splits the
- * slug into its base model id plus a `reasoning` effort parameter. Mirror that
- * for OpenAI-family ids: split the tier with the compiled catalog policy
- * (`collapseVariantId`, KDL suffix/lane rules) and emit
- * `{ id: "reasoning", value: <effort> }`. The off tier (`-none`) is a sibling
- * slug too, so it normalizes to the bare (lane-preserving) base with no
- * reasoning parameter instead of going out raw.
+ * Cursor validates both fields independently: legacy `modelDetails.modelId`
+ * retains the account-usable sibling slug, while `requestedModel.modelId`
+ * carries the rich base id plus its parameter values. Sending the base id in
+ * both fields produces `BAD_MODEL_NAME`; sending an OpenAI effort sibling in
+ * both produces resource exhaustion (errorId 528384).
  *
- * Non-OpenAI ids pass through unchanged — Cursor-native ids (`composer-*`,
- * `cursor-grok-*`, `default`) carry no effort suffix, and Claude/other siblings
- * need additional parameters (`thinking`, `context`) whose per-model values are
- * not exposed by the decoded `GetUsableModels` schema, so guessing them would
- * re-trigger 528384.
+ * Rich discovery supplies the exact pair. Legacy discovery has only sibling
+ * slugs, so OpenAI-family ids strip a trailing effort tier into
+ * `{ id: "reasoning", value: <effort> }`. Other legacy ids pass through
+ * unchanged because guessing their extra `thinking`, `context`, or `fast`
+ * parameters would recreate the same wire failures.
  */
 function resolveCursorWireModel(
 	model: Model<"cursor-agent">,
@@ -5254,38 +5874,70 @@ function resolveCursorWireModel(
 	wireMode: CursorWireMode = "normalized",
 ): {
 	modelId: string;
+	modelDetailsId: string;
 	parameters: RequestedModel_ModelParameterbytes[];
+	maxMode: boolean;
 } {
 	const wireModelId = requestModelId ?? model.requestModelId ?? model.id;
-	if (wireMode === "discovered") return { modelId: wireModelId, parameters: [] };
-	// `collapseVariantId` keeps the lane in the logical id (`-high-fast` →
-	// base `-fast`) and decodes the KDL effort (`-none` → `off`).
+	const discoveredRoute = model.cursorModelRoutes?.[wireModelId];
+	if (discoveredRoute) {
+		return {
+			modelId: discoveredRoute.modelId,
+			modelDetailsId: wireModelId,
+			parameters: discoveredRoute.parameters.map(parameter =>
+				create(RequestedModel_ModelParameterbytesSchema, parameter),
+			),
+			maxMode: discoveredRoute.maxMode ?? model.cursorMaxMode === true,
+		};
+	}
+	if (wireMode === "discovered") {
+		return {
+			modelId: wireModelId,
+			modelDetailsId: wireModelId,
+			parameters: (model.cursorModelParameters ?? []).map(parameter =>
+				create(RequestedModel_ModelParameterbytesSchema, parameter),
+			),
+			maxMode: model.cursorMaxMode === true,
+		};
+	}
+	// Legacy discovery had only sibling slugs. Normalize OpenAI effort suffixes
+	// through the compiled catalog policy when no rich parameter route is
+	// available. `collapseVariantId` keeps the lane in the logical id
+	// (`-high-fast` → base `-fast`) and decodes the KDL effort (`-none` → off).
 	const collapsed = collapseVariantId("cursor", wireModelId);
 	const effort = collapsed.effort;
 	const base = effort !== undefined ? collapsed.logicalId : undefined;
 	if (effort !== undefined && base && classifyModel("cursor", base).class === "openai") {
 		if (effort === "off") {
-			return { modelId: base, parameters: [] };
+			return { modelId: base, modelDetailsId: wireModelId, parameters: [], maxMode: model.cursorMaxMode === true };
 		}
 		if ((THINKING_EFFORTS as readonly string[]).includes(effort)) {
 			return {
 				modelId: base,
+				modelDetailsId: wireModelId,
 				parameters: [
 					create(RequestedModel_ModelParameterbytesSchema, { id: "reasoning", value: collapsed.effort }),
 				],
+				maxMode: model.cursorMaxMode === true,
 			};
 		}
 	}
-	// A bare `composer-2.5` id resolves to the Fast variant server-side
-	// (can1357/oh-my-pi#9012). Pin the Standard tier explicitly; `-fast`
-	// selections keep the Fast lane by omitting the parameter.
+	// A bare `composer-2.5` id resolves to the Fast variant server-side. Pin the
+	// Standard tier; `-fast` selections omit the parameter and keep Fast.
 	if (wireModelId === "composer-2.5") {
 		return {
 			modelId: wireModelId,
+			modelDetailsId: wireModelId,
 			parameters: [create(RequestedModel_ModelParameterbytesSchema, { id: "fast", value: "false" })],
+			maxMode: model.cursorMaxMode === true,
 		};
 	}
-	return { modelId: wireModelId, parameters: [] };
+	return {
+		modelId: wireModelId,
+		modelDetailsId: wireModelId,
+		parameters: [],
+		maxMode: model.cursorMaxMode === true,
+	};
 }
 
 async function buildGrpcRequestForWireMode(
@@ -5306,6 +5958,10 @@ async function buildGrpcRequestForWireMode(
 	const activeMessage = context.messages[activeUserMessageIndex];
 	let activeUserMessage =
 		activeMessage?.role === "user" || activeMessage?.role === "developer" ? activeMessage : undefined;
+	if (state.resume) {
+		activeUserMessageIndex = -1;
+		activeUserMessage = undefined;
+	}
 	if (state.rotatedFresh && !activeUserMessage && lastUserMessageIndex >= 0) {
 		activeUserMessageIndex = lastUserMessageIndex;
 		const lastUser = context.messages[lastUserMessageIndex];
@@ -5395,14 +6051,14 @@ async function buildGrpcRequestForWireMode(
 		turns,
 	});
 
-	const { modelId: wireModelId, parameters: wireParameters } = resolveCursorWireModel(
-		model,
-		options?.wireModelId,
-		wireMode,
-	);
-	const cursorMaxMode = model.cursorMaxMode === true;
-	const modelDetails = create(ModelDetailsSchema, {
+	const {
 		modelId: wireModelId,
+		modelDetailsId: wireModelDetailsId,
+		parameters: wireParameters,
+		maxMode: cursorMaxMode,
+	} = resolveCursorWireModel(model, options?.wireModelId, wireMode);
+	const modelDetails = create(ModelDetailsSchema, {
+		modelId: wireModelDetailsId,
 		displayModelId: model.id,
 		displayName: model.name,
 		...(cursorMaxMode ? { maxMode: true } : undefined),
@@ -5440,7 +6096,7 @@ async function buildGrpcRequestForWireMode(
 		wireParameters.length > 0 &&
 		wireModelId !== discoveredWireModelId &&
 		runRequest.requestedModel?.modelId === wireModelId &&
-		runRequest.modelDetails?.modelId === wireModelId &&
+		runRequest.modelDetails?.modelId === wireModelDetailsId &&
 		serializedParameters?.length === wireParameters.length &&
 		serializedParameters.every((parameter, index) => {
 			const expected = wireParameters[index];

--- a/packages/ai/src/providers/cursor/interaction-query.ts
+++ b/packages/ai/src/providers/cursor/interaction-query.ts
@@ -1,4 +1,3 @@
-import type http2 from "node:http2";
 import {
 	AgentClientMessageSchema,
 	AskQuestionInteractionResponseSchema,
@@ -22,12 +21,16 @@ import {
 	WebSearchRequestResponseSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
 import { create, toBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
-import { $env } from "@oh-my-pi/pi-utils";
+import { $env, logger } from "@oh-my-pi/pi-utils";
 
 const NOT_IMPLEMENTED_SUFFIX = "not implemented by this client";
 
 type ProtoUnknownField = { no: number; wireType: number; data: Uint8Array };
 type ProtoUnknownBag = { $unknown?: ProtoUnknownField[] };
+
+interface CursorInteractionWriter {
+	write(frame: Uint8Array): void;
+}
 
 type InteractionQueryCase = NonNullable<InteractionQuery["query"]["case"]>;
 type InteractionResult = Exclude<InteractionResponse["result"], { case: undefined; value?: undefined }>;
@@ -65,12 +68,12 @@ function attachUnknownApprovedField(response: InteractionResponse, fieldNo: numb
 
 function log(type: string, subtype?: string, data?: unknown): void {
 	if (!$env.DEBUG_CURSOR) return;
-	const verbose = $env.DEBUG_CURSOR === "2" || $env.DEBUG_CURSOR === "verbose";
-	const dataStr = verbose && data ? ` ${JSON.stringify(data)?.slice(0, 500)}` : "";
-	console.error(`[CURSOR] ${type}${subtype ? `: ${subtype}` : ""}${dataStr}`);
+	logger.debug(`cursor interaction: ${type}${subtype ? `: ${subtype}` : ""}`, {
+		...($env.DEBUG_CURSOR === "2" || $env.DEBUG_CURSOR === "verbose" ? { data } : undefined),
+	});
 }
 
-function sendInteractionResponse(h2Request: http2.ClientHttp2Stream, queryId: number, result: InteractionResult): void {
+function sendInteractionResponse(h2Request: CursorInteractionWriter, queryId: number, result: InteractionResult): void {
 	const response = create(InteractionResponseSchema, { id: queryId, result });
 	const clientMessage = create(AgentClientMessageSchema, {
 		message: { case: "interactionResponse", value: response },
@@ -80,7 +83,7 @@ function sendInteractionResponse(h2Request: http2.ClientHttp2Stream, queryId: nu
 }
 
 function sendUnknownApprovedInteractionResponse(
-	h2Request: http2.ClientHttp2Stream,
+	h2Request: CursorInteractionWriter,
 	queryId: number,
 	fieldNo: number,
 ): void {
@@ -107,7 +110,7 @@ function sendUnknownApprovedInteractionResponse(
  * Unsupported interactive queries are rejected so the server is not stranded.
  * VM setup is left unanswered rather than reporting a fake success.
  */
-export function handleInteractionQuery(query: InteractionQuery, h2Request: http2.ClientHttp2Stream): void {
+export function handleInteractionQuery(query: InteractionQuery, h2Request: CursorInteractionWriter): void {
 	const queryCase = query.query.case;
 	log("interactionQuery", queryCase, query.query.value);
 	if (!queryCase) {

--- a/packages/ai/src/providers/cursor/proto/agent.proto
+++ b/packages/ai/src/providers/cursor/proto/agent.proto
@@ -836,6 +836,11 @@ message ShellOutputDeltaUpdate {
 }
 
 message TurnEndedUpdate {
+   optional int64 input_tokens = 1;
+   optional int64 output_tokens = 2;
+   optional int64 cached_input_tokens = 3;
+   optional int64 cache_write_tokens = 4;
+   optional int64 reasoning_output_tokens = 5;
 }
 
 // Only: user message appended update

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -1,3 +1,4 @@
+import { CURSOR_DEFAULT_BASE_URL } from "@oh-my-pi/pi-catalog/wire/cursor";
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import { extractCursorAccessTokenUserId } from "../registry/oauth/cursor";
 import type {
@@ -18,10 +19,8 @@ function parseTimestamp(value: unknown): number | undefined {
 	return parseIsoTimestamp(value);
 }
 
-const DEFAULT_CURSOR_BASE_URL = "https://api2.cursor.sh";
-
 function normalizeCursorBaseUrl(baseUrl?: string): string {
-	if (!baseUrl) return DEFAULT_CURSOR_BASE_URL;
+	if (!baseUrl) return CURSOR_DEFAULT_BASE_URL;
 	return baseUrl.replace(/\/+$/, "");
 }
 
@@ -391,7 +390,7 @@ export const cursorUsageProvider: UsageProvider = {
 
 		let summaryReportPromise = Promise.resolve<UsageReport | null>(null);
 		let profileEmailPromise = Promise.resolve<string | undefined>(undefined);
-		if (credential.type === "oauth" && baseUrl === DEFAULT_CURSOR_BASE_URL) {
+		if (credential.type === "oauth" && baseUrl === CURSOR_DEFAULT_BASE_URL) {
 			const userId = extractCursorAccessTokenUserId(token);
 			if (userId) {
 				const sessionHeaders: Record<string, string> = {

--- a/packages/ai/test/cursor-checkpoint-retry.test.ts
+++ b/packages/ai/test/cursor-checkpoint-retry.test.ts
@@ -1,0 +1,154 @@
+import { expect, it } from "bun:test";
+import * as http2 from "node:http2";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	AgentClientMessageSchema,
+	AgentServerMessageSchema,
+	ConversationStateStructureSchema,
+	ConversationTokenDetailsSchema,
+	InteractionUpdateSchema,
+	TextDeltaUpdateSchema,
+	TurnEndedUpdateSchema,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { create, fromBinary, toBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+
+function frameConnectMessage(data: Uint8Array): Buffer {
+	const frame = Buffer.alloc(5 + data.length);
+	frame.writeUInt32BE(data.length, 1);
+	frame.set(data, 5);
+	return frame;
+}
+
+function textDeltaFrame(text: string): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "interactionUpdate",
+					value: create(InteractionUpdateSchema, {
+						message: { case: "textDelta", value: create(TextDeltaUpdateSchema, { text }) },
+					}),
+				},
+			}),
+		),
+	);
+}
+
+function checkpointFrame(): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "conversationCheckpointUpdate",
+					value: create(ConversationStateStructureSchema, {
+						tokenDetails: create(ConversationTokenDetailsSchema, { usedTokens: 42 }),
+					}),
+				},
+			}),
+		),
+	);
+}
+
+function turnEndedFrame(): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "interactionUpdate",
+					value: create(InteractionUpdateSchema, {
+						message: { case: "turnEnded", value: create(TurnEndedUpdateSchema, {}) },
+					}),
+				},
+			}),
+		),
+	);
+}
+
+function decodeRunAction(chunk: Buffer): string | undefined {
+	const length = chunk.readUInt32BE(1);
+	const message = fromBinary(AgentClientMessageSchema, chunk.subarray(5, 5 + length));
+	return message.message.case === "runRequest" ? message.message.value.action?.action.case : undefined;
+}
+
+function makeModel(baseUrl: string): Model<"cursor-agent"> {
+	return buildModel({
+		id: "cursor-checkpoint-retry-fixture",
+		name: "Cursor checkpoint retry fixture",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1,
+		maxTokens: 1,
+	});
+}
+
+const context: Context = { messages: [{ role: "user", content: "retry", timestamp: 1 }] };
+
+it("resumes from the latest replay-safe checkpoint after an incomplete stream", async () => {
+	const sessions = new Set<http2.Http2Session>();
+	const requestIds: string[] = [];
+	const originalRequestIds: string[] = [];
+	const actions: (string | undefined)[] = [];
+	let requestCount = 0;
+	const server = http2.createServer();
+	server.on("session", session => {
+		sessions.add(session);
+		session.on("close", () => sessions.delete(session));
+	});
+	server.on("stream", (providerStream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+		requestCount++;
+		requestIds.push(String(headers["x-request-id"] ?? ""));
+		originalRequestIds.push(String(headers["x-original-request-id"] ?? ""));
+		let handled = false;
+		providerStream.on("data", (chunk: Buffer) => {
+			if (handled) return;
+			handled = true;
+			actions.push(decodeRunAction(chunk));
+			providerStream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+			if (requestCount === 1) {
+				providerStream.end(Buffer.concat([textDeltaFrame("before"), checkpointFrame()]));
+				return;
+			}
+			providerStream.end(Buffer.concat([textDeltaFrame(" after"), turnEndedFrame()]));
+		});
+	});
+	const listening = Promise.withResolvers<void>();
+	server.once("error", listening.reject);
+	server.listen(0, "127.0.0.1", listening.resolve);
+	await listening.promise;
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("expected HTTP/2 fixture server address");
+
+	try {
+		const delays: number[] = [];
+		const response = streamCursor(makeModel(`http://127.0.0.1:${address.port}`), context, {
+			apiKey: "test-token",
+			providerRetryWait: async delayMs => {
+				delays.push(delayMs);
+			},
+		});
+		let startEvents = 0;
+		for await (const event of response) {
+			if (event.type === "start") startEvents++;
+		}
+		const result = await response.result();
+
+		expect(requestCount).toBe(2);
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "before after" })]);
+		expect(actions).toEqual(["userMessageAction", "resumeAction"]);
+		expect(delays).toEqual([500]);
+		expect(startEvents).toBe(1);
+		expect(originalRequestIds).toEqual(["", requestIds[0]]);
+	} finally {
+		for (const session of sessions) session.destroy();
+		server.close();
+	}
+});

--- a/packages/ai/test/cursor-effort-routing.test.ts
+++ b/packages/ai/test/cursor-effort-routing.test.ts
@@ -3,8 +3,8 @@
 // selection never reached the wire. `mapOptionsForApi` now resolves the effort
 // to a routed wire id; `buildGrpcRequest` splits an OpenAI effort suffix off
 // `options.wireModelId` into a `reasoning` parameter (suffixed sibling ids
-// trigger Cursor's 528384) and sends the base id on both `requestedModel` and
-// `modelDetails`, keeping the logical id only as the display id.
+// trigger Cursor's 528384), sends the rich base through `requestedModel`, and
+// retains the usable sibling through legacy `modelDetails`.
 // buildGrpcRequest is exercised directly (the transport is HTTP/2)
 // and the serialized run request is decoded back from the wire bytes.
 import { describe, expect, it } from "bun:test";
@@ -60,7 +60,7 @@ describe("cursor effort routing", () => {
 		);
 		const run = decodeRunRequest(requestBytes).value;
 		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra");
-		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra");
+		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra-medium");
 		expect(run.requestedModel.parameters).toEqual([expect.objectContaining({ id: "reasoning", value: "medium" })]);
 
 		// Logical id stays as the display id for local attribution.
@@ -74,9 +74,10 @@ describe("cursor effort routing", () => {
 		});
 		const run = decodeRunRequest(requestBytes).value;
 		// The routed off-tier sibling still normalizes: suffixed sibling ids
-		// trigger Cursor's 528384, so -none goes out as the bare base id.
+		// trigger Cursor's 528384, so -none goes out as the bare base id, with
+		// the usable sibling retained on legacy modelDetails.
 		expect(run.requestedModel.modelId).toBe("gpt-5.6-terra");
-		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra");
+		expect(run.modelDetails.modelId).toBe("gpt-5.6-terra-none");
 		expect(run.requestedModel.parameters).toEqual([]);
 	});
 });

--- a/packages/ai/test/cursor-exec-modern.test.ts
+++ b/packages/ai/test/cursor-exec-modern.test.ts
@@ -7,6 +7,7 @@ import {
 	handleServerMessage,
 	processInteractionUpdate,
 	type ToolCallState,
+	type UsageState,
 } from "@oh-my-pi/pi-ai/providers/cursor";
 import type { AssistantMessage, CursorExecHandlers, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { kCursorExecResolved, setStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
@@ -50,6 +51,7 @@ import {
 	PiEditExecArgsSchema,
 	PiEditReplacementSchema,
 	PiFindExecArgsSchema,
+	InteractionUpdateSchema,
 	PiGrepExecArgsSchema,
 	PiLsExecArgsSchema,
 	PiReadExecArgsSchema,
@@ -65,6 +67,7 @@ import {
 	SubagentArgsSchema,
 	SubagentAwaitArgsSchema,
 	ToolCallSchema,
+	TurnEndedUpdateSchema,
 	WebFetchAllowlistPrecheckArgsSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
 import { create, fromBinary, toBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
@@ -208,7 +211,41 @@ function soleResult(frames: AgentClientMessage[]) {
 
 describe("Cursor modern exec protocol activation", () => {
 	it("advertises the client build whose schema includes modern exec frames", () => {
-		expect(CURSOR_CLIENT_VERSION).toBe("cli-2026.07.23-e383d2b");
+		expect(CURSOR_CLIENT_VERSION).toBe("cli-2026.09.02-c22c1a3");
+	});
+
+	it("uses TurnEnded totals as the authoritative usage snapshot", () => {
+		const output = cursorAssistantMessage();
+		const stream = new AssistantMessageEventStream();
+		const usageState: UsageState = { sawTokenDelta: true };
+		processInteractionUpdate(
+			create(InteractionUpdateSchema, {
+				message: {
+					case: "turnEnded",
+					value: create(TurnEndedUpdateSchema, {
+						inputTokens: 11n,
+						outputTokens: 7n,
+						cachedInputTokens: 5n,
+						cacheWriteTokens: 3n,
+						reasoningOutputTokens: 2n,
+					}),
+				},
+			}),
+			output,
+			stream,
+			newBlockState(),
+			usageState,
+		);
+
+		expect(output.usage).toMatchObject({
+			input: 11,
+			output: 7,
+			cacheRead: 5,
+			cacheWrite: 3,
+			reasoningTokens: 2,
+			totalTokens: 26,
+		});
+		expect(usageState.sawAuthoritativeUsage).toBe(true);
 	});
 });
 

--- a/packages/ai/test/cursor-h2-transport-error.test.ts
+++ b/packages/ai/test/cursor-h2-transport-error.test.ts
@@ -14,7 +14,7 @@ describe("mapH2TransportError", () => {
 		expect(err.kind).toBe("runtime");
 		expect(err.message).toContain(BASE_URL);
 		expect(err.message).toContain("ALPN");
-		expect(err.message).toContain("providers.cursor.baseUrl");
+		expect(err.message).toContain("RunSSE/BidiAppend");
 		expect(err.cause).toBe(raw);
 	});
 

--- a/packages/ai/test/cursor-http1-transport.test.ts
+++ b/packages/ai/test/cursor-http1-transport.test.ts
@@ -1,0 +1,131 @@
+import { expect, it } from "bun:test";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	AgentClientMessageSchema,
+	AgentServerMessageSchema,
+	BidiAppendRequestSchema,
+	BidiRequestIdSchema,
+	InteractionUpdateSchema,
+	TextDeltaUpdateSchema,
+	TurnEndedUpdateSchema,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
+import { create, fromBinary, toBinary } from "@oh-my-pi/pi-catalog/discovery/protobuf";
+
+function frameConnectMessage(data: Uint8Array): Buffer {
+	const frame = Buffer.alloc(5 + data.length);
+	frame.writeUInt32BE(data.length, 1);
+	frame.set(data, 5);
+	return frame;
+}
+
+function readConnectMessage(frame: Uint8Array): Uint8Array {
+	if (frame.length < 5) throw new Error("truncated Connect frame");
+	const length = new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(1, false);
+	if (frame.length !== length + 5) throw new Error("invalid Connect frame length");
+	return frame.subarray(5);
+}
+
+function textDeltaFrame(text: string): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: { case: "textDelta", value: create(TextDeltaUpdateSchema, { text }) },
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function turnEndedFrame(): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: { case: "turnEnded", value: create(TurnEndedUpdateSchema, {}) },
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function makeModel(baseUrl: string): Model<"cursor-agent"> {
+	return buildModel({
+		id: "cursor-http1-fixture",
+		name: "Cursor HTTP1 fixture",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1,
+		maxTokens: 1,
+	});
+}
+
+const context: Context = { messages: [{ role: "user", content: "transport", timestamp: 1 }] };
+
+it("streams through RunSSE and sends AgentClientMessage frames through BidiAppend", async () => {
+	const streamReady = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+	const runRequestIds: string[] = [];
+	const appendRequestIds: string[] = [];
+	const appendSeqnos: bigint[] = [];
+	const appendedCases: string[] = [];
+	const streamingHeaders: string[] = [];
+
+	const server = Bun.serve({
+		port: 0,
+		async fetch(request) {
+			const url = new URL(request.url);
+			streamingHeaders.push(request.headers.get("x-cursor-streaming") ?? "");
+			const body = new Uint8Array(await request.arrayBuffer());
+			if (url.pathname === "/agent.v1.AgentService/RunSSE") {
+				const requestId = fromBinary(BidiRequestIdSchema, readConnectMessage(body));
+				runRequestIds.push(requestId.requestId);
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamReady.resolve(controller);
+						},
+					}),
+					{ headers: { "content-type": "application/connect+proto" } },
+				);
+			}
+			if (url.pathname === "/aiserver.v1.BidiService/BidiAppend") {
+				const append = fromBinary(BidiAppendRequestSchema, readConnectMessage(body));
+				appendRequestIds.push(append.requestId?.requestId ?? "");
+				appendSeqnos.push(append.appendSeqno);
+				appendedCases.push(fromBinary(AgentClientMessageSchema, append.dataBinary).message.case ?? "");
+				const controller = await streamReady.promise;
+				controller.enqueue(textDeltaFrame("http1 ok"));
+				controller.enqueue(turnEndedFrame());
+				controller.close();
+				return new Response(null, { headers: { "content-type": "application/connect+proto" } });
+			}
+			return new Response(null, { status: 404 });
+		},
+	});
+
+	try {
+		const response = streamCursor(makeModel(server.url.toString()), context, {
+			apiKey: "test-token",
+			transport: "http1",
+		});
+		for await (const _event of response) {
+			// Drain the full provider stream.
+		}
+		const result = await response.result();
+
+		expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "http1 ok" })]);
+		expect(runRequestIds).toHaveLength(1);
+		expect(appendRequestIds).toEqual(runRequestIds);
+		expect(appendSeqnos).toEqual([0n]);
+		expect(appendedCases).toEqual(["runRequest"]);
+		expect(streamingHeaders).toEqual(["true", "true"]);
+	} finally {
+		server.stop(true);
+	}
+});

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -40,8 +40,8 @@ describe("Cursor requestedModel wire shape", () => {
 		const payload = await capture(cursorModel("gpt-5.4-mini-low"));
 		expect(payload.requestedModel?.modelId).toBe("gpt-5.4-mini");
 		expect(payload.requestedModel?.parameters).toEqual([expect.objectContaining({ id: "reasoning", value: "low" })]);
-		// modelDetails is still read server-side, so it must carry the base id too.
-		expect(payload.modelDetails?.modelId).toBe("gpt-5.4-mini");
+		// Cursor still validates the legacy model_details field independently.
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.4-mini-low");
 	});
 
 	it("handles multi-segment GPT bases and the xhigh tier", async () => {
@@ -64,14 +64,15 @@ describe("Cursor requestedModel wire shape", () => {
 		const payload = await capture(cursorModel("gpt-5.6-sol-none"));
 		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol");
 		expect(payload.requestedModel?.parameters).toEqual([]);
-		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol");
+		// modelDetails keeps the account-usable sibling; the base goes out raw.
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol-none");
 	});
 
 	it("normalizes a fast-lane off-tier sibling preserving the lane", async () => {
 		const payload = await capture(cursorModel("gpt-5.6-sol-none-fast"));
 		expect(payload.requestedModel?.modelId).toBe("gpt-5.6-sol-fast");
 		expect(payload.requestedModel?.parameters).toEqual([]);
-		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol-fast");
+		expect(payload.modelDetails?.modelId).toBe("gpt-5.6-sol-none-fast");
 	});
 
 	it("leaves Cursor-native ids untouched with no parameters", async () => {
@@ -96,5 +97,27 @@ describe("Cursor requestedModel wire shape", () => {
 		const payload = await capture(cursorModel("claude-fable-5-low"));
 		expect(payload.requestedModel?.modelId).toBe("claude-fable-5-low");
 		expect(payload.requestedModel?.parameters).toEqual([]);
+	});
+
+	it("uses authoritative rich-catalog routes after variant collapse", async () => {
+		const model = cursorModel("cursor-rich-low");
+		model.cursorModelRoutes = {
+			"cursor-rich-low": {
+				modelId: "cursor-rich",
+				parameters: [
+					{ id: "reasoning", value: "low" },
+					{ id: "context", value: "long" },
+				],
+				maxMode: true,
+			},
+		};
+		const payload = await capture(model);
+		expect(payload.requestedModel?.modelId).toBe("cursor-rich");
+		expect(payload.requestedModel?.parameters).toEqual([
+			expect.objectContaining({ id: "reasoning", value: "low" }),
+			expect.objectContaining({ id: "context", value: "long" }),
+		]);
+		expect(payload.requestedModel?.maxMode).toBe(true);
+		expect(payload.modelDetails?.modelId).toBe("cursor-rich-low");
 	});
 });

--- a/packages/ai/test/cursor-terminal-error.test.ts
+++ b/packages/ai/test/cursor-terminal-error.test.ts
@@ -7,6 +7,9 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	AgentServerMessageSchema,
 	ExecServerMessageSchema,
+	CustomErrorDetailsSchema,
+	CursorError,
+	ErrorDetailsSchema,
 	InteractionUpdateSchema,
 	ReadArgsSchema,
 	TextDeltaUpdateSchema,
@@ -25,6 +28,7 @@ type Scenario =
 	| { kind: "connect-error-after-turn" }
 	| { kind: "connect-detailed-error-after-turn" }
 	| { kind: "connect-classification-detail-after-turn" }
+	| { kind: "connect-structured-error-after-turn" }
 	| { kind: "grpc-trailer-after-turn" }
 	| { kind: "end-before-turn" }
 	| { kind: "hang-after-turn" }
@@ -260,6 +264,27 @@ async function startServer(): Promise<string> {
 			return;
 		}
 
+		if (scenario.kind === "connect-structured-error-after-turn") {
+			const details = create(ErrorDetailsSchema, {
+				error: CursorError.ERROR_RATE_LIMITED,
+				details: create(CustomErrorDetailsSchema, {
+					title: "Capacity reached",
+					detail: "Retry this request shortly",
+					isRetryable: true,
+				}),
+			});
+			stream.write(
+				connectEndErrorFrame("invalid_argument", "Error", [
+					{
+						type: "type.googleapis.com/aiserver.v1.ErrorDetails",
+						value: Buffer.from(toBinary(ErrorDetailsSchema, details)).toString("base64"),
+					},
+				]),
+			);
+			stream.end();
+			return;
+		}
+
 		if (scenario.kind === "hang-after-turn") {
 			return;
 		}
@@ -375,6 +400,15 @@ describe("Cursor terminal lifecycle after turnEnded", () => {
 		const { result } = await collectStream(makeModel(baseUrl));
 		expect(result.errorMessage).toContain("quota exceeded for this account");
 		expect(AIError.is(result.errorId, AIError.Flag.UsageLimit)).toBe(false);
+	});
+
+	it("maps Cursor ErrorDetails into retryable provider status and message", async () => {
+		scenario = { kind: "connect-structured-error-after-turn" };
+		const baseUrl = await startServer();
+		const { result } = await collectStream(makeModel(baseUrl));
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(429);
+		expect(result.errorMessage).toContain("Cursor RATE_LIMITED: Capacity reached: Retry this request shortly");
 	});
 
 	it("surfaces nonzero gRPC trailers that arrive after turnEnded", async () => {

--- a/packages/ai/test/cursor-wire-model-fallback.test.ts
+++ b/packages/ai/test/cursor-wire-model-fallback.test.ts
@@ -7,6 +7,9 @@ import {
 	AgentClientMessageSchema,
 	type AgentRunRequest,
 	AgentServerMessageSchema,
+	CustomErrorDetailsSchema,
+	CursorError,
+	ErrorDetailsSchema,
 	ExecServerMessageSchema,
 	HeartbeatUpdateSchema,
 	InteractionUpdateSchema,
@@ -20,7 +23,14 @@ import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 const CONNECT_END_STREAM_FLAG = 0b00000010;
 
 type Response = (
-	| { kind: "error"; code: string; message: string; partialText?: string; heartbeat?: boolean }
+	| {
+			kind: "error";
+			code: string;
+			message: string;
+			partialText?: string;
+			heartbeat?: boolean;
+			structuredError?: CursorError;
+	  }
 	| { kind: "success"; text: string }
 	| { kind: "exec-success" }
 ) & { delayMs?: number };
@@ -100,9 +110,27 @@ function execReadRequestFrame(): Buffer {
 	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
 }
 
-function connectErrorFrame(code: string, message: string): Buffer {
-	const payload = Buffer.from(JSON.stringify({ error: { code, message } }), "utf8");
+function connectErrorFrame(code: string, message: string, details?: unknown): Buffer {
+	const payload = Buffer.from(
+		JSON.stringify({ error: { code, message, ...(details === undefined ? {} : { details }) } }),
+		"utf8",
+	);
 	return frameConnectMessage(payload, CONNECT_END_STREAM_FLAG);
+}
+function structuredConnectErrorFrame(error: CursorError): Buffer {
+	const details = create(ErrorDetailsSchema, {
+		error,
+		details: create(CustomErrorDetailsSchema, {
+			title: "AI Model Not Found",
+			detail: "Model name is not valid",
+		}),
+	});
+	return connectErrorFrame("invalid_argument", "Error", [
+		{
+			type: "type.googleapis.com/aiserver.v1.ErrorDetails",
+			value: Buffer.from(toBinary(ErrorDetailsSchema, details)).toString("base64"),
+		},
+	]);
 }
 
 function decodeRunRequest(frame: Buffer): AgentRunRequest {
@@ -158,7 +186,11 @@ async function startServer(): Promise<string> {
 			}
 			const frames = response.heartbeat ? [heartbeatFrame()] : [];
 			if (response.partialText) frames.push(textDeltaFrame(response.partialText));
-			frames.push(connectErrorFrame(response.code, response.message));
+			frames.push(
+				response.structuredError === undefined
+					? connectErrorFrame(response.code, response.message)
+					: structuredConnectErrorFrame(response.structuredError),
+			);
 			stream.end(Buffer.concat(frames));
 		};
 		stream.on("data", onData);
@@ -245,6 +277,23 @@ describe("Cursor discovered effort wire fallback", () => {
 		expect(requests[1].requestedModel?.modelId).toBe("gpt-5.6-sol-medium");
 		expect(requests[1].requestedModel?.parameters).toEqual([]);
 		expect(requests[1].modelDetails?.modelId).toBe("gpt-5.6-sol-medium");
+	});
+	it("retries a structured BAD_MODEL_NAME with the exact discovered sibling id", async () => {
+		responses = [
+			{
+				kind: "error",
+				code: "invalid_argument",
+				message: "Error",
+				structuredError: CursorError.ERROR_BAD_MODEL_NAME,
+			},
+			{ kind: "success", text: "OK" },
+		];
+		const baseUrl = await startServer();
+		const { result } = await runStream(baseUrl);
+
+		expect(result.stopReason).toBe("stop");
+		expect(requests).toHaveLength(2);
+		expect(requests[1]?.requestedModel?.modelId).toBe("gpt-5.6-sol-medium");
 	});
 
 	it("still retries when a heartbeat precedes the not_found", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Cursor model discovery now uses account-specific model metadata, variant routing, capabilities, context limits, retention eligibility, and provider defaults ([#11613](https://github.com/can1357/oh-my-pi/pull/11613) by [@will-bogusz](https://github.com/will-bogusz)).
+
+### Fixed
+
+- Cursor models now refresh token rates from Cursor's first-party pricing document during discovery instead of appearing free; missing rates remain unknown, while Cursor Router is explicitly marked as variably priced ([#11613](https://github.com/can1357/oh-my-pi/pull/11613) by [@will-bogusz](https://github.com/will-bogusz)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -61,6 +61,7 @@ import {
 	YOLO_AUTO_STATIC_MODELS,
 } from "../src/provider-models/openai-compat";
 import {
+	CURSOR_STATIC_MODELS,
 	DEVIN_STATIC_MODELS,
 	type OpenAICodexAccount,
 	openaiCodexModelManagerOptions,
@@ -100,7 +101,7 @@ const DISCOVERY_ONLY_PROVIDERS = new Set(["ollama", "vllm", "lm-studio", "litell
  * runtime discovery is authoritative per credential (mirrors the GitLab Duo
  * fallback-only policy below).
  */
-const CREDENTIAL_SCOPED_PROVIDERS = new Set(["devin"]);
+const CREDENTIAL_SCOPED_PROVIDERS = new Set(["cursor", "devin"]);
 
 /**
  * Restores unfetched rows from a previous generated catalog while pruning
@@ -685,6 +686,9 @@ async function generateModels() {
 	if (!authoritativeCatalogProviders.has("gitlab-duo-agent")) {
 		allModels.push(buildGitLabDuoWorkflowFallbackModel());
 	}
+	// Cursor's catalog varies by account entitlements, admin allowlist, and
+	// privacy mode. Bundle only the synchronous descriptor-default seed.
+	allModels.push(...CURSOR_STATIC_MODELS);
 	// Seed Devin's SWE-1.6 lanes. Cascade's catalog is credential-scoped, so it
 	// is never fetched during generation (CREDENTIAL_SCOPED_PROVIDERS) and the
 	// seed is the entire bundled surface: the descriptor's `swe-1-6`

--- a/packages/catalog/scripts/generate-protocols.ts
+++ b/packages/catalog/scripts/generate-protocols.ts
@@ -3,6 +3,7 @@ import { generateProtoTs, ProtoContext, parseProto } from "./proto-parser";
 
 const PACKAGES_DIR = path.resolve(import.meta.dir, "../..");
 const CURSOR_PROTO = path.join(PACKAGES_DIR, "ai/src/providers/cursor/proto/agent.proto");
+const CURSOR_MODELS_PROTO = path.join(PACKAGES_DIR, "catalog/src/discovery/cursor-models.proto");
 const DEVIN_PROTO_DIR = path.join(PACKAGES_DIR, "ai/src/providers/devin/proto");
 const DISCOVERY_DIR = path.resolve(import.meta.dir, "../src/discovery");
 
@@ -14,7 +15,7 @@ const CURSOR_CONSUMER_DIRS = [
 	path.join(PACKAGES_DIR, "coding-agent/test"),
 ];
 
-const CURSOR_ENUMS = ["CursorRuleSource", "ForceBackgroundShellStatus", "ForceBackgroundSubagentStatus"];
+const CURSOR_ENUMS = ["CursorError", "CursorRuleSource", "ForceBackgroundShellStatus", "ForceBackgroundSubagentStatus"];
 const DEVIN_MESSAGES = [
 	"exa.api_server_pb.AssignModelRequest",
 	"exa.api_server_pb.AssignModelResponse",
@@ -101,8 +102,10 @@ async function parseProtoDirectory(directory: string): Promise<ProtoContext> {
 
 async function generateProtocols(): Promise<void> {
 	const cursorSource = await Bun.file(CURSOR_PROTO).text();
+	const cursorModelsSource = await Bun.file(CURSOR_MODELS_PROTO).text();
 	const cursorContext = new ProtoContext();
 	cursorContext.addFile(parseProto(cursorSource, "agent.proto"));
+	cursorContext.addFile(parseProto(cursorModelsSource, "cursor-models.proto"));
 
 	const cursor = generateProtoTs(cursorContext, {
 		includeMessages: await collectCursorMessages(),

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -57,6 +57,15 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 	if (editPromptVariant === "full" || editPromptVariant === "compact") {
 		model.editPromptVariant = editPromptVariant;
 	}
+	const pricingStatus = catalog.pricingStatus;
+	if (
+		pricingStatus === "free" ||
+		pricingStatus === "included" ||
+		pricingStatus === "variable" ||
+		pricingStatus === "unknown"
+	) {
+		model.pricingStatus = pricingStatus;
+	}
 	const requiresCursorToolSchemaProjection = catalog.requiresCursorToolSchemaProjection;
 	if (requiresCursorToolSchemaProjection === true) {
 		model.requiresCursorToolSchemaProjection = true;

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -280,6 +280,12 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
 	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
 	"max-context-window": { key: "maxContextWindow", set: "catalog", shape: "scalar" },
+	"pricing-status": {
+		key: "pricingStatus",
+		set: "catalog",
+		shape: "scalar",
+		values: ["free", "included", "variable", "unknown"],
+	},
 	"requires-cursor-tool-schema-projection": {
 		key: "requiresCursorToolSchemaProjection",
 		set: "catalog",

--- a/packages/catalog/src/compat/collapse.ts
+++ b/packages/catalog/src/compat/collapse.ts
@@ -845,6 +845,9 @@ function collapseWithTable<TSpec extends VariantSpecLike>(
 			contextWindow: maxOrNull(memberSpecs.map(spec => spec.contextWindow)),
 			maxTokens: maxOrNull(memberSpecs.map(spec => spec.maxTokens)),
 		};
+		if (memberSpecs.some(spec => spec.isProviderDefault === true)) {
+			collapsed.isProviderDefault = true;
+		}
 		// The default wire id is the family's declared `defaultMember` when live,
 		// else the highest-priority live member. Omitted when it equals the
 		// logical id (bare/thinking pairs) — `resolveWireModelId` falls back.

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -9318,6 +9318,21 @@
 			},
 			{
 				"source": "providers/cursor.kdl:6",
+				"providers": [
+					"cursor"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "default"
+					}
+				],
+				"catalog": {
+					"pricingStatus": "variable"
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:11",
 				"class": "anthropic",
 				"providers": [
 					"cursor"
@@ -9328,7 +9343,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:14",
+				"source": "providers/cursor.kdl:19",
 				"class": "kimi",
 				"providers": [
 					"cursor"
@@ -9343,7 +9358,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:19",
+				"source": "providers/cursor.kdl:24",
 				"providers": [
 					"cursor"
 				],
@@ -9366,7 +9381,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:25",
+				"source": "providers/cursor.kdl:30",
 				"providers": [
 					"cursor"
 				],
@@ -9400,7 +9415,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:28",
+				"source": "providers/cursor.kdl:33",
 				"providers": [
 					"cursor"
 				],
@@ -9434,7 +9449,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:32",
+				"source": "providers/cursor.kdl:37",
 				"providers": [
 					"cursor"
 				],
@@ -9452,7 +9467,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:36",
+				"source": "providers/cursor.kdl:41",
 				"providers": [
 					"cursor"
 				],
@@ -9485,7 +9500,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:40",
+				"source": "providers/cursor.kdl:45",
 				"providers": [
 					"cursor"
 				],
@@ -9525,7 +9540,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:45",
+				"source": "providers/cursor.kdl:50",
 				"providers": [
 					"cursor"
 				],
@@ -9544,7 +9559,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:49",
+				"source": "providers/cursor.kdl:54",
 				"providers": [
 					"cursor"
 				],
@@ -16759,6 +16774,18 @@
 						"peerId": "claude-sonnet-4-6@default"
 					}
 				]
+			},
+			{
+				"provider": "cursor",
+				"peers": [
+					"anthropic",
+					"openai",
+					"google",
+					"xai",
+					"zai",
+					"moonshot"
+				],
+				"aliases": []
 			},
 			{
 				"provider": "xai-oauth",

--- a/packages/catalog/src/compat/rules/providers/cursor.kdl
+++ b/packages/catalog/src/compat/rules/providers/cursor.kdl
@@ -2,6 +2,11 @@
 
 provider "cursor" {
 	thinking-mode "effort"
+	// Cursor's default route selects a differently priced backing model per request.
+	models "default" {
+		pricing-status "variable"
+	}
+
 	class "anthropic" {
 		family "fable" {
 			requires-cursor-tool-schema-projection #true

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -250,6 +250,11 @@ behavior {
 		alias "claude-sonnet-4-5" peer-id="claude-sonnet-4-5@20250929"
 		alias "claude-sonnet-4-6" peer-id="claude-sonnet-4-6@default"
 	}
+	// Cursor discovery joins first-party published rates. If that optional
+	// document is unavailable or lacks a row, use authoritative upstream list
+	// prices from the model vendor rather than treating the model as free.
+	pricing-peer provider="cursor" peers="anthropic" "openai" "google" "xai" "zai" "moonshot" {
+	}
 	// SuperGrok surfaces a few models under IDs that differ from their public
 	// xai equivalent, so the exact-id price mirror misses them.
 	pricing-peer provider="xai-oauth" peers="xai" {

--- a/packages/catalog/src/discovery/cursor-models.proto
+++ b/packages/catalog/src/discovery/cursor-models.proto
@@ -1,0 +1,261 @@
+syntax = "proto3";
+
+package aiserver.v1;
+
+// Sanitized subset of Cursor's current AvailableModels protocol. Field numbers
+// and wire types match the official CLI; unknown fields remain forward-compatible.
+message AvailableModelsRequest {
+  bool is_nightly = 1;
+  bool include_long_context_models = 2;
+  bool exclude_max_named_models = 3;
+  repeated string additional_model_names = 4;
+  optional bool use_model_parameters = 5;
+  optional bool include_hidden_models = 6;
+  optional bool do_not_use_markdown = 7;
+  optional bool variants_will_be_shown_in_exploded_list = 8;
+  optional bool for_automations = 9;
+  optional int32 scope = 10;
+  optional bool use_react_model_picker = 11;
+  optional bool use_cloud_agent_effort_modes = 12;
+  optional string admin_settings_group_public_id = 13;
+  optional bool byok_enabled = 14;
+}
+
+message AvailableModelsResponse {
+  repeated string model_names = 1;
+  repeated ModelDetails models = 2;
+  bool use_model_parameters = 11;
+
+  enum DegradationStatus {
+    DEGRADATION_STATUS_UNSPECIFIED = 0;
+    DEGRADATION_STATUS_DEGRADED = 1;
+    DEGRADATION_STATUS_DISABLED = 2;
+  }
+
+  enum ModelVendorId {
+    MODEL_VENDOR_ID_UNSPECIFIED = 0;
+    MODEL_VENDOR_ID_ANTHROPIC = 1;
+    MODEL_VENDOR_ID_OPENAI = 2;
+    MODEL_VENDOR_ID_GOOGLE = 3;
+    MODEL_VENDOR_ID_XAI = 4;
+    MODEL_VENDOR_ID_MOONSHOT = 5;
+    MODEL_VENDOR_ID_CURSOR = 6;
+    MODEL_VENDOR_ID_NVIDIA = 7;
+    MODEL_VENDOR_ID_ZAI = 8;
+    MODEL_VENDOR_ID_META = 9;
+  }
+
+  message TooltipData {
+    string primary_text = 1;
+    string secondary_text = 2;
+    string secondary_warning_text = 3;
+    string icon = 4;
+    string tertiary_text = 5;
+    optional string tertiary_text_url = 6;
+    optional string markdown_content = 7;
+  }
+
+  message ModelVendor {
+    ModelVendorId id = 1;
+    string display_name = 2;
+  }
+
+  message ModelVariantConfig {
+    repeated ModelParameterValue parameter_values = 1;
+    optional string display_name = 2;
+    optional bool is_max_mode = 3;
+    optional bool is_default_max_config = 4;
+    optional bool is_default_non_max_config = 5;
+    optional TooltipData tooltip_data = 6;
+    optional string tagline = 7;
+    optional string display_name_outside_picker = 8;
+    optional string variant_string_representation = 9;
+    optional ConfirmationDialogue confirmation_dialogue = 10;
+    optional string legacy_slug = 11;
+  }
+
+  message ConfirmationDialogue {
+    string title = 1;
+    string body = 2;
+    string key = 3;
+    bool blocks_submission = 4;
+  }
+
+  message ModelDetails {
+    string name = 1;
+    bool default_on = 2;
+    optional bool is_long_context_only = 3;
+    optional bool is_chat_only = 4;
+    optional bool supports_agent = 5;
+    optional DegradationStatus degradation_status = 6;
+    optional double price = 7;
+    optional TooltipData tooltip_data = 8;
+    optional bool supports_thinking = 9;
+    optional bool supports_images = 10;
+    optional bool supports_auto_context = 11;
+    optional uint32 auto_context_max_tokens = 12;
+    optional uint32 auto_context_extended_max_tokens = 13;
+    optional bool supports_max_mode = 14;
+    optional uint32 context_token_limit = 15;
+    optional uint32 context_token_limit_for_max_mode = 16;
+    optional string client_display_name = 17;
+    optional string server_model_name = 18;
+    optional bool supports_non_max_mode = 19;
+    optional TooltipData tooltip_data_for_max_mode = 20;
+    optional bool is_recommended_for_background_composer = 21;
+    optional bool supports_plan_mode = 22;
+    optional bool is_user_added = 23;
+    optional string inputbox_short_model_name = 24;
+    optional bool supports_sandboxing = 25;
+    optional bool supports_cmd_k = 26;
+    optional bool only_supports_cmd_k = 27;
+    optional uint32 background_composer_sort_order = 28;
+    repeated ModelParameterDefinition parameter_definitions = 29;
+    repeated ModelVariantConfig variants = 30;
+    optional int32 cloud_agent_effort_mode = 32;
+    optional string cloud_migrate_to_model = 33;
+    optional string upgrade_model_id = 34;
+    optional bool is_hidden = 35;
+    repeated string legacy_slugs = 36;
+    repeated string id_aliases = 37;
+    optional uint32 named_model_section_index = 38;
+    optional string tagline = 39;
+    optional bool visible_in_routed_model_view = 40;
+    optional string vendor_name = 41;
+    optional ModelVendor vendor = 42;
+    optional bool default_disabled_in_admin_allowlist = 43;
+    repeated int32 cloud_agent_effort_modes = 44;
+    optional bool supports_smart_mode_classifier = 45;
+    optional bool requires_data_retention = 46;
+    optional string reason_for_zdr_consent_block = 47;
+  }
+}
+
+message ModelParameterValue {
+  string id = 1;
+  string value = 2;
+}
+
+message ModelParameterDefinition {
+  string id = 1;
+  string name = 2;
+  optional string markdown_tooltip = 3;
+  ModelParameterType parameter_type = 4;
+  optional bool is_cycleable_by_hotkey = 5;
+
+  message ModelParameterType {
+    optional BooleanParameterDefinition boolean_parameter = 1;
+    optional EnumParameterDefinition enum_parameter = 2;
+  }
+
+  message BooleanParameterDefinition {
+    repeated BooleanParameterValue values = 1;
+
+    message BooleanParameterValue {
+      string value = 1;
+      optional string display_name = 2;
+      optional bool increases_model_cost = 3;
+      optional bool default_blocked_in_admin_allowlist = 4;
+      optional bool hide_from_user_picker_when_admin_blocked = 5;
+      optional bool blocked_by_admin_allowlist = 6;
+    }
+  }
+
+  message EnumParameterDefinition {
+    repeated EnumParameterValue values = 1;
+
+    message EnumParameterValue {
+      string value = 1;
+      optional string display_name = 2;
+      optional bool increases_model_cost = 3;
+      optional bool blocked_by_admin_allowlist = 4;
+      optional string markdown_tooltip = 5;
+    }
+  }
+}
+
+message ErrorDetails {
+  CursorError error = 1;
+  CustomErrorDetails details = 2;
+  optional bool is_expected = 3;
+
+  enum CursorError {
+    ERROR_UNSPECIFIED = 0;
+    ERROR_BAD_API_KEY = 1;
+    ERROR_NOT_LOGGED_IN = 2;
+    ERROR_INVALID_AUTH_ID = 3;
+    ERROR_NOT_HIGH_ENOUGH_PERMISSIONS = 4;
+    ERROR_BAD_MODEL_NAME = 5;
+    ERROR_USER_NOT_FOUND = 6;
+    ERROR_FREE_USER_RATE_LIMIT_EXCEEDED = 7;
+    ERROR_PRO_USER_RATE_LIMIT_EXCEEDED = 8;
+    ERROR_FREE_USER_USAGE_LIMIT = 9;
+    ERROR_PRO_USER_USAGE_LIMIT = 10;
+    ERROR_AUTH_TOKEN_NOT_FOUND = 11;
+    ERROR_AUTH_TOKEN_EXPIRED = 12;
+    ERROR_OPENAI = 13;
+    ERROR_OPENAI_RATE_LIMIT_EXCEEDED = 14;
+    ERROR_AGENT_REQUIRES_LOGIN = 18;
+    ERROR_MAX_TOKENS = 20;
+    ERROR_USER_ABORTED_REQUEST = 21;
+    ERROR_GENERIC_RATE_LIMIT_EXCEEDED = 22;
+    ERROR_PRO_USER_ONLY = 23;
+    ERROR_TIMEOUT = 25;
+    ERROR_GPT_4_VISION_PREVIEW_RATE_LIMIT = 28;
+    ERROR_CUSTOM_MESSAGE = 29;
+    ERROR_OUTDATED_CLIENT = 30;
+    ERROR_CLAUDE_IMAGE_TOO_LARGE = 31;
+    ERROR_FILE_NOT_FOUND = 33;
+    ERROR_API_KEY_RATE_LIMIT = 34;
+    ERROR_DEBOUNCED = 35;
+    ERROR_BAD_REQUEST = 36;
+    ERROR_REPOSITORY_SERVICE_REPOSITORY_IS_NOT_INITIALIZED = 37;
+    ERROR_UNAUTHORIZED = 38;
+    ERROR_NOT_FOUND = 39;
+    ERROR_DEPRECATED = 40;
+    ERROR_RESOURCE_EXHAUSTED = 41;
+    ERROR_BAD_USER_API_KEY = 42;
+    ERROR_CONVERSATION_TOO_LONG = 43;
+    ERROR_USAGE_PRICING_REQUIRED = 44;
+    ERROR_USAGE_PRICING_REQUIRED_CHANGEABLE = 45;
+    ERROR_GITHUB_NO_USER_CREDENTIALS = 46;
+    ERROR_GITHUB_USER_NO_ACCESS = 47;
+    ERROR_GITHUB_APP_NO_ACCESS = 48;
+    ERROR_GITHUB_MULTIPLE_OWNERS = 49;
+    ERROR_RATE_LIMITED = 50;
+    ERROR_RATE_LIMITED_CHANGEABLE = 51;
+    ERROR_CUSTOM = 52;
+    ERROR_HOOKS_BLOCKED = 53;
+    ERROR_SUSPICIOUS_USAGE_BLOCKED = 54;
+    ERROR_EXTENSION_HOST_TIMEOUT = 55;
+    ERROR_NETWORK_ERROR = 56;
+    ERROR_PROVIDER_ERROR = 57;
+    ERROR_MODEL_BLOCKED = 58;
+    ERROR_INTERNAL = 59;
+    ERROR_MAX_MODE_REQUIRED = 60;
+    ERROR_MODEL_NO_LONGER_SUPPORTED = 61;
+    ERROR_PRICING_WARNING = 62;
+    ERROR_SLOW_POOL = 63;
+    ERROR_UNSUPPORTED_REGION = 64;
+    ERROR_ACCOUNT_CLOSED = 65;
+  }
+}
+
+message CustomErrorDetails {
+  string title = 1;
+  string detail = 2;
+  optional bool allow_command_links_potentially_unsafe_please_only_use_for_handwritten_trusted_markdown = 3;
+  optional bool is_retryable = 4;
+  optional bool show_request_id = 5;
+  optional bool should_show_immediate_error = 6;
+}
+
+
+message BidiAppendRequest {
+  string data = 1;
+  agent.v1.BidiRequestId request_id = 2;
+  int64 append_seqno = 3;
+  bytes data_binary = 4;
+}
+
+message BidiAppendResponse {}

--- a/packages/catalog/src/discovery/cursor-proto.ts
+++ b/packages/catalog/src/discovery/cursor-proto.ts
@@ -22,11 +22,80 @@ export enum ConversationSearchSource {
 	CLOUD_CACHE = 2,
 }
 
+/** Cursor agent enum CursorError. */
+export enum CursorError {
+	ERROR_UNSPECIFIED = 0,
+	ERROR_BAD_API_KEY = 1,
+	ERROR_NOT_LOGGED_IN = 2,
+	ERROR_INVALID_AUTH_ID = 3,
+	ERROR_NOT_HIGH_ENOUGH_PERMISSIONS = 4,
+	ERROR_BAD_MODEL_NAME = 5,
+	ERROR_USER_NOT_FOUND = 6,
+	ERROR_FREE_USER_RATE_LIMIT_EXCEEDED = 7,
+	ERROR_PRO_USER_RATE_LIMIT_EXCEEDED = 8,
+	ERROR_FREE_USER_USAGE_LIMIT = 9,
+	ERROR_PRO_USER_USAGE_LIMIT = 10,
+	ERROR_AUTH_TOKEN_NOT_FOUND = 11,
+	ERROR_AUTH_TOKEN_EXPIRED = 12,
+	ERROR_OPENAI = 13,
+	ERROR_OPENAI_RATE_LIMIT_EXCEEDED = 14,
+	ERROR_AGENT_REQUIRES_LOGIN = 18,
+	ERROR_MAX_TOKENS = 20,
+	ERROR_USER_ABORTED_REQUEST = 21,
+	ERROR_GENERIC_RATE_LIMIT_EXCEEDED = 22,
+	ERROR_PRO_USER_ONLY = 23,
+	ERROR_TIMEOUT = 25,
+	ERROR_GPT_4_VISION_PREVIEW_RATE_LIMIT = 28,
+	ERROR_CUSTOM_MESSAGE = 29,
+	ERROR_OUTDATED_CLIENT = 30,
+	ERROR_CLAUDE_IMAGE_TOO_LARGE = 31,
+	ERROR_FILE_NOT_FOUND = 33,
+	ERROR_API_KEY_RATE_LIMIT = 34,
+	ERROR_DEBOUNCED = 35,
+	ERROR_BAD_REQUEST = 36,
+	ERROR_REPOSITORY_SERVICE_REPOSITORY_IS_NOT_INITIALIZED = 37,
+	ERROR_UNAUTHORIZED = 38,
+	ERROR_NOT_FOUND = 39,
+	ERROR_DEPRECATED = 40,
+	ERROR_RESOURCE_EXHAUSTED = 41,
+	ERROR_BAD_USER_API_KEY = 42,
+	ERROR_CONVERSATION_TOO_LONG = 43,
+	ERROR_USAGE_PRICING_REQUIRED = 44,
+	ERROR_USAGE_PRICING_REQUIRED_CHANGEABLE = 45,
+	ERROR_GITHUB_NO_USER_CREDENTIALS = 46,
+	ERROR_GITHUB_USER_NO_ACCESS = 47,
+	ERROR_GITHUB_APP_NO_ACCESS = 48,
+	ERROR_GITHUB_MULTIPLE_OWNERS = 49,
+	ERROR_RATE_LIMITED = 50,
+	ERROR_RATE_LIMITED_CHANGEABLE = 51,
+	ERROR_CUSTOM = 52,
+	ERROR_HOOKS_BLOCKED = 53,
+	ERROR_SUSPICIOUS_USAGE_BLOCKED = 54,
+	ERROR_EXTENSION_HOST_TIMEOUT = 55,
+	ERROR_NETWORK_ERROR = 56,
+	ERROR_PROVIDER_ERROR = 57,
+	ERROR_MODEL_BLOCKED = 58,
+	ERROR_INTERNAL = 59,
+	ERROR_MAX_MODE_REQUIRED = 60,
+	ERROR_MODEL_NO_LONGER_SUPPORTED = 61,
+	ERROR_PRICING_WARNING = 62,
+	ERROR_SLOW_POOL = 63,
+	ERROR_UNSUPPORTED_REGION = 64,
+	ERROR_ACCOUNT_CLOSED = 65,
+}
+
 /** Cursor agent enum CursorRuleSource. */
 export enum CursorRuleSource {
 	UNSPECIFIED = 0,
 	TEAM = 1,
 	USER = 2,
+}
+
+/** Cursor agent enum DegradationStatus. */
+export enum DegradationStatus {
+	UNSPECIFIED = 0,
+	DEGRADED = 1,
+	DISABLED = 2,
 }
 
 /** Cursor agent enum DiagnosticSeverity. */
@@ -66,6 +135,20 @@ export enum GitDiff_DiffType {
 	UNSPECIFIED = 0,
 	DIFF_TO_HEAD = 1,
 	DIFF_FROM_BRANCH_TO_MAIN = 2,
+}
+
+/** Cursor agent enum ModelVendorId. */
+export enum ModelVendorId {
+	UNSPECIFIED = 0,
+	ANTHROPIC = 1,
+	OPENAI = 2,
+	GOOGLE = 3,
+	XAI = 4,
+	MOONSHOT = 5,
+	CURSOR = 6,
+	NVIDIA = 7,
+	ZAI = 8,
+	META = 9,
 }
 
 /** Cursor agent enum ShellBackgroundReason. */
@@ -567,6 +650,229 @@ export const AsyncAskQuestionCompletionActionSchema: MessageCodec<AsyncAskQuesti
 	{ no: 3, name: "result", kind: "message", T: () => AskQuestionResultSchema },
 ]);
 
+/** Cursor agent message aiserver.v1.AvailableModelsRequest. */
+export interface AvailableModelsRequest extends ProtoMessage {
+	isNightly: boolean;
+	includeLongContextModels: boolean;
+	excludeMaxNamedModels: boolean;
+	additionalModelNames: string[];
+	useModelParameters?: boolean;
+	includeHiddenModels?: boolean;
+	doNotUseMarkdown?: boolean;
+	variantsWillBeShownInExplodedList?: boolean;
+	forAutomations?: boolean;
+	scope?: number;
+	useReactModelPicker?: boolean;
+	useCloudAgentEffortModes?: boolean;
+	adminSettingsGroupPublicId?: string;
+	byokEnabled?: boolean;
+}
+
+export const AvailableModelsRequestSchema: MessageCodec<AvailableModelsRequest> = pb<AvailableModelsRequest>("aiserver.v1.AvailableModelsRequest", [
+	{ no: 1, name: "isNightly", kind: "bool" },
+	{ no: 2, name: "includeLongContextModels", kind: "bool" },
+	{ no: 3, name: "excludeMaxNamedModels", kind: "bool" },
+	{ no: 4, name: "additionalModelNames", kind: "string", repeat: true },
+	{ no: 5, name: "useModelParameters", kind: "bool", optional: true },
+	{ no: 6, name: "includeHiddenModels", kind: "bool", optional: true },
+	{ no: 7, name: "doNotUseMarkdown", kind: "bool", optional: true },
+	{ no: 8, name: "variantsWillBeShownInExplodedList", kind: "bool", optional: true },
+	{ no: 9, name: "forAutomations", kind: "bool", optional: true },
+	{ no: 10, name: "scope", kind: "int32", optional: true },
+	{ no: 11, name: "useReactModelPicker", kind: "bool", optional: true },
+	{ no: 12, name: "useCloudAgentEffortModes", kind: "bool", optional: true },
+	{ no: 13, name: "adminSettingsGroupPublicId", kind: "string", optional: true },
+	{ no: 14, name: "byokEnabled", kind: "bool", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse. */
+export interface AvailableModelsResponse extends ProtoMessage {
+	modelNames: string[];
+	models: AvailableModelsResponse_ModelDetails[];
+	useModelParameters: boolean;
+}
+
+export const AvailableModelsResponseSchema: MessageCodec<AvailableModelsResponse> = pb<AvailableModelsResponse>("aiserver.v1.AvailableModelsResponse", [
+	{ no: 1, name: "modelNames", kind: "string", repeat: true },
+	{ no: 2, name: "models", kind: "message", T: () => AvailableModelsResponse_ModelDetailsSchema, repeat: true },
+	{ no: 11, name: "useModelParameters", kind: "bool" },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse_ConfirmationDialogue. */
+export interface AvailableModelsResponse_ConfirmationDialogue extends ProtoMessage {
+	title: string;
+	body: string;
+	key: string;
+	blocksSubmission: boolean;
+}
+
+export const AvailableModelsResponse_ConfirmationDialogueSchema: MessageCodec<AvailableModelsResponse_ConfirmationDialogue> = pb<AvailableModelsResponse_ConfirmationDialogue>("aiserver.v1.AvailableModelsResponse_ConfirmationDialogue", [
+	{ no: 1, name: "title", kind: "string" },
+	{ no: 2, name: "body", kind: "string" },
+	{ no: 3, name: "key", kind: "string" },
+	{ no: 4, name: "blocksSubmission", kind: "bool" },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse_ModelDetails. */
+export interface AvailableModelsResponse_ModelDetails extends ProtoMessage {
+	name: string;
+	defaultOn: boolean;
+	isLongContextOnly?: boolean;
+	isChatOnly?: boolean;
+	supportsAgent?: boolean;
+	degradationStatus?: DegradationStatus;
+	price?: number;
+	tooltipData?: AvailableModelsResponse_TooltipData;
+	supportsThinking?: boolean;
+	supportsImages?: boolean;
+	supportsAutoContext?: boolean;
+	autoContextMaxTokens?: number;
+	autoContextExtendedMaxTokens?: number;
+	supportsMaxMode?: boolean;
+	contextTokenLimit?: number;
+	contextTokenLimitForMaxMode?: number;
+	clientDisplayName?: string;
+	serverModelName?: string;
+	supportsNonMaxMode?: boolean;
+	tooltipDataForMaxMode?: AvailableModelsResponse_TooltipData;
+	isRecommendedForBackgroundComposer?: boolean;
+	supportsPlanMode?: boolean;
+	isUserAdded?: boolean;
+	inputboxShortModelName?: string;
+	supportsSandboxing?: boolean;
+	supportsCmdK?: boolean;
+	onlySupportsCmdK?: boolean;
+	backgroundComposerSortOrder?: number;
+	parameterDefinitions: ModelParameterDefinition[];
+	variants: AvailableModelsResponse_ModelVariantConfig[];
+	cloudAgentEffortMode?: number;
+	cloudMigrateToModel?: string;
+	upgradeModelId?: string;
+	isHidden?: boolean;
+	legacySlugs: string[];
+	idAliases: string[];
+	namedModelSectionIndex?: number;
+	tagline?: string;
+	visibleInRoutedModelView?: boolean;
+	vendorName?: string;
+	vendor?: AvailableModelsResponse_ModelVendor;
+	defaultDisabledInAdminAllowlist?: boolean;
+	cloudAgentEffortModes: number[];
+	supportsSmartModeClassifier?: boolean;
+	requiresDataRetention?: boolean;
+	reasonForZdrConsentBlock?: string;
+}
+
+export const AvailableModelsResponse_ModelDetailsSchema: MessageCodec<AvailableModelsResponse_ModelDetails> = pb<AvailableModelsResponse_ModelDetails>("aiserver.v1.AvailableModelsResponse_ModelDetails", [
+	{ no: 1, name: "name", kind: "string" },
+	{ no: 2, name: "defaultOn", kind: "bool" },
+	{ no: 3, name: "isLongContextOnly", kind: "bool", optional: true },
+	{ no: 4, name: "isChatOnly", kind: "bool", optional: true },
+	{ no: 5, name: "supportsAgent", kind: "bool", optional: true },
+	{ no: 6, name: "degradationStatus", kind: "enum", optional: true },
+	{ no: 7, name: "price", kind: "double", optional: true },
+	{ no: 8, name: "tooltipData", kind: "message", T: () => AvailableModelsResponse_TooltipDataSchema },
+	{ no: 9, name: "supportsThinking", kind: "bool", optional: true },
+	{ no: 10, name: "supportsImages", kind: "bool", optional: true },
+	{ no: 11, name: "supportsAutoContext", kind: "bool", optional: true },
+	{ no: 12, name: "autoContextMaxTokens", kind: "uint32", optional: true },
+	{ no: 13, name: "autoContextExtendedMaxTokens", kind: "uint32", optional: true },
+	{ no: 14, name: "supportsMaxMode", kind: "bool", optional: true },
+	{ no: 15, name: "contextTokenLimit", kind: "uint32", optional: true },
+	{ no: 16, name: "contextTokenLimitForMaxMode", kind: "uint32", optional: true },
+	{ no: 17, name: "clientDisplayName", kind: "string", optional: true },
+	{ no: 18, name: "serverModelName", kind: "string", optional: true },
+	{ no: 19, name: "supportsNonMaxMode", kind: "bool", optional: true },
+	{ no: 20, name: "tooltipDataForMaxMode", kind: "message", T: () => AvailableModelsResponse_TooltipDataSchema },
+	{ no: 21, name: "isRecommendedForBackgroundComposer", kind: "bool", optional: true },
+	{ no: 22, name: "supportsPlanMode", kind: "bool", optional: true },
+	{ no: 23, name: "isUserAdded", kind: "bool", optional: true },
+	{ no: 24, name: "inputboxShortModelName", kind: "string", optional: true },
+	{ no: 25, name: "supportsSandboxing", kind: "bool", optional: true },
+	{ no: 26, name: "supportsCmdK", kind: "bool", optional: true },
+	{ no: 27, name: "onlySupportsCmdK", kind: "bool", optional: true },
+	{ no: 28, name: "backgroundComposerSortOrder", kind: "uint32", optional: true },
+	{ no: 29, name: "parameterDefinitions", kind: "message", T: () => ModelParameterDefinitionSchema, repeat: true },
+	{ no: 30, name: "variants", kind: "message", T: () => AvailableModelsResponse_ModelVariantConfigSchema, repeat: true },
+	{ no: 32, name: "cloudAgentEffortMode", kind: "int32", optional: true },
+	{ no: 33, name: "cloudMigrateToModel", kind: "string", optional: true },
+	{ no: 34, name: "upgradeModelId", kind: "string", optional: true },
+	{ no: 35, name: "isHidden", kind: "bool", optional: true },
+	{ no: 36, name: "legacySlugs", kind: "string", repeat: true },
+	{ no: 37, name: "idAliases", kind: "string", repeat: true },
+	{ no: 38, name: "namedModelSectionIndex", kind: "uint32", optional: true },
+	{ no: 39, name: "tagline", kind: "string", optional: true },
+	{ no: 40, name: "visibleInRoutedModelView", kind: "bool", optional: true },
+	{ no: 41, name: "vendorName", kind: "string", optional: true },
+	{ no: 42, name: "vendor", kind: "message", T: () => AvailableModelsResponse_ModelVendorSchema },
+	{ no: 43, name: "defaultDisabledInAdminAllowlist", kind: "bool", optional: true },
+	{ no: 44, name: "cloudAgentEffortModes", kind: "int32", repeat: true },
+	{ no: 45, name: "supportsSmartModeClassifier", kind: "bool", optional: true },
+	{ no: 46, name: "requiresDataRetention", kind: "bool", optional: true },
+	{ no: 47, name: "reasonForZdrConsentBlock", kind: "string", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse_ModelVariantConfig. */
+export interface AvailableModelsResponse_ModelVariantConfig extends ProtoMessage {
+	parameterValues: ModelParameterValue[];
+	displayName?: string;
+	isMaxMode?: boolean;
+	isDefaultMaxConfig?: boolean;
+	isDefaultNonMaxConfig?: boolean;
+	tooltipData?: AvailableModelsResponse_TooltipData;
+	tagline?: string;
+	displayNameOutsidePicker?: string;
+	variantStringRepresentation?: string;
+	confirmationDialogue?: AvailableModelsResponse_ConfirmationDialogue;
+	legacySlug?: string;
+}
+
+export const AvailableModelsResponse_ModelVariantConfigSchema: MessageCodec<AvailableModelsResponse_ModelVariantConfig> = pb<AvailableModelsResponse_ModelVariantConfig>("aiserver.v1.AvailableModelsResponse_ModelVariantConfig", [
+	{ no: 1, name: "parameterValues", kind: "message", T: () => ModelParameterValueSchema, repeat: true },
+	{ no: 2, name: "displayName", kind: "string", optional: true },
+	{ no: 3, name: "isMaxMode", kind: "bool", optional: true },
+	{ no: 4, name: "isDefaultMaxConfig", kind: "bool", optional: true },
+	{ no: 5, name: "isDefaultNonMaxConfig", kind: "bool", optional: true },
+	{ no: 6, name: "tooltipData", kind: "message", T: () => AvailableModelsResponse_TooltipDataSchema },
+	{ no: 7, name: "tagline", kind: "string", optional: true },
+	{ no: 8, name: "displayNameOutsidePicker", kind: "string", optional: true },
+	{ no: 9, name: "variantStringRepresentation", kind: "string", optional: true },
+	{ no: 10, name: "confirmationDialogue", kind: "message", T: () => AvailableModelsResponse_ConfirmationDialogueSchema },
+	{ no: 11, name: "legacySlug", kind: "string", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse_ModelVendor. */
+export interface AvailableModelsResponse_ModelVendor extends ProtoMessage {
+	id: ModelVendorId;
+	displayName: string;
+}
+
+export const AvailableModelsResponse_ModelVendorSchema: MessageCodec<AvailableModelsResponse_ModelVendor> = pb<AvailableModelsResponse_ModelVendor>("aiserver.v1.AvailableModelsResponse_ModelVendor", [
+	{ no: 1, name: "id", kind: "enum" },
+	{ no: 2, name: "displayName", kind: "string" },
+]);
+
+/** Cursor agent message aiserver.v1.AvailableModelsResponse_TooltipData. */
+export interface AvailableModelsResponse_TooltipData extends ProtoMessage {
+	primaryText: string;
+	secondaryText: string;
+	secondaryWarningText: string;
+	icon: string;
+	tertiaryText: string;
+	tertiaryTextUrl?: string;
+	markdownContent?: string;
+}
+
+export const AvailableModelsResponse_TooltipDataSchema: MessageCodec<AvailableModelsResponse_TooltipData> = pb<AvailableModelsResponse_TooltipData>("aiserver.v1.AvailableModelsResponse_TooltipData", [
+	{ no: 1, name: "primaryText", kind: "string" },
+	{ no: 2, name: "secondaryText", kind: "string" },
+	{ no: 3, name: "secondaryWarningText", kind: "string" },
+	{ no: 4, name: "icon", kind: "string" },
+	{ no: 5, name: "tertiaryText", kind: "string" },
+	{ no: 6, name: "tertiaryTextUrl", kind: "string", optional: true },
+	{ no: 7, name: "markdownContent", kind: "string", optional: true },
+]);
+
 /** Cursor agent message agent.v1.AzureCredentials. */
 export interface AzureCredentials extends ProtoMessage {
 	apiKey: string;
@@ -697,6 +1003,30 @@ export const BeforeSubmitPromptRequestResponseSchema: MessageCodec<BeforeSubmitP
 	{ no: 1, name: "continue", kind: "bool", optional: true },
 	{ no: 2, name: "userMessage", kind: "string", optional: true },
 	{ no: 3, name: "additionalContext", kind: "string", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.BidiAppendRequest. */
+export interface BidiAppendRequest extends ProtoMessage {
+	data: string;
+	requestId?: BidiRequestId;
+	appendSeqno: bigint;
+	dataBinary: Uint8Array;
+}
+
+export const BidiAppendRequestSchema: MessageCodec<BidiAppendRequest> = pb<BidiAppendRequest>("aiserver.v1.BidiAppendRequest", [
+	{ no: 1, name: "data", kind: "string" },
+	{ no: 2, name: "requestId", kind: "message", T: () => BidiRequestIdSchema },
+	{ no: 3, name: "appendSeqno", kind: "int64" },
+	{ no: 4, name: "dataBinary", kind: "bytes" },
+]);
+
+/** Cursor agent message agent.v1.BidiRequestId. */
+export interface BidiRequestId extends ProtoMessage {
+	requestId: string;
+}
+
+export const BidiRequestIdSchema: MessageCodec<BidiRequestId> = pb<BidiRequestId>("agent.v1.BidiRequestId", [
+	{ no: 1, name: "requestId", kind: "string" },
 ]);
 
 /** Cursor agent message agent.v1.CallFrame. */
@@ -1423,6 +1753,25 @@ export interface CursorRuleTypeManuallyAttached extends ProtoMessage {
 export const CursorRuleTypeManuallyAttachedSchema: MessageCodec<CursorRuleTypeManuallyAttached> = pb<CursorRuleTypeManuallyAttached>("agent.v1.CursorRuleTypeManuallyAttached", [
 ]);
 
+/** Cursor agent message aiserver.v1.CustomErrorDetails. */
+export interface CustomErrorDetails extends ProtoMessage {
+	title: string;
+	detail: string;
+	allowCommandLinksPotentiallyUnsafePleaseOnlyUseForHandwrittenTrustedMarkdown?: boolean;
+	isRetryable?: boolean;
+	showRequestId?: boolean;
+	shouldShowImmediateError?: boolean;
+}
+
+export const CustomErrorDetailsSchema: MessageCodec<CustomErrorDetails> = pb<CustomErrorDetails>("aiserver.v1.CustomErrorDetails", [
+	{ no: 1, name: "title", kind: "string" },
+	{ no: 2, name: "detail", kind: "string" },
+	{ no: 3, name: "allowCommandLinksPotentiallyUnsafePleaseOnlyUseForHandwrittenTrustedMarkdown", kind: "bool", optional: true },
+	{ no: 4, name: "isRetryable", kind: "bool", optional: true },
+	{ no: 5, name: "showRequestId", kind: "bool", optional: true },
+	{ no: 6, name: "shouldShowImmediateError", kind: "bool", optional: true },
+]);
+
 /** Cursor agent message agent.v1.CustomSubagent. */
 export interface CustomSubagent extends ProtoMessage {
 	fullPath: string;
@@ -1875,6 +2224,19 @@ export interface Error extends ProtoMessage {
 
 export const ErrorSchema: MessageCodec<Error> = pb<Error>("agent.v1.Error", [
 	{ no: 1, name: "message", kind: "string" },
+]);
+
+/** Cursor agent message aiserver.v1.ErrorDetails. */
+export interface ErrorDetails extends ProtoMessage {
+	error: CursorError;
+	details?: CustomErrorDetails;
+	isExpected?: boolean;
+}
+
+export const ErrorDetailsSchema: MessageCodec<ErrorDetails> = pb<ErrorDetails>("aiserver.v1.ErrorDetails", [
+	{ no: 1, name: "error", kind: "enum" },
+	{ no: 2, name: "details", kind: "message", T: () => CustomErrorDetailsSchema },
+	{ no: 3, name: "isExpected", kind: "bool", optional: true },
 ]);
 
 /** Cursor agent message agent.v1.ExaFetchArgs. */
@@ -2797,6 +3159,22 @@ export interface GetBlobResult extends ProtoMessage {
 
 export const GetBlobResultSchema: MessageCodec<GetBlobResult> = pb<GetBlobResult>("agent.v1.GetBlobResult", [
 	{ no: 1, name: "blobData", kind: "bytes", optional: true },
+]);
+
+/** Cursor agent message agent.v1.GetDefaultModelForCliRequest. */
+export interface GetDefaultModelForCliRequest extends ProtoMessage {
+}
+
+export const GetDefaultModelForCliRequestSchema: MessageCodec<GetDefaultModelForCliRequest> = pb<GetDefaultModelForCliRequest>("agent.v1.GetDefaultModelForCliRequest", [
+]);
+
+/** Cursor agent message agent.v1.GetDefaultModelForCliResponse. */
+export interface GetDefaultModelForCliResponse extends ProtoMessage {
+	model?: ModelDetails;
+}
+
+export const GetDefaultModelForCliResponseSchema: MessageCodec<GetDefaultModelForCliResponse> = pb<GetDefaultModelForCliResponse>("agent.v1.GetDefaultModelForCliResponse", [
+	{ no: 1, name: "model", kind: "message", T: () => ModelDetailsSchema },
 ]);
 
 /** Cursor agent message agent.v1.GetDiffRequest. */
@@ -4131,6 +4509,99 @@ export const ModelDetailsSchema: MessageCodec<ModelDetails> = pb<ModelDetails>("
 			{ no: 10, name: "bedrockCredentials", kind: "message", T: () => BedrockCredentialsSchema },
 		],
 	},
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition. */
+export interface ModelParameterDefinition extends ProtoMessage {
+	id: string;
+	name: string;
+	markdownTooltip?: string;
+	parameterType?: ModelParameterDefinition_ModelParameterType;
+	isCycleableByHotkey?: boolean;
+}
+
+export const ModelParameterDefinitionSchema: MessageCodec<ModelParameterDefinition> = pb<ModelParameterDefinition>("aiserver.v1.ModelParameterDefinition", [
+	{ no: 1, name: "id", kind: "string" },
+	{ no: 2, name: "name", kind: "string" },
+	{ no: 3, name: "markdownTooltip", kind: "string", optional: true },
+	{ no: 4, name: "parameterType", kind: "message", T: () => ModelParameterDefinition_ModelParameterTypeSchema },
+	{ no: 5, name: "isCycleableByHotkey", kind: "bool", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition_BooleanParameterDefinition. */
+export interface ModelParameterDefinition_BooleanParameterDefinition extends ProtoMessage {
+	values: ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue[];
+}
+
+export const ModelParameterDefinition_BooleanParameterDefinitionSchema: MessageCodec<ModelParameterDefinition_BooleanParameterDefinition> = pb<ModelParameterDefinition_BooleanParameterDefinition>("aiserver.v1.ModelParameterDefinition_BooleanParameterDefinition", [
+	{ no: 1, name: "values", kind: "message", T: () => ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValueSchema, repeat: true },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue. */
+export interface ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue extends ProtoMessage {
+	value: string;
+	displayName?: string;
+	increasesModelCost?: boolean;
+	defaultBlockedInAdminAllowlist?: boolean;
+	hideFromUserPickerWhenAdminBlocked?: boolean;
+	blockedByAdminAllowlist?: boolean;
+}
+
+export const ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValueSchema: MessageCodec<ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue> = pb<ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue>("aiserver.v1.ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValue", [
+	{ no: 1, name: "value", kind: "string" },
+	{ no: 2, name: "displayName", kind: "string", optional: true },
+	{ no: 3, name: "increasesModelCost", kind: "bool", optional: true },
+	{ no: 4, name: "defaultBlockedInAdminAllowlist", kind: "bool", optional: true },
+	{ no: 5, name: "hideFromUserPickerWhenAdminBlocked", kind: "bool", optional: true },
+	{ no: 6, name: "blockedByAdminAllowlist", kind: "bool", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition_EnumParameterDefinition. */
+export interface ModelParameterDefinition_EnumParameterDefinition extends ProtoMessage {
+	values: ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue[];
+}
+
+export const ModelParameterDefinition_EnumParameterDefinitionSchema: MessageCodec<ModelParameterDefinition_EnumParameterDefinition> = pb<ModelParameterDefinition_EnumParameterDefinition>("aiserver.v1.ModelParameterDefinition_EnumParameterDefinition", [
+	{ no: 1, name: "values", kind: "message", T: () => ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, repeat: true },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue. */
+export interface ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue extends ProtoMessage {
+	value: string;
+	displayName?: string;
+	increasesModelCost?: boolean;
+	blockedByAdminAllowlist?: boolean;
+	markdownTooltip?: string;
+}
+
+export const ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema: MessageCodec<ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue> = pb<ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue>("aiserver.v1.ModelParameterDefinition_EnumParameterDefinition_EnumParameterValue", [
+	{ no: 1, name: "value", kind: "string" },
+	{ no: 2, name: "displayName", kind: "string", optional: true },
+	{ no: 3, name: "increasesModelCost", kind: "bool", optional: true },
+	{ no: 4, name: "blockedByAdminAllowlist", kind: "bool", optional: true },
+	{ no: 5, name: "markdownTooltip", kind: "string", optional: true },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterDefinition_ModelParameterType. */
+export interface ModelParameterDefinition_ModelParameterType extends ProtoMessage {
+	booleanParameter?: ModelParameterDefinition_BooleanParameterDefinition;
+	enumParameter?: ModelParameterDefinition_EnumParameterDefinition;
+}
+
+export const ModelParameterDefinition_ModelParameterTypeSchema: MessageCodec<ModelParameterDefinition_ModelParameterType> = pb<ModelParameterDefinition_ModelParameterType>("aiserver.v1.ModelParameterDefinition_ModelParameterType", [
+	{ no: 1, name: "booleanParameter", kind: "message", T: () => ModelParameterDefinition_BooleanParameterDefinitionSchema },
+	{ no: 2, name: "enumParameter", kind: "message", T: () => ModelParameterDefinition_EnumParameterDefinitionSchema },
+]);
+
+/** Cursor agent message aiserver.v1.ModelParameterValue. */
+export interface ModelParameterValue extends ProtoMessage {
+	id: string;
+	value: string;
+}
+
+export const ModelParameterValueSchema: MessageCodec<ModelParameterValue> = pb<ModelParameterValue>("aiserver.v1.ModelParameterValue", [
+	{ no: 1, name: "id", kind: "string" },
+	{ no: 2, name: "value", kind: "string" },
 ]);
 
 /** Cursor agent message agent.v1.MouseDownAction. */
@@ -7837,9 +8308,19 @@ export const TruncatedToolCallSuccessSchema: MessageCodec<TruncatedToolCallSucce
 
 /** Cursor agent message agent.v1.TurnEndedUpdate. */
 export interface TurnEndedUpdate extends ProtoMessage {
+	inputTokens?: bigint;
+	outputTokens?: bigint;
+	cachedInputTokens?: bigint;
+	cacheWriteTokens?: bigint;
+	reasoningOutputTokens?: bigint;
 }
 
 export const TurnEndedUpdateSchema: MessageCodec<TurnEndedUpdate> = pb<TurnEndedUpdate>("agent.v1.TurnEndedUpdate", [
+	{ no: 1, name: "inputTokens", kind: "int64", optional: true },
+	{ no: 2, name: "outputTokens", kind: "int64", optional: true },
+	{ no: 3, name: "cachedInputTokens", kind: "int64", optional: true },
+	{ no: 4, name: "cacheWriteTokens", kind: "int64", optional: true },
+	{ no: 5, name: "reasoningOutputTokens", kind: "int64", optional: true },
 ]);
 
 /** Cursor agent message agent.v1.TypeAction. */

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -1,19 +1,37 @@
 import * as http2 from "node:http2";
 import { type } from "@oh-my-pi/omptype";
+import { pricingPeerFor } from "../compat/behavior";
+import { collapseVariants, type EffortVariantFamily } from "../compat/collapse";
 import { compareRevision, parseRevision } from "../compat/revision";
 import { classifyModel } from "../compat/taxonomy";
-import { getBundledModels } from "../models";
+import { Effort, THINKING_EFFORTS } from "../effort";
+import { buildModelReferenceIndex, resolveModelReference, type ModelReferenceIndex } from "../identity/reference";
+import { getBundledModels, type GeneratedProvider } from "../models";
 import { toModelSpec } from "../provider-models/bundled-references";
-import type { Model, ModelSpec } from "../types";
-import { GetUsableModelsRequestSchema, GetUsableModelsResponseSchema } from "./cursor-proto";
-import { create, fromBinary, toBinary } from "./protobuf";
-
-const CURSOR_DEFAULT_BASE_URL = "https://api2.cursor.sh";
-const CURSOR_DEFAULT_CLIENT_VERSION = "cli-2026.02.13-41ac335";
-const CURSOR_GET_USABLE_MODELS_PATH = "/agent.v1.AgentService/GetUsableModels";
+import type { CursorModelRoute, Model, ModelSpec, TokenCost } from "../types";
+import {
+	CURSOR_AVAILABLE_MODELS_PATH,
+	CURSOR_DEFAULT_BASE_URL,
+	CURSOR_GET_DEFAULT_MODEL_PATH,
+	CURSOR_GET_USABLE_MODELS_PATH,
+	cursorClientHeaders,
+} from "../wire/cursor";
+import {
+	type AvailableModelsResponse_ModelDetails,
+	AvailableModelsRequestSchema,
+	AvailableModelsResponseSchema,
+	GetDefaultModelForCliRequestSchema,
+	GetDefaultModelForCliResponseSchema,
+	GetUsableModelsRequestSchema,
+	GetUsableModelsResponseSchema,
+} from "./cursor-proto";
+import { create, fromBinary, toBinary, type MessageCodec, type ProtoMessage } from "./protobuf";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 64_000;
+const CURSOR_PRICING_URL = "https://cursor.com/docs/models-and-pricing.md";
+const CURSOR_PRICING_MAX_LENGTH = 256 * 1024;
+const CURSOR_PRICING_TIMEOUT_MS = 2_000;
 
 /**
  * `GetUsableModels` carries no context-window field, so the 1M ceiling is
@@ -57,9 +75,7 @@ const CursorDecodedResponseSchema = type({
 
 type CursorModelDetailsValue = typeof CursorModelDetailsSchema.infer;
 
-/**
- * Options for fetching dynamic Cursor models from `GetUsableModels`.
- */
+/** Options for authenticated Cursor model discovery. */
 export interface CursorModelDiscoveryOptions {
 	/** Cursor access token used for bearer authentication. */
 	apiKey: string;
@@ -71,106 +87,168 @@ export interface CursorModelDiscoveryOptions {
 	timeoutMs?: number;
 	/** Optional list of custom Cursor model ids to include in request context. */
 	customModelIds?: string[];
+	/** Optional first-party pricing document URL override. */
+	pricingUrl?: string;
 }
 
 /**
- * Fetches Cursor models through `GetUsableModels` and normalizes them into canonical model entries.
+ * Joins Cursor's account-scoped model RPCs:
+ * - `AvailableModels` supplies rich base models, parameter axes, variants,
+ *   capabilities, aliases, and cost-multiplier metadata.
+ * - `GetUsableModels` supplies the exact legacy wire slugs the account can run.
+ * - `GetDefaultModelForCli` identifies the account's current default.
+ * - Cursor's first-party pricing document supplies current per-token rates.
  *
- * Returns `null` on request/decode failures.
- * Returns `[]` only when the endpoint responds successfully with no usable models.
+ * Returns `null` only when every RPC fails. A successful empty catalog returns
+ * `[]`, preserving model-manager retry and fallback semantics.
  */
 export async function fetchCursorUsableModels(
 	options: CursorModelDiscoveryOptions,
 ): Promise<ModelSpec<"cursor-agent">[] | null> {
 	const timeoutMs = options.timeoutMs ?? 5_000;
-	try {
-		const requestPayload = create(GetUsableModelsRequestSchema, {
-			customModelIds: normalizeCustomModelIds(options.customModelIds),
-		});
-		const body = toBinary(GetUsableModelsRequestSchema, requestPayload);
-		const baseUrl = (options.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
+	const baseUrl = (options.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
+	const pricingUrl = options.pricingUrl ?? (baseUrl === CURSOR_DEFAULT_BASE_URL ? CURSOR_PRICING_URL : undefined);
+	const usableRequest = create(GetUsableModelsRequestSchema, {
+		customModelIds: normalizeCustomModelIds(options.customModelIds),
+	});
+	const availableRequest = create(AvailableModelsRequestSchema, {
+		includeLongContextModels: true,
+		useModelParameters: true,
+		doNotUseMarkdown: true,
+		useCloudAgentEffortModes: true,
+	});
+	const defaultRequest = create(GetDefaultModelForCliRequestSchema, {});
 
-		const responseBuffer = await fetchViaHttp2(baseUrl, body, options, timeoutMs);
+	const [usablePayload, availablePayload, defaultPayload, pricing] = await Promise.all([
+		fetchCursorUnary(
+			baseUrl,
+			CURSOR_GET_USABLE_MODELS_PATH,
+			toBinary(GetUsableModelsRequestSchema, usableRequest),
+			options,
+			timeoutMs,
+		),
+		fetchCursorUnary(
+			baseUrl,
+			CURSOR_AVAILABLE_MODELS_PATH,
+			toBinary(AvailableModelsRequestSchema, availableRequest),
+			options,
+			Math.min(timeoutMs, 2_000),
+		),
+		fetchCursorUnary(
+			baseUrl,
+			CURSOR_GET_DEFAULT_MODEL_PATH,
+			toBinary(GetDefaultModelForCliRequestSchema, defaultRequest),
+			options,
+			timeoutMs,
+		),
+		pricingUrl === undefined
+			? Promise.resolve<CursorPricingCatalog | undefined>(undefined)
+			: fetchCursorPricingCatalog(pricingUrl, Math.min(timeoutMs, CURSOR_PRICING_TIMEOUT_MS)),
+	]);
+	if (usablePayload === null && availablePayload === null && defaultPayload === null) return null;
 
-		if (!responseBuffer) {
-			return null;
-		}
-		const decoded = decodeGetUsableModelsResponse(responseBuffer);
-		const parsedDecoded = CursorDecodedResponseSchema(decoded);
-		if (parsedDecoded instanceof type.errors) {
-			return null;
-		}
+	const usable = decodeUnary(GetUsableModelsResponseSchema, usablePayload);
+	const available = decodeUnary(AvailableModelsResponseSchema, availablePayload);
+	const defaultModel = decodeUnary(GetDefaultModelForCliResponseSchema, defaultPayload)?.model;
+	const parsedUsable = CursorDecodedResponseSchema(usable);
+	const references = createCursorReferenceMap();
+	const legacyModels =
+		parsedUsable instanceof type.errors
+			? []
+			: normalizeCursorModels(parsedUsable.models, options.baseUrl, references, pricing);
+	const usableModelIds = usable === null ? undefined : new Set(legacyModels.map(model => model.id));
+	if (!available || available.models.length === 0) return legacyModels;
+	const richModels = normalizeRichCursorModels(
+		available.models,
+		usableModelIds,
+		options.baseUrl,
+		references,
+		pricing,
+		defaultModel?.modelId,
+		defaultModel?.maxMode,
+	);
+	const richCatalogIds = collectRichCursorCatalogIds(available.models);
 
-		const references = createCursorReferenceMap();
-		return normalizeCursorModels(parsedDecoded.models, options.baseUrl, references);
-	} catch {
-		return null;
+	// Rich variants carry `legacy_slug`; retain an otherwise-unrepresented
+	// usable row so schema drift cannot hide a model the run endpoint accepts.
+	const representedIds = new Set<string>();
+	for (const model of richModels) {
+		representedIds.add(model.id);
+		representedIds.add(model.requestModelId ?? model.id);
+		for (const routeId of Object.keys(model.cursorModelRoutes ?? {})) representedIds.add(routeId);
 	}
+	for (const model of legacyModels) {
+		if (!representedIds.has(model.id) && !richCatalogIds.has(model.id)) richModels.push(model);
+	}
+	return richModels.sort((a, b) => a.id.localeCompare(b.id));
 }
 
-function buildRequestHeaders(options: CursorModelDiscoveryOptions): Record<string, string> {
-	return {
-		"content-type": "application/proto",
-		te: "trailers",
-		authorization: `Bearer ${options.apiKey}`,
-		"x-ghost-mode": "true",
-		"x-cursor-client-version": options.clientVersion ?? CURSOR_DEFAULT_CLIENT_VERSION,
-		"x-cursor-client-type": "cli",
-	};
+async function fetchCursorUnary(
+	baseUrl: string,
+	path: string,
+	body: Uint8Array,
+	options: CursorModelDiscoveryOptions,
+	timeoutMs: number,
+): Promise<Uint8Array | null> {
+	try {
+		const response = await fetch(new URL(path, baseUrl), {
+			method: "POST",
+			headers: {
+				...cursorClientHeaders(options.apiKey, { clientVersion: options.clientVersion }),
+				"connect-protocol-version": "1",
+				"x-request-id": crypto.randomUUID(),
+			},
+			body,
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (response.ok) return new Uint8Array(await response.arrayBuffer());
+	} catch {
+		// Older/custom Cursor endpoints may accept only an HTTP/2 Connect request.
+	}
+	return fetchViaHttp2(baseUrl, path, body, options, timeoutMs);
 }
 
-/** HTTP/2 transport required by Cursor API (HTTP/1.1 is rejected with 464). */
+/** HTTP/2 transport used by Cursor's unary protobuf RPCs. */
 async function fetchViaHttp2(
 	baseUrl: string,
+	path: string,
 	body: Uint8Array,
 	options: CursorModelDiscoveryOptions,
 	timeoutMs: number,
 ): Promise<Uint8Array | null> {
 	const { promise, resolve } = Promise.withResolvers<Uint8Array | null>();
 	const client = http2.connect(baseUrl);
+	let settled = false;
+	const finish = (value: Uint8Array | null): void => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timer);
+		client.close();
+		resolve(value);
+	};
 	const timer = setTimeout(() => {
 		client.destroy();
-		resolve(null);
+		finish(null);
 	}, timeoutMs);
 
-	client.on("error", () => {
-		clearTimeout(timer);
-		resolve(null);
-	});
-
+	client.on("error", () => finish(null));
 	const req = client.request({
 		":method": "POST",
-		":path": CURSOR_GET_USABLE_MODELS_PATH,
-		...buildRequestHeaders(options),
+		":path": path,
+		te: "trailers",
+		...cursorClientHeaders(options.apiKey, { clientVersion: options.clientVersion }),
+		"connect-protocol-version": "1",
+		"x-request-id": crypto.randomUUID(),
 	});
-
 	const chunks: Buffer[] = [];
 	req.on("data", (chunk: Buffer) => chunks.push(chunk));
-	req.on("end", () => {
-		clearTimeout(timer);
-		client.close();
-		resolve(new Uint8Array(Buffer.concat(chunks)));
-	});
-	req.on("error", () => {
-		clearTimeout(timer);
-		client.close();
-		resolve(null);
-	});
+	req.on("end", () => finish(new Uint8Array(Buffer.concat(chunks))));
+	req.on("error", () => finish(null));
 	req.on("response", headers => {
 		const status = Number(headers[":status"] ?? 0);
-		if (status < 200 || status >= 300) {
-			clearTimeout(timer);
-			client.close();
-			resolve(null);
-		}
+		if (status < 200 || status >= 300) finish(null);
 	});
-
-	if (body.length > 0) {
-		req.end(Buffer.from(body));
-	} else {
-		req.end();
-	}
-
+	req.end(Buffer.from(body));
 	return promise;
 }
 
@@ -200,22 +278,223 @@ function createCursorReferenceMap(): Map<string, ModelSpec<"cursor-agent">> {
 	return references;
 }
 
-function decodeGetUsableModelsResponse(payload: Uint8Array) {
-	if (payload.length === 0) {
-		return null;
-	}
+type CursorPricingCatalog = ReadonlyMap<string, TokenCost>;
 
-	const framedBody = decodeConnectUnaryBody(payload);
-	if (framedBody) {
-		try {
-			return fromBinary(GetUsableModelsResponseSchema, framedBody);
-		} catch {
-			return null;
+interface CursorPricingFlags {
+	fast?: boolean;
+	longContext?: boolean;
+}
+interface CursorPricingColumns {
+	model: number;
+	input: number;
+	cacheWrite: number;
+	cacheRead: number;
+	output: number;
+}
+
+const CURSOR_NON_PRICING_VARIANT_TOKENS = new Set([
+	"high",
+	"low",
+	"max",
+	"medium",
+	"minimal",
+	"standard",
+	"thinking",
+	"xhigh",
+]);
+
+let cursorPricingReferenceIndex: ModelReferenceIndex | null | undefined;
+
+async function fetchCursorPricingCatalog(url: string, timeoutMs: number): Promise<CursorPricingCatalog | undefined> {
+	try {
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (!response.ok) return undefined;
+		const declaredLength = Number(response.headers.get("content-length"));
+		if (Number.isFinite(declaredLength) && declaredLength > CURSOR_PRICING_MAX_LENGTH) return undefined;
+		const markdown = await response.text();
+		if (markdown.length > CURSOR_PRICING_MAX_LENGTH) return undefined;
+		return parseCursorPricingCatalog(markdown);
+	} catch {
+		return undefined;
+	}
+}
+
+function parseCursorPricingCatalog(markdown: string): CursorPricingCatalog | undefined {
+	const costs = new Map<string, TokenCost>();
+	const ambiguousKeys = new Set<string>();
+	const lines = markdown.split("\n");
+	let lineIndex = 0;
+	while (lineIndex < lines.length - 1) {
+		const header = parseMarkdownTableRow(lines[lineIndex]);
+		const separator = parseMarkdownTableRow(lines[lineIndex + 1]);
+		const columns = header ? cursorPricingColumns(header) : undefined;
+		if (!columns || !separator || !isMarkdownTableDivider(separator, header?.length ?? 0)) {
+			lineIndex++;
+			continue;
+		}
+
+		lineIndex += 2;
+		while (lineIndex < lines.length) {
+			const cells = parseMarkdownTableRow(lines[lineIndex]);
+			if (!cells || isMarkdownTableDivider(cells, cells.length) || cursorPricingColumns(cells)) break;
+			lineIndex++;
+
+			const input = parseCursorPrice(cells[columns.input]);
+			const cacheWrite = parseCursorPrice(cells[columns.cacheWrite]);
+			const cacheRead = parseCursorPrice(cells[columns.cacheRead]);
+			const output = parseCursorPrice(cells[columns.output]);
+			if (input === undefined || cacheWrite === undefined || cacheRead === undefined || output === undefined)
+				continue;
+			const key = cursorPricingLookupKey(cells[columns.model] ?? "");
+			if (!key || ambiguousKeys.has(key)) continue;
+			const cost = { input, output, cacheRead, cacheWrite };
+			const existing = costs.get(key);
+			if (existing && !equalTokenCost(existing, cost)) {
+				costs.delete(key);
+				ambiguousKeys.add(key);
+			} else {
+				costs.set(key, cost);
+			}
 		}
 	}
+	return costs.size > 0 ? costs : undefined;
+}
 
+function parseMarkdownTableRow(line: string | undefined): string[] | undefined {
+	const trimmed = line?.trim();
+	if (!trimmed?.startsWith("|") || !trimmed.endsWith("|")) return undefined;
+	return trimmed
+		.slice(1, -1)
+		.split("|")
+		.map(cell => cell.trim());
+}
+
+function cursorPricingColumns(header: readonly string[]): CursorPricingColumns | undefined {
+	const normalized = header.map(cell =>
+		cell
+			.replace(/\*\*/g, "")
+			.toLowerCase()
+			.replace(/[^a-z]+/g, " ")
+			.trim(),
+	);
+	const columns = {
+		model: normalized.indexOf("model"),
+		input: normalized.indexOf("input"),
+		cacheWrite: normalized.indexOf("cache write"),
+		cacheRead: normalized.indexOf("cache read"),
+		output: normalized.indexOf("output"),
+	};
+	return Object.values(columns).every(index => index >= 0) ? columns : undefined;
+}
+
+function isMarkdownTableDivider(cells: readonly string[], expectedLength: number): boolean {
+	return cells.length === expectedLength && cells.every(cell => /^:?-{3,}:?$/.test(cell));
+}
+
+function parseCursorPrice(value: string | undefined): number | undefined {
+	const normalized = value?.trim();
+	if (!normalized) return undefined;
+	if (normalized === "-" || normalized === "—") return 0;
+	const match = /^\$?(\d+(?:\.\d+)?)$/.exec(normalized.replace(/,/g, ""));
+	if (!match?.[1]) return undefined;
+	const price = Number(match[1]);
+	return Number.isFinite(price) ? price : undefined;
+}
+
+function cursorPricingLookupKey(label: string, flags: CursorPricingFlags = {}): string | undefined {
+	const link = /^\[([^\]]+)\]\([^)]+\)$/.exec(label.trim());
+	const normalized = (link?.[1] ?? label)
+		.replace(/\u200b/g, "")
+		.replace(/\(\s*fast(?:\s+mode)?\s*\)/gi, " fast ")
+		.replace(/\*\*/g, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim();
+	if (!normalized) return undefined;
+	const rawTokens = normalized.split(/\s+/);
+	const fast = flags.fast ?? rawTokens.includes("fast");
+	const longContext = flags.longContext ?? rawTokens.includes("1m");
+	const tokens = rawTokens.filter(
+		(token, index) =>
+			!(index === 0 && token === "cursor") &&
+			token !== "fast" &&
+			token !== "1m" &&
+			!(longContext && token === "context") &&
+			!CURSOR_NON_PRICING_VARIANT_TOKENS.has(token),
+	);
+	if (tokens.length === 0) return undefined;
+	return `${tokens.sort().join("-")}\u0000fast=${fast}\u0000long=${longContext}`;
+}
+
+function equalTokenCost(left: TokenCost, right: TokenCost): boolean {
+	return (
+		left.input === right.input &&
+		left.output === right.output &&
+		left.cacheRead === right.cacheRead &&
+		left.cacheWrite === right.cacheWrite
+	);
+}
+
+function copyTokenCost(cost: TokenCost): TokenCost {
+	return {
+		input: cost.input,
+		output: cost.output,
+		cacheRead: cost.cacheRead,
+		cacheWrite: cost.cacheWrite,
+	};
+}
+
+function hasBillableCursorCost(cost: TokenCost): boolean {
+	return cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0;
+}
+
+function getCursorPricingReferenceIndex(): ModelReferenceIndex | undefined {
+	if (cursorPricingReferenceIndex !== undefined) return cursorPricingReferenceIndex ?? undefined;
+	const peer = pricingPeerFor("cursor", "");
+	if (!peer) {
+		cursorPricingReferenceIndex = null;
+		return undefined;
+	}
+	cursorPricingReferenceIndex = buildModelReferenceIndex(
+		peer.peers.flatMap(provider => getBundledModels(provider as GeneratedProvider)),
+	);
+	return cursorPricingReferenceIndex;
+}
+
+function resolveCursorPeerCost(candidates: readonly string[]): TokenCost | undefined {
+	const index = getCursorPricingReferenceIndex();
+	if (!index) return undefined;
+	for (const candidate of candidates) {
+		const reference = resolveModelReference(candidate, index);
+		if (reference && hasBillableCursorCost(reference.cost)) return copyTokenCost(reference.cost);
+	}
+	return undefined;
+}
+
+function resolveCursorDocumentCost(
+	pricing: CursorPricingCatalog | undefined,
+	candidates: readonly string[],
+	flags: CursorPricingFlags = {},
+): TokenCost | undefined {
+	if (!pricing) return undefined;
+	for (const candidate of candidates) {
+		const key = cursorPricingLookupKey(candidate, flags);
+		const cost = key ? pricing.get(key) : undefined;
+		if (cost) return copyTokenCost(cost);
+	}
+	return undefined;
+}
+
+function decodeUnary<TMessage extends ProtoMessage>(
+	schema: MessageCodec<TMessage>,
+	payload: Uint8Array | null,
+): TMessage | null {
+	if (!payload || payload.length === 0) return null;
+	const body = decodeConnectUnaryBody(payload) ?? payload;
 	try {
-		return fromBinary(GetUsableModelsResponseSchema, payload);
+		return fromBinary(schema, body);
 	} catch {
 		return null;
 	}
@@ -270,11 +549,554 @@ function isCursorGlm52CodingModel(id: string): boolean {
 	const floor = parseRevision("5.2");
 	return revision !== undefined && floor !== undefined && compareRevision(revision, floor) >= 0;
 }
+type RichCursorVariant = AvailableModelsResponse_ModelDetails["variants"][number];
+
+type CursorRouteEffort = Effort | "off";
+
+interface NormalizedRichVariant {
+	id: string;
+	parameters: { id: string; value: string }[];
+	variant: RichCursorVariant | undefined;
+	effort: CursorRouteEffort | undefined;
+}
+
+function collectRichCursorCatalogIds(models: readonly AvailableModelsResponse_ModelDetails[]): Set<string> {
+	const ids = new Set<string>();
+	for (const details of models) {
+		const baseId = details.name.trim();
+		if (baseId) ids.add(baseId);
+		for (const id of [...details.legacySlugs, ...details.idAliases]) {
+			if (id.trim()) ids.add(id.trim());
+		}
+		for (const [index, variant] of details.variants.entries()) {
+			const parameters = variant.parameterValues
+				.map(parameter => ({ id: parameter.id.trim(), value: parameter.value.trim() }))
+				.filter(parameter => parameter.id.length > 0);
+			const parameterSuffix = parameters.map(parameter => `${parameter.id}=${parameter.value}`).join(",");
+			const id =
+				variant.legacySlug?.trim() ||
+				variant.variantStringRepresentation?.trim() ||
+				(parameterSuffix ? `${baseId}@${parameterSuffix}` : `${baseId}@variant-${index + 1}`);
+			if (id) ids.add(id);
+		}
+	}
+	return ids;
+}
+
+const CURSOR_REASONING_PARAMETER_IDS = new Set([
+	"effort",
+	"reasoning",
+	"reasoning_effort",
+	"thinking",
+	"thinking_effort",
+]);
+
+function cursorRichPricingCandidates(details: AvailableModelsResponse_ModelDetails): string[] {
+	return [
+		details.name,
+		details.clientDisplayName,
+		details.serverModelName,
+		details.inputboxShortModelName,
+		...details.legacySlugs,
+		...details.idAliases,
+	].filter((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+}
+
+function cursorPricingFlags(parameters: readonly { id: string; value: string }[]): CursorPricingFlags {
+	const fastValue = parameters.find(parameter => parameter.id === "fast")?.value.toLowerCase();
+	const contextValue = parameters.find(parameter => parameter.id === "context")?.value;
+	const contextWindow = parseCursorContextWindow(contextValue);
+	return {
+		...(fastValue === undefined ? undefined : { fast: fastValue === "true" }),
+		...(contextWindow === undefined ? undefined : { longContext: contextWindow >= CURSOR_1M_CONTEXT_WINDOW }),
+	};
+}
+
+function cursorVariantCostMultiplier(
+	details: AvailableModelsResponse_ModelDetails,
+	entry: NormalizedRichVariant,
+): number {
+	let multiplier = 1;
+	for (const parameter of entry.parameters) {
+		const definition = details.parameterDefinitions.find(candidate => candidate.id === parameter.id);
+		if (!definition) continue;
+		const booleanValue = definition.parameterType?.booleanParameter?.values.find(
+			candidate => candidate.value === parameter.value,
+		);
+		const enumValue = definition.parameterType?.enumParameter?.values.find(
+			candidate => candidate.value === parameter.value,
+		);
+		const selectedValue = booleanValue ?? enumValue;
+		if (selectedValue?.increasesModelCost !== true) continue;
+		for (const description of [enumValue?.markdownTooltip, definition.markdownTooltip]) {
+			const match = description ? /\b(\d+(?:\.\d+)?)\s*[x×]\b/i.exec(description) : undefined;
+			if (!match?.[1]) continue;
+			const parameterMultiplier = Number(match[1]);
+			if (Number.isFinite(parameterMultiplier) && parameterMultiplier > 0) {
+				multiplier *= parameterMultiplier;
+				break;
+			}
+		}
+	}
+	return multiplier;
+}
+
+function resolveRichCursorCost(
+	pricing: CursorPricingCatalog | undefined,
+	details: AvailableModelsResponse_ModelDetails,
+	entry: NormalizedRichVariant,
+): TokenCost | undefined {
+	const candidates = cursorRichPricingCandidates(details);
+	const flags = cursorPricingFlags(entry.parameters);
+	const exact = resolveCursorDocumentCost(pricing, candidates, flags);
+	if (exact) return exact;
+	if (flags.fast === true && flags.longContext === true) {
+		const fast = resolveCursorDocumentCost(pricing, candidates, { fast: true, longContext: false });
+		if (fast) return fast;
+	}
+	const base =
+		resolveCursorDocumentCost(pricing, candidates, { fast: false, longContext: flags.longContext }) ??
+		resolveCursorDocumentCost(pricing, candidates, { fast: false, longContext: false }) ??
+		resolveCursorPeerCost(candidates);
+	if (!base) return undefined;
+	const multiplier = cursorVariantCostMultiplier(details, entry);
+	if (multiplier === 1) return base;
+	return {
+		input: base.input * multiplier,
+		output: base.output * multiplier,
+		cacheRead: base.cacheRead * multiplier,
+		cacheWrite: base.cacheWrite * multiplier,
+	};
+}
+
+function resolveLegacyCursorCost(
+	pricing: CursorPricingCatalog | undefined,
+	details: CursorModelDetailsValue,
+	id: string,
+): TokenCost | undefined {
+	const candidates = [
+		id,
+		details.displayName,
+		details.displayNameShort,
+		details.displayModelId,
+		...details.aliases,
+	].filter((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+	return resolveCursorDocumentCost(pricing, candidates) ?? resolveCursorPeerCost(candidates);
+}
+
+function normalizeRichCursorModels(
+	models: readonly AvailableModelsResponse_ModelDetails[],
+	usableModelIds: ReadonlySet<string> | undefined,
+	baseUrlOverride: string | undefined,
+	references: Map<string, ModelSpec<"cursor-agent">>,
+	pricing: CursorPricingCatalog | undefined,
+	defaultModelId: string | undefined,
+	defaultMaxMode: boolean | undefined,
+): ModelSpec<"cursor-agent">[] {
+	const normalized: ModelSpec<"cursor-agent">[] = [];
+	for (const details of models) {
+		const baseId = details.name.trim();
+		if (!baseId || details.supportsAgent === false || details.isChatOnly === true) continue;
+		// OMP always sends Cursor's zero-data-retention header. Advertising a
+		// retention-required model would expose a route every invocation rejects.
+		if (details.requiresDataRetention === true) continue;
+
+		const variants = normalizeRichCursorVariants(details, baseId, usableModelIds);
+		if (variants.length === 0) continue;
+		const parameterDefaults = new Map<string, string>();
+		for (const entry of variants) {
+			for (const parameter of cursorLaneParameters(entry.parameters)) {
+				if (!parameterDefaults.has(parameter.id)) parameterDefaults.set(parameter.id, parameter.value);
+			}
+		}
+
+		const lanes = new Map<string, NormalizedRichVariant[]>();
+		for (const entry of variants) {
+			const dimensions = cursorLaneParameters(entry.parameters);
+			const key = JSON.stringify([dimensions, entry.variant?.isMaxMode === true]);
+			const lane = lanes.get(key);
+			if (lane) {
+				lane.push(entry);
+			} else {
+				lanes.set(key, [entry]);
+			}
+		}
+
+		const claimedLaneIds = new Set<string>();
+		for (const entries of lanes.values()) {
+			const first = entries[0];
+			if (!first) continue;
+			const dimensions = cursorLaneParameters(first.parameters);
+			const laneId = cursorLaneId(
+				baseId,
+				dimensions,
+				parameterDefaults,
+				first.variant?.isMaxMode === true,
+				claimedLaneIds,
+			);
+			const laneName = cursorLaneName(details, laneId, baseId);
+			normalized.push(
+				...buildRichCursorLane(
+					details,
+					entries,
+					laneId,
+					laneName,
+					baseUrlOverride,
+					references,
+					pricing,
+					defaultModelId,
+					defaultMaxMode,
+				),
+			);
+		}
+	}
+	return normalized.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function normalizeRichCursorVariants(
+	details: AvailableModelsResponse_ModelDetails,
+	baseId: string,
+	usableModelIds: ReadonlySet<string> | undefined,
+): NormalizedRichVariant[] {
+	if (details.variants.length === 0) {
+		const candidates = [baseId, ...details.legacySlugs, ...details.idAliases];
+		if (usableModelIds !== undefined && !candidates.some(id => usableModelIds.has(id))) return [];
+		return [{ id: baseId, parameters: [], variant: undefined, effort: undefined }];
+	}
+
+	const variants: NormalizedRichVariant[] = [];
+	const seenRoutes = new Set<string>();
+	for (const [index, variant] of details.variants.entries()) {
+		if (isRichVariantBlocked(details, variant)) continue;
+		const parameters = variant.parameterValues
+			.map(parameter => ({ id: parameter.id.trim(), value: parameter.value.trim() }))
+			.filter(parameter => parameter.id.length > 0);
+		const parameterSuffix = parameters.map(parameter => `${parameter.id}=${parameter.value}`).join(",");
+		const id =
+			variant.legacySlug?.trim() ||
+			variant.variantStringRepresentation?.trim() ||
+			(parameterSuffix ? `${baseId}@${parameterSuffix}` : `${baseId}@variant-${index + 1}`);
+		const entitlementIds = [variant.legacySlug?.trim(), id, baseId, ...details.idAliases].filter(
+			(candidate): candidate is string => Boolean(candidate),
+		);
+		if (usableModelIds !== undefined && !entitlementIds.some(candidate => usableModelIds.has(candidate))) continue;
+		const routeSignature = `${parameterSuffix}\u0000${variant.isMaxMode === true ? "max" : "standard"}`;
+		if (seenRoutes.has(routeSignature)) continue;
+		seenRoutes.add(routeSignature);
+		variants.push({
+			id,
+			parameters,
+			variant,
+			effort: cursorVariantEffort(parameters),
+		});
+	}
+	return variants;
+}
+
+function cursorVariantEffort(parameters: readonly { id: string; value: string }[]): CursorRouteEffort | undefined {
+	const thinking = parameters.find(parameter => parameter.id === "thinking")?.value.toLowerCase();
+	if (thinking === "false" || thinking === "off" || thinking === "none") return "off";
+	const rawEffort = parameters.find(parameter =>
+		["reasoning", "reasoning_effort", "thinking_effort", "effort"].includes(parameter.id),
+	)?.value;
+	if (rawEffort === undefined) return undefined;
+	const normalized = rawEffort.toLowerCase().replace(/[_\s]+/g, "-");
+	if (normalized === "none" || normalized === "off" || normalized === "disabled") return "off";
+	if (
+		normalized === Effort.Minimal ||
+		normalized === Effort.Low ||
+		normalized === Effort.Medium ||
+		normalized === Effort.High ||
+		normalized === Effort.XHigh ||
+		normalized === Effort.Max
+	) {
+		return normalized;
+	}
+	if (normalized === "extra-high") return Effort.XHigh;
+	return undefined;
+}
+
+function cursorLaneParameters(parameters: readonly { id: string; value: string }[]): { id: string; value: string }[] {
+	return parameters.filter(parameter => !CURSOR_REASONING_PARAMETER_IDS.has(parameter.id));
+}
+
+function cursorLaneId(
+	baseId: string,
+	parameters: readonly { id: string; value: string }[],
+	defaults: ReadonlyMap<string, string>,
+	isMaxMode: boolean,
+	claimed: Set<string>,
+): string {
+	const suffixes: string[] = [];
+	for (const parameter of parameters) {
+		const id = sanitizeCursorLanePart(parameter.id);
+		const value = sanitizeCursorLanePart(parameter.value);
+		if (!id || !value || parameter.value === defaults.get(parameter.id) || parameter.value === "false") continue;
+		if (parameter.value === "true") {
+			suffixes.push(id);
+		} else if (parameter.id === "context") {
+			suffixes.push(value);
+		} else {
+			suffixes.push(`${id}-${value}`);
+		}
+	}
+	const root = [baseId, ...suffixes].join("-");
+	let candidate = root;
+	if (claimed.has(candidate)) candidate = `${root}-${isMaxMode ? "max-mode" : "standard"}`;
+	let duplicate = 2;
+	while (claimed.has(candidate)) {
+		candidate = `${root}-${duplicate}`;
+		duplicate += 1;
+	}
+	claimed.add(candidate);
+	return candidate;
+}
+
+function sanitizeCursorLanePart(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function cursorLaneName(details: AvailableModelsResponse_ModelDetails, laneId: string, baseId: string): string {
+	const baseName =
+		details.clientDisplayName?.trim() || details.serverModelName?.trim() || details.name.trim() || baseId;
+	const suffix = laneId
+		.slice(baseId.length)
+		.replace(/^-/, "")
+		.split("-")
+		.filter(Boolean)
+		.map(part => (part === "1m" ? "1M" : part.charAt(0).toUpperCase() + part.slice(1)))
+		.join(" ");
+	return suffix ? `${baseName} ${suffix}` : baseName;
+}
+
+function buildRichCursorLane(
+	details: AvailableModelsResponse_ModelDetails,
+	entries: readonly NormalizedRichVariant[],
+	laneId: string,
+	laneName: string,
+	baseUrlOverride: string | undefined,
+	references: Map<string, ModelSpec<"cursor-agent">>,
+	pricing: CursorPricingCatalog | undefined,
+	defaultModelId: string | undefined,
+	defaultMaxMode: boolean | undefined,
+): ModelSpec<"cursor-agent">[] {
+	const selectedByEffort = new Map<CursorRouteEffort | "fixed", NormalizedRichVariant>();
+	for (const entry of entries) {
+		const slot = entry.effort ?? "fixed";
+		const current = selectedByEffort.get(slot);
+		if (
+			current === undefined ||
+			cursorVariantPreference(details, entry, defaultModelId, defaultMaxMode) >
+				cursorVariantPreference(details, current, defaultModelId, defaultMaxMode)
+		) {
+			selectedByEffort.set(slot, entry);
+		}
+	}
+	const selected = [...selectedByEffort.values()];
+	if (selected.length === 0) return [];
+
+	const routeKeys = new Map<NormalizedRichVariant, string>();
+	const usedRouteKeys = new Set<string>();
+	const routes: Record<string, CursorModelRoute> = {};
+	for (const entry of selected) {
+		let routeKey = entry.id;
+		if (usedRouteKeys.has(routeKey)) {
+			routeKey =
+				entry.variant?.variantStringRepresentation?.trim() ||
+				`${entry.id}@${entry.parameters.map(parameter => `${parameter.id}=${parameter.value}`).join(",")}`;
+		}
+		let duplicate = 2;
+		const root = routeKey;
+		while (usedRouteKeys.has(routeKey)) {
+			routeKey = `${root}#${duplicate}`;
+			duplicate += 1;
+		}
+		usedRouteKeys.add(routeKey);
+		routeKeys.set(entry, routeKey);
+		routes[routeKey] = {
+			modelId: details.name.trim(),
+			parameters: entry.parameters,
+			...(entry.variant?.isMaxMode === undefined ? undefined : { maxMode: entry.variant.isMaxMode }),
+		};
+	}
+
+	const members: ModelSpec<"cursor-agent">[] = [];
+	const routing: Partial<Record<CursorRouteEffort, string>> = {};
+	let defaultMember: string | undefined;
+	for (const entry of selected) {
+		const routeKey = routeKeys.get(entry);
+		if (!routeKey) continue;
+		const variant = entry.variant;
+		const reference =
+			references.get(entry.id) ??
+			references.get(details.name.trim()) ??
+			details.legacySlugs.map(id => references.get(id)).find(candidate => candidate !== undefined);
+		const isMaxMode = variant?.isMaxMode ?? false;
+		const contextParameter = entry.parameters.find(parameter => parameter.id === "context")?.value;
+		const contextLimit =
+			parseCursorContextWindow(contextParameter) ??
+			(isMaxMode ? details.contextTokenLimitForMaxMode : details.contextTokenLimit);
+		const discoveredContextWindow =
+			contextLimit ?? details.autoContextExtendedMaxTokens ?? details.autoContextMaxTokens;
+		const fallbackContext = reference?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+		const input: ("text" | "image")[] =
+			details.supportsImages === undefined
+				? resolveCursorInput(entry.id, reference?.input)
+				: details.supportsImages
+					? ["text", "image"]
+					: ["text"];
+		const isProviderDefault = isCursorProviderDefault(details, entry, defaultModelId, defaultMaxMode);
+		const reasoning =
+			entry.effort === "off"
+				? false
+				: entry.effort !== undefined
+					? true
+					: (details.supportsThinking ?? reference?.reasoning ?? false);
+		const cost = resolveRichCursorCost(pricing, details, entry) ?? {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		};
+		members.push({
+			...(reference ?? {
+				id: routeKey,
+				name: laneName,
+				api: "cursor-agent" as const,
+				provider: "cursor" as const,
+				baseUrl: baseUrlOverride ?? CURSOR_DEFAULT_BASE_URL,
+				reasoning,
+				input,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: fallbackContext,
+				maxTokens: DEFAULT_MAX_TOKENS,
+			}),
+			id: routeKey,
+			name: laneName,
+			baseUrl: baseUrlOverride ?? reference?.baseUrl ?? CURSOR_DEFAULT_BASE_URL,
+			reasoning,
+			input,
+			cost,
+			supportsTools: details.supportsAgent ?? reference?.supportsTools,
+			contextWindow: discoveredContextWindow ?? fallbackContext,
+			cursorMaxMode: isMaxMode,
+			cursorModelParameters: entry.parameters,
+			cursorModelRoutes: routes,
+			cursorPrice: details.price,
+			cursorRequiresDataRetention: details.requiresDataRetention,
+			cursorSupportsAgent: details.supportsAgent,
+			cursorSupportsSandboxing: details.supportsSandboxing,
+			isProviderDefault,
+			isRecommended: isProviderDefault || details.defaultOn,
+			description:
+				variant?.tooltipData?.markdownContent ??
+				variant?.tagline ??
+				details.tooltipData?.markdownContent ??
+				details.tagline ??
+				reference?.description,
+		});
+		if (entry.effort !== undefined) routing[entry.effort] = routeKey;
+		if (isProviderDefault) defaultMember = routeKey;
+	}
+	if (members.length === 0) return [];
+
+	defaultMember ??= selected
+		.filter(entry => entry.variant?.isDefaultNonMaxConfig === true || entry.variant?.isDefaultMaxConfig === true)
+		.map(entry => routeKeys.get(entry))
+		.find((routeKey): routeKey is string => routeKey !== undefined);
+	defaultMember ??= routing.off ?? members[0]?.id;
+	const efforts = THINKING_EFFORTS.filter(effort => routing[effort] !== undefined);
+	const family: EffortVariantFamily = {
+		id: laneId,
+		name: laneName,
+		members: members.map(member => member.id),
+		routing,
+		...(defaultMember === undefined ? undefined : { defaultMember }),
+		...(efforts.length === 0
+			? undefined
+			: {
+					thinking: {
+						mode: "effort",
+						efforts,
+						...(routing.off === undefined ? { requiresEffort: true } : {}),
+						...(defaultMember === undefined
+							? undefined
+							: {
+									defaultLevel: efforts.find(effort => routing[effort] === defaultMember),
+								}),
+					},
+				}),
+	};
+	return collapseVariants(members, { table: { families: [family] } });
+}
+
+function cursorVariantPreference(
+	details: AvailableModelsResponse_ModelDetails,
+	entry: NormalizedRichVariant,
+	defaultModelId: string | undefined,
+	defaultMaxMode: boolean | undefined,
+): number {
+	if (isCursorProviderDefault(details, entry, defaultModelId, defaultMaxMode)) return 3;
+	if (entry.variant?.isDefaultNonMaxConfig === true || entry.variant?.isDefaultMaxConfig === true) return 2;
+	return 1;
+}
+
+function isCursorProviderDefault(
+	details: AvailableModelsResponse_ModelDetails,
+	entry: NormalizedRichVariant,
+	defaultModelId: string | undefined,
+	defaultMaxMode: boolean | undefined,
+): boolean {
+	const variant = entry.variant;
+	if (defaultModelId !== undefined) {
+		if (defaultModelId === entry.id) {
+			return defaultMaxMode === undefined || defaultMaxMode === (variant?.isMaxMode ?? false);
+		}
+		if (
+			defaultModelId !== details.name &&
+			!details.legacySlugs.includes(defaultModelId) &&
+			!details.idAliases.includes(defaultModelId)
+		) {
+			return false;
+		}
+		if (variant === undefined) return true;
+		return defaultMaxMode === true ? variant.isDefaultMaxConfig === true : variant.isDefaultNonMaxConfig === true;
+	}
+	if (!details.defaultOn) return false;
+	return variant === undefined || variant.isDefaultNonMaxConfig === true || variant.isDefaultMaxConfig === true;
+}
+
+function parseCursorContextWindow(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const match = /^(\d+(?:\.\d+)?)([km])?$/i.exec(value.trim());
+	if (!match?.[1]) return undefined;
+	const amount = Number(match[1]);
+	if (!Number.isFinite(amount) || amount <= 0) return undefined;
+	const unit = match[2]?.toLowerCase();
+	return Math.round(amount * (unit === "m" ? 1_000_000 : unit === "k" ? 1_000 : 1));
+}
+
+function isRichVariantBlocked(details: AvailableModelsResponse_ModelDetails, variant: RichCursorVariant): boolean {
+	for (const parameter of variant.parameterValues) {
+		const definition = details.parameterDefinitions.find(candidate => candidate.id === parameter.id);
+		const values = [
+			...(definition?.parameterType?.booleanParameter?.values ?? []),
+			...(definition?.parameterType?.enumParameter?.values ?? []),
+		];
+		const value = values.find(candidate => candidate.value === parameter.value);
+		if (value?.blockedByAdminAllowlist === true) return true;
+	}
+	return false;
+}
 
 function normalizeCursorModels(
 	models: readonly unknown[] | undefined,
 	baseUrlOverride: string | undefined,
 	references: Map<string, ModelSpec<"cursor-agent">>,
+	pricing: CursorPricingCatalog | undefined,
 ): ModelSpec<"cursor-agent">[] {
 	if (!models || models.length === 0) {
 		return [];
@@ -282,7 +1104,7 @@ function normalizeCursorModels(
 
 	const byId = new Map<string, ModelSpec<"cursor-agent">>();
 	for (const model of models) {
-		const normalized = normalizeCursorModel(model, baseUrlOverride, references);
+		const normalized = normalizeCursorModel(model, baseUrlOverride, references, pricing);
 		if (!normalized) {
 			continue;
 		}
@@ -296,6 +1118,7 @@ function normalizeCursorModel(
 	model: unknown,
 	baseUrlOverride: string | undefined,
 	references: Map<string, ModelSpec<"cursor-agent">>,
+	pricing: CursorPricingCatalog | undefined,
 ): ModelSpec<"cursor-agent"> | null {
 	const parsedModel = CursorModelDetailsSchema(model);
 	if (parsedModel instanceof type.errors) {
@@ -320,6 +1143,12 @@ function normalizeCursorModel(
 		isCursorVersionedGrok(id) ||
 		Boolean(details.thinkingDetails) ||
 		reference?.reasoning === true;
+	const cost = resolveLegacyCursorCost(pricing, details, id) ?? {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+	};
 
 	if (reference) {
 		return {
@@ -329,6 +1158,7 @@ function normalizeCursorModel(
 			baseUrl: baseUrlOverride ?? reference.baseUrl,
 			reasoning,
 			input: resolveCursorInput(id, reference.input),
+			cost,
 			contextWindow: resolveCursorContextWindow(details, id, reference.contextWindow),
 			cursorMaxMode: details.maxMode,
 		};
@@ -341,7 +1171,7 @@ function normalizeCursorModel(
 		baseUrl: baseUrlOverride ?? CURSOR_DEFAULT_BASE_URL,
 		reasoning,
 		input: resolveCursorInput(id),
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		cost,
 		contextWindow: resolveCursorContextWindow(details, id, DEFAULT_CONTEXT_WINDOW),
 		maxTokens: DEFAULT_MAX_TOKENS,
 		cursorMaxMode: details.maxMode,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -77,6 +77,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -171,6 +172,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -270,6 +272,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -301,7 +304,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -311,14 +314,15 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
+			"int": 34.5,
+			"tps": 138.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
 			},
-			"int": 51.8,
-			"tps": 140,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -373,8 +377,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -392,7 +395,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -402,14 +405,15 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
+			"int": 36.3,
+			"tps": 68.8,
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
 			},
-			"int": 53.2,
-			"tps": 60.2,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -464,8 +468,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -485,7 +488,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -496,10 +499,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gemma"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -553,12 +557,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
-		"moonshotai/kimi-k2.7-code": {
-			"id": "moonshotai/kimi-k2.7-code",
-			"name": "Kimi K2.7 Code",
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -568,7 +571,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
+				"input": 0.85,
 				"output": 3.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -585,14 +588,15 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
+			"int": 31.3,
+			"tps": 46,
 			"identity": {
 				"class": "kimi",
-				"family": "k2.7-code"
+				"family": "k2.6"
 			},
-			"int": 43,
-			"tps": 39,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -647,8 +651,101 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"int": 26.3,
+			"tps": 57,
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -866,13 +963,14 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
+			"int": 12.3,
+			"tps": 194.4,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
-			"int": 24.1,
-			"tps": 153,
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -926,8 +1024,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -941,13 +1038,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -957,14 +1054,15 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
+			"int": 21.9,
+			"tps": 55.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
 			},
-			"int": 37.7,
-			"tps": 52.5,
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -1018,8 +1116,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -1113,9 +1210,9 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/glm-5.2": {
-			"id": "zai-org/glm-5.2",
-			"name": "GLM 5.2",
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -1124,12 +1221,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 4,
+				"input": 1.4,
+				"output": 4.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 202752,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -1138,15 +1235,16 @@
 					"low",
 					"medium",
 					"high",
-					"max"
+					"xhigh"
 				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -1200,8 +1298,97 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"zai-org/glm-5.2": {
+			"id": "zai-org/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"zai-org/glm-5.3": {
 			"id": "zai-org/glm-5.3",
@@ -11748,7 +11935,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -29551,8 +29738,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 16384,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29645,8 +29832,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 16384,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29741,7 +29928,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 36,
+			"int": 23.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29836,8 +30023,8 @@
 			},
 			"contextWindow": 196608,
 			"maxTokens": 24576,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -29930,8 +30117,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 108.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30372,8 +30559,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30467,8 +30654,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -30563,8 +30750,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -31879,6 +32066,101 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"apac.amazon.nova-lite-v1:0": {
+			"id": "apac.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.063,
+				"output": 0.252,
+				"cacheRead": 0.01575,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"apac.amazon.nova-micro-v1:0": {
+			"id": "apac.amazon.nova-micro-v1:0",
+			"name": "Nova Micro (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.037,
+				"output": 0.148,
+				"cacheRead": 0.00925,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"apac.amazon.nova-pro-v1:0": {
+			"id": "apac.amazon.nova-pro-v1:0",
+			"name": "Nova Pro (APAC)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.84,
+				"output": 3.36,
+				"cacheRead": 0.21,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
 			"name": "Claude Haiku 4.5 (AU)",
@@ -31965,6 +32247,51 @@
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
 				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"au.anthropic.claude-opus-4-7": {
+			"id": "au.anthropic.claude-opus-4-7",
+			"name": "Claude Opus 4.7 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "opus",
+				"revision": "4.7.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v47",
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": true,
+				"promptCacheMinimumTokens": 4096,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 900000
 			}
 		},
 		"au.anthropic.claude-opus-4-8": {
@@ -32190,6 +32517,38 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"ca.amazon.nova-lite-v1:0": {
+			"id": "ca.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (CA)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.064,
+				"output": 0.256,
+				"cacheRead": 0.016,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
 		"cohere.command-r-plus-v1:0": {
 			"id": "cohere.command-r-plus-v1:0",
 			"name": "Command R+",
@@ -32309,7 +32668,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 81920,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -32373,6 +32732,143 @@
 				"streamIdleTimeoutMs": 600000
 			},
 			"supportsComputerUse": false
+		},
+		"eu.amazon.nova-2-lite-v1:0": {
+			"id": "eu.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.374,
+				"output": 3.157,
+				"cacheRead": 0.0935,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"eu.amazon.nova-lite-v1:0": {
+			"id": "eu.amazon.nova-lite-v1:0",
+			"name": "Nova Lite (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.069,
+				"output": 0.276,
+				"cacheRead": 0.01725,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"eu.amazon.nova-micro-v1:0": {
+			"id": "eu.amazon.nova-micro-v1:0",
+			"name": "Nova Micro (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.16,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
+		},
+		"eu.amazon.nova-pro-v1:0": {
+			"id": "eu.amazon.nova-pro-v1:0",
+			"name": "Nova Pro (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.92,
+				"output": 3.68,
+				"cacheRead": 0.23,
+				"cacheWrite": 0
+			},
+			"contextWindow": 300000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4
+			}
 		},
 		"eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
 			"id": "eu.anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -33235,6 +33731,37 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"eu.mistral.pixtral-large-2502-v1:0": {
+			"id": "eu.mistral.pixtral-large-2502-v1:0",
+			"name": "Pixtral Large (25.02) (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
 		"global.amazon.nova-2-lite-v1:0": {
 			"id": "global.amazon.nova-2-lite-v1:0",
 			"name": "Nova 2 Lite",
@@ -33941,6 +34468,90 @@
 				"streamIdleTimeoutMs": 600000
 			}
 		},
+		"global.openai.gpt-6-astra": {
+			"id": "global.openai.gpt-6-astra",
+			"name": "GPT-6 Astra (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"global.xai.grok-4.6": {
+			"id": "global.xai.grok-4.6",
+			"name": "Grok 4.6 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
 		"google.gemma-3-27b-it": {
 			"id": "google.gemma-3-27b-it",
 			"name": "Google Gemma 3 27B Instruct",
@@ -34001,6 +34612,48 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"jp.amazon.nova-2-lite-v1:0": {
+			"id": "jp.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.396,
+				"output": 3.311,
+				"cacheRead": 0.099,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
 			}
 		},
 		"jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -34983,8 +35636,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.2,
-			"tps": 159.9,
+			"int": 6.8,
+			"tps": 146.9,
 			"identity": {
 				"class": "unknown"
 			},
@@ -35026,6 +35679,49 @@
 			},
 			"identity": {
 				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"openai.gpt-6-astra": {
+			"id": "openai.gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -36039,6 +36735,48 @@
 				"streamIdleTimeoutMs": 900000
 			}
 		},
+		"us.amazon.nova-2-lite-v1:0": {
+			"id": "us.amazon.nova-2-lite-v1:0",
+			"name": "Nova 2 Lite (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.33,
+				"output": 2.75,
+				"cacheRead": 0.0825,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "amazon",
+				"family": "nova"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "explicit",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 1024,
+				"promptCacheMaximumCheckpoints": 4,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
 		"us.amazon.nova-lite-v1:0": {
 			"id": "us.amazon.nova-lite-v1:0",
 			"name": "Nova Lite",
@@ -36874,6 +37612,66 @@
 				"streamIdleTimeoutMs": 600000
 			}
 		},
+		"us.meta.llama3-1-70b-instruct-v1:0": {
+			"id": "us.meta.llama3-1-70b-instruct-v1:0",
+			"name": "Llama 3.1 70B Instruct (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.72,
+				"output": 0.72,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.meta.llama3-1-8b-instruct-v1:0": {
+			"id": "us.meta.llama3-1-8b-instruct-v1:0",
+			"name": "Llama 3.1 8B Instruct (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.22,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
 		"us.meta.llama3-2-11b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-11b-instruct-v1:0",
 			"name": "Llama 3.2 11B Instruct",
@@ -37086,6 +37884,330 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.mistral.pixtral-large-2502-v1:0": {
+			"id": "us.mistral.pixtral-large-2502-v1:0",
+			"name": "Pixtral Large (25.02) (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0
+			}
+		},
+		"us.openai.gpt-5.6-luna": {
+			"id": "us.openai.gpt-5.6-luna",
+			"name": "GPT-5.6 Luna (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 1.32,
+				"cacheRead": 0.022,
+				"cacheWrite": 0.275
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-5.6-sol": {
+			"id": "us.openai.gpt-5.6-sol",
+			"name": "GPT-5.6 Sol (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.4,
+				"output": 22,
+				"cacheRead": 0.44,
+				"cacheWrite": 5.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-5.6-terra": {
+			"id": "us.openai.gpt-5.6-terra",
+			"name": "GPT-5.6 Terra (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 13.2,
+				"cacheRead": 0.22,
+				"cacheWrite": 2.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.openai.gpt-6-astra": {
+			"id": "us.openai.gpt-6-astra",
+			"name": "GPT-6 Astra (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.writer.palmyra-x4-v1:0": {
+			"id": "us.writer.palmyra-x4-v1:0",
+			"name": "Palmyra X4 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 10,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 122880,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.writer.palmyra-x5-v1:0": {
+			"id": "us.writer.palmyra-x5-v1:0",
+			"name": "Palmyra X5 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1040000,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
+			}
+		},
+		"us.xai.grok-4.6": {
+			"id": "us.xai.grok-4.6",
+			"name": "Grok 4.6 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 6.6,
+				"cacheRead": 0.55,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"promptCacheMode": "none",
+				"supportsLongPromptCacheRetention": false,
+				"promptCacheMinimumTokens": 0,
+				"promptCacheMaximumCheckpoints": 0,
+				"streamIdleTimeoutMs": 600000
 			}
 		},
 		"writer.palmyra-x4-v1:0": {
@@ -37550,8 +38672,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -37615,8 +38737,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.2,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38100,8 +39222,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -38226,8 +39348,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38289,8 +39411,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38354,8 +39476,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38419,8 +39541,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38724,8 +39846,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38786,8 +39908,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -38911,6 +40033,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -38991,6 +40114,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39071,6 +40195,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39103,8 +40228,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 31.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39155,6 +40280,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39236,6 +40362,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39267,8 +40394,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39319,6 +40446,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39350,8 +40478,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 111.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39402,6 +40530,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39433,8 +40562,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 107.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -39485,6 +40614,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39516,8 +40646,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 130.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -39567,6 +40697,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39599,7 +40730,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -39649,6 +40780,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39680,8 +40812,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39741,6 +40873,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39772,7 +40905,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39832,6 +40965,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39863,8 +40997,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39924,6 +41058,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -39955,8 +41090,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 152.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40016,6 +41151,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40106,6 +41242,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40137,8 +41274,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40198,6 +41335,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40287,6 +41425,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40319,7 +41458,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40379,6 +41518,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40471,6 +41611,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40502,7 +41643,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40560,6 +41701,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40591,8 +41733,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40652,6 +41794,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40741,6 +41884,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40773,7 +41917,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -40833,6 +41977,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40922,6 +42067,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -40954,8 +42100,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41015,6 +42161,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41046,8 +42193,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41107,6 +42254,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41138,8 +42286,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41199,6 +42347,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41230,8 +42379,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41291,6 +42440,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41381,6 +42531,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41412,8 +42563,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41474,6 +42625,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41505,8 +42657,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41567,6 +42719,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41598,8 +42751,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41660,6 +42813,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41691,8 +42845,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41753,6 +42907,101 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": true,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": true,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41843,6 +43092,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -41874,7 +43124,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -41935,6 +43185,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42025,6 +43276,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42057,8 +43309,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 105,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42119,6 +43371,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42149,8 +43402,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42212,6 +43465,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -42243,8 +43497,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -42306,6 +43560,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43815,6 +45070,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43905,6 +45161,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -43995,6 +45252,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44085,6 +45343,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44175,6 +45434,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -44224,7 +45484,6 @@
 				"class": "gemma"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44278,7 +45537,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -44298,8 +45558,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 40960,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -44611,28 +45871,39 @@
 		},
 		"qwen-3.8-27b": {
 			"id": "qwen-3.8-27b",
-			"name": "qwen-3.8-27b",
+			"name": "Qwen3.8 27B",
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"baseUrl": "https://api.cerebras.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.99,
+				"output": 1.49,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 65536,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -44686,8 +45957,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"zai-glm-4.6": {
 			"id": "zai-glm-4.6",
@@ -44943,6 +46213,173 @@
 				"wireModelIdMode": "raw"
 			}
 		},
+		"cline-free/muse-spark-1.3-contributor": {
+			"id": "cline-free/muse-spark-1.3-contributor",
+			"name": "Muse Spark 1.3 Contributor (free)",
+			"api": "openai-completions",
+			"provider": "cline-pass",
+			"baseUrl": "https://api.cline.bot/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
+			"identity": {
+				"class": "meta",
+				"family": "muse-spark",
+				"revision": "1.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "cline-enabled-false",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false,
+				"wireModelIdMode": "raw"
+			}
+		},
+		"cline-free/solar-pro4": {
+			"id": "cline-free/solar-pro4",
+			"name": "Solar Pro 4 (free)",
+			"api": "openai-completions",
+			"provider": "cline-pass",
+			"baseUrl": "https://api.cline.bot/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "cline-enabled-false",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false,
+				"wireModelIdMode": "raw"
+			}
+		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
 			"name": "DeepSeek V4 Flash",
@@ -45119,6 +46556,91 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"deepseek-v4.1-flash": {
+			"id": "deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "cline-pass",
+			"baseUrl": "https://api.cline.bot/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "cline-enabled-false",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "cline-pass",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
 			}
 		},
 		"deepseek/deepseek-v4-flash": {
@@ -45395,7 +46917,7 @@
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
-			"name": "GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
 			"api": "openai-completions",
 			"provider": "cline-pass",
 			"baseUrl": "https://api.cline.bot/api/v1",
@@ -45405,9 +46927,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
@@ -46478,8 +48000,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 45.9,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -46530,8 +48052,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46592,8 +48114,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46655,8 +48177,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -46718,8 +48240,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 38.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -47094,8 +48616,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47130,6 +48652,72 @@
 				"supportsMidConversationToolChanges": true,
 				"supportsPerMessageEffort": false,
 				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": false,
+				"supportsSamplingParams": false,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			}
+		},
+		"anthropic/claude-fable-5.1": {
+			"id": "anthropic/claude-fable-5.1",
+			"name": "Claude Fable 5.1",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 0.25,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"int": 53.4,
+			"tps": 67.2,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true,
+				"prefixBinding": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": true,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": true,
+				"supportsTurnScopedSystem": true,
+				"supportsMidConversationToolChanges": true,
+				"supportsPerMessageEffort": true,
+				"supportsThinkingBindingControls": true,
 				"supportsForcedToolChoice": false,
 				"supportsSamplingParams": false,
 				"requiresToolResultId": false,
@@ -47656,8 +49244,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -47720,8 +49308,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47783,8 +49371,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47848,8 +49436,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -47913,8 +49501,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48224,8 +49812,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48286,8 +49874,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -48412,8 +50000,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48476,8 +50064,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48643,8 +50231,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48696,8 +50284,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 111.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48749,8 +50337,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 107.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -48802,8 +50390,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 130.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -48855,7 +50443,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -48906,8 +50494,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -48968,8 +50556,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49030,8 +50618,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 152.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49152,8 +50740,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49692,8 +51280,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49754,8 +51342,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49816,8 +51404,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -49938,8 +51526,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50123,8 +51711,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50186,8 +51774,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50249,8 +51837,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50436,8 +52024,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 105,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50498,8 +52086,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -50625,8 +52213,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -51333,8 +52921,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51428,8 +53016,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51609,8 +53197,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51698,8 +53286,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51876,8 +53464,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51967,8 +53555,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52059,8 +53647,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52151,8 +53739,8 @@
 			},
 			"contextWindow": 1310720,
 			"maxTokens": 1310720,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52244,8 +53832,8 @@
 			},
 			"contextWindow": 1310720,
 			"maxTokens": 1048576,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52338,7 +53926,7 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"identity": {
 				"class": "xai",
 				"family": "grok",
@@ -52391,7 +53979,7 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52455,8 +54043,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 133.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52519,8 +54107,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -52583,8 +54171,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -53492,7 +55080,6 @@
 				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -53547,7 +55134,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
@@ -54122,7 +55710,6 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -54176,7 +55763,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -54388,6 +55976,7 @@
 					"xhigh"
 				]
 			},
+			"contextPromotionTarget": "commandcode/gpt-5.4",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -58337,7 +59926,7 @@
 			},
 			"contextWindow": 161000,
 			"maxTokens": 161000,
-			"int": 21.4,
+			"int": 13.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -58419,8 +60008,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -58599,8 +60188,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -58868,8 +60457,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 6.4,
-			"tps": 104,
+			"int": 6.6,
+			"tps": 88.6,
 			"identity": {
 				"class": "unknown"
 			},
@@ -58948,8 +60537,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 19.6,
-			"tps": 144,
+			"int": 11.8,
+			"tps": 98.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59602,8 +61191,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59787,8 +61376,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -59882,8 +61471,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60165,8 +61754,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 38.3,
-			"tps": 158.6,
+			"int": 23.4,
+			"tps": 156.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60343,8 +61932,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60432,8 +62021,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60521,8 +62110,8 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 32768,
-			"int": 6.8,
-			"tps": 62.3,
+			"int": 6.7,
+			"tps": 62,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -61026,8 +62615,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 142.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61118,8 +62707,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61210,8 +62799,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 18.8,
+			"tps": 128.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61302,8 +62891,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61565,8 +63154,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61638,149 +63227,103 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			}
+		},
+		"zai-org/GLM-5.3-Flash": {
+			"id": "zai-org/GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
+			"api": "openai-completions",
+			"provider": "coreweave",
+			"baseUrl": "https://api.inference.wandb.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"int": 41.9,
+			"tps": 85.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		}
 	},
 	"cursor": {
-		"claude-4-sonnet": {
-			"id": "claude-4-sonnet",
-			"name": "Claude Sonnet 4",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4-sonnet",
-					"minimal": "claude-4-sonnet-thinking",
-					"low": "claude-4-sonnet-thinking",
-					"medium": "claude-4-sonnet-thinking",
-					"high": "claude-4-sonnet-thinking"
-				}
-			},
-			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "4.0.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-4.5-opus-high": {
-			"id": "claude-4.5-opus-high",
-			"name": "Claude Opus 4.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4.5-opus-high",
-					"minimal": "claude-4.5-opus-high-thinking",
-					"low": "claude-4.5-opus-high-thinking",
-					"medium": "claude-4.5-opus-high-thinking",
-					"high": "claude-4.5-opus-high-thinking"
-				}
-			},
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.5.0",
-				"effort": "high",
-				"logicalId": "claude-4.5-opus"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-4.5-sonnet": {
-			"id": "claude-4.5-sonnet",
-			"name": "Claude Sonnet 4.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4.5-sonnet",
-					"minimal": "claude-4.5-sonnet-thinking",
-					"low": "claude-4.5-sonnet-thinking",
-					"medium": "claude-4.5-sonnet-thinking",
-					"high": "claude-4.5-sonnet-thinking"
-				}
-			},
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "4.5.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
 		"claude-4.6-opus-high": {
 			"id": "claude-4.6-opus-high",
 			"name": "Claude Opus 4.6 1M",
@@ -61789,7 +63332,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -61806,18 +63350,8 @@
 					"low",
 					"medium",
 					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4.6-opus-high",
-					"minimal": "claude-4.6-opus-high-thinking",
-					"low": "claude-4.6-opus-high-thinking",
-					"medium": "claude-4.6-opus-high-thinking",
-					"high": "claude-4.6-opus-high-thinking"
-				}
+				]
 			},
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
 			"identity": {
 				"class": "anthropic",
 				"family": "opus",
@@ -61825,4711 +63359,9 @@
 				"effort": "high",
 				"logicalId": "claude-4.6-opus"
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-4.6-opus-max": {
-			"id": "claude-4.6-opus-max",
-			"name": "Claude Opus 4.6 1M Max",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4.6-opus-max",
-					"minimal": "claude-4.6-opus-max-thinking",
-					"low": "claude-4.6-opus-max-thinking",
-					"medium": "claude-4.6-opus-max-thinking",
-					"high": "claude-4.6-opus-max-thinking"
-				}
-			},
+			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.6.0",
-				"effort": "max",
-				"logicalId": "claude-4.6-opus"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-4.6-sonnet-medium": {
-			"id": "claude-4.6-sonnet-medium",
-			"name": "Claude Sonnet 4.6 1M",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-4.6-sonnet-medium",
-					"minimal": "claude-4.6-sonnet-medium-thinking",
-					"low": "claude-4.6-sonnet-medium-thinking",
-					"medium": "claude-4.6-sonnet-medium-thinking",
-					"high": "claude-4.6-sonnet-medium-thinking"
-				}
-			},
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v3",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "4.6.0",
-				"effort": "medium",
-				"logicalId": "claude-4.6-sonnet"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-1-high": {
-			"id": "claude-fable-5-1-high",
-			"name": "Claude Fable 5.1 1M (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5-sonnet",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-1-high",
-					"minimal": "claude-fable-5-1-thinking-high",
-					"low": "claude-fable-5-1-thinking-high",
-					"medium": "claude-fable-5-1-thinking-high",
-					"high": "claude-fable-5-1-thinking-high"
-				},
-				"prefixBinding": true
-			},
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.1.0",
-				"effort": "high",
-				"logicalId": "claude-fable-5-1"
-			},
-			"requiresGlyphTokenization": true,
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-1-low": {
-			"id": "claude-fable-5-1-low",
-			"name": "Claude Fable 5.1 1M Low (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5-sonnet",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-1-low",
-					"minimal": "claude-fable-5-1-thinking-low",
-					"low": "claude-fable-5-1-thinking-low",
-					"medium": "claude-fable-5-1-thinking-low",
-					"high": "claude-fable-5-1-thinking-low"
-				},
-				"prefixBinding": true
-			},
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.1.0",
-				"effort": "low",
-				"logicalId": "claude-fable-5-1"
-			},
-			"requiresGlyphTokenization": true,
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-1-max": {
-			"id": "claude-fable-5-1-max",
-			"name": "Claude Fable 5.1 1M Max (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5-sonnet",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-1-max",
-					"minimal": "claude-fable-5-1-thinking-max",
-					"low": "claude-fable-5-1-thinking-max",
-					"medium": "claude-fable-5-1-thinking-max",
-					"high": "claude-fable-5-1-thinking-max"
-				},
-				"prefixBinding": true
-			},
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.1.0",
-				"effort": "max",
-				"logicalId": "claude-fable-5-1"
-			},
-			"requiresGlyphTokenization": true,
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-1-medium": {
-			"id": "claude-fable-5-1-medium",
-			"name": "Claude Fable 5.1 1M Medium (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5-sonnet",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-1-medium",
-					"minimal": "claude-fable-5-1-thinking-medium",
-					"low": "claude-fable-5-1-thinking-medium",
-					"medium": "claude-fable-5-1-thinking-medium",
-					"high": "claude-fable-5-1-thinking-medium"
-				},
-				"prefixBinding": true
-			},
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.1.0",
-				"effort": "medium",
-				"logicalId": "claude-fable-5-1"
-			},
-			"requiresGlyphTokenization": true,
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-1-xhigh": {
-			"id": "claude-fable-5-1-xhigh",
-			"name": "Claude Fable 5.1 1M Extra High (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5-sonnet",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-1-xhigh",
-					"minimal": "claude-fable-5-1-thinking-xhigh",
-					"low": "claude-fable-5-1-thinking-xhigh",
-					"medium": "claude-fable-5-1-thinking-xhigh",
-					"high": "claude-fable-5-1-thinking-xhigh"
-				},
-				"prefixBinding": true
-			},
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.1.0",
-				"effort": "xhigh",
-				"logicalId": "claude-fable-5-1"
-			},
-			"requiresGlyphTokenization": true,
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-high": {
-			"id": "claude-fable-5-high",
-			"name": "Claude Fable 5 1M (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-high",
-					"minimal": "claude-fable-5-thinking-high",
-					"low": "claude-fable-5-thinking-high",
-					"medium": "claude-fable-5-thinking-high",
-					"high": "claude-fable-5-thinking-high"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.0.0",
-				"effort": "high",
-				"logicalId": "claude-fable-5"
-			},
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-low": {
-			"id": "claude-fable-5-low",
-			"name": "Claude Fable 5 1M Low (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-low",
-					"minimal": "claude-fable-5-thinking-low",
-					"low": "claude-fable-5-thinking-low",
-					"medium": "claude-fable-5-thinking-low",
-					"high": "claude-fable-5-thinking-low"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.0.0",
-				"effort": "low",
-				"logicalId": "claude-fable-5"
-			},
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-max": {
-			"id": "claude-fable-5-max",
-			"name": "Claude Fable 5 1M Max (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-max",
-					"minimal": "claude-fable-5-thinking-max",
-					"low": "claude-fable-5-thinking-max",
-					"medium": "claude-fable-5-thinking-max",
-					"high": "claude-fable-5-thinking-max"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.0.0",
-				"effort": "max",
-				"logicalId": "claude-fable-5"
-			},
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-medium": {
-			"id": "claude-fable-5-medium",
-			"name": "Claude Fable 5 1M Medium (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-medium",
-					"minimal": "claude-fable-5-thinking-medium",
-					"low": "claude-fable-5-thinking-medium",
-					"medium": "claude-fable-5-thinking-medium",
-					"high": "claude-fable-5-thinking-medium"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.0.0",
-				"effort": "medium",
-				"logicalId": "claude-fable-5"
-			},
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-fable-5-xhigh": {
-			"id": "claude-fable-5-xhigh",
-			"name": "Claude Fable 5 1M Extra High (NO ZDR)",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-fable-5-xhigh",
-					"minimal": "claude-fable-5-thinking-xhigh",
-					"low": "claude-fable-5-thinking-xhigh",
-					"medium": "claude-fable-5-thinking-xhigh",
-					"high": "claude-fable-5-thinking-xhigh"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "fable",
-				"revision": "5.0.0",
-				"effort": "xhigh",
-				"logicalId": "claude-fable-5"
-			},
-			"requiresCursorToolSchemaProjection": true,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-high": {
-			"id": "claude-opus-4-7-high",
-			"name": "Claude Opus 4.7 1M High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-high",
-					"minimal": "claude-opus-4-7-thinking-high",
-					"low": "claude-opus-4-7-thinking-high",
-					"medium": "claude-opus-4-7-thinking-high",
-					"high": "claude-opus-4-7-thinking-high"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "high",
-				"logicalId": "claude-opus-4-7"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-high-fast": {
-			"id": "claude-opus-4-7-high-fast",
-			"name": "Claude Opus 4.7 1M High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-high-fast",
-					"minimal": "claude-opus-4-7-thinking-high-fast",
-					"low": "claude-opus-4-7-thinking-high-fast",
-					"medium": "claude-opus-4-7-thinking-high-fast",
-					"high": "claude-opus-4-7-thinking-high-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "high",
-				"logicalId": "claude-opus-4-7-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-low": {
-			"id": "claude-opus-4-7-low",
-			"name": "Claude Opus 4.7 1M Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-low",
-					"minimal": "claude-opus-4-7-thinking-low",
-					"low": "claude-opus-4-7-thinking-low",
-					"medium": "claude-opus-4-7-thinking-low",
-					"high": "claude-opus-4-7-thinking-low"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "low",
-				"logicalId": "claude-opus-4-7"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-low-fast": {
-			"id": "claude-opus-4-7-low-fast",
-			"name": "Claude Opus 4.7 1M Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-low-fast",
-					"minimal": "claude-opus-4-7-thinking-low-fast",
-					"low": "claude-opus-4-7-thinking-low-fast",
-					"medium": "claude-opus-4-7-thinking-low-fast",
-					"high": "claude-opus-4-7-thinking-low-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "low",
-				"logicalId": "claude-opus-4-7-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-max": {
-			"id": "claude-opus-4-7-max",
-			"name": "Claude Opus 4.7 1M Max",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-max",
-					"minimal": "claude-opus-4-7-thinking-max",
-					"low": "claude-opus-4-7-thinking-max",
-					"medium": "claude-opus-4-7-thinking-max",
-					"high": "claude-opus-4-7-thinking-max"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "max",
-				"logicalId": "claude-opus-4-7"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-max-fast": {
-			"id": "claude-opus-4-7-max-fast",
-			"name": "Claude Opus 4.7 1M Max Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-max-fast",
-					"minimal": "claude-opus-4-7-thinking-max-fast",
-					"low": "claude-opus-4-7-thinking-max-fast",
-					"medium": "claude-opus-4-7-thinking-max-fast",
-					"high": "claude-opus-4-7-thinking-max-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "max",
-				"logicalId": "claude-opus-4-7-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-medium": {
-			"id": "claude-opus-4-7-medium",
-			"name": "Claude Opus 4.7 1M Medium",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-medium",
-					"minimal": "claude-opus-4-7-thinking-medium",
-					"low": "claude-opus-4-7-thinking-medium",
-					"medium": "claude-opus-4-7-thinking-medium",
-					"high": "claude-opus-4-7-thinking-medium"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-4-7"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-medium-fast": {
-			"id": "claude-opus-4-7-medium-fast",
-			"name": "Claude Opus 4.7 1M Medium Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-medium-fast",
-					"minimal": "claude-opus-4-7-thinking-medium-fast",
-					"low": "claude-opus-4-7-thinking-medium-fast",
-					"medium": "claude-opus-4-7-thinking-medium-fast",
-					"high": "claude-opus-4-7-thinking-medium-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-4-7-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-xhigh": {
-			"id": "claude-opus-4-7-xhigh",
-			"name": "Claude Opus 4.7 1M",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-xhigh",
-					"minimal": "claude-opus-4-7-thinking-xhigh",
-					"low": "claude-opus-4-7-thinking-xhigh",
-					"medium": "claude-opus-4-7-thinking-xhigh",
-					"high": "claude-opus-4-7-thinking-xhigh"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-4-7"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-7-xhigh-fast": {
-			"id": "claude-opus-4-7-xhigh-fast",
-			"name": "Claude Opus 4.7 1M Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-7-xhigh-fast",
-					"minimal": "claude-opus-4-7-thinking-xhigh-fast",
-					"low": "claude-opus-4-7-thinking-xhigh-fast",
-					"medium": "claude-opus-4-7-thinking-xhigh-fast",
-					"high": "claude-opus-4-7-thinking-xhigh-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.7.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-4-7-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-high": {
-			"id": "claude-opus-4-8-high",
-			"name": "Claude Opus 4.8 1M",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-high",
-					"minimal": "claude-opus-4-8-thinking-high",
-					"low": "claude-opus-4-8-thinking-high",
-					"medium": "claude-opus-4-8-thinking-high",
-					"high": "claude-opus-4-8-thinking-high"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "high",
-				"logicalId": "claude-opus-4-8"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-high-fast": {
-			"id": "claude-opus-4-8-high-fast",
-			"name": "Claude Opus 4.8 1M Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-high-fast",
-					"minimal": "claude-opus-4-8-thinking-high-fast",
-					"low": "claude-opus-4-8-thinking-high-fast",
-					"medium": "claude-opus-4-8-thinking-high-fast",
-					"high": "claude-opus-4-8-thinking-high-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "high",
-				"logicalId": "claude-opus-4-8-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-low": {
-			"id": "claude-opus-4-8-low",
-			"name": "Claude Opus 4.8 1M Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-low",
-					"minimal": "claude-opus-4-8-thinking-low",
-					"low": "claude-opus-4-8-thinking-low",
-					"medium": "claude-opus-4-8-thinking-low",
-					"high": "claude-opus-4-8-thinking-low"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "low",
-				"logicalId": "claude-opus-4-8"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-low-fast": {
-			"id": "claude-opus-4-8-low-fast",
-			"name": "Claude Opus 4.8 1M Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-low-fast",
-					"minimal": "claude-opus-4-8-thinking-low-fast",
-					"low": "claude-opus-4-8-thinking-low-fast",
-					"medium": "claude-opus-4-8-thinking-low-fast",
-					"high": "claude-opus-4-8-thinking-low-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "low",
-				"logicalId": "claude-opus-4-8-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-max": {
-			"id": "claude-opus-4-8-max",
-			"name": "Claude Opus 4.8 1M Max",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-max",
-					"minimal": "claude-opus-4-8-thinking-max",
-					"low": "claude-opus-4-8-thinking-max",
-					"medium": "claude-opus-4-8-thinking-max",
-					"high": "claude-opus-4-8-thinking-max"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "max",
-				"logicalId": "claude-opus-4-8"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-max-fast": {
-			"id": "claude-opus-4-8-max-fast",
-			"name": "Claude Opus 4.8 1M Max Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-max-fast",
-					"minimal": "claude-opus-4-8-thinking-max-fast",
-					"low": "claude-opus-4-8-thinking-max-fast",
-					"medium": "claude-opus-4-8-thinking-max-fast",
-					"high": "claude-opus-4-8-thinking-max-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "max",
-				"logicalId": "claude-opus-4-8-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-medium": {
-			"id": "claude-opus-4-8-medium",
-			"name": "Claude Opus 4.8 1M Medium",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-medium",
-					"minimal": "claude-opus-4-8-thinking-medium",
-					"low": "claude-opus-4-8-thinking-medium",
-					"medium": "claude-opus-4-8-thinking-medium",
-					"high": "claude-opus-4-8-thinking-medium"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-4-8"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-medium-fast": {
-			"id": "claude-opus-4-8-medium-fast",
-			"name": "Claude Opus 4.8 1M Medium Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-medium-fast",
-					"minimal": "claude-opus-4-8-thinking-medium-fast",
-					"low": "claude-opus-4-8-thinking-medium-fast",
-					"medium": "claude-opus-4-8-thinking-medium-fast",
-					"high": "claude-opus-4-8-thinking-medium-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-4-8-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-xhigh": {
-			"id": "claude-opus-4-8-xhigh",
-			"name": "Claude Opus 4.8 1M Extra High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-xhigh",
-					"minimal": "claude-opus-4-8-thinking-xhigh",
-					"low": "claude-opus-4-8-thinking-xhigh",
-					"medium": "claude-opus-4-8-thinking-xhigh",
-					"high": "claude-opus-4-8-thinking-xhigh"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-4-8"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-4-8-xhigh-fast": {
-			"id": "claude-opus-4-8-xhigh-fast",
-			"name": "Claude Opus 4.8 1M Extra High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-4-8-xhigh-fast",
-					"minimal": "claude-opus-4-8-thinking-xhigh-fast",
-					"low": "claude-opus-4-8-thinking-xhigh-fast",
-					"medium": "claude-opus-4-8-thinking-xhigh-fast",
-					"high": "claude-opus-4-8-thinking-xhigh-fast"
-				}
-			},
-			"tokenizer": "claude-v47",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "4.8.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-4-8-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-high": {
-			"id": "claude-opus-5-high",
-			"name": "Claude Opus 5 1M",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-high",
-					"minimal": "claude-opus-5-thinking-high",
-					"low": "claude-opus-5-thinking-high",
-					"medium": "claude-opus-5-thinking-high",
-					"high": "claude-opus-5-thinking-high"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "high",
-				"logicalId": "claude-opus-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-high-fast": {
-			"id": "claude-opus-5-high-fast",
-			"name": "Claude Opus 5 1M Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-high-fast",
-					"minimal": "claude-opus-5-thinking-high-fast",
-					"low": "claude-opus-5-thinking-high-fast",
-					"medium": "claude-opus-5-thinking-high-fast",
-					"high": "claude-opus-5-thinking-high-fast"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "high",
-				"logicalId": "claude-opus-5-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-low": {
-			"id": "claude-opus-5-low",
-			"name": "Claude Opus 5 1M Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-low",
-					"minimal": "claude-opus-5-thinking-low",
-					"low": "claude-opus-5-thinking-low",
-					"medium": "claude-opus-5-thinking-low",
-					"high": "claude-opus-5-thinking-low"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "low",
-				"logicalId": "claude-opus-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-low-fast": {
-			"id": "claude-opus-5-low-fast",
-			"name": "Claude Opus 5 1M Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-low-fast",
-					"minimal": "claude-opus-5-thinking-low-fast",
-					"low": "claude-opus-5-thinking-low-fast",
-					"medium": "claude-opus-5-thinking-low-fast",
-					"high": "claude-opus-5-thinking-low-fast"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "low",
-				"logicalId": "claude-opus-5-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-medium": {
-			"id": "claude-opus-5-medium",
-			"name": "Claude Opus 5 1M Medium",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-medium",
-					"minimal": "claude-opus-5-thinking-medium",
-					"low": "claude-opus-5-thinking-medium",
-					"medium": "claude-opus-5-thinking-medium",
-					"high": "claude-opus-5-thinking-medium"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-medium-fast": {
-			"id": "claude-opus-5-medium-fast",
-			"name": "Claude Opus 5 1M Medium Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-opus-5-medium-fast",
-					"minimal": "claude-opus-5-thinking-medium-fast",
-					"low": "claude-opus-5-thinking-medium-fast",
-					"medium": "claude-opus-5-thinking-medium-fast",
-					"high": "claude-opus-5-thinking-medium-fast"
-				}
-			},
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "medium",
-				"logicalId": "claude-opus-5-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-thinking-max": {
-			"id": "claude-opus-5-thinking-max",
-			"name": "Claude Opus 5 1M Max Thinking",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "max",
-				"logicalId": "claude-opus-5-thinking"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-thinking-max-fast": {
-			"id": "claude-opus-5-thinking-max-fast",
-			"name": "Claude Opus 5 1M Max Thinking Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "max",
-				"logicalId": "claude-opus-5-thinking-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-thinking-xhigh": {
-			"id": "claude-opus-5-thinking-xhigh",
-			"name": "Claude Opus 5 1M Extra High Thinking",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-5-thinking"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-opus-5-thinking-xhigh-fast": {
-			"id": "claude-opus-5-thinking-xhigh-fast",
-			"name": "Claude Opus 5 1M Extra High Thinking Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": true,
-			"tokenizer": "claude-v5",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "opus",
-				"revision": "5.0.0",
-				"effort": "xhigh",
-				"logicalId": "claude-opus-5-thinking-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-sonnet-5-high": {
-			"id": "claude-sonnet-5-high",
-			"name": "Claude Sonnet 5 1M",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-sonnet-5-high",
-					"minimal": "claude-sonnet-5-thinking-high",
-					"low": "claude-sonnet-5-thinking-high",
-					"medium": "claude-sonnet-5-thinking-high",
-					"high": "claude-sonnet-5-thinking-high"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "5.0.0",
-				"effort": "high",
-				"logicalId": "claude-sonnet-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-sonnet-5-low": {
-			"id": "claude-sonnet-5-low",
-			"name": "Claude Sonnet 5 1M Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-sonnet-5-low",
-					"minimal": "claude-sonnet-5-thinking-low",
-					"low": "claude-sonnet-5-thinking-low",
-					"medium": "claude-sonnet-5-thinking-low",
-					"high": "claude-sonnet-5-thinking-low"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "5.0.0",
-				"effort": "low",
-				"logicalId": "claude-sonnet-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-sonnet-5-max": {
-			"id": "claude-sonnet-5-max",
-			"name": "Claude Sonnet 5 1M Max",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-sonnet-5-max",
-					"minimal": "claude-sonnet-5-thinking-max",
-					"low": "claude-sonnet-5-thinking-max",
-					"medium": "claude-sonnet-5-thinking-max",
-					"high": "claude-sonnet-5-thinking-max"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "5.0.0",
-				"effort": "max",
-				"logicalId": "claude-sonnet-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-sonnet-5-medium": {
-			"id": "claude-sonnet-5-medium",
-			"name": "Claude Sonnet 5 1M Medium",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-sonnet-5-medium",
-					"minimal": "claude-sonnet-5-thinking-medium",
-					"low": "claude-sonnet-5-thinking-medium",
-					"medium": "claude-sonnet-5-thinking-medium",
-					"high": "claude-sonnet-5-thinking-medium"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "5.0.0",
-				"effort": "medium",
-				"logicalId": "claude-sonnet-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"claude-sonnet-5-xhigh": {
-			"id": "claude-sonnet-5-xhigh",
-			"name": "Claude Sonnet 5 1M Extra High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortRouting": {
-					"off": "claude-sonnet-5-xhigh",
-					"minimal": "claude-sonnet-5-thinking-xhigh",
-					"low": "claude-sonnet-5-thinking-xhigh",
-					"medium": "claude-sonnet-5-thinking-xhigh",
-					"high": "claude-sonnet-5-thinking-xhigh"
-				}
-			},
-			"tokenizer": "claude-v5-sonnet",
-			"requiresGlyphTokenization": true,
-			"identity": {
-				"class": "anthropic",
-				"family": "sonnet",
-				"revision": "5.0.0",
-				"effort": "xhigh",
-				"logicalId": "claude-sonnet-5"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"composer-1": {
-			"id": "composer-1",
-			"name": "Composer 1",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"composer-1.5": {
-			"id": "composer-1.5",
-			"name": "Composer 1.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"composer-2.5": {
-			"id": "composer-2.5",
-			"name": "Composer 2.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"composer-2.5-fast": {
-			"id": "composer-2.5-fast",
-			"name": "Composer 2.5 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"cursor-grok-4.5": {
-			"id": "cursor-grok-4.5",
-			"name": "Grok 4.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "cursor-grok-4.5-low",
-					"medium": "cursor-grok-4.5-medium",
-					"high": "cursor-grok-4.5-high"
-				}
-			},
-			"requestModelId": "cursor-grok-4.5-medium",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"cursor-grok-4.5-fast": {
-			"id": "cursor-grok-4.5-fast",
-			"name": "Grok 4.5 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "cursor-grok-4.5-low-fast",
-					"medium": "cursor-grok-4.5-medium-fast",
-					"high": "cursor-grok-4.5-high-fast"
-				}
-			},
-			"requestModelId": "cursor-grok-4.5-medium-fast",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"cursor-grok-4.6": {
-			"id": "cursor-grok-4.6",
-			"name": "Grok 4.6",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "cursor-grok-4.6-low",
-					"medium": "cursor-grok-4.6-medium",
-					"high": "cursor-grok-4.6-high",
-					"xhigh": "cursor-grok-4.6-xhigh"
-				}
-			},
-			"requestModelId": "cursor-grok-4.6-medium",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"cursor-grok-4.6-fast": {
-			"id": "cursor-grok-4.6-fast",
-			"name": "Grok 4.6 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "cursor-grok-4.6-low-fast",
-					"medium": "cursor-grok-4.6-medium-fast",
-					"high": "cursor-grok-4.6-high-fast",
-					"xhigh": "cursor-grok-4.6-xhigh-fast"
-				}
-			},
-			"requestModelId": "cursor-grok-4.6-medium-fast",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"default": {
-			"id": "default",
-			"name": "Auto",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3-flash": {
-			"id": "gemini-3-flash",
-			"name": "Gemini 3 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.0.0"
-			},
-			"int": 27.9,
-			"tps": 186.6,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3-pro": {
-			"id": "gemini-3-pro",
-			"name": "Gemini 3 Pro",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "pro",
-				"revision": "3.0.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3.1-pro": {
-			"id": "gemini-3.1-pro",
-			"name": "Gemini 3.1 Pro Preview",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "pro",
-				"revision": "3.1.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3.5-flash": {
-			"id": "gemini-3.5-flash",
-			"name": "Gemini 3.5 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.5.0"
-			},
-			"int": 52,
-			"tps": 204.6,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3.6-flash": {
-			"id": "gemini-3.6-flash",
-			"name": "Gemini 3.6 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gemini-3.6-flash-minimal",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"minimal": "gemini-3.6-flash-minimal",
-					"low": "gemini-3.6-flash-low",
-					"medium": "gemini-3.6-flash-medium",
-					"high": "gemini-3.6-flash-high"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.6.0"
-			},
-			"int": 51.6,
-			"tps": 182.3,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3.7-flash": {
-			"id": "gemini-3.7-flash",
-			"name": "Gemini 3.7 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gemini-3.7-flash-low",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "gemini-3.7-flash-low",
-					"medium": "gemini-3.7-flash-medium",
-					"high": "gemini-3.7-flash-high"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.7.0"
-			},
-			"int": 56,
-			"tps": 310.5,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gemini-3.8-flash": {
-			"id": "gemini-3.8-flash",
-			"name": "Gemini 3.8 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "gemini-3.8-flash-low",
-					"medium": "gemini-3.8-flash-medium",
-					"high": "gemini-3.8-flash-high"
-				}
-			},
-			"requestModelId": "gemini-3.8-flash-low",
-			"identity": {
-				"class": "gemini",
-				"family": "flash",
-				"revision": "3.8.0"
-			},
-			"requiresGlyphTokenization": false,
-			"int": 58.7,
-			"tps": 326.9,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"glm-5.2": {
-			"id": "glm-5.2",
-			"name": "GLM-5.2",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"tokenizer": "glm5",
-			"requestModelId": "glm-5.2-high",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"high",
-					"max"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"high": "glm-5.2-high",
-					"max": "glm-5.2-max"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
-			"int": 52.6,
-			"tps": 69.1,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5-mini": {
-			"id": "gpt-5-mini",
-			"name": "GPT-5 Mini",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.0.0"
-			},
-			"int": 25.8,
-			"tps": 105.9,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1": {
-			"id": "gpt-5.1",
-			"name": "GPT-5.1",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.1.0"
-			},
-			"int": 37.5,
-			"tps": 87.4,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1-codex-max": {
-			"id": "gpt-5.1-codex-max",
-			"name": "GPT-5.1 Codex Max",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.1.0",
-				"effort": "max",
-				"logicalId": "gpt-5.1-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1-codex-max-high": {
-			"id": "gpt-5.1-codex-max-high",
-			"name": "GPT-5.1 Codex Max High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.1.0",
-				"effort": "high",
-				"logicalId": "gpt-5.1-codex-max"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1-codex-mini": {
-			"id": "gpt-5.1-codex-mini",
-			"name": "GPT-5.1 Codex Mini",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.1.0"
-			},
-			"int": 31.3,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1-high": {
-			"id": "gpt-5.1-high",
-			"name": "GPT-5.1 High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.1.0",
-				"effort": "high",
-				"logicalId": "gpt-5.1"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.1-low": {
-			"id": "gpt-5.1-low",
-			"name": "GPT-5.1 Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.1.0",
-				"effort": "low",
-				"logicalId": "gpt-5.1"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2": {
-			"id": "gpt-5.2",
-			"name": "GPT-5.2",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0"
-			},
-			"int": 43.3,
-			"tps": 71.7,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex": {
-			"id": "gpt-5.2-codex",
-			"name": "GPT-5.2 Codex",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0"
-			},
-			"int": 41.2,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-fast": {
-			"id": "gpt-5.2-codex-fast",
-			"name": "GPT-5.2 Codex Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-high": {
-			"id": "gpt-5.2-codex-high",
-			"name": "GPT-5.2 Codex High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "high",
-				"logicalId": "gpt-5.2-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-high-fast": {
-			"id": "gpt-5.2-codex-high-fast",
-			"name": "GPT-5.2 Codex High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "high",
-				"logicalId": "gpt-5.2-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-low": {
-			"id": "gpt-5.2-codex-low",
-			"name": "GPT-5.2 Codex Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "low",
-				"logicalId": "gpt-5.2-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-low-fast": {
-			"id": "gpt-5.2-codex-low-fast",
-			"name": "GPT-5.2 Codex Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "low",
-				"logicalId": "gpt-5.2-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-xhigh": {
-			"id": "gpt-5.2-codex-xhigh",
-			"name": "GPT-5.2 Codex Extra High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.2-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-codex-xhigh-fast": {
-			"id": "gpt-5.2-codex-xhigh-fast",
-			"name": "GPT-5.2 Codex Extra High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.2.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.2-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-fast": {
-			"id": "gpt-5.2-fast",
-			"name": "GPT-5.2 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-high": {
-			"id": "gpt-5.2-high",
-			"name": "GPT-5.2 High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "high",
-				"logicalId": "gpt-5.2"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-high-fast": {
-			"id": "gpt-5.2-high-fast",
-			"name": "GPT-5.2 High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "high",
-				"logicalId": "gpt-5.2-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-low": {
-			"id": "gpt-5.2-low",
-			"name": "GPT-5.2 Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "low",
-				"logicalId": "gpt-5.2"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-low-fast": {
-			"id": "gpt-5.2-low-fast",
-			"name": "GPT-5.2 Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "low",
-				"logicalId": "gpt-5.2-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-xhigh": {
-			"id": "gpt-5.2-xhigh",
-			"name": "GPT-5.2 Extra High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.2"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.2-xhigh-fast": {
-			"id": "gpt-5.2-xhigh-fast",
-			"name": "GPT-5.2 Extra High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.2.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.2-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex": {
-			"id": "gpt-5.3-codex",
-			"name": "GPT-5.3 Codex",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0"
-			},
-			"int": 45.5,
-			"tps": 123.1,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-fast": {
-			"id": "gpt-5.3-codex-fast",
-			"name": "Codex 5.3 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-high": {
-			"id": "gpt-5.3-codex-high",
-			"name": "Codex 5.3 High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "high",
-				"logicalId": "gpt-5.3-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-high-fast": {
-			"id": "gpt-5.3-codex-high-fast",
-			"name": "Codex 5.3 High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "high",
-				"logicalId": "gpt-5.3-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-low": {
-			"id": "gpt-5.3-codex-low",
-			"name": "Codex 5.3 Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "low",
-				"logicalId": "gpt-5.3-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-low-fast": {
-			"id": "gpt-5.3-codex-low-fast",
-			"name": "Codex 5.3 Low Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "low",
-				"logicalId": "gpt-5.3-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-spark-preview": {
-			"id": "gpt-5.3-codex-spark-preview",
-			"name": "GPT-5.3 Codex Spark",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"contextPromotionTarget": "cursor/gpt-5.5",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex-spark",
-				"revision": "5.3.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-xhigh": {
-			"id": "gpt-5.3-codex-xhigh",
-			"name": "Codex 5.3 Extra High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.3-codex"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.3-codex-xhigh-fast": {
-			"id": "gpt-5.3-codex-xhigh-fast",
-			"name": "Codex 5.3 Extra High Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 272000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "codex",
-				"revision": "5.3.0",
-				"effort": "xhigh",
-				"logicalId": "gpt-5.3-codex-fast"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.4": {
-			"id": "gpt-5.4",
-			"name": "GPT-5.4",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.4-low",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"low": "gpt-5.4-low",
-					"medium": "gpt-5.4-medium",
-					"high": "gpt-5.4-high",
-					"xhigh": "gpt-5.4-xhigh"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"int": 53.1,
-			"tps": 134.4,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.4-fast": {
-			"id": "gpt-5.4-fast",
-			"name": "GPT-5.4 Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.4-medium-fast",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"requiresEffort": true,
-				"effortRouting": {
-					"medium": "gpt-5.4-medium-fast",
-					"high": "gpt-5.4-high-fast",
-					"xhigh": "gpt-5.4-xhigh-fast"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.4-mini": {
-			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 mini",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.4-mini-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortRouting": {
-					"off": "gpt-5.4-mini-none",
-					"low": "gpt-5.4-mini-low",
-					"medium": "gpt-5.4-mini-medium",
-					"high": "gpt-5.4-mini-high",
-					"xhigh": "gpt-5.4-mini-xhigh"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"int": 40.9,
-			"tps": 200.3,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.4-nano": {
-			"id": "gpt-5.4-nano",
-			"name": "GPT-5.4 nano",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.4-nano-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortRouting": {
-					"off": "gpt-5.4-nano-none",
-					"low": "gpt-5.4-nano-low",
-					"medium": "gpt-5.4-nano-medium",
-					"high": "gpt-5.4-nano-high",
-					"xhigh": "gpt-5.4-nano-xhigh"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"int": 39.7,
-			"tps": 162.3,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.5": {
-			"id": "gpt-5.5",
-			"name": "GPT-5.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"contextPromotionTarget": "cursor/gpt-5.4",
-			"requestModelId": "gpt-5.5-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortRouting": {
-					"off": "gpt-5.5-none",
-					"low": "gpt-5.5-low",
-					"medium": "gpt-5.5-medium",
-					"high": "gpt-5.5-high",
-					"xhigh": "gpt-5.5-extra-high"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.5.0"
-			},
-			"int": 56.3,
-			"tps": 85.7,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.5-fast": {
-			"id": "gpt-5.5-fast",
-			"name": "GPT-5.5 Extra Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"contextPromotionTarget": "cursor/gpt-5.4",
-			"requestModelId": "gpt-5.5-none-fast",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortRouting": {
-					"off": "gpt-5.5-none-fast",
-					"low": "gpt-5.5-low-fast",
-					"medium": "gpt-5.5-medium-fast",
-					"high": "gpt-5.5-high-fast",
-					"xhigh": "gpt-5.5-extra-high-fast"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.5.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-luna": {
-			"id": "gpt-5.6-luna",
-			"name": "GPT-5.6 Luna",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-luna-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-luna-none",
-					"low": "gpt-5.6-luna-low",
-					"medium": "gpt-5.6-luna-medium",
-					"high": "gpt-5.6-luna-high",
-					"xhigh": "gpt-5.6-luna-xhigh",
-					"max": "gpt-5.6-luna-max"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"int": 52.3,
-			"tps": 123.3,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-luna-fast": {
-			"id": "gpt-5.6-luna-fast",
-			"name": "GPT-5.6 Luna Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-luna-none-fast",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-luna-none-fast",
-					"low": "gpt-5.6-luna-low-fast",
-					"medium": "gpt-5.6-luna-medium-fast",
-					"high": "gpt-5.6-luna-high-fast",
-					"xhigh": "gpt-5.6-luna-xhigh-fast",
-					"max": "gpt-5.6-luna-max-fast"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-sol": {
-			"id": "gpt-5.6-sol",
-			"name": "GPT-5.6 Sol",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-sol-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-sol-none",
-					"low": "gpt-5.6-sol-low",
-					"medium": "gpt-5.6-sol-medium",
-					"high": "gpt-5.6-sol-high",
-					"xhigh": "gpt-5.6-sol-xhigh",
-					"max": "gpt-5.6-sol-max"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"int": 60.9,
-			"tps": 76.5,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-sol-fast": {
-			"id": "gpt-5.6-sol-fast",
-			"name": "GPT-5.6 Sol Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-sol-none-fast",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-sol-none-fast",
-					"low": "gpt-5.6-sol-low-fast",
-					"medium": "gpt-5.6-sol-medium-fast",
-					"high": "gpt-5.6-sol-high-fast",
-					"xhigh": "gpt-5.6-sol-xhigh-fast",
-					"max": "gpt-5.6-sol-max-fast"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-terra": {
-			"id": "gpt-5.6-terra",
-			"name": "GPT-5.6 Terra",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-terra-none",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-terra-none",
-					"low": "gpt-5.6-terra-low",
-					"medium": "gpt-5.6-terra-medium",
-					"high": "gpt-5.6-terra-high",
-					"xhigh": "gpt-5.6-terra-xhigh",
-					"max": "gpt-5.6-terra-max"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"int": 56.6,
-			"tps": 103.2,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"gpt-5.6-terra-fast": {
-			"id": "gpt-5.6-terra-fast",
-			"name": "GPT-5.6 Terra Fast",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"requestModelId": "gpt-5.6-terra-none-fast",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				],
-				"effortRouting": {
-					"off": "gpt-5.6-terra-none-fast",
-					"low": "gpt-5.6-terra-low-fast",
-					"medium": "gpt-5.6-terra-medium-fast",
-					"high": "gpt-5.6-terra-high-fast",
-					"xhigh": "gpt-5.6-terra-xhigh-fast",
-					"max": "gpt-5.6-terra-max-fast"
-				}
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.6.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"grok-code-fast-1": {
-			"id": "grok-code-fast-1",
-			"name": "Grok Code Fast 1",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 10000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "1.0.0"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"kimi-k2.5": {
-			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k2.5"
-			},
-			"int": 36,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"kimi-k2.7-code": {
-			"id": "kimi-k2.7-code",
-			"name": "Kimi K2.7 Code",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k2.7-code"
-			},
-			"int": 43,
-			"tps": 39,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"kimi-k3-high": {
-			"id": "kimi-k3-high",
-			"name": "Kimi K3 High",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k3",
-				"effort": "high",
-				"logicalId": "kimi-k3"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"kimi-k3-low": {
-			"id": "kimi-k3-low",
-			"name": "Kimi K3 Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k3",
-				"effort": "low",
-				"logicalId": "kimi-k3"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"kimi-k3-max": {
-			"id": "kimi-k3-max",
-			"name": "Kimi K3",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"cursorMaxMode": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				],
-				"defaultLevel": "max",
-				"requiresEffort": true
-			},
-			"tokenizer": "kimi-k2",
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "kimi",
-				"family": "k3",
-				"effort": "max",
-				"logicalId": "kimi-k3"
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUse": false
 		}
 	},
 	"deepinfra": {
@@ -68064,9 +64896,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
+				"input": 0.060000000000000005,
 				"output": 0.18,
-				"cacheRead": 0.016,
+				"cacheRead": 0.015000000000000001,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -68156,7 +64988,7 @@
 			"cost": {
 				"input": 0.43999999999999995,
 				"output": 1.32,
-				"cacheRead": 0.1400000008,
+				"cacheRead": 0.013999999199999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -68354,6 +65186,96 @@
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"deepseek-ai/DeepSeek-V4.1-Flash": {
+			"id": "deepseek-ai/DeepSeek-V4.1-Flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
 			},
 			"compat": {
 				"supportsStore": true,
@@ -70170,6 +67092,95 @@
 			},
 			"supportsComputerUse": false
 		},
+		"inclusionAI/Ling-3.0-flash-VL": {
+			"id": "inclusionAI/Ling-3.0-flash-VL",
+			"name": "inclusionAI/Ling-3.0-flash-VL",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.060000000000000005,
+				"output": 0.18,
+				"cacheRead": 0.012000000000000002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 			"name": "Llama 3.3 70B",
@@ -70801,96 +67812,6 @@
 				"stripDeepseekSpecialTokens": false,
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
-		"MiniMaxAI/MiniMax-M2.7": {
-			"id": "MiniMaxAI/MiniMax-M2.7",
-			"name": "MiniMax-M2.7",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.05,
-				"cacheWrite": 0
-			},
-			"contextWindow": 196608,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "minimax",
-				"family": "m2"
-			},
-			"int": 38.9,
-			"tps": 76.8,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": true,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false,
 				"dropThinkingWhenReasoningEffort": false,
@@ -75289,190 +72210,6 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/GLM-4.7-Flash": {
-			"id": "zai-org/GLM-4.7-Flash",
-			"name": "GLM-4.7-Flash",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.060000000000000005,
-				"output": 0.4,
-				"cacheRead": 0.0100000002,
-				"cacheWrite": 0
-			},
-			"contextWindow": 202752,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "glm",
-				"family": "flash",
-				"revision": "4.7.0"
-			},
-			"int": 23.3,
-			"tps": 82.9,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
-		"zai-org/GLM-5": {
-			"id": "zai-org/GLM-5",
-			"name": "GLM-5",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.6,
-				"output": 2.08,
-				"cacheRead": 0.12,
-				"cacheWrite": 0
-			},
-			"contextWindow": 202752,
-			"maxTokens": 131072,
-			"tokenizer": "glm5",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "glm",
-				"revision": "5.0.0"
-			},
-			"int": 40.6,
-			"tps": 66.5,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
-		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
 			"name": "GLM-5.1",
@@ -75751,7 +72488,7 @@
 		},
 		"zai-org/GLM-5.3-Flash": {
 			"id": "zai-org/GLM-5.3-Flash",
-			"name": "GLM-5.3-Flash",
+			"name": "GLM 5.3 Flash",
 			"api": "openai-completions",
 			"provider": "deepinfra",
 			"baseUrl": "https://api.deepinfra.com/v1/openai",
@@ -75965,7 +72702,8 @@
 			"baseUrl": "https://api.deepseek.com",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.3,
@@ -76002,8 +72740,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76398,8 +73136,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76635,12 +73373,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76654,6 +73386,12 @@
 					"minimal": "none"
 				}
 			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -76729,12 +73467,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"identity": {
-				"class": "kimi",
-				"family": "k3"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76748,6 +73480,12 @@
 				},
 				"requiresEffort": true
 			},
+			"identity": {
+				"class": "kimi",
+				"family": "k3"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -77594,6 +74332,8 @@
 				"class": "glm",
 				"revision": "5.1.0"
 			},
+			"int": 41,
+			"tps": 50.5,
 			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
@@ -77783,6 +74523,8 @@
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"int": 52.6,
+			"tps": 69.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -77933,7 +74675,7 @@
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
-			"name": "GLM-5.3-Flash",
+			"name": "cline-pass/glm-5.3-flash",
 			"api": "openai-completions",
 			"provider": "fireworks",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
@@ -78291,7 +75033,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "fireworks",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
@@ -78525,11 +75267,13 @@
 				"class": "kimi",
 				"family": "k2.6"
 			},
+			"int": 45.1,
+			"tps": 40.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -78548,7 +75292,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -78581,7 +75325,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -78721,11 +75468,13 @@
 				"class": "kimi",
 				"family": "k2.7-code"
 			},
+			"int": 43,
+			"tps": 39,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -78744,7 +75493,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -78776,7 +75525,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -80029,8 +76781,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -80054,6 +76806,80 @@
 				"class": "anthropic",
 				"family": "fable",
 				"revision": "5.0.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": true,
+				"supportsContextManagement": false,
+				"supportsOutputEffort": true,
+				"disableStrictTools": true,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": false,
+				"supportsSamplingParams": false,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			}
+		},
+		"claude-fable-5.1": {
+			"id": "claude-fable-5.1",
+			"name": "Claude Fable 5.1",
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 0.25,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"int": 53.4,
+			"tps": 67.2,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
+			},
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true,
+				"prefixBinding": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
@@ -80200,7 +77026,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80224,7 +77049,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.6": {
 			"id": "claude-opus-4.6",
@@ -80272,7 +77098,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80296,7 +77121,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-opus-4.7": {
 			"id": "claude-opus-4.7",
@@ -80317,8 +77143,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -80390,8 +77216,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -80463,8 +77289,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -80561,7 +77387,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80585,7 +77410,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
@@ -80631,7 +77457,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -80655,7 +77480,8 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4.6": {
 			"id": "claude-sonnet-4.6",
@@ -80676,8 +77502,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -80746,8 +77572,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81129,6 +77955,20 @@
 				"Openai-Intent": "conversation-agent",
 				"X-GitHub-Api-Version": "2026-08-01"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "pro",
+				"revision": "3.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -81184,20 +78024,6 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"identity": {
-				"class": "gemini",
-				"family": "pro",
-				"revision": "3.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81224,8 +78050,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81331,8 +78157,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81438,8 +78264,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81526,27 +78352,27 @@
 				"supportsReasoningEffort": false
 			}
 		},
-		"gpt-4.1": {
-			"id": "gpt-4.1",
-			"name": "GPT-4.1",
+		"gemini-3.8-flash": {
+			"id": "gemini-3.8-flash",
+			"name": "Gemini 3.8 Flash",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 8,
-				"cacheRead": 0.5,
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 16384,
-			"int": 19.6,
-			"tps": 167.7,
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"int": 41.2,
+			"tps": 267.7,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81605,9 +78431,62 @@
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
 				"stripImageInput": false,
+				"thinkingLoopGuard": "gemini",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			}
+		},
+		"gpt-4.1": {
+			"id": "gpt-4.1",
+			"name": "GPT-4.1",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"int": 19.6,
+			"tps": 167.7,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
 			},
 			"identity": {
 				"class": "openai",
@@ -81615,6 +78494,60 @@
 				"revision": "4.1.0"
 			},
 			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": false,
+				"supportsReasoningParams": false,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": true,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsStore": false,
@@ -81800,6 +78733,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -81832,8 +78766,8 @@
 			},
 			"contextWindow": 264000,
 			"maxTokens": 64000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -81901,6 +78835,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82000,6 +78935,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82099,6 +79035,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82199,6 +79136,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82296,6 +79234,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82353,7 +79292,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82397,6 +79335,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82407,7 +79346,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -82452,7 +79392,6 @@
 				"revision": "5.2.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsDeveloperRole": true,
 				"supportsStrictMode": true,
@@ -82496,6 +79435,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82506,7 +79446,8 @@
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -82527,8 +79468,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -82596,6 +79537,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82627,8 +79569,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -82696,6 +79638,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82727,8 +79670,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -82797,6 +79740,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82828,8 +79772,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -82897,6 +79841,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -82928,8 +79873,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -82998,6 +79943,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83029,8 +79975,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83099,6 +80045,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83123,15 +80070,15 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 4,
+				"output": 20,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83200,6 +80147,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83231,8 +80179,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83301,6 +80249,109 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"headers": {
+				"User-Agent": "copilot/1.0.82",
+				"Editor-Version": "copilot/1.0.82",
+				"Copilot-Integration-Id": "copilot-developer-cli",
+				"Copilot-Harness-Id": "copilot-sdk",
+				"Openai-Intent": "conversation-agent",
+				"X-GitHub-Api-Version": "2026-08-01"
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": true,
+				"supportsImageDetailOriginal": false,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83332,8 +80383,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 128000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83403,6 +80454,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83434,8 +80486,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83505,6 +80557,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -83636,8 +80689,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32000,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83742,8 +80795,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"headers": {
 				"User-Agent": "copilot/1.0.82",
 				"Editor-Version": "copilot/1.0.82",
@@ -83922,6 +80975,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84019,6 +81073,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84335,8 +81390,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84426,8 +81481,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84575,6 +81630,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84665,6 +81721,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -84697,8 +81754,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84908,8 +81965,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -85030,8 +82087,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -85151,6 +82208,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85241,6 +82299,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85331,6 +82390,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -85401,8 +82461,8 @@
 					"max"
 				]
 			},
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
@@ -85827,8 +82887,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -85887,7 +82947,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -86232,8 +83292,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 122.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -86606,8 +83666,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 287.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -86708,8 +83768,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -86806,8 +83866,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -86858,8 +83918,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -86910,8 +83970,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -86962,8 +84022,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -87013,8 +84073,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -87755,8 +84815,8 @@
 					"high"
 				]
 			},
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"identity": {
 				"class": "anthropic",
 				"family": "opus",
@@ -87865,8 +84925,8 @@
 					"high"
 				]
 			},
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"identity": {
 				"class": "anthropic",
 				"family": "sonnet",
@@ -87924,8 +84984,8 @@
 					"high": "gemini-2.5-flash-thinking"
 				}
 			},
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -87950,7 +85010,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
 			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
@@ -87968,7 +85028,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -88095,8 +85155,8 @@
 				"requiresEffort": true
 			},
 			"requestModelId": "gemini-3.5-flash-extra-low",
-			"int": 27.9,
-			"tps": 186.6,
+			"int": 17.9,
+			"tps": 193,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -88367,8 +85427,8 @@
 				"suppressWhenOff": true,
 				"requiresEffort": true
 			},
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -88388,6 +85448,58 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
+				"thinkingLoopGuard": "gemini"
+			}
+		},
+		"gemini-3.5-flash-lite": {
+			"id": "gemini-3.5-flash-lite",
+			"name": "Gemini 3.5 Flash Lite",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
+			"int": 22.7,
+			"tps": 347.7,
+			"thinking": {
+				"mode": "google-level",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "gemini",
+				"family": "lite",
+				"revision": "3.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsFunctionPartId": false,
+				"requiresSkipThoughtSignature": false,
+				"requiresSkipThoughtSignatureOnFirstFunctionCall": true,
+				"dropUnsignedThinking": false,
+				"ccaLegacyParametersSchema": false,
+				"multimodalFunctionResponse": true,
+				"flashStreamLeakWorkaround": false,
+				"claudeThinkingBetaHeader": false,
+				"antigravityClaudeToolMode": false,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
 			}
 		},
@@ -88427,8 +85539,8 @@
 					"high": "gemini-3.6-flash-high"
 				}
 			},
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -88487,8 +85599,8 @@
 					"high": "gemini-3.7-flash-high"
 				}
 			},
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -88547,8 +85659,8 @@
 					"high": "gemini-3.8-flash-high"
 				}
 			},
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"identity": {
 				"class": "gemini",
 				"family": "flash",
@@ -88599,8 +85711,8 @@
 					"high"
 				]
 			},
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
@@ -89754,8 +86866,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -89814,7 +86926,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -89872,8 +86984,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 122.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -90032,8 +87144,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90130,8 +87242,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90182,8 +87294,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90234,8 +87346,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90286,8 +87398,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90337,8 +87449,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -90628,6 +87740,373 @@
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
 				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"xai/grok-4.20-non-reasoning": {
+			"id": "xai/grok-4.20-non-reasoning",
+			"name": "Grok 4.20 (Non-Reasoning)",
+			"api": "openai-completions",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 30000,
+			"int": 25.7,
+			"tps": 103.1,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"xai/grok-4.20-reasoning": {
+			"id": "xai/grok-4.20-reasoning",
+			"name": "Grok 4.20 (Reasoning)",
+			"api": "openai-completions",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 30000,
+			"int": 25.7,
+			"tps": 103.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"xai/grok-4.3": {
+			"id": "xai/grok-4.3",
+			"name": "Grok 4.3",
+			"api": "openai-completions",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 30000,
+			"int": 25.4,
+			"tps": 133.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"xai/grok-4.6": {
+			"id": "xai/grok-4.6",
+			"name": "Grok 4.6",
+			"api": "openai-completions",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 500000,
+			"int": 44.4,
+			"tps": 55.4,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
@@ -91712,8 +89191,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 65536,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91801,8 +89280,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 65536,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92144,8 +89623,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 16384,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92236,8 +89715,8 @@
 			},
 			"contextWindow": 131042,
 			"maxTokens": 16384,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92329,7 +89808,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 32768,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92506,7 +89985,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 8192,
-			"int": 14.2,
+			"int": 8.5,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -92588,7 +90067,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 163840,
-			"int": 15.2,
+			"int": 9.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -92670,7 +90149,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"int": 21.4,
+			"int": 13.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92759,7 +90238,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -92848,8 +90327,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93118,8 +90597,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93220,6 +90699,96 @@
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"deepseek-ai/DeepSeek-V4.1-Flash": {
+			"id": "deepseek-ai/DeepSeek-V4.1-Flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
@@ -93713,8 +91282,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93803,8 +91372,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93893,8 +91462,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -93983,8 +91552,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94074,8 +91643,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94327,8 +91896,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 33.5,
-			"tps": 116.4,
+			"int": 22,
+			"tps": 118.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94424,7 +91993,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94517,8 +92086,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94612,8 +92181,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94706,8 +92275,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94807,8 +92376,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94896,8 +92465,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -94985,7 +92554,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"int": 6.9,
+			"int": 6.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "2.5.0"
@@ -95153,8 +92722,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 18.4,
-			"tps": 57.1,
+			"int": 12,
+			"tps": 58.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -95499,8 +93068,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 85.6,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -95581,8 +93150,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 18.2,
-			"tps": 65,
+			"int": 11.9,
+			"tps": 52.9,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -95663,8 +93232,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 108.8,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -95745,8 +93314,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 13.8,
-			"tps": 170.2,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -95910,8 +93479,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 14.4,
-			"tps": 51.2,
+			"int": 9.9,
+			"tps": 50,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -96086,8 +93655,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 127.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96178,8 +93747,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96270,8 +93839,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 142.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96362,8 +93931,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96454,8 +94023,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 85.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96546,8 +94115,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96638,8 +94207,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 18.8,
+			"tps": 128.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96729,8 +94298,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 57.7,
-			"tps": 40,
+			"int": 40,
+			"tps": 38.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96821,8 +94390,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -96912,8 +94481,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 216.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97004,8 +94573,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 88.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97095,8 +94664,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 84.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97186,8 +94755,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 74.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97277,8 +94846,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 1048576,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 133.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97367,7 +94936,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 4096,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97548,8 +95117,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97640,7 +95209,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97730,8 +95299,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 51.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97823,8 +95392,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 32.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -97914,8 +95483,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 54.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98096,8 +95665,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98187,8 +95756,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98279,8 +95848,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98371,8 +95940,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98463,8 +96032,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98555,8 +96124,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98648,8 +96217,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -99372,9 +96941,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 14,
-				"cacheRead": 0.29,
+				"input": 2.4,
+				"output": 12,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -99734,9 +97303,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07125,
-				"output": 0.2375,
-				"cacheRead": 0.01425,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -99823,13 +97392,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.148,
-				"output": 3.608,
-				"cacheRead": 0.1886,
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 943718,
+			"contextWindow": 1024000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -101775,7 +99344,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 4096,
-			"int": 3.5,
+			"int": 5.6,
 			"identity": {
 				"class": "anthropic",
 				"family": "haiku",
@@ -102199,8 +99768,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102293,8 +99862,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102664,8 +100233,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102758,8 +100327,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102945,8 +100514,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -103131,8 +100700,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -103317,8 +100886,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -103687,8 +101256,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -103781,8 +101350,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -104269,8 +101838,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 80000,
-			"int": 18.7,
-			"tps": 313.7,
+			"int": 10.9,
+			"tps": 322,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -106508,13 +104077,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 0.89,
+				"input": 0.2574,
+				"output": 1.0287,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
-			"maxTokens": 16384,
+			"contextWindow": 128000,
+			"maxTokens": 16000,
 			"identity": {
 				"class": "deepseek"
 			},
@@ -106588,9 +104157,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0,
+				"input": 0.29,
+				"output": 1.14,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -106673,8 +104242,8 @@
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 161000,
-			"maxTokens": 144900,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -106762,7 +104331,7 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 16000,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -107099,7 +104668,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 21.7,
+			"int": 13.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -107270,7 +104839,7 @@
 			},
 			"contextWindow": 163840,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -107529,8 +105098,8 @@
 			},
 			"contextWindow": 1024000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -107709,7 +105278,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -107970,8 +105539,8 @@
 			},
 			"contextWindow": 1024000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -108056,11 +105625,11 @@
 			"cost": {
 				"input": 1.32,
 				"output": 3.96,
-				"cacheRead": 0.132,
+				"cacheRead": 0.044,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1024000,
-			"maxTokens": 384000,
+			"contextWindow": 1048576,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -108220,6 +105789,96 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUse": false
+		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"dots-studio/dots-3-note-preview:free": {
 			"id": "dots-studio/dots-3-note-preview:free",
@@ -108750,8 +106409,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -108925,7 +106584,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -109109,8 +106768,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 122.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110085,8 +107744,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 287.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110179,8 +107838,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110361,8 +108020,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110455,8 +108114,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110549,8 +108208,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110643,8 +108302,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -110737,8 +108396,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111302,8 +108961,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -111799,7 +109458,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -111853,7 +109511,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -111873,8 +109532,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 19.6,
-			"tps": 144,
+			"int": 11.8,
+			"tps": 98.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -112042,8 +109701,96 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 743.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 0.75,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -112146,7 +109893,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -112200,7 +109946,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-coder": {
 			"id": "inception/mercury-coder",
@@ -112597,7 +110344,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -112613,8 +110360,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 37.8,
-			"tps": 346.2,
+			"int": 24.9,
+			"tps": 285,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -112782,6 +110529,183 @@
 			"reasoning": true,
 			"input": [
 				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inclusionai/ling-3.0-flash-sante:free": {
+			"id": "inclusionai/ling-3.0-flash-sante:free",
+			"name": "Ling 3.0 Flash Sante (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inclusionai/ling-3.0-flash-vl:free": {
+			"id": "inclusionai/ling-3.0-flash-vl:free",
+			"name": "Ling 3.0 Flash VL (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -114212,7 +112136,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 144000,
-			"int": 33.7,
+			"int": 21.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -114851,8 +112775,8 @@
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 262144,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 47,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -115412,7 +113336,7 @@
 		},
 		"meta-llama/llama-3.1-70b-instruct": {
 			"id": "meta-llama/llama-3.1-70b-instruct",
-			"name": "Llama 3.1 70B Instruct",
+			"name": "Llama-3.1-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -115904,8 +113828,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 115200,
-			"int": 14.5,
-			"tps": 86.3,
+			"int": 9.3,
+			"tps": 89,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -115986,8 +113910,8 @@
 			},
 			"contextWindow": 327680,
 			"maxTokens": 16384,
-			"int": 10.3,
-			"tps": 93.8,
+			"int": 6.5,
+			"tps": 84.4,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -116476,8 +114400,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 53.2,
-			"tps": 178.6,
+			"int": 34.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -116569,8 +114492,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 199.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -116753,7 +114676,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 62.1,
+			"int": 48.2,
+			"tps": 196.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117337,8 +115261,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117506,8 +115430,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117596,8 +115520,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117766,8 +115690,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -117870,7 +115794,6 @@
 				"family": "m2"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -117924,7 +115847,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
@@ -117945,8 +115869,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -118132,7 +116056,6 @@
 				"family": "m3"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -118186,7 +116109,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
@@ -119077,7 +117001,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 102400,
-			"int": 4.1,
+			"int": 5.8,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -119157,7 +117081,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 7,
+			"int": 6.8,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -119398,8 +117322,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 12.5,
-			"tps": 132.1,
+			"int": 9,
+			"tps": 139.5,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -119480,8 +117404,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 209715,
-			"int": 30.4,
-			"tps": 131.9,
+			"int": 14.9,
+			"tps": 136.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -119572,8 +117496,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 104857,
-			"int": 14.7,
-			"tps": 133.3,
+			"int": 9.9,
+			"tps": 130.6,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -119732,7 +117656,7 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 26214,
-			"int": 6.2,
+			"int": 6.5,
 			"identity": {
 				"class": "mistral",
 				"family": "mistral"
@@ -120538,8 +118462,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 100352,
-			"int": 19.7,
-			"tps": 39.9,
+			"int": 12.7,
+			"tps": 40.3,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -120621,8 +118545,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 100352,
-			"int": 24,
-			"tps": 40.4,
+			"int": 15.3,
+			"tps": 39.9,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -120786,8 +118710,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 100352,
-			"int": 33.5,
-			"tps": 116.4,
+			"int": 22,
+			"tps": 118.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -120881,7 +118805,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121056,8 +118980,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121233,8 +119157,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121327,8 +119251,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -121919,7 +119843,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -121973,7 +119896,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -122010,7 +119934,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -122064,7 +119987,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -122144,6 +120068,184 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"nex-agi/nex-n2.5-mini:free": {
+			"id": "nex-agi/nex-n2.5-mini:free",
+			"name": "Nex-N2.5-Mini (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"nex-agi/nex-n2.5-pro:free": {
+			"id": "nex-agi/nex-n2.5-pro:free",
+			"name": "Nex-N2.5-Pro (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -123168,8 +121270,8 @@
 				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202800,
-			"maxTokens": 182520,
+			"contextWindow": 256000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -123328,6 +121430,84 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"nvidia/nemotron-3.5-content-safety": {
+			"id": "nvidia/nemotron-3.5-content-safety",
+			"name": "Nemotron 3.5 Content Safety",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"nvidia/nemotron-3.5-content-safety:free": {
 			"id": "nvidia/nemotron-3.5-content-safety:free",
 			"name": "Nemotron 3.5 Content Safety (free)",
@@ -123424,8 +121604,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 23.6,
-			"tps": 285.8,
+			"int": 13.6,
+			"tps": 271.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -124101,7 +122281,7 @@
 			},
 			"contextWindow": 8191,
 			"maxTokens": 4096,
-			"int": 6.8,
+			"int": 6.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -124345,8 +122525,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 31.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -124508,8 +122688,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -124591,8 +122771,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 111.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -124674,8 +122854,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 107.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -124757,8 +122937,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 130.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -124839,8 +123019,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 8.4,
-			"tps": 80.4,
+			"int": 7.3,
+			"tps": 85.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -124921,8 +123101,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 99,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -125164,7 +123344,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -125565,8 +123745,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126010,8 +124190,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126102,8 +124282,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 152.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126284,8 +124464,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126458,7 +124638,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126641,7 +124821,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126730,8 +124910,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -126903,7 +125083,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127165,8 +125345,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127257,8 +125437,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127429,8 +125609,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127521,8 +125701,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127703,8 +125883,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -127887,8 +126067,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128071,8 +126251,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128157,10 +126337,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -128346,8 +126526,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128453,6 +126633,190 @@
 				"class": "openai",
 				"family": "gpt",
 				"revision": "5.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -128767,8 +127131,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128936,8 +127300,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129112,7 +127476,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129296,8 +127660,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 105,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129481,8 +127845,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129574,8 +127938,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 15.7,
-			"tps": 236.6,
+			"int": 11,
+			"tps": 217.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129670,7 +128034,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 33.3,
+			"int": 21.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129763,8 +128127,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -129950,8 +128314,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -133259,8 +131623,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
-			"maxTokens": 16384,
+			"contextWindow": 131072,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -133436,7 +131800,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -134117,8 +132481,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 85.6,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -134279,8 +132643,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 108.8,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -134522,8 +132886,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 45.9,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -134603,7 +132967,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.5,
+			"int": 21.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134694,9 +133058,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 13.8,
-			"tps": 170.2,
+			"maxTokens": 16384,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -134775,8 +133139,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -134870,8 +133234,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 14.4,
-			"tps": 51.2,
+			"int": 9.9,
+			"tps": 50,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -135046,8 +133410,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 9.9,
-			"tps": 112,
+			"int": 7.9,
+			"tps": 109.7,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -135222,8 +133586,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 11,
-			"tps": 59.4,
+			"int": 8.4,
+			"tps": 66.6,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -135305,8 +133669,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 8.2,
-			"tps": 112.4,
+			"int": 7.3,
+			"tps": 119.7,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -135480,9 +133844,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
-			"int": 32.8,
-			"tps": 131.9,
+			"maxTokens": 65536,
+			"int": 16.2,
+			"tps": 127.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135573,8 +133937,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135663,10 +134027,10 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 29.9,
-			"tps": 151.7,
+			"contextWindow": 256000,
+			"maxTokens": 16384,
+			"int": 19.3,
+			"tps": 142.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135757,8 +134121,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -135849,8 +134213,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 85.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136210,9 +134574,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
-			"int": 37.7,
-			"tps": 52.5,
+			"maxTokens": 65536,
+			"int": 21.9,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136303,8 +134667,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 18.8,
+			"tps": 128.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136574,8 +134938,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -136917,8 +135281,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137009,8 +135373,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137180,9 +135544,9 @@
 				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 262144,
-			"int": 57.7,
-			"tps": 40,
+			"maxTokens": 131072,
+			"int": 40,
+			"tps": 38.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137273,8 +135637,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -137457,6 +135821,96 @@
 			"maxTokens": 131072,
 			"int": 58.1,
 			"tps": 38.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen3.8-max-0902": {
+			"id": "qwen/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138668,8 +137122,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138762,8 +137216,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138856,8 +137310,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -138950,8 +137404,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139225,8 +137679,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139316,8 +137770,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 216.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -139488,8 +137942,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 230400,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 88.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -140060,8 +138514,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 84.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -140150,7 +138604,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 235929,
-			"int": 34.4,
+			"int": 22.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -140726,8 +139180,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 26214,
+			"contextWindow": 1024000,
+			"maxTokens": 819200,
 			"identity": {
 				"class": "unknown"
 			},
@@ -140805,10 +139259,10 @@
 				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
-			"contextWindow": 524288,
-			"maxTokens": 471859,
-			"int": 42.3,
-			"tps": 73.5,
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
+			"int": 25.5,
+			"tps": 74.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -140898,8 +139352,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 262144,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 133.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -141326,8 +139780,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 14.5,
-			"tps": 143.9,
+			"int": 7.8,
+			"tps": 150.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -141416,8 +139870,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 41.6,
-			"tps": 78.2,
+			"int": 28.2,
+			"tps": 59.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -142192,8 +140646,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 1800000,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 103.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -142542,8 +140996,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 900000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 133.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -142636,8 +141090,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 450000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -142730,8 +141184,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 450000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -143623,8 +142077,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -143795,7 +142249,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -143885,8 +142339,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 51.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -143978,8 +142432,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 32.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144062,15 +142516,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
-				"cacheRead": 0.11,
+				"input": 0.43,
+				"output": 1.75,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"contextWindow": 198000,
+			"maxTokens": 16384,
+			"int": 14.9,
+			"tps": 54.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144241,8 +142695,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 56.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144332,8 +142786,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144416,15 +142870,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.0605,
 				"output": 0.4,
-				"cacheRead": 0.01,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
-			"maxTokens": 16384,
-			"int": 23.3,
-			"tps": 82.9,
+			"contextWindow": 131072,
+			"maxTokens": 117964,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144515,8 +142969,8 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144607,7 +143061,7 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144699,8 +143153,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144789,10 +143243,10 @@
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"contextWindow": 1024000,
+			"maxTokens": 128000,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -144963,9 +143417,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
-			"int": 59.5,
-			"tps": 69.2,
+			"maxTokens": 943718,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -145057,8 +143511,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -145151,7 +143605,7 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -145787,7 +144241,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "kimi-code",
 			"baseUrl": "https://api.kimi.com/coding/v1",
@@ -146386,8 +144840,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146451,8 +144905,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146516,8 +144970,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146707,8 +145161,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146836,8 +145290,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146902,8 +145356,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -146967,8 +145421,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -147032,8 +145486,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -147223,8 +145677,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -147352,8 +145806,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -147418,8 +145872,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -147514,8 +145968,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -147704,8 +146158,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -147988,8 +146442,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148179,8 +146633,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148277,8 +146731,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148373,8 +146827,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148563,8 +147017,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -148847,8 +147301,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149038,8 +147492,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -149526,7 +147980,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 11.8,
+			"int": 8.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -149850,7 +148304,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"int": 10.6,
+			"int": 8.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -151659,7 +150113,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151714,7 +150167,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-0905-preview": {
 			"id": "kimi-k2-0905-preview",
@@ -151740,7 +150194,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151795,7 +150248,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking": {
 			"id": "kimi-k2-thinking",
@@ -151835,7 +150289,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151890,7 +150343,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-thinking-turbo": {
 			"id": "kimi-k2-thinking-turbo",
@@ -151926,7 +150380,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -151981,7 +150434,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2-turbo-preview": {
 			"id": "kimi-k2-turbo-preview",
@@ -152007,7 +150461,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152062,11 +150515,12 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "moonshot",
 			"baseUrl": "https://api.moonshot.ai/v1",
@@ -152099,7 +150553,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -152154,7 +150607,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.6": {
 			"id": "kimi-k2.6",
@@ -152175,8 +150629,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -152270,8 +150724,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -152456,8 +150910,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -153286,8 +151740,8 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 46.8,
-			"tps": 260,
+			"int": 39.8,
+			"tps": 199.5,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -153483,8 +151937,8 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"int": 53,
-			"tps": 190.1,
+			"int": 48.2,
+			"tps": 196.9,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",
@@ -154016,6 +152470,95 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 999990,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"agnes-3.0-flash": {
+			"id": "agnes-3.0-flash",
+			"name": "Agnes 3.0 Flash",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.15,
+				"cacheRead": 0.005,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -154753,8 +153296,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
@@ -155000,8 +153543,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.16,
-				"output": 0.47,
+				"input": 0.14,
+				"output": 0.42,
 				"cacheRead": 0.016,
 				"cacheWrite": 0.2
 			},
@@ -155994,8 +154537,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -156088,8 +154631,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -156365,8 +154908,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -156827,8 +155370,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -157013,8 +155556,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -157199,8 +155742,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -157384,8 +155927,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -157570,8 +156113,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"identity": {
 				"class": "anthropic",
 				"family": "sonnet",
@@ -158576,7 +157119,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158630,7 +157172,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"azure-gpt-4o-mini": {
 			"id": "azure-gpt-4o-mini",
@@ -158655,7 +157198,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -158709,7 +157251,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"azure-o1": {
 			"id": "azure-o1",
@@ -159301,7 +157844,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -159356,7 +157898,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"brave": {
 			"id": "brave",
@@ -159613,7 +158156,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -161847,7 +160390,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -161939,7 +160482,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -164365,8 +162908,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 163840,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -164455,7 +162998,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 21.4,
+			"int": 13.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -164537,7 +163080,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 21.7,
+			"int": 13.9,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -165119,7 +163662,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 20.4,
+			"int": 13.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -165454,7 +163997,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 15.2,
+			"int": 9.7,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -165704,7 +164247,7 @@
 			},
 			"contextWindow": 163000,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -165956,8 +164499,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -166040,9 +164583,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.014,
+				"input": 0.05,
+				"output": 0.16,
+				"cacheRead": 0.013,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -166309,9 +164852,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.014,
+				"input": 0.05,
+				"output": 0.16,
+				"cacheRead": 0.013,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -166398,9 +164941,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.014,
+				"input": 0.05,
+				"output": 0.16,
+				"cacheRead": 0.013,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -166583,8 +165126,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -167103,6 +165646,186 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"deepseek/deepseek-v4.1-flash:thinking": {
+			"id": "deepseek/deepseek-v4.1-flash:thinking",
+			"name": "DeepSeek V4.1 Flash Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"dmind/dmind-1": {
 			"id": "dmind/dmind-1",
 			"name": "dmind/dmind-1",
@@ -167373,7 +166096,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -167427,7 +166149,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"dots-studio/dots-3-note-preview:free": {
 			"id": "dots-studio/dots-3-note-preview:free",
@@ -170846,10 +169569,10 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -170939,10 +169662,10 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -171124,9 +169847,9 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 13.1,
+			"int": 9.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -171489,9 +170212,9 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 19.1,
+			"int": 12.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -171588,10 +170311,10 @@
 				"cacheRead": 0.125,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 122.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -172763,6 +171486,184 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
+			"identity": {
+				"class": "gemma"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"gemma-4-12b-it-semancer": {
+			"id": "gemma-4-12b-it-semancer",
+			"name": "Gemma 4 12B Semancer",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.25,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "gemma"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"gemma-4-12b-it-station-keeper": {
+			"id": "gemma-4-12b-it-station-keeper",
+			"name": "Gemma 4 12B StationKeeper",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.25,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
 			"identity": {
 				"class": "gemma"
 			},
@@ -179294,7 +178195,6 @@
 				"revision": "1.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -179348,7 +178248,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-z1-airx": {
 			"id": "glm-z1-airx",
@@ -179526,7 +178427,7 @@
 				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -179795,10 +178696,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -179887,7 +178788,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -179977,10 +178878,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180071,10 +178972,10 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180167,8 +179068,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180261,8 +179162,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180355,8 +179256,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180445,12 +179346,12 @@
 				"input": 0.75,
 				"output": 3.75,
 				"cacheRead": 0.075,
-				"cacheWrite": 0.075
+				"cacheWrite": 0.041667
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180539,12 +179440,12 @@
 				"input": 0.75,
 				"output": 3.75,
 				"cacheRead": 0.075,
-				"cacheWrite": 0.075
+				"cacheWrite": 0.041667
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -180899,7 +179800,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048756,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -183428,7 +182329,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 65536,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -183517,7 +182418,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 65536,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -184171,7 +183072,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -184225,7 +183125,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ibm-granite/granite-4.2-8b": {
 			"id": "ibm-granite/granite-4.2-8b",
@@ -184245,8 +183146,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 117964,
-			"int": 19.6,
-			"tps": 144,
+			"int": 11.8,
+			"tps": 98.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -184579,8 +183480,99 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 37.8,
-			"tps": 346.2,
+			"int": 24.9,
+			"tps": 285,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"inclusionai/ling-3.0-flash-vl": {
+			"id": "inclusionai/ling-3.0-flash-vl",
+			"name": "Ling 3.0 Flash VL",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.06,
+				"output": 0.18,
+				"cacheRead": 0.012,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"int": 24.8,
+			"tps": 138.8,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
 			"identity": {
 				"class": "unknown"
 			},
@@ -186044,7 +185036,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "kimi-k2",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -186099,7 +185090,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-thinking-preview": {
 			"id": "kimi-thinking-preview",
@@ -190604,8 +189596,8 @@
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 262144,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 47,
 			"identity": {
 				"class": "unknown"
 			},
@@ -191325,8 +190317,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 743.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -191813,8 +190805,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 14.5,
-			"tps": 86.3,
+			"int": 9.3,
+			"tps": 89,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -191895,8 +190887,8 @@
 			},
 			"contextWindow": 328000,
 			"maxTokens": 65536,
-			"int": 10.3,
-			"tps": 93.8,
+			"int": 6.5,
+			"tps": 84.4,
 			"identity": {
 				"class": "meta",
 				"family": "llama"
@@ -191976,7 +190968,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 117964,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -192160,8 +191152,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 199.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -192344,7 +191336,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 943718,
-			"int": 62.1,
+			"int": 48.2,
+			"tps": 196.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -193103,8 +192096,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -193193,8 +192186,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -193283,8 +192276,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -193462,8 +192455,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 80000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"identity": {
 				"class": "minimax",
 				"family": "m3"
@@ -194269,8 +193262,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 30.4,
-			"tps": 131.9,
+			"int": 14.9,
+			"tps": 136.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196486,8 +195479,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
+			"contextWindow": 262144,
+			"maxTokens": 100352,
 			"identity": {
 				"class": "kimi",
 				"family": "k2"
@@ -196569,8 +195562,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 98304,
-			"int": 33.5,
-			"tps": 116.4,
+			"int": 22,
+			"tps": 118.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -196830,7 +195823,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.5"
@@ -197005,8 +195998,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.6"
@@ -197182,8 +196175,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197367,9 +196360,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 59.7,
-			"tps": 38,
+			"maxTokens": 943718,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -197469,7 +196462,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -198335,7 +197328,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198389,7 +197381,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -198426,7 +197419,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -198480,7 +197472,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -198737,8 +197730,8 @@
 			},
 			"contextWindow": 65536,
 			"maxTokens": 8192,
-			"int": 4.8,
-			"tps": 35.1,
+			"int": 6,
+			"tps": 29.5,
 			"identity": {
 				"class": "unknown"
 			},
@@ -199388,7 +198381,7 @@
 		},
 		"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
 			"id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-			"name": "Nvidia Nemotron 3 Nano Omni",
+			"name": "Nemotron 3 Nano Omni",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -199422,7 +198415,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -199476,7 +198468,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
@@ -199850,8 +198843,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 23.6,
-			"tps": 285.8,
+			"int": 13.6,
+			"tps": 271.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -200525,8 +199518,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -200776,8 +199769,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 130.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -200858,8 +199851,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 99,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -201263,8 +200256,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -201804,8 +200797,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -201893,8 +200886,8 @@
 				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 32768,
+			"contextWindow": 400000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -202422,8 +201415,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -202596,7 +201589,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -202859,8 +201852,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -202949,10 +201942,10 @@
 				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": 922000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203043,8 +202036,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203135,8 +202128,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203316,10 +202309,10 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203411,8 +202404,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203595,8 +202588,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203779,8 +202772,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -203944,6 +202937,190 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT 6 Astra",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT 6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
 			"name": "GPT Chat Latest",
@@ -204046,10 +203223,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -204142,8 +203319,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -204231,8 +203408,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -204861,8 +204038,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -204954,8 +204131,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 15.7,
-			"tps": 236.6,
+			"int": 11,
+			"tps": 217.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205049,8 +204226,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205235,8 +204412,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205421,8 +204598,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205887,7 +205064,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -205941,7 +205117,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"ornith-ai/ornith-1.5-9b:thinking": {
 			"id": "ornith-ai/ornith-1.5-9b:thinking",
@@ -205976,7 +205153,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -206030,7 +205206,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"owl": {
 			"id": "owl",
@@ -207849,8 +207026,8 @@
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 41000,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 16384,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -208017,10 +207194,10 @@
 				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
-			"int": 18.4,
-			"tps": 57.1,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"int": 12,
+			"tps": 58.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -208340,8 +207517,8 @@
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
+			"contextWindow": 131072,
+			"maxTokens": 117964,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -208920,8 +208097,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.3,
-			"tps": 128.9,
+			"int": 10.1,
+			"tps": 108.8,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -209163,10 +208340,10 @@
 				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144,
-			"int": 13.8,
-			"tps": 170.2,
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -209508,8 +208685,8 @@
 			},
 			"contextWindow": 258048,
 			"maxTokens": 65536,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -209607,8 +208784,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 85.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -209797,8 +208974,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 18.8,
+			"tps": 128.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
@@ -209988,7 +209165,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210042,7 +209218,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.6-35b-a3b-uncensored:thinking": {
 			"id": "qwen/qwen3.6-35b-a3b-uncensored:thinking",
@@ -210078,7 +209255,6 @@
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -210132,7 +209308,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/Qwen3.6-35B-A3B:thinking": {
 			"id": "qwen/Qwen3.6-35B-A3B:thinking",
@@ -210243,8 +209420,8 @@
 			},
 			"contextWindow": 991000,
 			"maxTokens": 65536,
-			"int": 57.7,
-			"tps": 40,
+			"int": 40,
+			"tps": 38.8,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.2"
@@ -210490,6 +209667,96 @@
 		"qwen/qwen3.8-27b-obliterated:thinking": {
 			"id": "qwen/qwen3.8-27b-obliterated:thinking",
 			"name": "Qwen 3.8 27B Obliterated Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"qwen/qwen3.8-27b-queen": {
+			"id": "qwen/qwen3.8-27b-queen",
+			"name": "Qwen 3.8 27B Queen",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -211096,8 +210363,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 65536,
-			"int": 13.6,
-			"tps": 89.6,
+			"int": 9.6,
+			"tps": 85.6,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -211423,7 +210690,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 5.2,
+			"int": 6.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -211513,8 +210780,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 127.6,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -211685,8 +210952,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 34.6,
-			"tps": 77.8,
+			"int": 22.9,
+			"tps": 74.8,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -215523,7 +214790,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 7.4,
+			"int": 6.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -215614,8 +214881,8 @@
 			},
 			"contextWindow": 260096,
 			"maxTokens": 65536,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 142.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.5.0"
@@ -215787,8 +215054,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 20.4,
-			"tps": 23.5,
+			"int": 13.1,
+			"tps": 28.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216391,8 +215658,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216572,8 +215839,8 @@
 			},
 			"contextWindow": 991808,
 			"maxTokens": 65536,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216754,8 +216021,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -216936,8 +216203,8 @@
 			},
 			"contextWindow": 991000,
 			"maxTokens": 65536,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 38.2,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
@@ -218160,14 +217427,14 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.045,
-				"output": 0.177,
-				"cacheRead": 0.028,
+				"input": 0.054,
+				"output": 0.2124,
+				"cacheRead": 0.0336,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
 			"maxTokens": 4096,
-			"int": 11.9,
+			"int": 8.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -220703,9 +219970,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 51.8,
-			"tps": 140,
+			"maxTokens": 393216,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -221989,8 +221256,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 65535,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222083,14 +221350,14 @@
 			],
 			"cost": {
 				"input": 1.4,
-				"output": 4.6,
-				"cacheRead": 0.5,
+				"output": 4.4,
+				"cacheRead": 0.7,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222175,8 +221442,8 @@
 			],
 			"cost": {
 				"input": 1.4,
-				"output": 4.6,
-				"cacheRead": 0.5,
+				"output": 4.4,
+				"cacheRead": 0.7,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -222271,8 +221538,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222364,8 +221631,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222802,8 +222069,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"identity": {
 				"class": "kimi",
 				"family": "k2.6"
@@ -222886,8 +222153,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -222979,9 +222246,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"int": 59.7,
-			"tps": 38,
+			"maxTokens": 65535,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -223643,6 +222910,94 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"TEE/qwen3-8b": {
+			"id": "TEE/qwen3-8b",
+			"name": "Qwen3 8B TEE",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.11,
+				"output": 0.45,
+				"cacheRead": 0.11,
+				"cacheWrite": 0
+			},
+			"contextWindow": 40960,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"TEE/qwen3-coder": {
 			"id": "TEE/qwen3-coder",
@@ -224328,8 +223683,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 52,
-			"tps": 38.8,
+			"int": 33.9,
+			"tps": 43.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -224497,9 +223852,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"int": 42.2,
-			"tps": 94.4,
+			"maxTokens": 128000,
+			"int": 25.8,
+			"tps": 84.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -224905,6 +224260,95 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"TheDrummer/Artemis-v1.1": {
+			"id": "TheDrummer/Artemis-v1.1",
+			"name": "TheDrummer/Artemis v1.1",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.45,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"TheDrummer/Cydonia-24B-v2": {
 			"id": "TheDrummer/Cydonia-24B-v2",
@@ -225636,8 +225080,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 32768,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 74.9,
 			"identity": {
 				"class": "unknown"
 			},
@@ -225717,8 +225161,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 32768,
-			"int": 41.2,
-			"tps": 106.9,
+			"int": 26.1,
+			"tps": 133.3,
 			"identity": {
 				"class": "unknown"
 			},
@@ -227270,8 +226714,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 41.6,
-			"tps": 78.2,
+			"int": 28.2,
+			"tps": 59.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -228189,8 +227633,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 131072,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 103.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -228620,9 +228064,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 1000000,
-			"int": 37.9,
-			"tps": 134.9,
+			"maxTokens": 900000,
+			"int": 25.4,
+			"tps": 133.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -228714,9 +228158,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"maxTokens": 450000,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -228808,9 +228252,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"maxTokens": 450000,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -228902,7 +228346,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"maxTokens": 230400,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -229086,7 +228530,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": 500000,
+			"maxTokens": 450000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -229652,8 +229096,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -230515,8 +229959,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 51.3,
 			"identity": {
 				"class": "glm",
 				"family": "air",
@@ -230780,8 +230224,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 65535,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 54.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -231390,8 +230834,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 65535,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -231481,8 +230925,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -232110,8 +231554,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -232382,7 +231826,7 @@
 			},
 			"contextWindow": 202800,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"identity": {
 				"class": "glm",
 				"family": "turbo",
@@ -232554,8 +231998,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -232736,8 +232180,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -232918,8 +232362,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -233011,8 +232455,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -233287,7 +232731,7 @@
 			},
 			"contextWindow": 202800,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"identity": {
 				"class": "glm",
 				"family": "vision"
@@ -237939,7 +237383,7 @@
 			"cost": {
 				"input": 1.32,
 				"output": 3.96,
-				"cacheRead": 0.132,
+				"cacheRead": 0.044,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -238016,6 +237460,97 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 393216,
+			"supportsTools": true,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"dev/glm46": {
 			"id": "dev/glm46",
@@ -238602,9 +238137,189 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"hermes/mercury-oss-120b": {
+			"id": "hermes/mercury-oss-120b",
+			"name": "hermes/mercury-oss-120b",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.05,
+				"output": 0.25,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"hermes/mercury-oss-20b": {
+			"id": "hermes/mercury-oss-20b",
+			"name": "hermes/mercury-oss-20b",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"supportsTools": false,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -238906,6 +238621,8 @@
 					"xhigh"
 				]
 			},
+			"int": 24.8,
+			"tps": 138.8,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -241271,188 +240988,6 @@
 			},
 			"supportsComputerUseConfig": false
 		},
-		"openai/gpt-oss-120b": {
-			"id": "openai/gpt-oss-120b",
-			"name": "GPT OSS 120B",
-			"api": "openai-completions",
-			"provider": "novita",
-			"baseUrl": "https://api.novita.ai/openai/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.05,
-				"output": 0.25,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"supportsTools": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gpt-oss",
-				"family": "120b"
-			},
-			"int": 24.1,
-			"tps": 153,
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUseConfig": false
-		},
-		"openai/gpt-oss-20b": {
-			"id": "openai/gpt-oss-20b",
-			"name": "GPT OSS 20B",
-			"api": "openai-completions",
-			"provider": "novita",
-			"baseUrl": "https://api.novita.ai/openai/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.04,
-				"output": 0.15,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"supportsTools": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "gpt-oss",
-				"family": "20b"
-			},
-			"int": 15.2,
-			"tps": 128.4,
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUseConfig": false
-		},
 		"paddlepaddle/paddleocr-vl": {
 			"id": "paddlepaddle/paddleocr-vl",
 			"name": "PaddleOCR VL",
@@ -242294,7 +241829,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next 80B-A3B Instruct",
+			"name": "Qwen3-Next-80B-A3B-Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -244458,7 +243993,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -246009,9 +245544,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -246828,8 +246363,8 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 262000,
-			"int": 18.5,
-			"tps": 34.8,
+			"int": 12.1,
+			"tps": 29.9,
 			"identity": {
 				"class": "unknown"
 			},
@@ -247418,8 +246953,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -247598,8 +247133,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 393216,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251526,8 +251061,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -251617,8 +251152,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 16384,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -252846,7 +252381,7 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 16384,
-			"int": 2,
+			"int": 5.1,
 			"identity": {
 				"class": "mistral",
 				"family": "mixtral"
@@ -253357,8 +252892,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -253452,8 +252987,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -254785,8 +254320,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 8.9,
-			"tps": 52.3,
+			"int": 7.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -255773,8 +255307,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 15,
-			"tps": 328.2,
+			"int": 10.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257309,8 +256842,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 7.2,
-			"tps": 159.9,
+			"int": 6.8,
+			"tps": 146.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257633,8 +257166,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257722,8 +257255,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -257899,7 +257432,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 6.9,
+			"int": 6.7,
 			"identity": {
 				"class": "qwen",
 				"revision": "2.5.0"
@@ -258042,11 +257575,11 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B-A22B",
+			"name": "Qwen 3 235b A22B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -258058,15 +257591,6 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -258146,8 +257670,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 66536,
-			"int": 18.2,
-			"tps": 65,
+			"int": 11.9,
+			"tps": 52.9,
 			"identity": {
 				"class": "qwen",
 				"family": "coder",
@@ -258228,8 +257752,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 16384,
-			"int": 13.8,
-			"tps": 170.2,
+			"int": 9.6,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"family": "next",
@@ -258403,8 +257927,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 32.8,
-			"tps": 131.9,
+			"int": 16.2,
+			"tps": 127.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258495,8 +258019,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 8192,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258586,7 +258110,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192,
-			"int": 2.6,
+			"int": 5.3,
 			"identity": {
 				"class": "unknown"
 			},
@@ -258743,8 +258267,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 216.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -258835,8 +258359,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 88.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259005,8 +258529,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 16384,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 74.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -259655,8 +259179,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -260109,8 +259633,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260216,8 +259740,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260646,8 +260170,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260684,8 +260208,8 @@
 			},
 			"contextWindow": 976000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260720,8 +260244,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260760,8 +260284,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260939,7 +260463,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -260977,8 +260501,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261016,8 +260540,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261055,8 +260579,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261168,8 +260692,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261206,8 +260730,8 @@
 			},
 			"contextWindow": 196608,
 			"maxTokens": 196608,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261245,8 +260769,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 131072,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
@@ -261777,6 +261301,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -261875,6 +261400,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -261966,6 +261492,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -261996,7 +261523,7 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 8192,
-			"int": 6.8,
+			"int": 6.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -262047,6 +261574,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262077,8 +261605,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 7.7,
-			"tps": 32.6,
+			"int": 7,
+			"tps": 31.2,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -262129,6 +261657,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262159,8 +261688,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 19.6,
-			"tps": 167.7,
+			"int": 12.7,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -262211,6 +261740,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262241,8 +261771,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 14.8,
-			"tps": 78.8,
+			"int": 10.2,
+			"tps": 111.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -262293,6 +261823,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262323,8 +261854,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"int": 9.6,
-			"tps": 133.4,
+			"int": 7.8,
+			"tps": 107.7,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -262375,6 +261906,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262405,8 +261937,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 11.1,
-			"tps": 117.3,
+			"int": 8.4,
+			"tps": 130.9,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -262456,6 +261988,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262486,8 +262019,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"int": 8.4,
-			"tps": 80.4,
+			"int": 7.3,
+			"tps": 85.3,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -262537,6 +262070,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262567,8 +262101,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 9.4,
-			"tps": 86.9,
+			"int": 7.7,
+			"tps": 99,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -262618,6 +262152,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262697,6 +262232,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262728,7 +262264,7 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384,
 			"int": 6.7,
-			"tps": 123.9,
+			"tps": 153.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt"
@@ -262778,6 +262314,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262808,8 +262345,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -262869,6 +262406,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -262950,6 +262488,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263041,6 +262580,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263072,8 +262612,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 25.8,
-			"tps": 105.9,
+			"int": 17.4,
+			"tps": 101.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263133,6 +262673,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263164,8 +262705,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 152.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263225,6 +262766,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263315,6 +262857,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263346,8 +262889,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263407,6 +262950,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263497,6 +263041,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263588,6 +263133,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263680,6 +263226,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263769,6 +263316,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263800,8 +263348,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -263861,6 +263409,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -263951,6 +263500,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264042,6 +263592,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264132,6 +263683,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264213,6 +263765,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264244,8 +263797,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264305,6 +263858,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264396,6 +263950,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264427,8 +263982,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264488,6 +264043,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264519,8 +264075,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264580,6 +264136,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264611,8 +264168,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264672,6 +264229,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264762,6 +264320,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264793,8 +264352,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -264855,6 +264414,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -264946,6 +264506,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265045,6 +264606,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265137,6 +264699,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265175,8 +264738,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265238,6 +264801,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265276,8 +264840,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"requestModelId": "gpt-5.6-luna",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -265341,6 +264905,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265379,8 +264944,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265442,6 +265007,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265480,8 +265046,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"requestModelId": "gpt-5.6-sol",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -265545,6 +265111,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265583,8 +265150,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265646,6 +265213,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265684,8 +265252,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"requestModelId": "gpt-5.6-terra",
 			"reasoningMode": "pro",
 			"thinking": {
@@ -265749,6 +265317,109 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": true,
+				"officialEndpoint": true,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": true
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "https://api.openai.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5,
+				"longContext": {
+					"inputThreshold": 272000,
+					"input": 20,
+					"output": 75,
+					"cacheRead": 2,
+					"cacheWrite": 25
+				}
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": true,
+			"compat": {
+				"supportsDeveloperRole": true,
+				"supportsStrictMode": true,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": true,
+				"supportsPromptCacheBreakpoints": true,
+				"promptCacheBreakpointTtl": "30m",
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265840,6 +265511,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265870,7 +265542,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 23.9,
+			"int": 15.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -265931,6 +265603,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -265961,7 +265634,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.1,
+			"int": 12.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266023,6 +265696,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266053,8 +265727,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 31.1,
-			"tps": 108.5,
+			"int": 20.2,
+			"tps": 105,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266115,6 +265789,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266205,6 +265880,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266235,8 +265911,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 19.2,
-			"tps": 203.5,
+			"int": 12.5,
+			"tps": 232.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266298,6 +265974,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266328,7 +266005,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 33.3,
+			"int": 21.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266390,6 +266067,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266420,8 +266098,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 100000,
-			"int": 26.1,
-			"tps": 144.9,
+			"int": 16.7,
+			"tps": 140.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266483,6 +266161,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266573,6 +266252,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": true,
 				"officialEndpoint": true,
 				"harmonyLeakMitigation": false,
@@ -266609,6 +266289,7 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 128000,
+			"maxContextWindow": 128000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 26,
@@ -266672,214 +266353,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
-				"supportsObfuscationOptOut": false,
-				"officialEndpoint": false,
-				"harmonyLeakMitigation": true,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
-			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
-		},
-		"gpt-5.4": {
-			"id": "gpt-5.4",
-			"name": "GPT-5.4",
-			"api": "openai-codex-responses",
-			"provider": "openai-codex",
-			"baseUrl": "https://chatgpt.com/backend-api",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
-			},
-			"remoteCompaction": {
-				"enabled": true,
-				"api": "openai-codex-responses",
-				"v2StreamingEnabled": true
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"preferWebsockets": true,
-			"priority": 0,
-			"int": 53.1,
-			"tps": 134.4,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsDeveloperRole": false,
-				"supportsStrictMode": false,
-				"supportsReasoningEffort": true,
-				"supportsLongPromptCacheRetention": false,
-				"supportsPromptCacheBreakpoints": false,
-				"strictResponsesPairing": false,
-				"supportsImageDetailOriginal": true,
-				"supportsReasoningSummary": true,
-				"supportsAllTurnsReasoningContext": true,
-				"supportsConfigurationUpdate": false,
-				"requiresReasoningOffJuiceInstruction": false,
-				"stripImageInput": false,
-				"reasoningEffortMap": {},
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": false,
-				"supportsPenaltyAndStopParams": true,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresAssistantContentForToolCalls": false,
-				"isOpenRouterHost": false,
-				"isVercelGatewayHost": false,
-				"wireModelIdMode": "raw",
-				"alwaysSendMaxTokens": false,
-				"supportsObfuscationOptOut": false,
-				"officialEndpoint": false,
-				"harmonyLeakMitigation": true,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
-			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
-		},
-		"gpt-5.4-mini": {
-			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 mini",
-			"api": "openai-codex-responses",
-			"provider": "openai-codex",
-			"baseUrl": "https://chatgpt.com/backend-api",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.75,
-				"output": 4.5,
-				"cacheRead": 0.075,
-				"cacheWrite": 0
-			},
-			"remoteCompaction": {
-				"enabled": true,
-				"api": "openai-codex-responses",
-				"v2StreamingEnabled": true
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"preferWebsockets": true,
-			"priority": 1,
-			"int": 40.9,
-			"tps": 200.3,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"identity": {
-				"class": "openai",
-				"family": "gpt",
-				"revision": "5.4.0"
-			},
-			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsDeveloperRole": false,
-				"supportsStrictMode": false,
-				"supportsReasoningEffort": true,
-				"supportsLongPromptCacheRetention": false,
-				"supportsPromptCacheBreakpoints": false,
-				"strictResponsesPairing": false,
-				"supportsImageDetailOriginal": true,
-				"supportsReasoningSummary": true,
-				"supportsAllTurnsReasoningContext": true,
-				"supportsConfigurationUpdate": false,
-				"requiresReasoningOffJuiceInstruction": false,
-				"stripImageInput": false,
-				"reasoningEffortMap": {},
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": false,
-				"supportsPenaltyAndStopParams": true,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresAssistantContentForToolCalls": false,
-				"isOpenRouterHost": false,
-				"isVercelGatewayHost": false,
-				"wireModelIdMode": "raw",
-				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -266920,11 +266394,12 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 272000,
+			"maxContextWindow": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 12,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -266934,7 +266409,6 @@
 					"xhigh"
 				]
 			},
-			"contextPromotionTarget": "openai-codex/gpt-5.4",
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -266985,6 +266459,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267032,13 +266507,14 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 1000000,
+			"maxContextWindow": 872000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
 			"toolMode": "code_mode_only",
 			"priority": 8,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267099,6 +266575,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267146,13 +266623,14 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 1000000,
+			"maxContextWindow": 872000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
 			"toolMode": "code_mode_only",
 			"priority": 6,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267213,6 +266691,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267260,13 +266739,14 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 1000000,
+			"maxContextWindow": 872000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
 			"toolMode": "code_mode_only",
 			"priority": 7,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267327,6 +266807,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267346,7 +266827,7 @@
 		},
 		"gpt-6-astra": {
 			"id": "gpt-6-astra",
-			"name": "GPT-6-Astra",
+			"name": "GPT-6 Astra",
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"baseUrl": "https://chatgpt.com/backend-api",
@@ -267367,11 +266848,14 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 272000,
+			"maxContextWindow": 872000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
 			"toolMode": "code_mode_only",
 			"priority": 1,
+			"int": 52.8,
+			"tps": 54.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267432,6 +266916,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267472,6 +266957,7 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 272000,
+			"maxContextWindow": 872000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -267537,6 +267023,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": true,
@@ -267567,15 +267054,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267635,6 +267122,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -267659,9 +267147,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -267810,8 +267298,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -267898,6 +267386,151 @@
 					"supportsForcedToolChoice": false,
 					"supportsNamedToolChoice": true,
 					"maxTokensField": "max_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": true,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "dsml",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": true,
+					"thinkingLoopGuard": "deepseek",
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
+		"deepseek-v4.1-flash": {
+			"id": "deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": false,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": true,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": true,
+					"supportsToolChoice": false,
+					"supportsForcedToolChoice": false,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
 					"requiresToolResultName": false,
 					"requiresAssistantAfterToolResult": false,
 					"requiresThinkingAsText": false,
@@ -268104,8 +267737,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 32768,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268252,8 +267885,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268400,8 +268033,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268532,7 +268165,7 @@
 		},
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
-			"name": "GLM-5.3-Flash (2x usage)",
+			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -268542,15 +268175,15 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268699,8 +268332,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268761,6 +268394,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268854,6 +268488,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268886,8 +268521,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -268949,6 +268584,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -268979,8 +268615,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 128000,
-			"int": 42.2,
-			"tps": 94.4,
+			"int": 25.8,
+			"tps": 84.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269249,7 +268885,7 @@
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
-			"name": "Kimi K2.5",
+			"name": "kimi-k2.5",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -269414,8 +269050,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269565,8 +269201,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269714,8 +269350,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -269875,8 +269511,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 34,
-			"tps": 44.5,
+			"int": 19.7,
+			"tps": 47,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270470,8 +270106,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 128000,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270684,8 +270320,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -270829,8 +270465,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271035,6 +270671,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -271126,6 +270763,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -271443,8 +271081,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271588,8 +271226,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271734,8 +271372,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271941,8 +271579,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 58.1,
-			"tps": 38.8,
+			"int": 40.3,
+			"tps": 38.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -272282,8 +271920,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272347,8 +271985,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.2,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272537,8 +272175,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -272601,8 +272239,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272664,8 +272302,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272729,8 +272367,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272794,8 +272432,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -272983,8 +272621,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -273045,8 +272683,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -273109,8 +272747,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -273381,6 +273019,151 @@
 			},
 			"supportsComputerUse": false
 		},
+		"deepseek-v4-flash-vision-exp": {
+			"id": "deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": true,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": true,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": false,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": true,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"thinkingLoopGuard": "deepseek",
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -273399,8 +273182,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -273546,8 +273329,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 27.9,
-			"tps": 186.6,
+			"int": 17.9,
+			"tps": 193,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -273694,8 +273477,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -273746,8 +273529,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -273798,8 +273581,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -273850,8 +273633,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -273901,8 +273684,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
@@ -274242,8 +274025,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274390,8 +274173,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274538,8 +274321,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274553,6 +274336,304 @@
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 600000,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": false,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": false,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": false,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 600000,
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
+		"glm-5.3": {
+			"id": "glm-5.3",
+			"name": "GLM-5.3",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"int": 44.9,
+			"tps": 58.1,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 600000,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": false,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": false,
+					"supportsToolChoice": true,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_completion_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": false,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": false,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": false,
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 600000,
+					"stripDeepseekSpecialTokens": false,
+					"streamMarkupHealingPattern": "thinking",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
+			}
+		},
+		"glm-5.3-flash": {
+			"id": "glm-5.3-flash",
+			"name": "GLM-5.3-Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"int": 41.9,
+			"tps": 85.2,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash",
+				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
@@ -274687,8 +274768,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274748,6 +274829,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274779,7 +274861,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274839,6 +274921,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274870,8 +274953,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 20.1,
-			"tps": 146.1,
+			"int": 13,
+			"tps": 152.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -274931,6 +275014,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -274962,8 +275046,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275023,6 +275107,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275054,7 +275139,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275114,6 +275199,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275206,6 +275292,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275237,7 +275324,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275295,6 +275382,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275326,8 +275414,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275387,6 +275475,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275418,7 +275507,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275478,6 +275567,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275509,8 +275599,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275570,6 +275660,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275660,6 +275751,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275691,8 +275783,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275752,6 +275844,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275783,8 +275876,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275844,6 +275937,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -275875,8 +275969,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -275936,6 +276030,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276026,6 +276121,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276057,8 +276153,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276119,6 +276215,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276210,6 +276307,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276241,8 +276339,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276303,6 +276401,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276334,8 +276433,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276396,6 +276495,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276427,8 +276527,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276489,6 +276589,101 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-responses",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"int": 52.8,
+			"tps": 54.3,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsStrictMode": false,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": true,
+				"requiresReasoningOffJuiceInstruction": true,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276520,8 +276715,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276583,6 +276778,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276614,8 +276810,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -276677,6 +276873,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -276769,6 +276966,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -277238,7 +277436,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -277386,8 +277584,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -277537,8 +277735,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -277686,8 +277884,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -279367,8 +279565,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -279574,8 +279772,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -279719,8 +279917,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 128000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -280009,8 +280207,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 56.8,
-			"tps": 233.9,
+			"int": 39.8,
+			"tps": 199.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -280071,6 +280269,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280162,6 +280361,102 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
+				"supportsObfuscationOptOut": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false
+			}
+		},
+		"muse-spark-1.3": {
+			"id": "muse-spark-1.3",
+			"name": "Muse Spark 1.3",
+			"api": "openai-responses",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"int": 48.2,
+			"tps": 196.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "meta",
+				"family": "muse-spark",
+				"revision": "1.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsStrictMode": false,
+				"supportsReasoningEffort": true,
+				"supportsLongPromptCacheRetention": false,
+				"supportsPromptCacheBreakpoints": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsReasoningSummary": true,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"stripImageInput": false,
+				"reasoningEffortMap": {},
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": false,
+				"supportsNamedToolChoice": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresAssistantContentForToolCalls": false,
+				"isOpenRouterHost": false,
+				"isVercelGatewayHost": false,
+				"wireModelIdMode": "raw",
+				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280253,6 +280548,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -280913,8 +281209,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -282194,9 +282490,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 14,
-				"cacheRead": 0.29,
+				"input": 2.4,
+				"output": 12,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -282598,9 +282894,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07125000000000001,
-				"output": 0.2375,
-				"cacheRead": 0.01425,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
@@ -282697,13 +282993,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.1480000000000001,
-				"output": 3.608,
-				"cacheRead": 0.18860000000000002,
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 943718,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -288706,7 +289002,7 @@
 		},
 		"bytedance-seed/seed-2-1-turbo": {
 			"id": "bytedance-seed/seed-2-1-turbo",
-			"name": "ByteDance Seed 2.1 Turbo",
+			"name": "Seed 2.1 Turbo",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -289389,13 +289685,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 0.8899999999999999,
+				"input": 0.2574,
+				"output": 1.0287,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 16384,
+			"maxTokens": 16000,
 			"tokenizer": "deepseek-v3",
 			"requiresGlyphTokenization": false,
 			"identity": {
@@ -289480,9 +289776,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.135,
+				"input": 0.29,
+				"output": 1.1400000000000001,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -289571,13 +289867,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 1.6500000000000001,
-				"cacheRead": 0.55,
+				"input": 0.25,
+				"output": 0.95,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 144900,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -290259,9 +290555,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07784,
-				"output": 0.15568,
-				"cacheRead": 0.015568,
+				"input": 0.08707999999999999,
+				"output": 0.17415999999999998,
+				"cacheRead": 0.017415999999999997,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -290461,9 +290757,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.03,
+				"input": 0.11,
+				"output": 0.33,
+				"cacheRead": 0.0035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -290567,7 +290863,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -290582,6 +290878,106 @@
 				"class": "deepseek",
 				"family": "flash"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"deepseek/deepseek-v4-flash-vision-exp:batch": {
+			"id": "deepseek/deepseek-v4-flash-vision-exp:batch",
+			"name": "DeepSeek V4 Flash Vision Exp (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.11,
+				"output": 0.33,
+				"cacheRead": 0.0035,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -290760,9 +291156,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.0274699999999999,
-				"output": 2.0549399999999998,
-				"cacheRead": 0.0856225,
+				"input": 0.87,
+				"output": 1.74,
+				"cacheRead": 0.0725,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -290860,13 +291256,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.66,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.022,
+				"input": 0.57948,
+				"output": 1.73844,
+				"cacheRead": 0.018438,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -290960,9 +291356,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.32,
-				"output": 3.9600000000000004,
-				"cacheRead": 0.13,
+				"input": 0.66,
+				"output": 1.9800000000000002,
+				"cacheRead": 0.022,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -290981,6 +291377,106 @@
 				"class": "deepseek",
 				"family": "pro"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "dsml",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -292454,7 +292950,7 @@
 		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
-			"name": "Gemini 3 Flash (Preview)",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -293167,7 +293663,7 @@
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
-			"name": "Gemini 3.1 Pro (Preview)",
+			"name": "Gemini 3.1 Pro Preview",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -293272,7 +293768,7 @@
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
 			"id": "google/gemini-3.1-pro-preview-customtools",
-			"name": "Gemini 3.1 Pro (Preview Custom Tools)",
+			"name": "Gemini 3.1 Pro Preview Custom Tools",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -294802,13 +295298,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07,
-				"output": 0.33999999999999997,
+				"input": 0.041999999999999996,
+				"output": 0.22,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -295386,9 +295882,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.15,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.06,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -295662,6 +296158,103 @@
 				"supportsReasoningSummary": true
 			},
 			"supportsComputerUseConfig": false
+		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0.004,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"inception/mercury-2.5-preview": {
 			"id": "inception/mercury-2.5-preview",
@@ -296207,7 +296800,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -296432,6 +297025,201 @@
 			},
 			"identity": {
 				"class": "unknown"
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"inclusionai/ling-3.0-flash-sante:free": {
+			"id": "inclusionai/ling-3.0-flash-sante:free",
+			"name": "Ling 3.0 Flash Sante (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"inclusionai/ling-3.0-flash-vl:free": {
+			"id": "inclusionai/ling-3.0-flash-vl:free",
+			"name": "Ling 3.0 Flash VL (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			},
 			"compat": {
 				"supportsStore": true,
@@ -297818,7 +298606,7 @@
 		},
 		"meta-llama/llama-3.1-70b-instruct": {
 			"id": "meta-llama/llama-3.1-70b-instruct",
-			"name": "Llama 3.1 70B Instruct",
+			"name": "Llama-3.1-70B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -298475,9 +299263,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.35,
-				"output": 1.5,
-				"cacheRead": 0.04,
+				"input": 0.175,
+				"output": 0.75,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -298904,7 +299692,8 @@
 					"low",
 					"medium",
 					"high",
-					"xhigh"
+					"xhigh",
+					"max"
 				],
 				"defaultLevel": "medium",
 				"requiresEffort": true
@@ -298916,6 +299705,7 @@
 			},
 			"requiresGlyphTokenization": false,
 			"int": 62.1,
+			"tps": 196.9,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -299008,7 +299798,8 @@
 					"low",
 					"medium",
 					"high",
-					"xhigh"
+					"xhigh",
+					"max"
 				],
 				"defaultLevel": "medium",
 				"requiresEffort": true
@@ -300186,9 +300977,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 0.8999999999999999,
-				"cacheRead": 0.03,
+				"input": 0.15,
+				"output": 0.44999999999999996,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -300814,9 +301605,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.15,
-				"cacheRead": 0.015,
+				"input": 0.075,
+				"output": 0.075,
+				"cacheRead": 0.0075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -301266,9 +302057,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 1.5,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.25,
+				"output": 0.75,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -301743,9 +302534,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2,
-				"cacheRead": 0.04,
+				"input": 0.19999999999999998,
+				"output": 1,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -302204,9 +302995,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
-				"cacheRead": 0.015,
+				"input": 0.075,
+				"output": 0.3,
+				"cacheRead": 0.0075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -303721,9 +304512,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
-				"output": 3.4,
-				"cacheRead": 0.18,
+				"input": 0.71,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -304529,6 +305320,202 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"nex-agi/nex-n2.5-mini:free": {
+			"id": "nex-agi/nex-n2.5-mini:free",
+			"name": "Nex-N2.5-Mini (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"nex-agi/nex-n2.5-pro:free": {
+			"id": "nex-agi/nex-n2.5-pro:free",
+			"name": "Nex-N2.5-Pro (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 235929,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"nousresearch/deephermes-3-mistral-24b-preview": {
 			"id": "nousresearch/deephermes-3-mistral-24b-preview",
 			"name": "DeepHermes 3 Mistral 24B Preview",
@@ -305226,7 +306213,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 262144,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -305417,13 +306404,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 2.4,
-				"cacheRead": 0.12,
+				"input": 0.625,
+				"output": 3.125,
+				"cacheRead": 0.1875,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 182520,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -313672,6 +314659,420 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"int": 52.8,
+			"tps": 54.3,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-pro": {
+			"id": "openai/gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-pro:batch": {
+			"id": "openai/gpt-6-astra-pro:batch",
+			"name": "GPT-6 Astra Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra:batch": {
+			"id": "openai/gpt-6-astra:batch",
+			"name": "GPT-6 Astra (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "medium",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": true,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
 			"name": "GPT Audio",
@@ -318674,107 +320075,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.24,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 16384,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "qwen",
-				"revision": "3.0.0"
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openrouter",
-				"reasoningDisableMode": "openrouter-enabled-false",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": true,
-				"wireModelIdMode": "openrouter",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": true,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false,
-				"supportsLongPromptCacheRetention": false,
-				"strictResponsesPairing": false,
-				"supportsImageDetailOriginal": true,
-				"supportsObfuscationOptOut": false,
-				"supportsAllTurnsReasoningContext": false,
-				"supportsConfigurationUpdate": false,
-				"officialEndpoint": false,
-				"harmonyLeakMitigation": false,
-				"requiresReasoningOffJuiceInstruction": false,
-				"supportsReasoningSummary": true
-			},
-			"supportsComputerUseConfig": false
-		},
-		"qwen/qwen3-235b-a22b": {
-			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B-A22B",
-			"api": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"provider": "openrouter",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.45499999999999996,
-				"output": 1.8199999999999998,
+				"input": 0.22749999999999998,
+				"output": 0.9099999999999999,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -318861,6 +320163,96 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3-235b-a22b": {
+			"id": "qwen/qwen3-235b-a22b",
+			"name": "Qwen 3 235b A22B",
+			"api": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"provider": "openrouter",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.45499999999999996,
+				"output": 1.8199999999999998,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"requiresGlyphTokenization": false,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUseConfig": false
+		},
 		"qwen/qwen3-235b-a22b-2507": {
 			"id": "qwen/qwen3-235b-a22b-2507",
 			"name": "Qwen3 235B A22B Instruct 2507",
@@ -318872,13 +320264,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0875,
-				"output": 0.35,
+				"input": 0.22,
+				"output": 0.88,
 				"cacheRead": 0.0175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -320565,7 +321957,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next 80B-A3B Instruct",
+			"name": "Qwen3-Next-80B-A3B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -320574,13 +321966,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.09,
 				"output": 1.1,
 				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "qwen",
@@ -320764,7 +322156,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -321550,13 +322942,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.29,
-				"output": 2.4,
+				"input": 0.26,
+				"output": 2.08,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -321756,13 +323148,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
+				"input": 0.3125,
 				"output": 1.25,
-				"cacheRead": 0.25,
+				"cacheRead": 0.15625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -322468,13 +323860,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.5999999999999996,
-				"cacheRead": 0.12,
+				"input": 0.3,
+				"output": 2,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 235929,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -323490,7 +324882,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"tokenizer": "qwen3",
 			"requiresGlyphTokenization": false,
 			"identity": {
@@ -323984,6 +325376,109 @@
 				"supportsReasoningSummary": true
 			},
 			"supportsComputerUseConfig": false
+		},
+		"qwen/qwen3.8-max-0902": {
+			"id": "qwen/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"defaultLevel": "xhigh",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -325134,7 +326629,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -325730,7 +327225,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1024000,
-			"maxTokens": 26214,
+			"maxTokens": 819200,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
@@ -325820,7 +327315,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 471859,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -327899,6 +329394,107 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"x-ai/grok-4.3:batch": {
+			"id": "x-ai/grok-4.3:batch",
+			"name": "Grok 4.3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 900000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
 		"x-ai/grok-4.5": {
 			"id": "x-ai/grok-4.5",
 			"name": "Grok 4.5",
@@ -329321,7 +330917,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM-4.6",
+			"name": "GLM 4.6",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -329330,13 +330926,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
-				"cacheRead": 0.11,
+				"input": 0.43,
+				"output": 1.75,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -329724,7 +331320,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM-4.7-Flash",
+			"name": "GLM 4.7 Flash",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -329733,13 +331329,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.060500000000000005,
 				"output": 0.39999999999999997,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
-			"maxTokens": 16384,
+			"contextWindow": 200000,
+			"maxTokens": 117964,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330123,7 +331719,7 @@
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
-			"name": "GLM-5.2",
+			"name": "GLM 5.2",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -330132,13 +331728,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.966,
-				"output": 3.036,
-				"cacheRead": 0.1932,
+				"input": 0.28,
+				"output": 0.88,
+				"cacheRead": 0.052000000000000005,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330235,13 +331831,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048575,
-			"maxTokens": 131072,
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330439,11 +332035,11 @@
 			"cost": {
 				"input": 1.4,
 				"output": 4.4,
-				"cacheRead": 0.14,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 262144,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330541,9 +332137,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
@@ -330645,13 +332241,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.5,
-				"cacheRead": 0.03,
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048575,
-			"maxTokens": 943717,
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -330669,6 +332265,106 @@
 				"family": "flash",
 				"revision": "5.3.0"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"supportsConfigurationUpdate": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
+		},
+		"z-ai/glm-5.3:batch": {
+			"id": "z-ai/glm-5.3:batch",
+			"name": "GLM 5.3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 943718,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.3.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331148,6 +332844,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -331238,6 +332935,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -331328,6 +333026,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -331352,9 +333051,195 @@
 		}
 	},
 	"synthetic": {
+		"hf:MiniMaxAI/MiniMax-M3": {
+			"id": "hf:MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 1.2,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"int": 29.6,
+			"tps": 95.7,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m3"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:moonshotai/Kimi-K2.7-Code": {
+			"id": "hf:moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"int": 26.3,
+			"tps": 57,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"hf:moonshotai/Kimi-K3": {
 			"id": "hf:moonshotai/Kimi-K3",
-			"name": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331371,6 +333256,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331384,12 +333271,13 @@
 				},
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"identity": {
 				"class": "kimi",
 				"family": "k3"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331449,12 +333337,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331465,7 +333352,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1,
-				"cacheRead": 0.06,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -331480,10 +333367,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331537,12 +333425,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331553,11 +333440,13 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331566,11 +333455,12 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331624,8 +333514,99 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:Qwen/Qwen3.6-27B": {
+			"id": "hf:Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.45,
+				"output": 3.6,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"int": 21.9,
+			"tps": 55.7,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"hf:Qwen/Qwen3.8-27B": {
 			"id": "hf:Qwen/Qwen3.8-27B",
@@ -331719,7 +333700,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331730,11 +333711,13 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.5,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
 			"maxTokens": 65536,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331745,12 +333728,13 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "4.7.0"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331804,12 +333788,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331818,13 +333801,15 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.16,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 1.4,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331835,12 +333820,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331894,12 +333880,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.3-Flash": {
 			"id": "hf:zai-org/GLM-5.3-Flash",
-			"name": "zai-org/GLM-5.3-Flash",
+			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -331916,6 +333901,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -331926,13 +333913,14 @@
 				"defaultLevel": "max",
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "5.3.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -331986,8 +333974,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"syn:large:text": {
 			"id": "syn:large:text",
@@ -332457,7 +334444,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 14.2,
+			"int": 8.5,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
@@ -332539,7 +334526,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 21.4,
+			"int": 13.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -332799,8 +334786,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333385,8 +335372,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333475,8 +335462,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333566,8 +335553,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 250000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333641,7 +335628,7 @@
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
 			"id": "moonshotai/Kimi-K2-Instruct-0905",
-			"name": "Kimi-K2-Instruct-0905",
+			"name": "Kimi K2 0905",
 			"api": "openai-completions",
 			"provider": "together",
 			"baseUrl": "https://api.together.xyz/v1",
@@ -333739,7 +335726,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333832,8 +335819,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131000,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -333926,8 +335913,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334020,8 +336007,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334209,8 +336196,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 24.1,
-			"tps": 153,
+			"int": 12.3,
+			"tps": 194.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334298,8 +336285,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
-			"int": 15.2,
-			"tps": 128.4,
+			"int": 9,
+			"tps": 178.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334706,8 +336693,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 130000,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334798,8 +336785,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 85.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334889,8 +336876,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 500000,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -334980,8 +336967,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 500000,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.7.0"
@@ -335063,8 +337050,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 131072,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 74.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335244,8 +337231,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335336,8 +337323,8 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335428,8 +337415,8 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 164000,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335520,8 +337507,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 262144,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335613,8 +337600,8 @@
 			},
 			"contextWindow": 1048575,
 			"maxTokens": 400000,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -335708,8 +337695,8 @@
 				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"contextWindow": 1048576,
+			"maxTokens": 131071,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -335819,68 +337806,6 @@
 				"escapeBuiltinToolNames": true
 			}
 		},
-		"umans-deepseek-v4-flash-vision-exp-lab": {
-			"id": "umans-deepseek-v4-flash-vision-exp-lab",
-			"name": "Umans DeepSeek V4 Flash Vision Exp (lab)",
-			"api": "anthropic-messages",
-			"provider": "umans",
-			"baseUrl": "https://api.code.umans.ai",
-			"reasoning": true,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 393215,
-			"identity": {
-				"class": "unknown"
-			},
-			"requiresGlyphTokenization": false,
-			"compat": {
-				"officialEndpoint": false,
-				"signingEndpoint": false,
-				"supportsContextManagement": true,
-				"supportsOutputEffort": true,
-				"disableStrictTools": false,
-				"disableAdaptiveThinking": false,
-				"allowAnthropicHeaderOverrides": false,
-				"supportsEagerToolInputStreaming": false,
-				"supportsLongCacheRetention": false,
-				"supportsMidConversationSystem": false,
-				"supportsTurnScopedSystem": false,
-				"supportsMidConversationToolChanges": false,
-				"supportsPerMessageEffort": false,
-				"supportsThinkingBindingControls": false,
-				"supportsForcedToolChoice": true,
-				"supportsSamplingParams": true,
-				"requiresToolResultId": false,
-				"requiresThinkingEnabled": false,
-				"replayUnsignedThinking": true,
-				"escapeBuiltinToolNames": true,
-				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
-			},
-			"supportsComputerUse": false,
-			"compatConfig": {
-				"escapeBuiltinToolNames": true
-			}
-		},
 		"umans-deepseek-v4-pro-0813": {
 			"id": "umans-deepseek-v4-pro-0813",
 			"requiresGlyphTokenization": false,
@@ -335940,6 +337865,68 @@
 				"stripImageInput": false
 			},
 			"supportsComputerUseConfig": false,
+			"compatConfig": {
+				"escapeBuiltinToolNames": true
+			}
+		},
+		"umans-deepseek-v4.1-flash-lab": {
+			"id": "umans-deepseek-v4.1-flash-lab",
+			"name": "Umans DeepSeek V4.1 Flash (lab)",
+			"api": "anthropic-messages",
+			"provider": "umans",
+			"baseUrl": "https://api.code.umans.ai",
+			"reasoning": true,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 393215,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": true,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false,
 			"compatConfig": {
 				"escapeBuiltinToolNames": true
 			}
@@ -336129,21 +338116,22 @@
 				"escapeBuiltinToolNames": true
 			}
 		},
-		"umans-glm-5.3-flash-lab": {
-			"id": "umans-glm-5.3-flash-lab",
-			"name": "Umans GLM 5.3 Flash (lab)",
+		"umans-glm-5.3-flash": {
+			"id": "umans-glm-5.3-flash",
+			"name": "Umans GLM 5.3 Flash",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
 			"reasoning": true,
 			"thinking": {
-				"mode": "anthropic-budget-effort",
+				"mode": "budget",
 				"efforts": [
+					"minimal",
 					"low",
+					"medium",
 					"high",
-					"max"
+					"xhigh"
 				],
-				"defaultLevel": "max",
 				"requiresEffort": true
 			},
 			"input": [
@@ -336158,13 +338146,10 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131071,
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
-				"class": "glm",
-				"family": "flash",
-				"revision": "5.3.0"
+				"class": "unknown"
 			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -336834,8 +338819,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -336928,8 +338913,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 65.7,
-			"tps": 66.4,
+			"int": 53.4,
+			"tps": 67.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337023,8 +339008,8 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 32768,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337117,8 +339102,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337304,8 +339289,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337491,8 +339476,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -337770,8 +339755,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 63.1,
-			"tps": 58.7,
+			"int": 50.7,
+			"tps": 51.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338048,8 +340033,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338235,8 +340220,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338328,7 +340313,7 @@
 			},
 			"contextWindow": 160000,
 			"maxTokens": 32768,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338339,6 +340324,96 @@
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"deepseek-v4-1-flash": {
+			"id": "deepseek-v4-1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.375,
+				"output": 1.5,
+				"cacheRead": 0.0075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "deepseek-v3",
@@ -338417,8 +340492,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -338686,8 +340761,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -339583,6 +341658,168 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-glm-5-3-flash": {
+			"id": "e2ee-glm-5-3-flash",
+			"name": "e2ee-glm-5-3-flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-glm-5-3-p": {
+			"id": "e2ee-glm-5-3-p",
+			"name": "e2ee-glm-5-3-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-gpt-oss-120b-p": {
 			"id": "e2ee-gpt-oss-120b-p",
 			"name": "e2ee-gpt-oss-120b-p",
@@ -339745,6 +341982,168 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-kimi-k2-6": {
+			"id": "e2ee-kimi-k2-6",
+			"name": "e2ee-kimi-k2-6",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-kimi-k3-p": {
+			"id": "e2ee-kimi-k3-p",
+			"name": "e2ee-kimi-k3-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsUsageInStreaming": false
 			}
@@ -340235,6 +342634,87 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-qwen3-8-27b": {
+			"id": "e2ee-qwen3-8-27b",
+			"name": "e2ee-qwen3-8-27b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": false,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-qwen3-vl-30b-a3b-p": {
 			"id": "e2ee-qwen3-vl-30b-a3b-p",
 			"name": "e2ee-qwen3-vl-30b-a3b-p",
@@ -340416,8 +342896,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -340510,8 +342990,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -340604,8 +343084,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 37.4,
-			"tps": 390.5,
+			"int": 22.7,
+			"tps": 347.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -340698,8 +343178,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 51.6,
-			"tps": 182.3,
+			"int": 34.3,
+			"tps": 193.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -340792,8 +343272,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 56,
-			"tps": 310.5,
+			"int": 39.4,
+			"tps": 292.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -340886,8 +343366,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 58.7,
-			"tps": 326.9,
+			"int": 41.2,
+			"tps": 267.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -341657,8 +344137,8 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 128000,
-			"int": 38,
-			"tps": 106.7,
+			"int": 25.7,
+			"tps": 103.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342000,8 +344480,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 133.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342094,8 +344574,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 32000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342188,8 +344668,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 200000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342641,8 +345121,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 65536,
-			"int": 42.3,
-			"tps": 73.5,
+			"int": 25.5,
+			"tps": 74.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342732,7 +345212,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342825,8 +345305,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -342919,8 +345399,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -343110,8 +345590,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -343469,8 +345949,96 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 50000,
-			"int": 21.9,
-			"tps": 804.1,
+			"int": 11.5,
+			"tps": 743.9,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"mercury-2-5": {
+			"id": "mercury-2-5",
+			"name": "Mercury 2.5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04999999999999999,
+				"output": 0.18749999999999994,
+				"cacheRead": 0.004999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -344345,8 +346913,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 7.2,
-			"tps": 202.8,
+			"int": 6.8,
+			"tps": 165.6,
 			"identity": {
 				"class": "unknown"
 			},
@@ -344425,8 +346993,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 38.3,
-			"tps": 158.6,
+			"int": 23.4,
+			"tps": 156.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -345565,10 +348133,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26666667,
-				"output": 1.6,
-				"cacheRead": 0.02666667,
-				"cacheWrite": 0.33333334
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -345655,10 +348223,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 7.5,
-				"cacheRead": 0.125,
-				"cacheWrite": 1.5625
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -345745,10 +348313,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 6.25,
-				"output": 37.5,
-				"cacheRead": 0.625,
-				"cacheWrite": 7.8125
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -345835,10 +348403,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 6.25,
-				"output": 37.5,
-				"cacheRead": 0.625,
-				"cacheWrite": 7.8125
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -345925,10 +348493,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.125,
-				"output": 18.75,
-				"cacheRead": 0.3125,
-				"cacheWrite": 3.90625
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -346015,10 +348583,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.125,
-				"output": 18.75,
-				"cacheRead": 0.3125,
-				"cacheWrite": 3.90625
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -346035,6 +348603,186 @@
 			"identity": {
 				"class": "openai",
 				"revision": "56.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai-gpt-6-astra": {
+			"id": "openai-gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"openai-gpt-6-astra-pro": {
+			"id": "openai-gpt-6-astra-pro",
+			"name": "GPT-6 Astra Pro",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 12.5,
+				"output": 62.5,
+				"cacheRead": 1.25,
+				"cacheWrite": 15.625
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "openai",
+				"revision": "6.0.0"
 			},
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
@@ -346631,6 +349379,96 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"qwen-3-8-flash": {
+			"id": "qwen-3-8-flash",
+			"name": "Qwen 3.8 Flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.49,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "venice-disable-thinking",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"qwen-3-8-max": {
 			"id": "qwen-3-8-max",
 			"name": "Qwen 3.8 Max",
@@ -346739,8 +349577,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 18.4,
-			"tps": 57.1,
+			"int": 12,
+			"tps": 58.3,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.0.0"
@@ -346999,8 +349837,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 16384,
-			"int": 29.9,
-			"tps": 151.7,
+			"int": 19.3,
+			"tps": 142.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -347091,8 +349929,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 34.3,
-			"tps": 90.2,
+			"int": 19.1,
+			"tps": 78.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -347183,8 +350021,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 32768,
-			"int": 21.8,
-			"tps": 81.3,
+			"int": 13.7,
+			"tps": 85.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -347275,8 +350113,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 37.7,
-			"tps": 52.5,
+			"int": 21.9,
+			"tps": 55.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -347367,8 +350205,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
-			"int": 32.1,
-			"tps": 122.2,
+			"int": 18.8,
+			"tps": 128.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -347700,8 +350538,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"int": 20.9,
-			"tps": 54.1,
+			"int": 13.4,
+			"tps": 57.4,
 			"identity": {
 				"class": "qwen",
 				"family": "vl",
@@ -353143,7 +355981,6 @@
 		},
 		"deepseek/deepseek-v3.2": {
 			"id": "deepseek/deepseek-v3.2",
-			"requiresGlyphTokenization": false,
 			"name": "DeepSeek V3.2",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -353153,8 +355990,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.28,
-				"output": 0.42,
+				"input": 0.62,
+				"output": 1.85,
 				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
@@ -353171,11 +356008,12 @@
 				]
 			},
 			"tokenizer": "deepseek-v3",
+			"int": 25.1,
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
 			},
-			"int": 25.1,
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -353205,40 +356043,28 @@
 		},
 		"deepseek/deepseek-v3.2-thinking": {
 			"id": "deepseek/deepseek-v3.2-thinking",
-			"requiresGlyphTokenization": false,
 			"name": "DeepSeek V3.2 Thinking",
 			"api": "anthropic-messages",
-			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": true,
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0.62,
 				"output": 1.85,
-				"cacheRead": 0.028,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"requiresEffort": true
-			},
-			"tokenizer": "deepseek-v3",
 			"identity": {
 				"class": "deepseek",
 				"family": "v3"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -353258,7 +356084,7 @@
 				"supportsSamplingParams": true,
 				"requiresToolResultId": false,
 				"requiresThinkingEnabled": false,
-				"replayUnsignedThinking": true,
+				"replayUnsignedThinking": false,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": true,
@@ -353548,6 +356374,68 @@
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek"
+			},
+			"supportsComputerUse": false
+		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.8999999999999999,
+				"output": 0.8999999999999999,
+				"cacheRead": 0.44999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			},
 			"compat": {
 				"officialEndpoint": false,
@@ -354239,7 +357127,7 @@
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
 			"requiresGlyphTokenization": false,
-			"name": "Gemini 3.1 Pro (Preview)",
+			"name": "Gemini 3.1 Pro Preview",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -354796,6 +357684,64 @@
 			},
 			"supportsComputerUse": false
 		},
+		"inception/mercury-2.5": {
+			"id": "inception/mercury-2.5",
+			"name": "Mercury 2.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.15,
+				"cacheRead": 0.004,
+				"cacheWrite": 0
+			},
+			"contextWindow": 260000,
+			"maxTokens": 65536,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
 		"inception/mercury-coder-small": {
 			"id": "inception/mercury-coder-small",
 			"requiresGlyphTokenization": false,
@@ -354847,7 +357793,7 @@
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
 			"requiresGlyphTokenization": false,
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -355078,6 +358024,122 @@
 				"stripImageInput": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-flash-sante": {
+			"id": "inclusionai/ling-3.0-flash-sante",
+			"name": "Ling 3.0 Flash Sante",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"inclusionai/ling-3.0-flash-sante-free": {
+			"id": "inclusionai/ling-3.0-flash-sante-free",
+			"name": "Ling 3.0 Flash Sante (Free)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ling-3.0-tiny-free": {
 			"id": "inclusionai/ling-3.0-tiny-free",
@@ -356203,6 +359265,7 @@
 				]
 			},
 			"int": 62.1,
+			"tps": 196.9,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -361407,7 +364470,7 @@
 				"input": 0.39999999999999997,
 				"output": 2.4,
 				"cacheRead": 0.04,
-				"cacheWrite": 0.25
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -361531,7 +364594,7 @@
 				"input": 4,
 				"output": 20,
 				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -361655,7 +364718,7 @@
 				"input": 4,
 				"output": 24,
 				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -361673,6 +364736,130 @@
 				"class": "openai",
 				"family": "gpt",
 				"revision": "5.6.0"
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"int": 52.8,
+			"tps": 54.3,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-6-astra-fast": {
+			"id": "openai/gpt-6-astra-fast",
+			"name": "GPT-6 Astra (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 20,
+				"output": 100,
+				"cacheRead": 2,
+				"cacheWrite": 25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
 			},
 			"compat": {
 				"officialEndpoint": false,
@@ -363675,7 +366862,7 @@
 		"tencent/hy3": {
 			"id": "tencent/hy3",
 			"requiresGlyphTokenization": false,
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -364695,7 +367882,7 @@
 		"xai/grok-4.20-non-reasoning": {
 			"id": "xai/grok-4.20-non-reasoning",
 			"requiresGlyphTokenization": false,
-			"name": "Grok 4.20 Non-Reasoning",
+			"name": "Grok 4.20 (Non-Reasoning)",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -364717,6 +367904,8 @@
 				"family": "grok",
 				"revision": "4.20.0"
 			},
+			"int": 25.7,
+			"tps": 103.1,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -364799,7 +367988,7 @@
 		"xai/grok-4.20-reasoning": {
 			"id": "xai/grok-4.20-reasoning",
 			"requiresGlyphTokenization": false,
-			"name": "Grok 4.20 Reasoning",
+			"name": "Grok 4.20 (Reasoning)",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -364832,6 +368021,8 @@
 				"family": "grok",
 				"revision": "4.20.0"
 			},
+			"int": 25.7,
+			"tps": 103.1,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -366394,9 +369585,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7,
-				"output": 2.2,
-				"cacheRead": 0.13,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -368450,6 +371641,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368540,6 +371732,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368630,6 +371823,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368721,6 +371915,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368812,6 +372007,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368903,6 +372099,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -368993,6 +372190,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369083,6 +372281,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369173,6 +372372,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369263,6 +372463,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369365,6 +372566,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369472,6 +372674,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369579,6 +372782,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369686,6 +372890,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369781,6 +372986,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369872,6 +373078,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -369963,6 +373170,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370054,6 +373262,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370145,6 +373354,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370190,7 +373400,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -370239,6 +373449,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370290,7 +373501,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.4,
+			"int": 25.2,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -370339,6 +373550,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370444,6 +373656,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370543,6 +373756,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370653,6 +373867,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370701,8 +373916,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 30000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 133.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -370751,6 +373966,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370819,8 +374035,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -370869,6 +374085,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -370937,8 +374154,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 60.9,
-			"tps": 61.3,
+			"int": 44.4,
+			"tps": 55.4,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -370985,6 +374202,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371096,6 +374314,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371189,6 +374408,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371285,6 +374505,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371375,6 +374596,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371477,6 +374699,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371580,6 +374803,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371692,6 +374916,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371811,6 +375036,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -371932,6 +375158,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372052,6 +375279,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372157,6 +375385,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372259,6 +375488,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372361,6 +375591,7 @@
 				"isVercelGatewayHost": false,
 				"wireModelIdMode": "raw",
 				"alwaysSendMaxTokens": false,
+				"clampOutputToModelMax": false,
 				"supportsObfuscationOptOut": false,
 				"officialEndpoint": false,
 				"harmonyLeakMitigation": false,
@@ -372402,7 +375633,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -372500,7 +375731,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
-			"int": 35.9,
+			"int": 23.9,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -372597,7 +375828,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -372791,8 +376022,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -373078,7 +376309,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373258,8 +376489,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373442,7 +376673,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373622,8 +376853,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373806,7 +377037,7 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -373986,8 +377217,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -374098,7 +377329,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": null,
+			"maxTokens": 384000,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -374187,7 +377418,7 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374247,8 +377478,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 98304,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 51.3,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374370,8 +377601,8 @@
 			},
 			"contextWindow": 64000,
 			"maxTokens": 16384,
-			"int": 6.8,
-			"tps": 70.1,
+			"int": 6.7,
+			"tps": 32.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374431,8 +377662,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 54.8,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374493,8 +377724,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 56.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374554,8 +377785,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374615,8 +377846,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 23.3,
-			"tps": 82.9,
+			"int": 14.9,
+			"tps": 89.2,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374737,8 +377968,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374799,7 +378030,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374861,8 +378092,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -374923,8 +378154,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -374982,8 +378213,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -375045,8 +378276,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -375140,7 +378371,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -375184,6 +378415,164 @@
 		}
 	},
 	"zenmux": {
+		"alibaba/wan3.0-video": {
+			"id": "alibaba/wan3.0-video",
+			"name": "Wan3.0-Video",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"alibaba/wan3.0-video-prime": {
+			"id": "alibaba/wan3.0-video-prime",
+			"name": "Wan3.0-Video-Prime",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-3.5-haiku": {
 			"id": "anthropic/claude-3.5-haiku",
 			"requiresGlyphTokenization": true,
@@ -375372,8 +378761,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 62.1,
-			"tps": 69.6,
+			"int": 49.7,
+			"tps": 63.6,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -375743,8 +379132,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 35.6,
-			"tps": 46.8,
+			"int": 23.7,
+			"tps": 44.3,
 			"thinking": {
 				"mode": "anthropic-budget-effort",
 				"efforts": [
@@ -375807,8 +379196,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 38.8,
-			"tps": 36.7,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -375870,8 +379259,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55,
-			"tps": 52.2,
+			"int": 40.7,
+			"tps": 43.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -375935,8 +379324,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 57.3,
-			"tps": 61.5,
+			"int": 42,
+			"tps": 57.7,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -376189,8 +379578,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 36.8,
-			"tps": 43.7,
+			"int": 24.7,
+			"tps": 42.4,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -376251,8 +379640,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"int": 55.3,
-			"tps": 74.2,
+			"int": 38.4,
+			"tps": 76,
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
@@ -376379,7 +379768,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 22.3,
+			"int": 14.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -376573,6 +379962,95 @@
 			"identity": {
 				"class": "baidu",
 				"family": "ernie"
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bfl/flux-3-video": {
+			"id": "bfl/flux-3-video",
+			"name": "FLUX.3 Video",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			},
 			"compat": {
 				"supportsStore": true,
@@ -377260,6 +380738,85 @@
 			},
 			"supportsComputerUse": false
 		},
+		"bytedance/doubao-seed-asr-2.0": {
+			"id": "bytedance/doubao-seed-asr-2.0",
+			"name": "Doubao-Seed-ASR-2.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1024,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"bytedance/doubao-seed-character": {
 			"id": "bytedance/doubao-seed-character",
 			"name": "Doubao-Seed-Character",
@@ -377474,6 +381031,166 @@
 				"class": "bytedance",
 				"family": "doubao"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bytedance/doubao-seedance-2.0": {
+			"id": "bytedance/doubao-seedance-2.0",
+			"name": "Doubao-Seedance-2.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"bytedance/doubao-seedance-2.5": {
+			"id": "bytedance/doubao-seedance-2.5",
+			"name": "Doubao-Seedance-2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "bytedance",
+				"family": "doubao"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -377894,7 +381611,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378071,8 +381788,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 51.8,
-			"tps": 140,
+			"int": 34.5,
+			"tps": 138.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378432,8 +382149,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"int": 53.2,
-			"tps": 60.2,
+			"int": 36.3,
+			"tps": 68.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378594,6 +382311,96 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"deepseek/deepseek-v4.1-flash": {
+			"id": "deepseek/deepseek-v4.1-flash",
+			"name": "DeepSeek V4.1 Flash",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": true,
+				"thinkingLoopGuard": "deepseek",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"dots-studio/dots3-note-prev": {
 			"id": "dots-studio/dots3-note-prev",
@@ -378869,8 +382676,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 14.2,
-			"tps": 217.5,
+			"int": 9.9,
+			"tps": 186.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -378963,7 +382770,7 @@
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"int": 6.7,
-			"tps": 276.3,
+			"tps": 278.6,
 			"identity": {
 				"class": "gemini",
 				"family": "lite",
@@ -379046,8 +382853,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 25.9,
-			"tps": 121.9,
+			"int": 16.7,
+			"tps": 122.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -379506,8 +383313,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 65530,
-			"int": 25.6,
-			"tps": 278.8,
+			"int": 16,
+			"tps": 287.6,
 			"identity": {
 				"class": "gemini",
 				"family": "lite",
@@ -379571,6 +383378,87 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"google/gemini-3.1-flash-tts-preview": {
+			"id": "google/gemini-3.1-flash-tts-preview",
+			"name": "Gemini 3.1 Flash TTS Preview",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": null,
+			"identity": {
+				"class": "gemini",
+				"family": "flash",
+				"revision": "3.1.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "gemini",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
 			"name": "Gemini 3.1 Pro Preview",
@@ -379590,8 +383478,8 @@
 			},
 			"contextWindow": 1048000,
 			"maxTokens": 64000,
-			"int": 47.7,
-			"tps": 111.3,
+			"int": 30.4,
+			"tps": 110.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -379682,8 +383570,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"int": 52,
-			"tps": 204.6,
+			"int": 33,
+			"tps": 209.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -380234,7 +384122,8 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.2,
@@ -380801,7 +384690,7 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "Ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -381479,8 +385368,8 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 65000,
-			"int": 31.7,
-			"tps": 128.3,
+			"int": 17.3,
+			"tps": 115.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -381728,6 +385617,243 @@
 				"supportsPromptCacheKey": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"klingai/kling-3.0": {
+			"id": "klingai/kling-3.0",
+			"name": "Kling-3.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"klingai/kling-3.0-omni": {
+			"id": "klingai/kling-3.0-omni",
+			"name": "Kling-3.0-Omni",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"klingai/kling-3.0-turbo": {
+			"id": "klingai/kling-3.0-turbo",
+			"name": "Kling-3.0-Turbo",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 20000,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"kuaishou/kat-coder-air-v2.5": {
 			"id": "kuaishou/kat-coder-air-v2.5",
@@ -381983,7 +386109,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"int": 33.7,
+			"int": 21.7,
 			"identity": {
 				"class": "unknown"
 			},
@@ -382672,6 +386798,7 @@
 				]
 			},
 			"int": 62.1,
+			"tps": 196.9,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -382995,6 +387122,166 @@
 			},
 			"supportsComputerUse": false
 		},
+		"minimax/minimax-h3": {
+			"id": "minimax/minimax-h3",
+			"name": "MiniMax H3",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "minimax"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"minimax/minimax-h3-max": {
+			"id": "minimax/minimax-h3-max",
+			"name": "MiniMax H3 Max",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 12800,
+			"maxTokens": null,
+			"identity": {
+				"class": "minimax",
+				"effort": "max",
+				"logicalId": "minimax/minimax-h3"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
 			"name": "MiniMax M2",
@@ -383013,8 +387300,8 @@
 			},
 			"contextWindow": 204000,
 			"maxTokens": 64000,
-			"int": 28.9,
-			"tps": 97.3,
+			"int": 18.6,
+			"tps": 83.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383182,8 +387469,8 @@
 			},
 			"contextWindow": 204000,
 			"maxTokens": 64000,
-			"int": 32.1,
-			"tps": 96.3,
+			"int": 20.9,
+			"tps": 80.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383272,8 +387559,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97,
+			"int": 22.8,
+			"tps": 82.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383450,8 +387737,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131070,
-			"int": 38.9,
-			"tps": 76.8,
+			"int": 23.2,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -383629,8 +387916,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 512000,
-			"int": 45.4,
-			"tps": 89.4,
+			"int": 29.6,
+			"tps": 95.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -384157,7 +388444,7 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 64000,
-			"int": 36,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -384250,8 +388537,8 @@
 			},
 			"contextWindow": 262140,
 			"maxTokens": 262140,
-			"int": 45.1,
-			"tps": 40.1,
+			"int": 31.3,
+			"tps": 46,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -384345,8 +388632,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"int": 43,
-			"tps": 39,
+			"int": 26.3,
+			"tps": 57,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -384623,8 +388910,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 59.7,
-			"tps": 38,
+			"int": 43.8,
+			"tps": 35.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -384808,7 +389095,7 @@
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
-			"name": "Nex N2 Pro",
+			"name": "Nex-N2-Pro",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -385408,8 +389695,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 35.3,
-			"tps": 87,
+			"int": 23,
+			"tps": 69.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -385581,7 +389868,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 37,
+			"int": 24.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -385946,8 +390233,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 37.5,
-			"tps": 87.4,
+			"int": 24.7,
+			"tps": 95.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386044,7 +390331,6 @@
 				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -386098,7 +390384,8 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -386119,7 +390406,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 35.6,
+			"int": 23.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386210,7 +390497,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 31.3,
+			"int": 20.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386299,8 +390586,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 64000,
-			"int": 43.3,
-			"tps": 71.7,
+			"int": 30.4,
+			"tps": 68.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386472,7 +390759,7 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"int": 41.2,
+			"int": 28.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386732,8 +391019,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
-			"int": 45.5,
-			"tps": 123.1,
+			"int": 32.5,
+			"tps": 121.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386824,8 +391111,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 53.1,
-			"tps": 134.4,
+			"int": 39,
+			"tps": 134,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -386915,8 +391202,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 40.9,
-			"tps": 200.3,
+			"int": 24.6,
+			"tps": 218.5,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -386997,8 +391284,8 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"int": 39.7,
-			"tps": 162.3,
+			"int": 21.2,
+			"tps": 170.4,
 			"identity": {
 				"class": "openai",
 				"family": "gpt",
@@ -387170,8 +391457,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.3,
-			"tps": 85.7,
+			"int": 38.6,
+			"tps": 84.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387445,8 +391732,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 52.3,
-			"tps": 123.3,
+			"int": 37.5,
+			"tps": 109.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387538,8 +391825,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 60.9,
-			"tps": 76.5,
+			"int": 47.1,
+			"tps": 57.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387631,8 +391918,8 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"int": 56.6,
-			"tps": 103.2,
+			"int": 42.3,
+			"tps": 82.2,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -387704,6 +391991,99 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			}
+		},
+		"openai/gpt-6-astra": {
+			"id": "openai/gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "6.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"int": 52.8,
+			"tps": 54.3,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": false,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-image-1.5": {
 			"id": "openai/gpt-image-1.5",
@@ -387811,6 +392191,247 @@
 				"family": "gpt",
 				"revision": "2.0.0"
 			},
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-image-2.5-flare": {
+			"id": "openai/gpt-image-2.5-flare",
+			"name": "GPT-Image-2.5-Flare",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 0,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-image-2.5-sunburst": {
+			"id": "openai/gpt-image-2.5-sunburst",
+			"name": "GPT-Image-2.5-Sunburst",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 0,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-transcribe": {
+			"id": "openai/gpt-transcribe",
+			"name": "GPT Transcribe",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "openai",
+				"family": "gpt"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -388084,6 +392705,243 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"pixverse/c1": {
+			"id": "pixverse/c1",
+			"name": "C1",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"pixverse/v6": {
+			"id": "pixverse/v6",
+			"name": "V6",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "unknown"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen-audio-3.0-tts-plus": {
+			"id": "qwen/qwen-audio-3.0-tts-plus",
+			"name": "Qwen-Audio-3.0-TTS-Plus",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 20,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
 				"omitReasoningEffort": false,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
@@ -388639,8 +393497,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 24.5,
-			"tps": 42.7,
+			"int": 15.6,
+			"tps": 45.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -388800,6 +393658,85 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3-rerank": {
+			"id": "qwen/qwen3-rerank",
+			"name": "Qwen3 Rerank",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"qwen/qwen3-vl-embedding": {
 			"id": "qwen/qwen3-vl-embedding",
 			"name": "Qwen3 VL Embedding",
@@ -388808,7 +393745,8 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.1,
@@ -388914,6 +393852,87 @@
 				"family": "vl",
 				"revision": "3.0.0"
 			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen3-vl-rerank": {
+			"id": "qwen/qwen3-vl-rerank",
+			"name": "Qwen3 VL Rerank",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"family": "vl",
+				"revision": "3.0.0"
+			},
+			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -389338,8 +394357,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 40.5,
-			"tps": 55.7,
+			"int": 27,
+			"tps": 56.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -389519,8 +394538,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"int": 46.7,
-			"tps": 203.9,
+			"int": 29.9,
+			"tps": 175.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -389611,8 +394630,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
-			"int": 39.4,
-			"tps": 56.1,
+			"int": 25.8,
+			"tps": 56.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -389959,7 +394978,7 @@
 		},
 		"qwen/qwen3.8-max": {
 			"id": "qwen/qwen3.8-max",
-			"name": "Qwen3.8 Max",
+			"name": "Qwen3.8-Max",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -390051,7 +395070,7 @@
 		},
 		"qwen/qwen3.8-max-0902": {
 			"id": "qwen/qwen3.8-max-0902",
-			"name": "Qwen3.8-Max-0902",
+			"name": "Qwen3.8 Max 0902",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -390067,7 +395086,7 @@
 				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 131072,
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
@@ -390487,7 +395506,7 @@
 		},
 		"sapiens-ai/agnes-2.5-flash": {
 			"id": "sapiens-ai/agnes-2.5-flash",
-			"name": "Agnes-2.5-Flash",
+			"name": "Agnes 2.5 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -390576,7 +395595,7 @@
 		},
 		"sapiens-ai/agnes-2.5-pro": {
 			"id": "sapiens-ai/agnes-2.5-pro",
-			"name": "Agnes-2.5-Pro",
+			"name": "Agnes 2.5 Pro",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -390772,8 +395791,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 26.5,
-			"tps": 205,
+			"int": 17,
+			"tps": 216.3,
 			"identity": {
 				"class": "stepfun",
 				"family": "step"
@@ -390944,8 +395963,8 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"int": 30.9,
-			"tps": 105.7,
+			"int": 19.5,
+			"tps": 88.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -391201,7 +396220,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Tencent Hy3",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -391307,7 +396326,7 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"int": 34.4,
+			"int": 22.7,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -392637,8 +397656,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"int": 37.9,
-			"tps": 134.9,
+			"int": 25.4,
+			"tps": 133.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -392731,8 +397750,8 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"int": 55.8,
-			"tps": 56.3,
+			"int": 39.1,
+			"tps": 51.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393259,6 +398278,168 @@
 			},
 			"supportsComputerUse": false
 		},
+		"x-ai/grok-voice-stt-1.0": {
+			"id": "x-ai/grok-voice-stt-1.0",
+			"name": "Grok Voice STT 1.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "1.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"x-ai/grok-voice-tts-1.0": {
+			"id": "x-ai/grok-voice-tts-1.0",
+			"name": "Grok Voice TTS 1.0",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 15,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 15000,
+			"maxTokens": null,
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "1.0.0"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"xiaomi/mimo-v2-flash": {
 			"id": "xiaomi/mimo-v2-flash",
 			"name": "MiMo-V2-Flash",
@@ -393277,7 +398458,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"int": 25.1,
+			"int": 16,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393460,7 +398641,7 @@
 			},
 			"contextWindow": 265000,
 			"maxTokens": 265000,
-			"int": 35.9,
+			"int": 23.9,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393551,7 +398732,7 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 256000,
-			"int": 41.4,
+			"int": 28.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393715,6 +398896,88 @@
 				"supportsPromptCacheKey": false
 			}
 		},
+		"xiaomi/mimo-v2.5-asr": {
+			"id": "xiaomi/mimo-v2.5-asr",
+			"name": "MiMo-V2.5-ASR",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1024,
+			"maxTokens": null,
+			"identity": {
+				"class": "mimo",
+				"family": "v2"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {
+					"minimal": "low",
+					"xhigh": "high"
+				},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
 			"name": "MiMo-V2.5-Pro",
@@ -393733,8 +398996,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"int": 42.9,
-			"tps": 35.4,
+			"int": 26.4,
+			"tps": 36.4,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393825,7 +399088,7 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 19.7,
+			"int": 12.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -393915,8 +399178,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000,
-			"int": 16.7,
-			"tps": 84,
+			"int": 11.1,
+			"tps": 51.3,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394007,8 +399270,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 23.4,
-			"tps": 66.4,
+			"int": 14.9,
+			"tps": 54.8,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394099,8 +399362,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 56.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394372,8 +399635,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394643,8 +399906,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 40.6,
-			"tps": 66.5,
+			"int": 27.9,
+			"tps": 63.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394735,7 +399998,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 39.1,
+			"int": 26.6,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394827,8 +400090,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -394919,8 +400182,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -395187,9 +400450,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.25,
-				"cacheRead": 0.015,
+				"input": 0.15,
+				"output": 0.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -395378,7 +400641,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 128000,
-			"int": 35.3,
+			"int": 23.5,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -395741,8 +401004,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"int": 10.9,
-			"tps": 71.8,
+			"int": 8.4,
+			"tps": 56.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -395836,8 +401099,8 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
-			"int": 34.5,
-			"tps": 97.2,
+			"int": 22.2,
+			"tps": 70,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396023,7 +401286,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 39.1,
+			"int": 26.6,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396120,8 +401383,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 41,
-			"tps": 50.5,
+			"int": 26.4,
+			"tps": 64.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396217,8 +401480,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 52.6,
-			"tps": 69.1,
+			"int": 38.6,
+			"tps": 64.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396493,8 +401756,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 59.5,
-			"tps": 69.2,
+			"int": 44.9,
+			"tps": 58.1,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396592,8 +401855,8 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"int": 57.5,
-			"tps": 47.2,
+			"int": 41.9,
+			"tps": 85.2,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -396788,7 +402051,7 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 131072,
-			"int": 35.3,
+			"int": 23.5,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -6,6 +6,7 @@ import type {
 	KnownProvider,
 	Model,
 	ModelCost,
+	ModelPricingStatus,
 	TimeBasedCost,
 	TokenCost,
 	Usage,
@@ -57,6 +58,13 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 	const models = getProviderModels(provider);
 	return models ? (Array.from(models.values()) as Model<Api>[]) : [];
 }
+/** Resolve display semantics without mistaking an absent rate card for a free model. */
+export function getModelPricingStatus(model: Pick<Model<Api>, "cost" | "pricingStatus">): ModelPricingStatus {
+	const cost = model.cost;
+	if (cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0) return "fixed";
+	return model.pricingStatus ?? "unknown";
+}
+
 function resolveTokenCost(cost: ModelCost, promptInputTokens: number, timestamp: number | undefined): TokenCost {
 	let rates: ModelCost | EffectiveTokenCost = cost;
 	let effectiveFrom = -Infinity;

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -1,3 +1,4 @@
+import { CURSOR_DEFAULT_BASE_URL } from "../wire/cursor";
 import { PERSONAL_GITHUB_COPILOT_BASE_URL } from "../wire/github-copilot";
 
 export interface ModelCacheProviderIdOptions {
@@ -10,6 +11,7 @@ const CREDENTIAL_SCOPED_MODEL_CACHE_PROVIDERS: Readonly<Record<string, true>> = 
 	"opencode-zen": true,
 	"github-copilot": true,
 	"muse-code": true,
+	cursor: true,
 };
 
 /** Whether a provider's model-cache namespace requires its resolved credential. */
@@ -57,11 +59,16 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 	switch (providerId) {
 		case "ollama":
 			return resolveOllamaModelCacheProviderId(providerId, options.baseUrl);
-		case "cursor":
-			// v4: Grok 4.5/4.6 rows cached before the effort-less default-tier fix
-			// carry `requestModelId: *-low`, which the Start plan refuses; refetch
-			// so the collapsed default is re-pointed to `-medium` (issue #9478).
-			return "cursor:default-effort-v4";
+		case "cursor": {
+			// Cursor catalogs are entitlement-, admin-policy-, and privacy-mode
+			// scoped. A credential switch must never reuse another account's
+			// authoritative model rows.
+			// v3 invalidates zero-price rows written before discovery joined
+			// Cursor's first-party pricing document.
+			const baseUrl = (options.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
+			const scope = `${options.apiKey ?? ""}\u0000${baseUrl}`;
+			return `cursor:rich-models-v3:${Bun.hash(scope).toString(36)}`;
+		}
 		case "muse-code": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
 			const scope = `${options.apiKey ?? ""}\u0000${baseUrl}`;

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -109,6 +109,25 @@ function unionCodexModels(
 // Cursor
 // ---------------------------------------------------------------------------
 
+/**
+ * Minimal synchronous Cursor seed. Authenticated runtime discovery replaces
+ * this credential-agnostic fallback with the account's authoritative catalog.
+ */
+export const CURSOR_STATIC_MODELS: readonly ModelSpec<"cursor-agent">[] = [
+	{
+		id: "claude-4.6-opus-high",
+		name: "Claude Opus 4.6 1M",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "https://api2.cursor.sh",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 64_000,
+	},
+];
+
 export interface CursorModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
@@ -119,7 +138,8 @@ export function cursorModelManagerOptions(config: CursorModelManagerConfig = {})
 	const { apiKey, baseUrl, clientVersion } = config;
 	return {
 		providerId: "cursor",
-		cacheProviderId: resolveModelCacheProviderId("cursor"),
+		dynamicModelsAuthoritative: true,
+		cacheProviderId: resolveModelCacheProviderId("cursor", { apiKey, baseUrl }),
 		...(apiKey
 			? {
 					fetchDynamicModels: async () => {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1017,6 +1017,9 @@ export interface TokenCost {
 	cacheWrite: number;
 }
 
+/** User-facing interpretation of a model's token-rate card. */
+export type ModelPricingStatus = "fixed" | "free" | "included" | "variable" | "unknown";
+
 /**
  * Rates applied to the full request when its prompt exceeds `inputThreshold`,
  * or reaches it when `inputThresholdInclusive` is true. Prompt input is the
@@ -1072,6 +1075,19 @@ export type ModelTokenizer =
 	| "deepseek-v3"
 	| "kimi-k2"
 	| "glm5";
+
+/** One Cursor `RequestedModel.parameters` entry recovered from rich discovery. */
+export interface CursorModelParameter {
+	id: string;
+	value: string;
+}
+
+/** Cursor wire target selected after local effort/variant routing. */
+export interface CursorModelRoute {
+	modelId: string;
+	parameters: readonly CursorModelParameter[];
+	maxMode?: boolean;
+}
 
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
@@ -1138,7 +1154,27 @@ export interface Model<TApi extends Api = Api> {
 	gitlabDuoWorkflowRootNamespaceId?: string;
 	/** Cursor `max_mode` request flag returned by `GetUsableModels` for premium models that require max mode. */
 	cursorMaxMode?: boolean;
+	/** Cursor `RequestedModel.parameters` for this model's default variant. */
+	cursorModelParameters?: readonly CursorModelParameter[];
+	/**
+	 * Per-wire-id Cursor routes recovered from `AvailableModels`. Generic effort
+	 * collapse retains these while routing selects one key at request time.
+	 */
+	cursorModelRoutes?: Readonly<Record<string, CursorModelRoute>>;
+	/** Cursor's account-relative model price/multiplier; not a per-token USD rate. */
+	cursorPrice?: number;
+	/** Cursor requires data retention to invoke this model. */
+	cursorRequiresDataRetention?: boolean;
+	/** Cursor explicitly reports support for its Agent surface. */
+	cursorSupportsAgent?: boolean;
+	/** Cursor explicitly reports support for sandboxed execution. */
+	cursorSupportsSandboxing?: boolean;
 	cost: ModelCost;
+	/**
+	 * Interpretation of an all-zero token-rate card. Omitted zero-rate cards
+	 * are unknown; any non-zero rate is always treated as fixed pricing.
+	 */
+	pricingStatus?: Exclude<ModelPricingStatus, "fixed">;
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;
@@ -1202,6 +1238,8 @@ export interface Model<TApi extends Api = Api> {
 	isNew?: boolean;
 	/** Upstream marks this model as beta / preview quality. */
 	isBeta?: boolean;
+	/** Authenticated provider catalog marks this as the account's default model. */
+	isProviderDefault?: boolean;
 	/** Upstream marks this model as one of its recommended picks. */
 	isRecommended?: boolean;
 	/** Canonical thinking capability metadata for this model. */

--- a/packages/catalog/src/wire/cursor.ts
+++ b/packages/catalog/src/wire/cursor.ts
@@ -1,0 +1,32 @@
+/**
+ * Cursor wire constants shared by authenticated catalog discovery, the pi-ai
+ * provider, and account usage. Keep the announced client build aligned with the
+ * released Cursor agent CLI because the service gates protocol features on it.
+ */
+
+/** Default host for Cursor's Connect RPCs and account API. */
+export const CURSOR_DEFAULT_BASE_URL = "https://api2.cursor.sh";
+
+/** Released Cursor agent CLI build whose protocol surface this client mirrors. */
+export const CURSOR_CLIENT_VERSION = "cli-2026.09.02-c22c1a3";
+
+export const CURSOR_RUN_PATH = "/agent.v1.AgentService/Run";
+export const CURSOR_RUN_SSE_PATH = "/agent.v1.AgentService/RunSSE";
+export const CURSOR_BIDI_APPEND_PATH = "/aiserver.v1.BidiService/BidiAppend";
+export const CURSOR_GET_USABLE_MODELS_PATH = "/agent.v1.AgentService/GetUsableModels";
+export const CURSOR_GET_DEFAULT_MODEL_PATH = "/agent.v1.AgentService/GetDefaultModelForCli";
+export const CURSOR_AVAILABLE_MODELS_PATH = "/aiserver.v1.AiService/AvailableModels";
+
+/** Headers shared by Cursor's authenticated CLI RPCs. */
+export function cursorClientHeaders(
+	apiKey: string,
+	options: { clientVersion?: string; contentType?: "application/proto" | "application/connect+proto" } = {},
+): Record<string, string> {
+	return {
+		"content-type": options.contentType ?? "application/proto",
+		authorization: `Bearer ${apiKey}`,
+		"x-cursor-client-type": "cli",
+		"x-cursor-client-version": options.clientVersion ?? CURSOR_CLIENT_VERSION,
+		"x-ghost-mode": "true",
+	};
+}

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -8,8 +8,26 @@ import { buildModel } from "../src/build";
 // Import from source, not the package specifier: the workspace `node_modules`
 // copy resolves to the primary checkout, not this worktree.
 import { fetchCursorUsableModels } from "../src/discovery/cursor";
-import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "../src/discovery/cursor-proto";
-import { create, toBinary } from "../src/discovery/protobuf";
+import {
+	type AvailableModelsRequest,
+	AvailableModelsRequestSchema,
+	AvailableModelsResponse_ModelDetailsSchema,
+	AvailableModelsResponse_ModelVariantConfigSchema,
+	AvailableModelsResponseSchema,
+	GetDefaultModelForCliResponseSchema,
+	GetUsableModelsResponseSchema,
+	ModelDetailsSchema,
+	ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValueSchema,
+	ModelParameterDefinition_BooleanParameterDefinitionSchema,
+	ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema,
+	ModelParameterDefinition_EnumParameterDefinitionSchema,
+	ModelParameterDefinition_ModelParameterTypeSchema,
+	ModelParameterDefinitionSchema,
+	ModelParameterValueSchema,
+	ModelVendorId,
+} from "../src/discovery/cursor-proto";
+import { create, fromBinary, toBinary } from "../src/discovery/protobuf";
+import { collapseBuiltVariants } from "../src/compat/collapse";
 import { resolveProviderModels } from "../src/model-manager";
 import { cursorModelManagerOptions } from "../src/provider-models/special";
 import type { ModelSpec } from "../src/types";
@@ -122,7 +140,9 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 			"composer-2.5-fast",
 		];
 		for (const id of verifiedIds) {
-			expect(byId.get(id)?.input).toEqual(["text", "image"]);
+			const spec = byId.get(id);
+			expect(spec).toBeDefined();
+			if (spec) expect(buildModel(spec).input).toEqual(["text", "image"]);
 		}
 	});
 
@@ -132,15 +152,6 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 		expect(byId.get("cursor-grok-4.6-xhigh")?.reasoning).toBe(true);
 		// grok-code-* coding models lack the version digit and stay non-reasoning.
 		expect(byId.get("grok-code-fast-2")?.reasoning).toBe(false);
-	});
-
-	it("keeps bundled references authoritative outside verified image families", async () => {
-		const byId = await discover();
-		// The id-based native-family inference must not override bundled
-		// classifications in either direction.
-		expect(byId.get("claude-4.5-opus-high")?.input).toEqual(["text", "image"]);
-		expect(byId.get("claude-4.6-opus-high")?.input).toEqual(["text"]);
-		expect(byId.get("composer-1")?.input).toEqual(["text"]);
 	});
 
 	it("preserves fallback defaults for reference-less models", async () => {
@@ -198,6 +209,30 @@ function startCursorDiscoveryServer(body: Uint8Array): Promise<string> {
 	return promise;
 }
 
+function startCursorDiscoveryRpcServer(responses: Readonly<Record<string, Uint8Array>>): Promise<string> {
+	const { promise, resolve, reject } = Promise.withResolvers<string>();
+	const srv = http2.createServer();
+	servers.add(srv);
+	srv.once("error", reject);
+	srv.on("stream", (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+		stream.on("data", () => {});
+		stream.on("end", () => {
+			const body = responses[String(headers[":path"])];
+			if (!body) {
+				stream.respond({ ":status": 404 });
+				stream.end();
+				return;
+			}
+			stream.respond({ ":status": 200, "content-type": "application/proto" });
+			stream.end(Buffer.from(body));
+		});
+	});
+	srv.listen(0, "127.0.0.1", () => {
+		resolve(`http://127.0.0.1:${requireTcpAddress(srv.address()).port}`);
+	});
+	return promise;
+}
+
 async function createTempCachePath(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cursor-cache-"));
 	tempDirs.add(dir);
@@ -220,6 +255,408 @@ function cursorModelSpec(id: string): ModelSpec<"cursor-agent"> {
 }
 
 describe("fetchCursorUsableModels", () => {
+	it("joins rich model metadata, account defaults, routes, and ZDR eligibility", async () => {
+		const effortValues = [
+			create(ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, { value: "low" }),
+			create(ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, { value: "high" }),
+			create(ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, { value: "medium" }),
+			create(ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, { value: "max" }),
+			create(ModelParameterDefinition_EnumParameterDefinition_EnumParameterValueSchema, {
+				value: "xhigh",
+				blockedByAdminAllowlist: true,
+			}),
+		];
+		const effortDefinition = create(ModelParameterDefinitionSchema, {
+			id: "thinking_effort",
+			name: "Thinking effort",
+			parameterType: create(ModelParameterDefinition_ModelParameterTypeSchema, {
+				enumParameter: create(ModelParameterDefinition_EnumParameterDefinitionSchema, {
+					values: effortValues,
+				}),
+			}),
+		});
+		const variant = (
+			id: string,
+			effort: string,
+			isMaxMode: boolean,
+			isDefaultNonMaxConfig = false,
+			thinking: boolean | undefined = undefined,
+			context = "300k",
+		) =>
+			create(AvailableModelsResponse_ModelVariantConfigSchema, {
+				legacySlug: id,
+				displayName: effort,
+				isMaxMode,
+				isDefaultNonMaxConfig,
+				parameterValues: [
+					create(ModelParameterValueSchema, {
+						id: "thinking_effort",
+						value: effort,
+					}),
+					...(thinking === undefined
+						? []
+						: [
+								create(ModelParameterValueSchema, {
+									id: "thinking",
+									value: String(thinking),
+								}),
+							]),
+					create(ModelParameterValueSchema, {
+						id: "context",
+						value: context,
+					}),
+				],
+			});
+		const usable = create(GetUsableModelsResponseSchema, {
+			models: [
+				"claude-4.6-opus-low",
+				"claude-4.6-opus-high",
+				"claude-4.6-opus-max",
+				"claude-4.6-opus-xhigh",
+				"fable-retention",
+				"legacy-only",
+			].map(modelId => create(ModelDetailsSchema, { modelId })),
+		});
+		const available = create(AvailableModelsResponseSchema, {
+			models: [
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "claude-4.6-opus",
+					defaultOn: true,
+					supportsAgent: true,
+					supportsThinking: true,
+					supportsImages: true,
+					supportsSandboxing: true,
+					contextTokenLimit: 200_000,
+					contextTokenLimitForMaxMode: 1_000_000,
+					price: 2.5,
+					requiresDataRetention: false,
+					legacySlugs: [
+						"claude-4.6-opus-low",
+						"claude-4.6-opus-high",
+						"claude-4.6-opus-max",
+						"claude-4.6-opus-xhigh",
+					],
+					parameterDefinitions: [effortDefinition],
+					variants: [
+						variant("claude-4.6-opus-low", "low", false, true, false),
+						variant("claude-4.6-opus-high", "high", false, false, true),
+						variant("claude-4.6-opus-max", "max", true),
+						variant("claude-4.6-opus-medium", "medium", false),
+						variant("claude-4.6-opus-high", "max", true),
+						variant("claude-4.6-opus-xhigh", "xhigh", false),
+						variant("claude-4.6-opus-high", "high", true, false, true, "1m"),
+					],
+				}),
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "fable",
+					supportsAgent: true,
+					requiresDataRetention: true,
+					legacySlugs: ["fable-retention"],
+				}),
+			],
+		});
+		const providerDefault = create(GetDefaultModelForCliResponseSchema, {
+			model: create(ModelDetailsSchema, { modelId: "claude-4.6-opus-low" }),
+		});
+		const richBaseUrl = await startCursorDiscoveryRpcServer({
+			"/agent.v1.AgentService/GetUsableModels": toBinary(GetUsableModelsResponseSchema, usable),
+			"/aiserver.v1.AiService/AvailableModels": toBinary(AvailableModelsResponseSchema, available),
+			"/agent.v1.AgentService/GetDefaultModelForCli": toBinary(GetDefaultModelForCliResponseSchema, providerDefault),
+		});
+
+		const pricing = [
+			"| Model | Provider | Input | Cache write | Cache read | Output | Notes |",
+			"| --- | --- | --- | --- | --- | --- | --- |",
+			"| Claude 4.6 Opus | Anthropic | $5 | $6.25 | $0.5 | $25 | - |",
+		].join("\n");
+		const models = await fetchCursorUsableModels({
+			apiKey: "account-token",
+			baseUrl: richBaseUrl,
+			pricingUrl: `data:text/markdown,${encodeURIComponent(pricing)}`,
+			timeoutMs: 1_000,
+		});
+
+		expect(models?.map(model => model.id)).toEqual([
+			"claude-4.6-opus",
+			"claude-4.6-opus-1m",
+			"claude-4.6-opus-max-mode",
+			"legacy-only",
+		]);
+		const lane = models?.find(model => model.id === "claude-4.6-opus");
+		expect(lane).toEqual(
+			expect.objectContaining({
+				requestModelId: "claude-4.6-opus-low",
+				reasoning: true,
+				input: ["text", "image"],
+				supportsTools: true,
+				contextWindow: 300_000,
+				cursorPrice: 2.5,
+				cursorRequiresDataRetention: false,
+				cursorSupportsSandboxing: true,
+				isProviderDefault: true,
+				thinking: {
+					mode: "effort",
+					efforts: ["high"],
+					effortRouting: {
+						off: "claude-4.6-opus-low",
+						high: "claude-4.6-opus-high",
+					},
+				},
+			}),
+		);
+		expect(lane?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+		expect(lane?.cursorModelRoutes).toEqual({
+			"claude-4.6-opus-low": {
+				modelId: "claude-4.6-opus",
+				parameters: [
+					{ id: "thinking_effort", value: "low" },
+					{ id: "thinking", value: "false" },
+					{ id: "context", value: "300k" },
+				],
+				maxMode: false,
+			},
+			"claude-4.6-opus-high": {
+				modelId: "claude-4.6-opus",
+				parameters: [
+					{ id: "thinking_effort", value: "high" },
+					{ id: "thinking", value: "true" },
+					{ id: "context", value: "300k" },
+				],
+				maxMode: false,
+			},
+		});
+		const longContextLane = models?.find(model => model.id === "claude-4.6-opus-1m");
+		expect(longContextLane).toEqual(
+			expect.objectContaining({
+				contextWindow: 1_000_000,
+				thinking: expect.objectContaining({
+					efforts: ["high"],
+					requiresEffort: true,
+					effortRouting: { high: "claude-4.6-opus-high" },
+				}),
+			}),
+		);
+		const maxLane = models?.find(model => model.id === "claude-4.6-opus-max-mode");
+		expect(maxLane).toEqual(
+			expect.objectContaining({
+				contextWindow: 300_000,
+				reasoning: true,
+				thinking: expect.objectContaining({
+					efforts: ["max"],
+					requiresEffort: true,
+					effortRouting: { max: "claude-4.6-opus-max" },
+				}),
+			}),
+		);
+		expect(models?.some(model => model.id === "claude-4.6-opus-medium")).toBe(false);
+		expect(models?.some(model => model.id === "claude-4.6-opus-xhigh")).toBe(false);
+		expect(models?.some(model => model.id === "fable-retention")).toBe(false);
+
+		const collapsed = collapseBuiltVariants((models ?? []).map(model => buildModel(model)));
+		const rebuiltLane = collapsed.find(model => model.id === "claude-4.6-opus");
+		expect(rebuiltLane?.cursorPrice).toBe(2.5);
+		expect(rebuiltLane?.input).toEqual(["text", "image"]);
+		expect(rebuiltLane?.supportsTools).toBe(true);
+		expect(rebuiltLane?.cursorModelRoutes).toEqual(lane?.cursorModelRoutes);
+		expect(rebuiltLane?.thinking?.effortRouting).toEqual(lane?.thinking?.effortRouting);
+		expect(rebuiltLane?.isProviderDefault).toBe(true);
+	});
+
+	it("prices rich variants from Cursor's live document and declared multipliers", async () => {
+		const fastDefinition = create(ModelParameterDefinitionSchema, {
+			id: "fast",
+			name: "Fast",
+			markdownTooltip: "2x more expensive, but significantly faster.",
+			parameterType: create(ModelParameterDefinition_ModelParameterTypeSchema, {
+				booleanParameter: create(ModelParameterDefinition_BooleanParameterDefinitionSchema, {
+					values: [
+						create(ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValueSchema, {
+							value: "false",
+						}),
+						create(ModelParameterDefinition_BooleanParameterDefinition_BooleanParameterValueSchema, {
+							value: "true",
+							increasesModelCost: true,
+						}),
+					],
+				}),
+			}),
+		});
+		const fastVariant = (id: string, fast: boolean) =>
+			create(AvailableModelsResponse_ModelVariantConfigSchema, {
+				legacySlug: id,
+				parameterValues: [create(ModelParameterValueSchema, { id: "fast", value: String(fast) })],
+			});
+		const usable = create(GetUsableModelsResponseSchema, {
+			models: ["composer-2.5-fast", "composer-2.5", "claude-opus-4-8", "claude-opus-4-8-fast", "gpt-5.1"].map(
+				modelId => create(ModelDetailsSchema, { modelId }),
+			),
+		});
+		const available = create(AvailableModelsResponseSchema, {
+			models: [
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "composer-2.5",
+					clientDisplayName: "Composer 2.5",
+					supportsAgent: true,
+					legacySlugs: ["composer-2.5-fast", "composer-2.5"],
+					parameterDefinitions: [fastDefinition],
+					variants: [fastVariant("composer-2.5-fast", true), fastVariant("composer-2.5", false)],
+				}),
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "claude-opus-4-8",
+					clientDisplayName: "Claude Opus 4.8",
+					supportsAgent: true,
+					legacySlugs: ["claude-opus-4-8", "claude-opus-4-8-fast"],
+					parameterDefinitions: [fastDefinition],
+					variants: [fastVariant("claude-opus-4-8", false), fastVariant("claude-opus-4-8-fast", true)],
+				}),
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "gpt-5.1",
+					clientDisplayName: "GPT-5.1",
+					supportsAgent: true,
+				}),
+			],
+		});
+		const pricing = [
+			"| Notes | Output | Provider | Cache read | Model | Cache write | Input |",
+			"| --- | --- | --- | --- | --- | --- | --- |",
+			"| - | $2.5 | Cursor | $0.2 | Composer 2.5 | - | $0.5 |",
+			"| - | $15 | Cursor | $0.5 | Composer 2.5 (Fast) | - | $3 |",
+			"| - | $25 | Anthropic | $0.5 | [Claude 4.8 Opus](https://cursor.example/opus) | $6.25 | $5 |",
+		].join("\n");
+		const pricingBaseUrl = await startCursorDiscoveryRpcServer({
+			"/agent.v1.AgentService/GetUsableModels": toBinary(GetUsableModelsResponseSchema, usable),
+			"/aiserver.v1.AiService/AvailableModels": toBinary(AvailableModelsResponseSchema, available),
+		});
+
+		const models = await fetchCursorUsableModels({
+			apiKey: "account-token",
+			baseUrl: pricingBaseUrl,
+			pricingUrl: `data:text/markdown,${encodeURIComponent(pricing)}`,
+			timeoutMs: 1_000,
+		});
+		const byId = new Map((models ?? []).map(model => [model.id, model]));
+
+		expect(byId.get("composer-2.5")?.cost).toEqual({
+			input: 3,
+			output: 15,
+			cacheRead: 0.5,
+			cacheWrite: 0,
+		});
+		expect(byId.get("composer-2.5-standard")?.cost).toEqual({
+			input: 0.5,
+			output: 2.5,
+			cacheRead: 0.2,
+			cacheWrite: 0,
+		});
+		expect(byId.get("claude-opus-4-8")?.cost).toEqual({
+			input: 5,
+			output: 25,
+			cacheRead: 0.5,
+			cacheWrite: 6.25,
+		});
+		expect(byId.get("claude-opus-4-8-fast")?.cost).toEqual({
+			input: 10,
+			output: 50,
+			cacheRead: 1,
+			cacheWrite: 12.5,
+		});
+		expect(byId.get("gpt-5.1")?.cost).toEqual({
+			input: 1.25,
+			output: 10,
+			cacheRead: 0.125,
+			cacheWrite: 0,
+		});
+	});
+	it("decodes Cursor's length-delimited vendor metadata", () => {
+		const encoded = Uint8Array.from(Buffer.from("0a0766697874757265d202020801", "hex"));
+		const details = fromBinary(AvailableModelsResponse_ModelDetailsSchema, encoded);
+		expect(details.name).toBe("fixture");
+		expect(details.vendor?.id).toBe(ModelVendorId.ANTHROPIC);
+	});
+
+	it("uses Cursor's HTTP/1 unary RPC shape for rich discovery", async () => {
+		const usable = create(GetUsableModelsResponseSchema, {
+			models: [create(ModelDetailsSchema, { modelId: "default" })],
+		});
+		const available = create(AvailableModelsResponseSchema, {
+			models: [
+				create(AvailableModelsResponse_ModelDetailsSchema, {
+					name: "default",
+					supportsAgent: true,
+					supportsImages: true,
+					contextTokenLimit: 123_456,
+				}),
+			],
+		});
+		const providerDefault = create(GetDefaultModelForCliResponseSchema, {
+			model: create(ModelDetailsSchema, { modelId: "default" }),
+		});
+		const requests: {
+			path: string;
+			connectVersion: string | null;
+			clientType: string | null;
+			requestId: string | null;
+		}[] = [];
+		let decodedAvailableRequest: AvailableModelsRequest | undefined;
+		const httpServer = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				const url = new URL(request.url);
+				requests.push({
+					path: url.pathname,
+					connectVersion: request.headers.get("connect-protocol-version"),
+					clientType: request.headers.get("x-cursor-client-type"),
+					requestId: request.headers.get("x-request-id"),
+				});
+				const body = new Uint8Array(await request.arrayBuffer());
+				if (url.pathname === "/agent.v1.AgentService/GetUsableModels") {
+					return new Response(toBinary(GetUsableModelsResponseSchema, usable));
+				}
+				if (url.pathname === "/aiserver.v1.AiService/AvailableModels") {
+					decodedAvailableRequest = fromBinary(AvailableModelsRequestSchema, body);
+					return new Response(toBinary(AvailableModelsResponseSchema, available));
+				}
+				if (url.pathname === "/agent.v1.AgentService/GetDefaultModelForCli") {
+					return new Response(toBinary(GetDefaultModelForCliResponseSchema, providerDefault));
+				}
+				return new Response(null, { status: 404 });
+			},
+		});
+
+		try {
+			const models = await fetchCursorUsableModels({
+				apiKey: "account-token",
+				baseUrl: httpServer.url.toString(),
+				timeoutMs: 1_000,
+			});
+			expect(requests.map(request => request.path).sort()).toEqual(
+				[
+					"/agent.v1.AgentService/GetDefaultModelForCli",
+					"/agent.v1.AgentService/GetUsableModels",
+					"/aiserver.v1.AiService/AvailableModels",
+				].sort(),
+			);
+			expect(requests.every(request => request.connectVersion === "1")).toBe(true);
+			expect(requests.every(request => request.clientType === "cli")).toBe(true);
+			expect(requests.every(request => Boolean(request.requestId))).toBe(true);
+			expect(decodedAvailableRequest).toMatchObject({
+				useModelParameters: true,
+				doNotUseMarkdown: true,
+			});
+			expect(models).toEqual([
+				expect.objectContaining({
+					id: "default",
+					contextWindow: 123_456,
+					input: ["text", "image"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					isProviderDefault: true,
+				}),
+			]);
+		} finally {
+			httpServer.stop(true);
+		}
+	});
+
 	it("preserves Cursor max-mode metadata from GetUsableModels", async () => {
 		const response = create(GetUsableModelsResponseSchema, {
 			models: [

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -132,6 +132,14 @@ describe("generated model policies", () => {
 		expect(rebuiltGrok.requiresCursorToolSchemaProjection).toBeUndefined();
 	});
 
+	it("marks Cursor's default router as variably priced", () => {
+		const routed = buildGenerated(createSpec({ id: "default", api: "cursor-agent", provider: "cursor" }));
+		const named = buildGenerated(createSpec({ id: "composer-2.5", api: "cursor-agent", provider: "cursor" }));
+
+		expect(routed.pricingStatus).toBe("variable");
+		expect(named.pricingStatus).toBeUndefined();
+	});
+
 	it("preserves OpenRouter's mandatory provider-authored effort ladder", () => {
 		const models: ModelSpec<Api>[] = [
 			createSpec({

--- a/packages/catalog/test/provider-cache-id.test.ts
+++ b/packages/catalog/test/provider-cache-id.test.ts
@@ -51,3 +51,31 @@ test("ollama cache scope preserves reverse-proxy path prefixes", () => {
 	expect(teamA).toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a/" }));
 	expect(teamA).not.toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-b/v1" }));
 });
+
+test("cursor cache scope isolates account catalogs without exposing credentials", () => {
+	const accountA = resolveModelCacheProviderId("cursor", {
+		apiKey: "cursor-account-a",
+		baseUrl: "https://api2.cursor.sh/",
+	});
+	expect(accountA).toStartWith("cursor:rich-models-v3:");
+	expect(accountA).toBe(
+		resolveModelCacheProviderId("cursor", {
+			apiKey: "cursor-account-a",
+			baseUrl: "https://api2.cursor.sh",
+		}),
+	);
+	expect(accountA).not.toBe(
+		resolveModelCacheProviderId("cursor", {
+			apiKey: "cursor-account-b",
+			baseUrl: "https://api2.cursor.sh",
+		}),
+	);
+	expect(accountA).not.toBe(
+		resolveModelCacheProviderId("cursor", {
+			apiKey: "cursor-account-a",
+			baseUrl: "https://cursor-proxy.example",
+		}),
+	);
+	expect(accountA).not.toContain("cursor-account-a");
+	expect(accountA).not.toContain("api2.cursor.sh");
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Cursor sessions now start with the account-selected provider default model when the catalog advertises one ([#11613](https://github.com/can1357/oh-my-pi/pull/11613) by [@will-bogusz](https://github.com/will-bogusz)).
+
+### Fixed
+
+- Model browsing and JSON listings now distinguish fixed, variable, included, free, and unknown pricing instead of labeling every missing rate as free ([#11613](https://github.com/can1357/oh-my-pi/pull/11613) by [@will-bogusz](https://github.com/will-bogusz)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -13,6 +13,8 @@
  */
 import type { Api, Effort, Model } from "@oh-my-pi/pi-ai";
 import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
+import { getModelPricingStatus } from "@oh-my-pi/pi-catalog/models";
+import type { ModelPricingStatus } from "@oh-my-pi/pi-catalog/types";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
@@ -77,6 +79,7 @@ interface ModelJson {
 	thinking: readonly Effort[] | null;
 	input: ("text" | "image")[];
 	cost: Model<Api>["cost"];
+	pricingStatus: ModelPricingStatus;
 }
 
 interface ModelsJson {
@@ -117,6 +120,7 @@ function toModelJson(model: Model<Api>): ModelJson {
 		thinking: model.thinking ? getSupportedEfforts(model) : null,
 		input: model.input,
 		cost: model.cost,
+		pricingStatus: getModelPricingStatus(model),
 	};
 }
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -52,7 +52,8 @@ function isKnownProvider(provider: string): provider is KnownProvider {
 }
 
 /**
- * Pick the first provider-default model in availability order.
+ * Pick the first per-provider default in availability order. Authenticated
+ * catalog defaults and static descriptor defaults share that ordering.
  *
  * When `hasConcreteCredential` is supplied and at least one available model
  * belongs to a provider with a concrete credential, the candidate pool is
@@ -85,10 +86,28 @@ export function pickDefaultAvailableModel(
 					});
 					return concrete.length > 0 ? concrete : availableModels;
 				})();
-	const firstDefault = models.find(
-		model => isKnownProvider(model.provider) && DEFAULT_MODEL_PER_PROVIDER[model.provider] === model.id,
-	);
+	const defaultByProvider = new Map<string, Model<Api> | undefined>();
+	for (const model of models) {
+		if (!defaultByProvider.has(model.provider)) defaultByProvider.set(model.provider, undefined);
+		const current = defaultByProvider.get(model.provider);
+		if (model.isProviderDefault === true) {
+			if (current?.isProviderDefault !== true) defaultByProvider.set(model.provider, model);
+		} else if (
+			current === undefined &&
+			isKnownProvider(model.provider) &&
+			DEFAULT_MODEL_PER_PROVIDER[model.provider] === model.id
+		) {
+			defaultByProvider.set(model.provider, model);
+		}
+	}
+	let firstDefault: Model<Api> | undefined;
+	for (const candidate of defaultByProvider.values()) {
+		if (!candidate) continue;
+		firstDefault = candidate;
+		break;
+	}
 	if (!firstDefault) return models[0];
+	if (firstDefault.isProviderDefault === true) return firstDefault;
 
 	const providerPriority = buildModelProviderPriorityRank();
 	const sharedDefaultMatches = models.filter(

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -10,7 +10,7 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import { getModelPricingStatus, modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import {
 	type Component,
 	fuzzyRank,
@@ -355,16 +355,44 @@ export function formatRoleChip(role: string, assignment: RoleAssignment, setting
 	return theme.fg(info.color ?? "muted", `${theme.status.enabled} ${label}`) + suffix;
 }
 
-/** `$in/out` per-million cost pair; `free` when both legs are zero. */
+/** Compact input/output pricing for the model list's right-hand column. */
 function formatCostPair(model: Model): string {
+	const status = getModelPricingStatus(model);
+	if (status !== "fixed") {
+		switch (status) {
+			case "free":
+				return "free";
+			case "included":
+				return "included";
+			case "variable":
+				return "varies";
+			case "unknown":
+				return "unknown";
+		}
+	}
 	const cost = model.cost;
-	if (!cost || (cost.input <= 0 && cost.output <= 0)) return "free";
 	const fmt = (n: number): string => {
 		if (n <= 0) return "0";
 		const s = n >= 100 ? String(Math.round(n)) : n >= 10 ? n.toFixed(1) : n.toFixed(2);
 		return s.replace(/\.?0+$/, "");
 	};
 	return `$${fmt(cost.input)}/${fmt(cost.output)}`;
+}
+
+function formatPricingDetail(model: Model): string {
+	const status = getModelPricingStatus(model);
+	switch (status) {
+		case "fixed":
+			return `${formatCostPair(model)} per M`;
+		case "free":
+			return "free";
+		case "included":
+			return "included";
+		case "variable":
+			return "price varies";
+		case "unknown":
+			return "pricing unknown";
+	}
 }
 
 /** Provider-supplied blurb, flattened to a single renderable detail-line cell. */
@@ -958,7 +986,7 @@ export class ModelBrowser implements Component {
 		if (model.isRecommended) facts.push("recommended");
 		if (model.contextWindow) facts.push(`${formatNumber(model.contextWindow).toLowerCase()} ctx`);
 		if (model.maxTokens) facts.push(`${formatNumber(model.maxTokens).toLowerCase()} out`);
-		facts.push(`${formatCostPair(model)} per M`);
+		facts.push(formatPricingDetail(model));
 		if (model.reasoning) facts.push("reasoning");
 		if (model.input.includes("image")) facts.push("vision");
 		const intelligence = formatIntelligence(model);

--- a/packages/coding-agent/test/model-browser.test.ts
+++ b/packages/coding-agent/test/model-browser.test.ts
@@ -13,7 +13,9 @@ import {
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 /** Optional presentation metadata a catalog or discovery source may attach. */
-type NativeMetadata = Pick<Model, "description" | "isNew" | "isBeta" | "isRecommended" | "int" | "tps">;
+type NativeMetadata = Partial<
+	Pick<Model, "description" | "isNew" | "isBeta" | "isRecommended" | "int" | "tps" | "cost" | "pricingStatus">
+>;
 
 function makeModel(provider: string, id: string, metadata?: NativeMetadata): Model {
 	return buildModel({
@@ -249,12 +251,34 @@ describe("ModelBrowser native model metadata", () => {
 			}),
 		);
 
-		expect(detail).toContain("swe-2 · new · beta · recommended · 128k ctx · 1k out · free per M");
+		expect(detail).toContain("swe-2 · new · beta · recommended · 128k ctx · 1k out · pricing unknown");
 		// Tabs and newlines are flattened so the blurb stays one detail row.
-		expect(detail).toMatch(/free per M · Fast {2,}agentic coder$/);
+		expect(detail).toMatch(/pricing unknown · Fast {2,}agentic coder$/);
 	});
 
-	test("models without upstream metadata render the plain detail line", () => {
-		expect(renderDetail(makeModel("openai", "gpt-5"))).toContain("gpt-5 · 128k ctx · 1k out · free per M");
+	test("models without upstream metadata label missing rates as unknown", () => {
+		expect(renderDetail(makeModel("openai", "gpt-5"))).toContain("gpt-5 · 128k ctx · 1k out · pricing unknown");
+	});
+
+	test("distinguishes fixed, free, included, and variable pricing", () => {
+		expect(
+			renderDetail(
+				makeModel("openai", "metered", {
+					cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+					pricingStatus: "unknown",
+				}),
+			),
+		).toContain("$1.25/10 per M");
+		expect(renderDetail(makeModel("local", "free", { pricingStatus: "free" }))).toContain(" · free");
+		expect(renderDetail(makeModel("subscription", "included", { pricingStatus: "included" }))).toContain(
+			" · included",
+		);
+
+		const variable = makeModel("cursor", "default", { pricingStatus: "variable" });
+		const browser = new ModelBrowser(Settings.isolated({}));
+		browser.setItems(buildBrowserItems([variable]));
+		const lines = browser.render(160).map(line => Bun.stripANSI(line));
+		expect(lines[2]).toContain("varies");
+		expect(lines[lines.length - 2]).toContain("price varies");
 	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -454,6 +454,31 @@ describe("pickDefaultAvailableModel", () => {
 		expect(pickDefaultAvailableModel([paid])?.provider).toBe("xai");
 	});
 
+	test("uses an authenticated catalog model marked as the provider default", () => {
+		const cursorModel = (id: string, isProviderDefault = false) =>
+			buildModel({
+				id,
+				name: id,
+				api: "cursor-agent",
+				provider: "cursor",
+				baseUrl: "https://api2.cursor.sh",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200000,
+				maxTokens: 64000,
+				isProviderDefault,
+			});
+		const first = cursorModel("claude-4.6-opus-high");
+		const accountDefault = cursorModel("composer-2.5");
+
+		expect(pickDefaultAvailableModel([first, accountDefault])).toBe(first);
+		accountDefault.isProviderDefault = true;
+		const earlier = createOpusModel("anthropic", DEFAULT_MODEL_PER_PROVIDER.anthropic, "Claude Opus");
+		expect(pickDefaultAvailableModel([earlier, first, accountDefault])).toBe(earlier);
+		expect(pickDefaultAvailableModel([first, accountDefault])).toBe(accountDefault);
+	});
+
 	test("prefers a concretely-authed provider over a sentinel-only ambient provider (issue #9967)", () => {
 		const bedrockDefault = createBedrockDefaultModel();
 		const anthropicDefault = createOpusModel("anthropic", DEFAULT_MODEL_PER_PROVIDER.anthropic, "Claude Opus");


### PR DESCRIPTION
## Why

Cursor's agent API (the same HTTP/2 Connect service behind `cursor-agent` and the IDE) gates its real surface behind the account: the model roster, context limits, tool/image support, data-retention and max-mode requirements, and pricing all vary per subscription, admin policy, and privacy mode. OMP previously consumed only the legacy usable-model slug list, so selections could carry no parameters, no per-variant limits, and a zero price that the UI then reported as "free". Static analysis of the installed Cursor CLI plus read-only model and pricing RPCs established the contract; this PR adopts it end to end.

## What

| Capability | Before → now |
|---|---|
| Model lineup | Legacy slug list, no limits → rich discovery over `GetUsableModels`/`AvailableModels`: per-variant context/output limits, image/tool support, retention and max-mode flags, server-declared default model |
| Variant routing | Effort suffix stripped by regex → per-wire-id routes recovered from `AvailableModels` carry the exact `RequestedModel` parameter pairs; effort collapse retains every sibling as a route key |
| Request identity | Same base id on both model fields → paired identities the server validates independently: rich base + parameters on `requestedModel`, account-usable sibling on legacy `modelDetails`, plus `maxMode` |
| Pricing | Zero rates shown as "free" → rates join from Cursor's first-party `models-and-pricing.md`, falling back to the vendor's published list price; a `pricingStatus` axis distinguishes fixed / variable / included / free / unknown, and Cursor's `default` router is marked variable |
| Model browser / `omp models --json` | `free` for every unknown rate → explicit `varies` / `unknown` / `included` labels, and a machine-readable `pricingStatus` field |
| Transport | Run RPC only → official `RunSSE`/`BidiAppend` HTTP/1 fallback, structured service errors decoded into OMP's status vocabulary, authoritative `TurnEnded` token usage, checkpoint-safe resume |
| Caching | Shared per-provider rows → Cursor's model cache is scoped to credential + base URL, so one account's entitlements never leak into another's |

Non-goals: Cursor's `auto` router selection logic (OMP selects models itself), team/admin settings management, and any dependency on the Cursor CLI — auth stays on OMP's credential store and nothing requires Cursor installed.

## Testing

- `bun check` clean for `ai`, `catalog`, and `coding-agent` after rebasing onto current main (7 commits, generated `models.json`/`rules.json` regenerated against the merged sources).
- Focused suites: 628 tests across 28 files (Cursor transport, discovery, variant collapse, cache namespace, model browser, model resolver) — 628 pass, 0 fail.
- Live Cursor account: rich discovery returned 60 priced lanes (59 fixed, 1 variable), `cursor/default` resolves to the Auto router with `pricingStatus: "variable"`, and the model browser renders `price varies` for it.
- Verification commands: `bun test packages/ai/test/cursor*.test.ts packages/catalog/test/cursor-discovery.test.ts packages/coding-agent/test/model-browser.test.ts`; `omp models --json | jq '.models[] | select(.provider=="cursor")'`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
