### PR TITLE
fix(catalog): give DeepSeek V4.1 Flash its upstream capabilities

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added dated, announced price changes to the catalog, so rates switch on their effective date (e.g. DeepSeek Pro moving to Flash rates).
 
 - Added Command Code as a built-in provider with API-key login, live model discovery, per-model pricing, native OpenAI/Anthropic-compatible routing, cache-aware token usage, and TTFT metrics ([#11391](https://github.com/can1357/oh-my-pi/pull/11391) by [@CherkaSSH](https://github.com/CherkaSSH)).
+- DeepSeek V4.1 Flash (`deepseek-flash`) now accepts image inputs and resolves its reasoning metadata, name, and effort ladder from upstream instead of shipping as a text-only row without them.
 
 ### Fixed
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -429,6 +429,11 @@
 						"priority": 0
 					},
 					{
+						"id": "flash",
+						"glob": "*deepseek-flash",
+						"priority": 0
+					},
+					{
 						"id": "pro",
 						"glob": "*deepseek*v4*pro*",
 						"priority": 0
@@ -4575,7 +4580,20 @@
 				}
 			},
 			{
-				"source": "classes/deepseek.kdl:76",
+				"source": "classes/deepseek.kdl:78",
+				"class": "deepseek",
+				"models": [
+					{
+						"kind": "exact",
+						"value": "deepseek-flash"
+					}
+				],
+				"wire": {
+					"stripImageInput": false
+				}
+			},
+			{
+				"source": "classes/deepseek.kdl:81",
 				"class": "deepseek",
 				"providers": [
 					"ollama-cloud",

--- a/packages/catalog/src/compat/rules/classes/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/classes/deepseek.kdl
@@ -73,6 +73,11 @@ class "deepseek" {
 	models token="vision" {
 		strip-image-input #false
 	}
+	// V4.1 Flash is natively multimodal (vision encoder + projector, image-text
+	// pre-training) but its release id carries no `vision` token to key on.
+	models "deepseek-flash" {
+		strip-image-input #false
+	}
 	on "ollama-cloud" "nvidia" "deepseek" "fireworks" "nanogpt" "opencode-go" "openrouter" {
 		stream-markup-healing-pattern "dsml"
 	}

--- a/packages/catalog/src/compat/rules/providers/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/providers/deepseek.kdl
@@ -13,8 +13,8 @@ provider "deepseek" {
 	// First-party peak USD / 1M tokens; all other UTC hours receive 50% off.
 	// Source: https://api-docs.deepseek.com/quick_start/pricing (2026-09-10).
 	// residue: the pricing page's Flash-priced names, not a taxonomy family: the
-	// bare alias carries no family, and the retired `v4-flash`/`-vision-exp` ids
-	// are still accepted and billed at the Flash card.
+	// retired `v4-flash`/`-vision-exp` ids are still accepted and billed at the
+	// Flash card.
 	models "deepseek-flash" "deepseek-v4-flash" "deepseek-v4-flash-vision-exp" {
 		time-based-cost {
 			off-peak-multiplier 0.5
@@ -38,9 +38,9 @@ provider "deepseek" {
 			cache-write 0
 		}
 	}
-	// residue: upstream discovery has not seeded the bare alias's limits; the
-	// pricing page documents this SKU (DeepSeek-V4.1-Flash) as 1M context / 384K
-	// output, and without them the agent cannot enforce its context budget.
+	// residue: the pricing page documents this SKU (DeepSeek-V4.1-Flash) as 1M
+	// context / 384K output; pinned as a reviewed correction so the documented
+	// window survives an upstream metadata gap.
 	models "deepseek-flash" {
 		limits-patch {
 			context-window 1000000

--- a/packages/catalog/src/compat/rules/taxonomy/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/taxonomy/deepseek.kdl
@@ -5,6 +5,11 @@ class "deepseek" {
     family "r1" glob="*deepseek-r1*"
     family "reasoner" glob="*deepseek-reasoner*"
     family "flash" glob="*deepseek*v4*flash*"
+    // V4.1 Flash dropped the generation digit from its release id: the native
+    // roster serves it as bare `deepseek-flash`, which the `v4` glob cannot
+    // match. Without a family the descriptor's V4-generation filter drops the
+    // row, so it survived only as a stale previous-snapshot entry.
+    family "flash" glob="*deepseek-flash"
     family "pro" glob="*deepseek*v4*pro*"
     // Bare V4 chat/reasoner ids without a flash/pro segment.
     family "v4" glob="*deepseek-v4*"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -75847,13 +75847,14 @@
 	"deepseek": {
 		"deepseek-flash": {
 			"id": "deepseek-flash",
-			"name": "deepseek-flash",
+			"name": "DeepSeek V4.1 Flash",
 			"api": "openai-completions",
 			"provider": "deepseek",
 			"baseUrl": "https://api.deepseek.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.3,
@@ -75890,11 +75891,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
-			"identity": {
-				"class": "deepseek"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -75907,8 +75903,8 @@
 				"supportsUsageInStreaming": true,
 				"alwaysSendMaxTokens": false,
 				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
+				"disableReasoningOnToolChoice": true,
+				"supportsToolChoice": false,
 				"supportsForcedToolChoice": true,
 				"supportsNamedToolChoice": true,
 				"maxTokensField": "max_tokens",
@@ -75917,29 +75913,25 @@
 				"requiresThinkingAsText": false,
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
+				"reasoningDisableMode": "zai-thinking-disabled",
 				"omitReasoningEffort": false,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
 				"replayReasoningContent": false,
 				"qwenPreserveThinking": false,
 				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true,
 				"supportsPromptCacheBreakpoints": false,
 				"isOpenRouterHost": false,
 				"wireModelIdMode": "raw",
 				"isVercelGatewayHost": false,
 				"supportsStrictMode": true,
-				"extraBody": {
-					"thinking": {
-						"type": "enabled"
-					}
-				},
 				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 300000,
 				"stripDeepseekSpecialTokens": true,
 				"streamMarkupHealingPattern": "dsml",
 				"reasoningDeltasMayBeCumulative": false,
@@ -75949,13 +75941,102 @@
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
 				"clampOutputToModelMax": false,
-				"stripImageInput": true,
+				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"whenThinking": {
+					"supportsStore": false,
+					"supportsDeveloperRole": false,
+					"supportsMultipleSystemMessages": true,
+					"supportsReasoningEffort": true,
+					"supportsReasoningParams": true,
+					"supportsSamplingParams": true,
+					"supportsPenaltyAndStopParams": true,
+					"reasoningEffortMap": {},
+					"supportsUsageInStreaming": true,
+					"alwaysSendMaxTokens": false,
+					"disableReasoningOnForcedToolChoice": false,
+					"disableReasoningOnToolChoice": true,
+					"supportsToolChoice": false,
+					"supportsForcedToolChoice": true,
+					"supportsNamedToolChoice": true,
+					"maxTokensField": "max_tokens",
+					"requiresToolResultName": false,
+					"requiresAssistantAfterToolResult": false,
+					"requiresThinkingAsText": false,
+					"requiresMistralToolIds": false,
+					"thinkingFormat": "openai",
+					"reasoningDisableMode": "lowest-effort",
+					"omitReasoningEffort": false,
+					"includeEncryptedReasoning": true,
+					"filterReasoningHistory": false,
+					"reasoningContentField": "reasoning_content",
+					"requiresReasoningContentForToolCalls": true,
+					"requiresReasoningContentForAllAssistantTurns": true,
+					"allowsSyntheticReasoningContentForToolCalls": false,
+					"replayReasoningContent": false,
+					"qwenPreserveThinking": false,
+					"qwenTemplateReasoningEffort": false,
+					"requiresAssistantContentForToolCalls": true,
+					"supportsPromptCacheBreakpoints": false,
+					"isOpenRouterHost": false,
+					"wireModelIdMode": "raw",
+					"isVercelGatewayHost": false,
+					"supportsStrictMode": true,
+					"extraBody": {
+						"thinking": {
+							"type": "enabled"
+						}
+					},
+					"toolStrictMode": "mixed",
+					"streamIdleTimeoutMs": 300000,
+					"stripDeepseekSpecialTokens": true,
+					"streamMarkupHealingPattern": "dsml",
+					"reasoningDeltasMayBeCumulative": false,
+					"emptyLengthFinishIsContextError": false,
+					"usesOpenAIToolCallIdLimit": false,
+					"dropThinkingWhenReasoningEffort": false,
+					"nativeKimiK3Reasoning": false,
+					"zaiReasoningEffortDialect": false,
+					"clampOutputToModelMax": false,
+					"stripImageInput": false,
+					"thinkingLoopGuard": "deepseek",
+					"rejectRootObjectUnion": false,
+					"retryWithoutStrictOnGrammarError": false,
+					"supportsPromptCacheKey": false
+				}
 			},
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"maxTokensField": "max_tokens",
+				"supportsToolChoice": false,
+				"extraBody": {
+					"thinking": {
+						"type": "enabled"
+					}
+				},
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresAssistantContentForToolCalls": true
+			}
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",

--- a/packages/catalog/test/deepseek-v41-flash.test.ts
+++ b/packages/catalog/test/deepseek-v41-flash.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { Effort } from "../src/effort";
+import { getBundledModels } from "../src/models";
+import type { Model } from "../src/types";
+
+function bundled(provider: Parameters<typeof getBundledModels>[0], id: string): Model<"openai-completions"> {
+	const model = getBundledModels(provider).find(candidate => candidate.id === id);
+	if (!model) throw new Error(`${provider}/${id} is not bundled`);
+	return model as Model<"openai-completions">;
+}
+
+/**
+ * DeepSeek V4.1 Flash is natively multimodal (vision encoder + projector,
+ * image-text pre-training) but its release id carries no `vision` token, and
+ * the deepseek class default strips image inputs.
+ */
+describe("DeepSeek V4.1 Flash", () => {
+	test("the bundled native row accepts image input", () => {
+		const model = bundled("deepseek", "deepseek-flash");
+		expect(model.name).toBe("DeepSeek V4.1 Flash");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.compat.stripImageInput).toBe(false);
+		expect(model.identity).toMatchObject({ class: "deepseek", family: "flash" });
+		expect(model.thinking?.efforts).toEqual([Effort.Low, Effort.High, Effort.Max]);
+	});
+
+	test("the exemption does not widen to lookalike or retired SKUs", () => {
+		// Retired V4 SKUs stay text-only by reviewed census decision.
+		expect(bundled("deepseek", "deepseek-v4-flash").compat.stripImageInput).toBe(true);
+		expect(bundled("deepseek", "deepseek-v4-pro").compat.stripImageInput).toBe(true);
+		// Yolo-Auto resells the same model behind an id the release-name glob
+		// must not claim.
+		expect(bundled("yolo-auto", "deepseek-flash-v4").compat.stripImageInput).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Give the bundled DeepSeek V4.1 Flash row (`deepseek/deepseek-flash`) its real capabilities:

- it now accepts **image inputs** (native vision encoder + projector; DeepSeek's vision guide, the model card, and models.dev all put `deepseek-flash` at `text,image`),
- it gets its upstream **display name, `reasoning: true`, and the `low/high/max` effort ladder**,
- the retired `deepseek-v4-flash` / `deepseek-v4-flash-vision-exp` SKUs and yolo-auto's lookalike `deepseek-flash-v4` keep their existing policy.

Two rules changed, plus the regenerated `rules.json` and the one regenerated row:

- `taxonomy/deepseek.kdl` — V4.1 dropped the generation digit from its release id, so `deepseek-flash` matched no family glob.
- `classes/deepseek.kdl` — exempt the release id from the deepseek class default `strip-image-input`.

## Why

`isDeepseekV4Generation` (the DeepSeek descriptor's `filterModel`) accepts only families `v4` / `flash` / `pro`. `deepseek-flash` classified as class `deepseek` with **no family**, so the filter dropped the models.dev row at generation time and the model survived only through `mergePreviousSnapshotModels` — as a stale entry with a raw id for its name, `reasoning: false`, no `thinking` ladder, `input: ["text"]`, and `tool_choice`/`reasoning_content` compat that never picked up the descriptor's policy. Classifying the release id into the flash family makes the row generated from upstream again, so the descriptor's transport compat and models.dev attributes apply like they do for the sibling V4 SKUs.

Even with correct input metadata the model could not see images: the class default is `strip-image-input #true`, and the existing exemptions key on `ocr`/`vision` tokens, which the V4.1 release id does not carry. The exemption is intentionally an exact id — a `*deepseek-flash*` glob would also claim yolo-auto's `deepseek-flash-v4`, whose endpoint strips images for its own reasons.

## Testing

- `bun test` in `packages/catalog`: 925 pass / 0 fail (includes the new `test/deepseek-v41-flash.test.ts`, which pins the bundled row's name/reasoning/ladder/image policy and the two lookalike guards, plus `compat-parity`, `compat-compile`, and `time-based-pricing`).
- Catalog-dependent coding-agent tests: 157 pass / 0 fail.
- `bun check` in `packages/catalog`: clean (oxlint, oxfmt, tsgo).
- End-to-end: `omp models deepseek` reports `deepseek-flash  1M  384K  low,high,max  images yes`, with `v4-flash`/`v4-pro` still `images no`. Converting a message with an attachment through the real openai-completions converter emits one `image_url` block for `deepseek-flash` and zero for the text-only SKUs.

Note: `commandcode/deepseek/deepseek-v4.1-flash` is left text-only — that host is not in models.dev and I found no wire evidence for image support there.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
