### PR TITLE
fix(tui): retire finished streamed lines into terminal scrollback mid-turn

### DIFF
--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -233,6 +233,19 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"supports-function-part-id": wire("supportsFunctionPartId", ["google"]),
 
 	// ── wire: shared across surfaces ──
+	/**
+	 * Whether this wire may revise text it has already streamed: bytes
+	 * reclassified out of the visible channel (a leaned-on thinking opener),
+	 * carved into a tool call, reordered by content-block index, or replaced
+	 * wholesale by an authoritative final payload. Unassigned means the wire
+	 * only appends, so the transcript may retire finished lines into native
+	 * scrollback while the turn is still streaming (see
+	 * `AssistantMessageComponent`). Declare `possible` only with a citable
+	 * mechanism: the renderer also verifies published rows every frame and stops
+	 * retiring the block on the first mismatch, so this axis decides where
+	 * mid-stream retirement is attempted, not whether it is safe.
+	 */
+	"stream-revision": wire("streamRevision", [...OAI, "bedrock"], "scalar", ["none", "possible"]),
 	"stream-first-event-timeout-ms": wire("streamFirstEventTimeoutMs", [...OAI, "google"]),
 	"stream-idle-timeout-ms": wire("streamIdleTimeoutMs", [...OAI, "anthropic", "bedrock", "google"]),
 	"strip-image-input": wire("stripImageInput", [...OAI, "anthropic", "google"]),

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -5316,7 +5316,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:8",
+				"source": "classes/kimi.kdl:14",
 				"class": "kimi",
 				"providers": [
 					"baseten",
@@ -5343,7 +5343,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:14",
+				"source": "classes/kimi.kdl:20",
 				"class": "kimi",
 				"providers": [
 					"kimi-code",
@@ -5355,7 +5355,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:17",
+				"source": "classes/kimi.kdl:23",
 				"class": "kimi",
 				"providers": [
 					"kimi-code",
@@ -5367,7 +5367,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:23",
+				"source": "classes/kimi.kdl:29",
 				"class": "kimi",
 				"providers": [
 					"aiand",
@@ -5396,7 +5396,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:27",
+				"source": "classes/kimi.kdl:33",
 				"class": "kimi",
 				"family": "k3",
 				"wire": {
@@ -5418,7 +5418,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:42",
+				"source": "classes/kimi.kdl:48",
 				"class": "kimi",
 				"providers": [
 					"alibaba-coding-plan",
@@ -5439,7 +5439,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:46",
+				"source": "classes/kimi.kdl:52",
 				"class": "kimi",
 				"providers": [
 					"alibaba-coding-plan",
@@ -5451,7 +5451,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:51",
+				"source": "classes/kimi.kdl:57",
 				"class": "kimi",
 				"providers": [
 					"baseten",
@@ -5481,7 +5481,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:58",
+				"source": "classes/kimi.kdl:64",
 				"class": "kimi",
 				"providers": [
 					"cloudflare-ai-gateway",
@@ -5510,7 +5510,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:63",
+				"source": "classes/kimi.kdl:69",
 				"class": "kimi",
 				"providers": [
 					"cursor",
@@ -5531,7 +5531,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:68",
+				"source": "classes/kimi.kdl:74",
 				"class": "kimi",
 				"providers": [
 					"huggingface",
@@ -5548,7 +5548,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:73",
+				"source": "classes/kimi.kdl:79",
 				"class": "kimi",
 				"providers": [
 					"huggingface",
@@ -5572,7 +5572,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:78",
+				"source": "classes/kimi.kdl:84",
 				"class": "kimi",
 				"providers": [
 					"kilo",
@@ -5587,7 +5587,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:83",
+				"source": "classes/kimi.kdl:89",
 				"class": "kimi",
 				"providers": [
 					"kilo",
@@ -5606,7 +5606,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:88",
+				"source": "classes/kimi.kdl:94",
 				"class": "kimi",
 				"providers": [
 					"moonshot",
@@ -5623,7 +5623,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:93",
+				"source": "classes/kimi.kdl:99",
 				"class": "kimi",
 				"providers": [
 					"moonshot",
@@ -5642,7 +5642,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:98",
+				"source": "classes/kimi.kdl:104",
 				"class": "kimi",
 				"providers": [
 					"moonshot",
@@ -5659,7 +5659,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:104",
+				"source": "classes/kimi.kdl:110",
 				"class": "kimi",
 				"models": [
 					{
@@ -5672,7 +5672,7 @@
 				}
 			},
 			{
-				"source": "classes/kimi.kdl:108",
+				"source": "classes/kimi.kdl:114",
 				"class": "kimi",
 				"providers": [
 					"kimi-code",
@@ -5682,6 +5682,13 @@
 				"wire": {
 					"nativeKimiK3Reasoning": true,
 					"clampOutputToModelMax": true
+				}
+			},
+			{
+				"source": "classes/kimi.kdl:3",
+				"class": "kimi",
+				"wire": {
+					"streamRevision": "possible"
 				}
 			},
 			{
@@ -7083,7 +7090,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:6",
+				"source": "providers/amazon-bedrock.kdl:9",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -7104,7 +7111,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:10",
+				"source": "providers/amazon-bedrock.kdl:13",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -7132,7 +7139,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:16",
+				"source": "providers/amazon-bedrock.kdl:19",
 				"class": "openai",
 				"providers": [
 					"amazon-bedrock"
@@ -7142,7 +7149,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:19",
+				"source": "providers/amazon-bedrock.kdl:22",
 				"class": "deepseek",
 				"providers": [
 					"amazon-bedrock"
@@ -7160,7 +7167,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:24",
+				"source": "providers/amazon-bedrock.kdl:27",
 				"class": "minimax",
 				"providers": [
 					"amazon-bedrock"
@@ -7171,7 +7178,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:28",
+				"source": "providers/amazon-bedrock.kdl:31",
 				"class": "unknown",
 				"providers": [
 					"amazon-bedrock"
@@ -7187,7 +7194,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:33",
+				"source": "providers/amazon-bedrock.kdl:36",
 				"providers": [
 					"amazon-bedrock"
 				],
@@ -7199,6 +7206,15 @@
 				],
 				"thinking": {
 					"requiresEffort": true
+				}
+			},
+			{
+				"source": "providers/amazon-bedrock.kdl:3",
+				"providers": [
+					"amazon-bedrock"
+				],
+				"wire": {
+					"streamRevision": "possible"
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/classes/kimi.kdl
+++ b/packages/catalog/src/compat/rules/classes/kimi.kdl
@@ -1,6 +1,12 @@
 // Model-lineage compat for "kimi"; regenerated from the frozen census using class taxonomy selectors.
 
 class "kimi" {
+	// Kimi chat templates can revise bytes they have already streamed: a leaned-on
+	// thinking opener reclassifies visible text as reasoning, and native
+	// section/tool-call tokens are carved out of the visible channel mid-stream.
+	// Declared revision-possible so finished prose stays in the live viewport
+	// instead of retiring into native scrollback ahead of the turn.
+	stream-revision "possible"
 	// Replaces the K2.6 reasoning stream-idle baseline on OpenAI-compatible routes.
 	on "baseten" "cline-pass" "cloudflare-ai-gateway" "coreweave" "deepinfra" "firepass" "fireworks" \
 		"huggingface" "moonshot" "novita" "nvidia" "opencode-go" "opencode-zen" "openrouter" \

--- a/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
+++ b/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
@@ -1,6 +1,9 @@
 // Provider-wire compat for "amazon-bedrock"; regenerated from the frozen census using deployment contract selectors.
 
 provider "amazon-bedrock" {
+	// The Converse assembler positions content blocks by wire index
+	// (`amazon-bedrock.ts`), so a block can land above text already rendered.
+	stream-revision "possible"
 	class "anthropic" {
 		family "opus" {
 			revision ">=4.6 <4.7" {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -646,7 +646,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -748,7 +749,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -21278,7 +21280,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -21359,7 +21362,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -21440,7 +21444,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -21521,7 +21526,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -29796,7 +29802,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"thinking": {
 				"mode": "effort",
@@ -31481,7 +31488,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 2048,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31515,7 +31523,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31549,7 +31558,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31583,7 +31593,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31617,7 +31628,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31651,7 +31663,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -31696,7 +31709,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"anthropic.claude-opus-4-7": {
@@ -31741,7 +31755,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"anthropic.claude-opus-4-8": {
@@ -31786,7 +31801,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"anthropic.claude-opus-5": {
@@ -31831,7 +31847,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"anthropic.claude-sonnet-5": {
@@ -31876,7 +31893,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -31920,7 +31938,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-opus-4-6-v1": {
@@ -31964,7 +31983,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-opus-4-8": {
@@ -32009,7 +32029,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-opus-5": {
@@ -32054,7 +32075,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -32098,7 +32120,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-sonnet-4-6": {
@@ -32142,7 +32165,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"au.anthropic.claude-sonnet-5": {
@@ -32187,7 +32211,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"cohere.command-r-plus-v1:0": {
@@ -32216,7 +32241,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32246,7 +32272,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32288,7 +32315,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"deepseek.v3.2": {
@@ -32330,7 +32358,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"deepseek.v3.2-v1:0": {
@@ -32370,7 +32399,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32404,7 +32434,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 2048,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32438,7 +32469,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32472,7 +32504,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32506,7 +32539,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32540,7 +32574,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32574,7 +32609,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32608,7 +32644,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32654,7 +32691,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-fable-5-1": {
@@ -32700,7 +32738,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -32744,7 +32783,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-4-1-20250805-v1:0": {
@@ -32788,7 +32828,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-4-20250514-v1:0": {
@@ -32831,7 +32872,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -32876,7 +32918,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-4-6-v1": {
@@ -32920,7 +32963,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-4-7": {
@@ -32965,7 +33009,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-4-8": {
@@ -33010,7 +33055,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-opus-5": {
@@ -33055,7 +33101,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -33098,7 +33145,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -33143,7 +33191,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-sonnet-4-6": {
@@ -33187,7 +33236,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"eu.anthropic.claude-sonnet-5": {
@@ -33232,7 +33282,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.amazon.nova-2-lite-v1:0": {
@@ -33274,7 +33325,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-fable-5": {
@@ -33319,7 +33371,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-fable-5-1": {
@@ -33365,7 +33418,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -33409,7 +33463,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
@@ -33453,7 +33508,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-opus-4-6-v1": {
@@ -33497,7 +33553,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-opus-4-7": {
@@ -33542,7 +33599,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-opus-4-8": {
@@ -33587,7 +33645,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-opus-5": {
@@ -33632,7 +33691,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -33675,7 +33735,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -33720,7 +33781,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-sonnet-4-6": {
@@ -33764,7 +33826,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.anthropic.claude-sonnet-5": {
@@ -33809,7 +33872,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.openai.gpt-5.6-luna": {
@@ -33852,7 +33916,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.openai.gpt-5.6-sol": {
@@ -33895,7 +33960,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"global.openai.gpt-5.6-terra": {
@@ -33938,7 +34004,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"google.gemma-3-27b-it": {
@@ -33969,7 +34036,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"google.gemma-3-4b-it": {
@@ -34000,7 +34068,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -34044,7 +34113,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-opus-4-7": {
@@ -34089,7 +34159,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-opus-4-8": {
@@ -34134,7 +34205,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -34178,7 +34250,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-sonnet-4-6": {
@@ -34222,7 +34295,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"jp.anthropic.claude-sonnet-5": {
@@ -34267,7 +34341,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"meta.llama3-1-405b-instruct-v1:0": {
@@ -34296,7 +34371,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -34327,7 +34403,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"meta.llama3-1-8b-instruct-v1:0": {
@@ -34357,7 +34434,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"minimax.minimax-m2": {
@@ -34399,7 +34477,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"minimax.minimax-m2.1": {
@@ -34441,7 +34520,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"minimax.minimax-m2.5": {
@@ -34483,7 +34563,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.devstral-2-123b": {
@@ -34514,7 +34595,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.magistral-small-2509": {
@@ -34556,7 +34638,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.ministral-3-14b-instruct": {
@@ -34587,7 +34670,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.ministral-3-3b-instruct": {
@@ -34619,7 +34703,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.ministral-3-8b-instruct": {
@@ -34650,7 +34735,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.mistral-large-2402-v1:0": {
@@ -34680,7 +34766,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -34713,7 +34800,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.pixtral-large-2502-v1:0": {
@@ -34745,7 +34833,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.voxtral-mini-3b-2507": {
@@ -34776,7 +34865,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"mistral.voxtral-small-24b-2507": {
@@ -34807,7 +34897,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshot.kimi-k2-thinking": {
@@ -34850,7 +34941,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai.kimi-k2.5": {
@@ -34891,7 +34983,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"nvidia.nemotron-nano-12b-v2": {
@@ -34922,7 +35015,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"nvidia.nemotron-nano-3-30b": {
@@ -34962,7 +35056,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"nvidia.nemotron-nano-9b-v2": {
@@ -34994,7 +35089,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"nvidia.nemotron-super-3-120b": {
@@ -35034,7 +35130,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-120b": {
@@ -35075,7 +35172,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-120b-1:0": {
@@ -35116,7 +35214,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-20b": {
@@ -35157,7 +35256,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-20b-1:0": {
@@ -35198,7 +35298,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-safeguard-120b": {
@@ -35228,7 +35329,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"openai.gpt-oss-safeguard-20b": {
@@ -35258,7 +35360,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-235b-a22b-2507-v1:0": {
@@ -35289,7 +35392,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-32b-v1:0": {
@@ -35330,7 +35434,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-coder-30b-a3b-v1:0": {
@@ -35362,7 +35467,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-coder-480b-a35b-v1:0": {
@@ -35394,7 +35500,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-coder-next": {
@@ -35436,7 +35543,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-next-80b-a3b": {
@@ -35468,7 +35576,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"qwen.qwen3-vl-235b-a22b": {
@@ -35501,7 +35610,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-fable-5": {
@@ -35546,7 +35656,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-fable-5-1": {
@@ -35592,7 +35703,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -35636,7 +35748,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-4-1-20250805-v1:0": {
@@ -35680,7 +35793,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-4-5-20251101-v1:0": {
@@ -35724,7 +35838,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-4-6-v1": {
@@ -35768,7 +35883,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-4-7": {
@@ -35813,7 +35929,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-4-8": {
@@ -35858,7 +35975,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-opus-5": {
@@ -35903,7 +36021,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -35947,7 +36066,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-sonnet-4-6": {
@@ -35991,7 +36111,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us-gov.anthropic.claude-sonnet-5": {
@@ -36036,7 +36157,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.amazon.nova-lite-v1:0": {
@@ -36068,7 +36190,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			}
 		},
 		"us.amazon.nova-micro-v1:0": {
@@ -36099,7 +36222,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			}
 		},
 		"us.amazon.nova-premier-v1:0": {
@@ -36140,7 +36264,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36173,7 +36298,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
@@ -36206,7 +36332,8 @@
 				"promptCacheMode": "explicit",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
-				"promptCacheMaximumCheckpoints": 4
+				"promptCacheMaximumCheckpoints": 4,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36252,7 +36379,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-fable-5-1": {
@@ -36298,7 +36426,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -36342,7 +36471,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
@@ -36386,7 +36516,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-4-20250514-v1:0": {
@@ -36429,7 +36560,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36474,7 +36606,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-4-6-v1": {
@@ -36518,7 +36651,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-4-7": {
@@ -36563,7 +36697,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-4-8": {
@@ -36608,7 +36743,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-opus-5": {
@@ -36653,7 +36789,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 512,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -36696,7 +36833,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36741,7 +36879,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-sonnet-4-6": {
@@ -36785,7 +36924,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 1024,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.anthropic.claude-sonnet-5": {
@@ -36830,7 +36970,8 @@
 				"supportsLongPromptCacheRetention": true,
 				"promptCacheMinimumTokens": 4096,
 				"promptCacheMaximumCheckpoints": 4,
-				"streamIdleTimeoutMs": 900000
+				"streamIdleTimeoutMs": 900000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.deepseek.r1-v1:0": {
@@ -36871,7 +37012,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"us.meta.llama3-2-11b-instruct-v1:0": {
@@ -36901,7 +37043,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36931,7 +37074,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36961,7 +37105,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -36992,7 +37137,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -37023,7 +37169,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"us.meta.llama4-maverick-17b-instruct-v1:0": {
@@ -37054,7 +37201,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"us.meta.llama4-scout-17b-instruct-v1:0": {
@@ -37085,7 +37233,8 @@
 				"promptCacheMode": "none",
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
-				"promptCacheMaximumCheckpoints": 0
+				"promptCacheMaximumCheckpoints": 0,
+				"streamRevision": "possible"
 			}
 		},
 		"writer.palmyra-x4-v1:0": {
@@ -37125,7 +37274,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"writer.palmyra-x5-v1:0": {
@@ -37165,7 +37315,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"xai.grok-4.3": {
@@ -37206,7 +37357,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"xai.grok-4.6": {
@@ -37247,7 +37399,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"zai.glm-4.7": {
@@ -37287,7 +37440,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"zai.glm-4.7-flash": {
@@ -37327,7 +37481,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		},
 		"zai.glm-5": {
@@ -37367,7 +37522,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
-				"streamIdleTimeoutMs": 600000
+				"streamIdleTimeoutMs": 600000,
+				"streamRevision": "possible"
 			}
 		}
 	},
@@ -42664,7 +42820,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -42757,7 +42914,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -42858,7 +43016,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -45559,7 +45718,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -45644,7 +45804,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -45748,7 +45909,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"mimo-v2.5": {
@@ -51406,7 +51568,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"workers-ai/@cf/moonshotai/kimi-k2.7-code": {
@@ -51500,7 +51663,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"workers-ai/@cf/nvidia/nemotron-3-120b-a12b": {
@@ -54075,7 +54239,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -54171,7 +54336,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.7-Code": {
@@ -54265,7 +54431,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K3": {
@@ -54366,7 +54533,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -65724,7 +65892,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -65818,7 +65987,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -65920,7 +66090,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -70815,7 +70986,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		}
@@ -72391,7 +72563,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -72489,7 +72662,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -72588,7 +72762,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -72685,7 +72860,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -72783,7 +72959,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -72885,7 +73062,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -77708,7 +77886,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"thinking": {
 				"mode": "effort",
@@ -77819,7 +77998,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"thinking": {
 				"mode": "effort",
@@ -85618,7 +85798,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -85699,7 +85880,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -88234,7 +88416,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
@@ -88315,7 +88498,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2-Thinking": {
@@ -88411,7 +88595,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.5": {
@@ -88504,7 +88689,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.6": {
@@ -88599,7 +88785,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.7-Code": {
@@ -88693,7 +88880,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K3": {
@@ -88795,7 +88983,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"openai/gpt-oss-120b": {
@@ -93457,7 +93646,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"~openai/gpt-latest": {
@@ -114609,7 +114799,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-0905": {
@@ -114692,7 +114883,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
@@ -114773,7 +114965,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -114868,7 +115061,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.5": {
@@ -114961,7 +115155,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.5:free": {
@@ -115042,7 +115237,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -115138,7 +115334,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.6:free": {
@@ -115219,7 +115416,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -115314,7 +115512,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k3": {
@@ -115416,7 +115615,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"morph-warp-grep-v2": {
@@ -139515,7 +139715,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": true
+				"supportsPromptCacheKey": true,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -139611,7 +139812,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": true
+				"supportsPromptCacheKey": true,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -139703,7 +139905,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": true
+				"supportsPromptCacheKey": true,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -139790,7 +139993,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": true
+				"supportsPromptCacheKey": true,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -139888,7 +140092,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": true
+				"supportsPromptCacheKey": true,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		}
@@ -145722,7 +145927,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-0905-preview": {
@@ -145803,7 +146009,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-thinking": {
@@ -145898,7 +146105,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-thinking-turbo": {
@@ -145989,7 +146197,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-turbo-preview": {
@@ -146070,7 +146279,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2.5": {
@@ -146162,7 +146372,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2.6": {
@@ -146257,7 +146468,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2.7-code": {
@@ -146351,7 +146563,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2.7-code-highspeed": {
@@ -146443,7 +146656,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k3": {
@@ -146546,7 +146760,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshot-v1-128k": {
@@ -153364,7 +153579,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"brave": {
@@ -180107,7 +180323,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-thinking-preview": {
@@ -180187,7 +180404,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -190313,7 +190531,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -190395,7 +190614,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-instruct-0711": {
@@ -190476,7 +190696,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2-Instruct-0905": {
@@ -190557,7 +190778,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-thinking": {
@@ -190653,7 +190875,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-thinking-original": {
@@ -190734,7 +190957,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -190816,7 +191040,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -190900,7 +191125,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.5:thinking": {
@@ -190992,7 +191218,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.6": {
@@ -191076,7 +191303,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.6:thinking": {
@@ -191169,7 +191397,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.7-code": {
@@ -191263,7 +191492,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
@@ -191355,7 +191585,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k3": {
@@ -191457,7 +191688,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-latest": {
@@ -191548,7 +191780,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"nano-gpt-help": {
@@ -216688,7 +216921,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -216788,7 +217022,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -216873,7 +217108,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"TEE/kimi-k2.7-code": {
@@ -216967,7 +217203,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"TEE/kimi-k3": {
@@ -217069,7 +217306,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"TEE/llama3-3-70b": {
@@ -234533,7 +234771,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -234616,7 +234855,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -234714,7 +234954,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -234809,7 +235050,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -234906,7 +235148,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -235002,7 +235245,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -235106,7 +235350,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -247073,7 +247318,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -247155,7 +247401,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2-thinking": {
@@ -247250,7 +247497,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -247343,7 +247591,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -247439,7 +247688,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k3": {
@@ -247541,7 +247791,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"nv-mistralai/mistral-nemo-12b-instruct": {
@@ -263346,6 +263597,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -263399,7 +263651,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			},
 			"supportsComputerUse": false
@@ -263497,6 +263750,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -263551,7 +263805,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -263647,6 +263902,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -263700,7 +263956,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -263804,6 +264061,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -263862,7 +264120,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -271170,6 +271429,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -271223,7 +271483,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			},
 			"supportsComputerUse": false
@@ -271319,6 +271580,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -271372,7 +271634,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -271469,6 +271732,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -271523,7 +271787,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -271619,6 +271884,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -271672,7 +271938,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -271776,6 +272043,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"whenThinking": {
 					"supportsStore": false,
 					"supportsDeveloperRole": false,
@@ -271834,7 +272102,8 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
+					"supportsPromptCacheKey": false,
+					"streamRevision": "possible"
 				}
 			}
 		},
@@ -276279,6 +276548,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297104,6 +297374,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297198,6 +297469,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297290,6 +297562,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297394,6 +297667,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297497,6 +297771,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297602,6 +297877,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297705,6 +297981,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297809,6 +298086,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -297911,6 +298189,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -298024,6 +298303,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -298134,6 +298414,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false,
+				"streamRevision": "possible",
 				"supportsLongPromptCacheRetention": false,
 				"strictResponsesPairing": false,
 				"supportsImageDetailOriginal": true,
@@ -325457,7 +325738,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -327725,7 +328007,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -327819,7 +328102,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.6": {
@@ -327914,7 +328198,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K2.7-Code": {
@@ -328007,7 +328292,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/Kimi-K3": {
@@ -328109,7 +328395,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
@@ -336812,7 +337099,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-6": {
@@ -336906,7 +337194,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-7-code": {
@@ -337000,7 +337289,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k2-thinking": {
@@ -337096,7 +337386,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -337199,7 +337490,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"kimi-k3-fast-api": {
@@ -337299,7 +337591,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"llama-3.2-3b": {
@@ -361708,7 +362001,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -361805,7 +362099,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false,
 			"compatConfig": {
@@ -361910,7 +362205,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -362016,7 +362312,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false,
 			"compatConfig": {
@@ -377869,7 +378166,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -377953,7 +378251,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -378050,7 +378349,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -378143,7 +378443,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUseConfig": false
 		},
@@ -378237,7 +378538,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.6": {
@@ -378332,7 +378634,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.7-code": {
@@ -378426,7 +378729,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.7-code-free": {
@@ -378518,7 +378822,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
@@ -378609,7 +378914,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			},
 			"supportsComputerUse": false
 		},
@@ -378712,7 +379018,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"moonshotai/kimi-k3-free": {
@@ -378812,7 +379119,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"streamRevision": "possible"
 			}
 		},
 		"nex-agi/nex-n2-pro": {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -427,6 +427,8 @@ export interface OpenAICompat {
 	stripDeepseekSpecialTokens?: boolean;
 	/** Heal leaked chat-template/tool-call/thinking markup from visible content deltas. Default: auto-detected. */
 	streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
+	/** Whether this wire may revise already-streamed text (`stream-revision` axis). Unassigned: append-only. */
+	streamRevision?: "none" | "possible";
 	/** Treat an empty length-finished stream as a context-window error. Default: auto-detected. */
 	emptyLengthFinishIsContextError?: boolean;
 	/** Normalize tool call ids to OpenAI's 40-character limit. Default: auto-detected. */
@@ -585,6 +587,8 @@ export interface AnthropicCompat {
 export interface BedrockCompat {
 	/** Whether this endpoint accepts no checkpoints, automatic caching, or explicit cachePoint blocks. */
 	promptCacheMode?: "none" | "automatic" | "explicit";
+	/** Whether this wire may revise already-streamed text (`stream-revision` axis). Unassigned: append-only. */
+	streamRevision?: "none" | "possible";
 	/** Whether explicit cachePoint blocks accept `ttl: "1h"`; omitted TTL means Bedrock's 5-minute default. */
 	supportsLongPromptCacheRetention?: boolean;
 	/**
@@ -609,6 +613,8 @@ export interface BedrockCompat {
 /** Fully-resolved Bedrock Converse prompt-cache capabilities, materialized once by `buildModel`. */
 export interface ResolvedBedrockCompat {
 	promptCacheMode: NonNullable<BedrockCompat["promptCacheMode"]>;
+	/** See {@link BedrockCompat.streamRevision}. */
+	streamRevision?: BedrockCompat["streamRevision"];
 	supportsLongPromptCacheRetention: boolean;
 	promptCacheMinimumTokens: number;
 	promptCacheMaximumCheckpoints: number;
@@ -691,6 +697,8 @@ export interface ResolvedOpenAISharedCompat {
 	requiresAssistantContentForToolCalls: boolean;
 	stripDeepseekSpecialTokens: boolean;
 	streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
+	/** See {@link OpenAICompat.streamRevision}. */
+	streamRevision?: OpenAICompat["streamRevision"];
 	/** See {@link OpenAICompat.streamFirstEventTimeoutMs}. */
 	streamFirstEventTimeoutMs?: number;
 	reasoningDeltasMayBeCumulative: boolean;
@@ -787,6 +795,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "toolSchemaFlavor"
 			| "streamFirstEventTimeoutMs"
 			| "streamIdleTimeoutMs"
+			| "streamRevision"
 			| "cacheControlFormat"
 			| "thinkingKeep"
 			| "strictResponsesPairing"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Fixed long streamed replies being clipped to the live viewport until the turn ended; finished lines now retire into terminal scrollback while the response is still streaming. Models whose wire can revise text it has already streamed (`stream-revision`) keep the old behaviour ([#11276](https://github.com/can1357/oh-my-pi/issues/11276)).
+
 	- Fixed GPT-6 Astra extended-context support and preserved maximum context windows reported by OpenAI Codex discovery ([#10980](https://github.com/can1357/oh-my-pi/pull/10980) by [@H4vC](https://github.com/H4vC)).
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -38,20 +38,20 @@ const EMPTY_LINK_TARGETS: ReadonlyMap<string, string> = new Map();
 
 type ThinkingContentBlock = Extract<AssistantMessage["content"][number], { type: "thinking" }>;
 type DisplayThinkingContentBlock = ThinkingContentBlock & { rawThinking?: string };
-type StableThinkingPart = { kind: "thinking"; text: string } | { kind: "spacer" };
+type StablePart = { kind: "thinking" | "text"; text: string } | { kind: "spacer" };
 
 /**
- * One published prefix of the leading visible-thinking run. Later snapshots
- * extend earlier ones part-wise (only the final thinking part may grow), so
- * rendered stable rows only ever gain a suffix — the append-only transcript
- * contract that lets them retire into native scrollback mid-stream.
+ * One published prefix of the block's finished content. Later snapshots extend
+ * earlier ones part-wise (only the final part may grow), so rendered stable
+ * rows only ever gain a suffix — the append-only transcript contract that lets
+ * them retire into native scrollback mid-stream.
  */
-interface ThinkingStableSnapshot {
+interface StableSnapshot {
 	readonly key: string;
-	readonly parts: readonly StableThinkingPart[];
+	readonly parts: readonly StablePart[];
 }
 
-function isSnapshotExtension(previous: ThinkingStableSnapshot, current: ThinkingStableSnapshot): boolean {
+function isSnapshotExtension(previous: StableSnapshot, current: StableSnapshot): boolean {
 	if (previous.parts.length > current.parts.length) return false;
 	for (let index = 0; index < previous.parts.length; index++) {
 		const before = previous.parts[index]!;
@@ -193,6 +193,8 @@ export class AssistantMessageComponent extends Container {
 	#showToolResultImages = true;
 	#kittyConversionsInFlight = new Set<string>();
 	#transcriptBlockFinalized: boolean;
+	/** See {@link setMidStreamPublication}; the wire's `stream-revision` axis decides it. */
+	#midStreamPublication = true;
 	/**
 	 * When true, the turn-ending `Error: …` line for `stopReason === "error"` is
 	 * suppressed because the same error is currently shown in the pinned banner
@@ -245,7 +247,7 @@ export class AssistantMessageComponent extends Container {
 	#lastTokenCount: number | undefined;
 	#lastTokenTime = 0;
 	/** Published width-independent thinking prefixes; grows only, never retracts. */
-	#stableSnapshots: ThinkingStableSnapshot[] = [];
+	#stableSnapshots: StableSnapshot[] = [];
 	#transcriptStableRows: TranscriptStableRow[] = [];
 	/** Rendered stable rows memoized by `${count}:${width}`, insertion-evicted. */
 	#stableRenderCache = new Map<string, readonly string[]>();
@@ -420,6 +422,18 @@ export class AssistantMessageComponent extends Container {
 		this.hideThinkingBlock = hide;
 	}
 
+	/**
+	 * Allow or withhold retiring finished lines into native scrollback while the
+	 * turn is still streaming. Wires the `stream-revision` axis marks as able to
+	 * revise already-streamed text must withhold it: published bytes go to
+	 * terminal history once and cannot be retracted, so a later revision would
+	 * leave the reader with a stale copy. Withholding costs only reachability —
+	 * the block still retires whole when the turn ends.
+	 */
+	setMidStreamPublication(allowed: boolean): void {
+		this.#midStreamPublication = allowed;
+	}
+
 	setProseOnlyThinking(proseOnly: boolean): void {
 		this.proseOnlyThinking = proseOnly;
 	}
@@ -588,14 +602,15 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	/**
-	 * Publish the frozen prefix of the leading visible-thinking run as stable
-	 * transcript rows so a long reasoning stream can retire into native
-	 * scrollback mid-turn. Only thinking publishes: streamed text deltas can
-	 * revise earlier Markdown, and published bytes must never change — they may
-	 * already sit in terminal history. Every guard skips publication; nothing
-	 * ever retracts it.
+	 * Publish the block's finished prefix as stable transcript rows so a long
+	 * stream can retire into native scrollback mid-turn instead of being clipped
+	 * to the live viewport until the turn ends. Finished means bytes that can no
+	 * longer change: closed child blocks, plus the streaming child's frozen
+	 * Markdown prefix. Published bytes may already sit in terminal history, so
+	 * every guard skips publication and nothing ever retracts it.
 	 */
 	#publishStableSnapshot(rendered: readonly string[], width: number): void {
+		if (!this.#midStreamPublication) return;
 		const snapshot = this.#currentStableSnapshot();
 		if (!snapshot) return;
 		const previous = this.#stableSnapshots.at(-1);
@@ -617,35 +632,36 @@ export class AssistantMessageComponent extends Container {
 
 	/**
 	 * Width-independent parts eligible for publication right now: the leading
-	 * run of visible thinking blocks, ending inside the streaming block at
-	 * Markdown's frozen boundary. Undefined whenever any prefix byte could
-	 * still change (finalized or non-transient renders, marker rows, extension
-	 * components, hidden thinking, or no frozen prefix yet).
+	 * run of finished blocks, ending inside the streaming block at Markdown's
+	 * frozen boundary. Undefined whenever any prefix byte could still change
+	 * (finalized or non-transient renders, marker rows, extension components,
+	 * hidden thinking, or no frozen prefix yet).
 	 */
-	#currentStableSnapshot(): ThinkingStableSnapshot | undefined {
+	#currentStableSnapshot(): StableSnapshot | undefined {
 		if (this.#transcriptBlockFinalized || !this.#lastUpdateTransient) return undefined;
 		if (this.#markerSlot.children.length > 0) return undefined;
 		const items = this.#fastPathItems;
 		if (!items || items.length === 0) return undefined;
-		const parts: StableThinkingPart[] = [];
+		const parts: StablePart[] = [];
 		let itemIndex = 0;
 		for (const child of this.#contentContainer.children) {
 			const item = items[itemIndex];
 			if (item?.md === child) {
-				// Text blocks never publish: their deltas can revise earlier rows.
-				if (item.blockType !== "thinking") break;
 				if (itemIndex === items.length - 1) {
-					// Streaming block: publish Markdown's frozen prefix, and only
-					// once non-blank content exists past it — the thinking fold may
-					// still rewrite the display text's last non-blank line (prose
-					// ellipsis), which must stay out of published bytes.
-					const frozen = item.md.getLastRenderStableText();
-					if (frozen.length > 0 && /\S/.test(item.lastText.slice(frozen.length))) {
-						parts.push({ kind: "thinking", text: frozen });
+					// Streaming child: publish Markdown's frozen prefix, and only
+					// once non-blank content exists past it — the block's last
+					// non-blank line is still being written (thinking's prose fold
+					// may rewrite it) and must stay out of published bytes.
+					const raw = item.md.getLastRenderStableText();
+					const frozen = raw.trim();
+					if (frozen.length > 0 && /\S/.test(item.lastText.slice(raw.length))) {
+						parts.push({ kind: item.blockType, text: frozen });
 					}
 					break;
 				}
-				parts.push({ kind: "thinking", text: item.lastText });
+				// Closed child: only the streaming tail may mutate in place, so
+				// everything before it is final.
+				parts.push({ kind: item.blockType, text: item.lastText });
 				itemIndex++;
 				continue;
 			}
@@ -657,23 +673,36 @@ export class AssistantMessageComponent extends Container {
 			break;
 		}
 		while (parts.at(-1)?.kind === "spacer") parts.pop();
-		if (!parts.some(part => part.kind === "thinking")) return undefined;
+		if (parts.length === 0) return undefined;
 		return { key: JSON.stringify(parts), parts };
 	}
 
-	#renderStableSnapshot(snapshot: ThinkingStableSnapshot, width: number): readonly string[] {
+	#renderStableSnapshot(snapshot: StableSnapshot, width: number): readonly string[] {
 		const rows: string[] = [];
 		for (const part of snapshot.parts) {
 			if (part.kind === "spacer") {
 				rows.push("");
 				continue;
 			}
-			// Constructor args mirror the live thinking Markdown exactly so these
-			// rows are byte-identical to the block render's prefix.
-			const markdown = new Markdown(part.text, 1, 0, getMarkdownTheme(), {
-				color: (text: string) => theme.fg("thinkingText", text),
-				italic: true,
-			});
+			// Constructor args mirror the live child Markdown exactly so these
+			// rows are byte-identical to the block render's prefix — including the
+			// trim the live children apply, which drops the trailing blank line a
+			// frozen prefix still carries.
+			const text = part.text.trim();
+			const markdown =
+				part.kind === "text"
+					? new Markdown(
+							text,
+							1,
+							0,
+							this.#getProseTheme(),
+							this.#textColorTransform ? { color: this.#textColorTransform } : undefined,
+							0,
+						)
+					: new Markdown(text, 1, 0, getMarkdownTheme(), {
+							color: (value: string) => theme.fg("thinkingText", value),
+							italic: true,
+						});
 			rows.push(...markdown.render(width));
 		}
 		return rows;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -441,21 +441,35 @@ export class TranscriptContainer extends Container {
 			head.state !== "committed" &&
 			head.emitted < head.stableRows.length
 		) {
-			const emittedEnd = head.emitted + 1;
+			// Emit as many finished rows as the overflow needs, in one batch. A
+			// fast stream adds finished rows quicker than one per pressure cycle,
+			// and the live region has to fall back under `room` to stay readable:
+			// rows left behind here are rows dropped from the top of the viewport.
+			const overflow = total - room;
 			const before = this.#renderStablePrefix(head, head.emitted, width);
-			const after = this.#renderStablePrefix(head, emittedEnd, width);
-			if (!isRowPrefix(before, after) || after.length === before.length) {
-				this.#freezeStableRows(head, EMPTY_ROWS, "semantic row render added no suffix");
-				return undefined;
+			let emittedEnd = head.emitted;
+			let rows: readonly string[] = EMPTY_ROWS;
+			while (emittedEnd < head.stableRows.length && rows.length < overflow) {
+				const after = this.#renderStablePrefix(head, emittedEnd + 1, width);
+				if (!isRowPrefix(before, after) || after.length === before.length) {
+					if (emittedEnd === head.emitted) {
+						this.#freezeStableRows(head, EMPTY_ROWS, "semantic row render added no suffix");
+					}
+					break;
+				}
+				rows = after.slice(before.length);
+				emittedEnd += 1;
 			}
-			const batch: HistoryBatch = {
-				id: this.#nextBatchId++,
-				rows: after.slice(before.length),
-				kind: "append",
-			};
-			this.#offered = { batch, kind: "append", entry: this.#frontier, emittedEnd };
-			this.#pinnedFrontier = undefined;
-			return batch;
+			if (emittedEnd > head.emitted) {
+				const batch: HistoryBatch = {
+					id: this.#nextBatchId++,
+					rows,
+					kind: "append",
+				};
+				this.#offered = { batch, kind: "append", entry: this.#frontier, emittedEnd };
+				this.#pinnedFrontier = undefined;
+				return batch;
+			}
 		}
 
 		let end = this.#frontier;
@@ -492,8 +506,10 @@ export class TranscriptContainer extends Container {
 		if (offered === undefined || offered.batch.id !== id) return;
 		if (offered.kind === "append") {
 			const entry = this.#entries[offered.entry];
-			if (entry === undefined || offered.entry !== this.#frontier || offered.emittedEnd !== entry.emitted + 1)
-				return;
+			// The offered end must still extend this entry's emitted prefix: a
+			// stale offer (already-advanced entry) or a retraction (entry reset to
+			// zero with the offer still live) must not move it backwards.
+			if (entry === undefined || offered.entry !== this.#frontier || offered.emittedEnd <= entry.emitted) return;
 			entry.emitted = offered.emittedEnd;
 		} else if (offered.kind === "commit") {
 			for (let index = this.#frontier; index < offered.end; index++) {

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -114,5 +114,11 @@ export function createAssistantMessageComponent(
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
 	component.setToolResultImagesVisible(!ctx.hideToolActivity);
 	component.setExpanded(ctx.toolOutputExpanded);
+	// A wire the `stream-revision` axis marks `possible` can rewrite text it has
+	// already streamed; published rows are unrecoverable once they reach native
+	// scrollback, so those wires keep finished lines in the live viewport.
+	const compat = ctx.viewSession.model?.compat;
+	const wireRevisable = compat !== undefined && "streamRevision" in compat && compat.streamRevision === "possible";
+	component.setMidStreamPublication(!wireRevisable);
 	return component;
 }

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -125,6 +125,41 @@ describe("AssistantMessageComponent transcript lifecycle", () => {
 		expect(flushText).toContain("Newer tail");
 	});
 
+	it("withholds mid-stream retirement when the wire may revise streamed text", () => {
+		const thinkingMessage = (thinking: string): AssistantMessage => ({
+			...createAssistantMessage(""),
+			content: [{ type: "thinking", thinking }],
+		});
+		const component = new AssistantMessageComponent();
+		const transcript = new TranscriptContainer();
+		transcript.addChild(component);
+		// `stream-revision "possible"`: bytes may be revised after they stream.
+		component.setMidStreamPublication(false);
+
+		component.updateContent(
+			thinkingMessage("Alpha reasoning paragraph.\n\nBeta reasoning paragraph.\n\nPartial tail"),
+			{ transient: true },
+		);
+		transcript.renderViewport(80, 20, { now: 0, tick: 0 });
+		component.updateContent(
+			thinkingMessage(
+				"Alpha reasoning paragraph.\n\nBeta reasoning paragraph.\n\nPartial tail keeps growing.\n\nNewer tail",
+			),
+			{ transient: true },
+		);
+		transcript.renderViewport(80, 20, { now: 1, tick: 1 });
+
+		// Nothing publishes under pressure: a revision could not be retracted from history.
+		expect(component.getTranscriptStableRows()).toHaveLength(0);
+		expect(transcript.peekFinalizedBatch(80, 0)).toBeUndefined();
+
+		// Withholding costs reachability only — finalization still retires the whole block.
+		component.markTranscriptBlockFinalized();
+		const flushText = Bun.stripANSI(transcript.peekFlushBatch(80)?.rows.join("\n") ?? "");
+		expect(flushText).toContain("Alpha reasoning paragraph.");
+		expect(flushText).toContain("Newer tail");
+	});
+
 	it("appends a late cache-miss marker after assistant output", () => {
 		const component = new AssistantMessageComponent();
 		component.updateContent(

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -261,12 +261,10 @@ describe("TranscriptContainer", () => {
 		const block = new AppendBlock(["reasoning one", "reasoning two", "answer"], ["reasoning one", "reasoning two"]);
 		transcript.addChild(block);
 
+		// Under pressure the finished rows the overflow needs retire in one batch.
 		const first = transcript.peekFinalizedBatch(80, 1)!;
-		expect(first.rows).toEqual(["reasoning one"]);
+		expect(first.rows).toEqual(["reasoning one", "reasoning two"]);
 		transcript.acknowledgeFinalizedBatch(first.id);
-		const second = transcript.peekFinalizedBatch(80, 1)!;
-		expect(second.rows).toEqual(["reasoning two"]);
-		transcript.acknowledgeFinalizedBatch(second.id);
 		expect(transcript.emittedStableRows()).toEqual([2]);
 
 		// Ctrl+T hides thinking: the block now renders only its answer and drops


### PR DESCRIPTION
## What

Streaming assistant text now retires finished lines into native terminal scrollback while the turn is still running, instead of holding the whole reply in the live viewport until the block finalizes.

- `AssistantMessageComponent` publishes the prefix it can no longer rewrite — closed children plus the streaming child's frozen Markdown boundary — for text as well as reasoning. Text previously never published at all (`#currentStableSnapshot`: "Text blocks never publish"), so a prose-only reply had an empty stable-row list and could not retire mid-stream by construction.
- `TranscriptContainer` hands over as many of those rows as the overflow needs, in one batch, instead of exactly one per pressure cycle; the append acknowledgement accepts a forward extension rather than a single-step one.
- A new `stream-revision` compat axis declares wires that can rewrite text they have already streamed; models declaring it keep today's behaviour.

## Why

A reply taller than the transcript is tail-sliced in the live region, so its beginning is in neither the viewport nor native scrollback until the turn ends, and then appears all at once ([#11276](https://github.com/can1357/oh-my-pi/issues/11276), [#9780](https://github.com/can1357/oh-my-pi/issues/9780)). Deterministic repro at 80x24: stream 30 numbered lines; `LINE-1`/`LINE-15` are unreachable mid-stream and all 30 are present after finalize.

## Testing

Harness driving the real `AssistantMessageComponent` + `TranscriptContainer` (before → after, same code path):

| case | before | after |
| --- | --- | --- |
| 30 paragraphs, 12-row transcript | 0 rows to history, `LINE-1`/`LINE-15` unreachable | 47 rows to history mid-stream; `LINE-1`, `LINE-15`, `LINE-30` reachable; viewport stays within 12 rows |
| reasoning then answer | reasoning prefix retires, answer never does | 17 rows retire mid-stream, both channels reach history, newest text still visible |
| provider rewrites an already-published paragraph | — | emission stops for that block, no duplicate reaches history |

- `bun test packages/coding-agent/test/modes/components/` — failure set identical to `main` (7 pre-existing `StatusLineComponent` failures caused by the stale local `pi_natives` binary); catalog compat suites 43/43; `bun run check` clean in both packages.
- New test: `withholds mid-stream retirement when the wire may revise streamed text`.
- One existing expectation updated (`transcript-container.test.ts`, #10177): the scenario consumed two one-row batches, now one two-row batch. Its contract — reset drops emitted stable rows — is unchanged.

**Note on `models.json`:** a full `bun run gen:models` picked up unrelated upstream catalog drift (~140k lines). The committed diff is spliced from that regeneration instead: only the 299 rows the new axis resolves on (Kimi models across 28 providers, all 149 Bedrock rows) carry the added key, inserted at the generator's key position, including `whenThinking` variants. `compat-parity.test.ts` proves the spliced file matches what the engine resolves.

## The choice (@can1357)

Whether native scrollback may ever hold bytes a provider later revises. Publishing early is what makes a long reply readable mid-stream; history is write-once, so a revised byte cannot be retracted.

This PR takes the conservative branch: a wire is published to only when it cannot revise, and the revision declaration is data — `stream-revision` in `packages/catalog/src/compat/rules/` — not a heuristic in TypeScript. Kimi and Bedrock declare `possible` with a cited mechanism (leaned-on thinking opener / in-band markup carving; Converse assembler positioning blocks by wire index); everything else is unassigned and assumed append-only. The renderer additionally re-verifies published rows against the live render every frame and stops the block on the first mismatch, so a misclassified wire degrades to today's behaviour instead of writing wrong bytes.

If that is the wrong default, the alternatives are both one-line-ish: invert the axis to an allow-list of append-only wires (safest, but nobody gets the fix until they are enumerated), or restore pre-18.0.1 unbounded emission behind an opt-in setting and accept duplicate rows — option 1 in #11276.

Refs #11276.
