### PR TITLE
feat(coding-agent): document shaken artifact recovery in system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Documented `[shaken ...]` artifact recovery in the default system prompt so models recognize pruned tool results as recoverable cache pointers rather than corrupted output.
+- Documented `[shaken ...]` artifact recovery in the default system prompt so models recognize pruned tool results as recoverable cache pointers rather than corrupted output ([#11630](https://github.com/can1357/oh-my-pi/pull/11630) by [@alvins82](https://github.com/alvins82)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Documented `[shaken ...]` artifact recovery in the default system prompt so models recognize pruned tool results as recoverable cache pointers rather than corrupted output.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -61,7 +61,7 @@ Most FS/bash tools auto-resolve these to FS paths.
   {{/if}}
 - `agent://<id>`: output artifact; `/<child>`: nested-subagent output; otherwise `/<path>`: JSON field
 - `history://<id>`: read-only agent transcript (live|parked|released); bare `history://`: all agents. Registered process-wide agents and persisted subagents discoverable from artifact trees; unregistered top-level sessions are not discovered solely from persisted session files.
-- `artifact://<id>`: content
+- `artifact://<id>`: content (large/older tool results may be pruned to `[shaken ~N tokens — recover: artifact://<id>]`; use `read` if raw details are needed)
 {{#if securityEnabled}}
 - `security://scans[/<id>/…]`: read-only OMP scans, findings, coverage, reports, SARIF, provenance
 {{/if}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -61,7 +61,7 @@ Most FS/bash tools auto-resolve these to FS paths.
   {{/if}}
 - `agent://<id>`: output artifact; `/<child>`: nested-subagent output; otherwise `/<path>`: JSON field
 - `history://<id>`: read-only agent transcript (live|parked|released); bare `history://`: all agents. Registered process-wide agents and persisted subagents discoverable from artifact trees; unregistered top-level sessions are not discovered solely from persisted session files.
-- `artifact://<id>`: content (large/older tool results may be pruned to `[shaken ~N tokens — recover: artifact://<id>]`; use `read` if raw details are needed)
+- `artifact://<id>`: content (large/older tool results may be pruned to `[shaken ~N tokens — recover: artifact://<id>]`{{#has tools "read"}}; inspect via `{{toolRefs.read}}` if raw details are needed{{/has}})
 {{#if securityEnabled}}
 - `security://scans[/<id>/…]`: read-only OMP scans, findings, coverage, reports, SARIF, provenance
 {{/if}}


### PR DESCRIPTION
## What

Document `[shaken ~N tokens — recover: artifact://<id>]` in the coding agent's default system prompt under `# Internal URLs`.

## Why

During long sessions with large command outputs, older or bulky tool results are pruned into artifacts to maintain context headroom (`[shaken ~... tokens — recover: artifact://...]`).

In live testing with reasoning models (e.g. `qwen3.8-27b` with high thinking), models that encounter shaken regions for the first time without prompt orientation can perceive them as data corruption (e.g., thinking *"The output is garbled. Let me use the artifact to check the results"*).

Explaining that this placeholder is normal context management and pointing to `artifact://<id>` ensures models treat shaken output as an intentional cache tier rather than an error or network corruption.

Discovered during live verification in https://github.com/can1357/oh-my-pi/pull/11502.

## Testing

- `bun test packages/coding-agent/test/system-prompt-*.test.ts` (58 passed)
- `bun run check` passes
