### PR TITLE
feat(agent): guide handoff compaction on confirmed disk state and live ground truth

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved compaction handoff instructions to distinguish confirmed filesystem state from planned intent and emphasize live environment ground truth over summarized history.
+
 ## [18.1.17] - 2026-09-10
 
 ### Changed

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Improved compaction handoff instructions to distinguish confirmed filesystem state from planned intent and emphasize live environment ground truth over summarized history.
+- Improved compaction handoff instructions to distinguish confirmed filesystem state from planned intent and emphasize live environment ground truth over summarized history ([#11631](https://github.com/can1357/oh-my-pi/pull/11631) by [@alvins82](https://github.com/alvins82)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/agent/src/compaction/prompts/handoff-document.md
+++ b/packages/agent/src/compaction/prompts/handoff-document.md
@@ -10,8 +10,8 @@ Capture exact technical state, not abstractions.
 - Test results, observed failures
 - Decisions made
 - Partial work affecting the next step
-- Confirmed disk state: distinguish files actually written/created on disk from planned intent. Scratchpad thoughts from previous turns being summarized away does not indicate interrupted execution or write failure.
-- Ground truth: instruct the successor to trust live environment inspection (filesystem, git, DOM) over summarized history when verifying current state.
+- Confirmed disk state: distinguish files actually written/created on disk from planned intent. Scratchpad thoughts from previous turns being summarized away do not indicate interrupted execution or write failure.
+- Live environment ground truth: when verifying current state, inspect the live environment (filesystem, git, DOM) rather than relying on summarized history.
 Register: address the successor directly in the imperative ("Fix X", "Run Y") — never first person ("I need to…", "my attempt…").
 The handoff mechanism is invisible to the document: NEVER list writing, generating, or delivering a handoff/summary/context document as progress or a next step. Progress and Next Steps cover the user's task only.
 </instruction>

--- a/packages/agent/src/compaction/prompts/handoff-document.md
+++ b/packages/agent/src/compaction/prompts/handoff-document.md
@@ -10,6 +10,8 @@ Capture exact technical state, not abstractions.
 - Test results, observed failures
 - Decisions made
 - Partial work affecting the next step
+- Confirmed disk state: distinguish files actually written/created on disk from planned intent. Scratchpad thoughts from previous turns being summarized away does not indicate interrupted execution or write failure.
+- Ground truth: instruct the successor to trust live environment inspection (filesystem, git, DOM) over summarized history when verifying current state.
 Register: address the successor directly in the imperative ("Fix X", "Run Y") — never first person ("I need to…", "my attempt…").
 The handoff mechanism is invisible to the document: NEVER list writing, generating, or delivering a handoff/summary/context document as progress or a next step. Progress and Next Steps cover the user's task only.
 </instruction>


### PR DESCRIPTION
## What

Improve `handoff-document.md` compaction instructions to:
1. Distinguish confirmed filesystem state from planned intent, clarifying that absent pre-compaction scratchpad thoughts do not indicate an interrupted execution or failed write.
2. Instruct the successor instance to trust live environment inspection (filesystem, git, DOM) over summarized history when verifying current state.

## Why

During dogfooding of https://github.com/can1357/oh-my-pi/pull/11502 in long goal-mode sessions with heavy reasoning models (e.g., `qwen3.8-27b` with high thinking), two recurring behavioral failure modes were observed post-compaction:

1. **"Turn Truncation" Hallucinations**: When a pre-compaction turn contained extensive reasoning about planned file writes (but only executed setup/inspection commands before compaction triggered), the successor model woke up and saw the planned files missing from disk. Because the pre-compaction thought chain was summarized away, the model mistakenly concluded that its previous turn had crashed mid-write (e.g., *"The previous turn was truncated, so app.js and the HTML templates didn't survive..."*).
2. **State Desynchronization on Dynamic UI**: When compaction summarized interactive UI toggles across turns, the summary contained historical references to multiple button states. Rather than checking live DOM ground truth immediately, the model tried to deduce the current state from the summarized history before realizing the context was ambiguous.

Explicitly instructing the handoff generator to record confirmed disk modifications and direct the successor to inspect the live environment prevents both issues.

## Testing

- `bun test packages/agent/test/compaction*.test.ts` (52 passed)
- `bun run check` passes
