### PR TITLE
fix(tui): skip hidden thinking formatting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced memory usage during long responses while thinking is hidden ([#11632](https://github.com/can1357/oh-my-pi/pull/11632) by [@redsolver](https://github.com/redsolver)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -865,10 +865,12 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text") {
 				parts.push(canonicalizeMessage(content.text) ? "T1" : "T0");
 			} else if (content.type === "thinking") {
-				const display = resolveThinkingDisplay(content, this.proseOnlyThinking);
-				if (!display.visible) parts.push("K0");
-				else if (this.hideThinkingBlock) parts.push("KH");
-				else parts.push("KV");
+				if (this.hideThinkingBlock) {
+					// Match the pulse's empty/nonempty transition without formatting hidden text.
+					parts.push(canonicalizeMessage(content.thinking) ? "KH" : "K0");
+				} else {
+					parts.push(resolveThinkingDisplay(content, this.proseOnlyThinking).visible ? "KV" : "K0");
+				}
 			} else {
 				// Non-rendered blocks (toolCall, redactedThinking, …) still occupy a
 				// content index. Encode their position so an inserted/removed one shifts
@@ -894,7 +896,7 @@ export class AssistantMessageComponent extends Container {
 		}
 		// Extension stability: if thinking renderers exist and any tracked thinking
 		// block's text changed, extensions may produce a different child count.
-		if (this.thinkingRenderers.length > 0 && this.#fastPathItems) {
+		if (!this.hideThinkingBlock && this.thinkingRenderers.length > 0 && this.#fastPathItems) {
 			for (const item of this.#fastPathItems) {
 				if (item.blockType === "thinking") {
 					const content = message.content[item.contentIndex];
@@ -1044,12 +1046,14 @@ export class AssistantMessageComponent extends Container {
 				this.#emergencyText = md;
 				captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
 				hasRenderedContent = true;
-			} else if (content.type === "thinking" && resolveThinkingDisplay(content, this.proseOnlyThinking).visible) {
-				const thinkingText = resolveThinkingDisplay(content, this.proseOnlyThinking).text;
+			} else if (content.type === "thinking") {
 				if (this.hideThinkingBlock) {
 					thinkingIndex += 1;
 					continue;
 				}
+				const display = resolveThinkingDisplay(content, this.proseOnlyThinking);
+				if (!display.visible) continue;
+				const thinkingText = display.text;
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming-fastpath.test.ts
@@ -216,6 +216,38 @@ Average Latency: 1,240 ms
 		reused.updateContent(filled);
 		expect(reused.render(W).join("\n")).toBe(teardownRender(filled));
 	});
+
+	it("matches fresh live output across hidden thinking emptiness transitions and reveal", () => {
+		const reused = new AssistantMessageComponent(undefined, true);
+		const latestReasoning = "Latest canonical reasoning";
+		try {
+			// A comment is raw-nonempty but display-empty; whitespace is canonically empty.
+			// Neither transition may leave the live pulse missing or stale.
+			for (const thinking of ["", "<!-- -->", " \n", latestReasoning]) {
+				const message = msg([
+					{ type: "text", text: "Visible answer" },
+					{ type: "thinking", thinking },
+				]);
+				const fresh = new AssistantMessageComponent(undefined, true);
+				try {
+					reused.updateContent(message, { transient: true });
+					fresh.updateContent(message, { transient: true });
+					expect(reused.render(W).join("\n")).toBe(fresh.render(W).join("\n"));
+				} finally {
+					fresh.dispose();
+				}
+			}
+
+			reused.setHideThinkingBlock(false);
+			reused.invalidate();
+			const revealed = Bun.stripANSI(reused.render(W).join("\n"));
+			expect(revealed).toContain(latestReasoning);
+			expect(revealed).toContain("Visible answer");
+		} finally {
+			reused.dispose();
+		}
+	});
+
 	it("does not re-format an already-display thinking block (rawThinking set)", () => {
 		// buildDisplayMessage emits a thinking block whose `thinking` is already the
 		// formatted display text and stamps the original under `rawThinking`.


### PR DESCRIPTION
While having a few omp instances open, I was surprised by its high RAM footprint. One reason for this seems to be that display formatting of reasoning traces happens even when their display is disabled, which is fixed by this PR. In a fresh isolated short test it resulted in 12.7% memory savings, while a larger one will likely yield even higher savings.

## What

Skip display formatting for hidden thinking in `AssistantMessageComponent`. Check visibility before preparing display text, preserving canonical reasoning, the live indicator, and reveal/replay behavior.

## Why


Hidden thinking still passed through the incremental formatter despite not being displayed. The guards avoid unnecessary display work and memory retention without changing model output.

## Testing

### Real-model comparison

Six fresh interactive OMP TUI sessions: three sequential A/B pairs with alternating order, using the same coin-weighing prompt. Both variants used the same source base and runtime, differing only by this fix.

- `ollama-cloud/glm-5.3-flash`, maximum thinking as reported by the application; tools disabled.
- `hideThinkingBlock=true`, `proseOnlyThinking=true`, 120×40 terminal, normal session persistence.
- Main-process PSS sampled approximately once per second, with 15 seconds of natural idle after each turn; no forced GC.

Medians across three runs per variant:

| Main-process memory | Unpatched | Patched |
|---|---:|---:|
| Sampled peak during generation | 396.5 MiB | 352.4 MiB |
| Settled near the end of the idle period | 306.8 MiB | 267.9 MiB |
| Settled growth above pre-prompt PSS | 45.7 MiB | 4.5 MiB |

Observed median settled PSS was **12.7% lower**, but this is a small, single-turn sample with different generated streams (30.8k–51.8k UTF-16 units), not a fixed savings estimate. The closest-length pair (38.9k versus 42.1k) settled at 272.1 versus 267.9 MiB—only **1.6% lower**, with a higher patched peak.

### Correctness checks

- All six real-model runs displayed the live indicator and final answer, passed the construction checker, and exited normally.
- The hidden-thinking transition regression fails before the fix and passes afterward; **145 tests passed** across 8 relevant files.
- `bun --cwd=packages/coding-agent run check` passed with one existing unused-variable warning.
- Real-terminal smoke and 80/100-column reveal/replay checks passed; canonical reasoning remained intact.
---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
