### PR TITLE
fix(plugins): refresh npm manifest cache on plugin install

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `omp plugin install <name>` for npm packages now bypasses bun's manifest cache, so a reinstall picks up a newly published version instead of a stale one, and installing an explicit `<name>@<version>` no longer fails to resolve a version that exists on the registry ([#11634](https://github.com/can1357/oh-my-pi/issues/11634)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -496,7 +496,17 @@ export class PluginManager {
 			}
 
 			// Step 1: write the spec into plugins/package.json + node_modules.
-			const installProc = Bun.spawn(["bun", "install", packageInstallSpec], {
+			// npm specs resolve through bun's manifest (packument) cache, which honors
+			// the registry's Cache-Control TTL and so keeps serving a stale version
+			// after a new one is published — an uninstall/reinstall or an explicit
+			// `pkg@newVersion` then resolves the old version or fails outright (#11634).
+			// `--no-cache` re-fetches the manifest while leaving the tarball cache
+			// intact. Git specs don't use the manifest cache; their cache staleness is
+			// handled by refreshBunGitCache + `bun update` below.
+			const installArgs = gitSource
+				? ["bun", "install", packageInstallSpec]
+				: ["bun", "install", "--no-cache", packageInstallSpec];
+			const installProc = Bun.spawn(installArgs, {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",

--- a/packages/coding-agent/test/plugin-install-validation.test.ts
+++ b/packages/coding-agent/test/plugin-install-validation.test.ts
@@ -89,7 +89,7 @@ describe("PluginManager.install load validation", () => {
 
 	test("installs npm protocol specs with the resolved package name", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "npm:pi-figma-remote-auth"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "npm:pi-figma-remote-auth"]);
 
 			const prepare = (async () => {
 				await Bun.write(
@@ -126,9 +126,46 @@ describe("PluginManager.install load validation", () => {
 		expect(result.path).toBe(path.join(pluginsNodeModules, "pi-figma-remote-auth"));
 	});
 
+	// #11634: bun caches the registry packument per its Cache-Control TTL, so a
+	// plain `bun install <name>` kept re-resolving a stale version after a new one
+	// was published (and `install <name>@<newVersion>` failed to resolve). The npm
+	// branch must pass `--no-cache` so the manifest is re-fetched; the exact spec —
+	// including a version pin — must survive unchanged.
+	test("bypasses bun's manifest cache for npm installs so new versions resolve", async () => {
+		let recordedCmd: string[] | undefined;
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			recordedCmd = cmd;
+			const prepare = (async () => {
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{ name: "omp-plugins", private: true, dependencies: { "welcome-plugin": "0.1.9" } },
+						null,
+						2,
+					),
+				);
+				await writePluginPackage(pluginsNodeModules, "welcome-plugin", {
+					version: "0.1.9",
+					source: "export default function() {}\n",
+				});
+			})();
+			return {
+				pid: 1,
+				stdout: emptyStream(),
+				stderr: emptyStream(),
+				exited: prepare.then(() => 0),
+			} as Subprocess;
+		}) as typeof Bun.spawn);
+
+		const result = await new PluginManager(tmpRoot).install("welcome-plugin@0.1.9");
+
+		expect(recordedCmd).toEqual(["bun", "install", "--no-cache", "welcome-plugin@0.1.9"]);
+		expect(result.version).toBe("0.1.9");
+	});
+
 	test("rejects and rolls back an install when the extension factory throws", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "factory-failure-plugin"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "factory-failure-plugin"]);
 
 			const prepare = (async () => {
 				await Bun.write(
@@ -170,7 +207,7 @@ describe("PluginManager.install load validation", () => {
 
 	test("rejects an install whose extension entry cannot resolve its dependencies", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "broken-plugin"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "broken-plugin"]);
 
 			const prepare = (async () => {
 				await Bun.write(
@@ -224,7 +261,7 @@ describe("PluginManager.install load validation", () => {
 		});
 
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "broken-plugin"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "broken-plugin"]);
 
 			const prepare = (async () => {
 				await Bun.write(
@@ -346,7 +383,7 @@ describe("PluginManager.install load validation", () => {
 
 	test("rejects an install whose manifest declares a missing extension entry", async () => {
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "partial-plugin"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "partial-plugin"]);
 
 			const prepare = (async () => {
 				await Bun.write(
@@ -485,7 +522,7 @@ describe("PluginManager.install load validation", () => {
 		expect(await Bun.file(bunLockPath).exists()).toBe(false);
 
 		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
-			expect(cmd).toEqual(["bun", "install", "broken-plugin"]);
+			expect(cmd).toEqual(["bun", "install", "--no-cache", "broken-plugin"]);
 			const prepare = (async () => {
 				await Bun.write(bunLockPath, '# bun.lock\n"broken-plugin": "1.0.0"\n');
 				await Bun.write(


### PR DESCRIPTION
## Repro
On bun 1.3.14 against a controlled local registry that serves the packument with `Cache-Control: max-age=3600` (mirroring the npmjs.org CDN): install `welcome-pkg` while latest is `0.1.8`, then "publish" `0.1.9`. `bun uninstall welcome-pkg && bun install welcome-pkg` re-installs `0.1.8` (stale), and `bun install welcome-pkg@0.1.9` fails with `failed to resolve` — matching the reporter's `omp plugin install @getpipher/welcome` re-installing the old version and `@0.1.9` reporting `No version matching`.

## Cause
`omp plugin install @scope/pkg` routes to `PluginManager.install` (`packages/coding-agent/src/extensibility/plugins/manager.ts`), which ran `bun install <spec>` for npm packages with no manifest refresh. Bun's cached packument honors the registry's Cache-Control TTL, so it shadows newly published versions until the TTL expires. The git path already busts bun's cache (`refreshBunGitCache`, refs #3063/#5401); the npm path had no equivalent.

## Fix
- `PluginManager.install` now passes `--no-cache` on the npm install branch so bun re-fetches the packument; the tarball cache is untouched, so already-downloaded versions aren't re-downloaded. Git specs are unchanged (their staleness is handled by `refreshBunGitCache` + `bun update`).
- Updated the npm-branch argv assertions in `plugin-install-validation.test.ts` to expect `--no-cache`, and added a dedicated regression test (`bypasses bun's manifest cache for npm installs so new versions resolve`) that installs `welcome-plugin@0.1.9` and asserts the spawned command is `["bun","install","--no-cache","welcome-plugin@0.1.9"]`.
- Changelog entry under `[Unreleased]`.

The reporter's bonus (`plugin upgrade <name>` for npm-installed plugins erroring `Expected "name@marketplace"`) is a separate missing feature and is out of scope here.

## Verification
`bun test test/plugin-install-validation.test.ts test/plugin-install-git.test.ts` → 19 pass, 0 fail. The git tests still assert the git branch installs without `--no-cache`, confirming the branch distinction. `bun check` passed via the pre-publish gate. Fixes #11634