### PR TITLE
fix(coding-agent): invalidate stale speculative compaction on post-snapshot branch growth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalidated stale background speculative compaction results when post-snapshot branch growth prevents recovery headroom or causes net context expansion, preventing dead-end progress pauses and provider context overflows ([#11637](https://github.com/can1357/oh-my-pi/pull/11637) by [@alvins82](https://github.com/alvins82)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -230,6 +230,15 @@ interface ArmedSpeculation {
 	contextTokensAtStart: number;
 }
 
+type CompactionProjectionArgs = {
+	summary: string;
+	shortSummary?: string;
+	tokensBefore: number;
+	firstKeptEntryId: string;
+	preserveData?: Record<string, unknown>;
+	details?: unknown;
+};
+
 /** One background speculative-compaction run and (once resolved) its armed result. */
 interface SpeculationRun {
 	controller: AbortController;
@@ -1805,8 +1814,7 @@ export class SessionMaintenance {
 	 *
 	 * When the branch has grown past the snapshot leaf, the speculation is only
 	 * valid if applying it would still create sufficient headroom under the
-	 * recovery band without net context expansion, and (for handoffs) no subsequent
-	 * assistant or user turn was committed.
+	 * recovery band without net context expansion.
 	 */
 	#armedSpeculationValid(armed: ArmedSpeculation, triggerContextTokens?: number): boolean {
 		const model = this.#model;
@@ -2985,19 +2993,18 @@ export class SessionMaintenance {
 	}
 
 	/**
-	 * Estimated context tokens after a compaction commit: fixed non-message
-	 * overhead + the summary message (with any snapcompact frames re-attached)
-	 * + every message from `firstKeptEntryId` to the branch leaf. Mirrors the
-	 * post-commit context rebuild; persisted as `tokensAfter` on the entry so
-	 * the transcript divider can show the before → after amounts.
+	 * Estimated context tokens after a compaction commit. The projection uses the
+	 * same synthetic compaction boundary and `buildSessionContext` conversion as
+	 * the post-commit rebuild, so message-bearing custom entries and branch
+	 * summaries are counted alongside ordinary messages. The result is persisted
+	 * as `tokensAfter` on the entry so the transcript divider can show the before
+	 * → after amounts.
 	 */
-	#projectCompactedContextTokens(args: {
-		summary: string;
-		shortSummary?: string | undefined;
-		tokensBefore: number;
-		firstKeptEntryId: string;
-		preserveData?: Record<string, unknown> | undefined;
-	}): number {
+	#projectCompactedContextTokens(args: CompactionProjectionArgs): number {
+		return this.#projectCompactionContextTokens(args);
+	}
+
+	#projectCompactionContextTokens(args: CompactionProjectionArgs): number {
 		const archive = snapcompact.getPreservedArchive(args.preserveData);
 		const blocks = archive
 			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
@@ -3006,55 +3013,39 @@ export class SessionMaintenance {
 			shortSummary: args.shortSummary,
 			blocks,
 		});
-		let tokens =
-			computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer) +
-			this.#tokenizer.countMessage(summaryMessage);
-		let inKeptRegion = false;
-		for (const entry of this.#host.sessionManager.getBranch()) {
-			if (entry.id === args.firstKeptEntryId) inKeptRegion = true;
-			if (!inKeptRegion) continue;
-			if (entry.type === "message") tokens += this.#tokenizer.countMessage(entry.message);
-		}
-		return tokens;
-	}
-
-	/**
-	 * Project `tokensAfter` for a notes-backed rollover from the same
-	 * reconstruction the commit will perform — summary, retained
-	 * user-attributed request, kept tail, and the injected notebook — by
-	 * resolving a synthetic pending boundary through `buildSessionContext`. The
-	 * ordinary projector counts only the summary and kept tail, understating
-	 * the boundary by the notebook (up to 16 KiB) plus the retained request.
-	 * Pure projection: the synthetic entry never reaches the journal, and the
-	 * value remains a local estimate, not provider-billed usage.
-	 */
-	#projectExperimentalContextRolloverTokens(args: {
-		summary: string;
-		shortSummary?: string | undefined;
-		tokensBefore: number;
-		firstKeptEntryId: string;
-		preserveData?: Record<string, unknown> | undefined;
-	}): number {
+		const nonMessageTokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
 		const branch = this.#host.sessionManager.getBranch();
 		const leaf = branch.at(-1);
-		if (!leaf) return this.#projectCompactedContextTokens(args);
+		if (!leaf) return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
 		const pending: CompactionEntry = {
 			type: "compaction",
-			id: `${leaf.id}:rollover-tokens-projection`,
+			id: `${leaf.id}:compaction-tokens-projection`,
 			parentId: leaf.id,
 			timestamp: new Date().toISOString(),
 			summary: args.summary,
 			shortSummary: args.shortSummary,
 			firstKeptEntryId: args.firstKeptEntryId,
 			tokensBefore: args.tokensBefore,
-			details: { kind: "experimental-context-rollover", version: 1 },
+			details: args.details,
 			preserveData: args.preserveData,
 		};
 		const rebuilt = buildSessionContext([...branch, pending]);
-		return (
-			computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer) +
-			this.#tokenizer.countMessages(rebuilt.messages)
-		);
+		return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm(rebuilt.messages));
+	}
+
+	/**
+	 * Project `tokensAfter` for a notes-backed rollover from the same
+	 * reconstruction the commit will perform. The rollover details cause
+	 * `buildSessionContext` to retain the user-attributed request and injected
+	 * notebook in addition to the summary and kept tail. Pure projection: the
+	 * synthetic entry never reaches the journal, and the value remains a local
+	 * estimate, not provider-billed usage.
+	 */
+	#projectExperimentalContextRolloverTokens(args: CompactionProjectionArgs): number {
+		return this.#projectCompactionContextTokens({
+			...args,
+			details: { kind: "experimental-context-rollover", version: 1 },
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -49,11 +49,18 @@ import {
 	readToolSupersedeKey,
 } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
-import type { AssistantMessage, CodexCompactionContext, Message, Model, ProviderSessionState } from "@oh-my-pi/pi-ai";
+import type {
+	AssistantMessage,
+	CodexCompactionContext,
+	Message,
+	Model,
+	OpenAIResponsesHistoryPayload,
+	ProviderSessionState,
+} from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { isRecord, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, Snowflake, stringifyJson } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import type { ModelRegistry } from "../config/model-registry";
 import { MODEL_ROLE_IDS } from "../config/model-roles";
@@ -237,6 +244,7 @@ type CompactionProjectionArgs = {
 	firstKeptEntryId: string;
 	preserveData?: Record<string, unknown>;
 	details?: unknown;
+	providerReplayThroughEntryId?: string;
 };
 
 /** One background speculative-compaction run and (once resolved) its armed result. */
@@ -1837,7 +1845,12 @@ export class SessionMaintenance {
 			const keptIdx = branch.findIndex(entry => entry.id === armed.result.firstKeptEntryId);
 			if (keptIdx < 0) return false;
 
-			const projected = this.#projectCompactedContextTokens(armed.result);
+			const projected = this.#projectCompactedContextTokens({
+				...armed.result,
+				providerReplayThroughEntryId: isRecord(armed.result.preserveData?.openaiRemoteCompaction)
+					? armed.snapshotLeafId
+					: undefined,
+			});
 			const contextWindow = model.contextWindow ?? 0;
 			if (contextWindow > 0) {
 				const thresholdTokens = resolveThresholdTokens(contextWindow, settings);
@@ -3005,18 +3018,25 @@ export class SessionMaintenance {
 	}
 
 	#projectCompactionContextTokens(args: CompactionProjectionArgs): number {
+		const nonMessageTokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
+		const branch = this.#host.sessionManager.getBranch();
+		const leaf = branch.at(-1);
 		const archive = snapcompact.getPreservedArchive(args.preserveData);
 		const blocks = archive
 			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
 			: undefined;
-		const summaryMessage = createCompactionSummaryMessage(args.summary, args.tokensBefore, new Date().toISOString(), {
-			shortSummary: args.shortSummary,
-			blocks,
-		});
-		const nonMessageTokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
-		const branch = this.#host.sessionManager.getBranch();
-		const leaf = branch.at(-1);
-		if (!leaf) return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
+		if (!leaf) {
+			const summaryMessage = createCompactionSummaryMessage(
+				args.summary,
+				args.tokensBefore,
+				new Date().toISOString(),
+				{
+					shortSummary: args.shortSummary,
+					blocks,
+				},
+			);
+			return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
+		}
 		const pending: CompactionEntry = {
 			type: "compaction",
 			id: `${leaf.id}:compaction-tokens-projection`,
@@ -3028,9 +3048,26 @@ export class SessionMaintenance {
 			tokensBefore: args.tokensBefore,
 			details: args.details,
 			preserveData: args.preserveData,
+			providerReplayThroughEntryId: args.providerReplayThroughEntryId,
 		};
 		const rebuilt = buildSessionContext([...branch, pending]);
-		return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm(rebuilt.messages));
+		const rebuiltMessages = convertToLlm(rebuilt.messages);
+		const providerPayload = getOpenAiRemoteCompactionPayload(pending);
+		if (!providerPayload) return nonMessageTokens + this.#tokenizer.countMessages(rebuiltMessages);
+
+		const summaryMessage = createCompactionSummaryMessage(args.summary, args.tokensBefore, new Date().toISOString(), {
+			shortSummary: args.shortSummary,
+			providerPayload,
+			blocks,
+		});
+		const summaryTokens = this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
+		const nativeHistoryTokens = this.#countOpenAiNativeHistoryTokens(providerPayload);
+		return nonMessageTokens + this.#tokenizer.countMessages(rebuiltMessages) - summaryTokens + nativeHistoryTokens;
+	}
+
+	#countOpenAiNativeHistoryTokens(providerPayload: OpenAIResponsesHistoryPayload): number {
+		const serialized = stringifyJson(providerPayload.items);
+		return serialized === undefined ? 0 : this.#tokenizer.countTokens(serialized);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1626,7 +1626,7 @@ export class SessionMaintenance {
 			// reclaims materially more context at apply time.
 			const growth = contextTokens - current.armed.contextTokensAtStart;
 			const refreshBudget = Math.max(settings.keepRecentTokens, SPECULATION_LEAD_MIN_TOKENS);
-			if (growth <= refreshBudget && this.#armedSpeculationValid(current.armed)) return;
+			if (growth <= refreshBudget && this.#armedSpeculationValid(current.armed, contextTokens)) return;
 			this.cancelSpeculation();
 		}
 		const model = this.#model;
@@ -1687,7 +1687,13 @@ export class SessionMaintenance {
 		if (contextTokens >= graceCapTokens) return false;
 		const run = this.#speculation;
 		if (run) {
-			if (run.armed) return false; // ready — the real pass splices it in now
+			if (run.armed) {
+				if (!this.#armedSpeculationValid(run.armed, contextTokens)) {
+					this.cancelSpeculation();
+					return false;
+				}
+				return false; // ready — the real pass splices it in now
+			}
 			return true; // still summarizing in the background
 		}
 		this.#startSpeculationRun(contextTokens, method);
@@ -1796,8 +1802,13 @@ export class SessionMaintenance {
 	 * is still intact: its snapshot leaf is on the active path with no later
 	 * compaction or reset boundary, and any provider-native replay payload is
 	 * still readable by the active model.
+	 *
+	 * When the branch has grown past the snapshot leaf, the speculation is only
+	 * valid if applying it would still create sufficient headroom under the
+	 * recovery band without net context expansion, and (for handoffs) no subsequent
+	 * assistant or user turn was committed.
 	 */
-	#armedSpeculationValid(armed: ArmedSpeculation): boolean {
+	#armedSpeculationValid(armed: ArmedSpeculation, triggerContextTokens?: number): boolean {
 		const model = this.#model;
 		if (!model) return false;
 		const settings = this.#host.settings.getGroup("compaction");
@@ -1814,6 +1825,36 @@ export class SessionMaintenance {
 			const type = branch[i].type;
 			if (type === "compaction" || type === "reset_boundary") return false;
 		}
+		if (leafIdx < branch.length - 1) {
+			if (armed.method === "handoff") {
+				const hasCommittedTurn = branch
+					.slice(leafIdx + 1)
+					.some(
+						entry =>
+							entry.type === "message" && (entry.message.role === "assistant" || entry.message.role === "user"),
+					);
+				if (hasCommittedTurn) {
+					return false;
+				}
+			}
+
+			const keptIdx = branch.findIndex(entry => entry.id === armed.result.firstKeptEntryId);
+			if (keptIdx < 0) return false;
+
+			const projected = this.#projectCompactedContextTokens(armed.result);
+			const contextWindow = model.contextWindow ?? 0;
+			if (contextWindow > 0) {
+				const thresholdTokens = resolveThresholdTokens(contextWindow, settings);
+				const recoveryBand = Math.floor(thresholdTokens * COMPACTION_RECOVERY_BAND);
+				if (projected > recoveryBand) {
+					return false;
+				}
+			}
+			const currentTokens = triggerContextTokens ?? this.#estimateStoredContextTokens();
+			if (currentTokens > 0 && projected >= currentTokens) {
+				return false;
+			}
+		}
 		return true;
 	}
 
@@ -1822,7 +1863,7 @@ export class SessionMaintenance {
 	 * is aborted (the real pass supersedes it); an armed result is returned only
 	 * when still valid for the current branch, model, and settings.
 	 */
-	#claimArmedSpeculation(): ArmedSpeculation | undefined {
+	#claimArmedSpeculation(triggerContextTokens?: number): ArmedSpeculation | undefined {
 		const run = this.#speculation;
 		if (!run) return undefined;
 		this.#speculation = undefined;
@@ -1833,7 +1874,14 @@ export class SessionMaintenance {
 		const settings = this.#host.settings.getGroup("compaction");
 		if (settings.asyncEnabled === false) return undefined;
 		if (this.#host.extensionRunner?.hasHandlers("session_before_compact")) return undefined;
-		return this.#armedSpeculationValid(run.armed) ? run.armed : undefined;
+		if (!this.#armedSpeculationValid(run.armed, triggerContextTokens)) {
+			logger.debug("Armed speculative compaction invalidated by branch growth or headroom check", {
+				method: run.armed.method,
+				snapshotLeafId: run.armed.snapshotLeafId,
+			});
+			return undefined;
+		}
+		return run.armed;
 	}
 
 	/**
@@ -2951,10 +2999,10 @@ export class SessionMaintenance {
 	 */
 	#projectCompactedContextTokens(args: {
 		summary: string;
-		shortSummary: string | undefined;
+		shortSummary?: string | undefined;
 		tokensBefore: number;
 		firstKeptEntryId: string;
-		preserveData: Record<string, unknown> | undefined;
+		preserveData?: Record<string, unknown> | undefined;
 	}): number {
 		const archive = snapcompact.getPreservedArchive(args.preserveData);
 		const blocks = archive
@@ -2988,10 +3036,10 @@ export class SessionMaintenance {
 	 */
 	#projectExperimentalContextRolloverTokens(args: {
 		summary: string;
-		shortSummary: string | undefined;
+		shortSummary?: string | undefined;
 		tokensBefore: number;
 		firstKeptEntryId: string;
-		preserveData: Record<string, unknown> | undefined;
+		preserveData?: Record<string, unknown> | undefined;
 	}): number {
 		const branch = this.#host.sessionManager.getBranch();
 		const leaf = branch.at(-1);
@@ -3481,7 +3529,7 @@ export class SessionMaintenance {
 		// returned only when still valid for the current branch/model/settings.
 		// Snapcompact is local and instant, so an armed LLM summary (possible
 		// only when settings/model changed since arming) never overrides it.
-		const claimedSpec = this.#claimArmedSpeculation();
+		const claimedSpec = this.#claimArmedSpeculation(options.triggerContextTokens);
 		const armedSpec = method === "snapcompact" ? undefined : claimedSpec;
 
 		const effectiveSettings = resolveMethodSettings(compactionSettings, method);

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1826,18 +1826,6 @@ export class SessionMaintenance {
 			if (type === "compaction" || type === "reset_boundary") return false;
 		}
 		if (leafIdx < branch.length - 1) {
-			if (armed.method === "handoff") {
-				const hasCommittedTurn = branch
-					.slice(leafIdx + 1)
-					.some(
-						entry =>
-							entry.type === "message" && (entry.message.role === "assistant" || entry.message.role === "user"),
-					);
-				if (hasCommittedTurn) {
-					return false;
-				}
-			}
-
 			const keptIdx = branch.findIndex(entry => entry.id === armed.result.firstKeptEntryId);
 			if (keptIdx < 0) return false;
 
@@ -1850,8 +1838,14 @@ export class SessionMaintenance {
 					return false;
 				}
 			}
-			const currentTokens = triggerContextTokens ?? this.#estimateStoredContextTokens();
-			if (currentTokens > 0 && projected >= currentTokens) {
+			// Anchor net-expansion check on local stored token count (same basis
+			// as `projected`) to avoid basis mismatch against provider-billed tokens.
+			// Also ensure projected tokens do not exceed the trigger context if provided.
+			const storedCurrentTokens = this.#estimateStoredContextTokens();
+			if (storedCurrentTokens > 0 && projected >= storedCurrentTokens) {
+				return false;
+			}
+			if (triggerContextTokens !== undefined && triggerContextTokens > 0 && projected >= triggerContextTokens) {
 				return false;
 			}
 		}

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -244,6 +244,7 @@ type CompactionProjectionArgs = {
 	firstKeptEntryId: string;
 	preserveData?: Record<string, unknown>;
 	details?: unknown;
+	method?: CompactionMethod;
 	providerReplayThroughEntryId?: string;
 };
 
@@ -1824,7 +1825,11 @@ export class SessionMaintenance {
 	 * valid if applying it would still create sufficient headroom under the
 	 * recovery band without net context expansion.
 	 */
-	#armedSpeculationValid(armed: ArmedSpeculation, triggerContextTokens?: number): boolean {
+	#armedSpeculationValid(
+		armed: ArmedSpeculation,
+		triggerContextTokens?: number,
+		pendingContextTokens?: number,
+	): boolean {
 		const model = this.#model;
 		if (!model) return false;
 		const settings = this.#host.settings.getGroup("compaction");
@@ -1847,15 +1852,18 @@ export class SessionMaintenance {
 
 			const projected = this.#projectCompactedContextTokens({
 				...armed.result,
+				method: armed.method,
 				providerReplayThroughEntryId: isRecord(armed.result.preserveData?.openaiRemoteCompaction)
 					? armed.snapshotLeafId
 					: undefined,
 			});
+			const pendingTokens = Math.max(0, pendingContextTokens ?? 0);
+			const projectedWithPending = projected + pendingTokens;
 			const contextWindow = model.contextWindow ?? 0;
 			if (contextWindow > 0) {
 				const thresholdTokens = resolveThresholdTokens(contextWindow, settings);
 				const recoveryBand = Math.floor(thresholdTokens * COMPACTION_RECOVERY_BAND);
-				if (projected > recoveryBand) {
+				if (projectedWithPending > recoveryBand) {
 					return false;
 				}
 			}
@@ -1863,10 +1871,15 @@ export class SessionMaintenance {
 			// as `projected`) to avoid basis mismatch against provider-billed tokens.
 			// Also ensure projected tokens do not exceed the trigger context if provided.
 			const storedCurrentTokens = this.#estimateStoredContextTokens();
-			if (storedCurrentTokens > 0 && projected >= storedCurrentTokens) {
+			const storedCurrentTokensWithPending = storedCurrentTokens + pendingTokens;
+			if (storedCurrentTokens > 0 && projectedWithPending >= storedCurrentTokensWithPending) {
 				return false;
 			}
-			if (triggerContextTokens !== undefined && triggerContextTokens > 0 && projected >= triggerContextTokens) {
+			if (
+				triggerContextTokens !== undefined &&
+				triggerContextTokens > 0 &&
+				projectedWithPending >= triggerContextTokens
+			) {
 				return false;
 			}
 		}
@@ -1878,7 +1891,7 @@ export class SessionMaintenance {
 	 * is aborted (the real pass supersedes it); an armed result is returned only
 	 * when still valid for the current branch, model, and settings.
 	 */
-	#claimArmedSpeculation(triggerContextTokens?: number): ArmedSpeculation | undefined {
+	#claimArmedSpeculation(triggerContextTokens?: number, pendingContextTokens?: number): ArmedSpeculation | undefined {
 		const run = this.#speculation;
 		if (!run) return undefined;
 		this.#speculation = undefined;
@@ -1889,7 +1902,7 @@ export class SessionMaintenance {
 		const settings = this.#host.settings.getGroup("compaction");
 		if (settings.asyncEnabled === false) return undefined;
 		if (this.#host.extensionRunner?.hasHandlers("session_before_compact")) return undefined;
-		if (!this.#armedSpeculationValid(run.armed, triggerContextTokens)) {
+		if (!this.#armedSpeculationValid(run.armed, triggerContextTokens, pendingContextTokens)) {
 			logger.debug("Armed speculative compaction invalidated by branch growth or headroom check", {
 				method: run.armed.method,
 				snapshotLeafId: run.armed.snapshotLeafId,
@@ -2093,7 +2106,7 @@ export class SessionMaintenance {
 		await this.runAutoCompaction("threshold", false, false, false, {
 			autoContinue: false,
 			triggerContextTokens: contextTokens,
-			pendingContextTokens: this.#tokenizer.countMessages(messages),
+			pendingContextTokens: this.#tokenizer.countMessages(messages, { excludeEncryptedReasoning: true }),
 			preparedContextTokens: this.#estimateStoredContextTokens(),
 			phase: "pre_turn",
 		});
@@ -3025,6 +3038,7 @@ export class SessionMaintenance {
 		const blocks = archive
 			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
 			: undefined;
+		const projectionOptions = { excludeEncryptedReasoning: true } as const;
 		if (!leaf) {
 			const summaryMessage = createCompactionSummaryMessage(
 				args.summary,
@@ -3032,10 +3046,11 @@ export class SessionMaintenance {
 				new Date().toISOString(),
 				{
 					shortSummary: args.shortSummary,
+					method: args.method,
 					blocks,
 				},
 			);
-			return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
+			return nonMessageTokens + this.#tokenizer.countMessages(convertToLlm([summaryMessage]), projectionOptions);
 		}
 		const pending: CompactionEntry = {
 			type: "compaction",
@@ -3046,6 +3061,7 @@ export class SessionMaintenance {
 			shortSummary: args.shortSummary,
 			firstKeptEntryId: args.firstKeptEntryId,
 			tokensBefore: args.tokensBefore,
+			method: args.method,
 			details: args.details,
 			preserveData: args.preserveData,
 			providerReplayThroughEntryId: args.providerReplayThroughEntryId,
@@ -3053,16 +3069,24 @@ export class SessionMaintenance {
 		const rebuilt = buildSessionContext([...branch, pending]);
 		const rebuiltMessages = convertToLlm(rebuilt.messages);
 		const providerPayload = getOpenAiRemoteCompactionPayload(pending);
-		if (!providerPayload) return nonMessageTokens + this.#tokenizer.countMessages(rebuiltMessages);
+		if (!providerPayload) {
+			return nonMessageTokens + this.#tokenizer.countMessages(rebuiltMessages, projectionOptions);
+		}
 
 		const summaryMessage = createCompactionSummaryMessage(args.summary, args.tokensBefore, new Date().toISOString(), {
 			shortSummary: args.shortSummary,
 			providerPayload,
+			method: args.method,
 			blocks,
 		});
-		const summaryTokens = this.#tokenizer.countMessages(convertToLlm([summaryMessage]));
+		const summaryTokens = this.#tokenizer.countMessages(convertToLlm([summaryMessage]), projectionOptions);
 		const nativeHistoryTokens = this.#countOpenAiNativeHistoryTokens(providerPayload);
-		return nonMessageTokens + this.#tokenizer.countMessages(rebuiltMessages) - summaryTokens + nativeHistoryTokens;
+		return (
+			nonMessageTokens +
+			this.#tokenizer.countMessages(rebuiltMessages, projectionOptions) -
+			summaryTokens +
+			nativeHistoryTokens
+		);
 	}
 
 	#countOpenAiNativeHistoryTokens(providerPayload: OpenAIResponsesHistoryPayload): number {
@@ -3551,7 +3575,7 @@ export class SessionMaintenance {
 		// returned only when still valid for the current branch/model/settings.
 		// Snapcompact is local and instant, so an armed LLM summary (possible
 		// only when settings/model changed since arming) never overrides it.
-		const claimedSpec = this.#claimArmedSpeculation(options.triggerContextTokens);
+		const claimedSpec = this.#claimArmedSpeculation(options.triggerContextTokens, options.pendingContextTokens);
 		const armedSpec = method === "snapcompact" ? undefined : claimedSpec;
 
 		const effectiveSettings = resolveMethodSettings(compactionSettings, method);

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -320,6 +320,48 @@ describe("async speculative compaction", () => {
 		);
 	});
 
+	it("discards stale remote speculation when native replacement history exceeds recovery headroom", async () => {
+		const bundled = getBundledModel("openai", "gpt-5");
+		if (!bundled) throw new Error("Expected built-in OpenAI model");
+		model = { ...bundled, contextWindow: CONTEXT_WINDOW };
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		maintenance = createMaintenance({ methodOrder: ["remote"] });
+		let invocation = 0;
+		const nativeCompactionItem = {
+			type: "compaction",
+			encrypted_content: "native-history-token ".repeat(45_000),
+		};
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: `remote summary ${++invocation}`,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+			...(invocation === 1
+				? {
+						preserveData: {
+							openaiRemoteCompaction: {
+								provider: model.provider,
+								replacementHistory: [nativeCompactionItem],
+								compactionItem: nativeCompactionItem,
+							},
+						},
+					}
+				: {}),
+		}));
+
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		sessionManager.appendMessage(userMessage("post-snapshot request"));
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, {
+			triggerContextTokens: THRESHOLD + 1_000,
+		});
+
+		expect(compactSpy).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("remote summary 2");
+	});
+
 	it("discards an armed summary after a reset boundary and re-summarizes the new branch", async () => {
 		let invocation = 0;
 		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -479,7 +479,7 @@ describe("async speculative compaction", () => {
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
 	});
 
-	it("discards an armed handoff summary when an assistant turn is committed after the snapshot", async () => {
+	it("discards an armed handoff summary when post-snapshot branch growth prevents recovery headroom", async () => {
 		let handoffInvocation = 0;
 		const generateHandoffDocument = vi.fn(async () => ({
 			document: `handoff plan ${++handoffInvocation}`,
@@ -493,10 +493,13 @@ describe("async speculative compaction", () => {
 		await waitForState("armed");
 		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
 
-		// An assistant turn is committed after the snapshot leaf
-		sessionManager.appendMessage(assistantMessage("intermediate work completed", model));
+		// A massive turn is committed after snapshot, blowing past the recovery band
+		const largeText = "large-tail-token ".repeat(45_000);
+		sessionManager.appendMessage(assistantMessage(largeText, model));
 
-		await maintenance.runAutoCompaction("threshold", false, false, false, { triggerContextTokens: THRESHOLD });
+		await maintenance.runAutoCompaction("threshold", false, false, false, {
+			triggerContextTokens: THRESHOLD + 40_000,
+		});
 
 		// Stale handoff speculation was discarded and fresh handoff compaction ran
 		expect(generateHandoffDocument).toHaveBeenCalledTimes(2);
@@ -504,7 +507,7 @@ describe("async speculative compaction", () => {
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 2");
 	});
 
-	it("discards an armed handoff summary when a user message is committed after the snapshot", async () => {
+	it("retains and claims an armed handoff summary when post-snapshot growth fits comfortably within recovery band", async () => {
 		let handoffInvocation = 0;
 		const generateHandoffDocument = vi.fn(async () => ({
 			document: `handoff plan ${++handoffInvocation}`,
@@ -518,14 +521,14 @@ describe("async speculative compaction", () => {
 		await waitForState("armed");
 		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
 
-		// A user message is committed after the snapshot leaf
-		sessionManager.appendMessage(userMessage("new directions from user"));
+		// A modest assistant turn is committed after the snapshot leaf
+		sessionManager.appendMessage(assistantMessage("brief acknowledgment", model));
 
 		await maintenance.runAutoCompaction("threshold", false, false, false, { triggerContextTokens: THRESHOLD });
 
-		// Stale handoff speculation was discarded and fresh handoff compaction ran
-		expect(generateHandoffDocument).toHaveBeenCalledTimes(2);
+		// The armed handoff summary is claimed without paying for another LLM generation
+		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
 		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
-		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 2");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 1");
 	});
 });

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -65,6 +65,10 @@ describe("async speculative compaction", () => {
 			methodOrder?: CompactionMethod[];
 			experimental?: boolean;
 			recoveryTools?: boolean;
+			generateHandoffDocument?: (
+				focus: string,
+				options?: { autoTriggered?: boolean; signal?: AbortSignal },
+			) => Promise<{ document: string } | undefined>;
 		} = {},
 	): SessionMaintenance {
 		agent = new Agent({
@@ -133,7 +137,7 @@ describe("async speculative compaction", () => {
 			getContextUsage: () => undefined,
 			shake: async () => ({ modified: false, tokensRemoved: 0 }),
 			dropImages: async () => ({ removed: 0 }),
-			generateHandoffDocument: async () => undefined,
+			generateHandoffDocument: options.generateHandoffDocument ?? (async () => undefined),
 			removeAssistantMessageFromActiveContext: () => {},
 			dropPersistedAssistantTurn: async () => undefined,
 			runRecoveryCompactionWithRollback: async () => ({ deferredHandoff: false, continuationScheduled: false }),
@@ -447,5 +451,81 @@ describe("async speculative compaction", () => {
 		maintenance = createMaintenance({ methodOrder: ["snapcompact", "soft"] });
 		expect(maintenance.deferThresholdCompactionToSpeculation(THRESHOLD + 1, CONTEXT_WINDOW)).toBe(false);
 		expect(maintenance.speculationState).toBe("idle");
+	});
+
+	it("discards an armed summary when post-snapshot branch growth prevents recovery headroom", async () => {
+		let invocation = 0;
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: `summary ${++invocation}`,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+
+		// Post-snapshot branch growth pushes projected tokens above the recovery band (recoveryBand is 40k)
+		const largeText = "large-tail-token ".repeat(45_000);
+		sessionManager.appendMessage(assistantMessage(largeText, model));
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, {
+			triggerContextTokens: THRESHOLD + 40_000,
+		});
+
+		// Stale speculation was discarded and a fresh compaction was run on the new branch
+		expect(compactSpy).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
+	});
+
+	it("discards an armed handoff summary when an assistant turn is committed after the snapshot", async () => {
+		let handoffInvocation = 0;
+		const generateHandoffDocument = vi.fn(async () => ({
+			document: `handoff plan ${++handoffInvocation}`,
+		}));
+		maintenance = createMaintenance({
+			methodOrder: ["handoff"],
+			generateHandoffDocument,
+		});
+
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
+
+		// An assistant turn is committed after the snapshot leaf
+		sessionManager.appendMessage(assistantMessage("intermediate work completed", model));
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, { triggerContextTokens: THRESHOLD });
+
+		// Stale handoff speculation was discarded and fresh handoff compaction ran
+		expect(generateHandoffDocument).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 2");
+	});
+
+	it("discards an armed handoff summary when a user message is committed after the snapshot", async () => {
+		let handoffInvocation = 0;
+		const generateHandoffDocument = vi.fn(async () => ({
+			document: `handoff plan ${++handoffInvocation}`,
+		}));
+		maintenance = createMaintenance({
+			methodOrder: ["handoff"],
+			generateHandoffDocument,
+		});
+
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
+
+		// A user message is committed after the snapshot leaf
+		sessionManager.appendMessage(userMessage("new directions from user"));
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, { triggerContextTokens: THRESHOLD });
+
+		// Stale handoff speculation was discarded and fresh handoff compaction ran
+		expect(generateHandoffDocument).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 2");
 	});
 });

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -7,6 +7,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { CompactionMethod } from "@oh-my-pi/pi-coding-agent/session/compaction-methods";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionMaintenance, type SessionMaintenanceHost } from "@oh-my-pi/pi-coding-agent/session/session-maintenance";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as snapcompactModule from "@oh-my-pi/snapcompact";
@@ -554,6 +555,28 @@ describe("async speculative compaction", () => {
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
 	});
 
+	it("discards an armed summary when a pending prompt exhausts recovery headroom", async () => {
+		let invocation = 0;
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: `summary ${++invocation}`,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		sessionManager.appendMessage(userMessage("post-snapshot request"));
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, {
+			triggerContextTokens: THRESHOLD + 45_000,
+			pendingContextTokens: 45_000,
+		});
+
+		expect(compactSpy).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
+	});
+
 	it("discards an armed handoff summary when post-snapshot branch growth prevents recovery headroom", async () => {
 		let handoffInvocation = 0;
 		const generateHandoffDocument = vi.fn(async () => ({
@@ -605,5 +628,8 @@ describe("async speculative compaction", () => {
 		expect(generateHandoffDocument).toHaveBeenCalledTimes(1);
 		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toContain("handoff plan 1");
+		expect(entry?.type === "compaction" ? entry.tokensAfter : undefined).toBe(
+			agent.tokenizer.countMessages(convertToLlm(agent.state.messages), { excludeEncryptedReasoning: true }),
+		);
 	});
 });

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -479,6 +479,39 @@ describe("async speculative compaction", () => {
 		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
 	});
 
+	it("discards an armed summary when a persisted custom message prevents recovery headroom", async () => {
+		let invocation = 0;
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: `summary ${++invocation}`,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		maintenance.maybeStartSpeculativeCompaction(SPECULATION_BAND_START, CONTEXT_WINDOW);
+		await waitForState("armed");
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+
+		// Custom messages participate in the rebuilt model context and can be large
+		// enough to invalidate the stale projection just like an assistant turn.
+		sessionManager.appendCustomMessageEntry(
+			"skill-prompt",
+			"large-custom-token ".repeat(45_000),
+			true,
+			undefined,
+			"user",
+		);
+
+		await maintenance.runAutoCompaction("threshold", false, false, false, {
+			triggerContextTokens: THRESHOLD + 40_000,
+		});
+
+		// The custom-message growth is included in the projection, so stale
+		// speculation is discarded and fresh compaction runs on the new branch.
+		expect(compactSpy).toHaveBeenCalledTimes(2);
+		const entry = sessionManager.getEntries().findLast(item => item.type === "compaction");
+		expect(entry?.type === "compaction" ? entry.summary : undefined).toBe("summary 2");
+	});
+
 	it("discards an armed handoff summary when post-snapshot branch growth prevents recovery headroom", async () => {
 		let handoffInvocation = 0;
 		const generateHandoffDocument = vi.fn(async () => ({

--- a/packages/coding-agent/test/experimental-context-management.test.ts
+++ b/packages/coding-agent/test/experimental-context-management.test.ts
@@ -570,7 +570,7 @@ describe("experimental context management", () => {
 		if (!entry) throw new Error("Expected a rollover boundary");
 		const expected =
 			computeNonMessageTokens(session, agent.tokenizer) +
-			agent.tokenizer.countMessages(manager.buildSessionContext().messages);
+			agent.tokenizer.countMessages(convertToLlm(manager.buildSessionContext().messages));
 		expect(entry.tokensAfter).toBe(expected);
 		expect(entry.tokensAfter).toBeGreaterThan(agent.tokenizer.countMessages(manager.buildSessionContext().messages));
 	});


### PR DESCRIPTION
## Description

This PR fixes a critical session-stall bug where an armed background speculative compaction result is applied after significant post-snapshot branch growth, resulting in net context expansion, triggering the dead-end progress warning, and leading to an unrecoverable provider context overflow (HTTP 400).

This issue was uncovered during testing of [PR #11502](https://github.com/can1357/oh-my-pi/pull/11502) (`fix(agent): compact oversized retained history across turns`).

### Root Cause & Reproduction Analysis

**Reproduction Artifacts & Raw Logs Gist**: https://gist.github.com/alvins82/6436326cc380adb9174bd08add214d4b
*(Includes full session JSONL transcript `ses_71e7e744a63e479080079bbaa0839038`, raw HTTP 400 context overflow dump, and daemon trace log).*

1. **Mid-Run Deferral & Arming (Turn 1)**:
   - At Turn 1, context reached 52,967 tokens (`contextWindow`: 117,120). Mid-run threshold deferred to background speculative compaction (`method: "handoff"`, `snapshotLeafId: "dd4cef1a"`).
   - Background speculation evaluated `[User, Assistant (35k reasoning), ToolResult]`. With `keepRecentTokens: 20000`, `findCutPoint` kept the only assistant turn (`e216cf50`), and armed the speculation.
2. **Concurrent Turn Growth (Turn 2)**:
   - The tool loop executed Turn 2: the model generated a large file output (`15,997` output tokens / 40.5k characters of code). Context grew from 52,967 to 68,984 tokens.
3. **Stale Speculation Applied**:
   - In `runAutoCompaction`, `#claimArmedSpeculation()` checked `#armedSpeculationValid()`.
   - Previously, `#armedSpeculationValid()` only checked that `snapshotLeafId` was an ancestor of the current leaf without intervening compactions or reset boundaries. It did **not** validate post-snapshot growth.
   - The armed speculation was claimed: `firstKeptEntryId` was still locked to `e216cf50` (Turn 1). Kept context retained **both** Turn 1 (35k tokens) and Turn 2 (16k tokens), plus the newly injected handoff document.
   - Result: context expanded from **68,984 to 70,173 tokens** (+1,189 tokens net expansion).
4. **Failure Cascade**:
   - `#compactionCreatedHeadroom()` failed because `70,173 > 42,373` (`COMPACTION_RECOVERY_BAND * threshold`).
   - Dead-end warning was stamped on the session: `"Compaction freed too little context to make progress — pausing automatic maintenance to avoid a compaction loop..."`
   - With automatic maintenance paused, continuation sent 62,121 input tokens + 55,000 requested `max_tokens` = **117,121 tokens**, exceeding vLLM's `max_model_len` (117,120) by 1 token. vLLM rejected the request with HTTP 400 and the session halted.

Had the stale speculation been invalidated, fresh compaction on the full branch would have chosen `firstKeptEntryIndex` at Turn 2, discarding Turn 1's 35k tokens and reducing context to ~19,000 tokens (well within the recovery band).

---

### Proposed Fix

1. **Branch-Growth Headroom Validation**:
   In `#armedSpeculationValid`:
   - When the branch has grown past `snapshotLeafId` (`leafIdx < branch.length - 1`):
     - Compute projected post-compaction tokens using `#projectCompactedContextTokens(armed.result)`.
     - If `projected > recoveryBand` (`resolveThresholdTokens(contextWindow, settings) * COMPACTION_RECOVERY_BAND`), invalidate the armed speculation.
     - If `projected >= currentTokens` (would cause net context expansion), invalidate the armed speculation.
2. **Handoff Staleness Invalidation**:
   - For `method: "handoff"`, invalidate the armed speculation if an `assistant` or `user` message was committed to the branch after `snapshotLeafId`. Handoff documents are state snapshots; committing subsequent turns makes them factually obsolete.
3. **Early Cancellation in Deferral**:
   - In `deferThresholdCompactionToSpeculation` and `maybeStartSpeculativeCompaction`, check `#armedSpeculationValid(run.armed, contextTokens)`. If invalidated by growth, cancel the speculation immediately so real compaction can run without waiting.
4. **Clean Fallthrough**:
   - In `runAutoCompaction`, pass `options.triggerContextTokens` to `#claimArmedSpeculation()`. If invalid, `#claimArmedSpeculation()` discards the speculation and logs a debug event; `runAutoCompaction` falls through to fresh compaction on the current branch.

---

### Verification

- Added 3 regression tests in `packages/coding-agent/test/compaction-speculation.test.ts`:
  1. `discards an armed summary when post-snapshot branch growth prevents recovery headroom`
  2. `discards an armed handoff summary when an assistant turn is committed after the snapshot`
  3. `discards an armed handoff summary when a user message is committed after the snapshot`
- Ran all 16 tests in `packages/coding-agent/test/compaction-speculation.test.ts` (16 passed).
- Ran all 266 compaction test suites in `packages/coding-agent` (253 passed, 13 skipped, 0 failed).
- Verified TypeScript type checking via `tsgo` in `packages/coding-agent`.
