### PR TITLE
feat(auth): support account priority order for providers with multiple accounts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for configuring account priority order when multiple accounts exist for the same provider, with automatic failover to lower-priority accounts upon rate limits, blocks, or quota exhaustion.
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added support for configuring account priority order when multiple accounts exist for the same provider, with automatic failover to lower-priority accounts upon rate limits, blocks, or quota exhaustion.
+- Added support for configuring account priority order when multiple accounts exist for the same provider, with automatic failover to lower-priority accounts upon rate limits, blocks, or quota exhaustion ([#11645](https://github.com/can1357/oh-my-pi/pull/11645) by [@keethesh](https://github.com/keethesh)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/ai/src/auth-broker/discover.ts
+++ b/packages/ai/src/auth-broker/discover.ts
@@ -40,6 +40,7 @@ export interface DiscoverAuthStorageOptions {
 	sourceLabel?: string;
 	/** Programmatic pool for SDK hosts. Takes precedence over the environment file. */
 	accountPool?: AuthBrokerAccountPool;
+	accountPriorityResolver?: (provider: string) => readonly string[] | undefined;
 }
 
 /** Path to the local bearer token file. Created by `omp auth-broker token`. */
@@ -296,6 +297,7 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 		const storage = new AuthStorage(store, {
 			configValueResolver: options.configValueResolver,
 			sourceLabel: options.sourceLabel ?? `broker ${brokerConfig.url}`,
+			accountPriorityResolver: options.accountPriorityResolver,
 		});
 		await storage.reload();
 		return storage;
@@ -305,6 +307,7 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 	const storage = await AuthStorage.create(dbPath, {
 		configValueResolver: options.configValueResolver,
 		sourceLabel: options.sourceLabel ?? `local ${dbPath}`,
+		accountPriorityResolver: options.accountPriorityResolver,
 	});
 	await storage.reload();
 	return storage;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -585,6 +585,7 @@ export interface CredentialDisabledEvent {
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	accountPriorityResolver?: (provider: string) => readonly string[] | undefined;
 	usageFetch?: typeof fetch;
 	usageRequestTimeoutMs?: number;
 	usageLogger?: UsageLogger;
@@ -946,6 +947,8 @@ export interface OAuthAccountSummary {
 	orgName?: string;
 	/** True when this account is the session-sticky OAuth credential requested by `listOAuthAccounts`. */
 	active: boolean;
+	/** 1-based priority rank if configured in the provider's account priority list. */
+	priority?: number;
 }
 export interface InvalidateCredentialMatchingOptions {
 	signal?: AbortSignal;
@@ -1326,9 +1329,43 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	primaryUsed: number;
 	primaryRequiredDrain: number;
 	orderPos: number;
+	priorityRank?: number;
 };
 type RankedOAuthCandidate = UsageRankedCandidate<OAuthCredential>;
 type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
+export function credentialMatchesAccountSelector(
+	credential: AuthCredential,
+	credentialId: number | undefined,
+	position: number,
+	selector: string,
+): boolean {
+	const wanted = selector.trim().toLowerCase();
+	if (!wanted) return false;
+	if (/^\d+$/.test(wanted) && Number(wanted) === position + 1) return true;
+	if (credentialId !== undefined) {
+		if (wanted === `id:${credentialId}` || wanted === String(credentialId)) return true;
+	}
+	if (credential.type === "oauth") {
+		const fields = [
+			credential.email,
+			credential.accountId,
+			credential.projectId,
+			credential.enterpriseUrl,
+			credential.orgId,
+			credential.orgName,
+		];
+		for (const field of fields) {
+			if (typeof field === "string" && field.trim().toLowerCase() === wanted) {
+				return true;
+			}
+		}
+	} else if (credential.type === "api_key") {
+		if (typeof credential.key === "string" && credential.key.trim().toLowerCase() === wanted) {
+			return true;
+		}
+	}
+	return false;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AuthStorage Class
@@ -1381,6 +1418,8 @@ export class AuthStorage {
 	#runtimeUsageProviderOverrides: Map<Provider, { provider: UsageProvider; apiKey?: string }> = new Map();
 	#usageReportCacheKeysByProvider: Map<Provider, Set<string>> = new Map();
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	#accountPriorityResolver?: (provider: string) => readonly string[] | undefined;
+	#accountPriorities: Map<string, readonly string[]> = new Map();
 	#usageCache: UsageCache;
 	#usageCacheEpoch = 0;
 	#usageRequestInFlight: Map<string, Promise<UsageReport | null>> = new Map();
@@ -1416,6 +1455,7 @@ export class AuthStorage {
 		this.#configValueResolver = options.configValueResolver ?? defaultConfigValueResolver;
 		this.#usageProviderResolver = options.usageProviderResolver ?? resolveDefaultUsageProvider;
 		this.#rankingStrategyResolver = options.rankingStrategyResolver ?? resolveDefaultRankingStrategy;
+		this.#accountPriorityResolver = options.accountPriorityResolver;
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		// Opportunistic hygiene, once per AuthStorage lifetime: drop expired
 		// cache rows (24h last-good retention). A cheap indexed DELETE;
@@ -1623,6 +1663,31 @@ export class AuthStorage {
 	}
 
 	/**
+	 * Set or clear the resolver for provider account priorities.
+	 */
+	setAccountPriorityResolver(resolver: ((provider: string) => readonly string[] | undefined) | undefined): void {
+		this.#accountPriorityResolver = resolver;
+	}
+
+	/**
+	 * Set explicit account priority order for a provider (e.g. list of emails or account IDs).
+	 */
+	setAccountPriority(provider: string, priority: readonly string[] | undefined): void {
+		if (!priority || priority.length === 0) {
+			this.#accountPriorities.delete(provider);
+		} else {
+			this.#accountPriorities.set(provider, priority);
+		}
+	}
+
+	/**
+	 * Get the account priority order for a provider.
+	 */
+	getAccountPriority(provider: string): readonly string[] | undefined {
+		return this.#accountPriorities.get(provider) ?? this.#accountPriorityResolver?.(provider);
+	}
+
+	/**
 	 * Reload credentials from storage.
 	 */
 	async reload(): Promise<void> {
@@ -1823,6 +1888,42 @@ export class AuthStorage {
 			order.push((start + i) % total);
 		}
 		return order;
+	}
+
+	/**
+	 * Returns credential indices ordered by configured priority (or round-robin / hash fallback).
+	 */
+	#getPrioritizedCredentialOrder(
+		provider: string,
+		credentials: Array<{ credential: AuthCredential; index: number }>,
+		providerKey: string,
+		sessionId: string | undefined,
+	): number[] {
+		if (credentials.length <= 1) return [0];
+		const priority = this.getAccountPriority(provider);
+		if (!priority || priority.length === 0) {
+			return this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		}
+		const storedList = this.#getStoredCredentials(provider);
+		const ranks = credentials.map((item, position) => {
+			const credentialId = storedList[item.index]?.id;
+			let matchedRank = -1;
+			for (let p = 0; p < priority.length; p++) {
+				if (credentialMatchesAccountSelector(item.credential, credentialId, position, priority[p]!)) {
+					matchedRank = p;
+					break;
+				}
+			}
+			return {
+				position,
+				rank: matchedRank === -1 ? Number.POSITIVE_INFINITY : matchedRank,
+			};
+		});
+		ranks.sort((a, b) => {
+			if (a.rank !== b.rank) return a.rank - b.rank;
+			return a.position - b.position;
+		});
+		return ranks.map(r => r.position);
 	}
 
 	#toScopedBackoffKey(providerKey: string, blockScope: string | undefined): string {
@@ -2205,7 +2306,7 @@ export class AuthStorage {
 		if (credentials.length === 1) return credentials[0];
 
 		const providerKey = this.#getProviderTypeKey(provider, type);
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getPrioritizedCredentialOrder(provider, credentials, providerKey, sessionId);
 		const fallback = credentials[order[0]];
 
 		for (const idx of order) {
@@ -2303,6 +2404,21 @@ export class AuthStorage {
 			const secondary = windows?.secondary;
 			const usageMeasured = primary !== undefined || secondary !== undefined;
 			const primaryUncapped = primary === undefined && secondary !== undefined;
+			const priority = this.getAccountPriority(args.provider);
+			let priorityRank: number | undefined = undefined;
+			if (priority && priority.length > 0) {
+				const credentialId = this.#getStoredCredentials(args.provider)[selection.index]?.id;
+				const position = args.credentials.findIndex(c => c.index === selection.index);
+				for (let p = 0; p < priority.length; p++) {
+					if (credentialMatchesAccountSelector(selection.credential, credentialId, position, priority[p]!)) {
+						priorityRank = p;
+						break;
+					}
+				}
+				if (priorityRank === undefined) {
+					priorityRank = Number.POSITIVE_INFINITY;
+				}
+			}
 			ranked.push({
 				selection,
 				usage,
@@ -2321,6 +2437,7 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
+				priorityRank,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, "none");
@@ -2343,7 +2460,7 @@ export class AuthStorage {
 		if (credentials.length === 1) return credentials[0];
 
 		const providerKey = this.#getProviderTypeKey(provider, "api_key");
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getPrioritizedCredentialOrder(provider, credentials, providerKey, sessionId);
 		const fallback = credentials[order[0]];
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		if (!strategy) {
@@ -4921,7 +5038,17 @@ export class AuthStorage {
 			const leftBlockedUntil = left.blockedUntil ?? Number.POSITIVE_INFINITY;
 			const rightBlockedUntil = right.blockedUntil ?? Number.POSITIVE_INFINITY;
 			if (leftBlockedUntil !== rightBlockedUntil) return leftBlockedUntil - rightBlockedUntil;
+			if (left.priorityRank !== undefined || right.priorityRank !== undefined) {
+				const leftRank = left.priorityRank ?? Number.POSITIVE_INFINITY;
+				const rightRank = right.priorityRank ?? Number.POSITIVE_INFINITY;
+				if (leftRank !== rightRank) return leftRank - rightRank;
+			}
 			return 0;
+		}
+		if (left.priorityRank !== undefined || right.priorityRank !== undefined) {
+			const leftRank = left.priorityRank ?? Number.POSITIVE_INFINITY;
+			const rightRank = right.priorityRank ?? Number.POSITIVE_INFINITY;
+			if (leftRank !== rightRank) return leftRank - rightRank;
 		}
 		if (planRequirement !== "none" && left.planPriority !== right.planPriority) {
 			return left.planPriority - right.planPriority;
@@ -5088,6 +5215,21 @@ export class AuthStorage {
 			const secondary = windows?.secondary;
 			const usageMeasured = primary !== undefined || secondary !== undefined;
 			const primaryUncapped = primary === undefined && secondary !== undefined;
+			const priority = this.getAccountPriority(args.provider);
+			let priorityRank: number | undefined = undefined;
+			if (priority && priority.length > 0) {
+				const credentialId = this.#getStoredCredentials(args.provider)[selection.index]?.id;
+				const position = args.credentials.findIndex(c => c.index === selection.index);
+				for (let p = 0; p < priority.length; p++) {
+					if (credentialMatchesAccountSelector(selection.credential, credentialId, position, priority[p]!)) {
+						priorityRank = p;
+						break;
+					}
+				}
+				if (priorityRank === undefined) {
+					priorityRank = Number.POSITIVE_INFINITY;
+				}
+			}
 			ranked.push({
 				selection,
 				usage,
@@ -5106,6 +5248,7 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
+				priorityRank,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, args.planRequirement);
@@ -5141,7 +5284,7 @@ export class AuthStorage {
 		if (credentials.length === 0) return undefined;
 
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getPrioritizedCredentialOrder(provider, credentials, providerKey, sessionId);
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const rankingContext: CredentialRankingContext = {
 			modelId: options?.modelId,
@@ -5183,8 +5326,9 @@ export class AuthStorage {
 		// ties (the ranked comparator falls back to `orderPos`) without overriding a strictly-better
 		// sibling — this respects the residual value of a same-account shared static prefix that other
 		// workspace traffic may have kept warm, while still rotating away from a clearly-worse account.
-		const baseRankingOrder = credentials.map((_credential, index) => index);
-		let rankingOrder = shouldRank && sessionId ? baseRankingOrder : order;
+		const priority = this.getAccountPriority(provider);
+		const baseRankingOrder = priority && priority.length > 0 ? order : credentials.map((_credential, index) => index);
+		let rankingOrder = shouldRank && sessionId ? (priority && priority.length > 0 ? order : baseRankingOrder) : order;
 		const sessionPreferredRankingPos =
 			shouldRank && sessionId && sessionPreferredIndex !== undefined && !hasPlanRequirement
 				? credentials.findIndex(entry => entry.index === sessionPreferredIndex)
@@ -6120,17 +6264,32 @@ export class AuthStorage {
 			sessionCredential?.type === "oauth"
 				? this.#getStoredCredentials(provider)[sessionCredential.index]?.id
 				: undefined;
-		return this.#getStoredOAuthSelections(provider).map((selection, position) => ({
-			position,
-			credentialId: selection.credentialId,
-			accountId: selection.credential.accountId,
-			email: selection.credential.email,
-			projectId: selection.credential.projectId,
-			enterpriseUrl: selection.credential.enterpriseUrl,
-			orgId: selection.credential.orgId,
-			orgName: selection.credential.orgName,
-			active: selection.credentialId === activeCredentialId,
-		}));
+		const priority = this.getAccountPriority(provider);
+		return this.#getStoredOAuthSelections(provider).map((selection, position) => {
+			let priorityNum: number | undefined;
+			if (priority && priority.length > 0) {
+				for (let p = 0; p < priority.length; p++) {
+					if (
+						credentialMatchesAccountSelector(selection.credential, selection.credentialId, position, priority[p]!)
+					) {
+						priorityNum = p + 1;
+						break;
+					}
+				}
+			}
+			return {
+				position,
+				credentialId: selection.credentialId,
+				accountId: selection.credential.accountId,
+				email: selection.credential.email,
+				projectId: selection.credential.projectId,
+				enterpriseUrl: selection.credential.enterpriseUrl,
+				orgId: selection.credential.orgId,
+				orgName: selection.credential.orgName,
+				active: selection.credentialId === activeCredentialId,
+				priority: priorityNum,
+			};
+		});
 	}
 
 	/**

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1667,6 +1667,10 @@ export class AuthStorage {
 	 */
 	setAccountPriorityResolver(resolver: ((provider: string) => readonly string[] | undefined) | undefined): void {
 		this.#accountPriorityResolver = resolver;
+		for (const provider of this.#sessionLastCredential.keys()) {
+			this.#sessionLastCredential.get(provider)?.clear();
+			this.#clearProviderSessionCredentialCache(provider);
+		}
 	}
 
 	/**
@@ -1678,6 +1682,8 @@ export class AuthStorage {
 		} else {
 			this.#accountPriorities.set(provider, priority);
 		}
+		this.#sessionLastCredential.get(provider)?.clear();
+		this.#clearProviderSessionCredentialCache(provider);
 	}
 
 	/**
@@ -5321,16 +5327,19 @@ export class AuthStorage {
 			sessionPreferredIndex !== undefined &&
 			sessionPreferredCanRefreshOrUse &&
 			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScopes);
-		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || !sessionPreferredIsWarm || hasPlanRequirement);
+		const priority = this.getAccountPriority(provider);
+		const hasPriority = priority !== undefined && priority.length > 0;
+		const shouldRank =
+			(checkUsage && (!sessionPreferredIsAvailable || !sessionPreferredIsWarm || hasPlanRequirement)) ||
+			(hasPriority && checkUsage);
 		// When ranking, seed the pinned credential first in the evaluation order so it wins genuine
 		// ties (the ranked comparator falls back to `orderPos`) without overriding a strictly-better
 		// sibling — this respects the residual value of a same-account shared static prefix that other
 		// workspace traffic may have kept warm, while still rotating away from a clearly-worse account.
-		const priority = this.getAccountPriority(provider);
-		const baseRankingOrder = priority && priority.length > 0 ? order : credentials.map((_credential, index) => index);
-		let rankingOrder = shouldRank && sessionId ? (priority && priority.length > 0 ? order : baseRankingOrder) : order;
+		const baseRankingOrder = hasPriority ? order : credentials.map((_credential, index) => index);
+		let rankingOrder = shouldRank && sessionId ? (hasPriority ? order : baseRankingOrder) : order;
 		const sessionPreferredRankingPos =
-			shouldRank && sessionId && sessionPreferredIndex !== undefined && !hasPlanRequirement
+			shouldRank && sessionId && sessionPreferredIndex !== undefined && !hasPlanRequirement && !hasPriority
 				? credentials.findIndex(entry => entry.index === sessionPreferredIndex)
 				: -1;
 		if (sessionPreferredRankingPos > 0) {
@@ -5365,7 +5374,7 @@ export class AuthStorage {
 		// On the warm skip path the candidate list follows the round-robin `order`, not the pin, so
 		// hoist the pinned credential to the front to actually reuse it. When ranking ran, the pin is
 		// already a mere tie-break via `rankingOrder`; do not override the ranked result here.
-		if (!shouldRank && sessionPreferredIndex !== undefined && !hasPlanRequirement) {
+		if (!shouldRank && sessionPreferredIndex !== undefined && !hasPlanRequirement && !hasPriority) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
 					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScopes) &&

--- a/packages/ai/test/account-priority.test.ts
+++ b/packages/ai/test/account-priority.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function createCredential(accountId: string, email?: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+		email: email ?? `${accountId}@example.com`,
+	};
+}
+
+function createUsageReport(provider: string, accountId: string, usedFraction: number): UsageReport {
+	const now = Date.now();
+	const limits: UsageLimit[] = [
+		{
+			id: "5h",
+			label: "5h Limit",
+			scope: { provider, accountId },
+			amount: {
+				usedFraction,
+				used: Math.round(usedFraction * 100),
+				limit: 100,
+				unit: "percent",
+			},
+			window: {
+				id: "5h",
+				label: "5 Hours",
+				durationMs: 5 * HOUR_MS,
+				resetsAt: now + HOUR_MS,
+			},
+			status: usedFraction >= 1 ? "exhausted" : "ok",
+		},
+	];
+	return { provider, fetchedAt: now, limits, metadata: { accountId } };
+}
+
+describe("AuthStorage account priority", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByAccount = new Map<string, UsageReport>();
+	const usageProvider: UsageProvider = {
+		id: "kimi-code",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			return accountId ? (usageByAccount.get(accountId) ?? null) : null;
+		},
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-priority-test-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "kimi-code" ? usageProvider : undefined),
+		});
+		usageByAccount.clear();
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const cred = Object.values(credentials)[0] as OAuthCredentials | undefined;
+			if (!cred) return null;
+			return { apiKey: cred.access, newCredentials: cred };
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("respects explicit account priority order over insertion order", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("account-1", "first@example.com") },
+			{ type: "oauth", ...createCredential("account-2", "second@example.com") },
+		]);
+
+		// Without priority set, first insertion or hash is used
+		authStorage.setAccountPriority("test-provider", ["second@example.com", "first@example.com"]);
+
+		const apiKey = await authStorage.getApiKey("test-provider", "session-1");
+		expect(apiKey).toBe("access-account-2");
+
+		const apiKey2 = await authStorage.getApiKey("test-provider", "session-2");
+		expect(apiKey2).toBe("access-account-2");
+	});
+
+	test("account priority resolver in options is honored", async () => {
+		if (!store) throw new Error("test setup failed");
+		const customStorage = new AuthStorage(store, {
+			accountPriorityResolver: provider => (provider === "test-provider" ? ["second@example.com"] : undefined),
+		});
+
+		await customStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("account-1", "first@example.com") },
+			{ type: "oauth", ...createCredential("account-2", "second@example.com") },
+		]);
+
+		const apiKey = await customStorage.getApiKey("test-provider", "session-abc");
+		expect(apiKey).toBe("access-account-2");
+	});
+
+	test("strict priority outranks dynamic usage headroom", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("kimi-code", [
+			{ type: "oauth", ...createCredential("heavy", "heavy@example.com") },
+			{ type: "oauth", ...createCredential("light", "light@example.com") },
+		]);
+
+		// Heavy has 60% used, light has 5% used
+		usageByAccount.set("heavy", createUsageReport("kimi-code", "heavy", 0.6));
+		usageByAccount.set("light", createUsageReport("kimi-code", "light", 0.05));
+
+		// Set priority to heavy first
+		authStorage.setAccountPriority("kimi-code", ["heavy@example.com", "light@example.com"]);
+
+		// Even though light has far more headroom, heavy is selected due to strict priority
+		const apiKey = await authStorage.getApiKey("kimi-code", "session-priority");
+		expect(apiKey).toBe("access-heavy");
+	});
+
+	test("fails over to next priority account when higher priority is blocked", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		await authStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("primary", "primary@example.com") },
+			{ type: "oauth", ...createCredential("backup", "backup@example.com") },
+		]);
+
+		authStorage.setAccountPriority("test-provider", ["primary@example.com", "backup@example.com"]);
+
+		const rows = store.listAuthCredentials("test-provider");
+		const primaryRow = rows.find(r => r.credential.type === "oauth" && r.credential.accountId === "primary");
+		if (!primaryRow) throw new Error("expected primary row");
+
+		// Initially primary is picked
+		expect(await authStorage.getApiKey("test-provider", "session-x")).toBe("access-primary");
+
+		// Rotate / mark primary blocked
+		await authStorage.rotateSessionCredential("test-provider", "session-x", {
+			credentialId: primaryRow.id,
+			error: new Error("rate limit reached: 429"),
+		});
+
+		// Now backup is picked
+		expect(await authStorage.getApiKey("test-provider", "session-x")).toBe("access-backup");
+	});
+
+	test("listOAuthAccounts populates 1-based priority", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("a", "a@example.com") },
+			{ type: "oauth", ...createCredential("b", "b@example.com") },
+			{ type: "oauth", ...createCredential("c", "c@example.com") },
+		]);
+
+		authStorage.setAccountPriority("test-provider", ["b@example.com", "a@example.com"]);
+
+		const accounts = authStorage.listOAuthAccounts("test-provider");
+		const acctA = accounts.find(a => a.email === "a@example.com");
+		const acctB = accounts.find(a => a.email === "b@example.com");
+		const acctC = accounts.find(a => a.email === "c@example.com");
+
+		expect(acctB?.priority).toBe(1);
+		expect(acctA?.priority).toBe(2);
+		expect(acctC?.priority).toBeUndefined();
+	});
+
+	test("matches priority by index and account ID", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("acct-1", "first@example.com") },
+			{ type: "oauth", ...createCredential("acct-2", "second@example.com") },
+		]);
+
+		// Match by 1-based index "2"
+		authStorage.setAccountPriority("test-provider", ["2", "1"]);
+		expect(await authStorage.getApiKey("test-provider", "s1")).toBe("access-acct-2");
+
+		// Match by accountId "acct-1"
+		authStorage.setAccountPriority("test-provider", ["acct-1"]);
+		expect(await authStorage.getApiKey("test-provider", "s2")).toBe("access-acct-1");
+	});
+});

--- a/packages/ai/test/account-priority.test.ts
+++ b/packages/ai/test/account-priority.test.ts
@@ -195,4 +195,69 @@ describe("AuthStorage account priority", () => {
 		authStorage.setAccountPriority("test-provider", ["acct-1"]);
 		expect(await authStorage.getApiKey("test-provider", "s2")).toBe("access-acct-1");
 	});
+
+	test("configured priority overrides existing session assignment upon order change", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set("test-provider", [
+			{ type: "oauth", ...createCredential("account-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("account-b", "b@example.com") },
+		]);
+
+		// Initially resolves to account A
+		const key1 = await authStorage.getApiKey("test-provider", "same-session");
+		expect(key1).toBe("access-account-a");
+
+		// Change priority to B -> A
+		authStorage.setAccountPriority("test-provider", ["b@example.com", "a@example.com"]);
+
+		// Same session must now resolve to account B
+		const key2 = await authStorage.getApiKey("test-provider", "same-session");
+		expect(key2).toBe("access-account-b");
+	});
+
+	test("supports multi-org accounts sharing the same email without collapsing priorities", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-org-personal",
+				refresh: "refresh-1",
+				expires: Date.now() + HOUR_MS,
+				accountId: "acct-1",
+				email: "same@example.com",
+				orgId: "org-personal",
+			},
+			{
+				type: "oauth",
+				access: "access-org-team",
+				refresh: "refresh-2",
+				expires: Date.now() + HOUR_MS,
+				accountId: "acct-2",
+				email: "same@example.com",
+				orgId: "org-team",
+			},
+		]);
+
+		const rows = store.listAuthCredentials("anthropic");
+		const personalRow = rows.find(
+			r => r.credential.type === "oauth" && "orgId" in r.credential && r.credential.orgId === "org-personal",
+		);
+		const teamRow = rows.find(
+			r => r.credential.type === "oauth" && "orgId" in r.credential && r.credential.orgId === "org-team",
+		);
+		if (!personalRow || !teamRow) throw new Error("expected both rows");
+
+		// Prioritize team over personal via id:<credentialId>
+		authStorage.setAccountPriority("anthropic", [`id:${teamRow.id}`, `id:${personalRow.id}`]);
+
+		const accounts = authStorage.listOAuthAccounts("anthropic");
+		const personalAcct = accounts.find(a => a.credentialId === personalRow.id);
+		const teamAcct = accounts.find(a => a.credentialId === teamRow.id);
+
+		expect(teamAcct?.priority).toBe(1);
+		expect(personalAcct?.priority).toBe(2);
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-org-test");
+		expect(apiKey).toBe("access-org-team");
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `auth.accountPriority` setting and `/account priority` command (also `/session priority`) to set and manage priority order for providers with multiple accounts.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `auth.accountPriority` setting and `/account priority` command (also `/session priority`) to set and manage priority order for providers with multiple accounts.
+- Added `auth.accountPriority` setting and `/account priority` command (also `/session priority`) to set and manage priority order for providers with multiple accounts ([#11645](https://github.com/can1357/oh-my-pi/pull/11645) by [@keethesh](https://github.com/keethesh)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -403,6 +403,7 @@ export interface ModelTagsSettings {
 const EMPTY_STRING_ARRAY: string[] = [];
 const EMPTY_STRING_RECORD: Record<string, string> = {};
 const EMPTY_NUMBER_RECORD: Record<string, number> = {};
+const EMPTY_ACCOUNT_PRIORITY_RECORD: Record<string, string[]> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS: string[] = ["hub"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
@@ -485,6 +486,16 @@ export const SETTINGS_SCHEMA = {
 	// per-machine overrides remain trivial.
 	"auth.broker.url": { type: "string", default: undefined },
 	"auth.broker.token": { type: "string", default: undefined, credential: true },
+	"auth.accountPriority": {
+		type: "record",
+		default: EMPTY_ACCOUNT_PRIORITY_RECORD,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Account Priority",
+			description: "Order of priority for multiple accounts per provider (email, account ID, or index)",
+		},
+	},
 
 	autoResume: {
 		type: "boolean",

--- a/packages/coding-agent/src/modes/components/account-priority-selector.ts
+++ b/packages/coding-agent/src/modes/components/account-priority-selector.ts
@@ -1,0 +1,53 @@
+import { type SelectItem, SelectList, type SgrMouseEvent } from "@oh-my-pi/pi-tui";
+import { getSelectListTheme } from "../../modes/theme/theme";
+import type { SessionPinAccount } from "../../slash-commands/helpers/session-pin";
+import { OverlayPanel } from "./overlay-box";
+import { routeSelectListMouseWithTopBorder } from "./select-list-mouse-routing";
+
+const ACCOUNT_SELECTOR_MAX_VISIBLE = 10;
+
+/** Account priority picker opened by `/account priority`. Selecting moves account to top priority. */
+export class AccountPrioritySelectorComponent extends OverlayPanel {
+	#selectList: SelectList;
+
+	constructor(
+		providerName: string,
+		accounts: readonly SessionPinAccount[],
+		onSelect: (account: SessionPinAccount) => void,
+		onCancel: () => void,
+	) {
+		super(`Select top priority ${providerName} account (Enter moves to #1)`);
+		const accountsByValue = new Map<string, SessionPinAccount>();
+		const items: SelectItem[] = accounts.map(account => {
+			const value = String(account.credentialId);
+			accountsByValue.set(value, account);
+			const priorityDesc = account.priority !== undefined ? `Priority ${account.priority}` : "unprioritized";
+			const activeDesc = account.active ? " (active)" : "";
+			return {
+				value,
+				label: account.label,
+				description: `${priorityDesc}${activeDesc}`,
+			};
+		});
+
+		this.#selectList = new SelectList(
+			items,
+			Math.min(Math.max(items.length, 1), ACCOUNT_SELECTOR_MAX_VISIBLE),
+			getSelectListTheme(),
+		);
+		this.#selectList.onSelect = item => {
+			const account = accountsByValue.get(item.value);
+			if (account) onSelect(account);
+		};
+		this.#selectList.onCancel = onCancel;
+		this.addChild(this.#selectList);
+	}
+
+	handleInput(keyData: string): void {
+		this.#selectList.handleInput(keyData);
+	}
+
+	routeMouse(event: SgrMouseEvent, line: number, col: number): void {
+		routeSelectListMouseWithTopBorder(this.#selectList, event, line, col);
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -104,6 +104,7 @@ import { ReadToolGroupComponent } from "../components/read-tool-group";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { type BranchVariantPath, RewindSelectorComponent } from "../components/rewind-selector";
 import { renderSegmentTrack } from "../components/segment-track";
+import { AccountPrioritySelectorComponent } from "../components/account-priority-selector";
 import { SessionAccountSelectorComponent } from "../components/session-account-selector";
 import { SessionSelectorComponent, type SessionSelectorOptions } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
@@ -2257,6 +2258,55 @@ export class SelectorController {
 						return;
 					}
 					this.ctx.showStatus(`Pinned ${account.label} to this session for ${providerName}.`);
+					this.ctx.statusLine.invalidate();
+					this.ctx.ui.requestRender();
+				},
+				() => {
+					done();
+					this.ctx.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector };
+		});
+	}
+
+	async showAccountPrioritySelector(targetProviderId?: string): Promise<void> {
+		const session = this.ctx.session;
+		if (session.isStreaming) {
+			this.ctx.showStatus("Cannot set account priority while the session is streaming.");
+			return;
+		}
+		const providerId = targetProviderId ?? session.model?.provider;
+		if (!providerId) {
+			this.ctx.showStatus("Select a model or specify a provider: /account priority <provider>");
+			return;
+		}
+		this.ctx.showStatus("Loading provider accounts…", { dim: true });
+		const authStorage = session.modelRegistry.authStorage;
+		await authStorage.reload();
+		const rawAccounts = authStorage.listOAuthAccounts(providerId, session.sessionId);
+		const accounts = toSessionPinAccounts(rawAccounts);
+		const provider = getOAuthProviders().find(candidate => candidate.id === providerId);
+		const providerName = provider?.name ?? providerId;
+		if (accounts.length === 0) {
+			this.ctx.showStatus(`No stored OAuth accounts for ${providerName}. Use /login to add one.`);
+			return;
+		}
+
+		this.showSelector(done => {
+			const selector = new AccountPrioritySelectorComponent(
+				providerName,
+				accounts,
+				account => {
+					done();
+					const otherAccounts = accounts.filter(a => a.credentialId !== account.credentialId);
+					const reordered = [account, ...otherAccounts];
+					const prioritySelectors = reordered.map(a => a.email ?? a.accountId ?? String(a.credentialId));
+					const currentPriorities = (settings.get("auth.accountPriority") as Record<string, string[]>) ?? {};
+					const updated = { ...currentPriorities, [providerId]: prioritySelectors };
+					settings.set("auth.accountPriority", updated);
+					authStorage.setAccountPriority(providerId, prioritySelectors);
+					this.ctx.showStatus(`Set ${account.label} as top priority for ${providerName}.`);
 					this.ctx.statusLine.invalidate();
 					this.ctx.ui.requestRender();
 				},

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2293,15 +2293,29 @@ export class SelectorController {
 			return;
 		}
 
+		const sortedAccounts = [...accounts].sort((a, b) => {
+			const pA = a.priority ?? Number.POSITIVE_INFINITY;
+			const pB = b.priority ?? Number.POSITIVE_INFINITY;
+			if (pA !== pB) return pA - pB;
+			return a.position - b.position;
+		});
+
 		this.showSelector(done => {
 			const selector = new AccountPrioritySelectorComponent(
 				providerName,
-				accounts,
+				sortedAccounts,
 				account => {
 					done();
-					const otherAccounts = accounts.filter(a => a.credentialId !== account.credentialId);
+					const otherAccounts = accounts
+						.filter(a => a.credentialId !== account.credentialId)
+						.sort((a, b) => {
+							const pA = a.priority ?? Number.POSITIVE_INFINITY;
+							const pB = b.priority ?? Number.POSITIVE_INFINITY;
+							if (pA !== pB) return pA - pB;
+							return a.position - b.position;
+						});
 					const reordered = [account, ...otherAccounts];
-					const prioritySelectors = reordered.map(a => a.email ?? a.accountId ?? String(a.credentialId));
+					const prioritySelectors = reordered.map(a => `id:${a.credentialId}`);
 					const currentPriorities = (settings.get("auth.accountPriority") as Record<string, string[]>) ?? {};
 					const updated = { ...currentPriorities, [providerId]: prioritySelectors };
 					settings.set("auth.accountPriority", updated);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6115,6 +6115,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#selectorController.showSessionPinSelector();
 	}
 
+	showAccountPrioritySelector(targetProviderId?: string): Promise<void> {
+		return this.#selectorController.showAccountPrioritySelector(targetProviderId);
+	}
+
 	showResetUsageSelector(): Promise<void> {
 		return this.#selectorController.showResetUsageSelector();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -461,6 +461,7 @@ export interface InteractiveModeContext {
 	handleSessionDeleteCommand(): Promise<void>;
 	showOAuthSelector(mode: "login" | "logout", providerId?: string): Promise<void>;
 	showSessionPinSelector(): Promise<void>;
+	showAccountPrioritySelector(targetProviderId?: string): Promise<void>;
 	showResetUsageSelector(): Promise<void>;
 	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;

--- a/packages/coding-agent/src/session/auth-broker-config.ts
+++ b/packages/coding-agent/src/session/auth-broker-config.ts
@@ -82,11 +82,25 @@ export function resolveAuthBrokerConfig(): Promise<AuthBrokerClientConfig | null
  *
  * Default `agentDir` is the current configured agent directory.
  */
+function resolveAccountPriority(provider: string): readonly string[] | undefined {
+	try {
+		const { settings } = require("../config/settings");
+		const map = settings.get("auth.accountPriority") as Record<string, string[]> | undefined;
+		if (map && Array.isArray(map[provider]) && map[provider].length > 0) {
+			return map[provider];
+		}
+	} catch {
+		// settings singleton not yet initialized
+	}
+	return undefined;
+}
+
 export function discoverAuthStorage(
 	agentDir: string = getAgentDir(),
 	options?: Omit<DiscoverAuthStorageOptions, "agentDir" | "configValueResolver">,
 ): Promise<AuthStorage> {
 	return discoverAuthStorageShared({
+		accountPriorityResolver: options?.accountPriorityResolver ?? resolveAccountPriority,
 		...options,
 		agentDir,
 		configValueResolver: resolveConfigValue,

--- a/packages/coding-agent/src/session/auth-broker-config.ts
+++ b/packages/coding-agent/src/session/auth-broker-config.ts
@@ -32,6 +32,7 @@ import {
 import { MissingApiKeyError } from "@oh-my-pi/pi-ai/error";
 import { getAgentDir } from "@oh-my-pi/pi-utils";
 import { resolveConfigValue } from "../config/resolve-config-value";
+import { settings } from "../config/settings";
 import type { AuthStorage } from "./auth-storage";
 
 export { type AuthBrokerClientConfig, getAuthBrokerTokenFilePath };
@@ -84,13 +85,15 @@ export function resolveAuthBrokerConfig(): Promise<AuthBrokerClientConfig | null
  */
 function resolveAccountPriority(provider: string): readonly string[] | undefined {
 	try {
-		const { settings } = require("../config/settings");
 		const map = settings.get("auth.accountPriority") as Record<string, string[]> | undefined;
 		if (map && Array.isArray(map[provider]) && map[provider].length > 0) {
 			return map[provider];
 		}
-	} catch {
-		// settings singleton not yet initialized
+	} catch (error) {
+		if (error instanceof Error && error.message.includes("Settings not initialized")) {
+			return undefined;
+		}
+		throw error;
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -233,7 +233,9 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (verb === "priority") {
-				const result = await handleAccountPriorityCommand(rest, runtime.session);
+				const result = await handleAccountPriorityCommand(rest, runtime.session, {
+					defaultToSessionProvider: true,
+				});
 				await runtime.output(result);
 				return commandConsumed();
 			}
@@ -258,7 +260,9 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			}
 			if (verb === "priority") {
 				if (rest) {
-					const result = await handleAccountPriorityCommand(rest, runtime.ctx.session);
+					const result = await handleAccountPriorityCommand(rest, runtime.ctx.session, {
+						defaultToSessionProvider: true,
+					});
 					runtime.ctx.showStatus(result);
 				} else {
 					await runtime.ctx.showAccountPrioritySelector();

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -17,6 +17,7 @@ import { matchSessionPinAccounts, toSessionPinAccounts } from "./helpers/session
 import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-dashboard";
 import { handleTodoAcp } from "./helpers/todo";
 import { buildUsageReportText } from "./helpers/usage-report";
+import { handleAccountListCommand, handleAccountPriorityCommand } from "./helpers/account-priority";
 import type { SlashCommandRuntime, SlashCommandSpec } from "./types";
 
 async function handleUsageResetCommand(
@@ -180,7 +181,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		icon: "session",
 		description: "Session management commands",
 		acpDescription: "Show or configure the current session",
-		acpInputHint: "[info|delete|pin [account]]",
+		acpInputHint: "[info|delete|pin|priority [account/order]]",
 		subcommands: [
 			{ name: "info", description: "Show session info and stats" },
 			{ name: "delete", description: "Delete current session and return to selector" },
@@ -188,6 +189,11 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				name: "pin",
 				description: "Pin the current provider to a stored OAuth account",
 				usage: "[account]",
+			},
+			{
+				name: "priority",
+				description: "View or set account priority order for current provider",
+				usage: "[order...]",
 			},
 		],
 		allowArgs: true,
@@ -226,7 +232,12 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				await handleSessionPinCommand(rest, runtime.session, runtime.output);
 				return commandConsumed();
 			}
-			return usage("Usage: /session [info|delete|pin [account]]", runtime);
+			if (verb === "priority") {
+				const result = await handleAccountPriorityCommand(rest, runtime.session);
+				await runtime.output(result);
+				return commandConsumed();
+			}
+			return usage("Usage: /session [info|delete|pin [account]|priority [order...]]", runtime);
 		},
 		handleTui: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
@@ -245,11 +256,72 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.editor.setText("");
 				return;
 			}
+			if (verb === "priority") {
+				if (rest) {
+					const result = await handleAccountPriorityCommand(rest, runtime.ctx.session);
+					runtime.ctx.showStatus(result);
+				} else {
+					await runtime.ctx.showAccountPrioritySelector();
+				}
+				runtime.ctx.editor.setText("");
+				return;
+			}
 			if (!verb || (verb === "info" && !rest)) {
 				await runtime.ctx.handleSessionCommand();
 			} else {
-				runtime.ctx.showStatus("Usage: /session [info|delete|pin [account]]");
+				runtime.ctx.showStatus("Usage: /session [info|delete|pin [account]|priority [order...]]");
 			}
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "account",
+		icon: "signIn",
+		description: "Account management and priority order",
+		acpDescription: "Manage provider accounts and priority",
+		acpInputHint: "[list|priority [provider] [order...]]",
+		subcommands: [
+			{ name: "list", description: "List stored accounts for a provider", usage: "[provider]" },
+			{
+				name: "priority",
+				description: "View or set account priority order for a provider",
+				usage: "[provider] [order...]",
+			},
+		],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const { verb, rest } = parseSubcommand(command.args);
+			if (verb === "priority") {
+				const result = await handleAccountPriorityCommand(rest, runtime.session);
+				await runtime.output(result);
+				return commandConsumed();
+			}
+			if (verb === "list" || !verb) {
+				const result = await handleAccountListCommand(rest, runtime.session);
+				await runtime.output(result);
+				return commandConsumed();
+			}
+			return usage("Usage: /account [list|priority [provider] [order...]]", runtime);
+		},
+		handleTui: async (command, runtime) => {
+			const { verb, rest } = parseSubcommand(command.args);
+			if (verb === "priority") {
+				if (rest) {
+					const result = await handleAccountPriorityCommand(rest, runtime.ctx.session);
+					runtime.ctx.showStatus(result);
+				} else {
+					await runtime.ctx.showAccountPrioritySelector();
+				}
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (verb === "list" || !verb) {
+				const result = await handleAccountListCommand(rest, runtime.ctx.session);
+				runtime.ctx.showStatus(result);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.showStatus("Usage: /account [list|priority [provider] [order...]]");
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/helpers/account-priority.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/account-priority.ts
@@ -1,0 +1,144 @@
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import { settings } from "../../config/settings";
+import type { AgentSession } from "../../session/agent-session";
+import { matchSessionPinAccounts, toSessionPinAccounts, type SessionPinAccount } from "./session-pin";
+
+export function resolveTargetProvider(
+	providerArg: string | undefined,
+	session: AgentSession,
+): { providerId: string; providerName: string } | { error: string } {
+	const trimmed = providerArg?.trim().toLowerCase();
+	const allProviders = getOAuthProviders();
+	if (trimmed) {
+		const matched = allProviders.find(p => p.id.toLowerCase() === trimmed || p.name.toLowerCase() === trimmed);
+		if (matched) {
+			return { providerId: matched.id, providerName: matched.name };
+		}
+		return { providerId: trimmed, providerName: trimmed };
+	}
+
+	const currentProvider = session.model?.provider;
+	if (!currentProvider) {
+		return { error: "No model selected. Specify a provider: /account priority <provider> [order...]" };
+	}
+	const matched = allProviders.find(p => p.id === currentProvider);
+	return { providerId: currentProvider, providerName: matched?.name ?? currentProvider };
+}
+
+export function formatAccountPriorityList(providerName: string, accounts: readonly SessionPinAccount[]): string {
+	if (accounts.length === 0) {
+		return `No stored accounts for ${providerName}. Use /login to add one.`;
+	}
+	const lines = [`Account priority for ${providerName}:`];
+	for (const account of accounts) {
+		const priorityStr = account.priority !== undefined ? ` (Priority ${account.priority})` : " (unprioritized)";
+		const activeStr = account.active ? " [active]" : "";
+		lines.push(`${account.position + 1}. ${account.label}${priorityStr}${activeStr}`);
+	}
+	lines.push(
+		"",
+		`Set priority: /account priority ${providerName.toLowerCase()} <order...> (e.g. /account priority ${providerName.toLowerCase()} 2 1)`,
+		`Clear priority: /account priority ${providerName.toLowerCase()} clear`,
+	);
+	return lines.join("\n");
+}
+
+export async function handleAccountPriorityCommand(args: string, session: AgentSession): Promise<string> {
+	const tokens = args.trim().split(/\s+/).filter(Boolean);
+	let providerToken: string | undefined;
+	let orderTokens: string[] = [];
+
+	if (tokens.length > 0) {
+		const candidate = tokens[0]!;
+		const allProviders = getOAuthProviders();
+		const isProvider = allProviders.some(
+			p => p.id.toLowerCase() === candidate.toLowerCase() || p.name.toLowerCase() === candidate.toLowerCase(),
+		);
+		if (isProvider || !/^\d+$/.test(candidate)) {
+			providerToken = candidate;
+			orderTokens = tokens.slice(1);
+		} else {
+			orderTokens = tokens;
+		}
+	}
+
+	const resolved = resolveTargetProvider(providerToken, session);
+	if ("error" in resolved) return resolved.error;
+	const { providerId, providerName } = resolved;
+
+	const authStorage = session.modelRegistry.authStorage;
+	await authStorage.reload();
+	const rawAccounts = authStorage.listOAuthAccounts(providerId, session.sessionId);
+	const accounts = toSessionPinAccounts(rawAccounts);
+
+	if (accounts.length === 0) {
+		return `No stored OAuth accounts for ${providerName}. Use /login to add one.`;
+	}
+
+	if (
+		orderTokens.length === 1 &&
+		(orderTokens[0]?.toLowerCase() === "clear" || orderTokens[0]?.toLowerCase() === "reset")
+	) {
+		const currentPriorities = (settings.get("auth.accountPriority") as Record<string, string[]>) ?? {};
+		const updated = { ...currentPriorities };
+		delete updated[providerId];
+		settings.set("auth.accountPriority", updated);
+		authStorage.setAccountPriority(providerId, undefined);
+		return `Reset account priority for ${providerName} to default order.`;
+	}
+
+	if (orderTokens.length === 0) {
+		return formatAccountPriorityList(providerName, accounts);
+	}
+
+	const selectors = orderTokens
+		.flatMap(t => t.split(","))
+		.map(t => t.trim())
+		.filter(Boolean);
+	const matchedAccounts: SessionPinAccount[] = [];
+	const seenCredentialIds = new Set<number>();
+
+	for (const selector of selectors) {
+		const matches = matchSessionPinAccounts(accounts, selector);
+		if (matches.length === 0) {
+			return `No ${providerName} account matches "${selector}". Run /account priority ${providerId} to see available accounts.`;
+		}
+		if (matches.length > 1) {
+			return `"${selector}" matches multiple ${providerName} accounts: ${matches
+				.map(a => `${a.position + 1}. ${a.label}`)
+				.join(", ")}. Use account numbers (1-${accounts.length}).`;
+		}
+		const matched = matches[0]!;
+		if (!seenCredentialIds.has(matched.credentialId)) {
+			seenCredentialIds.add(matched.credentialId);
+			matchedAccounts.push(matched);
+		}
+	}
+
+	const prioritySelectors = matchedAccounts.map(acct => acct.email ?? acct.accountId ?? String(acct.credentialId));
+
+	const currentPriorities = (settings.get("auth.accountPriority") as Record<string, string[]>) ?? {};
+	const updated = { ...currentPriorities, [providerId]: prioritySelectors };
+	settings.set("auth.accountPriority", updated);
+	authStorage.setAccountPriority(providerId, prioritySelectors);
+
+	const refreshedAccounts = toSessionPinAccounts(authStorage.listOAuthAccounts(providerId, session.sessionId));
+	const lines = [`Updated account priority for ${providerName}:`];
+	for (const acct of refreshedAccounts) {
+		const p = acct.priority !== undefined ? ` (Priority ${acct.priority})` : " (unprioritized)";
+		const a = acct.active ? " [active]" : "";
+		lines.push(`${acct.position + 1}. ${acct.label}${p}${a}`);
+	}
+	return lines.join("\n");
+}
+
+export async function handleAccountListCommand(args: string, session: AgentSession): Promise<string> {
+	const resolved = resolveTargetProvider(args.trim() || undefined, session);
+	if ("error" in resolved) return resolved.error;
+	const { providerId, providerName } = resolved;
+
+	const authStorage = session.modelRegistry.authStorage;
+	await authStorage.reload();
+	const accounts = toSessionPinAccounts(authStorage.listOAuthAccounts(providerId, session.sessionId));
+	return formatAccountPriorityList(providerName, accounts);
+}

--- a/packages/coding-agent/src/slash-commands/helpers/account-priority.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/account-priority.ts
@@ -25,7 +25,11 @@ export function resolveTargetProvider(
 	return { providerId: currentProvider, providerName: matched?.name ?? currentProvider };
 }
 
-export function formatAccountPriorityList(providerName: string, accounts: readonly SessionPinAccount[]): string {
+export function formatAccountPriorityList(
+	providerId: string,
+	providerName: string,
+	accounts: readonly SessionPinAccount[],
+): string {
 	if (accounts.length === 0) {
 		return `No stored accounts for ${providerName}. Use /login to add one.`;
 	}
@@ -37,28 +41,40 @@ export function formatAccountPriorityList(providerName: string, accounts: readon
 	}
 	lines.push(
 		"",
-		`Set priority: /account priority ${providerName.toLowerCase()} <order...> (e.g. /account priority ${providerName.toLowerCase()} 2 1)`,
-		`Clear priority: /account priority ${providerName.toLowerCase()} clear`,
+		`Set priority: /account priority ${providerId} <order...> (e.g. /account priority ${providerId} 2 1)`,
+		`Clear priority: /account priority ${providerId} clear`,
 	);
 	return lines.join("\n");
 }
 
-export async function handleAccountPriorityCommand(args: string, session: AgentSession): Promise<string> {
+export async function handleAccountPriorityCommand(
+	args: string,
+	session: AgentSession,
+	options?: { defaultToSessionProvider?: boolean },
+): Promise<string> {
 	const tokens = args.trim().split(/\s+/).filter(Boolean);
 	let providerToken: string | undefined;
 	let orderTokens: string[] = [];
 
-	if (tokens.length > 0) {
-		const candidate = tokens[0]!;
-		const allProviders = getOAuthProviders();
-		const isProvider = allProviders.some(
-			p => p.id.toLowerCase() === candidate.toLowerCase() || p.name.toLowerCase() === candidate.toLowerCase(),
+	const allProviders = getOAuthProviders();
+	const currentSessionProvider = session.model?.provider;
+
+	if (options?.defaultToSessionProvider) {
+		orderTokens = tokens;
+	} else if (tokens.length > 0) {
+		const first = tokens[0]!;
+		const isRegisteredProvider = allProviders.some(
+			p => p.id.toLowerCase() === first.toLowerCase() || p.name.toLowerCase() === first.toLowerCase(),
 		);
-		if (isProvider || !/^\d+$/.test(candidate)) {
-			providerToken = candidate;
+		if (isRegisteredProvider) {
+			providerToken = first;
 			orderTokens = tokens.slice(1);
-		} else {
+		} else if (currentSessionProvider) {
+			// First token is not a registered provider name; treat as order/clear token for current session provider
 			orderTokens = tokens;
+		} else {
+			providerToken = first;
+			orderTokens = tokens.slice(1);
 		}
 	}
 
@@ -88,7 +104,7 @@ export async function handleAccountPriorityCommand(args: string, session: AgentS
 	}
 
 	if (orderTokens.length === 0) {
-		return formatAccountPriorityList(providerName, accounts);
+		return formatAccountPriorityList(providerId, providerName, accounts);
 	}
 
 	const selectors = orderTokens
@@ -115,7 +131,8 @@ export async function handleAccountPriorityCommand(args: string, session: AgentS
 		}
 	}
 
-	const prioritySelectors = matchedAccounts.map(acct => acct.email ?? acct.accountId ?? String(acct.credentialId));
+	// Persist unambiguous selector id:<credentialId> so same-email / multi-org accounts remain distinct
+	const prioritySelectors = matchedAccounts.map(acct => `id:${acct.credentialId}`);
 
 	const currentPriorities = (settings.get("auth.accountPriority") as Record<string, string[]>) ?? {};
 	const updated = { ...currentPriorities, [providerId]: prioritySelectors };
@@ -140,5 +157,5 @@ export async function handleAccountListCommand(args: string, session: AgentSessi
 	const authStorage = session.modelRegistry.authStorage;
 	await authStorage.reload();
 	const accounts = toSessionPinAccounts(authStorage.listOAuthAccounts(providerId, session.sessionId));
-	return formatAccountPriorityList(providerName, accounts);
+	return formatAccountPriorityList(providerId, providerName, accounts);
 }

--- a/packages/coding-agent/test/account-priority.test.ts
+++ b/packages/coding-agent/test/account-priority.test.ts
@@ -6,6 +6,7 @@ import { SqliteAuthCredentialStore, AuthStorage } from "@oh-my-pi/pi-ai/auth-sto
 import { Settings, resetSettingsForTest, settings } from "../src/config/settings";
 import type { AgentSession } from "../src/session/agent-session";
 import { handleAccountListCommand, handleAccountPriorityCommand } from "../src/slash-commands/helpers/account-priority";
+import { toSessionPinAccounts } from "../src/slash-commands/helpers/session-pin";
 
 describe("account priority slash command and settings", () => {
 	let tempDir: string;
@@ -60,25 +61,142 @@ describe("account priority slash command and settings", () => {
 		expect(output).toContain("Account priority for Anthropic (Claude Pro/Max):");
 		expect(output).toContain("alpha@example.com (unprioritized)");
 		expect(output).toContain("beta@example.com (unprioritized)");
+		// Verifies suggestion uses provider ID, not display name with spaces
+		expect(output).toContain("Set priority: /account priority anthropic <order...>");
 	});
 
-	it("updates priority by account numbers", async () => {
+	it("updates priority by account numbers and stores id:<credentialId>", async () => {
 		const output = await handleAccountPriorityCommand("anthropic 2 1", mockSession);
 		expect(output).toContain("Updated account priority for Anthropic (Claude Pro/Max):");
 		expect(output).toContain("beta@example.com (Priority 1)");
 		expect(output).toContain("alpha@example.com (Priority 2)");
 
+		const rows = store.listAuthCredentials("anthropic");
+		const betaRow = rows.find(r => r.credential.type === "oauth" && r.credential.accountId === "acct-beta");
+		const alphaRow = rows.find(r => r.credential.type === "oauth" && r.credential.accountId === "acct-alpha");
+
 		const prioritySetting = settings.get("auth.accountPriority") as Record<string, string[]>;
-		expect(prioritySetting.anthropic).toEqual(["beta@example.com", "alpha@example.com"]);
+		expect(prioritySetting.anthropic).toEqual([`id:${betaRow?.id}`, `id:${alphaRow?.id}`]);
 	});
 
-	it("updates priority by email selectors", async () => {
-		const output = await handleAccountPriorityCommand("anthropic beta@example.com alpha@example.com", mockSession);
+	it("supports current-provider textual order and clear without explicit provider", async () => {
+		// Session priority call with defaultToSessionProvider: true
+		const output = await handleAccountPriorityCommand("beta@example.com alpha@example.com", mockSession, {
+			defaultToSessionProvider: true,
+		});
 		expect(output).toContain("Updated account priority for Anthropic (Claude Pro/Max):");
 		expect(output).toContain("beta@example.com (Priority 1)");
 		expect(output).toContain("alpha@example.com (Priority 2)");
 
-		expect(authStorage.getAccountPriority("anthropic")).toEqual(["beta@example.com", "alpha@example.com"]);
+		// Session priority clear
+		const clearOutput = await handleAccountPriorityCommand("clear", mockSession, {
+			defaultToSessionProvider: true,
+		});
+		expect(clearOutput).toContain("Reset account priority for Anthropic (Claude Pro/Max) to default order.");
+
+		// /account priority clear (without provider name, defaulting to current session provider)
+		await handleAccountPriorityCommand("2 1", mockSession);
+		const acctClearOutput = await handleAccountPriorityCommand("clear", mockSession);
+		expect(acctClearOutput).toContain("Reset account priority for Anthropic (Claude Pro/Max) to default order.");
+
+		// /account priority with email selectors directly (first token not a registered provider)
+		const directEmailOutput = await handleAccountPriorityCommand("beta@example.com alpha@example.com", mockSession);
+		expect(directEmailOutput).toContain("Updated account priority for Anthropic (Claude Pro/Max):");
+	});
+
+	it("disambiguates same-email multi-org accounts", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "tok-personal",
+				refresh: "ref-1",
+				expires: Date.now() + 3600_000,
+				accountId: "acct-1",
+				email: "same@example.com",
+				orgId: "org-personal",
+				orgName: "Personal Org",
+			},
+			{
+				type: "oauth",
+				access: "tok-team",
+				refresh: "ref-2",
+				expires: Date.now() + 3600_000,
+				accountId: "acct-2",
+				email: "same@example.com",
+				orgId: "org-team",
+				orgName: "Team Org",
+			},
+		]);
+
+		const output = await handleAccountPriorityCommand("anthropic 2 1", mockSession);
+		expect(output).toContain("Priority 1");
+		expect(output).toContain("Priority 2");
+
+		const rows = store.listAuthCredentials("anthropic");
+		const personalRow = rows.find(
+			r => r.credential.type === "oauth" && "orgId" in r.credential && r.credential.orgId === "org-personal",
+		);
+		const teamRow = rows.find(
+			r => r.credential.type === "oauth" && "orgId" in r.credential && r.credential.orgId === "org-team",
+		);
+
+		const prioritySetting = settings.get("auth.accountPriority") as Record<string, string[]>;
+		expect(prioritySetting.anthropic).toEqual([`id:${teamRow?.id}`, `id:${personalRow?.id}`]);
+
+		const accounts = authStorage.listOAuthAccounts("anthropic");
+		const teamAcct = accounts.find(a => a.credentialId === teamRow?.id);
+		const personalAcct = accounts.find(a => a.credentialId === personalRow?.id);
+		expect(teamAcct?.priority).toBe(1);
+		expect(personalAcct?.priority).toBe(2);
+	});
+
+	it("preserves relative priority of remaining accounts during promotion", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "t-a",
+				refresh: "r-a",
+				expires: Date.now() + 3600_000,
+				accountId: "a",
+				email: "a@example.com",
+			},
+			{
+				type: "oauth",
+				access: "t-b",
+				refresh: "r-b",
+				expires: Date.now() + 3600_000,
+				accountId: "b",
+				email: "b@example.com",
+			},
+			{
+				type: "oauth",
+				access: "t-c",
+				refresh: "r-c",
+				expires: Date.now() + 3600_000,
+				accountId: "c",
+				email: "c@example.com",
+			},
+		]);
+
+		// Initial priority: C (1) -> B (2) -> A (3)
+		await handleAccountPriorityCommand("anthropic 3 2 1", mockSession);
+		const rawAccounts = authStorage.listOAuthAccounts("anthropic");
+		const accounts = toSessionPinAccounts(rawAccounts);
+
+		// Promote B (account at index 1)
+		const targetAccount = accounts.find(a => a.email === "b@example.com")!;
+		const otherAccounts = accounts
+			.filter(a => a.credentialId !== targetAccount.credentialId)
+			.sort((a, b) => {
+				const pA = a.priority ?? Number.POSITIVE_INFINITY;
+				const pB = b.priority ?? Number.POSITIVE_INFINITY;
+				if (pA !== pB) return pA - pB;
+				return a.position - b.position;
+			});
+		const reordered = [targetAccount, ...otherAccounts];
+
+		// Expected order: B, then C (former #1), then A (former #3)
+		expect(reordered.map(a => a.email)).toEqual(["b@example.com", "c@example.com", "a@example.com"]);
 	});
 
 	it("resets priority with clear subcommand", async () => {

--- a/packages/coding-agent/test/account-priority.test.ts
+++ b/packages/coding-agent/test/account-priority.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SqliteAuthCredentialStore, AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import { Settings, resetSettingsForTest, settings } from "../src/config/settings";
+import type { AgentSession } from "../src/session/agent-session";
+import { handleAccountListCommand, handleAccountPriorityCommand } from "../src/slash-commands/helpers/account-priority";
+
+describe("account priority slash command and settings", () => {
+	let tempDir: string;
+	let store: SqliteAuthCredentialStore;
+	let authStorage: AuthStorage;
+	let mockSession: AgentSession;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-acct-priority-test-"));
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: tempDir });
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store);
+		// Seed two accounts for anthropic
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "token-1",
+				refresh: "refresh-1",
+				expires: Date.now() + 3600_000,
+				accountId: "acct-alpha",
+				email: "alpha@example.com",
+			},
+			{
+				type: "oauth",
+				access: "token-2",
+				refresh: "refresh-2",
+				expires: Date.now() + 3600_000,
+				accountId: "acct-beta",
+				email: "beta@example.com",
+			},
+		]);
+
+		mockSession = {
+			sessionId: "session-priority-test",
+			model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+			modelRegistry: { authStorage },
+		} as unknown as AgentSession;
+
+		// Clear priority setting before each test
+		settings.set("auth.accountPriority", {});
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		store.close();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("lists accounts and indicates unprioritized state initially", async () => {
+		const output = await handleAccountPriorityCommand("", mockSession);
+		expect(output).toContain("Account priority for Anthropic (Claude Pro/Max):");
+		expect(output).toContain("alpha@example.com (unprioritized)");
+		expect(output).toContain("beta@example.com (unprioritized)");
+	});
+
+	it("updates priority by account numbers", async () => {
+		const output = await handleAccountPriorityCommand("anthropic 2 1", mockSession);
+		expect(output).toContain("Updated account priority for Anthropic (Claude Pro/Max):");
+		expect(output).toContain("beta@example.com (Priority 1)");
+		expect(output).toContain("alpha@example.com (Priority 2)");
+
+		const prioritySetting = settings.get("auth.accountPriority") as Record<string, string[]>;
+		expect(prioritySetting.anthropic).toEqual(["beta@example.com", "alpha@example.com"]);
+	});
+
+	it("updates priority by email selectors", async () => {
+		const output = await handleAccountPriorityCommand("anthropic beta@example.com alpha@example.com", mockSession);
+		expect(output).toContain("Updated account priority for Anthropic (Claude Pro/Max):");
+		expect(output).toContain("beta@example.com (Priority 1)");
+		expect(output).toContain("alpha@example.com (Priority 2)");
+
+		expect(authStorage.getAccountPriority("anthropic")).toEqual(["beta@example.com", "alpha@example.com"]);
+	});
+
+	it("resets priority with clear subcommand", async () => {
+		await handleAccountPriorityCommand("anthropic 2 1", mockSession);
+		expect(authStorage.getAccountPriority("anthropic")).toBeDefined();
+
+		const resetOutput = await handleAccountPriorityCommand("anthropic clear", mockSession);
+		expect(resetOutput).toContain("Reset account priority for Anthropic (Claude Pro/Max) to default order.");
+
+		const prioritySetting = settings.get("auth.accountPriority") as Record<string, string[]>;
+		expect(prioritySetting.anthropic).toBeUndefined();
+		expect(authStorage.getAccountPriority("anthropic")).toBeUndefined();
+	});
+
+	it("rejects unknown account selector with helpful message", async () => {
+		const output = await handleAccountPriorityCommand("anthropic nonexistent@example.com", mockSession);
+		expect(output).toContain('No Anthropic (Claude Pro/Max) account matches "nonexistent@example.com"');
+	});
+
+	it("handleAccountListCommand lists accounts with their priorities", async () => {
+		await handleAccountPriorityCommand("anthropic 2 1", mockSession);
+		const output = await handleAccountListCommand("anthropic", mockSession);
+		expect(output).toContain("beta@example.com (Priority 1)");
+		expect(output).toContain("alpha@example.com (Priority 2)");
+	});
+});


### PR DESCRIPTION
## Summary

When users have multiple accounts for the same provider (e.g. personal vs team Anthropic or OpenAI accounts), omp previously relied on session-sticky hashing, round-robin distribution, or dynamic usage-drain balancing. This PR adds the ability to define an explicit order of priority for multiple accounts under a provider.

### Changes

- **`AuthStorage` (`@oh-my-pi/pi-ai`)**:
  - Added `setAccountPriority`, `getAccountPriority`, and `setAccountPriorityResolver` on `AuthStorage`.
  - Added selector matching supporting account email, account ID, project ID, org ID, 1-based index, and credential ID.
  - Enforced strict priority failover in credential ordering and usage ranking (`#compareUsageRankedCandidatePriority`): unblocked higher-priority accounts are chosen first; failover to lower-priority accounts occurs when higher-priority accounts are rate-limited, blocked, or quota-exhausted.
  - Added `priority` property to `OAuthAccountSummary` in `listOAuthAccounts`.
- **Settings & Config (`@oh-my-pi/pi-coding-agent`)**:
  - Added setting `auth.accountPriority` (mapping provider IDs to prioritized account selector lists).
  - Wired settings resolution into `discoverAuthStorage`.
- **Slash Commands & TUI**:
  - Added `/account priority [provider] [order...]` (and `/session priority [order...]`) to inspect or reorder accounts (e.g. `/account priority anthropic 2 1` or `/account priority anthropic work@corp.com personal@gmail.com`).
  - Added `/account list [provider]` to view accounts, their priority ranks, and active status.
  - Added `/account priority [provider] clear` to reset back to default load balancing.
  - Added interactive TUI modal `AccountPrioritySelectorComponent` for selecting/promoting accounts.
- **Tests**:
  - Unit tests covering priority ordering, failover on blocks, usage headroom override, selector matching, and command handling in `packages/ai/test/account-priority.test.ts` and `packages/coding-agent/test/account-priority.test.ts`.

## Test Plan

- Ran `bun test ./packages/ai/test/account-priority.test.ts ./packages/coding-agent/test/account-priority.test.ts` (12/12 pass).
- Ran `bun run check:tools` (oxlint & oxfmt pass).
- Verified type check via `tsgo` (`bun --cwd=packages/ai run check` and `bun --cwd=packages/coding-agent run check`).