### PR TITLE
fix(slash-commands): forward file command argument-hint to autocomplete and ACP

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- File slash commands now surface their `argument-hint` frontmatter as inline autocomplete ghost text and ACP `input.hint`, not only in the `/extensions` inspector ([#11647](https://github.com/can1357/oh-my-pi/issues/11647)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -1,5 +1,5 @@
 import { parseFrontmatter, prompt } from "@oh-my-pi/pi-utils";
-import { slashCommandCapability } from "../capability/slash-command";
+import { slashCommandCapability, slashCommandFrontmatterDisplay } from "../capability/slash-command";
 import type { EffectiveExtensionRoots } from "../capability/types";
 import { appendInlineArgsFallback, templateUsesInlineArgPlaceholders } from "../config/prompt-templates";
 import type { SlashCommand } from "../discovery";
@@ -27,6 +27,8 @@ export type { BuiltinSlashCommand, SubcommandDef } from "../slash-commands/types
 export interface FileSlashCommand {
 	name: string;
 	description: string;
+	/** Argument hint from `argument-hint`/`argumentHint` frontmatter, shown as inline ghost text. */
+	argumentHint?: string;
 	content: string;
 	source: string; // e.g., "via Claude Code (User)"
 	/** Source metadata for display */
@@ -38,12 +40,12 @@ const EMBEDDED_SLASH_COMMANDS = EMBEDDED_COMMAND_TEMPLATES;
 function parseCommandTemplate(
 	content: string,
 	options: { source: string; level?: "off" | "warn" | "fatal" },
-): { description: string; body: string } {
+): { description: string; body: string; argumentHint?: string } {
 	const { frontmatter, body } = parseFrontmatter(content, options);
-	const frontmatterDesc = typeof frontmatter.description === "string" ? frontmatter.description.trim() : "";
+	const { description: frontmatterDesc, argumentHint } = slashCommandFrontmatterDisplay(frontmatter);
 
 	// Get description from frontmatter or first non-empty line
-	let description = frontmatterDesc;
+	let description = frontmatterDesc ?? "";
 	if (!description) {
 		const firstLine = body.split("\n").find(line => line.trim());
 		if (firstLine) {
@@ -52,7 +54,7 @@ function parseCommandTemplate(
 		}
 	}
 
-	return { description, body };
+	return { description, body, argumentHint };
 }
 
 export interface LoadSlashCommandsOptions {
@@ -73,7 +75,7 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 	});
 
 	const fileCommands: FileSlashCommand[] = result.items.map(cmd => {
-		const { description, body } = parseCommandTemplate(cmd.content, {
+		const { description, body, argumentHint } = parseCommandTemplate(cmd.content, {
 			source: cmd.path ?? `slash-command:${cmd.name}`,
 			level: cmd.level === "native" ? "fatal" : "warn",
 		});
@@ -85,6 +87,7 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 		return {
 			name: cmd.name,
 			description,
+			argumentHint: cmd.argumentHint ?? argumentHint,
 			content: body,
 			source: sourceStr,
 			_source: { providerName: cmd._source.providerName, level: cmd.level },
@@ -96,13 +99,14 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 		const name = cmd.name.replace(/\.md$/, "");
 		if (seenNames.has(name)) continue;
 
-		const { description, body } = parseCommandTemplate(cmd.content, {
+		const { description, body, argumentHint } = parseCommandTemplate(cmd.content, {
 			source: `embedded:${cmd.name}`,
 			level: "fatal",
 		});
 		fileCommands.push({
 			name,
 			description,
+			argumentHint,
 			content: body,
 			source: "bundled",
 		});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1546,13 +1546,16 @@ export class InteractiveMode implements InteractiveModeContext {
 				});
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const promptIcon = getSlashCommandTypeIcon("prompt");
-		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => ({
-			name: cmd.name,
-			description: cmd.description,
-			icon: promptIcon,
-			argumentHint: cmd.argumentHint,
-			getInlineHint: cmd.argumentHint ? buildStaticInlineHint(cmd.argumentHint) : undefined,
-		}));
+		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => {
+			const argumentHint = cmd.argumentHint ? replaceTabs(cmd.argumentHint).replace(/[\r\n]+/g, " ") : undefined;
+			return {
+				name: cmd.name,
+				description: cmd.description,
+				icon: promptIcon,
+				argumentHint,
+				getInlineHint: argumentHint ? buildStaticInlineHint(argumentHint) : undefined,
+			};
+		});
 		// Surface discovered prompt templates in the picker. AgentSession.prompt() expands
 		// `expandSlashCommand` before `expandPromptTemplate`, and builtin command
 		// execution resolves aliases before template expansion. Mirror that command

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -117,6 +117,7 @@ import { getRecentSessions } from "../session/session-listing";
 import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
+import { buildStaticInlineHint } from "../slash-commands/builtin-completions";
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
 import { resolveCliEntryCmd } from "../subprocess/worker-client";
@@ -1549,6 +1550,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			name: cmd.name,
 			description: cmd.description,
 			icon: promptIcon,
+			argumentHint: cmd.argumentHint,
+			getInlineHint: cmd.argumentHint ? buildStaticInlineHint(cmd.argumentHint) : undefined,
 		}));
 		// Surface discovered prompt templates in the picker. AgentSession.prompt() expands
 		// `expandSlashCommand` before `expandPromptTemplate`, and builtin command

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -93,7 +93,12 @@ export async function buildAvailableSlashCommands(
 	const fileCommands = await loadFileCommands(session.sessionManager.getCwd());
 	session.setSlashCommands(fileCommands);
 	for (const command of fileCommands) {
-		appendCommand({ name: command.name, description: command.description, source: "file" });
+		appendCommand({
+			name: command.name,
+			description: command.description,
+			input: command.argumentHint ? { hint: command.argumentHint } : undefined,
+			source: "file",
+		});
 	}
 
 	return commands;

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -82,6 +82,33 @@ describe("buildAvailableSlashCommands", () => {
 		expect(commands.find(command => command.name === "notes")?.source).toBe("file");
 	});
 
+	test("forwards file-command argumentHint as ACP input hint", async () => {
+		const fileCommands = [
+			{
+				name: "git-sync",
+				description: "Rebase branch",
+				content: "body",
+				source: "test",
+				argumentHint: "[base-branch]",
+			},
+			{ name: "notes", description: "Open notes", content: "body", source: "test" },
+		];
+
+		const commands = await buildAvailableSlashCommands(
+			{
+				customCommands: [],
+				skills: [],
+				sessionManager: { getCwd: () => process.cwd() },
+				setSlashCommands() {},
+			} as never,
+			async () => fileCommands,
+		);
+		const byName = Object.fromEntries(commands.map(command => [command.name, command]));
+
+		expect(byName["git-sync"].input).toEqual({ hint: "[base-branch]" });
+		expect(byName.notes.input).toBeUndefined();
+	});
+
 	test("classifies MCP prompts by path and bundled custom commands as custom", async () => {
 		const commands = await buildAvailableSlashCommands(
 			{

--- a/packages/coding-agent/test/extensibility/slash-command-argument-hint.test.ts
+++ b/packages/coding-agent/test/extensibility/slash-command-argument-hint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
+
+describe("loadSlashCommands argument-hint", () => {
+	test("parses argument-hint frontmatter into FileSlashCommand.argumentHint", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-arg-hint-"));
+		try {
+			const commandsDir = path.join(cwd, ".agent", "commands");
+			await fs.mkdir(commandsDir, { recursive: true });
+			await Bun.write(
+				path.join(commandsDir, "git-sync-branch.md"),
+				[
+					"---",
+					"description: Rebase current branch",
+					'argument-hint: "[base-branch]"',
+					"---",
+					"Rebase onto $ARGUMENTS",
+					"",
+				].join("\n"),
+			);
+			await Bun.write(
+				path.join(commandsDir, "plain.md"),
+				["---", "description: No hint here", "---", "Body", ""].join("\n"),
+			);
+
+			const commands = await loadSlashCommands({ cwd });
+			const withHint = commands.find(command => command.name === "git-sync-branch");
+			const withoutHint = commands.find(command => command.name === "plain");
+
+			expect(withHint?.argumentHint).toBe("[base-branch]");
+			expect(withoutHint?.argumentHint).toBeUndefined();
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
@@ -75,9 +75,9 @@ describe("InteractiveMode prompt-template autocomplete (#2462)", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		mode?.stop();
 		await session?.dispose();
-		vi.restoreAllMocks();
 		mode = undefined;
 		session = undefined;
 	});
@@ -182,7 +182,6 @@ describe("InteractiveMode prompt-template autocomplete (#2462)", () => {
 
 	it("normalizes file-command hints before autocomplete renders them", async () => {
 		const created = createHarness([]);
-		vi.spyOn(created.mode, "stop").mockImplementation(() => {});
 		const providerSlot = captureAutocompleteProvider(created.mode);
 
 		await created.mode.refreshSlashCommandState(tempDir.path(), [

--- a/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
+++ b/packages/coding-agent/test/interactive-mode-prompt-template-autocomplete.test.ts
@@ -75,9 +75,9 @@ describe("InteractiveMode prompt-template autocomplete (#2462)", () => {
 	});
 
 	afterEach(async () => {
-		vi.restoreAllMocks();
 		mode?.stop();
 		await session?.dispose();
+		vi.restoreAllMocks();
 		mode = undefined;
 		session = undefined;
 	});
@@ -178,6 +178,32 @@ describe("InteractiveMode prompt-template autocomplete (#2462)", () => {
 		created.session.setFastMode(true);
 		const onFast = (await fetchSlashItems(providerSlot.current!, "/fast")).find(item => item.value === "fast");
 		expect(onFast?.description).toBe("Fast: on");
+	});
+
+	it("normalizes file-command hints before autocomplete renders them", async () => {
+		const created = createHarness([]);
+		vi.spyOn(created.mode, "stop").mockImplementation(() => {});
+		const providerSlot = captureAutocompleteProvider(created.mode);
+
+		await created.mode.refreshSlashCommandState(tempDir.path(), [
+			{
+				name: "git-sync",
+				description: "Sync branches",
+				content: "body",
+				source: "test",
+				argumentHint: "[base\tbranch]\n[next]",
+			},
+		]);
+
+		const provider = providerSlot.current;
+		expect(provider).toBeDefined();
+		const item = (await fetchSlashItems(provider!, "/git-sync")).find(candidate => candidate.value === "git-sync");
+		const inlineHint = provider!.getInlineHint?.(["/git-sync "], 0, "/git-sync ".length);
+
+		expect(item?.description).toContain("[next] - Sync branches");
+		expect(item?.description).not.toMatch(/[\t\r\n]/);
+		expect(inlineHint).toContain("[next]");
+		expect(inlineHint).not.toMatch(/[\t\r\n]/);
 	});
 
 	it("does not duplicate templates whose names collide with builtin slash commands", async () => {


### PR DESCRIPTION
## Repro
A file-based slash command with an `argument-hint` frontmatter key surfaces the hint only in the `/extensions` inspector. Adding `agent/commands/git-sync-branch.md` with `argument-hint: "[base-branch]"` and typing `/git-sync-branch` in the TUI (or listing ACP `available_commands`) shows only `description` — no inline hint, no `input.hint`. Reproduced by loading such a command: `loadSlashCommands({ cwd })` returned `{name, description}` with `argumentHint` absent.

## Cause
`capability/slash-command.ts` parses both `argumentHint` and `argument-hint` into `argumentHint`, but `extensibility/slash-commands.ts` dropped it: `parseCommandTemplate` returned only `{description, body}` and `loadSlashCommands` never copied `argumentHint` onto `FileSlashCommand`. Consequently `modes/interactive-mode.ts` (TUI autocomplete) and `slash-commands/available-commands.ts` (ACP listing for `source: "file"`) had no hint to forward — only the inspector (`modes/components/extensions/inspector-panel.ts`) read the capability-level field directly.

## Fix
- `extensibility/slash-commands.ts`: added `argumentHint` to `FileSlashCommand`; `parseCommandTemplate` now extracts it via `slashCommandFrontmatterDisplay`, and `loadSlashCommands` forwards `cmd.argumentHint ?? parsed` for both discovered and embedded commands (covers providers that pre-strip frontmatter, e.g. codex/opencode, and those that keep it, e.g. `.agent/commands`).
- `modes/interactive-mode.ts`: file commands now map to TUI autocomplete with `argumentHint` and a `getInlineHint` built via `buildStaticInlineHint`, mirroring builtins.
- `slash-commands/available-commands.ts`: ACP `source: "file"` commands now send `input: { hint: argumentHint }` when present.
- Unrelated: the pre-publish `bun run fix` gate autofixed a pre-existing unused-import oxlint warning in `packages/ai/src/registry/oauth/github-copilot.ts`.

## Verification
`bun test test/extensibility/slash-command-argument-hint.test.ts test/available-commands.test.ts` — 6 pass. New tests assert `loadSlashCommands` parses `argument-hint` into `argumentHint` (and omits it when absent) and that ACP forwards `input.hint` from `argumentHint`. `bun check` passes via the push gate. The unrelated `github-copilot.ts` line was produced by the gate's `bun run fix`, not by the fix itself.

Fixes #11647