### PR TITLE
feat(ai,catalog): seal Devin requests with a private device fingerprint

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- Added the native Devin `Metadata.f` device attestation to auth, model assignment, chat, and usage requests, sealed around a private per-account identity instead of hardware identifiers.
+- Added the native Devin `Metadata.f` device attestation to auth, model assignment, chat, and usage requests, sealed around a private per-account identity instead of hardware identifiers ([#11650](https://github.com/can1357/oh-my-pi/pull/11650) by [@will-bogusz](https://github.com/will-bogusz)).
 
 ### Changed
 
-- Updated the pinned Devin CLI request identity to `3000.10.21`, verified against the current released CLI.
+- Updated the pinned Devin CLI request identity to `3000.10.21`, verified against the current released CLI ([#11650](https://github.com/can1357/oh-my-pi/pull/11650) by [@will-bogusz](https://github.com/will-bogusz)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the native Devin `Metadata.f` device attestation to auth, model assignment, chat, and usage requests, sealed around a private per-account identity instead of hardware identifiers.
+
+### Changed
+
+- Updated the pinned Devin CLI request identity to `3000.10.21`, verified against the current released CLI.
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -180,7 +180,7 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 				assignment = await assignDevinModel(model, turn, chatBaseUrl, fetchImpl, options?.signal);
 				output.upstreamModel = assignment.modelUid;
 			}
-			const request = buildDevinChatRequest(model, context, options, turn, assignment);
+			const request = await buildDevinChatRequest(model, context, options, turn, assignment);
 			const reqBytes = toBinary(GetChatMessageRequestSchema, request);
 			const gz = gzipSync(reqBytes);
 			logger.debug("devin: sending chat request", {
@@ -489,7 +489,9 @@ async function fetchDevinAuthMetadata(
 	fetchImpl: NonNullable<StreamOptions["fetch"]>,
 	signal: AbortSignal | undefined,
 ): Promise<{ userJwt: string; baseUrl?: string }> {
-	const request = create(GetUserJwtRequestSchema, { metadata: create(MetadataSchema, devinCliMetadata(apiKey)) });
+	const request = create(GetUserJwtRequestSchema, {
+		metadata: create(MetadataSchema, await devinCliMetadata(apiKey)),
+	});
 	const response = await fetchImpl(`${baseUrl}${DEVIN_AUTH_PATH}`, {
 		method: "POST",
 		headers: {
@@ -532,7 +534,7 @@ async function assignDevinModel(
 	signal: AbortSignal | undefined,
 ): Promise<ModelAssignment> {
 	const request = create(AssignModelRequestSchema, {
-		metadata: create(MetadataSchema, devinCliMetadata(turn.apiKey)),
+		metadata: create(MetadataSchema, await devinCliMetadata(turn.apiKey)),
 		modelRouterUid: model.requestModelId ?? model.id,
 		cascadeId: turn.cascadeId,
 		chatMessagePrompt: buildRouterPrompt(turn.messages),
@@ -587,7 +589,7 @@ function buildRouterPrompt(messages: Message[]): ChatMessagePrompt | undefined {
  * conversation history maps to `chatMessagePrompts`. `assignment` is present only
  * for router models and supplies both the resolved uid and its JWT.
  */
-function buildDevinChatRequest(
+async function buildDevinChatRequest(
 	model: Model<"devin-agent">,
 	context: Context,
 	options: DevinOptions | undefined,
@@ -599,7 +601,7 @@ function buildDevinChatRequest(
 			? [...DEVIN_DEFAULT_STOP_PATTERNS, ...options.stopSequences]
 			: DEVIN_DEFAULT_STOP_PATTERNS;
 	return create(GetChatMessageRequestSchema, {
-		metadata: create(MetadataSchema, devinCliMetadata(turn.apiKey, turn.userJwt)),
+		metadata: create(MetadataSchema, await devinCliMetadata(turn.apiKey, turn.userJwt)),
 		prompt: normalizeSystemPrompts(context.systemPrompt).join("\n\n"),
 		chatMessagePrompts: buildChatMessagePrompts(turn.messages, turn.cascadeId, model),
 		chatModelUid: assignment?.modelUid ?? options?.chatModelUid ?? model.requestModelId ?? model.id,

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -267,7 +267,7 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 
 	try {
 		const request = create(GetUserStatusRequestSchema, {
-			metadata: create(MetadataSchema, devinCliMetadata(token)),
+			metadata: create(MetadataSchema, await devinCliMetadata(token)),
 		});
 		const response = await ctx.fetch(`${baseUrl}${GET_USER_STATUS_PATH}`, {
 			method: "POST",

--- a/packages/ai/test/devin-account-usage.test.ts
+++ b/packages/ai/test/devin-account-usage.test.ts
@@ -188,8 +188,8 @@ describe("Devin account usage", () => {
 		expect(capture.metadata?.ideName).toBe("devin-cli");
 		expect(capture.metadata?.ideType).toBe("chisel");
 		expect(capture.metadata?.extensionName).toBe("chisel");
-		expect(capture.metadata?.ideVersion).toBe("3000.6.2");
-		expect(capture.metadata?.extensionVersion).toBe("3000.6.2");
+		expect(capture.metadata?.ideVersion).toBe("3000.10.21");
+		expect(capture.metadata?.extensionVersion).toBe("3000.10.21");
 		expect(capture.metadata?.locale).toBe("en");
 		expect(capture.metadata?.os).toBe(EXPECTED_OS);
 		expect(capture.metadata?.f).toMatch(/^[0-9a-f]{412}$/);

--- a/packages/ai/test/devin-account-usage.test.ts
+++ b/packages/ai/test/devin-account-usage.test.ts
@@ -192,6 +192,7 @@ describe("Devin account usage", () => {
 		expect(capture.metadata?.extensionVersion).toBe("3000.6.2");
 		expect(capture.metadata?.locale).toBe("en");
 		expect(capture.metadata?.os).toBe(EXPECTED_OS);
+		expect(capture.metadata?.f).toMatch(/^[0-9a-f]{412}$/);
 
 		if (!report) throw new Error("expected a usage report");
 		const prompt = limitById(report, "devin:credits:prompt");

--- a/packages/ai/test/devin-router.test.ts
+++ b/packages/ai/test/devin-router.test.ts
@@ -159,11 +159,14 @@ describe("streamDevin router assignment", () => {
 			apiKey: "devin-session-token$token",
 			userJwt: "",
 		});
+		expect(recorded.assignment?.metadata?.f).toMatch(/^[0-9a-f]{404}$/);
 		// The router uid must never reach GetChatMessage as the chat model.
 		expect(recorded.chat?.chatModelUid).toBe("claude-sonnet-4-5");
 		expect(recorded.chat?.modelAssignmentJwt).toBe("assign-jwt");
 		expect(recorded.chat?.cascadeId).toBe("cascade-42");
 		expect(recorded.chat?.metadata).toMatchObject({ ideType: "chisel", userJwt: "user-jwt" });
+		expect(recorded.chat?.metadata?.f).toMatch(/^[0-9a-f]{404}$/);
+		expect(recorded.chat?.metadata?.f).not.toBe(recorded.assignment?.metadata?.f);
 		expect(result.upstreamModel).toBe("claude-sonnet-4-5");
 		expect(result.stopReason).toBe("stop");
 	});

--- a/packages/ai/test/devin-router.test.ts
+++ b/packages/ai/test/devin-router.test.ts
@@ -155,7 +155,7 @@ describe("streamDevin router assignment", () => {
 			ideName: "devin-cli",
 			ideType: "chisel",
 			extensionName: "chisel",
-			extensionVersion: "3000.6.2",
+			extensionVersion: "3000.10.21",
 			apiKey: "devin-session-token$token",
 			userJwt: "",
 		});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the native Devin `Metadata.f` device attestation to model discovery, sealed around a private per-account identity instead of hardware identifiers.
+- Added the native Devin `Metadata.f` device attestation to model discovery, sealed around a private per-account identity instead of hardware identifiers ([#11650](https://github.com/can1357/oh-my-pi/pull/11650) by [@will-bogusz](https://github.com/will-bogusz)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the native Devin `Metadata.f` device attestation to model discovery, sealed around a private per-account identity instead of hardware identifiers.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/catalog/src/discovery/devin.ts
+++ b/packages/catalog/src/discovery/devin.ts
@@ -313,9 +313,10 @@ export async function fetchDevinModels(
 	const signal = options.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal;
 
 	try {
+		const metadata = await devinDiscoveryMetadata(options.apiKey);
 		const request = create(GetCliModelConfigsRequestSchema, {
 			metadata: create(MetadataSchema, {
-				...devinDiscoveryMetadata(options.apiKey),
+				...metadata,
 				supportedModelDisplays: [...DEVIN_SUPPORTED_MODEL_DISPLAYS],
 			}),
 		});
@@ -349,7 +350,7 @@ export async function fetchDevinModels(
 			// this after filtering because a response containing only disabled or
 			// internal configs is equally unusable.
 			logger.warn("Devin returned an empty native model catalog; the pinned CLI identity may be stale", {
-				metadata: devinDiscoveryMetadata(undefined),
+				metadata: { ...metadata, apiKey: "", f: "" },
 			});
 			return null;
 		}

--- a/packages/catalog/src/wire/devin-fingerprint.ts
+++ b/packages/catalog/src/wire/devin-fingerprint.ts
@@ -1,0 +1,57 @@
+/**
+ * Native Devin `Metadata.f` device attestation.
+ *
+ * The envelope is the released CLI's, reverse-engineered from 3000.10.21:
+ * AES-256-GCM under a key derived from the CLI's embedded secret, sealing
+ * `device digest|credential|unix nanoseconds`, nonce-prefixed and
+ * hex-encoded. The gateway decrypts this field, so its byte format must
+ * match the native client exactly.
+ *
+ * The sealed device identity is OMP's own: SHA-512 over a domain separator
+ * and the normalized credential. It is stable per account, distinct across
+ * accounts (so `f` cannot link them), and reads no hardware identifiers —
+ * the native digest derives from MAC addresses, a board serial, and the OS
+ * username, which we deliberately do not collect.
+ */
+
+const FINGERPRINT_ENCRYPTION_SECRET = "df97465349f38646af1d66c263e25e08";
+const DEVICE_PSEUDONYM_DOMAIN = "omp-devin-private-device-v1";
+const encoder = new TextEncoder();
+
+let encryptionKey: Promise<CryptoKey> | undefined;
+
+function hex(bytes: ArrayBuffer): string {
+	return Buffer.from(bytes).toString("hex");
+}
+
+/** Private OMP device identity: stable per account, distinct across accounts, hardware-free. */
+async function createDevicePseudonym(credential: string): Promise<string> {
+	const input = encoder.encode(`${DEVICE_PSEUDONYM_DOMAIN}\0${credential}`);
+	return hex(await crypto.subtle.digest("SHA-512", input));
+}
+
+function getEncryptionKey(): Promise<CryptoKey> {
+	if (!encryptionKey) {
+		encryptionKey = crypto.subtle
+			.digest("SHA-256", encoder.encode(FINGERPRINT_ENCRYPTION_SECRET))
+			.then(key => crypto.subtle.importKey("raw", key, { name: "AES-GCM" }, false, ["encrypt"]));
+	}
+	return encryptionKey;
+}
+
+function unixEpochNanoseconds(): bigint {
+	return BigInt(Math.trunc((performance.timeOrigin + performance.now()) * 1_000_000));
+}
+
+/** Seal the native-format `Metadata.f` envelope around OMP's private device identity. */
+export async function createDevinFingerprint(credential: string): Promise<string> {
+	const plaintext = `${await createDevicePseudonym(credential)}|${credential}|${unixEpochNanoseconds()}`;
+	const nonce = crypto.getRandomValues(new Uint8Array(12));
+	const ciphertext = new Uint8Array(
+		await crypto.subtle.encrypt({ name: "AES-GCM", iv: nonce }, await getEncryptionKey(), encoder.encode(plaintext)),
+	);
+	const sealed = new Uint8Array(nonce.byteLength + ciphertext.byteLength);
+	sealed.set(nonce);
+	sealed.set(ciphertext, nonce.byteLength);
+	return Buffer.from(sealed.buffer, sealed.byteOffset, sealed.byteLength).toString("hex");
+}

--- a/packages/catalog/src/wire/devin.ts
+++ b/packages/catalog/src/wire/devin.ts
@@ -23,9 +23,9 @@ const DEVIN_LOCALE = "en";
 const DEVIN_CLI_METADATA = {
 	ideName: "devin-cli",
 	ideType: "chisel",
-	ideVersion: "3000.6.2",
+	ideVersion: "3000.10.21",
 	extensionName: "chisel",
-	extensionVersion: "3000.6.2",
+	extensionVersion: "3000.10.21",
 	locale: DEVIN_LOCALE,
 	os: DEVIN_OS,
 } as const;

--- a/packages/catalog/src/wire/devin.ts
+++ b/packages/catalog/src/wire/devin.ts
@@ -4,6 +4,7 @@
  * generated protobuf runtime so the synchronous model seed can import it
  * without pulling devin-gen into the boot path.
  */
+import { createDevinFingerprint } from "./devin-fingerprint";
 
 /** Base host for Codeium/Windsurf's Cascade API (Connect protocol over HTTP/1.1). */
 export const DEVIN_DEFAULT_BASE_URL = "https://server.codeium.com";
@@ -54,19 +55,24 @@ export function normalizeDevinSessionToken(apiKey: string | undefined): string {
  * Fields for `Metadata` on released-CLI calls (`GetUserJwt`, `AssignModel`,
  * `GetChatMessage`, `GetUserStatus`). `userJwt` stays empty for the calls the
  * CLI makes with the session token alone (auth, model assignment, usage).
+ * `f` seals a fresh native-format device attestation for every request.
  */
-export function devinCliMetadata(apiKey: string | undefined, userJwt = "") {
+export async function devinCliMetadata(apiKey: string | undefined, userJwt = "") {
+	const credential = normalizeDevinSessionToken(apiKey);
 	return {
-		apiKey: normalizeDevinSessionToken(apiKey),
+		apiKey: credential,
 		userJwt,
+		f: await createDevinFingerprint(credential),
 		...DEVIN_CLI_METADATA,
 	};
 }
 
 /** Fields for `Metadata` on the dev-channel `GetCliModelConfigs` call. */
-export function devinDiscoveryMetadata(apiKey: string | undefined) {
+export async function devinDiscoveryMetadata(apiKey: string | undefined) {
+	const credential = normalizeDevinSessionToken(apiKey);
 	return {
-		apiKey: normalizeDevinSessionToken(apiKey),
+		apiKey: credential,
+		f: await createDevinFingerprint(credential),
 		...DEVIN_DISCOVERY_METADATA,
 	};
 }

--- a/packages/catalog/test/devin-discovery.test.ts
+++ b/packages/catalog/test/devin-discovery.test.ts
@@ -387,6 +387,7 @@ describe("devin native discovery request", () => {
 			DISPLAY_OPTION_NORMAL,
 		]);
 		expect(requestMetadata?.apiKey).toBe("devin-session-token$fixture-token");
+		expect(requestMetadata?.f).toMatch(/^[0-9a-f]{420}$/);
 	});
 
 	it("treats an empty-but-200 catalog as failed discovery so the seed survives", async () => {

--- a/packages/catalog/test/devin-fingerprint.test.ts
+++ b/packages/catalog/test/devin-fingerprint.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { createDevinFingerprint } from "../src/wire/devin-fingerprint";
+
+/** Envelope key: SHA-256 of the native CLI's embedded secret (see devin-fingerprint.ts). */
+const envelopeKeyMaterial = crypto.subtle.digest(
+	"SHA-256",
+	new TextEncoder().encode("df97465349f38646af1d66c263e25e08"),
+);
+
+async function openEnvelope(value: string): Promise<string[]> {
+	const sealed = Uint8Array.fromHex(value);
+	const key = await crypto.subtle.importKey("raw", await envelopeKeyMaterial, { name: "AES-GCM" }, false, ["decrypt"]);
+	const plaintext = await crypto.subtle.decrypt(
+		{ name: "AES-GCM", iv: sealed.subarray(0, 12) },
+		key,
+		sealed.subarray(12),
+	);
+	return new TextDecoder().decode(plaintext).split("|");
+}
+
+describe("devin device fingerprint", () => {
+	it("seals the native envelope shape around the credential and a nanosecond timestamp", async () => {
+		const credential = "devin-session-token$fixture";
+		const [deviceDigest, sealedCredential, timestamp] = await openEnvelope(await createDevinFingerprint(credential));
+
+		expect(sealedCredential).toBe(credential);
+		expect(deviceDigest).toMatch(/^[0-9a-f]{128}$/);
+		expect(timestamp).toMatch(/^\d{19}$/);
+	});
+
+	it("keeps the device identity stable per account and distinct across accounts", async () => {
+		const first = (await openEnvelope(await createDevinFingerprint("devin-session-token$a")))[0];
+		const repeat = (await openEnvelope(await createDevinFingerprint("devin-session-token$a")))[0];
+		const other = (await openEnvelope(await createDevinFingerprint("devin-session-token$b")))[0];
+
+		expect(repeat).toBe(first);
+		expect(other).not.toBe(first);
+	});
+
+	it("pins the pseudonym derivation so releases do not silently rotate every device identity", async () => {
+		const credential = "devin-session-token$a";
+		const digest = (await openEnvelope(await createDevinFingerprint(credential)))[0];
+		const expected = Buffer.from(
+			await crypto.subtle.digest("SHA-512", new TextEncoder().encode(`omp-devin-private-device-v1\0${credential}`)),
+		).toString("hex");
+		expect(digest).toBe(expected);
+	});
+});


### PR DESCRIPTION
## Why

Devin's gateway expects an opaque `Metadata.f` device attestation on every request; the released CLI seals a fresh one per call and we sent nothing. `f` is AES-256-GCM under a key derivable from the CLI's embedded secret, so the gateway decrypts it, and its absence is a standing parity gap.

The native digest inside is SHA-512 over MAC addresses, a board serial, and the OS username — a cross-account device tracker. OMP instead seals a private identity: SHA-512 over a domain separator and the normalized credential. It is stable per account, distinct across accounts, and reads no hardware identifiers; the same account presents one device identity wherever OMP runs it.

## What

- `wire/devin-fingerprint.ts` `createDevinFingerprint` reimplements the native envelope (key derivation, 12-byte nonce, `digest|credential|unix-ns` plaintext, hex) around that private pseudonym.
- `devinCliMetadata` / `devinDiscoveryMetadata` seal a fresh envelope per request; `f` is redacted from discovery's stale-pin warning because it embeds the credential.
- Auth, assignment, chat, and usage RPCs await the sealed metadata.
- Pinned identity bumped to `3000.10.21` (released channel), verified against captured chat requests.

Non-goals: hardware-collection modes, the telemetry RPCs the CLI also carries (product analytics, trajectory segments), and `GetUserStatus` keeps the released identity — the current CLI sends its dev identity on that call, observed but not ported.

## Verification

Decoded MITM captures of the released 3000.10.21 CLI: chat metadata carries `devin-cli`/`chisel`/`3000.10.21` with a fresh 732-hex `f` per request, `teamId` and `deviceFingerprint` empty. A captured native `f` decrypts under the same key derivation to `digest|credential|ns-timestamp`, matching our envelope's shape, digest length, and timestamp width. Focused Devin suites (35 tests), catalog/ai type checks, and oxlint pass.

## Rollback

Clean revert; `f` is additive on the wire and requests without it were accepted when #8590 verified the surface live.
