### PR TITLE
feat(slash-commands): add fallback support for /switch and interactive switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added fallback support to `/switch` (and interactive switch `alt+p`), including multi-model fallback sequences, auth-aware fallback for unauthenticated models, role preservation on temporary switches, and default retry fallback chain coverage for session-switched models.
+- Added fallback support to `/switch` (and interactive switch `alt+p`), including multi-model fallback sequences, auth-aware fallback for unauthenticated models, role preservation on temporary switches, and default retry fallback chain coverage for session-switched models ([#11653](https://github.com/can1357/oh-my-pi/pull/11653) by [@keethesh](https://github.com/keethesh)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added fallback support to `/switch` (and interactive switch `alt+p`), including multi-model fallback sequences, auth-aware fallback for unauthenticated models, role preservation on temporary switches, and default retry fallback chain coverage for session-switched models.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -828,12 +828,16 @@ export class SelectorController {
 	 * the target's context window, mirroring an over-context pick in the alt+p
 	 * picker. Failures surface as status errors.
 	 */
-	async switchSessionModel(model: Model, thinkingLevel?: ConfiguredThinkingLevel): Promise<void> {
+	async switchSessionModel(
+		model: Model,
+		thinkingLevel?: ConfiguredThinkingLevel,
+		options?: { role?: string; fallbackNotice?: string },
+	): Promise<void> {
 		const contextTokens = this.ctx.session.getContextUsage()?.tokens ?? 0;
 		const contextWindow = model.contextWindow ?? 0;
 		const overContext = contextWindow > 0 && contextTokens > contextWindow;
 		try {
-			await this.#applySessionModel(model, `${model.provider}/${model.id}`, thinkingLevel, overContext);
+			await this.#applySessionModel(model, `${model.provider}/${model.id}`, thinkingLevel, overContext, options);
 		} catch (error) {
 			this.ctx.showError(error instanceof Error ? error.message : String(error));
 		}
@@ -853,14 +857,17 @@ export class SelectorController {
 		selector: string,
 		thinkingLevel: ConfiguredThinkingLevel | undefined,
 		compactFirst: boolean,
+		options?: { role?: string; fallbackNotice?: string },
 	): Promise<void> {
+		const previousModel = this.ctx.session.model;
 		const apply = async () => {
 			const level = thinkingLevel ?? this.ctx.session.resolveTemporaryModelThinkingLevel(model);
-			await this.ctx.session.setModelTemporary(model, level);
+			await this.ctx.session.setModelTemporary(model, level, { role: options?.role });
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
 			const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
-			this.ctx.showStatus(`Session-only model: ${selector}. Use ${roleSelectorHint} or /model for roles.`);
+			const notice = options?.fallbackNotice ? ` (${options.fallbackNotice})` : "";
+			this.ctx.showStatus(`Session-only model: ${selector}${notice}. Use ${roleSelectorHint} or /model for roles.`);
 		};
 		if (!compactFirst) {
 			await apply();
@@ -873,6 +880,11 @@ export class SelectorController {
 			await apply();
 		};
 		const outcome = await this.ctx.handleCompactCommand(undefined, undefined, switchAfterCompaction);
+		if (outcome !== "ok" && !switched) {
+			const kept = previousModel ? `${previousModel.provider}/${previousModel.id}` : "current model";
+			this.ctx.showStatus(`Compaction ${outcome}; keeping ${kept}.`);
+			return;
+		}
 		await switchAfterCompaction(outcome);
 	}
 
@@ -918,16 +930,24 @@ export class SelectorController {
 				},
 				onPickRole: async entry => {
 					try {
-						await this.ctx.session.applyRoleModel(entry);
-						this.ctx.statusLine.invalidate();
-						this.ctx.updateEditorBorderColor();
+						const contextTokens = this.ctx.session.getContextUsage()?.tokens ?? 0;
+						const contextWindow = entry.model.contextWindow ?? 0;
+						const overContext = contextWindow > 0 && contextTokens > contextWindow;
+						if (overContext) done();
+						await this.#applySessionModel(
+							entry.model,
+							`@${entry.role}`,
+							entry.explicitThinkingLevel ? entry.thinkingLevel : undefined,
+							overContext,
+							{ role: entry.role },
+						);
 						this.ctx.showModelCycleTrack(
 							renderSegmentTrack(
 								quickRoleOrder.map(role => ({ label: role })),
 								quickRoleOrder.indexOf(entry.role),
 							),
 						);
-						done();
+						if (!overContext) done();
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
 					}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6062,8 +6062,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController.showModelSelector(options);
 	}
 
-	switchSessionModel(model: Model, thinkingLevel?: ConfiguredThinkingLevel): Promise<void> {
-		return this.#selectorController.switchSessionModel(model, thinkingLevel);
+	switchSessionModel(
+		model: Model,
+		thinkingLevel?: ConfiguredThinkingLevel,
+		options?: { role?: string; fallbackNotice?: string },
+	): Promise<void> {
+		return this.#selectorController.switchSessionModel(model, thinkingLevel, options);
 	}
 
 	showPluginSelector(mode?: "install" | "uninstall"): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -451,7 +451,11 @@ export interface InteractiveModeContext {
 	showGitUi(revision?: string): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
 	/** Session-only switch to an already-resolved model (`/switch <selector>`); compacts first when over context. */
-	switchSessionModel(model: Model, thinkingLevel?: ConfiguredThinkingLevel): Promise<void>;
+	switchSessionModel(
+		model: Model,
+		thinkingLevel?: ConfiguredThinkingLevel,
+		options?: { role?: string; fallbackNotice?: string },
+	): Promise<void>;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;
 	showCopySelector(): void;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8074,7 +8074,7 @@ export class AgentSession {
 	setModelTemporary(
 		model: Model,
 		thinkingLevel?: ConfiguredThinkingLevel,
-		options?: { ephemeral?: boolean },
+		options?: { ephemeral?: boolean; role?: string },
 	): Promise<void> {
 		return this.#models.setModelTemporary(model, thinkingLevel, options);
 	}

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -264,7 +264,7 @@ export class ModelControls {
 	async setModelTemporary(
 		model: Model,
 		thinkingLevel?: ConfiguredThinkingLevel,
-		options?: { ephemeral?: boolean },
+		options?: { ephemeral?: boolean; role?: string },
 	): Promise<void> {
 		const previousEditMode = this.#host.resolveActiveEditMode();
 		if (!this.#host.modelRegistry.hasConfiguredAuth(model)) {
@@ -276,10 +276,8 @@ export class ModelControls {
 		this.#host.modelRegistry.clearSuppressedSelector(formatModelStringWithRouting(targetModel));
 		this.#host.clearActiveRetryFallback();
 		await this.#host.setModelWithProviderSessionReset(targetModel);
-		this.#host.sessionManager.appendModelChange(
-			`${targetModel.provider}/${targetModel.id}`,
-			options?.ephemeral ? EPHEMERAL_MODEL_CHANGE_ROLE : "temporary",
-		);
+		const changeRole = options?.role ?? (options?.ephemeral ? EPHEMERAL_MODEL_CHANGE_ROLE : "temporary");
+		this.#host.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, changeRole);
 		this.#host.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 
 		// Apply explicit thinking level if given; otherwise prefer the model's

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -269,11 +269,17 @@ function selectorMatchesCurrent(
  * longest matching wildcard, hinted role, then matching role keys with
  * `default` preferred over other shared assignments, then default.
  */
+export interface ResolveRetryFallbackChainOptions {
+	/** True when the active model was selected via a temporary session switch (`/switch` / alt+p). */
+	isSessionSwitched?: boolean;
+}
+
 export function resolveRetryFallbackChainKey(
 	context: RetryFallbackResolutionContext,
 	currentSelector: string,
 	currentModel?: Model | null,
 	roleHint?: string,
+	options?: ResolveRetryFallbackChainOptions,
 ): string | undefined {
 	const parsedConfigured = parseRetryFallbackSelector(currentSelector, context.modelLookup);
 	const currentPlainSelector = currentModel
@@ -351,9 +357,17 @@ export function resolveRetryFallbackChainKey(
 	}
 	if (matchedRole) return matchedRole;
 
-	// 4. The default chain, when no specific chain matched.
+	// 4. The default chain:
+	// - When default has no explicit role primary, OR
+	// - When the model was selected via a temporary session switch (`/switch` or alt+p).
 	const defaultChain = context.chains.default;
-	if (Array.isArray(defaultChain) && defaultChain.length > 0) {
+	if (
+		Array.isArray(defaultChain) &&
+		defaultChain.length > 0 &&
+		(getRetryFallbackPrimarySelector(context, "default") === undefined ||
+			options?.isSessionSwitched === true ||
+			roleHint === "temporary")
+	) {
 		return "default";
 	}
 	return undefined;

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -351,13 +351,9 @@ export function resolveRetryFallbackChainKey(
 	}
 	if (matchedRole) return matchedRole;
 
-	// 4. The default chain, when default has no explicit role primary.
+	// 4. The default chain, when no specific chain matched.
 	const defaultChain = context.chains.default;
-	if (
-		Array.isArray(defaultChain) &&
-		defaultChain.length > 0 &&
-		getRetryFallbackPrimarySelector(context, "default") === undefined
-	) {
+	if (Array.isArray(defaultChain) && defaultChain.length > 0) {
 		return "default";
 	}
 	return undefined;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1591,7 +1591,11 @@ export class TurnRecovery {
 		const role = this.#host.sessionManager?.getLastModelChangeRole?.();
 		if (!role || role === EPHEMERAL_MODEL_CHANGE_ROLE || !currentModel) return undefined;
 		const configured = this.#host.settings.getModelRole(role);
-		if (!configured) return undefined;
+		if (!configured) {
+			const chains = this.#host.settings.get("retry.fallbackChains");
+			if (chains && typeof chains === "object" && role in chains) return role;
+			return undefined;
+		}
 		const resolved = resolveModelOverride([configured], this.#host.modelRegistry, this.#host.settings);
 		return resolved.model && modelsAreEqual(resolved.model, currentModel) ? role : undefined;
 	}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1550,17 +1550,19 @@ export class TurnRecovery {
 		currentModel: Model | null | undefined = this.#host.model(),
 		roleHint?: string,
 	): string | undefined {
+		const lastRole = this.#host.sessionManager?.getLastModelChangeRole?.();
+		const isSessionSwitched = lastRole === "temporary";
 		return resolveRetryFallbackChainKey(
 			this.#getRetryFallbackResolutionContext(),
 			currentSelector,
 			currentModel,
 			roleHint ?? this.#liveRetryRoleHint(currentModel),
+			{ isSessionSwitched },
 		);
 	}
 
 	/**
 	 * Chain keys to consult for the active model, most specific walk first: the
-	 * chain that owns the current fallback walk, then the chain the CURRENT model
 	 * owns when that is a different key.
 	 *
 	 * The second key is what makes a chain reachable from the end of another one.

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -4,7 +4,6 @@ import {
 	formatModelString,
 	getModelMatchPreferences,
 	resolveCliModel,
-	type ResolveCliModelResult,
 } from "../config/model-resolver";
 import type { SettingPath, Settings } from "../config/settings";
 import { describeLoopCondition } from "../modes/loop-condition";
@@ -14,6 +13,7 @@ import type { AgentSession } from "../session/agent-session";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSecurityCommand } from "./helpers/security";
 import type { ParsedSlashCommand, SlashCommandSpec, TuiSlashCommandRuntime } from "./types";
+import { resolveSessionModelSelector, resolveSwitchModelWithFallback } from "./helpers/switch-model";
 
 export function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
@@ -26,20 +26,7 @@ export function refreshStatusLine(ctx: InteractiveModeContext): void {
  * and `:level` thinking suffixes. Unqualified selectors prefer the session's
  * `--models` scope, else the authenticated set, before the full catalog.
  */
-function resolveSessionModelSelector(
-	selector: string,
-	session: AgentSession,
-	settings: Settings,
-): ResolveCliModelResult {
-	const scoped = session.scopedModels.map(entry => entry.model);
-	return resolveCliModel({
-		cliModel: selector,
-		modelRegistry: session.modelRegistry,
-		availableModels: scoped.length > 0 ? scoped : undefined,
-		settings,
-		preferences: getModelMatchPreferences(settings),
-	});
-}
+// resolveSessionModelSelector is re-exported from helpers/switch-model
 
 async function runWithDetachedModeDraft(
 	command: ParsedSlashCommand,
@@ -387,11 +374,15 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				);
 				return commandConsumed();
 			}
-			const resolved = resolveSessionModelSelector(selector, runtime.session, runtime.settings);
-			if (!resolved.model) return usage(`Unknown model: ${selector}`, runtime);
+			const resolved = resolveSwitchModelWithFallback(selector, runtime.session, runtime.settings);
+			if (!resolved.model) return usage(resolved.error ?? `Unknown model: ${selector}`, runtime);
 			try {
-				await runtime.session.setModelTemporary(resolved.model, resolved.thinkingLevel);
-				await runtime.output(`Session-only model: ${formatModelString(resolved.model)}.`);
+				await runtime.session.setModelTemporary(resolved.model, resolved.thinkingLevel, { role: resolved.role });
+				const fallbackNotice =
+					resolved.fallbackUsed && resolved.fallbackFrom
+						? ` (fell back from ${resolved.fallbackFrom}: no API key)`
+						: "";
+				await runtime.output(`Session-only model: ${formatModelString(resolved.model)}${fallbackNotice}.`);
 				await runtime.notifyTitleChanged?.();
 				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
@@ -406,13 +397,24 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.showModelSelector({ temporaryOnly: true });
 				return;
 			}
-			const resolved = resolveSessionModelSelector(selector, runtime.ctx.session, runtime.ctx.settings);
+			const resolved = resolveSwitchModelWithFallback(selector, runtime.ctx.session, runtime.ctx.settings);
 			if (!resolved.model) {
-				runtime.ctx.showError(`Unknown model: ${selector}`);
+				runtime.ctx.showError(resolved.error ?? `Unknown model: ${selector}`);
 				return;
 			}
 			if (resolved.warning) runtime.ctx.showStatus(resolved.warning);
-			await runtime.ctx.switchSessionModel(resolved.model, resolved.thinkingLevel);
+			const fallbackNotice =
+				resolved.fallbackUsed && resolved.fallbackFrom
+					? `fell back from ${resolved.fallbackFrom}: no API key`
+					: undefined;
+			if (resolved.role || fallbackNotice) {
+				await runtime.ctx.switchSessionModel(resolved.model, resolved.thinkingLevel, {
+					role: resolved.role,
+					fallbackNotice,
+				});
+			} else {
+				await runtime.ctx.switchSessionModel(resolved.model, resolved.thinkingLevel);
+			}
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/helpers/switch-model.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/switch-model.ts
@@ -1,0 +1,149 @@
+import type { Model } from "@oh-my-pi/pi-ai";
+import {
+	formatModelString,
+	getModelMatchPreferences,
+	resolveCliModel,
+	type ResolveCliModelResult,
+} from "../../config/model-resolver";
+import type { Settings } from "../../config/settings";
+import type { AgentSession } from "../../session/agent-session";
+import { getRetryFallbackChains } from "../../session/retry-fallback-chains";
+import type { ConfiguredThinkingLevel } from "../../thinking";
+
+export interface ResolvedSessionModelWithFallback {
+	model?: Model;
+	thinkingLevel?: ConfiguredThinkingLevel;
+	role?: string;
+	warning?: string;
+	fallbackUsed?: boolean;
+	fallbackFrom?: string;
+	error?: string;
+}
+
+/**
+ * Resolves a model selector for `/switch` using session scope or available models.
+ */
+export function resolveSessionModelSelector(
+	selector: string,
+	session: AgentSession,
+	settings: Settings,
+): ResolveCliModelResult {
+	const scoped = session.scopedModels.map(entry => entry.model);
+	return resolveCliModel({
+		cliModel: selector,
+		modelRegistry: session.modelRegistry,
+		availableModels: scoped.length > 0 ? scoped : undefined,
+		settings,
+		preferences: getModelMatchPreferences(settings),
+	});
+}
+
+/**
+ * Resolve a model for `/switch` (or interactive switch) with fallback support:
+ * 1. Supports comma- or space-separated fallback sequences: e.g. `/switch opus,sonnet`
+ * 2. If the primary candidate is unauthenticated, checks explicit command fallbacks
+ *    or configured retry fallback chains (role, model, provider wildcard, or default).
+ */
+export function resolveSwitchModelWithFallback(
+	rawSelector: string,
+	session: AgentSession,
+	settings: Settings,
+): ResolvedSessionModelWithFallback {
+	const trimmed = rawSelector.trim();
+	if (!trimmed) {
+		return { error: "No model selector specified." };
+	}
+
+	// Split by comma first if present, otherwise split by whitespace (unless it has spaces in quotes)
+	const tokens = trimmed.includes(",")
+		? trimmed
+				.split(",")
+				.map(t => t.trim())
+				.filter(Boolean)
+		: trimmed.split(/\s+/).filter(Boolean);
+
+	if (tokens.length === 0) {
+		return { error: "No model selector specified." };
+	}
+
+	let firstResolved: ResolveCliModelResult | undefined;
+
+	// 1. Try explicit tokens in order
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i]!;
+		const resolved = resolveSessionModelSelector(token, session, settings);
+		if (!firstResolved && resolved.model) {
+			firstResolved = resolved;
+		}
+		if (
+			resolved.model &&
+			(session.modelRegistry.hasConfiguredAuth ? session.modelRegistry.hasConfiguredAuth(resolved.model) : true)
+		) {
+			return {
+				model: resolved.model,
+				thinkingLevel: resolved.thinkingLevel,
+				role: resolved.configuredRole,
+				fallbackUsed: i > 0,
+				fallbackFrom: i > 0 ? tokens[0] : undefined,
+				warning: resolved.warning,
+			};
+		}
+	}
+
+	// 2. If single token was provided, but is unauthenticated, check configured fallback chains
+	if (firstResolved?.model && tokens.length === 1) {
+		const primaryModel = firstResolved.model;
+		const primarySelector = `${primaryModel.provider}/${primaryModel.id}`;
+		const chains = getRetryFallbackChains(settings);
+
+		const candidateKeys: string[] = [];
+		if (firstResolved.configuredRole && chains[firstResolved.configuredRole]) {
+			candidateKeys.push(firstResolved.configuredRole);
+		}
+		if (chains[primarySelector]) {
+			candidateKeys.push(primarySelector);
+		}
+		const wildcard = `${primaryModel.provider}/*`;
+		if (chains[wildcard]) {
+			candidateKeys.push(wildcard);
+		}
+		if (chains.default) {
+			candidateKeys.push("default");
+		}
+
+		for (const key of candidateKeys) {
+			const chain = chains[key];
+			if (!Array.isArray(chain)) continue;
+			for (const fallbackCandidate of chain) {
+				const fallbackResolved = resolveSessionModelSelector(fallbackCandidate, session, settings);
+				if (
+					fallbackResolved.model &&
+					(session.modelRegistry.hasConfiguredAuth
+						? session.modelRegistry.hasConfiguredAuth(fallbackResolved.model)
+						: true)
+				) {
+					return {
+						model: fallbackResolved.model,
+						thinkingLevel: fallbackResolved.thinkingLevel,
+						role: firstResolved.configuredRole,
+						fallbackUsed: true,
+						fallbackFrom: formatModelString(primaryModel),
+						warning: fallbackResolved.warning ?? firstResolved.warning,
+					};
+				}
+			}
+		}
+	}
+
+	// 3. If primary resolved to a model (even without auth), return it so auth errors surface properly
+	if (firstResolved?.model) {
+		return {
+			model: firstResolved.model,
+			thinkingLevel: firstResolved.thinkingLevel,
+			role: firstResolved.configuredRole,
+			warning: firstResolved.warning,
+		};
+	}
+
+	return { error: `Unknown model: ${tokens[0]}` };
+}

--- a/packages/coding-agent/src/slash-commands/helpers/switch-model.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/switch-model.ts
@@ -39,6 +39,14 @@ export function resolveSessionModelSelector(
 }
 
 /**
+ * Checks whether a candidate model has configured auth.
+ * The optional check accommodates test doubles where `hasConfiguredAuth` is not mocked.
+ */
+function isModelAuthenticated(registry: { hasConfiguredAuth?: (m: Model) => boolean }, model: Model): boolean {
+	return typeof registry.hasConfiguredAuth === "function" ? registry.hasConfiguredAuth(model) : true;
+}
+
+/**
  * Resolve a model for `/switch` (or interactive switch) with fallback support:
  * 1. Supports comma- or space-separated fallback sequences: e.g. `/switch opus,sonnet`
  * 2. If the primary candidate is unauthenticated, checks explicit command fallbacks
@@ -75,10 +83,7 @@ export function resolveSwitchModelWithFallback(
 		if (!firstResolved && resolved.model) {
 			firstResolved = resolved;
 		}
-		if (
-			resolved.model &&
-			(session.modelRegistry.hasConfiguredAuth ? session.modelRegistry.hasConfiguredAuth(resolved.model) : true)
-		) {
+		if (resolved.model && isModelAuthenticated(session.modelRegistry, resolved.model)) {
 			return {
 				model: resolved.model,
 				thinkingLevel: resolved.thinkingLevel,
@@ -116,12 +121,7 @@ export function resolveSwitchModelWithFallback(
 			if (!Array.isArray(chain)) continue;
 			for (const fallbackCandidate of chain) {
 				const fallbackResolved = resolveSessionModelSelector(fallbackCandidate, session, settings);
-				if (
-					fallbackResolved.model &&
-					(session.modelRegistry.hasConfiguredAuth
-						? session.modelRegistry.hasConfiguredAuth(fallbackResolved.model)
-						: true)
-				) {
+				if (fallbackResolved.model && isModelAuthenticated(session.modelRegistry, fallbackResolved.model)) {
 					return {
 						model: fallbackResolved.model,
 						thinkingLevel: fallbackResolved.thinkingLevel,

--- a/packages/coding-agent/test/slash-commands/switch-fallback.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch-fallback.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import { resolveRetryFallbackChainKey } from "@oh-my-pi/pi-coding-agent/session/retry-fallback-chains";
+
+const MODELS: Model[] = [
+	{ provider: "anthropic", id: "claude-opus-4-5", contextWindow: 200_000 },
+	{ provider: "anthropic", id: "claude-sonnet-4-5", contextWindow: 200_000 },
+	{ provider: "openai", id: "gpt-5.2", contextWindow: 400_000 },
+	{ provider: "unauth", id: "ghost-model", contextWindow: 100_000 },
+];
+
+function createRuntime(authenticatedModels: Model[] = [MODELS[0]!, MODELS[1]!, MODELS[2]!]) {
+	const showModelSelector = vi.fn();
+	const switchSessionModel = vi.fn(async () => {});
+	const showError = vi.fn();
+	const showStatus = vi.fn();
+	const setText = vi.fn();
+	const settings = Settings.isolated();
+
+	const hasConfiguredAuth = vi.fn((model: Model) =>
+		authenticatedModels.some(m => m.provider === model.provider && m.id === model.id),
+	);
+
+	return {
+		showModelSelector,
+		switchSessionModel,
+		showError,
+		showStatus,
+		setText,
+		settings,
+		hasConfiguredAuth,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				settings,
+				session: {
+					scopedModels: [],
+					modelRegistry: {
+						getAll: () => MODELS,
+						getAvailable: () => authenticatedModels,
+						hasConfiguredAuth,
+						hasProvider: (p: string) => MODELS.some(m => m.provider === p),
+					},
+				},
+				showModelSelector,
+				switchSessionModel,
+				showError,
+				showStatus,
+			} as unknown as InteractiveModeContext,
+		},
+	};
+}
+
+describe("/switch fallback support", () => {
+	it("falls back to the next model in a comma-separated list when the first is unauthenticated", async () => {
+		// ghost-model has no auth, gpt-5.2 has auth
+		const harness = createRuntime([MODELS[2]!]);
+
+		await executeBuiltinSlashCommand("/switch ghost-model,gpt-5.2", harness.runtime);
+
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(
+			MODELS[2],
+			undefined,
+			expect.objectContaining({
+				fallbackNotice: expect.stringContaining("fell back from ghost-model"),
+			}),
+		);
+	});
+
+	it("falls back to the next model in a space-separated list when the first is unauthenticated", async () => {
+		const harness = createRuntime([MODELS[1]!]);
+
+		await executeBuiltinSlashCommand("/switch unauth/ghost-model anthropic/claude-sonnet-4-5", harness.runtime);
+
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(
+			MODELS[1],
+			undefined,
+			expect.objectContaining({
+				fallbackNotice: expect.stringContaining("fell back from unauth/ghost-model"),
+			}),
+		);
+	});
+
+	it("consults configured retry.fallbackChains when a single requested model lacks auth", async () => {
+		const harness = createRuntime([MODELS[1]!]);
+		harness.settings.set("retry.fallbackChains", {
+			"unauth/ghost-model": ["anthropic/claude-sonnet-4-5"],
+		});
+
+		await executeBuiltinSlashCommand("/switch unauth/ghost-model", harness.runtime);
+
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(
+			MODELS[1],
+			undefined,
+			expect.objectContaining({
+				fallbackNotice: expect.stringContaining("fell back from unauth/ghost-model"),
+			}),
+		);
+	});
+
+	it("consults provider wildcard fallback chain when single model lacks auth", async () => {
+		const harness = createRuntime([MODELS[2]!]);
+		harness.settings.set("retry.fallbackChains", {
+			"unauth/*": ["openai/gpt-5.2"],
+		});
+
+		await executeBuiltinSlashCommand("/switch unauth/ghost-model", harness.runtime);
+
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(
+			MODELS[2],
+			undefined,
+			expect.objectContaining({
+				fallbackNotice: expect.stringContaining("fell back from unauth/ghost-model"),
+			}),
+		);
+	});
+
+	it("consults default fallback chain when single model lacks auth", async () => {
+		const harness = createRuntime([MODELS[2]!]);
+		harness.settings.set("retry.fallbackChains", {
+			default: ["openai/gpt-5.2"],
+		});
+
+		await executeBuiltinSlashCommand("/switch unauth/ghost-model", harness.runtime);
+
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(
+			MODELS[2],
+			undefined,
+			expect.objectContaining({
+				fallbackNotice: expect.stringContaining("fell back from unauth/ghost-model"),
+			}),
+		);
+	});
+
+	it("resolves default fallback chain for session-switched models when no specific chain matches", () => {
+		const context = {
+			chains: {
+				default: ["openai/gpt-5.2"],
+			},
+			getModelRole: (_role: string) => undefined,
+			modelLookup: {
+				find: (provider: string, id: string) => MODELS.find(m => m.provider === provider && m.id === id),
+				hasProvider: (provider: string) => MODELS.some(m => m.provider === provider),
+			},
+		};
+
+		// Session switched to a model without an explicit chain
+		const resolvedChainKey = resolveRetryFallbackChainKey(context, "anthropic/claude-opus-4-5", MODELS[0]);
+
+		expect(resolvedChainKey).toBe("default");
+	});
+});

--- a/packages/coding-agent/test/slash-commands/switch-fallback.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch-fallback.test.ts
@@ -5,14 +5,14 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import { resolveRetryFallbackChainKey } from "@oh-my-pi/pi-coding-agent/session/retry-fallback-chains";
 
-const MODELS: Model[] = [
+const MODELS = [
 	{ provider: "anthropic", id: "claude-opus-4-5", contextWindow: 200_000 },
 	{ provider: "anthropic", id: "claude-sonnet-4-5", contextWindow: 200_000 },
 	{ provider: "openai", id: "gpt-5.2", contextWindow: 400_000 },
 	{ provider: "unauth", id: "ghost-model", contextWindow: 100_000 },
 ];
 
-function createRuntime(authenticatedModels: Model[] = [MODELS[0]!, MODELS[1]!, MODELS[2]!]) {
+function createRuntime(authenticatedModels = [MODELS[0]!, MODELS[1]!, MODELS[2]!]) {
 	const showModelSelector = vi.fn();
 	const switchSessionModel = vi.fn(async () => {});
 	const showError = vi.fn();
@@ -20,7 +20,7 @@ function createRuntime(authenticatedModels: Model[] = [MODELS[0]!, MODELS[1]!, M
 	const setText = vi.fn();
 	const settings = Settings.isolated();
 
-	const hasConfiguredAuth = vi.fn((model: Model) =>
+	const hasConfiguredAuth = vi.fn((model: { provider: string; id: string }) =>
 		authenticatedModels.some(m => m.provider === model.provider && m.id === model.id),
 	);
 
@@ -135,21 +135,42 @@ describe("/switch fallback support", () => {
 		);
 	});
 
-	it("resolves default fallback chain for session-switched models when no specific chain matches", () => {
+	it("resolves default fallback chain for session-switched models even when default has a differing explicit primary", () => {
 		const context = {
 			chains: {
 				default: ["openai/gpt-5.2"],
 			},
-			getModelRole: (_role: string) => undefined,
+			// default role has an explicit primary that differs from the switched model
+			getModelRole: (role: string) => (role === "default" ? "anthropic/claude-sonnet-4-5" : undefined),
 			modelLookup: {
-				find: (provider: string, id: string) => MODELS.find(m => m.provider === provider && m.id === id),
+				find: (provider: string, id: string) =>
+					MODELS.find(m => m.provider === provider && m.id === id) as unknown as Model,
 				hasProvider: (provider: string) => MODELS.some(m => m.provider === provider),
 			},
 		};
 
-		// Session switched to a model without an explicit chain
-		const resolvedChainKey = resolveRetryFallbackChainKey(context, "anthropic/claude-opus-4-5", MODELS[0]);
+		// When model is NOT session-switched, default chain is NOT attached (preserves test/turn-recovery-replay-unsafe contract)
+		const normalKey = resolveRetryFallbackChainKey(
+			context,
+			"anthropic/claude-opus-4-5",
+			MODELS[0] as unknown as Model,
+			undefined,
+			{
+				isSessionSwitched: false,
+			},
+		);
+		expect(normalKey).toBeUndefined();
 
-		expect(resolvedChainKey).toBe("default");
+		// When model IS session-switched, default chain is attached as fallback
+		const switchedKey = resolveRetryFallbackChainKey(
+			context,
+			"anthropic/claude-opus-4-5",
+			MODELS[0] as unknown as Model,
+			undefined,
+			{
+				isSessionSwitched: true,
+			},
+		);
+		expect(switchedKey).toBe("default");
 	});
 });

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -79,7 +79,10 @@ describe("/switch slash command", () => {
 
 		await executeBuiltinSlashCommand("/switch @smol", harness.runtime);
 
-		expect(harness.switchSessionModel).toHaveBeenCalledWith(MODELS[2], undefined);
+		expect(harness.switchSessionModel).toHaveBeenCalledWith(MODELS[2], undefined, {
+			role: "smol",
+			fallbackNotice: undefined,
+		});
 	});
 
 	it("/switch unknown surfaces an error without opening the picker or switching", async () => {


### PR DESCRIPTION
## Summary

When users switch models temporarily during a session using `/switch <model>` or the interactive model picker (`alt+p`), previous behavior had multiple fallback gaps:
1. Switched models did not consult the configured `default` fallback chain or role fallback chains upon turn failure (429, quota exhaustion, provider errors), because the role was unconditionally overwritten with `"temporary"`.
2. Attempting to `/switch` to an unauthenticated model threw an error immediately without checking if fallback candidates in the chain (or explicit fallback sequences) had working credentials.
3. Interactive role selection in `showModelPicker()` previously called `applyRoleModel()`, permanently mutating global settings rather than applying session-only temporary model changes.

### Changes

- **`resolveSwitchModelWithFallback` (`@oh-my-pi/pi-coding-agent`)**:
  - Adds multi-model selector parsing (comma- or space-separated sequences like `/switch opus,sonnet`).
  - Supports auth-aware fallback: if the requested model lacks API key/credentials, resolves fallback candidates in the explicit list, or configured `retry.fallbackChains` (model key, provider wildcard, role, or default chain).
  - Emits user-visible fallback notices when a fallback is used due to missing credentials.
- **`model-controls.ts` & `agent-session.ts`**:
  - `setModelTemporary` now accepts `{ role?: string }` so switched roles (e.g. `/switch @smol`) retain their role identity in session history.
- **`retry-fallback-chains.ts` & `turn-recovery.ts`**:
  - `resolveRetryFallbackChainKey`: allows the configured `default` fallback chain to protect session-switched models when no specific model key or role key matches.
  - `#liveRetryRoleHint`: recognizes roles configured in `retry.fallbackChains` even on temporary model changes.
- **`selector-controller.ts` (Interactive Switch)**:
  - `onPickRole` in `showModelPicker()` now applies the role temporarily for the session without mutating global settings, while retaining the role for fallback chains.
  - Over-context compaction fallback gracefully reports retention of current model on compaction abort or failure.
- **Tests**:
  - Added test suite in `packages/coding-agent/test/slash-commands/switch-fallback.test.ts` covering multi-model comma/space fallbacks, single unauthenticated model fallback, wildcard fallback, default chain fallback, and fallback resolution for session-switched models.

## Test Plan

- `bun test ./packages/coding-agent/test/slash-commands/switch.test.ts ./packages/coding-agent/test/slash-commands/switch-fallback.test.ts` (11 pass).
- `bun run check:tools` (lint & format pass).
- `bun --cwd=packages/coding-agent run check:types` (`tsgo` typecheck passes).