### PR TITLE
fix(coding-agent): build a named tool choice for OpenRouter models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/force` and other forced tool choices refusing every OpenRouter model: `buildNamedToolChoice` did not recognise the `openrouter` api.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/force` and other forced tool choices refusing every OpenRouter model: `buildNamedToolChoice` did not recognise the `openrouter` api.
+- Fixed `/force` and other forced tool choices refusing every OpenRouter model: `buildNamedToolChoice` did not recognise the `openrouter` api. Models whose compat disables tool choice or forced tool choice now report forcing as unsupported instead of queueing a choice the transport discards ([#11658](https://github.com/can1357/oh-my-pi/pull/11658) by [@datrixlab](https://github.com/datrixlab)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/utils/tool-choice.ts
+++ b/packages/coding-agent/src/utils/tool-choice.ts
@@ -12,11 +12,14 @@ export function buildNamedToolChoice(toolName: string, model?: Model<Api>): Tool
 		return { type: "tool", name: toolName };
 	}
 
+	// openrouter streams through the openai-responses or openai-completions path
+	// (stream.ts), both of which map a named function choice onto the wire.
 	if (
 		model.api === "openai-codex-responses" ||
 		model.api === "openai-responses" ||
 		model.api === "openai-completions" ||
-		model.api === "azure-openai-responses"
+		model.api === "azure-openai-responses" ||
+		model.api === "openrouter"
 	) {
 		return { type: "function", name: toolName };
 	}

--- a/packages/coding-agent/src/utils/tool-choice.ts
+++ b/packages/coding-agent/src/utils/tool-choice.ts
@@ -21,6 +21,11 @@ export function buildNamedToolChoice(toolName: string, model?: Model<Api>): Tool
 		model.api === "azure-openai-responses" ||
 		model.api === "openrouter"
 	) {
+		// Both OpenAI transports drop tool_choice when the model has none and turn a
+		// forced choice into "auto" when forcing is unsupported. Such a choice never
+		// reaches the wire, so it must not be reported as a forced one.
+		const compat = model.compat as { supportsToolChoice?: boolean; supportsForcedToolChoice?: boolean };
+		if (compat?.supportsToolChoice === false || compat?.supportsForcedToolChoice === false) return undefined;
 		return { type: "function", name: toolName };
 	}
 

--- a/packages/coding-agent/test/slash-commands/force.test.ts
+++ b/packages/coding-agent/test/slash-commands/force.test.ts
@@ -114,4 +114,23 @@ describe("/force slash command", () => {
 
 		expect(buildNamedToolChoice("write", model)).toEqual({ type: "function", name: "write" });
 	});
+
+	it("builds a named function choice for OpenRouter models", () => {
+		// OpenRouter used to be modelled as openai-completions and got this choice; since
+		// it became its own api, /force refused every OpenRouter model.
+		const model = buildModel({
+			id: "openai/gpt-5",
+			name: "GPT-5 (OpenRouter)",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+		}) satisfies Model<"openrouter">;
+
+		expect(buildNamedToolChoice("write", model)).toEqual({ type: "function", name: "write" });
+	});
 });

--- a/packages/coding-agent/test/slash-commands/force.test.ts
+++ b/packages/coding-agent/test/slash-commands/force.test.ts
@@ -133,4 +133,24 @@ describe("/force slash command", () => {
 
 		expect(buildNamedToolChoice("write", model)).toEqual({ type: "function", name: "write" });
 	});
+
+	it("does not report a forced choice for an OpenRouter model that drops it", () => {
+		// supportsToolChoice: false makes both OpenAI transports drop tool_choice, so a
+		// named choice here would let /force claim a force that never reaches the wire.
+		const model = buildModel({
+			id: "amazon/nova-lite-v1",
+			name: "Nova Lite (OpenRouter)",
+			api: "openrouter",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 300_000,
+			maxTokens: 5_120,
+			compat: { supportsToolChoice: false },
+		}) satisfies Model<"openrouter">;
+
+		expect(buildNamedToolChoice("write", model)).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What

`buildNamedToolChoice` now returns `{ type: "function", name }` for the `openrouter` api,
the same as the four OpenAI-family apis it already handled.

## Why

It returned `undefined` for every OpenRouter model, so:

- `/force <tool>` throws *"Current model does not support forcing a specific tool."*
  (`agent-session.ts:2055-2057`)
- `todo.eager=always` logs its "does not support a forced todo tool_choice" warning and
  does not force the tool
- the think-tool forcing and the task executor's yield reminder are skipped silently

The list is a regression rather than a gap. It dates from the eager-todo work (bb0026cb32,
2026-03-11), when OpenRouter models were modelled as `openai-completions` and so got a named
choice. `openrouter` became its own api later — the catalog still carries the note
*"Older builds cached OpenRouter discovery rows as `api: "openai-completions"`"*
(`provider-models/openai-compat.ts`) — and this function was not updated with it.

The transport already supports the choice. `stream.ts` routes `openrouter` through either
the `openai-responses` or the `openai-completions` path, and both pass
`toolChoice: mapOpenAiToolChoice(options?.toolChoice)`, which maps `{ type: "function", name }`
onto `{ type: "function", function: { name } }`. `blob-broker/context-images.ts` already
lists `openrouter` next to exactly these four OpenAI apis.

## Testing

Reproduced against the bundled catalog, then confirmed the same run no longer fails.
`getBundledModels("openrouter")` returns 502 models, all `api: "openrouter"`:

```
                         before              after
named function choice    0 / 502             494 / 502
refused                  502 (all)           8 -- the ones whose compat disables tool choice
```

The 8 are `~anthropic/claude-fable-latest`, `anthropic/claude-fable-5.1`, four
`amazon/nova-*`, and two `thinkingmachines/inkling*`. Their compat sets
`supportsToolChoice: false`, so both OpenAI transports would drop the choice
(`openai-completions.ts` only sets `tool_choice` when it is true;
`mapOpenAIResponsesToolChoiceForTools` returns `undefined`), and a forced choice becomes
`"auto"` when `supportsForcedToolChoice` is false. `buildNamedToolChoice` now reports
those as unsupported rather than let `/force` claim a force that never reaches the wire
(thanks to the Codex review for catching this).

That guard sits on the shared OpenAI-family branch, so it also changes one existing case:
3 of the 4 bundled direct DeepSeek models (`deepseek-v4-flash`, `-flash-vision-exp`,
`-v4-pro`) are `openai-completions` with `supportsToolChoice: false`. They used to get a
named choice their transport discarded; `/force` on them now says it is unsupported. All
54 bundled OpenAI models are unchanged.

Tests in `test/slash-commands/force.test.ts`, next to the existing Ollama case:

- an OpenRouter model gets a named function choice -- reverting the `openrouter` line
  fails it
- an OpenRouter model with `supportsToolChoice: false` gets none -- removing the compat
  guard fails it

`bun run check` in `packages/coding-agent` is clean. Force and todo suites: 86 pass.

Not exercised: a live `/force` against OpenRouter, which needs an API key. I verified the
function the command calls, against the real catalog, and the wire mapping it feeds.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
