### PR TITLE
fix(ai): ensure Anthropic tool array carries a cache breakpoint on OAuth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -171,6 +171,9 @@
 - Fixed Z.AI (GLM Coding Plan) browser sign-in by using the registered CLI callback address.
 - Fixed OpenAI Codex/Responses tool results being lost when composite call identifiers could not be paired with the corresponding assistant call.
 - Fixed native OpenAI Responses history replay becoming stuck on malformed or truncated function-call arguments; invalid history items are now discarded so the session can recover.
+### Fixed
+
+- Fixed direct Anthropic requests never caching the tool array. Anthropic writes a cache entry only at a `cache_control` marker, and the backward lookback finds entries earlier requests wrote rather than unmarked stable content behind them, so with markers only on the trailing two messages the `tools` -> `system` head had no entry at any position and every message-region divergence (compaction rebuilding history, a rewind onto another branch, a resumed session) reprocessed the tool definitions too. The last tool definition now carries a breakpoint, which caches every definition before it as a single prefix that survives message-region rewrites and is shared byte for byte between sibling subagents of the same definition. This spends a third of the four available breakpoints; breakpoints themselves are free, and a tool array below the model's minimum cacheable length is processed uncached without an error rather than failing.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents.
+- Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents.
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed
@@ -171,9 +175,6 @@
 - Fixed Z.AI (GLM Coding Plan) browser sign-in by using the registered CLI callback address.
 - Fixed OpenAI Codex/Responses tool results being lost when composite call identifiers could not be paired with the corresponding assistant call.
 - Fixed native OpenAI Responses history replay becoming stuck on malformed or truncated function-call arguments; invalid history items are now discarded so the session can recover.
-### Fixed
-
-- Fixed direct Anthropic requests never caching the tool array. Anthropic writes a cache entry only at a `cache_control` marker, and the backward lookback finds entries earlier requests wrote rather than unmarked stable content behind them, so with markers only on the trailing two messages the `tools` -> `system` head had no entry at any position and every message-region divergence (compaction rebuilding history, a rewind onto another branch, a resumed session) reprocessed the tool definitions too. The last tool definition now carries a breakpoint, which caches every definition before it as a single prefix that survives message-region rewrites and is shared byte for byte between sibling subagents of the same definition. This spends a third of the four available breakpoints; breakpoints themselves are free, and a tool array below the model's minimum cacheable length is processed uncached without an error rather than failing.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3478,8 +3478,38 @@ function applyCacheControlToLastBlock(blocks: ContentBlockParam[], cacheControl:
 	return false;
 }
 
+/**
+ * Mark the tool array so the stable head gets a cache entry of its own.
+ *
+ * Anthropic writes an entry only AT a marked block; the backward lookback finds
+ * entries prior requests wrote, never unmarked stable content behind them. With
+ * markers only in the trailing message window, the `tools` -> `system` head has
+ * no entry at any position, so any divergence in the message region (compaction
+ * rebuilding history, a rewind onto another branch, a resumed session) reprocesses
+ * the tool definitions along with everything else.
+ *
+ * The tool array sits first in wire order, so an entry here survives every
+ * message-region rewrite, and it is the one region sibling subagents of the same
+ * definition share byte for byte. Breakpoints themselves are free (only written
+ * and read tokens are billed) and a prefix below the model's minimum cacheable
+ * length is processed uncached without an error, so a short tool array degrades
+ * to a no-op rather than a failure.
+ */
+function applyToolPromptCaching(tools: AnthropicWireTool[] | undefined, cacheControl: AnthropicCacheControl): void {
+	if (!tools?.length) return;
+	const lastIndex = tools.length - 1;
+	const lastTool = tools[lastIndex];
+	if (!lastTool || lastTool.cache_control != null) return;
+	tools[lastIndex] = { ...lastTool, cache_control: cloneAnthropicCacheControl(cacheControl) };
+}
+
 function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
 	if (!cacheControl) return;
+
+	// One marker on the tool array plus the two-message rolling window below is
+	// three of Anthropic's four breakpoints, leaving one spare. Both carry the
+	// same TTL, so the "longer TTL must precede shorter" rule cannot be violated.
+	applyToolPromptCaching(params.tools, cacheControl);
 
 	// `convertAnthropicMessages` appends this neutral pad after a trailing
 	// assistant because Anthropic rejects assistant-prefill endings. It is absent

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3478,39 +3478,8 @@ function applyCacheControlToLastBlock(blocks: ContentBlockParam[], cacheControl:
 	return false;
 }
 
-/**
- * Mark the tool array so the stable head gets a cache entry of its own.
- *
- * Anthropic writes an entry only AT a marked block; the backward lookback finds
- * entries prior requests wrote, never unmarked stable content behind them. With
- * markers only in the trailing message window, the `tools` -> `system` head has
- * no entry at any position, so any divergence in the message region (compaction
- * rebuilding history, a rewind onto another branch, a resumed session) reprocesses
- * the tool definitions along with everything else.
- *
- * The tool array sits first in wire order, so an entry here survives every
- * message-region rewrite, and it is the one region sibling subagents of the same
- * definition share byte for byte. Breakpoints themselves are free (only written
- * and read tokens are billed) and a prefix below the model's minimum cacheable
- * length is processed uncached without an error, so a short tool array degrades
- * to a no-op rather than a failure.
- */
-function applyToolPromptCaching(tools: AnthropicWireTool[] | undefined, cacheControl: AnthropicCacheControl): void {
-	if (!tools?.length) return;
-	const lastIndex = tools.length - 1;
-	const lastTool = tools[lastIndex];
-	if (!lastTool || lastTool.cache_control != null) return;
-	tools[lastIndex] = { ...lastTool, cache_control: cloneAnthropicCacheControl(cacheControl) };
-}
-
 function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
 	if (!cacheControl) return;
-
-	// One marker on the tool array plus the two-message rolling window below is
-	// three of Anthropic's four breakpoints, leaving one spare. Both carry the
-	// same TTL, so the "longer TTL must precede shorter" rule cannot be violated.
-	applyToolPromptCaching(params.tools, cacheControl);
-
 	// `convertAnthropicMessages` appends this neutral pad after a trailing
 	// assistant because Anthropic rejects assistant-prefill endings. It is absent
 	// from the next normal turn, so anchor the rolling window on the preceding
@@ -3550,13 +3519,15 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
  *
  * Anthropic allows at most 4 cache breakpoints per request. At most one is
  * spent on tools and one on system here, leaving two for the message tail in
- * `applyPromptCaching`. Head caching is skipped entirely when the head is
- * already anchored — the OAuth Claude Code path caches its own instruction
- * block at buildAnthropicSystemBlocks, and via the canonical tools → system
- * order that single system breakpoint already caches every preceding tool. Re-
- * anchoring there would be redundant, would change the OAuth wire, and could
- * push a tool-heavy request over the 4-breakpoint budget, so the general
- * API-key path (nothing cached upstream) is the only one decorated here.
+ * `applyPromptCaching`.
+ *
+ * The tool array is anchored on both API-key and OAuth paths: the tool definitions
+ * sit first in wire order and survive message rewrites, and sibling subagents of
+ * the same definition share this prefix byte for byte.
+ *
+ * When the OAuth Claude Code path already anchors its identity system block at
+ * buildAnthropicSystemBlocks, the system check skips adding a second system
+ * breakpoint, while the tool check still anchors the last tool definition.
  *
  * Runs after the byte-stability plane (planStableAnthropicSystem /
  * planStableAnthropicTools), which hands back fresh block/tool copies each turn
@@ -3570,15 +3541,7 @@ function applyHeadCaching(
 ): void {
 	if (!cacheControl) return;
 
-	// If anything in the head already carries a breakpoint, the head is already
-	// cached (OAuth anchors its identity system block, which — canonical order
-	// tools → system — caches all tools too). Leave it untouched.
-	const headAlreadyCached =
-		(systemBlocks?.some(block => block.cache_control != null) ?? false) ||
-		(tools?.some(tool => tool.cache_control != null) ?? false);
-	if (headAlreadyCached) return;
-
-	if (tools && tools.length > 0) {
+	if (tools && tools.length > 0 && !tools.some(tool => tool.cache_control != null)) {
 		// Deferred tools are not part of the checked prefix until referenced, so
 		// anchor the last tool that actually sits in the stable prefix.
 		for (let index = tools.length - 1; index >= 0; index--) {
@@ -3589,7 +3552,7 @@ function applyHeadCaching(
 		}
 	}
 
-	if (systemBlocks && systemBlocks.length > 0) {
+	if (systemBlocks && systemBlocks.length > 0 && !systemBlocks.some(block => block.cache_control != null)) {
 		const lastBlock = systemBlocks[systemBlocks.length - 1];
 		if (lastBlock) lastBlock.cache_control = cloneAnthropicCacheControl(cacheControl);
 	}

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1672,14 +1672,14 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.tools?.[1]?.cache_control).toBeUndefined();
 		expect(payload.tools?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
 
-		// The trailing message window is untouched, and system blocks stay uncached
-		// because the OAuth cloak blocks carry per-request bytes.
+		// The trailing message window is untouched; the OAuth identity block carries its
+		// own breakpoint, while caller system blocks stay uncached.
 		const content = payload.messages?.at(-1)?.content;
 		expect(Array.isArray(content) ? content.at(-1)?.cache_control : undefined).toEqual({
 			type: "ephemeral",
 		});
-		expect(payload.system?.some(block => block.cache_control != null)).toBe(false);
-
+		expect(payload.system?.[1]?.cache_control).toEqual({ type: "ephemeral" });
+		expect(payload.system?.[2]?.cache_control).toBeUndefined();
 		// Anthropic rejects a fifth breakpoint, so the total must stay in budget.
 		const marked = (blocks: Array<{ cache_control?: unknown }> | undefined) =>
 			(blocks ?? []).filter(block => block.cache_control != null).length;

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1641,7 +1641,53 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.tools?.[0]?.name).toBe(`${claudeToolPrefix}bash`);
 		expect(payload.tools?.[0]?.strict).toBe(true);
 		expect(payload.tools?.[0]?.eager_input_streaming).toBe(true);
+		// Sole tool is also the last tool, so it carries the head breakpoint.
+		expect(payload.tools?.[0]?.cache_control).toEqual({ type: "ephemeral" });
+	});
+
+	it("breakpoints the last tool definition so the stable head gets its own cache entry", async () => {
+		const tools: Tool[] = ["search", "fetch", "run"].map(name => ({
+			name,
+			description: `${name} tool`,
+			parameters: {
+				type: "object",
+				properties: { value: { type: "string" } },
+				required: ["value"],
+			} as TJsonSchema,
+		}));
+
+		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["Stay concise."],
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			tools,
+		})) as {
+			tools?: Array<{ cache_control?: unknown }>;
+			system?: Array<{ cache_control?: unknown }>;
+			messages?: Array<{ content?: Array<{ cache_control?: unknown }> | string }>;
+		};
+
+		// Only the last tool is marked: it caches every definition before it as a
+		// single prefix, so earlier markers would spend breakpoints for nothing.
 		expect(payload.tools?.[0]?.cache_control).toBeUndefined();
+		expect(payload.tools?.[1]?.cache_control).toBeUndefined();
+		expect(payload.tools?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
+
+		// The trailing message window is untouched, and system blocks stay uncached
+		// because the OAuth cloak blocks carry per-request bytes.
+		const content = payload.messages?.at(-1)?.content;
+		expect(Array.isArray(content) ? content.at(-1)?.cache_control : undefined).toEqual({
+			type: "ephemeral",
+		});
+		expect(payload.system?.some(block => block.cache_control != null)).toBe(false);
+
+		// Anthropic rejects a fifth breakpoint, so the total must stay in budget.
+		const marked = (blocks: Array<{ cache_control?: unknown }> | undefined) =>
+			(blocks ?? []).filter(block => block.cache_control != null).length;
+		const messageBreakpoints = (payload.messages ?? []).reduce(
+			(total, message) => total + (Array.isArray(message.content) ? marked(message.content) : 0),
+			0,
+		);
+		expect(marked(payload.tools) + marked(payload.system) + messageBreakpoints).toBeLessThanOrEqual(4);
 	});
 
 	it("marks only the Anthropic strict allowlist strict", async () => {


### PR DESCRIPTION
## What

I was comparing omp's Anthropic prompt caching against how Claude Code does it, and found that the tool array never gets cached at all on OAuth requests. This change separates tool head anchoring from system block anchoring in `applyHeadCaching`, so `tools[last]` carries a breakpoint on both API-key and OAuth requests.

## Why

Anthropic writes a cache entry only at a `cache_control` marker. Upstream commit 5850d6b0e1 added `applyHeadCaching` for API keys, but skipped the head whenever any block already carried a marker (`headAlreadyCached`). On OAuth, `system[1]` holds the pre-anchored Claude Code identity block, which made the helper skip the head entirely. That left tool definitions uncached across history rewrites, compactions, and sibling subagents, and left one of Anthropic's four allowable breakpoints unused.

Anchoring `tools[last]` spends at most 4 of them:

1. `tools[last]` (last non-deferred tool)
2. `system[1]` (OAuth identity) or `systemBlocks[last]` (API keys)
3. Trailing message window (up to 2 messages)

Supersedes #10220.

## Testing

- `bun test packages/ai/test/anthropic-alignment.test.ts packages/ai/test/anthropic-head-caching.test.ts` (102 passed)
- `bun test packages/ai/test/anthropic-*.test.ts` (382 passed across 28 files)
- `bun check` passes in `packages/ai`
- Checked combinations of OAuth vs API-key, tool counts, deferred tools, thinking models, and message pads for breakpoint budget overflow; none exceeded 4

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)