### PR TITLE
fix(coding-agent): stop the browser relay stealing tab and window focus

### DIFF
--- a/packages/browser-relay/CHANGELOG.md
+++ b/packages/browser-relay/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tabs opened through the relay now open in the background without stealing focus from the user's foreground tab ([#11662](https://github.com/can1357/oh-my-pi/pull/11662) by [@jwaldrip](https://github.com/jwaldrip)).
+- Activating a driven tab for screenshots no longer raises or focuses the browser window ([#11662](https://github.com/can1357/oh-my-pi/pull/11662) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Changed

--- a/packages/browser-relay/extension/background.ts
+++ b/packages/browser-relay/extension/background.ts
@@ -10,6 +10,7 @@
  * and re-dials after Chrome reaps it while disconnected.
  */
 import type { ExtToRelayMessage, RelayToExtMessage, TabSnapshot } from "../../coding-agent/src/tools/browser/relay/protocol";
+import { activateRelayTab, createRelayTab } from "../../coding-agent/src/tools/browser/relay/tab-ops";
 
 const DEFAULT_PORT = 9224;
 const PING_INTERVAL_MS = 20_000;
@@ -173,7 +174,7 @@ async function runRpc(msg: Extract<RelayToExtMessage, { t: "rpc" }>): Promise<un
 				msg.params,
 			);
 		case "createTab": {
-			const tab = await chrome.tabs.create({ url: msg.url });
+			const tab = await createRelayTab(chrome.tabs, msg.url);
 			const snap = snapshot(tab);
 			if (!snap) throw new Error("created tab has no id");
 			return { tab: snap };
@@ -181,12 +182,9 @@ async function runRpc(msg: Extract<RelayToExtMessage, { t: "rpc" }>): Promise<un
 		case "removeTab":
 			await chrome.tabs.remove(msg.tabId);
 			return {};
-		case "activateTab": {
-			const tab = await chrome.tabs.get(msg.tabId);
-			await chrome.windows.update(tab.windowId, { focused: true });
-			await chrome.tabs.update(msg.tabId, { active: true });
+		case "activateTab":
+			await activateRelayTab(chrome.tabs, msg.tabId);
 			return {};
-		}
 		case "group":
 			return await enqueueGroupOp(() => groupTabs(msg.tabIds, msg.title, msg.color));
 		case "ungroup":

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `browser` now takes `new_tab: true` on `open`, which drives a dedicated background tab in relay sessions instead of adopting one the user is working in ([#11662](https://github.com/can1357/oh-my-pi/pull/11662) by [@jwaldrip](https://github.com/jwaldrip)).
+
+### Fixed
+
+- The browser relay no longer steals window focus when activating driven tabs for screenshots ([#11662](https://github.com/can1357/oh-my-pi/pull/11662) by [@jwaldrip](https://github.com/jwaldrip)).
+
 ## [18.1.19] - 2026-09-12
 
 - Fixed `--mode json` returning exit 0 on a turn-fatal provider/auth/network error ([#11498](https://github.com/can1357/oh-my-pi/issues/11498)).

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -26,8 +26,9 @@ Application modes:
 - `app.path`: spawn the specified browser or Electron executable.
 - `app.cdp_url`: attach to an existing CDP endpoint.
 - `app.relay: true`: drive the user's Chrome through the omp relay. `app.target` selects a tab by URL/title substring; without it, the visible tab is adopted. Opening with `url` navigates that adopted tab.
-- Relay sessions are the user's real logged-in browser. Sites attribute actions to the user. Name a target or create a dedicated tab; NEVER navigate the visible tab without authorization.
-- Closing releases the managed tab. It never closes relay/CDP-attached pages. Spawned browsers remain open unless `kill: true`.
+- `new_tab: true` (relay only) opens a background tab of its own instead of adopting one the user is working in, and closes it on release. Prefer it for anything that navigates; it ignores `app.target`. A screenshot still has to make that tab the active one in its window (no window is ever raised).
+- Relay sessions are the user's real logged-in browser. Sites attribute actions to the user. Use `new_tab: true` or name a target; NEVER navigate the visible tab without authorization.
+- Closing releases the managed tab, and closes it when `new_tab: true` created it. It never closes a relay/CDP tab it merely adopted. Spawned browsers remain open unless `kill: true`.
 - Idle tabs auto-freeze at turn settle (animated pages stop burning CPU/GPU) and unfreeze on next use; tabs idle past the idle-close timeout are closed. Pass `persist: true` on `open` to keep a tab live across turns (e.g. multi-step login); `browser.close` still releases explicitly.
 </instruction>
 

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -68,6 +68,9 @@ const browserSchema = type({
 	"name?": type("string").describe("tab id (default 'main')"),
 	"url?": type("string").describe("url to open"),
 	"app?": appSchema,
+	"new_tab?": type("boolean").describe(
+		"open a new background tab instead of adopting the user's current one (relay only)",
+	),
 	"viewport?": {
 		width: "number",
 		height: "number",
@@ -286,6 +289,7 @@ async function openBrowser(
 							}
 						: undefined,
 					target: params.app?.target,
+					newTab: params.new_tab,
 					timeoutMs,
 					deadlineStartMs: deadlineStart,
 					dialogs: params.dialogs,

--- a/packages/coding-agent/src/tools/browser/relay/bridge.ts
+++ b/packages/coding-agent/src/tools/browser/relay/bridge.ts
@@ -545,6 +545,20 @@ export class RelayBridge {
 			this.#reply(conn, msg, {});
 			return;
 		}
+		// Activation is relay policy, not passthrough. Chrome implements
+		// `Page.bringToFront` by activating the tab's WINDOW, which takes OS
+		// focus from whatever the user is typing in; the relay drives tabs the
+		// user is working in, so it activates the tab inside its own window
+		// instead (`activateRelayTab`) and never raises the window.
+		if (msg.method === "Page.bringToFront") {
+			try {
+				await this.#rpc({ op: "activateTab", tabId });
+				this.#reply(conn, msg, {});
+			} catch (err) {
+				this.#replyError(conn, msg, err instanceof Error ? err.message : String(err));
+			}
+			return;
+		}
 		try {
 			const result = await this.#rpc({
 				op: "send",

--- a/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
+++ b/packages/coding-agent/src/tools/browser/relay/extension-assets/background.js.txt
@@ -1,3 +1,11 @@
+// ../coding-agent/src/tools/browser/relay/tab-ops.ts
+function createRelayTab(tabs, url) {
+  return tabs.create({ url, active: false });
+}
+async function activateRelayTab(tabs, tabId) {
+  await tabs.update(tabId, { active: true });
+}
+
 // extension/background.ts
 var DEFAULT_PORT = 9224;
 var PING_INTERVAL_MS = 20000;
@@ -135,7 +143,7 @@ async function runRpc(msg) {
     case "send":
       return await chrome.debugger.sendCommand(msg.sessionId ? { tabId: msg.tabId, sessionId: msg.sessionId } : { tabId: msg.tabId }, msg.method, msg.params);
     case "createTab": {
-      const tab = await chrome.tabs.create({ url: msg.url });
+      const tab = await createRelayTab(chrome.tabs, msg.url);
       const snap = snapshot(tab);
       if (!snap)
         throw new Error("created tab has no id");
@@ -144,12 +152,9 @@ async function runRpc(msg) {
     case "removeTab":
       await chrome.tabs.remove(msg.tabId);
       return {};
-    case "activateTab": {
-      const tab = await chrome.tabs.get(msg.tabId);
-      await chrome.windows.update(tab.windowId, { focused: true });
-      await chrome.tabs.update(msg.tabId, { active: true });
+    case "activateTab":
+      await activateRelayTab(chrome.tabs, msg.tabId);
       return {};
-    }
     case "group":
       return await enqueueGroupOp(() => groupTabs(msg.tabIds, msg.title, msg.color));
     case "ungroup":

--- a/packages/coding-agent/src/tools/browser/relay/tab-ops.ts
+++ b/packages/coding-agent/src/tools/browser/relay/tab-ops.ts
@@ -1,0 +1,41 @@
+/**
+ * Tab-lifecycle policy for relay-driven tabs.
+ *
+ * Runs inside the Chrome extension against `chrome.tabs`, but lives here
+ * beside `protocol.ts` (which the extension also imports) because the
+ * extension package has no test surface: CI's buckets never load it, so
+ * policy that must not silently regress belongs on this side of the wire.
+ *
+ * One rule: driving a tab must not move the user. Chrome's defaults do the
+ * opposite, so both helpers exist to override a default.
+ */
+
+/** The `chrome.tabs` subset this policy touches; injected so it is testable without a browser. */
+export interface RelayTabsApi<TTab> {
+	create(createProperties: { url?: string; active?: boolean }): Promise<TTab>;
+	update(tabId: number, updateProperties: { active?: boolean }): Promise<unknown>;
+}
+
+/**
+ * Open a relay-driven tab in the background. `chrome.tabs.create` foregrounds
+ * the new tab by default, which pulls the user off whatever they were reading.
+ */
+export function createRelayTab<TTab>(tabs: RelayTabsApi<TTab>, url: string): Promise<TTab> {
+	return tabs.create({ url, active: false });
+}
+
+/**
+ * Make a tab the active one in ITS OWN window, without raising that window.
+ *
+ * Activation is what the compositor-surface screenshot path needs: CDP
+ * `Page.captureScreenshot` reads the surface, which follows the active target.
+ * Raising the window is not needed for pixels and is what actually disrupts
+ * the user: `chrome.windows.update({ focused: true })` (and CDP
+ * `Page.bringToFront`, which Chrome implements by activating the tab's
+ * window) take OS focus away from whatever they are typing in.
+ * `chrome.tabs.update({ active: true })` documents that it does not affect
+ * window focus, so it is the whole activation the relay performs.
+ */
+export async function activateRelayTab(tabs: RelayTabsApi<unknown>, tabId: number): Promise<void> {
+	await tabs.update(tabId, { active: true });
+}

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -71,10 +71,17 @@ export type WorkerInitPayload =
 			 */
 			recover?: boolean;
 			/**
-			 * Whether the worker may raise this tab before capturing a screenshot. Unset
-			 * behaves as `true`; the supervisor clears it for browsers we did not launch.
+			 * Whether the worker may activate this tab before capturing a screenshot.
+			 * Unset behaves as `true`; the supervisor clears it when it adopted a tab
+			 * the user was already looking at.
 			 */
 			activateForScreenshot?: boolean;
+			/**
+			 * The tab was created for this worker (`new_tab`) rather than adopted, so
+			 * closing the worker closes the tab. Adopted tabs belong to the user and
+			 * outlive the worker.
+			 */
+			ownsPage?: boolean;
 	  };
 
 /** Result of one host tool requested by browser-run JavaScript. */
@@ -134,7 +141,7 @@ export type WorkerOutbound =
 	| { type: "result"; id: string; ok: false; error: RunErrorPayload }
 	| { type: "tool-call"; id: string; runId: string; name: string; args: unknown }
 	| { type: "log"; level: "debug" | "warn" | "error"; msg: string; meta?: Record<string, unknown> }
-	| { type: "closed" };
+	| { type: "closed"; ok?: boolean; error?: string };
 
 export interface Transport {
 	send(msg: WorkerOutbound | WorkerInbound, transferList?: Transferable[]): void;

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -106,6 +106,8 @@ export interface WorkerTabSession extends TabSessionBase<PuppeteerBrowserHandle>
 	backend: "worker";
 	worker: WorkerHandle;
 	activateForScreenshot: boolean;
+	/** The tab was created for this session (`newTab`), so releasing it closes the tab. */
+	ownsPage: boolean;
 }
 
 export interface CmuxTabSession extends TabSessionBase<CmuxBrowserHandle> {
@@ -122,6 +124,15 @@ export interface AcquireTabOptions {
 	waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
 	viewport?: { width: number; height: number; deviceScaleFactor?: number };
 	target?: string;
+	/**
+	 * Open a new background tab instead of adopting one the user is already
+	 * using. Only supported for relay sessions (`app.relay: true`): headless
+	 * browsers always get their own page, and direct CDP connections
+	 * (`app.cdp_url`) cannot activate background tabs without raising the OS
+	 * window. The new tab is created in the background and closed again when the
+	 * tab is released.
+	 */
+	newTab?: boolean;
 	signal?: AbortSignal;
 	timeoutMs: number;
 	/**
@@ -293,6 +304,10 @@ async function acquireTabImpl(
 				holdBrowser(browser);
 				tempHold = true;
 				await releaseTab(name, { kill: false });
+			} else if (opts.newTab && (existing.backend !== "worker" || !existing.ownsPage)) {
+				holdBrowser(browser);
+				tempHold = true;
+				await releaseTab(name, { kill: false });
 			} else {
 				// Reuse counts as use: refresh the idle clock and resume a
 				// settle-frozen page before driving it again. A refused
@@ -362,103 +377,128 @@ async function acquireTabImpl(
 	}
 	let initPayload: WorkerInitPayload;
 	let worker: WorkerHandle;
+	let supervisorCreatedTargetId: string | undefined;
+	let published = false;
+	const cleanupSupervisorTarget = async () => {
+		if (supervisorCreatedTargetId) {
+			const tid = supervisorCreatedTargetId;
+			supervisorCreatedTargetId = undefined;
+			await closeTargetById(browser, tid).catch(() => undefined);
+		}
+	};
 	try {
-		initPayload = await buildInitPayload(browser, opts);
-		worker = await spawnTabWorker();
-	} catch (error) {
-		// Failing before the worker took its own hold must release the
-		// temporary one, or the browser's refCount never reaches 0 again.
-		if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
-		throw error;
-	}
-	// Init budget: the caller's timeout plus the supervisor grace — never a
-	// fixed floor. A floor larger than the caller's budget would keep a wedged
-	// worker (and its orphaned page on a shared browser) alive long after the
-	// caller gave up; the phase floors inside initializeTabWorker keep each
-	// phase positive for sub-second budgets, and the caller's abort signal is
-	// the hard backstop for floor overshoot.
-	const initBudgetMs = opts.timeoutMs + GRACE_MS;
-	let info: ReadyInfo;
-	try {
-		info = await initializeTabWorker(worker, initPayload, initBudgetMs, startedAt);
-	} catch (error) {
-		// `BuildMessage`-class failures arrive asynchronously via the worker's `error` event,
-		// after `spawnTabWorker`'s synchronous try/catch has already returned. Fall back to
-		// the inline worker here so module-resolution failures don't poison every tab open.
-		await worker.terminate().catch(() => undefined);
-		// A headless worker that died mid-init may have already created its page in the
-		// shared browser — a killed worker can't close it, so close the target the worker
-		// reported (no-op when it never got that far).
-		closeAbandonedWorkerPage(browser, worker);
-		if (worker.mode === "inline" || isReportedInitFailure(error)) {
+		try {
+			initPayload = await buildInitPayload(browser, opts);
+			if (initPayload.mode === "attach" && initPayload.ownsPage) {
+				supervisorCreatedTargetId = initPayload.targetId;
+			}
+			worker = await spawnTabWorker();
+		} catch (error) {
+			// Failing before the worker took its own hold must release the
+			// temporary one, or the browser's refCount never reaches 0 again.
+			await cleanupSupervisorTarget();
 			if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
 			throw error;
 		}
-		// Fail fast once the caller's init budget is exhausted: its timeout has already
-		// fired, so a retried result would only be discarded by the post-init abort check —
-		// don't spend the phase floors' excess on a cold start nobody is waiting for.
-		if (initBudgetExhausted(initBudgetMs, startedAt)) {
-			if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
-			throw error;
-		}
-		logger.warn("Tab worker init failed; retrying with inline tab worker (no sync-loop guard)", {
-			error: error instanceof Error ? error.message : String(error),
-		});
-		worker = await spawnInlineWorker();
+		// Init budget: the caller's timeout plus the supervisor grace — never a
+		// fixed floor. A floor larger than the caller's budget would keep a wedged
+		// worker (and its orphaned page on a shared browser) alive long after the
+		// caller gave up; the phase floors inside initializeTabWorker keep each
+		// phase positive for sub-second budgets, and the caller's abort signal is
+		// the hard backstop for floor overshoot.
+		const initBudgetMs = opts.timeoutMs + GRACE_MS;
+		let info: ReadyInfo;
 		try {
 			info = await initializeTabWorker(worker, initPayload, initBudgetMs, startedAt);
-		} catch (inlineError) {
+		} catch (error) {
+			// `BuildMessage`-class failures arrive asynchronously via the worker's `error` event,
+			// after `spawnTabWorker`'s synchronous try/catch has already returned. Fall back to
+			// the inline worker here so module-resolution failures don't poison every tab open.
+			await worker.terminate().catch(() => undefined);
+			// A headless worker that died mid-init may have already created its page in the
+			// shared browser — a killed worker can't close it, so close the target the worker
+			// reported (no-op when it never got that far).
+			closeAbandonedWorkerPage(browser, worker);
+			if (worker.mode === "inline" || isReportedInitFailure(error)) {
+				await cleanupSupervisorTarget();
+				if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
+				throw error;
+			}
+			// Fail fast once the caller's init budget is exhausted: its timeout has already
+			// fired, so a retried result would only be discarded by the post-init abort check —
+			// don't spend the phase floors' excess on a cold start nobody is waiting for.
+			if (initBudgetExhausted(initBudgetMs, startedAt)) {
+				await cleanupSupervisorTarget();
+				if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
+				throw error;
+			}
+			logger.warn("Tab worker init failed; retrying with inline tab worker (no sync-loop guard)", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			worker = await spawnInlineWorker();
+			try {
+				info = await initializeTabWorker(worker, initPayload, initBudgetMs, startedAt);
+			} catch (inlineError) {
+				await worker.terminate().catch(() => undefined);
+				closeAbandonedWorkerPage(browser, worker);
+				await cleanupSupervisorTarget();
+				if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
+				const finalError = new ToolError(
+					`Failed to start browser tab worker (inline fallback also failed): ${inlineError instanceof Error ? inlineError.message : String(inlineError)}`,
+				);
+				(finalError as { cause?: unknown }).cause = error;
+				throw finalError;
+			}
+		}
+
+		// If the caller aborted while we were spawning/initializing the worker, tear
+		// the freshly-built worker down before publishing the tab so the browser
+		// refCount (which `holdBrowser` below would take) never grows for a tab
+		// nobody is waiting for. Mirror the error paths' `refCount === 0` release so
+		// a fresh browser held by nothing but this aborted open is not orphaned in
+		// the registry; a browser still leased/held elsewhere (refCount > 0) is left
+		// for its owner to release.
+		if (opts.signal?.aborted) {
 			await worker.terminate().catch(() => undefined);
 			closeAbandonedWorkerPage(browser, worker);
-			if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false });
-			const finalError = new ToolError(
-				`Failed to start browser tab worker (inline fallback also failed): ${inlineError instanceof Error ? inlineError.message : String(inlineError)}`,
-			);
-			(finalError as { cause?: unknown }).cause = error;
-			throw finalError;
+			await cleanupSupervisorTarget();
+			if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false }).catch(() => undefined);
+			throw new ToolAbortError("Browser tab open aborted");
+		}
+
+		holdBrowser(browser);
+		if (tempHold) await releaseBrowser(browser, { kill: false });
+		const tab: WorkerTabSession = {
+			name,
+			browser,
+			targetId: info.targetId,
+			backend: "worker",
+			worker,
+			state: "alive",
+			info,
+			pending: new Map(),
+			dialogPolicy: opts.dialogs,
+			kindTag: browser.kind.kind,
+			activateForScreenshot: initPayload.mode === "headless" || initPayload.activateForScreenshot !== false,
+			ownsPage: initPayload.mode === "headless" || initPayload.ownsPage === true,
+			ownerSessionId: opts.ownerSessionId,
+			persist: opts.persist ?? false,
+			lastActivityAt: Date.now(),
+			frozen: false,
+		};
+		worker.onMessage(msg => handleTabMessage(tab, msg));
+		tabs.set(name, tab);
+		published = true;
+		// Durably record ownership so another live omp process can reap this page if
+		// this process dies abnormally before its own teardown closes the tab.
+		const scope = sharedScopeOf(browser);
+		if (scope) void recordSharedTarget(scope, info.targetId);
+		return { tab, created: true };
+	} finally {
+		if (!published) {
+			await cleanupSupervisorTarget();
 		}
 	}
-
-	// If the caller aborted while we were spawning/initializing the worker, tear
-	// the freshly-built worker down before publishing the tab so the browser
-	// refCount (which `holdBrowser` below would take) never grows for a tab
-	// nobody is waiting for. Mirror the error paths' `refCount === 0` release so
-	// a fresh browser held by nothing but this aborted open is not orphaned in
-	// the registry; a browser still leased/held elsewhere (refCount > 0) is left
-	// for its owner to release.
-	if (opts.signal?.aborted) {
-		await worker.terminate().catch(() => undefined);
-		closeAbandonedWorkerPage(browser, worker);
-		if (tempHold || browser.refCount === 0) await releaseBrowser(browser, { kill: false }).catch(() => undefined);
-		throw new ToolAbortError("Browser tab open aborted");
-	}
-
-	holdBrowser(browser);
-	if (tempHold) await releaseBrowser(browser, { kill: false });
-	const tab: WorkerTabSession = {
-		name,
-		browser,
-		targetId: info.targetId,
-		backend: "worker",
-		worker,
-		state: "alive",
-		info,
-		pending: new Map(),
-		dialogPolicy: opts.dialogs,
-		kindTag: browser.kind.kind,
-		activateForScreenshot: initPayload.mode === "headless" || initPayload.activateForScreenshot !== false,
-		ownerSessionId: opts.ownerSessionId,
-		persist: opts.persist ?? false,
-		lastActivityAt: Date.now(),
-		frozen: false,
-	};
-	worker.onMessage(msg => handleTabMessage(tab, msg));
-	tabs.set(name, tab);
-	// Durably record ownership so another live omp process can reap this page if
-	// this process dies abnormally before its own teardown closes the tab.
-	const scope = sharedScopeOf(browser);
-	if (scope) void recordSharedTarget(scope, info.targetId);
-	return { tab, created: true };
 }
 
 async function acquireCmuxTab(
@@ -833,12 +873,16 @@ async function releaseTabInner(tab: TabSession, name: string, opts: ReleaseTabOp
 		try {
 			tab.worker.send({ type: "close" });
 			await waitForClosed(tab);
-		} catch {
+		} catch (err) {
 			forced = true;
+			cleanupError = err;
 		}
 	}
 	await tab.worker.terminate().catch(() => undefined);
-	if (forced && tab.kindTag === "headless") {
+	// A worker that died before acking the close cannot close its own page, so
+	// the supervisor closes any target we own (headless page, or a `newTab` we
+	// created in a user-driven browser). Adopted tabs are the user's; never.
+	if (forced && tab.ownsPage) {
 		try {
 			await waitForTabCleanup(
 				tab,
@@ -846,6 +890,7 @@ async function releaseTabInner(tab: TabSession, name: string, opts: ReleaseTabOp
 				`orphan CDP target ${JSON.stringify(tab.targetId)} (Page.close)`,
 				closeOrphanTarget(tab),
 			);
+			cleanupError = undefined;
 		} catch (error) {
 			cleanupError = error;
 		}
@@ -1222,8 +1267,36 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 			timeoutMs: opts.timeoutMs,
 		};
 	}
+	// `newTab` asks for a tab of our own instead of one the user is working in.
+	// The relay creates it in the background, so opening it moves nothing; it is
+	// then ours to activate for pixels and ours to close on release.
+	if (opts.newTab) {
+		if (browser.kind.kind !== "relay") {
+			throw new ToolError("new_tab: true is only supported for browser relay sessions (app.relay: true)");
+		}
+		const created = await browser.browser.newPage();
+		let targetId: string;
+		try {
+			targetId = await targetIdForPage(created);
+		} catch (error) {
+			await created.close().catch(() => undefined);
+			throw error;
+		}
+		return {
+			mode: "attach",
+			browserWSEndpoint,
+			safeDir,
+			targetId,
+			dialogs: opts.dialogs,
+			url: opts.url,
+			waitUntil: opts.waitUntil,
+			timeoutMs: opts.timeoutMs,
+			activateForScreenshot: true,
+			ownsPage: true,
+		};
+	}
 	// Connected and relay browsers are user-driven. When no target is requested,
-	// adopt the visible tab and avoid raising it before screenshots. An explicit
+	// adopt the visible tab and avoid activating it before screenshots. An explicit
 	// target may be backgrounded, so retain activation for target-correct pixels.
 	const userDriven = browser.kind.kind === "connected" || browser.kind.kind === "relay";
 	const activateForScreenshot = !userDriven || !shouldPreserveConnectedBrowserFocus(opts.target);
@@ -1348,6 +1421,7 @@ async function recycleTimedOutWorkerTab(tab: WorkerTabSession, timeoutMs: number
 		recover: true,
 		timeoutMs,
 		activateForScreenshot: tab.activateForScreenshot,
+		ownsPage: tab.ownsPage,
 	};
 	let worker = await spawnTabWorker();
 	try {
@@ -1396,7 +1470,7 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 		return;
 	}
 	await tab.worker.terminate().catch(() => undefined);
-	if (tab.kindTag === "headless") await closeOrphanTarget(tab);
+	if (tab.ownsPage) await closeOrphanTarget(tab);
 	await releaseBrowser(tab.browser, { kill: false });
 	tabs.delete(name);
 	const scope = sharedScopeOf(tab.browser);
@@ -1427,11 +1501,13 @@ function sharedScopeOf(browser: BrowserHandle): SharedTargetScope | undefined {
 /**
  * Best-effort cleanup for a forced-kill path: close the page the tab's worker
  * reported as created. A run caller is never a browser ref holder, so the
- * browser is still in the registry; the tab's browser is the only place that
  * page can be, so no targetId guesswork across multiple sessions.
  */
 async function closeOrphanTarget(tab: WorkerTabSession): Promise<void> {
-	await closeTargetById(tab.browser, tab.targetId);
+	const closed = await closeCdpTarget(tab.browser.browser, tab.targetId);
+	if (!closed) {
+		throw new ToolError(`Failed to close target ${JSON.stringify(tab.targetId)}`);
+	}
 }
 
 /**
@@ -1456,11 +1532,16 @@ function closeAbandonedWorkerPage(browser: PuppeteerBrowserHandle, worker: Worke
 		.catch(() => undefined)
 		.finally(() => void releaseBrowser(browser, { kill: false }).catch(() => undefined));
 }
-
 async function waitForClosed(tab: WorkerTabSession): Promise<void> {
-	const { promise, resolve } = Promise.withResolvers<void>();
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
 	const unsubscribe = tab.worker.onMessage(msg => {
-		if (msg.type === "closed") resolve();
+		if (msg.type === "closed") {
+			if (msg.ok === false) {
+				reject(new ToolError(`Tab page close failed: ${msg.error ?? "unknown error"}`));
+			} else {
+				resolve();
+			}
+		}
 	});
 	try {
 		await raceWithTimeout(promise, GRACE_MS, "Timed out closing browser tab worker");

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -938,7 +938,9 @@ export async function preparePageForScreenshot(
 		() => false,
 	);
 	if (!visible) {
-		throw new ToolError("The attached browser tab is not visible; switch to it before taking a screenshot");
+		throw new ToolError(
+			"The attached browser tab is not visible: switch back to it, or reopen the tab with new_tab: true to drive one of our own",
+		);
 	}
 }
 
@@ -963,8 +965,9 @@ export class WorkerCore {
 	#unsub: () => void;
 	#isolated: boolean;
 	#uninstallRejectionGuard: () => void;
-	#mode?: WorkerInitPayload["mode"];
 	#activateForScreenshot = true;
+	/** True when the page was created for this worker, so closing the worker closes it. */
+	#ownsPage = false;
 	#dialogPolicy?: DialogPolicy;
 	#dialogHandler?: (dialog: Dialog) => void;
 	#openDialog?: OpenDialogInfo;
@@ -1068,8 +1071,8 @@ export class WorkerCore {
 
 	async #init(payload: WorkerInitPayload): Promise<void> {
 		try {
-			this.#mode = payload.mode;
 			this.#activateForScreenshot = payload.mode === "headless" || payload.activateForScreenshot !== false;
+			this.#ownsPage = payload.mode === "headless" || payload.ownsPage === true;
 			const puppeteer = await loadPuppeteerInWorker(payload.safeDir);
 			this.#browser = await puppeteer.connect({
 				browserWSEndpoint: payload.browserWSEndpoint,
@@ -1116,11 +1119,11 @@ export class WorkerCore {
 			this.#targetId = await targetIdForPage(this.#page);
 			this.#transport.send({ type: "ready", info: await this.#currentReadyInfo() });
 		} catch (error) {
-			// A failed headless init leaves the worker's page orphaned in the shared
+			// A failed headless or owned-page init leaves the worker's page orphaned in the shared
 			// browser (the supervisor retries with a fresh worker), so close it before
-			// reporting. Attach mode adopts an existing target — never close it.
+			// reporting. Adopted targets belong to the user — never close them.
 			const page = this.#page;
-			if (payload.mode === "headless" && page && !page.isClosed()) {
+			if (this.#ownsPage && page && !page.isClosed()) {
 				await page.close().catch(() => undefined);
 			}
 			this.#transport.send({ type: "init-failed", error: errorPayload(error) });
@@ -2187,9 +2190,21 @@ export class WorkerCore {
 		this.#clearElementCache();
 		const page = this.#page;
 		if (this.#dialogHandler && page && !page.isClosed()) page.off("dialog", this.#dialogHandler);
-		if (this.#mode === "headless" && page && !page.isClosed()) await page.close().catch(() => undefined);
+		let closeError: unknown;
+		if (this.#ownsPage && page && !page.isClosed()) {
+			try {
+				await page.close();
+			} catch (err) {
+				closeError = err;
+			}
+		}
 		if (this.#browser?.connected) this.#browser.disconnect();
-		this.#transport.send({ type: "closed" });
+		if (closeError) {
+			const errorMsg = closeError instanceof Error ? closeError.message : String(closeError);
+			this.#transport.send({ type: "closed", ok: false, error: errorMsg });
+		} else {
+			this.#transport.send({ type: "closed", ok: true });
+		}
 		this.#transport.close();
 	}
 

--- a/packages/coding-agent/test/tools/browser-new-tab.test.ts
+++ b/packages/coding-agent/test/tools/browser-new-tab.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "bun:test";
+import {
+	acquireBrowser,
+	type BrowserHandle,
+	holdBrowser,
+	releaseBrowser,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { acquireTab, releaseTab, runInTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { chromiumAvailable } from "./chromium-probe";
+
+const CHROMIUM_AVAILABLE = await chromiumAvailable();
+
+const page = (label: string) => `data:text/html,<title>${label}</title><main>${label}</main>`;
+
+function unique(prefix: string): string {
+	return `${prefix}-${process.pid}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Attaching to a browser we did not launch is the relay's shape: `kind:
+ * "connected"` takes the same user-driven branch of the init payload that a
+ * relay browser does, so a locally launched Chromium reached over CDP
+ * exercises adoption and `newTab` without needing the extension.
+ */
+async function connectToOwnBrowser(owned: BrowserHandle): Promise<BrowserHandle> {
+	if (!("browser" in owned)) throw new Error("Expected a Puppeteer browser");
+	const wsEndpoint = owned.browser.wsEndpoint();
+	const port = new URL(wsEndpoint).port;
+	return await acquireBrowser({ kind: "connected", cdpUrl: `http://127.0.0.1:${port}` }, { cwd: process.cwd() });
+}
+
+async function connectAsRelay(owned: BrowserHandle): Promise<BrowserHandle> {
+	if (!("browser" in owned)) throw new Error("Expected a Puppeteer browser");
+	const wsEndpoint = owned.browser.wsEndpoint();
+	const port = new URL(wsEndpoint).port;
+	const connected = await acquireBrowser(
+		{ kind: "connected", cdpUrl: `http://127.0.0.1:${port}` },
+		{ cwd: process.cwd() },
+	);
+	return Object.assign(connected, {
+		kind: { kind: "relay" as const, cdpUrl: `http://127.0.0.1:${port}` },
+	});
+}
+
+describe("browser tabs in a browser we did not launch", () => {
+	it.skipIf(!CHROMIUM_AVAILABLE)(
+		"opens its own tab for new_tab and leaves the user's tab alone, but adopts one otherwise",
+		async () => {
+			const userUrl = page("user-tab");
+			const agentUrl = page("agent-tab");
+			const adoptedUrl = page("adopted-tab");
+			const newTabName = unique("own-tab");
+			const adoptName = unique("adopted-tab");
+			let owned: BrowserHandle | undefined;
+			let connected: BrowserHandle | undefined;
+			const openedTabs: string[] = [];
+			try {
+				owned = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+				holdBrowser(owned);
+				connected = await connectAsRelay(owned);
+				holdBrowser(connected);
+				if (!("browser" in connected)) throw new Error("Expected a Puppeteer browser");
+				const remote = connected.browser;
+
+				// Stand in for the tab the user is working in.
+				const userPages = await remote.pages();
+				const userPage = userPages[0];
+				if (!userPage) throw new Error("Expected the launch's initial page");
+				await userPage.goto(userUrl, { waitUntil: "load" });
+				expect((await remote.pages()).length).toBe(1);
+
+				// `new_tab`: a tab of our own, and the user's is untouched.
+				const created = await acquireTab(newTabName, connected, {
+					url: agentUrl,
+					newTab: true,
+					timeoutMs: 30_000,
+				});
+				openedTabs.push(newTabName);
+				if (created.tab.backend !== "worker") throw new Error("Expected a worker-backed tab");
+				const afterCreate = await remote.pages();
+				expect(afterCreate.map(p => p.url()).sort()).toEqual([agentUrl, userUrl].sort());
+				expect(userPage.url()).toBe(userUrl);
+				expect(created.tab.ownsPage).toBe(true);
+
+				// Releasing an owned tab closes it; the user's tab survives.
+				await releaseTab(newTabName, { kill: false });
+				openedTabs.pop();
+				expect((await remote.pages()).map(p => p.url())).toEqual([userUrl]);
+
+				// Without `new_tab` the tab the user is in is adopted and navigated:
+				// the behavior `new_tab` exists to avoid.
+				const adopted = await acquireTab(adoptName, connected, { url: adoptedUrl, timeoutMs: 30_000 });
+				openedTabs.push(adoptName);
+				if (adopted.tab.backend !== "worker") throw new Error("Expected a worker-backed tab");
+				expect(adopted.tab.ownsPage).toBe(false);
+				expect((await remote.pages()).map(p => p.url())).toEqual([adoptedUrl]);
+
+				// An adopted tab is the user's: releasing must not close it.
+				await releaseTab(adoptName, { kill: false });
+				openedTabs.pop();
+				expect((await remote.pages()).map(p => p.url())).toEqual([adoptedUrl]);
+			} finally {
+				for (const name of openedTabs.reverse()) await releaseTab(name, { kill: false }).catch(() => undefined);
+				if (connected) await releaseBrowser(connected, { kill: false }).catch(() => undefined);
+				if (owned) await releaseBrowser(owned, { kill: true }).catch(() => undefined);
+			}
+		},
+		60_000,
+	);
+
+	it.skipIf(!CHROMIUM_AVAILABLE)(
+		"reopening an adopted session with new_tab: true produces an owned tab and does not navigate the adopted one",
+		async () => {
+			const userUrl = page("user-tab");
+			const agentUrl = page("agent-tab");
+			const sessionName = unique("adopted-then-owned");
+			let owned: BrowserHandle | undefined;
+			let relay: BrowserHandle | undefined;
+			const openedTabs: string[] = [];
+			try {
+				owned = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+				holdBrowser(owned);
+				relay = await connectAsRelay(owned);
+				holdBrowser(relay);
+				if (!("browser" in relay)) throw new Error("Expected a Puppeteer browser");
+				const remote = relay.browser;
+
+				const userPages = await remote.pages();
+				const userPage = userPages[0];
+				if (!userPage) throw new Error("Expected initial page");
+				await userPage.goto(userUrl, { waitUntil: "load" });
+
+				// 1. Adopt the user's tab without new_tab
+				const adopted = await acquireTab(sessionName, relay, { timeoutMs: 30_000 });
+				openedTabs.push(sessionName);
+				if (adopted.tab.backend !== "worker") throw new Error("Expected a worker-backed tab");
+				expect(adopted.tab.ownsPage).toBe(false);
+				expect(userPage.url()).toBe(userUrl);
+
+				// 2. Reopen the same session name with new_tab: true and a new URL
+				const reopened = await acquireTab(sessionName, relay, {
+					url: agentUrl,
+					newTab: true,
+					timeoutMs: 30_000,
+				});
+				if (reopened.tab.backend !== "worker") throw new Error("Expected a worker-backed tab");
+				expect(reopened.tab.ownsPage).toBe(true);
+				// User's tab was NOT navigated!
+				expect(userPage.url()).toBe(userUrl);
+				const pages = await remote.pages();
+				expect(pages.map(p => p.url()).sort()).toEqual([agentUrl, userUrl].sort());
+
+				// 3. Releasing the owned session closes the owned tab; user's tab survives
+				await releaseTab(sessionName, { kill: false });
+				openedTabs.pop();
+				expect((await remote.pages()).map(p => p.url())).toEqual([userUrl]);
+			} finally {
+				for (const name of openedTabs.reverse()) await releaseTab(name, { kill: false }).catch(() => undefined);
+				if (relay) await releaseBrowser(relay, { kill: false }).catch(() => undefined);
+				if (owned) await releaseBrowser(owned, { kill: true }).catch(() => undefined);
+			}
+		},
+		60_000,
+	);
+
+	it.skipIf(!CHROMIUM_AVAILABLE)(
+		"cleans up supervisor-created target when worker initialization or navigation fails",
+		async () => {
+			const userUrl = page("user-tab");
+			const failName = unique("failing-tab");
+			let owned: BrowserHandle | undefined;
+			let relay: BrowserHandle | undefined;
+			try {
+				owned = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+				holdBrowser(owned);
+				relay = await connectAsRelay(owned);
+				holdBrowser(relay);
+				if (!("browser" in relay)) throw new Error("Expected a Puppeteer browser");
+				const remote = relay.browser;
+
+				const userPages = await remote.pages();
+				const userPage = userPages[0];
+				if (!userPage) throw new Error("Expected initial page");
+				await userPage.goto(userUrl, { waitUntil: "load" });
+				expect((await remote.pages()).length).toBe(1);
+
+				// Force navigation failure during new_tab initialization
+				await expect(
+					acquireTab(failName, relay, {
+						url: "http://127.0.0.1:1/nonexistent",
+						newTab: true,
+						timeoutMs: 2_000,
+					}),
+				).rejects.toThrow();
+
+				// The supervisor-created target MUST be closed, leaving only the original tab
+				const afterPages = await remote.pages();
+				expect(afterPages.length).toBe(1);
+				expect(afterPages[0]?.url()).toBe(userUrl);
+			} finally {
+				await releaseTab(failName, { kill: false }).catch(() => undefined);
+				if (relay) await releaseBrowser(relay, { kill: false }).catch(() => undefined);
+				if (owned) await releaseBrowser(owned, { kill: true }).catch(() => undefined);
+			}
+		},
+		60_000,
+	);
+
+	it.skipIf(!CHROMIUM_AVAILABLE)(
+		"rejects new_tab on direct CDP connected sessions",
+		async () => {
+			let owned: BrowserHandle | undefined;
+			let connected: BrowserHandle | undefined;
+			try {
+				owned = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+				holdBrowser(owned);
+				connected = await connectToOwnBrowser(owned);
+				holdBrowser(connected);
+
+				await expect(
+					acquireTab(unique("cdp-tab"), connected, {
+						url: page("agent-tab"),
+						newTab: true,
+						timeoutMs: 5_000,
+					}),
+				).rejects.toThrow("new_tab: true is only supported for browser relay sessions (app.relay: true)");
+			} finally {
+				if (connected) await releaseBrowser(connected, { kill: false }).catch(() => undefined);
+				if (owned) await releaseBrowser(owned, { kill: true }).catch(() => undefined);
+			}
+		},
+		60_000,
+	);
+
+	it.skipIf(!CHROMIUM_AVAILABLE)(
+		"surfaces page close error when tab release fails",
+		async () => {
+			const sessionName = unique("failing-close");
+			let owned: BrowserHandle | undefined;
+			let relay: BrowserHandle | undefined;
+			try {
+				owned = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
+				holdBrowser(owned);
+				relay = await connectAsRelay(owned);
+				holdBrowser(relay);
+				if (!relay || !("browser" in relay)) throw new Error("Expected a Puppeteer browser");
+
+				const created = await acquireTab(sessionName, relay, {
+					url: page("close-fail"),
+					newTab: true,
+					timeoutMs: 30_000,
+				});
+				if (created.tab.backend !== "worker") throw new Error("Expected a worker-backed tab");
+				expect(created.tab.ownsPage).toBe(true);
+
+				// Override page.close on the worker's page to simulate a close failure
+				await runInTab(sessionName, {
+					code: "page.close = async () => { throw new Error('simulated close failure'); };",
+					timeoutMs: 5_000,
+					session: {
+						cwd: process.cwd(),
+						hasUI: false,
+						settings: { get: () => undefined },
+					} as unknown as ToolSession,
+				});
+
+				// Break CDP closeTarget on the browser handle so supervisor fallback also fails:
+				const remote = relay.browser;
+				const originalTarget = remote.target.bind(remote);
+				remote.target = () => {
+					throw new Error("simulated CDP target session failure");
+				};
+				try {
+					await expect(releaseTab(sessionName, { kill: false })).rejects.toThrow();
+				} finally {
+					remote.target = originalTarget;
+				}
+			} finally {
+				await releaseTab(sessionName, { kill: false }).catch(() => undefined);
+				if (relay) await releaseBrowser(relay, { kill: false }).catch(() => undefined);
+				if (owned) await releaseBrowser(owned, { kill: true }).catch(() => undefined);
+			}
+		},
+		60_000,
+	);
+});

--- a/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-bridge.test.ts
@@ -40,6 +40,10 @@ class FakeCdpSocket implements RelaySocket {
 		const result = msg && "result" in msg && msg.result && typeof msg.result === "object" ? msg.result : undefined;
 		return result && "sessionId" in result && typeof result.sessionId === "string" ? result.sessionId : undefined;
 	}
+	/** The bridge's reply (or error) for a downstream command id. */
+	replyFor(commandId: number): Record<string, unknown> | undefined {
+		return this.messages.find(m => m.id === commandId);
+	}
 	/** Session ids the bridge announced through `Target.attachedToTarget`. */
 	attachedSessions(): string[] {
 		const out: string[] = [];
@@ -860,5 +864,96 @@ describe("RelayBridge attachment release", () => {
 				message => message.sessionId === sessionId && message.method === "Runtime.executionContextCreated",
 			),
 		).toEqual([]);
+	});
+});
+
+describe("RelayBridge activation policy", () => {
+	it("activates the tab for Page.bringToFront instead of forwarding it to Chrome", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 }), tab({ tabId: 2 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 2);
+
+		const commandId = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: commandId, sessionId, method: "Page.bringToFront" }));
+		await flush();
+
+		// Chrome implements `Page.bringToFront` by activating the tab's window,
+		// which steals OS focus from whatever the user is typing in. Forwarding
+		// it verbatim is the defect: the relay must activate the tab itself.
+		expect(ext.rpcs("send").filter(rpc => rpc.method === "Page.bringToFront")).toEqual([]);
+		const activations = ext.rpcs("activateTab");
+		expect(activations).toHaveLength(1);
+		expect(activations[0]!.tabId).toBe(2);
+
+		ack(bridge, ext, "activateTab");
+		await flush();
+		expect(cdp.replyFor(commandId)).toEqual({ id: commandId, sessionId, result: {} });
+	});
+
+	it("reports an activation failure to the caller rather than a silent success", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+		const sessionId = await attachPage(bridge, ext, cdp, connId, 1);
+
+		const commandId = ++msgSeq;
+		bridge.cdpMessage(connId, JSON.stringify({ id: commandId, sessionId, method: "Page.bringToFront" }));
+		await flush();
+		nack(bridge, ext, "activateTab", "tab is gone");
+		await flush();
+
+		const reply = cdp.replyFor(commandId);
+		expect(reply && "error" in reply).toBe(true);
+		expect(JSON.stringify(reply)).toContain("tab is gone");
+	});
+
+	it("reports a rejected removeTab RPC to the caller rather than a silent success", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+
+		const commandId = ++msgSeq;
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: commandId, method: "Target.closeTarget", params: { targetId: "PAGE1" } }),
+		);
+		await flush();
+		nack(bridge, ext, "removeTab", "tab cannot be closed");
+		await flush();
+
+		const reply = cdp.replyFor(commandId);
+		expect(reply && "error" in reply).toBe(true);
+		expect(JSON.stringify(reply)).toContain("tab cannot be closed");
+	});
+
+	it("activates the tab for Target.activateTarget through activateTab RPC without raising window", async () => {
+		const bridge = new RelayBridge({});
+		const ext = new FakeExtSocket();
+		connect(bridge, ext, [tab({ tabId: 1 }), tab({ tabId: 2 })]);
+		const cdp = new FakeCdpSocket();
+		const connId = bridge.cdpConnected(cdp);
+
+		const commandId = ++msgSeq;
+		bridge.cdpMessage(
+			connId,
+			JSON.stringify({ id: commandId, method: "Target.activateTarget", params: { targetId: "PAGE2" } }),
+		);
+		await flush();
+
+		expect(ext.rpcs("send").filter(rpc => rpc.method === "Target.activateTarget")).toEqual([]);
+		const activations = ext.rpcs("activateTab");
+		expect(activations).toHaveLength(1);
+		expect(activations[0]!.tabId).toBe(2);
+
+		ack(bridge, ext, "activateTab");
+		await flush();
+		expect(cdp.replyFor(commandId)).toEqual({ id: commandId, result: {} });
 	});
 });

--- a/packages/coding-agent/test/tools/browser-relay-tab-ops.test.ts
+++ b/packages/coding-agent/test/tools/browser-relay-tab-ops.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { activateRelayTab, createRelayTab } from "@oh-my-pi/pi-coding-agent/tools/browser/relay/tab-ops";
+
+/**
+ * Records what the extension would ask Chrome to do. The relay extension runs
+ * these two helpers against `chrome.tabs`, and nothing in a unit test can
+ * observe Chrome itself, so the call the extension makes IS the contract: it
+ * is what decides whether the user keeps the tab and window they were in.
+ */
+class FakeTabs {
+	readonly created: Array<{ url?: string; active?: boolean }> = [];
+	readonly updated: Array<{ tabId: number; active?: boolean }> = [];
+	async create(createProperties: { url?: string; active?: boolean }): Promise<{ id: number }> {
+		this.created.push(createProperties);
+		return { id: 7 };
+	}
+	async update(tabId: number, updateProperties: { active?: boolean }): Promise<unknown> {
+		this.updated.push({ tabId, ...updateProperties });
+		return undefined;
+	}
+}
+
+describe("relay tab policy", () => {
+	it("creates a driven tab in the background instead of foregrounding it", async () => {
+		const tabs = new FakeTabs();
+
+		const created = await createRelayTab(tabs, "https://example.com/");
+
+		expect(created).toEqual({ id: 7 });
+		// `chrome.tabs.create` defaults to `active: true`, which pulls the user
+		// off whatever they were reading; the policy must pass it explicitly.
+		expect(tabs.created).toEqual([{ url: "https://example.com/", active: false }]);
+	});
+
+	it("activates a tab without raising its window", async () => {
+		const tabs = new FakeTabs();
+
+		await activateRelayTab(tabs, 42);
+
+		// Exactly one mutation, and it is the one that does not move OS focus:
+		// `chrome.tabs.update({ active: true })` cannot focus a window, while
+		// the `chrome.windows.update({ focused: true })` this replaced takes
+		// keyboard focus away from whatever application the user is typing in.
+		expect(tabs.updated).toEqual([{ tabId: 42, active: true }]);
+		expect(tabs.created).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

The browser relay drives tabs inside a browser the user is actively working in, and three separate paths move them out of it: a screenshot raises the tab's window, a relay-created tab takes over the foreground, and there is no way to ask for a tab of your own, so the tool navigates the one the user is reading.

This fixes the first two and adds the third. It does not touch the screenshot capture path itself (see "Not fixed here").

## Why each one moved the user

**`Page.bringToFront` was passthrough.** `RelayBridge.#forwardToTab` has cases for `Browser.close` and `OMP.claimTarget` and forwards everything else verbatim to `chrome.debugger.sendCommand`. Chrome implements `Page.bringToFront` by activating the tab's *window*, so it takes OS keyboard focus. The tab worker calls it before every screenshot on a tab opened with `app.target` (`preparePageForScreenshot`, activate branch), and any `tab.run` calling `page.bringToFront()` hits it too. Notably `Target.activateTarget` already went through the relay's own `activateTab` RPC, so the two activation paths disagreed: one was policy, the other was a hole.

**`chrome.tabs.create` foregrounds by default.** The extension called `chrome.tabs.create({ url })`, and Chrome's `active` defaults to `true`. The cmux backend already passes `focus: false` for the equivalent operation (`tab-supervisor.ts`, `browser.open_split`), so this was an asymmetry rather than a considered choice.

**`activateTab` raised the window before activating the tab.** The extension did `chrome.windows.update(tab.windowId, { focused: true })` and then `chrome.tabs.update(tabId, { active: true })`. The window raise is the part that steals focus; `tabs.update({ active: true })` is documented as not affecting window focus, and tab activation is all the compositor-surface capture needs.

**Nothing could open its own tab.** `buildInitPayload` either adopts the visible tab (`preferVisible`, when no `app.target` is given) or picks one by matcher, and then the worker runs `page.goto(url)` on it. The only route to a fresh tab was `tab.run` reaching raw puppeteer and calling `browser.newPage()`.

## Change

- `bridge.ts`: `Page.bringToFront` is answered by the relay's `activateTab` RPC instead of being forwarded to Chrome, and an activation failure is reported to the caller rather than swallowed.
- New `tools/browser/relay/tab-ops.ts` holds the two tab-lifecycle policies (`createRelayTab`, `activateRelayTab`) that the extension executes against `chrome.tabs`. It lives in the coding-agent package, which the extension already imports its wire types from, because CI's test buckets never load `packages/browser-relay` — policy that must not silently regress needs a test surface on this side of the wire. The chrome API is a parameter, so the module structurally cannot reach `chrome.windows`.
- `extension/background.ts` calls those two helpers; `extension-assets/background.js.txt` regenerated with `bun run build`.
- `open` takes `new_tab: true`: `buildInitPayload` creates the page itself, marks the payload `ownsPage`, and the worker closes that page on close. `releaseTab`'s forced path and `forceKillTab` now close an owned target for any browser kind instead of headless only. Adopted tabs are unchanged: still never closed.
- `new_tab` sets `activateForScreenshot: true` (the tab is ours to activate, and after this change activating it costs no window focus). The "tab is not visible" screenshot error now names `new_tab` as the way out instead of only telling the caller to switch tabs.

## Testing

`bun test test/tools/browser` in `packages/coding-agent`: **238 pass, 0 fail** (30 files) on this branch. `bun run check:ts` across the workspace exits 0; the two lint warnings it prints (`test/task/executor-subagent-reminders.test.ts`, `packages/ai/src/registry/oauth/github-copilot.ts`) are pre-existing and in files this branch does not touch.

Three new tests, each run against the unfixed source to prove it detects the defect:

**`browser-relay-tab-ops.test.ts`** — the Chrome calls the extension makes. Mutating `createRelayTab` back to `tabs.create({ url })`:

```
- "active": false,
(fail) relay tab policy > creates a driven tab in the background instead of foregrounding it
```

The activation test pins that the only mutation is `tabs.update({ active: true })`. That half is a no-regression guard, not a mutation proof: the window raise it replaced is unreachable from the injected API. The evidence for the shipped extension is the regenerated bundle, which loses the line:

```
-    case "activateTab": {
-      const tab = await chrome.tabs.get(msg.tabId);
-      await chrome.windows.update(tab.windowId, { focused: true });
-      await chrome.tabs.update(msg.tabId, { active: true });
+    case "activateTab":
+      await activateRelayTab(chrome.tabs, msg.tabId);
```

**`browser-relay-bridge.test.ts`** — two cases in a new `RelayBridge activation policy` block. With `bridge.ts` reverted, both fail (25 pass, 2 fail): pre-fix the command arrives at the extension as a raw `send` of `Page.bringToFront` and no `activateTab` RPC is issued.

**`browser-new-tab.test.ts`** — a real Chromium reached over CDP as `kind: "connected"`, which takes the same user-driven branch of the init payload a relay browser does, so adoption and `new_tab` are exercised without the extension. It asserts the whole contract in one pass: `new_tab` leaves the user's tab at its own URL and adds a second tab, releasing that tab closes it and keeps the user's, and without `new_tab` the user's tab is adopted and navigated and survives release. With the supervisor/protocol/worker/tool changes reverted, it fails on exactly the symptom this PR is about:

```
  [
    "data:text/html,<title>agent-tab</title><main>agent-tab</main>",
-   "data:text/html,<title>user-tab</title><main>user-tab</main>",
  ]
(fail) opens its own tab for new_tab and leaves the user's tab alone, but adopts one otherwise
```

The user's tab is gone, navigated out from under them, and no new tab exists.

## Not fixed here

A screenshot of a relay tab still has to make that tab the active one in its window. That is `Page.captureScreenshot` reading the compositor surface, which follows the active target; puppeteer defaults `fromSurface: true`. So `new_tab` opens quietly and stays quiet until the first screenshot, which then switches the visible tab within that window (no window is raised any more).

Removing that last tab switch means capturing a background tab, which looks like `fromSurface: false` plus something to stop Chrome freezing a background renderer (`Page.setWebLifecycleState`; nothing in the tree sets it today). Both have caveats worth measuring rather than asserting: `fromSurface: false` drops OS-composited layers and can return blank frames, and it is unclear how much an occluded-but-active window is throttled, which is the same question the dropped window raise raises for a Chrome window sitting behind another application. That is a separate change with its own before/after measurements on real backgrounded tabs, not something to infer from the protocol docs.

---

## Update: rebased and review feedback addressed

Rebased onto `main` (`8fad7f1006`) as a single commit. All eight review findings are answered in the threads above; four were substantive and changed the code:

- **`new_tab` was ignorable.** `acquireTabImpl` returned through the existing-tab reuse branch without comparing `opts.newTab` against `existing.ownsPage`, so `open({ new_tab: true })` on an adopted `main` session navigated the user's tab and reported `Reused`. It now releases and recreates when an adopted session is reopened with `new_tab` (`tab-supervisor.ts:307`).
- **The created target leaked.** The supervisor creates the target before the worker starts but only published ownership after init, and `closeAbandonedWorkerPage()` only knew targets from the worker's headless-only `page-created`. The supervisor now tracks its own target (`tab-supervisor.ts:380`) and closes it on every pre-publication exit; the worker's init-failure cleanup keys off ownership instead of `mode === "headless"` (`tab-worker.ts:1126`).
- **`new_tab` is now relay-only.** On a direct CDP connection there is no `chrome.tabs.update({ active: true })`, and both `Target.activateTarget` and `Page.bringToFront` raise the window, so a connected `new_tab` could be created quietly but never activated for a screenshot without the window raise this PR removes. `app.cdp_url` with `new_tab: true` is now refused rather than silently foregrounding (`tab-supervisor.ts:1273`), and the option docs say so.
- **`browser.close` could lie.** A swallowed `page.close()` failure let `releaseTabInner` take the clean path and skip its orphan-target fallback. The worker now encodes the failure as `{ type: "closed", ok: false, error }` (`tab-protocol.ts:144`, `tab-worker.ts:2193-2207`) and the supervisor surfaces it.

Changelog entries in both packages carry the PR attribution suffix and are trimmed to user-visible behaviour.

**Testing on this head:** `bun run check:ts` exits 0. `bun test` on the touched files: 36 pass, 0 fail (`browser-new-tab` 5, `browser-relay-bridge` 29, `browser-relay-tab-ops` 2). The three new-tab cases each fail against the unfixed source: ownership `Expected: true / Received: false`, leak cleanup `Expected: 1 / Received: 2`, and CDP refusal `Expected promise that rejects / Received promise that resolved`.
