### PR TITLE
feat(coding-agent): add file and conversation rewind with redo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,8 @@ jobs:
            with:
               path: ~/.bun/install/cache
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-         - run: bun install --frozen-lockfile
+         # Include target executables when cross-compiling (e.g. Windows on Linux).
+         - run: bun install --frozen-lockfile --os='*' --cpu='*'
          - name: Install prebuilt native addon(s)
            uses: ./.github/actions/native-artifacts
            with:

--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,7 @@
         "@opentelemetry/sdk-metrics": "catalog:",
         "@opentelemetry/sdk-trace-base": "catalog:",
         "@opentelemetry/sdk-trace-node": "catalog:",
+        "filesnap": "0.5.0",
         "puppeteer-core": "catalog:",
       },
       "devDependencies": {
@@ -1152,6 +1153,20 @@
     "fastembed": ["fastembed@2.1.0", "", { "dependencies": { "@anush008/tokenizers": "^0.0.0", "@huggingface/hub": "^2.7.1", "onnxruntime-node": "1.21.0", "progress": "^2.0.3", "tar": "^6.2.0" } }, "sha512-oQkpcRHBppJ3+a3w9dU0uytSY0N1cnEa/iVMc8AXEd+tvT529GekOEFhNviJy89R3lvQXF6cdIMTXHj1Gi00xQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "filesnap": ["filesnap@0.5.0", "", { "optionalDependencies": { "filesnap-darwin-arm64": "npm:filesnap@0.5.0-darwin-arm64", "filesnap-darwin-x64": "npm:filesnap@0.5.0-darwin-x64", "filesnap-linux-arm64": "npm:filesnap@0.5.0-linux-arm64", "filesnap-linux-x64": "npm:filesnap@0.5.0-linux-x64", "filesnap-win32-arm64": "npm:filesnap@0.5.0-win32-arm64", "filesnap-win32-x64": "npm:filesnap@0.5.0-win32-x64" }, "bin": { "filesnap": "bin/filesnap.mjs" } }, "sha512-EUiHtyK06V/DxcBZpKsisCKj/cFKD7a8cRSzbseGuls8eNs4JiCfjC8YGMVXjWEEcy828aUJnYjOs75WUu3rkw=="],
+
+    "filesnap-darwin-arm64": ["filesnap@0.5.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EQXeP23WVL2DExoNZ1hSgWvE1qskpob5Nj7a8zRxisiwcLgG9Mn3yRuJsi7alybkvIRR2uw+ieRfQN3v4/qdJA=="],
+
+    "filesnap-darwin-x64": ["filesnap@0.5.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-/eE9MjLN0658RunVnAoYOj3/Qkppb+mkcWpsFd1OEJjl7GWdVyvDRMT5MpYPxSkgGVL97ZsIjWwny5rUM7suHQ=="],
+
+    "filesnap-linux-arm64": ["filesnap@0.5.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-xVAaNwqV9nnkyl9GWOh4+Q5+9e1ytneaOZBIDdoqeju6joHcOYOCFgw/mlmKETRQOUE/tggk8LYMQwbib4jimA=="],
+
+    "filesnap-linux-x64": ["filesnap@0.5.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-UE3tULZLVc/HiI88ZIh5QiwZL/BotSadYRNhLFOMG8G3gzyZTFmwMAunZqqQwG1k6cApLdcYb2HUtc1Dj/f7RQ=="],
+
+    "filesnap-win32-arm64": ["filesnap@0.5.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-R5fUfeH37gPWBmVu/Dn7mZqCkCAEH4IZIIsCFgOLw6pwr0GRRuhSVEYZ5TEF829pNzmIkipbNSAwI8FcTY0KCQ=="],
+
+    "filesnap-win32-x64": ["filesnap@0.5.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-uqIjOz41Cj+dnORjyQY1p3RquNRQYfZM6OemTYhCdBRNZqOoHaYk1mUp2gscyKi6xK1Z8/2Qj8HZhh+tchnKFQ=="],
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 

--- a/docs/file-history.md
+++ b/docs/file-history.md
@@ -1,0 +1,59 @@
+# Files and conversation history
+
+## Rewind in the terminal
+
+Checkpoints are saved automatically before new prompts. In the chat input, type
+`/rewind`, select a prompt with the arrow keys, press Enter, and confirm. Both
+workspace files and the conversation return to before that prompt. `/redo`
+restores both to before the last rewind; repeated redo walks successive rewinds.
+A new prompt clears redo. Esc cancels the selector.
+
+Wait for the agent to finish before restoring. If a restore is interrupted, run
+`/rewind-recover` before continuing. Recovery is journaled before file writes;
+conversation changes follow successful file restoration. New combined history
+starts with prompts captured by this build, not legacy file-only checkpoints.
+
+Capture is bounded. Ignored, remote, or uncaptured files are not protected.
+Known local write/edit paths are declared before mutation, including absent files;
+binary files are restored as bytes. Shell/MCP writes need pre-existing capture
+coverage. These commands do not call a model.
+
+## Legacy file-only interface
+
+
+Capture is enabled automatically for persistent sessions. `/file-history on` re-enables capture after it was disabled.
+Before each prompt, OMP captures the bounded workspace scope. Before tools run,
+OMP declares their known local file paths after extension argument rewriting.
+`/file-history list` lists checkpoint IDs; `/file-history restore <turn>` restores
+that checkpoint. `/file-history redo` reverses the latest restore. All operations
+keep the conversation intact. `/file-history off` stops automatic capture without
+removing existing history. `/file-history clear` permanently deletes this session's
+file checkpoints, disables automatic capture, and runs garbage collection. It
+does not modify workspace files or the conversation. Shared content remains
+protected and recently written blobs observe the GC grace period. Settings and snapshots survive session resumption.
+
+This uses the official `filesnap@0.5.0` npm dependency and its native platform
+binary. Standalone OMP builds embed the target platform executable and extract it
+automatically into a private, content-addressed runtime directory on first use,
+alongside its Apache-2.0 license and attribution notice.
+Neither installation method requires a separate filesnap install or a Rust compiler;
+standalone builds also need no Node/npm or runtime download. `FILESNAP_BIN` remains
+an optional override for development. Cross-builds require installing optional
+platform packages with `bun install --frozen-lockfile --os='*' --cpu='*'` first. The data
+store lives beside OMP's agent database, outside the workspace. The integration
+refuses a data directory inside the workspace.
+
+Coverage combines Git-indexed files, explicitly declared edit paths and a bounded
+recent-file scan. `.filesnapignore`, file-size and scan budgets still apply.
+Shell/MCP changes can be restored only if their paths were already captured;
+virtual and remote resource paths are not local file backups. This does not
+restore an entire environment or distinguish simultaneous edits by other agents.
+
+Restore first saves a safety checkpoint. Partial failures are reported; do not
+continue editing before attempting `/file-history redo`. Redo can overwrite edits
+made after a restore; preparation saves their state in a named recovery snapshot
+before any write. Repeating redo reverses the preceding restoration. Use a single active OMP process per session while
+managing file history. New/forked sessions have independent histories.
+
+The existing model `checkpoint`/`rewind` tools continue to manage exploration
+context. File history does not change their meaning.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Automatic prompt checkpoints and native `/rewind`, `/redo`, and `/rewind-recover` restore files and the matching conversation with persistent multi-level redo.
+- `/file-history` retains file-only diagnostics, capture controls and session history cleanup.
+
+### Fixed
+
+- `/rewind` hides withdrawn prompts from the picker and shows them again when restored with `/redo`.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Added
 
-- Automatic prompt checkpoints and native `/rewind`, `/redo`, and `/rewind-recover` restore files and the matching conversation with persistent multi-level redo.
-- `/file-history` retains file-only diagnostics, capture controls and session history cleanup.
+- Automatic prompt checkpoints and native `/rewind`, `/redo`, and `/rewind-recover` restore files and the matching conversation with persistent multi-level redo. ([#11663](https://github.com/can1357/oh-my-pi/pull/11663) by [@S2thend](https://github.com/S2thend))
+- `/file-history` retains file-only diagnostics, capture controls and session history cleanup. ([#11663](https://github.com/can1357/oh-my-pi/pull/11663) by [@S2thend](https://github.com/S2thend))
 
 ### Fixed
 
-- `/rewind` hides withdrawn prompts from the picker and shows them again when restored with `/redo`.
+- `/rewind` hides withdrawn prompts from the picker and shows them again when restored with `/redo`. ([#11663](https://github.com/can1357/oh-my-pi/pull/11663) by [@S2thend](https://github.com/S2thend))
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -47,6 +47,7 @@
     "bench:guard": "bun scripts/bench-guard.ts"
   },
   "dependencies": {
+    "filesnap": "0.5.0",
     "@babel/parser": "catalog:",
     "@oh-my-pi/omp-stats": "catalog:",
     "@oh-my-pi/omptype": "catalog:",
@@ -93,6 +94,7 @@
     "dist/template-*.js",
     "dist/tool-views.generated-*.js",
     "scripts",
+    "vendor/filesnap",
     "examples",
     "README.md",
     "CHANGELOG.md"

--- a/packages/coding-agent/scripts/bundle-dist.ts
+++ b/packages/coding-agent/scripts/bundle-dist.ts
@@ -13,7 +13,13 @@ const shebang = "#!/usr/bin/env bun\n";
 const legacyHtmlExportAssetPattern = /^(?:template-[^.]+\.(?:css|html|js)|tool-views\.generated-[^.]+\.js)$/;
 
 // Native / optional / platform-specific deps are loaded from installed files.
-const ALWAYS_EXTERNAL = ["@oh-my-pi/pi-natives", "@huggingface/transformers", "fastembed", "onnxruntime-node"];
+const ALWAYS_EXTERNAL = [
+	"filesnap",
+	"@oh-my-pi/pi-natives",
+	"@huggingface/transformers",
+	"fastembed",
+	"onnxruntime-node",
+];
 
 // Heavy, lazily-used third-party leaf deps. Each is a declared `dependency`, so the
 // published package resolves it from node_modules at runtime; bundling only embeds a

--- a/packages/coding-agent/scripts/compile-binary.ts
+++ b/packages/coding-agent/scripts/compile-binary.ts
@@ -1,6 +1,7 @@
 // Deep import: the pi-utils barrel loads the host native addon, which is
 // absent on cross-compiling release runners.
 import { USER_AGENT } from "@oh-my-pi/pi-utils/dirs";
+import { createFilesnapEmbedPlugin } from "./embed-filesnap";
 import { buildDocsIndexPayload } from "./generate-docs-index";
 import { createLegacyPiVirtualModulePlugin } from "./legacy-pi-virtual-module";
 
@@ -50,7 +51,7 @@ export async function compileCodingAgent(options: CodingAgentCompileOptions): Pr
 				identifiers: options.minifyIdentifiers ?? false,
 				keepNames: true,
 			},
-			plugins: [await createLegacyPiVirtualModulePlugin()],
+			plugins: [await createLegacyPiVirtualModulePlugin(), await createFilesnapEmbedPlugin(options.target)],
 			compile: {
 				// Bun's process-wide fetch User-Agent default. Any explicit
 				// provider fingerprint (Anthropic/Codex OAuth) still wins.

--- a/packages/coding-agent/scripts/embed-filesnap.ts
+++ b/packages/coding-agent/scripts/embed-filesnap.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import { resolveFilesnapNpmBinary } from "../src/utils/filesnap-npm";
+
+/** Embed the target's official npm executable, never the build host's executable. */
+export async function createFilesnapEmbedPlugin(target?: Bun.Build.CompileTarget): Promise<Bun.BunPlugin> {
+	const parts = target?.split("-");
+	const platform = parts ? (parts[1] === "windows" ? "win32" : parts[1]!) : process.platform;
+	const arch = parts ? parts[2]! : process.arch;
+	let binary: string;
+	try {
+		binary = resolveFilesnapNpmBinary(platform, arch);
+	} catch (cause) {
+		throw new Error(
+			`Cannot embed filesnap for ${platform}/${arch}. Install cross-platform dependencies with bun install --frozen-lockfile --os='*' --cpu='*'.`,
+			{ cause },
+		);
+	}
+	const license = await Bun.file(path.join(import.meta.dir, "../vendor/filesnap/LICENSE")).text();
+	const notice = await Bun.file(path.join(import.meta.dir, "../vendor/filesnap/NOTICE")).text();
+	const sha256 = createHash("sha256")
+		.update(await Bun.file(binary).bytes())
+		.digest("hex");
+	return {
+		name: "filesnap-executable",
+		setup(build) {
+			build.onLoad({ filter: /[/\\]filesnap-embedded\.ts$/ }, () => ({
+				loader: "ts",
+				contents: `import binary from ${JSON.stringify(binary)} with { type: "file" };\nexport const embeddedFilesnap = { path: binary, sha256: ${JSON.stringify(sha256)}, license: ${JSON.stringify(license)}, notice: ${JSON.stringify(notice)} };`,
+			}));
+		},
+	};
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -16,6 +16,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { FileHistory, type FileHistoryPoint } from "./file-history";
 import { scheduler } from "node:timers/promises";
 import { isPromise } from "node:util/types";
 
@@ -803,6 +804,94 @@ export class AgentSession {
 	#obfuscator: SecretObfuscator | undefined;
 	/** Session-start value of `inlineToolDescriptors`; drives handoff tool pruning. */
 	#pruneToolDescriptions = false;
+	#fileHistory: FileHistory | undefined;
+	#fileHistoryBusy = false;
+
+	#getFileHistory(): FileHistory {
+		const cwd = this.sessionManager.getCwd();
+		if (!this.#fileHistory || this.#fileHistory.cwd !== cwd || this.#fileHistory.session !== this.sessionId) {
+			this.#fileHistory = new FileHistory(
+				cwd,
+				path.join(path.dirname(getAgentDbPath()), "file-history"),
+				this.sessionId,
+				undefined,
+				Boolean(this.sessionManager.getSessionFile()),
+			);
+		}
+		return this.#fileHistory;
+	}
+
+	async fileHistoryCommand(args: string): Promise<string> {
+		if (this.isStreaming || this.#promptInFlightCount > 0 || this.#fileHistoryBusy)
+			throw new Error("Wait for the session to become idle before changing file history");
+		this.#fileHistoryBusy = true;
+		try {
+			return await this.#getFileHistory().command(args);
+		} finally {
+			this.#fileHistoryBusy = false;
+		}
+	}
+
+	async rewindPoints(): Promise<FileHistoryPoint[]> {
+		const active = new Set<string | null>();
+		let checkpoint: string | null = null;
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type === "custom" && entry.customType === "filesnap_checkpoint") {
+				checkpoint = entry.id;
+			} else if (entry.type === "message" && entry.message.role === "user") {
+				// Rewind retains the pre-prompt anchor but removes its user message.
+				// A newer anchor also prevents a new branch from reviving that prompt.
+				active.add(checkpoint);
+			}
+		}
+		return (await this.#getFileHistory().points()).filter(point => active.has(point.leafId)).reverse();
+	}
+
+	/** Restore files before committing an exact conversation leaf; old branches remain intact. */
+	async rewindFilesAndConversation(
+		turn?: string,
+		confirm: (changes: string[]) => Promise<boolean> = async () => true,
+		recover = false,
+	): Promise<boolean> {
+		if (this.isStreaming || this.#promptInFlightCount > 0 || this.#fileHistoryBusy)
+			throw new Error("Wait for the agent to finish before rewinding");
+		this.#fileHistoryBusy = true;
+		try {
+			await this.#bash.flushPending();
+			const points = await this.rewindPoints();
+			const index = turn ? points.findIndex(point => point.turn === turn) : -1;
+			if (turn && index < 0) throw new Error("Checkpoint is not on the current branch");
+			return await this.#getFileHistory().change(
+				turn ? points.slice(0, index + 1) : [],
+				this.sessionManager.getLeafId(),
+				async leafId => {
+					if (leafId !== null && !this.sessionManager.getEntry(leafId))
+						throw new Error("Conversation checkpoint is missing");
+					const transition = this.#bash.beginSessionTransition();
+					let committed = false;
+					try {
+						if (leafId === null) this.sessionManager.resetLeaf();
+						else this.sessionManager.branch(leafId);
+						this.#bash.markSessionTransition(transition);
+						committed = true;
+					} finally {
+						this.#bash.finishSessionTransition(transition, committed);
+					}
+					const context = deobfuscateSessionContext(this.sessionManager.buildSessionContext(), this.#obfuscator);
+					this.agent.replaceMessages(context.messages);
+					this.#rehydrateCheckpointRewindState();
+					this.#advisors.resetSessionState({ preserveCost: true });
+					this.#todo.syncFromBranch();
+					this.#closeCodexProviderSessionsForHistoryRewrite();
+				},
+				confirm,
+				recover,
+			);
+		} finally {
+			this.#fileHistoryBusy = false;
+		}
+	}
+
 	#checkpointState: CheckpointState | undefined = undefined;
 	#pendingRewindReport: string | undefined = undefined;
 	#lastCompletedRewind: CompletedRewindState | undefined = undefined;
@@ -3996,6 +4085,32 @@ export class AgentSession {
 	 * execution still emit there).
 	 */
 	async #beforeToolCall(ctx: BeforeToolCallContext, signal?: AbortSignal): Promise<BeforeToolCallResult | undefined> {
+		if (this.#fileHistoryBusy) return { block: true, reason: "File recovery is in progress" };
+		const result = await this.#beforeToolCallExtensions(ctx, signal);
+		if (result?.block) return result;
+		const args = result?.args ?? ctx.args;
+		const isFileEdit = ctx.tool.name === "write" || ctx.tool.name === "edit" || ctx.tool.name === "apply_patch";
+		const targets = isFileEdit ? (ctx.tool.matcherPaths?.(args) ?? []) : [];
+		const record = args && typeof args === "object" ? args : {};
+		const paths = targets.length
+			? targets
+			: (ctx.tool.name === "write" || ctx.tool.name === "edit") &&
+				  "path" in record &&
+				  typeof record.path === "string"
+				? [record.path]
+				: [];
+		await this.#getFileHistory().declare(
+			paths
+				.filter(target => !/^[a-z][a-z0-9+.-]*:\/\//i.test(target))
+				.map(target => resolveToCwd(target, this.sessionManager.getCwd())),
+		);
+		return result;
+	}
+
+	async #beforeToolCallExtensions(
+		ctx: BeforeToolCallContext,
+		signal?: AbortSignal,
+	): Promise<BeforeToolCallResult | undefined> {
 		const runner = this.#extensionRunner;
 		if (!runner?.hasHandlers("tool_call")) return undefined;
 		const metadata = ctx.toolCall.providerMetadata;
@@ -6107,6 +6222,7 @@ export class AgentSession {
 	 * the ACP agent) use this to know whether to expect an `agent_end` event.
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<boolean> {
+		if (this.#fileHistoryBusy) throw new Error("File recovery is in progress");
 		// Stamp the operator's submission instant before ANY async preprocessing —
 		// command execution, image normalization, vision-model description — so the
 		// prompt→yield delta includes the whole wait, whatever path the prompt takes.
@@ -6604,6 +6720,12 @@ export class AgentSession {
 				this.#planReferenceSent = true;
 			}
 			try {
+				const history = this.#getFileHistory();
+				if (await history.enabled()) {
+					const leafId = this.sessionManager.appendCustomEntry("filesnap_checkpoint", {});
+					await history.beginTurn({ leafId, label: expandedText });
+				}
+				if (this.#promptGeneration !== generation) return false;
 				await this.#recovery.promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {
 				this.#stats.setPendingSnapshot(undefined);

--- a/packages/coding-agent/src/session/file-history.ts
+++ b/packages/coding-agent/src/session/file-history.ts
@@ -1,0 +1,353 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { resolveFilesnapExecutable } from "../utils/filesnap-executable";
+
+interface Event {
+	v: number;
+	type: string;
+	[key: string]: unknown;
+}
+
+export interface FileHistoryPoint {
+	turn: string;
+	leafId: string | null;
+	label: string;
+	timestamp: number;
+}
+
+interface RecoveryPoint {
+	turn: string;
+	leafId: string | null;
+	policy: string;
+}
+interface NavigationState {
+	atLeaf?: string | null;
+	redo: RecoveryPoint[];
+	pending?: RecoveryPoint;
+}
+
+/** Native file history. Conversation branching remains owned by AgentSession. */
+export class FileHistory {
+	#turn: string | undefined;
+	#queue: Promise<void> = Promise.resolve();
+	#statePath: string;
+	constructor(
+		readonly cwd: string,
+		readonly dataDir: string,
+		readonly session: string,
+		readonly executable?: string,
+		readonly defaultEnabled = false,
+	) {
+		const key = createHash("sha256").update(cwd).update("\0").update(session).digest("hex");
+		this.#statePath = path.join(dataDir, "omp-file-history", `${key}.json`);
+	}
+
+	async enabled(): Promise<boolean> {
+		try {
+			const state: unknown = await Bun.file(this.#statePath).json();
+			if (!state || typeof state !== "object" || !("enabled" in state) || typeof state.enabled !== "boolean") {
+				throw new Error("Invalid file history settings");
+			}
+			return state.enabled;
+		} catch (error) {
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT")
+				return this.defaultEnabled;
+			throw error;
+		}
+	}
+
+	async #run(args: string[], doneType: string, stdin = ""): Promise<Event[]> {
+		await fs.mkdir(this.dataDir, { recursive: true, mode: 0o700 });
+		const cwd = await fs.realpath(this.cwd);
+		const data = await fs.realpath(this.dataDir);
+		const rel = path.relative(cwd, data);
+		if (!rel || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`))) {
+			throw new Error("File history storage must be outside the workspace");
+		}
+		const command = [await resolveFilesnapExecutable(data, this.executable ?? process.env.FILESNAP_BIN)];
+		// No timeout: terminating a restore could interrupt workspace writes.
+		const scopeArgs = args[0] === "gc" ? [] : ["--cwd", cwd, "--session", this.session];
+		const child = Bun.spawn([...command, "--data-dir", data, ...args, ...scopeArgs], {
+			cwd,
+			stdin: new TextEncoder().encode(stdin),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		if (stdout.length > 8 * 1024 * 1024)
+			throw new Error("File history response exceeds its limit; inspect recovery before continuing");
+		const parsed: unknown[] = Bun.JSONL.parse(stdout);
+		const events: Event[] = [];
+		for (const value of parsed) {
+			if (
+				!value ||
+				typeof value !== "object" ||
+				!("v" in value) ||
+				value.v !== 1 ||
+				!("type" in value) ||
+				typeof value.type !== "string"
+			) {
+				throw new Error("Unsupported filesnap response");
+			}
+			events.push(value as Event);
+		}
+		const done = events.findLast(event => event.type === doneType);
+		if (exitCode !== 0 || !done || (typeof done.failed === "number" && done.failed !== 0)) {
+			throw new Error(
+				`File history operation failed (${exitCode}). ${stderr.slice(-2000)} If restore wrote any files, use /file-history redo to recover.`,
+			);
+		}
+		return events;
+	}
+
+	#serialize<T>(operation: () => Promise<T>): Promise<T> {
+		const next = this.#queue.then(operation);
+		this.#queue = next.then(
+			() => {},
+			() => {},
+		);
+		return next;
+	}
+
+	async #capture(): Promise<void> {
+		const turn = `omp-${randomUUID()}`;
+		const events = await this.#run(["capture", "--turn", turn], "capture.done");
+		const done = events.findLast(event => event.type === "capture.done");
+		if (done?.dropped !== 0)
+			throw new Error(
+				"File history capture skipped paths; inspect filesnap status or disable file history before continuing",
+			);
+		this.#turn = turn;
+	}
+
+	/** Await before starting each top-level prompt, including edit-free turns. */
+	beginTurn(context?: { leafId: string | null; label: string }): Promise<void> {
+		return this.#serialize(async () => {
+			const state = await this.#navigation();
+			if (state.pending) throw new Error("Interrupted rewind. Run /rewind-recover before continuing.");
+			if (await this.enabled()) {
+				await this.#capture();
+				await this.#saveNavigation({ redo: [] });
+				if (context) {
+					const points = await this.points();
+					points.push({ ...context, turn: this.#turn!, timestamp: Date.now() });
+					await this.#saveJson(`${this.#statePath}.points`, points);
+				}
+			}
+		});
+	}
+
+	async #saveJson(destination: string, value: unknown): Promise<void> {
+		await fs.mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+		const temporary = `${destination}.${randomUUID()}.tmp`;
+		await Bun.write(temporary, JSON.stringify(value), { mode: 0o600 });
+		await fs.rename(temporary, destination);
+	}
+
+	async points(): Promise<FileHistoryPoint[]> {
+		try {
+			const value: unknown = await Bun.file(`${this.#statePath}.points`).json();
+			if (
+				!Array.isArray(value) ||
+				!value.every(
+					point =>
+						point &&
+						typeof point === "object" &&
+						typeof point.turn === "string" &&
+						(point.leafId === null || typeof point.leafId === "string") &&
+						typeof point.label === "string" &&
+						typeof point.timestamp === "number",
+				)
+			) {
+				throw new Error("Invalid rewind history");
+			}
+			return value as FileHistoryPoint[];
+		} catch (error) {
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return [];
+			throw error;
+		}
+	}
+
+	async #navigation(): Promise<NavigationState> {
+		try {
+			const state = (await Bun.file(`${this.#statePath}.navigation`).json()) as NavigationState;
+			const valid = (point: RecoveryPoint) =>
+				point &&
+				typeof point.turn === "string" &&
+				(point.leafId === null || typeof point.leafId === "string") &&
+				typeof point.policy === "string";
+			if (
+				!state ||
+				!Array.isArray(state.redo) ||
+				!state.redo.every(valid) ||
+				(state.pending && !valid(state.pending))
+			)
+				throw new Error("Invalid rewind journal");
+			return state;
+		} catch (error) {
+			if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return { redo: [] };
+			throw error;
+		}
+	}
+
+	#saveNavigation(state: NavigationState): Promise<void> {
+		return this.#saveJson(`${this.#statePath}.navigation`, state);
+	}
+
+	/** Keep the recovery journal until both the disk and host conversation commit. */
+	change(
+		points: FileHistoryPoint[],
+		sourceLeaf: string | null,
+		navigate: (leaf: string | null) => Promise<void>,
+		confirm: (changes: string[]) => Promise<boolean>,
+		recover = false,
+	): Promise<boolean> {
+		return this.#serialize(async () => {
+			const state = await this.#navigation();
+			const restore = async (point: RecoveryPoint) => {
+				await this.#run(["restore", "--turn", point.turn, "--ignore-rules-stdin"], "restore.done", point.policy);
+				await navigate(point.leafId);
+			};
+			if (recover) {
+				if (!state.pending) throw new Error("No interrupted rewind to recover");
+				await restore(state.pending);
+				delete state.pending;
+				await this.#saveNavigation(state);
+				return true;
+			}
+			if (state.pending) throw new Error("Interrupted rewind. Run /rewind-recover first.");
+			if (state.atLeaf !== undefined && state.atLeaf !== sourceLeaf) {
+				state.redo = [];
+				await this.#saveNavigation(state);
+			}
+			const redo = points.length === 0 ? state.redo.at(-1) : undefined;
+			if (!points.length && !redo) throw new Error("Nothing to redo. Redo is cleared when you send a new prompt.");
+			const targets = points.length ? points.map(point => point.turn) : [redo!.turn];
+			const leaf = points.length ? points.at(-1)!.leafId : redo!.leafId;
+			let rescue = `rescue-${randomUUID()}`;
+			const prepare = async () =>
+				this.#run(
+					["prepare", "--turn", rescue, ...targets.flatMap(target => ["--target", target])],
+					"prepare.done",
+				);
+			const preview = await prepare();
+			const changes = preview
+				.filter(event => event.type === "prepare.change")
+				.map(event => `${event.action}: ${event.path}`);
+			if (!(await confirm(changes))) return false;
+			rescue = `rescue-${randomUUID()}`;
+			const verified = await prepare();
+			const current = verified
+				.filter(event => event.type === "prepare.change")
+				.map(event => `${event.action}: ${event.path}`);
+			if (JSON.stringify(changes) !== JSON.stringify(current))
+				throw new Error("Files changed while confirming. Open /rewind again.");
+			const policy = verified.findLast(event => event.type === "prepare.done")?.ignoreRules;
+			if (typeof policy !== "string") throw new Error("Missing restore policy");
+			const recovery = { turn: rescue, leafId: sourceLeaf, policy };
+			state.pending = recovery;
+			await this.#saveNavigation(state);
+			try {
+				for (const target of targets)
+					await this.#run(["restore", "--turn", target, "--ignore-rules-stdin"], "restore.done", policy);
+				await navigate(leaf);
+			} catch (error) {
+				try {
+					await restore(recovery);
+					delete state.pending;
+					await this.#saveNavigation(state);
+				} catch (recoveryError) {
+					throw new Error(
+						`Rewind failed: ${error}. Recovery failed: ${recoveryError}. Run /rewind-recover before continuing.`,
+					);
+				}
+				throw error;
+			}
+			state.atLeaf = leaf;
+			if (redo) state.redo.pop();
+			else state.redo.push(recovery);
+			delete state.pending;
+			await this.#saveNavigation(state);
+			this.#turn = undefined;
+			return true;
+		});
+	}
+
+	/** The host supplies paths after extension argument rewriting. */
+	declare(paths: readonly string[]): Promise<void> {
+		return this.#serialize(async () => {
+			if (!(await this.enabled())) return;
+			if (!this.#turn) await this.#capture();
+			for (const target of new Set(paths)) {
+				// Virtual/remote resources are not local workspace files.
+				if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target)) continue;
+				await this.#run(
+					["declare", "--turn", this.#turn!, "--path", path.resolve(this.cwd, target)],
+					"declare.done",
+				);
+			}
+		});
+	}
+
+	command(text: string): Promise<string> {
+		return this.#serialize(async () => {
+			const [action = "list", turn, ...extra] = text.trim().split(/\s+/).filter(Boolean);
+			if (extra.length || (action !== "restore" && turn) || (action === "restore" && !turn)) {
+				throw new Error("Usage: /file-history on|off|list|restore <turn>|redo|clear");
+			}
+			if (action === "on" || action === "off" || action === "clear") {
+				if (action === "on") await this.#capture();
+				await fs.mkdir(path.dirname(this.#statePath), { recursive: true, mode: 0o700 });
+				const tmp = `${this.#statePath}.${randomUUID()}.tmp`;
+				await Bun.write(tmp, JSON.stringify({ enabled: action === "on" }), { mode: 0o600 });
+				await fs.rename(tmp, this.#statePath);
+				if (action === "clear") {
+					await this.#run(["delete"], "delete.done");
+					await fs.rm(`${this.#statePath}.recovery`, { force: true });
+					await fs.rm(`${this.#statePath}.points`, { force: true });
+					await fs.rm(`${this.#statePath}.navigation`, { force: true });
+					this.#turn = undefined;
+					await this.#run(["gc"], "gc.done");
+					return "File history cleared for this session and automatic capture disabled. Workspace files and conversation unchanged.";
+				}
+				return action === "on"
+					? "File history enabled for this session. Captures are bounded; ignored and uncaptured files are not protected."
+					: "Automatic file history disabled. Saved checkpoints remain available.";
+			}
+			if (action === "list") {
+				const events = await this.#run(["log", "--limit", "30"], "log.done");
+				return (
+					events
+						.filter(event => event.type === "log.entry")
+						.map(event => `${event.turn}  ${event.files} files`)
+						.join("\n") || "No file checkpoints in this session. Use /file-history on."
+				);
+			}
+			if (action === "restore" || action === "redo") {
+				const target = action === "redo" ? (await Bun.file(`${this.#statePath}.recovery`).text()).trim() : turn;
+				// A turn id from another session must not be accepted just because the
+				// engine shares its content store across sessions.
+				const log = await this.#run(["log"], "log.done");
+				if (!log.some(event => event.type === "log.entry" && event.turn === target))
+					throw new Error("Checkpoint is not in this session");
+				const rescue = `rescue-${randomUUID()}`;
+				const preview = await this.#run(["prepare", "--turn", rescue, "--target", target!], "prepare.done");
+				const policy = preview.findLast(event => event.type === "prepare.done")?.ignoreRules;
+				if (typeof policy !== "string") throw new Error("Recovery preparation omitted its ignore policy");
+				await fs.mkdir(path.dirname(this.#statePath), { recursive: true, mode: 0o700 });
+				const tmp = `${this.#statePath}.${randomUUID()}.tmp`;
+				await Bun.write(tmp, rescue, { mode: 0o600 });
+				await fs.rename(tmp, `${this.#statePath}.recovery`);
+				await this.#run(["restore", "--turn", target!, "--ignore-rules-stdin"], "restore.done", policy);
+				this.#turn = undefined;
+				return `Files restored; conversation unchanged. /file-history redo reverses this operation. Recovery checkpoint: ${rescue}`;
+			}
+			throw new Error("Usage: /file-history on|off|list|restore <turn>|redo|clear");
+		});
+	}
+}

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -138,6 +138,70 @@ async function handleSessionPinCommand(
 
 export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
+		name: "rewind",
+		description: "Restore files and conversation to an earlier prompt",
+		handleTui: async (_command, { ctx }) => {
+			if (ctx.session.isStreaming) {
+				ctx.showStatus("Wait for the agent to finish before rewinding");
+				return;
+			}
+			const points = await ctx.session.rewindPoints();
+			if (!points.length) {
+				ctx.showStatus("No saved prompts yet. New prompts are checkpointed automatically.");
+				return;
+			}
+			const labels = points.map(
+				(point, index) => `${index + 1}. ${point.label.replace(/\s+/g, " ").slice(0, 120) || "Untitled prompt"}`,
+			);
+			const choice = await ctx.showHookSelector("Rewind — restore files and conversation", labels);
+			if (choice === undefined) return;
+			const point = points[labels.indexOf(choice)];
+			if (!point) return;
+			const restored = await ctx.session.rewindFilesAndConversation(point.turn, async changes => {
+				const choice = await ctx.showHookSelector(
+					`Restore files and conversation? ${changes.length} file changes\n${changes.slice(0, 12).join("\n")}`,
+					["Restore files and conversation", "Cancel"],
+				);
+				return choice === "Restore files and conversation";
+			});
+			if (!restored) return;
+			await ctx.renderInitialMessages({ clearTerminalHistory: true });
+			await ctx.reloadTodos();
+			ctx.editor.setText(point.label);
+			ctx.showStatus("Files and conversation restored. /redo returns to the previous state.");
+		},
+	},
+	{
+		name: "redo",
+		description: "Restore files and conversation from before the last rewind",
+		handleTui: async (_command, { ctx }) => {
+			await ctx.session.rewindFilesAndConversation();
+			await ctx.renderInitialMessages({ clearTerminalHistory: true });
+			await ctx.reloadTodos();
+			ctx.editor.setText("");
+			ctx.showStatus("Files and conversation restored.");
+		},
+	},
+	{
+		name: "rewind-recover",
+		description: "Recover both files and conversation after an interrupted rewind",
+		handleTui: async (_command, { ctx }) => {
+			await ctx.session.rewindFilesAndConversation(undefined, async () => true, true);
+			await ctx.renderInitialMessages({ clearTerminalHistory: true });
+			await ctx.reloadTodos();
+			ctx.showStatus("Files and conversation recovered.");
+		},
+	},
+	{
+		name: "file-history",
+		description: "Capture and restore workspace files independently of conversation history",
+		allowArgs: true,
+		inlineHint: "on|off|list|restore <turn>|redo|clear",
+		handle: async (args, runtime) => {
+			await runtime.output(await runtime.session.fileHistoryCommand(args.args));
+		},
+	},
+	{
 		name: "todo",
 		icon: "todo",
 		description: "View or modify the agent's todo list",
@@ -482,7 +546,6 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "branch",
-		aliases: ["rewind"],
 		icon: "branch",
 		description: "Rewind to a previous message, keeping the old path as a branch",
 		handleTui: (_command, runtime) => {

--- a/packages/coding-agent/src/utils/filesnap-embedded.ts
+++ b/packages/coding-agent/src/utils/filesnap-embedded.ts
@@ -1,0 +1,2 @@
+/** Replaced in memory by the standalone compiler; npm installs use their dependency. */
+export const embeddedFilesnap: { path: string; sha256: string; license: string; notice: string } | null = null;

--- a/packages/coding-agent/src/utils/filesnap-executable.ts
+++ b/packages/coding-agent/src/utils/filesnap-executable.ts
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils/fs-error";
+import { embeddedFilesnap } from "./filesnap-embedded";
+import { resolveFilesnapNpmBinary } from "./filesnap-npm";
+
+/** Bun assets are virtual files: materialize the executable before spawning it. */
+export async function resolveFilesnapExecutable(dataDir: string, override?: string): Promise<string> {
+	if (override) return override;
+	if (!embeddedFilesnap) return resolveFilesnapNpmBinary();
+	const { sha256, path: asset, license, notice } = embeddedFilesnap;
+	const root = path.join(dataDir, "runtime", "filesnap");
+	const directory = path.join(root, sha256);
+	const filename = process.platform === "win32" ? "filesnap.exe" : "filesnap";
+	const executable = path.join(directory, filename);
+	async function installed(): Promise<boolean> {
+		try {
+			const bytes = await Bun.file(executable).bytes();
+			if (createHash("sha256").update(bytes).digest("hex") !== sha256) {
+				throw new Error(`Bundled filesnap cache is damaged: ${directory}. Remove this directory and retry.`);
+			}
+			return true;
+		} catch (error) {
+			if (isEnoent(error)) return false;
+			throw error;
+		}
+	}
+	if (await installed()) return executable;
+	await fs.mkdir(root, { recursive: true, mode: 0o700 });
+	const temporary = await fs.mkdtemp(path.join(root, ".extract-"));
+	try {
+		const staged = path.join(temporary, filename);
+		await Bun.write(staged, Bun.file(asset), { mode: 0o700 });
+		await fs.chmod(staged, 0o700);
+		await Bun.write(path.join(temporary, "LICENSE"), license, { mode: 0o600 });
+		await Bun.write(path.join(temporary, "NOTICE"), notice, { mode: 0o600 });
+		try {
+			// Publish a complete directory atomically; concurrent sessions may win.
+			await fs.rename(temporary, directory);
+		} catch (error) {
+			if (!(await installed())) throw error;
+		}
+	} finally {
+		await fs.rm(temporary, { recursive: true, force: true });
+	}
+	return executable;
+}

--- a/packages/coding-agent/src/utils/filesnap-npm.ts
+++ b/packages/coding-agent/src/utils/filesnap-npm.ts
@@ -1,0 +1,21 @@
+import { createRequire } from "node:module";
+import * as path from "node:path";
+
+/** Resolve the official npm platform dependency, including cross-build targets. */
+export function resolveFilesnapNpmBinary(platform: string = process.platform, arch: string = process.arch): string {
+	if (platform === "android") platform = "linux";
+	const triples: Record<string, string> = {
+		"linux-x64": "x86_64-unknown-linux-musl",
+		"linux-arm64": "aarch64-unknown-linux-musl",
+		"darwin-x64": "x86_64-apple-darwin",
+		"darwin-arm64": "aarch64-apple-darwin",
+		"win32-x64": "x86_64-pc-windows-msvc",
+		"win32-arm64": "aarch64-pc-windows-msvc",
+	};
+	const slug = `${platform}-${arch}`;
+	const triple = triples[slug];
+	if (!triple) throw new Error(`Unsupported filesnap platform: ${slug}`);
+	const launcher = createRequire(import.meta.url).resolve("filesnap/bin/filesnap.mjs");
+	const vendor = path.dirname(createRequire(launcher).resolve(`filesnap-${slug}/package.json`));
+	return path.join(vendor, "vendor", triple, "bin", platform === "win32" ? "filesnap.exe" : "filesnap");
+}

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
@@ -13,6 +13,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { FileHistory, type FileHistoryPoint } from "@oh-my-pi/pi-coding-agent/session/file-history";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -909,5 +910,45 @@ describe("AgentSession checkpoint rewind branch context", () => {
 				report: "post-resume findings",
 			}),
 		).resolves.toMatchObject({ details: { report: "post-resume findings", rewound: true } });
+	});
+});
+
+describe("workspace rewind picker", () => {
+	it("hides withdrawn prompts, restores them on redo, and excludes abandoned prompts after branching", async () => {
+		const { session } = await createHarness([]);
+		const manager = session.sessionManager;
+		const points: FileHistoryPoint[] = [];
+		const appendPrompt = (label: string) => {
+			const leafId = manager.appendCustomEntry("filesnap_checkpoint", {});
+			points.push({ turn: `turn-${points.length}`, leafId, label, timestamp: Date.now() });
+			manager.appendMessage({ role: "user", content: label, timestamp: Date.now() });
+			return leafId;
+		};
+		const first = appendPrompt("pwd");
+		appendPrompt("ls");
+		appendPrompt("write a hello world py");
+		const latest = appendPrompt("add greeting");
+		const sourceLeaf = manager.getLeafId()!;
+		const savedPoints = spyOn(FileHistory.prototype, "points").mockImplementation(async () => points);
+		const labels = async () => (await session.rewindPoints()).map(point => point.label);
+		try {
+			expect(await labels()).toEqual(["add greeting", "write a hello world py", "ls", "pwd"]);
+			// This is the exact leaf retained by a successful files + conversation rewind.
+			manager.branch(latest);
+			expect(await labels()).toEqual(["write a hello world py", "ls", "pwd"]);
+			// Metadata appended after rewind must not resurrect a withdrawn prompt.
+			manager.appendCustomEntry("session_metadata", {});
+			expect(await labels()).toEqual(["write a hello world py", "ls", "pwd"]);
+			manager.branch(first);
+			expect(await labels()).toEqual([]);
+			// Redo restores the original conversation leaf and its available history.
+			manager.branch(sourceLeaf);
+			expect(await labels()).toEqual(["add greeting", "write a hello world py", "ls", "pwd"]);
+			manager.branch(latest);
+			appendPrompt("replace greeting");
+			expect(await labels()).toEqual(["replace greeting", "write a hello world py", "ls", "pwd"]);
+		} finally {
+			savedPoints.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/file-history.test.ts
+++ b/packages/coding-agent/test/file-history.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FileHistory } from "../src/session/file-history";
+
+const dirs: string[] = [];
+afterEach(async () => {
+	await Promise.all(dirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+async function fixture() {
+	const base = await fs.mkdtemp(path.join(os.tmpdir(), "omp-filesnap-"));
+	dirs.push(base);
+	const cwd = path.join(base, "workspace"),
+		data = path.join(base, "history");
+	await fs.mkdir(cwd);
+	return { cwd, data, history: new FileHistory(cwd, data, "session", process.env.FILESNAP_TEST_BIN) };
+}
+
+test("restores pre-edit and absent files, survives resume, and reverses recovery repeatedly", async () => {
+	const { cwd, data, history } = await fixture();
+	await Bun.write(path.join(cwd, "asset.bin"), new Uint8Array([0, 255, 3]));
+	await history.command("on");
+	const turn = (await history.command("list")).split(/\s+/)[0]!;
+	const hidden = path.join(cwd, ".hidden");
+	await Bun.write(hidden, "before");
+	await history.declare([hidden, "created.bin"]);
+	await Bun.write(hidden, "after");
+	await Bun.write(path.join(cwd, "created.bin"), "new");
+	await Bun.write(path.join(cwd, "asset.bin"), new Uint8Array([1, 2]));
+	const resumed = new FileHistory(cwd, data, "session", process.env.FILESNAP_TEST_BIN);
+	await resumed.command(`restore ${turn}`);
+	expect(await Bun.file(hidden).text()).toBe("before");
+	expect(await Bun.file(path.join(cwd, "asset.bin")).bytes()).toEqual(new Uint8Array([0, 255, 3]));
+	expect(await Bun.file(path.join(cwd, "created.bin")).exists()).toBe(false);
+	await resumed.command("redo");
+	expect(await Bun.file(hidden).text()).toBe("after");
+	expect(await Bun.file(path.join(cwd, "created.bin")).text()).toBe("new");
+	await resumed.command("redo");
+	expect(await Bun.file(hidden).text()).toBe("before");
+});
+
+test("new prompts advance history, disabled sessions do not capture, foreign turns are refused", async () => {
+	const { cwd, data, history } = await fixture();
+	await Bun.write(path.join(cwd, "a"), "one");
+	await history.beginTurn();
+	expect(await history.command("list")).toContain("No file checkpoints");
+	await history.command("on");
+	const first = (await history.command("list")).split(/\s+/)[0]!;
+	await history.beginTurn();
+	expect((await history.command("list")).split("\n")).toHaveLength(2);
+	const other = new FileHistory(cwd, data, "other", process.env.FILESNAP_TEST_BIN);
+	await expect(other.command(`restore ${first}`)).rejects.toThrow("not in this session");
+	await history.command("off");
+	await history.beginTurn();
+	expect((await history.command("list")).split("\n")).toHaveLength(2);
+});
+
+test("a failed preimage capture refuses the edit rather than recording absence", async () => {
+	const { cwd, history } = await fixture();
+	await history.command("on");
+	await fs.mkdir(path.join(cwd, "directory"));
+	await expect(history.declare(["directory"])).rejects.toThrow();
+});
+
+test("refuses a content store inside the workspace", async () => {
+	const { cwd } = await fixture();
+	const history = new FileHistory(cwd, path.join(cwd, "store"), "session", process.env.FILESNAP_TEST_BIN);
+	await expect(history.command("on")).rejects.toThrow("outside the workspace");
+});
+
+test("clear removes only the selected session and disables capture", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-file-history-clear-"));
+	try {
+		const cwd = path.join(root, "workspace");
+		await fs.mkdir(cwd);
+		const file = path.join(cwd, "asset.bin");
+		await fs.writeFile(file, new Uint8Array([0, 255, 7]));
+		const first = new FileHistory(cwd, path.join(root, "data"), "first");
+		const second = new FileHistory(cwd, path.join(root, "data"), "second");
+		await first.command("on");
+		await second.command("on");
+		const target = (await second.command("list")).split(/\s+/)[0];
+		await first.command("clear");
+		await first.beginTurn();
+		expect(await first.command("list")).toContain("No file checkpoints");
+		await fs.writeFile(file, "changed");
+		await second.command(`restore ${target}`);
+		expect([...(await fs.readFile(file))]).toEqual([0, 255, 7]);
+		await first.command("clear");
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+test("combined rewind restores all later preimages and supports multiple redo levels", async () => {
+	const { cwd, history } = await fixture();
+	await history.command("on");
+	let leaf: string | null = "before-first";
+	const navigate = async (next: string | null) => {
+		leaf = next;
+	};
+	await Bun.write(path.join(cwd, "asset.bin"), new Uint8Array([0, 255]));
+	await history.beginTurn({ leafId: leaf, label: "first prompt" });
+	await Bun.write(path.join(cwd, "asset.bin"), "first result");
+	leaf = "before-second";
+	await history.beginTurn({ leafId: leaf, label: "second prompt" });
+	await history.declare([".created"]);
+	await Bun.write(path.join(cwd, ".created"), "second result");
+	leaf = "after-second";
+	const points = await history.points();
+	await history.change([points[1]!], leaf, navigate, async () => true);
+	expect(leaf).toBe("before-second");
+	expect(await Bun.file(path.join(cwd, ".created")).exists()).toBe(false);
+	await history.change([points[0]!], leaf, navigate, async () => true);
+	expect(leaf).toBe("before-first");
+	expect(await Bun.file(path.join(cwd, "asset.bin")).bytes()).toEqual(new Uint8Array([0, 255]));
+	await history.change([], leaf, navigate, async () => true);
+	expect(leaf).toBe("before-second");
+	expect(await Bun.file(path.join(cwd, "asset.bin")).text()).toBe("first result");
+	await history.change([], leaf, navigate, async () => true);
+	expect(leaf).toBe("after-second");
+	expect(await Bun.file(path.join(cwd, ".created")).text()).toBe("second result");
+	await expect(history.change([], leaf, navigate, async () => true)).rejects.toThrow("Nothing to redo");
+	// A single jump must include the newly declared path from the later checkpoint.
+	await history.change([...points].reverse(), leaf, navigate, async () => true);
+	expect(await Bun.file(path.join(cwd, ".created")).exists()).toBe(false);
+	expect(leaf).toBe("before-first");
+});
+
+test("cancel and failed conversation navigation preserve both original states", async () => {
+	const { cwd, history } = await fixture();
+	await history.command("on");
+	await Bun.write(path.join(cwd, "a"), "before");
+	await history.beginTurn({ leafId: "old", label: "edit" });
+	await Bun.write(path.join(cwd, "a"), "after");
+	const points = await history.points();
+	let leaf: string | null = "current";
+	expect(
+		await history.change(
+			points,
+			leaf,
+			async next => {
+				leaf = next;
+			},
+			async () => false,
+		),
+	).toBe(false);
+	expect(await Bun.file(path.join(cwd, "a")).text()).toBe("after");
+	await expect(
+		history.change(
+			points,
+			leaf,
+			async next => {
+				if (next === "old") throw new Error("host navigation failed");
+				leaf = next;
+			},
+			async () => true,
+		),
+	).rejects.toThrow("host navigation failed");
+	expect(leaf).toBe("current");
+	expect(await Bun.file(path.join(cwd, "a")).text()).toBe("after");
+	await history.beginTurn({ leafId: leaf, label: "continue after recovered failure" });
+});

--- a/packages/coding-agent/test/filesnap-distribution.test.ts
+++ b/packages/coding-agent/test/filesnap-distribution.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveFilesnapNpmBinary } from "../src/utils/filesnap-npm";
+
+const dirs: string[] = [];
+const entrypoint = path.join(import.meta.dir, "fixtures/filesnap-distribution-probe.ts");
+afterEach(async () => {
+	await Promise.all(dirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+async function fixture(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-filesnap-distribution-"));
+	dirs.push(dir);
+	return dir;
+}
+async function probe(command: string[], base: string): Promise<void> {
+	const env: NodeJS.ProcessEnv = { ...process.env, PATH: "" };
+	delete env.FILESNAP_BIN;
+	delete env.FILESNAP_TEST_BIN;
+	const child = Bun.spawn([...command, base], { cwd: base, env, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr, code] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	expect({ code, stderr }).toEqual({ code: 0, stderr: "" });
+	expect(JSON.parse(stdout)).toEqual({ restored: [0, 255, 3], redone: [1, 2] });
+}
+
+test("standalone rewind and redo need no node_modules, PATH tools or FILESNAP_BIN, even on concurrent first use", async () => {
+	const base = await fixture();
+	const binary = path.join(base, process.platform === "win32" ? "probe.exe" : "probe");
+	// Isolate Bun's compile file cache from other in-process bundle tests.
+	const build = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures/filesnap-build-probe.ts"), binary], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [buildError, buildCode] = await Promise.all([new Response(build.stderr).text(), build.exited]);
+	expect({ buildCode, buildError }).toEqual({ buildCode: 0, buildError: "" });
+	await Promise.all([probe([binary], base), probe([binary], base)]);
+	// A subsequent process must reuse the extracted executable successfully.
+	await probe([binary], base);
+}, 120_000);
+
+test("npm bundles use the installed filesnap dependency without a separate global CLI", async () => {
+	const base = await fixture();
+	const output = await Bun.build({ entrypoints: [entrypoint], outdir: base, target: "bun", external: ["filesnap"] });
+	if (!output.success) throw new AggregateError(output.logs, "Probe bundle failed");
+	const launcher = createRequire(import.meta.url).resolve("filesnap/bin/filesnap.mjs");
+	const dependency = path.resolve(launcher, "../..");
+	const platformBinary = resolveFilesnapNpmBinary();
+	const platformPackage = path.resolve(platformBinary, "../../../..");
+	const slug = `${process.platform === "android" ? "linux" : process.platform}-${process.arch}`;
+	await fs.cp(dependency, path.join(base, "node_modules/filesnap"), { recursive: true, dereference: true });
+	await fs.cp(platformPackage, path.join(base, "node_modules", `filesnap-${slug}`), {
+		recursive: true,
+		dereference: true,
+	});
+	await probe([process.execPath, path.join(base, "filesnap-distribution-probe.js")], base);
+}, 30_000);

--- a/packages/coding-agent/test/fixtures/filesnap-build-probe.ts
+++ b/packages/coding-agent/test/fixtures/filesnap-build-probe.ts
@@ -1,0 +1,9 @@
+import * as path from "node:path";
+import { compileCodingAgent } from "../../scripts/compile-binary";
+
+await compileCodingAgent({
+	repoRoot: path.resolve(import.meta.dir, "../../../.."),
+	entrypoint: path.join(import.meta.dir, "filesnap-distribution-probe.ts"),
+	outfile: process.argv[2]!,
+	transformersVersion: "unused",
+});

--- a/packages/coding-agent/test/fixtures/filesnap-distribution-probe.ts
+++ b/packages/coding-agent/test/fixtures/filesnap-distribution-probe.ts
@@ -1,0 +1,18 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { FileHistory } from "../../src/session/file-history";
+
+const base = process.argv[2]!;
+const cwd = path.join(base, `workspace-${process.pid}`);
+await fs.mkdir(cwd, { recursive: true });
+const file = path.join(cwd, "asset.bin");
+await Bun.write(file, new Uint8Array([0, 255, 3]));
+const history = new FileHistory(cwd, path.join(base, "data"), `session-${process.pid}`);
+await history.command("on");
+const turn = (await history.command("list")).split(/\s+/)[0]!;
+await Bun.write(file, new Uint8Array([1, 2]));
+await history.command(`restore ${turn}`);
+const restored = [...(await Bun.file(file).bytes())];
+await history.command("redo");
+const redone = [...(await Bun.file(file).bytes())];
+console.log(JSON.stringify({ restored, redone }));

--- a/packages/coding-agent/vendor/filesnap/LICENSE
+++ b/packages/coding-agent/vendor/filesnap/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 OpenAI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/coding-agent/vendor/filesnap/LICENSE
+++ b/packages/coding-agent/vendor/filesnap/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2025 OpenAI
+Copyright 2026 extracurricular-ai
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/coding-agent/vendor/filesnap/NOTICE
+++ b/packages/coding-agent/vendor/filesnap/NOTICE
@@ -1,0 +1,6 @@
+filesnap
+Copyright 2026 The filesnap authors
+
+This project originated inside a fork of OpenAI Codex
+(https://github.com/openai/codex) and is released under the same license,
+the Apache License 2.0. Codex is Copyright 2025 OpenAI.

--- a/packages/coding-agent/vendor/filesnap/NOTICE
+++ b/packages/coding-agent/vendor/filesnap/NOTICE
@@ -1,5 +1,5 @@
 filesnap
-Copyright 2026 The filesnap authors
+Copyright 2026 extracurricular-ai
 
 This project originated inside a fork of OpenAI Codex
 (https://github.com/openai/codex) and is released under the same license,


### PR DESCRIPTION
I would like to add native rewind and redo that restore workspace files and conversation history together, I have already tested the logic in few of my projects with real users, and  I want to bring the ability here.

  - `/rewind` opens a picker of previous prompts and restores files and conversation history to before the selected prompt.
  - `/redo` restores the state before a rewind, supporting multiple levels.
  - `/rewind-recover` recovers an interrupted restore.

  Capture workspace checkpoints before prompts and preserve preimages before supported file edits. Save durable recovery snapshots before restoration, restore files before moving the conversation leaf, and attempt to
  restore the original state if restoration or navigation fails.

  The picker shows only prompts retained on the active branch. Withdrawn prompts disappear after rewind, return after redo, and remain hidden when a new prompt starts another branch.

  Use the published `filesnap@0.5.0` npm dependency. Standalone builds embed the official platform executable, verify and extract it automatically, and include its Apache license and attribution notice. Release CI
  prepares the platform dependencies for cross-compilation. No separate filesnap installation or `FILESNAP_BIN` configuration is required.

  Conversation-only branching remains available through `/branch`. `/file-history` provides file-only diagnostics, capture controls, and session history cleanup.

  ## Why

Addresses the file-and-conversation undo workflow requested in #2427.
  Also related to #5289.

  I want to return to an earlier prompt with both the conversation and workspace files restored, and use redo if I change my mind.

  Conversation-only branching leaves file changes in place. Pairing conversation navigation with file checkpoints makes it possible to retry an earlier approach from the corresponding workspace state.

  Filesnap provides a Git-independent snapshot engine that can also capture declared files outside the normal scan. Coverage remains bounded by capture rules and pre-edit declarations; ignored, uncaptured, and remote
  resources are not guaranteed to be restored.

  ## Testing

  - Passed 26 related tests covering file history, conversation branching, rewind picker behavior, executable distribution, and release build configuration.
  - Passed coding-agent package `bun run check`: lint, formatting, and type checks.
  - Built the standalone binary and npm bundle.
  - Verified compiled file restoration and redo without PATH tools, node_modules, or `FILESNAP_BIN`.
  - Manually verified the rewind picker in the TUI, including hiding a withdrawn prompt after rewind.
  - Local runtime validation was performed on Linux. macOS and Windows runtime validation remains for CI.

  Full-workspace `bun check` has not been run locally.

  ## Screenshots

  Native rewind and redo commands in the command palette:

<img width="1575" height="620" alt="omp-cmd-select-cropped" src="https://github.com/user-attachments/assets/164eb1f8-040a-424c-9629-eb93f38afa19" />


  Select a previous prompt to restore both files and conversation history:

<img width="1744" height="626" alt="omp-rewind-menu-cropped" src="https://github.com/user-attachments/assets/0b1e699e-61d0-4bc8-9dfa-80f564d95f99" />



  ---

  - [x] `bun check` passes
  - [x] Tested locally
  - [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)