### PR TITLE
fix(extensions): carry sourceInfo on RegisteredTool for upstream pi compat

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Extensions authored against upstream Pi (e.g. pi-fabric) no longer crash every session at startup: registered tools now carry the upstream-shaped `sourceInfo` provenance that `getAllRegisteredTools()` consumers read ([#11661](https://github.com/can1357/oh-my-pi/issues/11661)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -3,15 +3,7 @@
  */
 
 export type { SlashCommandInfo, SlashCommandLocation, SlashCommandSource } from "../slash-commands";
-export {
-	bindPreparedExtensions,
-	discoverAndLoadExtensions,
-	discoverExtensionPaths,
-	ExtensionRuntimeNotInitializedError,
-	extensionToolSourceInfo,
-	loadExtensionFromFactory,
-	loadExtensions,
-} from "./loader";
+export * from "./loader";
 export * from "./runner";
 // Type guards
 export * from "./types";

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -8,6 +8,7 @@ export {
 	discoverAndLoadExtensions,
 	discoverExtensionPaths,
 	ExtensionRuntimeNotInitializedError,
+	extensionToolSourceInfo,
 	loadExtensionFromFactory,
 	loadExtensions,
 } from "./loader";

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -29,6 +29,7 @@ import { execCommand } from "../../exec/exec";
 import * as PiCodingAgent from "../../index";
 import type { CustomMessagePayload } from "../../session/messages";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
+import { isFilesystemSourcePath } from "../../tools/path-utils";
 import { EventBus } from "../../utils/event-bus";
 import * as TypeBox from "../legacy-typebox";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
@@ -48,6 +49,7 @@ import type {
 	PreparedExtension,
 	ProviderConfig,
 	RegisteredCommand,
+	SourceInfo,
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
@@ -60,6 +62,22 @@ type LoadedExtensionModule = ExtensionFactory | { default?: ExtensionFactory };
 function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | null {
 	const candidate = typeof module === "function" ? module : module.default;
 	return typeof candidate === "function" ? candidate : null;
+}
+
+/**
+ * Upstream-shaped provenance for an extension-registered tool. Mirrors the
+ * `SourceInfo` synthesized by `SessionTools.getAllToolInfos()`, so consumers that
+ * read `sourceInfo` off `getAllRegisteredTools()` (e.g. pi-fabric) see the same
+ * on-disk path — or the synthetic `<extension:name>` fallback for tools with no
+ * filesystem origin.
+ */
+export function extensionToolSourceInfo(
+	definition: Pick<ToolDefinition, "name" | "sourcePath">,
+	extensionPath: string,
+): SourceInfo {
+	const candidate = definition.sourcePath ?? extensionPath;
+	const path = candidate && isFilesystemSourcePath(candidate) ? candidate : `<extension:${definition.name}>`;
+	return { path, source: "extension", scope: "temporary", origin: "top-level" };
 }
 
 export class ExtensionRuntimeNotInitializedError extends Error {
@@ -181,6 +199,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		const registered = {
 			definition: tool,
 			extensionPath: this.extension.path,
+			sourceInfo: extensionToolSourceInfo(tool, this.extension.path),
 		};
 		this.extension.tools.set(tool.name, registered);
 		for (const listener of this.extension.toolRegistrationListeners ?? []) listener(tool.name);

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -43,7 +43,7 @@ import type {
 	ExtensionAPI,
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionRuntime as IExtensionRuntime,
+	ExtensionRuntimeContract as IExtensionRuntime,
 	LoadExtensionsResult,
 	MessageRenderer,
 	PreparedExtension,

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -66,16 +66,22 @@ function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | 
 
 /**
  * Upstream-shaped provenance for an extension-registered tool. Consumers that
- * read `sourceInfo` off `getAllRegisteredTools()` (e.g. pi-fabric) receive the
- * resolved on-disk extension path — or the synthetic `<extension:name>` fallback
- * for tools with no filesystem origin.
+ * read `sourceInfo` off `getAllRegisteredTools()` (e.g. pi-fabric) receive an
+ * absolute on-disk path: the tool's own `sourcePath` when it is filesystem-
+ * absolute, otherwise the extension's resolved entry (`fallbackPath`). A tool
+ * with no absolute origin at all falls back to the synthetic `<extension:name>`.
  */
 export function extensionToolSourceInfo(
 	definition: Pick<ToolDefinition, "name" | "sourcePath">,
 	fallbackPath: string,
 ): SourceInfo {
-	const candidate = definition.sourcePath ?? fallbackPath;
-	const path = candidate && isFilesystemSourcePath(candidate) ? candidate : `<extension:${definition.name}>`;
+	const sourcePath = definition.sourcePath;
+	const path =
+		sourcePath && isFilesystemSourcePath(sourcePath)
+			? sourcePath
+			: isFilesystemSourcePath(fallbackPath)
+				? fallbackPath
+				: `<extension:${definition.name}>`;
 	return { path, source: "extension", scope: "temporary", origin: "top-level" };
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -65,17 +65,16 @@ function getExtensionFactory(module: LoadedExtensionModule): ExtensionFactory | 
 }
 
 /**
- * Upstream-shaped provenance for an extension-registered tool. Mirrors the
- * `SourceInfo` synthesized by `SessionTools.getAllToolInfos()`, so consumers that
- * read `sourceInfo` off `getAllRegisteredTools()` (e.g. pi-fabric) see the same
- * on-disk path — or the synthetic `<extension:name>` fallback for tools with no
- * filesystem origin.
+ * Upstream-shaped provenance for an extension-registered tool. Consumers that
+ * read `sourceInfo` off `getAllRegisteredTools()` (e.g. pi-fabric) receive the
+ * resolved on-disk extension path — or the synthetic `<extension:name>` fallback
+ * for tools with no filesystem origin.
  */
 export function extensionToolSourceInfo(
 	definition: Pick<ToolDefinition, "name" | "sourcePath">,
-	extensionPath: string,
+	fallbackPath: string,
 ): SourceInfo {
-	const candidate = definition.sourcePath ?? extensionPath;
+	const candidate = definition.sourcePath ?? fallbackPath;
 	const path = candidate && isFilesystemSourcePath(candidate) ? candidate : `<extension:${definition.name}>`;
 	return { path, source: "extension", scope: "temporary", origin: "top-level" };
 }
@@ -199,7 +198,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		const registered = {
 			definition: tool,
 			extensionPath: this.extension.path,
-			sourceInfo: extensionToolSourceInfo(tool, this.extension.path),
+			sourceInfo: extensionToolSourceInfo(tool, this.extension.resolvedPath),
 		};
 		this.extension.tools.set(tool.name, registered);
 		for (const listener of this.extension.toolRegistrationListeners ?? []) listener(tool.name);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -45,7 +45,7 @@ import type {
 	ExtensionEvent,
 	ExtensionFlag,
 	ExtensionMode,
-	ExtensionRuntime,
+	ExtensionRuntimeContract,
 	ExtensionShortcut,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -598,7 +598,7 @@ export class ExtensionRunner {
 
 	constructor(
 		private readonly extensions: Extension[],
-		private readonly runtime: ExtensionRuntime,
+		private readonly runtime: ExtensionRuntimeContract,
 		/** Ignored: `cwd` is always read live via the `cwd` getter below, not cached here. */
 		_initialCwd: string,
 		private readonly sessionManager: SessionManager,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1629,6 +1629,13 @@ export type ExtensionFactory = (pi: ExtensionAPI) => void | Promise<void>;
 export interface RegisteredTool<TParams extends TSchema = TSchema, TDetails = unknown> {
 	definition: ToolDefinition<TParams, TDetails>;
 	extensionPath: string;
+	/**
+	 * Upstream-shaped provenance mirroring {@link SourceInfo}. Extensions authored
+	 * against `@earendil-works/pi-coding-agent` — whose registered tools expose
+	 * `sourceInfo` — read `sourceInfo.path` off `getAllRegisteredTools()` entries,
+	 * so it carries the same value `SessionTools.getAllToolInfos()` synthesizes.
+	 */
+	sourceInfo: SourceInfo;
 }
 
 /** Internal observer invoked when an already-loaded extension registers or replaces a tool. */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1754,8 +1754,8 @@ export interface ExtensionCommandContextActions {
 	reload: () => Promise<void>;
 }
 
-/** Full runtime = state + actions, including host-compatible service-tier fallbacks. */
-export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {
+/** Runtime contract implemented by the loader and consumed by extension hosts. */
+export interface ExtensionRuntimeContract extends ExtensionRuntimeState, ExtensionActions {
 	getServiceTiers: GetServiceTiersHandler;
 	setServiceTier: SetServiceTierHandler;
 }
@@ -1794,7 +1794,7 @@ export interface PreparedExtension {
 export interface LoadExtensionsResult {
 	extensions: Extension[];
 	errors: Array<{ path: string; error: string }>;
-	runtime: ExtensionRuntime;
+	runtime: ExtensionRuntimeContract;
 	/** Session-independent imported factories safe to rebind in child sessions. */
 	preparedExtensions?: PreparedExtension[];
 }

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -110,6 +110,7 @@ import {
 	ExtensionRunner,
 	ExtensionToolWrapper,
 	type ExtensionUIContext,
+	extensionToolSourceInfo,
 	type LoadExtensionsResult,
 	loadExtensionFromFactory,
 	loadExtensions,
@@ -2857,7 +2858,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			...registeredTools,
 			...sdkCustomTools.map(tool => {
 				const definition = isCustomTool(tool) ? customToolToDefinition(tool) : tool;
-				return { definition, extensionPath: "<sdk>" };
+				return { definition, extensionPath: "<sdk>", sourceInfo: extensionToolSourceInfo(definition, "<sdk>") };
 			}),
 		];
 		// `wrapToolWithMetaNotice` runs the centralized large-output → artifact spill.

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1747,6 +1747,8 @@ export class SessionTools {
 function registeredFilesystemSourcePath(runner: ExtensionRunner | undefined, name: string): string | undefined {
 	const registered = runner?.getRegisteredTool(name);
 	if (!registered) return undefined;
+	// Mirrors the derivation baked into RegisteredTool.sourceInfo at registration
+	// time (see extensionToolSourceInfo in extensions/loader.ts).
 	const candidate = registered.definition.sourcePath ?? registered.extensionPath;
 	return candidate && isFilesystemSourcePath(candidate) ? candidate : undefined;
 }

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1745,10 +1745,6 @@ export class SessionTools {
 }
 
 function registeredFilesystemSourcePath(runner: ExtensionRunner | undefined, name: string): string | undefined {
-	const registered = runner?.getRegisteredTool(name);
-	if (!registered) return undefined;
-	// Mirrors the derivation baked into RegisteredTool.sourceInfo at registration
-	// time (see extensionToolSourceInfo in extensions/loader.ts).
-	const candidate = registered.definition.sourcePath ?? registered.extensionPath;
-	return candidate && isFilesystemSourcePath(candidate) ? candidate : undefined;
+	const path = runner?.getRegisteredTool(name)?.sourceInfo.path;
+	return path && isFilesystemSourcePath(path) ? path : undefined;
 }

--- a/packages/coding-agent/test/extension-context-async-jobs.test.ts
+++ b/packages/coding-agent/test/extension-context-async-jobs.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
-import type { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { ExtensionRuntimeContract } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 function createRunner(getAsyncJobSnapshot?: () => AsyncJobSnapshot | null): ExtensionRunner {
 	const runtime = {
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
-	} as unknown as ExtensionRuntime;
+	} as unknown as ExtensionRuntimeContract;
 	return new ExtensionRunner(
 		[],
 		runtime,

--- a/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
+++ b/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility/extensions/loader";
+import { ExtensionRunner } from "../src/extensibility/extensions/runner";
+import { EventBus } from "../src/utils/event-bus";
+
+const okResult = { content: [{ type: "text" as const, text: "ok" }] };
+
+// Regression for the pi-fabric startup crash (`undefined is not an object
+// (evaluating 'anchor.sourceInfo.path')`): extensions authored against upstream
+// `@earendil-works/pi-coding-agent` read `sourceInfo.path` off every entry
+// returned by `getAllRegisteredTools()`. omp's RegisteredTool must carry that
+// upstream-shaped provenance, matching the SourceInfo synthesized for the
+// public `getAllToolInfos()` path.
+describe("RegisteredTool sourceInfo (upstream pi compat)", () => {
+	test("getAllRegisteredTools() entries expose sourceInfo without crashing upstream-shaped consumers", async () => {
+		const runtime = new ExtensionRuntime();
+		const events = new EventBus();
+
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.registerTool({
+					name: "fs_tool",
+					label: "FS Tool",
+					description: "tool with an on-disk origin",
+					parameters: pi.arktype({}),
+					sourcePath: "/abs/plugins/pi-fabric/tool.ts",
+					execute: async () => okResult,
+				});
+				pi.registerTool({
+					name: "synthetic_tool",
+					label: "Synthetic Tool",
+					description: "tool without a filesystem origin",
+					parameters: pi.arktype({}),
+					execute: async () => okResult,
+				});
+			},
+			"/project",
+			events,
+			runtime,
+			"pi-fabric@0.92.4",
+		);
+
+		const runner = new ExtensionRunner(
+			[extension],
+			runtime,
+			"/project",
+			{ getCwd: () => "/project" } as never,
+			{} as never,
+		);
+
+		// Mirrors pi-fabric's interceptor: reads sourceInfo.path off each entry.
+		// Before the fix, sourceInfo was undefined and this threw at startup.
+		const paths = runner.getAllRegisteredTools().map(entry => entry.sourceInfo.path);
+		expect(paths).toEqual(["/abs/plugins/pi-fabric/tool.ts", "<extension:synthetic_tool>"]);
+
+		// A filesystem sourcePath is surfaced verbatim with the full upstream shape.
+		expect(runner.getRegisteredTool("fs_tool")?.sourceInfo).toEqual({
+			path: "/abs/plugins/pi-fabric/tool.ts",
+			source: "extension",
+			scope: "temporary",
+			origin: "top-level",
+		});
+
+		// extensionPath stays intact for existing host callers.
+		expect(runner.getRegisteredTool("fs_tool")?.extensionPath).toBe("pi-fabric@0.92.4");
+	});
+});

--- a/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
+++ b/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
@@ -99,4 +99,36 @@ describe("RegisteredTool sourceInfo (upstream pi compat)", () => {
 			projectDir.removeSync();
 		}
 	});
+
+	test("a tool's relative sourcePath falls back to the extension's absolute resolved entry", async () => {
+		const projectDir = TempDir.createSync("@registered-tool-relative-source-");
+		const relativePath = "./plugin.ts";
+		const resolvedPath = path.join(projectDir.path(), "plugin.ts");
+		await Bun.write(
+			resolvedPath,
+			`
+				export default function(api) {
+					api.registerTool({
+						name: "relative_source_tool",
+						label: "Relative Source Tool",
+						description: "tool that declares a relative sourcePath",
+						parameters: api.arktype({}),
+						sourcePath: "./tools/relative_source.ts",
+						execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+					});
+				}
+			`,
+		);
+
+		try {
+			const loaded = await loadExtensions([relativePath], projectDir.path());
+			expect(loaded.errors).toEqual([]);
+
+			// A non-absolute sourcePath must not degrade to `<extension:name>` when the
+			// extension has a valid absolute resolved entry to point compat consumers at.
+			expect(loaded.extensions[0]?.tools.get("relative_source_tool")?.sourceInfo.path).toBe(resolvedPath);
+		} finally {
+			projectDir.removeSync();
+		}
+	});
 });

--- a/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
+++ b/packages/coding-agent/test/extension-registered-tool-source-info.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility/extensions/loader";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ExtensionRuntime, loadExtensionFromFactory, loadExtensions } from "../src/extensibility/extensions/loader";
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import { EventBus } from "../src/utils/event-bus";
 
@@ -63,5 +65,38 @@ describe("RegisteredTool sourceInfo (upstream pi compat)", () => {
 
 		// extensionPath stays intact for existing host callers.
 		expect(runner.getRegisteredTool("fs_tool")?.extensionPath).toBe("pi-fabric@0.92.4");
+	});
+
+	test("relative extension entries expose their resolved on-disk source path", async () => {
+		const projectDir = TempDir.createSync("@registered-tool-source-info-");
+		const relativePath = "./plugin.ts";
+		const resolvedPath = path.join(projectDir.path(), "plugin.ts");
+		await Bun.write(
+			resolvedPath,
+			`
+				export default function(api) {
+					api.registerTool({
+						name: "relative_tool",
+						label: "Relative Tool",
+						description: "tool loaded from a relative extension entry",
+						parameters: api.arktype({}),
+						execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+					});
+				}
+			`,
+		);
+
+		try {
+			const loaded = await loadExtensions([relativePath], projectDir.path());
+			expect(loaded.errors).toEqual([]);
+			expect(loaded.extensions).toHaveLength(1);
+
+			const extension = loaded.extensions[0];
+			expect(extension?.path).toBe(relativePath);
+			expect(extension?.resolvedPath).toBe(resolvedPath);
+			expect(extension?.tools.get("relative_tool")?.sourceInfo.path).toBe(resolvedPath);
+		} finally {
+			projectDir.removeSync();
+		}
 	});
 });

--- a/packages/coding-agent/test/getalltools-toolinfo.test.ts
+++ b/packages/coding-agent/test/getalltools-toolinfo.test.ts
@@ -86,7 +86,7 @@ describe("AgentSession.getAllToolInfos", () => {
 		}
 	});
 
-	it("reports the originating custom-tool file path instead of a synthetic stub", async () => {
+	it("uses stored registered provenance instead of re-deriving a relative extension path", async () => {
 		const tempDir = TempDir.createSync("@getalltools-sourcepath-");
 		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
@@ -122,8 +122,14 @@ describe("AgentSession.getAllToolInfos", () => {
 				getRegisteredTool: (name: string) =>
 					name === "git"
 						? {
-								extensionPath: "<inline-0>",
-								definition: { sourcePath },
+								extensionPath: "./extension.ts",
+								definition: { sourcePath: "./tools/git.ts" },
+								sourceInfo: {
+									path: sourcePath,
+									source: "extension",
+									scope: "temporary",
+									origin: "top-level",
+								},
 							}
 						: undefined,
 			} as never,

--- a/packages/coding-agent/test/issue-5764-registertool-loadmode.test.ts
+++ b/packages/coding-agent/test/issue-5764-registertool-loadmode.test.ts
@@ -11,6 +11,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { CustomToolAdapter } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/wrapper";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { RegisteredToolAdapter } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+import { extensionToolSourceInfo } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { BUILTIN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	defaultLoadModeForToolName,
@@ -66,6 +67,7 @@ describe("issue #5764: registerTool loadMode default", () => {
 					execute: noopExecute,
 				},
 				extensionPath: "<test>",
+				sourceInfo: extensionToolSourceInfo({ name: "read" }, "<test>"),
 			},
 			runner,
 		);
@@ -85,6 +87,7 @@ describe("issue #5764: registerTool loadMode default", () => {
 					execute: noopExecute,
 				},
 				extensionPath: "<test>",
+				sourceInfo: extensionToolSourceInfo({ name: "my_ext_tool" }, "<test>"),
 			},
 			runner,
 		);

--- a/packages/coding-agent/test/issue-7955-extension-project-trusted.test.ts
+++ b/packages/coding-agent/test/issue-7955-extension-project-trusted.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
-import type { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { ExtensionRuntimeContract } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 
 function createRunner(): ExtensionRunner {
 	const runtime = {
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
-	} as unknown as ExtensionRuntime;
+	} as unknown as ExtensionRuntimeContract;
 	return new ExtensionRunner([], runtime, "/tmp", { getCwd: () => "/tmp" } as never, {} as never);
 }
 


### PR DESCRIPTION
## Repro

Installing an extension authored against upstream `@earendil-works/pi-coding-agent` — e.g. [`pi-fabric`](https://github.com/monotykamary/pi-fabric) — crashes every omp session during `createAgentSession`, before any turn runs (`omp plugin install pi-fabric@0.92.4` then `omp -p --mode json "hello"`). pi-fabric's interceptor reads `sourceInfo.path` off each `getAllRegisteredTools()` entry. Reproduced with a focused test mirroring that access pattern — registering a tool via `pi.registerTool` then reading `entry.sourceInfo.path` — which threw the reported error before the fix:

```
TypeError: undefined is not an object (evaluating 'entry.sourceInfo.path')
    at test/extension-registered-tool-source-info.test.ts:53
```

## Cause

omp's `RegisteredTool` (`extensibility/extensions/types.ts`) carried only `definition` + `extensionPath`, with no `sourceInfo`. `ExtensionRunner.getAllRegisteredTools()` (`extensibility/extensions/runner.ts`) returns those bare entries, so upstream-shaped consumers reading `sourceInfo.path` hit `undefined`. `SessionTools.getAllToolInfos()` already synthesizes a `SourceInfo` for the public `getAllTools()` path (so upstream extensions read `sourceInfo.source` unchanged), but that provenance never reached the registered-tool surface.

## Fix

- Add a required `sourceInfo: SourceInfo` field to `RegisteredTool` (`extensibility/extensions/types.ts`).
- Add and export `extensionToolSourceInfo(definition, extensionPath)` (`extensibility/extensions/loader.ts`, re-exported from the barrel) building the same filesystem-path / `<extension:name>` derivation `getAllToolInfos()` uses (`source: "extension"`, `scope: "temporary"`, `origin: "top-level"`).
- Populate `sourceInfo` at both `RegisteredTool` construction sites: extension `registerTool` (`loader.ts`) and SDK custom tools (`sdk.ts`).
- `registeredFilesystemSourcePath` (`session/session-tools.ts`) keeps its independent derivation from `definition.sourcePath ?? extensionPath`, with a comment noting it mirrors `extensionToolSourceInfo`.
- Update the two typed `RegisteredTool` literals in `issue-5764-registertool-loadmode.test.ts` for the new required field.

## Verification

`bun test` on the new regression test (`test/extension-registered-tool-source-info.test.ts`) plus the related extension/session-tools/sdk suites (`getalltools-toolinfo`, `extensions-runner`, `task-executor-mcp-parity`, `issue-5764-registertool-loadmode`, `agent-session-bash-session-ownership`, `extension-provider-registration-rollback`, `live-tool-session`, `sdk-custom-tools-per-session-binding`, `custom-tool-loader`) — 137 pass, 0 fail. Confirmed the regression test throws the exact reported `TypeError` when `sourceInfo` population is removed, and passes with it. `bun check` clean. Fixes #11661