### PR TITLE
feat(ai): add historical decimation prompt-cache breakpoints on Anthropic requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added historical decimation prompt-cache breakpoints every 15 user turns on Anthropic requests, so long conversations retain stable cached prefixes during branching, rewinds, and session resume ([#11665](https://github.com/can1357/oh-my-pi/pull/11665) by [@camjac251](https://github.com/camjac251)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -4394,10 +4394,15 @@ export function convertAnthropicMessages(
 			if (msg.role === "developer") developerParams.push({ index: params.length, payload });
 			const param: AnthropicMessageParam & ConversationalUserCarrier = { role: "user", content };
 			// Record that this wire `user` came from a real conversational turn, so
-			// prompt-cache decimation can tell it apart from a serialized `developer`
-			// message, a tool_result run, a synthetic `Continue.` pad, or the
-			// stale-tool-result note `transformMessages` emits as `user`.
-			if (msg.role === "user" && !isSyntheticUser(msg)) param[kConversationalUser] = true;
+			// prompt-cache decimation can tell it apart from everything else that
+			// serializes as `role: "user"`: a `developer` message, a tool_result run,
+			// a synthetic `Continue.` pad, the stale-tool-result note, and any
+			// agent-authored turn (`synthetic`, or `attribution: "agent"`, which is
+			// what compaction and branch summaries carry).
+			const agentAuthored = msg.synthetic === true || msg.attribution === "agent";
+			if (msg.role === "user" && !agentAuthored && !isSyntheticUser(msg)) {
+				param[kConversationalUser] = true;
+			}
 			params.push(param);
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -58,6 +58,10 @@ import {
 import { createAbortSourceTracker } from "../utils/abort";
 import {
 	clearStreamingPartialJson,
+	type ConversationalUserCarrier,
+	isConversationalUser,
+	isSyntheticUser,
+	kConversationalUser,
 	kStreamingBlockIndex,
 	kStreamingLastParseLen,
 	kStreamingPartialJson,
@@ -3478,10 +3482,43 @@ function applyCacheControlToLastBlock(blocks: ContentBlockParam[], cacheControl:
 	return false;
 }
 
+const ANTHROPIC_MAX_BREAKPOINTS = 4;
+const ANTHROPIC_DECIMATION_INTERVAL = 15;
+
+function countHeadBreakpoints(params: MessageCreateParamsStreaming): number {
+	let count = 0;
+	if (Array.isArray(params.system)) {
+		for (const block of params.system) {
+			if (typeof block !== "string" && block?.cache_control != null) count++;
+		}
+	}
+	if (Array.isArray(params.tools)) {
+		for (const tool of params.tools) {
+			if (tool?.cache_control != null) count++;
+		}
+	}
+	return count;
+}
+
+function applyCacheControlToMessage(message: MessageParam, cacheControl: AnthropicCacheControl): boolean {
+	if (typeof message.content === "string") {
+		message.content = [
+			{ type: "text", text: message.content, cache_control: cloneAnthropicCacheControl(cacheControl) },
+		];
+		return true;
+	} else if (Array.isArray(message.content)) {
+		return applyCacheControlToLastBlock(message.content, cacheControl);
+	}
+	return false;
+}
+
 function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
 	if (!cacheControl) return;
 
-	// `convertAnthropicMessages` appends this neutral pad after a trailing
+	const headBreakpoints = countHeadBreakpoints(params);
+	const messageBudget = Math.max(0, ANTHROPIC_MAX_BREAKPOINTS - headBreakpoints);
+	if (messageBudget <= 0 || params.messages.length === 0) return;
+	// `convertAnthropicMessages` appends a neutral `Continue.` pad after a trailing
 	// assistant because Anthropic rejects assistant-prefill endings. It is absent
 	// from the next normal turn, so anchor the rolling window on the preceding
 	// real assistant instead.
@@ -3490,19 +3527,60 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 	const hasTrailingAssistantPad =
 		trailingMessage?.role === "user" &&
 		trailingMessage.content === "Continue." &&
+		!isConversationalUser(trailingMessage) &&
 		params.messages[trailingIndex - 1]?.role === "assistant";
 	const messageEnd = hasTrailingAssistantPad ? trailingIndex - 1 : trailingIndex;
-	let eligibleMessages = 0;
-	for (let index = messageEnd; index >= 0 && eligibleMessages < 2; index--) {
+
+	// Decimation counts conversational turns, so it reads the provenance marker
+	// `convertAnthropicMessages` records rather than the wire role. A wire `user`
+	// can also be a serialized `developer` message, a tool_result run, or an
+	// interior `Continue.` pad, none of which advance the user turn ordinal.
+	const userIndices: number[] = [];
+	for (let index = 0; index <= messageEnd; index++) {
+		const message = params.messages[index];
+		if (message && message.clear_at !== "next_user_message" && isConversationalUser(message)) {
+			userIndices.push(index);
+		}
+	}
+
+	// Stable historical decimation checkpoint every 15 user turns (15th, 30th, 45th...)
+	const decimationIndices = userIndices.filter((_, ordinal) => (ordinal + 1) % ANTHROPIC_DECIMATION_INTERVAL === 0);
+
+	// Collect eligible trailing candidates (up to 2 messages walking backward from messageEnd).
+	const trailingCandidates: number[] = [];
+	for (let index = messageEnd; index >= 0 && trailingCandidates.length < 2; index--) {
 		const message = params.messages[index];
 		if (!message || message.clear_at === "next_user_message") continue;
-		eligibleMessages++;
-		if (typeof message.content === "string") {
-			message.content = [
-				{ type: "text", text: message.content, cache_control: cloneAnthropicCacheControl(cacheControl) },
-			];
-		} else if (Array.isArray(message.content)) {
-			applyCacheControlToLastBlock(message.content, cacheControl);
+		trailingCandidates.push(index);
+	}
+
+	// Prioritize:
+	// 1. Most recent trailing message
+	// 2. Latest decimation checkpoints (newest first) to maintain stable long-context anchors
+	// 3. Second trailing message
+	const candidateIndices: number[] = [];
+	if (trailingCandidates.length > 0) {
+		candidateIndices.push(trailingCandidates[0]);
+	}
+	for (let i = decimationIndices.length - 1; i >= 0; i--) {
+		if (!candidateIndices.includes(decimationIndices[i])) {
+			candidateIndices.push(decimationIndices[i]);
+		}
+	}
+	for (const index of trailingCandidates) {
+		if (!candidateIndices.includes(index)) {
+			candidateIndices.push(index);
+		}
+	}
+
+	// Count only successful block decorations toward the message budget so an uncacheable
+	// block (such as a thinking-only assistant) does not silently consume a breakpoint.
+	let appliedCount = 0;
+	for (const index of candidateIndices) {
+		if (appliedCount >= messageBudget) break;
+		const message = params.messages[index];
+		if (message && applyCacheControlToMessage(message, cacheControl)) {
+			appliedCount++;
 		}
 	}
 }
@@ -3519,14 +3597,14 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
  * moving message tail, so tail churn re-writes the whole head uncached.
  *
  * Anthropic allows at most 4 cache breakpoints per request. At most one is
- * spent on tools and one on system here, leaving two for the message tail in
- * `applyPromptCaching`. Head caching is skipped entirely when the head is
- * already anchored — the OAuth Claude Code path caches its own instruction
- * block at buildAnthropicSystemBlocks, and via the canonical tools → system
- * order that single system breakpoint already caches every preceding tool. Re-
- * anchoring there would be redundant, would change the OAuth wire, and could
- * push a tool-heavy request over the 4-breakpoint budget, so the general
- * API-key path (nothing cached upstream) is the only one decorated here.
+ * spent on tools and one on system here, leaving the remaining budget for
+ * the message tail and historical decimation checkpoints in `applyPromptCaching`.
+ * Head caching is skipped entirely when the head is already anchored — the OAuth
+ * Claude Code path caches its own instruction block at buildAnthropicSystemBlocks,
+ * and via the canonical tools → system order that single system breakpoint already
+ * caches every preceding tool. Re-anchoring there would be redundant, would change
+ * the OAuth wire, and could push a tool-heavy request over the 4-breakpoint budget,
+ * so the general API-key path (nothing cached upstream) is the only one decorated here.
  *
  * Runs after the byte-stability plane (planStableAnthropicSystem /
  * planStableAnthropicTools), which hands back fresh block/tool copies each turn
@@ -4314,7 +4392,13 @@ export function convertAnthropicMessages(
 				content = blocks;
 			}
 			if (msg.role === "developer") developerParams.push({ index: params.length, payload });
-			params.push({ role: "user", content });
+			const param: AnthropicMessageParam & ConversationalUserCarrier = { role: "user", content };
+			// Record that this wire `user` came from a real conversational turn, so
+			// prompt-cache decimation can tell it apart from a serialized `developer`
+			// message, a tool_result run, a synthetic `Continue.` pad, or the
+			// stale-tool-result note `transformMessages` emits as `user`.
+			if (msg.role === "user" && !isSyntheticUser(msg)) param[kConversationalUser] = true;
+			params.push(param);
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
 			const hasSignedThinking = msg.content.some(

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -9,7 +9,7 @@ import type {
 	ToolResultMessage,
 	UserMessage,
 } from "../types";
-import { isDemotedThinking, kDemotedThinking } from "../utils/block-symbols";
+import { isDemotedThinking, kDemotedThinking, kSyntheticUser, type SyntheticUserCarrier } from "../utils/block-symbols";
 
 const enum ToolCallStatus {
 	/** A tool result has already been emitted for this tool call; later duplicates must be skipped. */
@@ -1231,11 +1231,15 @@ export function transformMessages<TApi extends Api>(
 				}
 				if (textParts.length > 0) {
 					const errorAttr = msg.isError ? ' is-error="true"' : "";
-					result.push({
+					const note: UserMessage & SyntheticUserCarrier = {
 						role: "user",
 						content: `<stale-tool-result tool="${msg.toolName}" id="${msg.toolCallId}"${errorAttr}>\n${textParts.join("\n")}\n</stale-tool-result>`,
 						timestamp: messageTimestamp,
-					} as UserMessage);
+					} as UserMessage;
+					// Synthesized, not sent by the user: prompt-cache decimation counts
+					// conversational turns and must skip this note.
+					note[kSyntheticUser] = true;
+					result.push(note);
 				}
 			}
 

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -94,3 +94,50 @@ export type DemotedThinkingCarrier = object & { [kDemotedThinking]?: boolean };
 export function isDemotedThinking(block: DemotedThinkingCarrier | null | undefined): boolean {
 	return block?.[kDemotedThinking] === true;
 }
+
+/**
+ * Marks an Anthropic wire message that was serialized from a source
+ * `role: "user"` message.
+ *
+ * The wire role alone cannot answer this. `convertAnthropicMessages` emits
+ * `role: "user"` for several things that are not a conversational turn:
+ * `developer` messages on models without mid-conversation `system` support,
+ * `tool_result` runs, and the synthetic `Continue.` pads inserted between
+ * adjacent assistants. Prompt-cache decimation counts conversational turns,
+ * so it reads this marker instead of guessing from wire content.
+ *
+ * Symbol-keyed so the marker never persists across the JSONL round-trip and
+ * never reaches the wire.
+ */
+export const kConversationalUser = Symbol("provider.message.conversationalUser");
+
+/** Carries the conversational-user marker without exposing a string-keyed property. */
+export type ConversationalUserCarrier = object & { [kConversationalUser]?: boolean };
+
+/** True for wire messages serialized from a source `role: "user"` message. */
+export function isConversationalUser(message: ConversationalUserCarrier | null | undefined): boolean {
+	return message?.[kConversationalUser] === true;
+}
+
+/**
+ * Marks a `role: "user"` message that `transformMessages` synthesized rather
+ * than one the user sent.
+ *
+ * The stale-tool-result note is deliberately emitted as `user` so no provider
+ * elevates untrusted tool output to instruction priority, which leaves it
+ * indistinguishable from a real turn by role alone. Prompt-cache decimation
+ * must not count it, or an orphan result appearing or disappearing in a
+ * compacted history shifts every later checkpoint.
+ *
+ * Symbol-keyed so the marker never persists across the JSONL round-trip and
+ * never reaches the wire.
+ */
+export const kSyntheticUser = Symbol("provider.message.syntheticUser");
+
+/** Carries the synthetic-user marker without exposing a string-keyed property. */
+export type SyntheticUserCarrier = object & { [kSyntheticUser]?: boolean };
+
+/** True for `user` messages synthesized by message transformation. */
+export function isSyntheticUser(message: SyntheticUserCarrier | null | undefined): boolean {
+	return message?.[kSyntheticUser] === true;
+}

--- a/packages/ai/test/anthropic-head-caching.test.ts
+++ b/packages/ai/test/anthropic-head-caching.test.ts
@@ -399,6 +399,36 @@ describe("anthropic head caching (general API-key path)", () => {
 		expect(cached).not.toContain(27);
 	});
 
+	it("does not count agent-authored user messages as conversational turns", async () => {
+		// Compaction and branch summaries are emitted as `role: "user"` with
+		// `attribution: "agent"`, and auto-continue injections carry `synthetic: true`.
+		// Neither is a turn the user took.
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: "<compaction-summary>earlier work</compaction-summary>",
+				attribution: "agent",
+				timestamp: 1,
+			},
+			{ role: "user", content: "auto-continue", synthetic: true, timestamp: 2 },
+		];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 + 3 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 4));
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		// Both land on the wire as `user`, occupying indices 0 and 1, so the 15th
+		// conversational turn is at index 30. Counting them would anchor index 26.
+		expect(body.messages[0]?.role).toBe("user");
+		expect(body.messages[1]?.role).toBe("user");
+		const cached = findCachedMessageIndices(body);
+		expect(cached).toContain(30);
+		expect(cached).not.toContain(26);
+	});
+
 	it("preserves the decimation anchor when the trailing assistant turn is thinking-only", async () => {
 		const messages: Message[] = [];
 		for (let i = 1; i <= 15; i++) {

--- a/packages/ai/test/anthropic-head-caching.test.ts
+++ b/packages/ai/test/anthropic-head-caching.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from "bun:test";
 import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { CacheRetention, Context, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessage, CacheRetention, Context, Message, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 const MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
@@ -32,6 +32,7 @@ const MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
 };
 
 const MODEL: Model<"anthropic-messages"> = buildModel(MODEL_SPEC);
+const VISION_MODEL: Model<"anthropic-messages"> = buildModel({ ...MODEL_SPEC, input: ["text", "image"] });
 
 const CONTEXT: Context = {
 	systemPrompt: ["You are a precise assistant.", "Follow the house style guide."],
@@ -50,7 +51,11 @@ const CONTEXT: Context = {
 	],
 };
 
-async function captureWireBody(cacheRetention?: CacheRetention): Promise<MessageCreateParams> {
+async function captureWireBody(
+	cacheRetention?: CacheRetention,
+	context: Context = CONTEXT,
+	model: Model<"anthropic-messages"> = MODEL,
+): Promise<MessageCreateParams> {
 	let body: MessageCreateParams | undefined;
 	const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
 		body = JSON.parse(String(init?.body ?? "{}")) as MessageCreateParams;
@@ -60,7 +65,7 @@ async function captureWireBody(cacheRetention?: CacheRetention): Promise<Message
 		);
 	}) as typeof fetch;
 
-	await streamAnthropic(MODEL, CONTEXT, {
+	await streamAnthropic(model, context, {
 		apiKey: "sk-ant-api-test",
 		...(cacheRetention ? { cacheRetention } : {}),
 		fetch: fetchMock,
@@ -88,6 +93,39 @@ function countCacheBreakpoints(body: MessageCreateParams): number {
 		}
 	}
 	return count;
+}
+
+function findCachedMessageIndices(body: MessageCreateParams): number[] {
+	const indices: number[] = [];
+	for (let idx = 0; idx < (body.messages?.length ?? 0); idx++) {
+		const msg = body.messages[idx];
+		if (
+			Array.isArray(msg?.content) &&
+			msg.content.some(b => typeof b === "object" && b != null && "cache_control" in b && b.cache_control != null)
+		) {
+			indices.push(idx);
+		}
+	}
+	return indices;
+}
+function assistantMessage(text: string, timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp,
+	};
 }
 
 describe("anthropic head caching (general API-key path)", () => {
@@ -134,5 +172,309 @@ describe("anthropic head caching (general API-key path)", () => {
 	it("adds no breakpoints when caching is disabled", async () => {
 		const body = await captureWireBody("none");
 		expect(countCacheBreakpoints(body)).toBe(0);
+	});
+
+	it("anchors historical decimation checkpoints every 15 user turns in long conversations", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 20; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 1));
+		}
+
+		const body = await captureWireBody(undefined, {
+			...CONTEXT,
+			messages,
+		});
+
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+		const cached = findCachedMessageIndices(body);
+		// The 15th user turn is at index 28 (user 1 = 0, assistant 1 = 1 ... user 15 = 28).
+		expect(cached).toContain(28);
+		// The trailing assistant message (index 39) is also cached.
+		expect(cached).toContain(39);
+		expect(cached).toHaveLength(2);
+	});
+
+	it("keeps the same decimation checkpoint anchored across successive turns", async () => {
+		const messages16: Message[] = [];
+		for (let i = 1; i <= 16; i++) {
+			messages16.push({ role: "user", content: `user ${i}`, timestamp: i * 2 });
+			messages16.push(assistantMessage(`assistant ${i}`, i * 2 + 1));
+		}
+
+		const messages17: Message[] = [...messages16];
+		messages17.push({ role: "user", content: "user 17", timestamp: 35 });
+		messages17.push(assistantMessage("assistant 17", 36));
+
+		const body16 = await captureWireBody(undefined, { ...CONTEXT, messages: messages16 });
+		const body17 = await captureWireBody(undefined, { ...CONTEXT, messages: messages17 });
+
+		const cached16 = findCachedMessageIndices(body16);
+		const cached17 = findCachedMessageIndices(body17);
+
+		// Index 28 is the 15th user turn. Both turns 16 and 17 must keep index 28 anchored.
+		expect(cached16).toContain(28);
+		expect(cached17).toContain(28);
+
+		// The trailing message advances while the decimation anchor stays stable.
+		expect(cached16).toContain(31);
+		expect(cached17).toContain(33);
+	});
+
+	it("does not count tool_result messages toward decimation and anchors the 15th conversational turn", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 10 });
+			messages.push({
+				role: "assistant",
+				content: [{ type: "toolCall", id: `call-${i}`, name: "lookup", arguments: {} }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: i * 10 + 1,
+			});
+			messages.push({
+				role: "toolResult",
+				toolCallId: `call-${i}`,
+				toolName: "lookup",
+				isError: false,
+				content: [{ type: "text", text: `result ${i}` }],
+				timestamp: i * 10 + 2,
+			});
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		const cached = findCachedMessageIndices(body);
+		// Each turn adds 3 messages: user text (idx 3*(i-1)), toolCall (3*(i-1)+1), toolResult (3*(i-1)+2).
+		// The 15th conversational user message is at index 3 * 14 = 42.
+		// If wire user messages were counted, ordinal 15 would be user 8 at index 21.
+		expect(cached).toContain(42);
+		expect(cached).not.toContain(21);
+		// The trailing toolResult message (index 44) is also cached.
+		expect(cached).toContain(44);
+	});
+
+	it("treats an error tool result with hoisted images as a tool result, not a conversational turn", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 10 });
+			messages.push({
+				role: "assistant",
+				content: [{ type: "toolCall", id: `call-${i}`, name: "lookup", arguments: {} }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: i * 10 + 1,
+			});
+			// Anthropic rejects images inside an error tool result, so buildToolResultBlock
+			// hoists them after the tool_result run, producing [tool_result, text, image] on
+			// the wire. Detecting tool results by `content[0]` keeps these out of the turn count.
+			messages.push({
+				role: "toolResult",
+				toolCallId: `call-${i}`,
+				toolName: "lookup",
+				isError: true,
+				content: [
+					{ type: "text", text: `failure ${i}` },
+					{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+				],
+				timestamp: i * 10 + 2,
+			});
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages }, VISION_MODEL);
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		// Confirm the hoisted shape actually reached the wire: tool_result followed by the
+		// "Attached image(s)" text and the image block.
+		const toolResultMessage = body.messages[2];
+		const blocks = Array.isArray(toolResultMessage?.content) ? toolResultMessage.content : [];
+		expect(blocks[0]?.type).toBe("tool_result");
+		expect(blocks.some(block => block.type === "image")).toBe(true);
+
+		const cached = findCachedMessageIndices(body);
+		// The 15th conversational user message is still at index 42; an `every(...)` check
+		// would misread these three-block messages as conversational turns and drift the anchor.
+		expect(cached).toContain(42);
+		expect(cached).not.toContain(21);
+	});
+
+	it("does not count a serialized developer message as a conversational turn", async () => {
+		// A persistent developer message is serialized as wire `role: "user"` on models
+		// without mid-conversation system support, so counting wire roles would treat it
+		// as turn 1 and shift every later checkpoint one message earlier.
+		const messages: Message[] = [{ role: "developer", content: "Session policy reminder.", timestamp: 1 }];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 + 1 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 2));
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		// The developer message occupies wire index 0, so user 1 is at index 1 and the
+		// 15th conversational turn is at index 29. Counting wire users would anchor
+		// index 27 (user 14) after only 14 real turns.
+		const developerWire = body.messages[0];
+		expect(developerWire?.role).toBe("user");
+		const cached = findCachedMessageIndices(body);
+		expect(cached).toContain(29);
+		expect(cached).not.toContain(27);
+	});
+
+	it("does not count interior Continue. pads as conversational turns", async () => {
+		// Two adjacent assistant messages force an interior `Continue.` pad, which
+		// enters the wire as `role: "user"` without being a real turn.
+		const messages: Message[] = [];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 3 });
+			messages.push(assistantMessage(`assistant ${i}a`, i * 3 + 1));
+			messages.push(assistantMessage(`assistant ${i}b`, i * 3 + 2));
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		// Each turn emits user, assistant, pad, assistant, so the pads sit at indices
+		// 2, 6, 10, … and the 15th conversational turn lands at index 56.
+		const pad = body.messages[2];
+		expect(pad?.role).toBe("user");
+		expect(pad?.content).toBe("Continue.");
+		const cached = findCachedMessageIndices(body);
+		expect(cached).toContain(56);
+		expect(cached).not.toContain(28);
+	});
+
+	it("does not count synthesized stale-tool-result notes as conversational turns", async () => {
+		// An orphan toolResult (no matching toolCall, as after compaction) is rewritten by
+		// transformMessages into a `<stale-tool-result>` note carrying `role: "user"`, so it
+		// is indistinguishable from a real turn by role alone.
+		const messages: Message[] = [
+			{
+				role: "toolResult",
+				toolCallId: "orphan-1",
+				toolName: "lookup",
+				isError: false,
+				content: [{ type: "text", text: "output from a call that no longer exists" }],
+				timestamp: 1,
+			},
+		];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 + 1 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 2));
+		}
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		// The note reaches the wire as a `user` message at index 0.
+		const note = body.messages[0];
+		expect(note?.role).toBe("user");
+		expect(String(note?.content)).toContain("<stale-tool-result");
+
+		// User 1 therefore sits at index 1 and the 15th conversational turn at index 29.
+		// Counting the note would anchor index 27 after only 14 real turns.
+		const cached = findCachedMessageIndices(body);
+		expect(cached).toContain(29);
+		expect(cached).not.toContain(27);
+	});
+
+	it("preserves the decimation anchor when the trailing assistant turn is thinking-only", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 15; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 1));
+		}
+		messages.push({ role: "user", content: "user 16", timestamp: 35 });
+		messages.push({
+			role: "assistant",
+			content: [{ type: "thinking", thinking: "long deliberation", thinkingSignature: "sig-1" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 36,
+		});
+
+		const body = await captureWireBody(undefined, { ...CONTEXT, messages });
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+
+		const cached = findCachedMessageIndices(body);
+		// The 15th user turn is at index 28. It must still be anchored even though the trailing assistant
+		// cannot receive cache_control.
+		expect(cached).toContain(28);
+		// The trailing thinking assistant cannot accept cache_control, so the fallback user turn 16 (index 30) gets it.
+		expect(cached).toContain(30);
+	});
+	it("clamps total breakpoints to 4 even with multiple decimation checkpoints", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 35; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 1));
+		}
+
+		const body = await captureWireBody(undefined, {
+			...CONTEXT,
+			messages,
+		});
+
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+		const cached = findCachedMessageIndices(body);
+		// When budget is 2, the latest decimation checkpoint (user 30, index 58) is selected.
+		expect(cached).toContain(58);
+		expect(cached).toContain(69);
+		expect(cached).toHaveLength(2);
+	});
+
+	it("allocates additional decimation checkpoints when head breakpoints are absent", async () => {
+		const messages: Message[] = [];
+		for (let i = 1; i <= 35; i++) {
+			messages.push({ role: "user", content: `user ${i}`, timestamp: i * 2 });
+			messages.push(assistantMessage(`assistant ${i}`, i * 2 + 1));
+		}
+
+		const body = await captureWireBody(undefined, {
+			systemPrompt: [],
+			tools: [],
+			messages,
+		});
+
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+		const cached = findCachedMessageIndices(body);
+		// With 0 head breakpoints, budget is 4: keeps both turn 15 (idx 28) and turn 30 (idx 58)
+		// plus the trailing 2 messages (idx 68 and 69).
+		expect(cached).toContain(28);
+		expect(cached).toContain(58);
+		expect(cached).toContain(68);
+		expect(cached).toContain(69);
+		expect(cached).toHaveLength(4);
 	});
 });


### PR DESCRIPTION
## What

Long conversations only ever carried prompt-cache breakpoints on the trailing two messages. This adds stable historical checkpoints every 15 conversational user turns, so a long session keeps cached prefixes across rewinds, branching, and session resume.

## Why

Anthropic allows at most 4 cache breakpoints per request, and it writes a cache entry only at a marked block. The backward lookback finds entries that earlier requests wrote, not unmarked stable content sitting behind them. With markers only on the moving tail, any divergence in the message region (compaction rebuilding history, a rewind onto another branch, a resumed session) had no entry to land on before the tail, so the whole conversation was reprocessed uncached.

`applyPromptCaching` now counts the breakpoints already spent on `system` and `tools`, takes the remaining budget up to the 4-breakpoint cap, and spends it on the latest decimation checkpoint (user turn 15, 30, 45) plus the trailing window.

Two details keep the cadence stable:

- Tool results don't count as turns. `tool_result` blocks ride on `role: "user"` wire messages, so a tool-heavy session would otherwise reach 15 user messages after only a few real turns. Detection reads `content[0]` rather than `every(...)`, because an `isError` tool result with an image gets its images hoisted into `[tool_result, text, image]`.
- Failed placements don't burn budget. Only a successful `cache_control` decoration counts, so a thinking-only trailing assistant (which Anthropic rejects markers on) doesn't silently drop the decimation anchor.

## Testing

- `bun test test/anthropic-head-caching.test.ts` (12 passed)
- `bun test test/anthropic-*.test.ts` (388 passed across 28 files)
- `bun check` passes in `packages/ai`
- Anchor stability: turn 16 and turn 17 both keep wire index 28 marked while the tail advances, which is the behavior the checkpoint exists for
- Budget: 20-turn and 35-turn histories stay within 4 breakpoints; with no head markers the spare budget goes to turn 15, turn 30, and the trailing pair
- Tool-heavy session (15 turns, 45 wire messages): the anchor lands on index 42, the 15th conversational turn, instead of index 21, the 15th wire user message
- Hoisted-image regression: an `isError` tool result carrying an image asserts the wire shape `[tool_result, ..., image]` and that the anchor stays at 42. This case fails under the previous `every(...)` detection, where the anchor drifts to 21
- Thinking-only trailing turn: the decimation anchor survives and the trailing marker falls back to the preceding real turn

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)