### PR TITLE
fix(settings): log dropped .claude/settings.json parse warnings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Eval cell timeouts no longer fatally terminate the session when a browser tab worker is being recycled ([#11707](https://github.com/can1357/oh-my-pi/issues/11707)).
 - Models whose images are stripped on the wire (`compat.stripImageInput`) now trigger the `describeForTextModels` vision fallback and are skipped when resolving the vision model, instead of silently dropping images ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
+- A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed the Windows PowerShell installer (`install.ps1`) aborting on Windows PowerShell 5.1 when bun or git wrote normal progress to stderr: native commands now run with `$ErrorActionPreference` scoped to `Continue` and success is gated on the process exit code, so `$ErrorActionPreference = "Stop"`'s stderr-as-terminating-error behavior no longer kills the install ([#11675](https://github.com/can1357/oh-my-pi/issues/11675)).
 - Eval cell timeouts no longer fatally terminate the session when a browser tab worker is being recycled ([#11707](https://github.com/can1357/oh-my-pi/issues/11707)).
 - Models whose images are stripped on the wire (`compat.stripImageInput`) now trigger the `describeForTextModels` vision fallback and are skipped when resolving the vision model, instead of silently dropping images ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
+- `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1812,25 +1812,30 @@ export class Settings {
 	}
 
 	async #readProjectSettings(quarantineInvalid: boolean): Promise<ProjectSettingsReadResult> {
+		// Resolve once: capability discovery, fs-cache invalidation, and the
+		// warning prefix below must all derive from the same absolute scope so
+		// relative cwds (e.g. ".") produce absolute provider paths that match.
+		const discoveryCwd = path.resolve(this.#cwd);
 		const projectConfigDir = getProjectAgentDir(this.#cwd);
 		const projectConfigPath = path.join(projectConfigDir, "config.yml");
 		invalidateCapabilityFsCache(projectConfigPath);
 		invalidateCapabilityFsCache(path.join(projectConfigDir, "settings.json"));
+		invalidateCapabilityFsCache(path.join(discoveryCwd, ".claude", "settings.json"));
 		let shellPathSource: string | undefined;
 		let merged: RawSettings = {};
 		try {
-			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
+			const result = await loadCapability(settingsCapability.id, { cwd: discoveryCwd });
 			// `loadCapability` aggregates warnings across every level, but this
 			// method only merges project items — user-level parse failures belong
 			// to the global layer and would misattribute here. Warnings embed
 			// their source file's absolute path, so keep only warnings rooted at
-			// the resolved cwd (a bare substring would over-match relative
+			// the discovery cwd (a bare substring would over-match relative
 			// scopes such as `cwd: "."` and sibling dir prefixes). Remember what
 			// was surfaced so reloads stay quiet while new failures still log.
 			// Level attribution below the path layer (e.g. a user-scoped dir
 			// mounted inside the project) needs warning metadata from the
 			// providers, which `LoadResult.warnings` does not carry.
-			const cwdRoot = path.resolve(this.#cwd) + path.sep;
+			const cwdRoot = discoveryCwd + path.sep;
 			const projectWarnings = (result.warnings ?? []).filter(warning => warning.includes(cwdRoot));
 			for (const warning of projectWarnings) {
 				if (this.#projectSettingsWarningsSeen.has(warning)) continue;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1822,10 +1822,16 @@ export class Settings {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
 			// `loadCapability` aggregates warnings across every level, but this
 			// method only merges project items — user-level parse failures belong
-			// to the global layer and would misattribute here. Project files live
-			// under the cwd, so scope to warnings referencing it, and remember
-			// what was surfaced so reloads stay quiet while new failures still log.
-			const projectWarnings = (result.warnings ?? []).filter(warning => warning.includes(this.#cwd));
+			// to the global layer and would misattribute here. Warnings embed
+			// their source file's absolute path, so keep only warnings rooted at
+			// the resolved cwd (a bare substring would over-match relative
+			// scopes such as `cwd: "."` and sibling dir prefixes). Remember what
+			// was surfaced so reloads stay quiet while new failures still log.
+			// Level attribution below the path layer (e.g. a user-scoped dir
+			// mounted inside the project) needs warning metadata from the
+			// providers, which `LoadResult.warnings` does not carry.
+			const cwdRoot = path.resolve(this.#cwd) + path.sep;
+			const projectWarnings = (result.warnings ?? []).filter(warning => warning.includes(cwdRoot));
 			for (const warning of projectWarnings) {
 				if (this.#projectSettingsWarningsSeen.has(warning)) continue;
 				logger.warn(`Settings: ${warning}`);

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -490,6 +490,8 @@ export class Settings {
 	#configOverlay: RawSettings = {};
 	/** Project settings file that most recently supplied shellPath. */
 	#projectShellPathSource: string | undefined;
+	/** Capability warnings already surfaced for the current project scope; reloads stay quiet. */
+	#projectSettingsWarningsSeen = new Set<string>();
 	/** Explicit config overlay that most recently supplied shellPath. */
 	#overlayShellPathSource: string | undefined;
 	/** Runtime overrides (not persisted) */
@@ -1818,9 +1820,17 @@ export class Settings {
 		let merged: RawSettings = {};
 		try {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
-			for (const warning of result.warnings ?? []) {
+			// `loadCapability` aggregates warnings across every level, but this
+			// method only merges project items — user-level parse failures belong
+			// to the global layer and would misattribute here. Project files live
+			// under the cwd, so scope to warnings referencing it, and remember
+			// what was surfaced so reloads stay quiet while new failures still log.
+			const projectWarnings = (result.warnings ?? []).filter(warning => warning.includes(this.#cwd));
+			for (const warning of projectWarnings) {
+				if (this.#projectSettingsWarningsSeen.has(warning)) continue;
 				logger.warn(`Settings: ${warning}`);
 			}
+			this.#projectSettingsWarningsSeen = new Set(projectWarnings);
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level === "project") {
 					merged = this.#deepMerge(merged, dropSettingsGroupShadows(item.data as RawSettings, item.path));

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1835,7 +1835,7 @@ export class Settings {
 			// Level attribution below the path layer (e.g. a user-scoped dir
 			// mounted inside the project) needs warning metadata from the
 			// providers, which `LoadResult.warnings` does not carry.
-			const cwdRoot = discoveryCwd + path.sep;
+			const cwdRoot = discoveryCwd.endsWith(path.sep) ? discoveryCwd : discoveryCwd + path.sep;
 			const projectWarnings = (result.warnings ?? []).filter(warning => warning.includes(cwdRoot));
 			for (const warning of projectWarnings) {
 				if (this.#projectSettingsWarningsSeen.has(warning)) continue;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1818,6 +1818,9 @@ export class Settings {
 		let merged: RawSettings = {};
 		try {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
+			for (const warning of result.warnings ?? []) {
+				logger.warn(`Settings: ${warning}`);
+			}
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level === "project") {
 					merged = this.#deepMerge(merged, dropSettingsGroupShadows(item.data as RawSettings, item.path));

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -21,7 +21,7 @@ import * as discovery from "@oh-my-pi/pi-coding-agent/discovery";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/tools/image-providers";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
-import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
 import * as fileLock from "@oh-my-pi/pi-utils/file-lock";
 import { YAML } from "bun";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -2363,6 +2363,24 @@ describe("Settings", () => {
 
 			settings.override("extensions", ["../override-ext"]);
 			expect(settings.extensionsSourceLevel()).toBe("user");
+		});
+	});
+
+	describe("project .claude/settings.json parse warnings", () => {
+		it("logs capability warnings when project settings.json fails to parse", async () => {
+			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
+			fs.mkdirSync(path.dirname(claudeSettings), { recursive: true });
+			fs.writeFileSync(claudeSettings, '{ "symbolPreset": "ascii", }');
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+			expect(settings.get("symbolPreset")).toBe("unicode");
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringMatching(/Settings: \[Claude Code\] Failed to parse JSON in .*settings\.json/),
+			);
+
+			warnSpy.mockRestore();
 		});
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -2382,5 +2382,37 @@ describe("Settings", () => {
 
 			warnSpy.mockRestore();
 		});
+
+		it("drops user-level warnings that #readProjectSettings does not merge", async () => {
+			const projectSettingsJson = path.join(projectDir, ".claude", "settings.json");
+			vi.spyOn(discovery, "loadCapability").mockResolvedValue({
+				items: [],
+				all: [],
+				warnings: [
+					`[Claude Code] Failed to parse JSON in ${path.join(tempDir.path(), "home", ".claude", "settings.json")}`,
+					`[Claude Code] Failed to parse JSON in ${projectSettingsJson}`,
+				],
+				providers: [],
+			});
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(projectSettingsJson));
+			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("home"))).toEqual([]);
+		});
+
+		it("logs a persistently malformed project file once across reloads", async () => {
+			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
+			fs.mkdirSync(path.dirname(claudeSettings), { recursive: true });
+			fs.writeFileSync(claudeSettings, '{ "symbolPreset": "ascii", }');
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to parse JSON"))).toHaveLength(1);
+
+			await settings.reloadFromDisk();
+			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to parse JSON"))).toHaveLength(1);
+		});
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -2390,6 +2390,7 @@ describe("Settings", () => {
 				all: [],
 				warnings: [
 					`[Claude Code] Failed to parse JSON in ${path.join(tempDir.path(), "home", ".claude", "settings.json")}`,
+					"[Claude Code] Failed to load: boom",
 					`[Claude Code] Failed to parse JSON in ${projectSettingsJson}`,
 				],
 				providers: [],
@@ -2399,6 +2400,7 @@ describe("Settings", () => {
 			await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
 			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(projectSettingsJson));
 			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("home"))).toEqual([]);
+			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to load"))).toEqual([]);
 		});
 
 		it("logs a persistently malformed project file once across reloads", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -2369,7 +2369,6 @@ describe("Settings", () => {
 	describe("project .claude/settings.json parse warnings", () => {
 		it("logs capability warnings when project settings.json fails to parse", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
-			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
 			await Bun.write(claudeSettings, '{ "symbolPreset": "ascii", }');
 
 			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
@@ -2420,7 +2419,6 @@ describe("Settings", () => {
 
 		it("logs a persistently malformed project file once across reloads", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
-			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
 			await Bun.write(claudeSettings, '{ "symbolPreset": "ascii", }');
 
 			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
@@ -2434,7 +2432,6 @@ describe("Settings", () => {
 
 		it("surfaces a project file that becomes malformed after startup", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
-			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
 
 			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -2403,6 +2403,21 @@ describe("Settings", () => {
 			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to load"))).toEqual([]);
 		});
 
+		it("logs project warnings when the cwd is a filesystem root", async () => {
+			const root = path.parse(projectDir).root;
+			const rootSettingsJson = path.join(root, ".claude", "settings.json");
+			vi.spyOn(discovery, "loadCapability").mockResolvedValue({
+				items: [],
+				all: [],
+				warnings: [`[Claude Code] Failed to parse JSON in ${rootSettingsJson}`],
+				providers: [],
+			});
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			await Settings.init({ cwd: root, agentDir, inMemory: true });
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(rootSettingsJson));
+		});
+
 		it("logs a persistently malformed project file once across reloads", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
 			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -2369,8 +2369,8 @@ describe("Settings", () => {
 	describe("project .claude/settings.json parse warnings", () => {
 		it("logs capability warnings when project settings.json fails to parse", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
-			fs.mkdirSync(path.dirname(claudeSettings), { recursive: true });
-			fs.writeFileSync(claudeSettings, '{ "symbolPreset": "ascii", }');
+			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
+			await Bun.write(claudeSettings, '{ "symbolPreset": "ascii", }');
 
 			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
@@ -2405,8 +2405,8 @@ describe("Settings", () => {
 
 		it("logs a persistently malformed project file once across reloads", async () => {
 			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
-			fs.mkdirSync(path.dirname(claudeSettings), { recursive: true });
-			fs.writeFileSync(claudeSettings, '{ "symbolPreset": "ascii", }');
+			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
+			await Bun.write(claudeSettings, '{ "symbolPreset": "ascii", }');
 
 			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
@@ -2415,6 +2415,21 @@ describe("Settings", () => {
 
 			await settings.reloadFromDisk();
 			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to parse JSON"))).toHaveLength(1);
+		});
+
+		it("surfaces a project file that becomes malformed after startup", async () => {
+			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
+			await fsp.mkdir(path.dirname(claudeSettings), { recursive: true });
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(warnSpy.mock.calls.filter(args => String(args[0]).includes("Failed to parse JSON"))).toHaveLength(0);
+
+			await Bun.write(claudeSettings, '{ "symbolPreset": "ascii", }');
+			await settings.reloadFromDisk();
+
+			expect(settings.get("symbolPreset")).toBe("unicode");
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(claudeSettings));
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Surface capability `LoadResult.warnings` in `#readProjectSettings` via `logger.warn`, matching the existing group-shadow warning channel.
- Malformed project `.claude/settings.json` files no longer fail silently: settings stay at defaults, but the parse warning is recorded.

Fixes #11570

## Test plan
- [x] `bun test test/settings-manager.test.ts --test-name-pattern "logs capability warnings"`
- [x] Trailing-comma `.claude/settings.json` fixture: warning logged, `symbolPreset` stays default `unicode`


Made with [Cursor](https://cursor.com)