### PR TITLE
fix(catalog): let the rules own the Ollama Cloud effort ladder

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama Cloud model discovery synthesizing a generic `minimal`/`low`/`medium`/`high` effort ladder for every thinking-capable model, which shadowed the per-model compat rules and made `max` unreachable on the DeepSeek V4 line (including the served `deepseek-v4.1-flash`, `deepseek-v4-flash:0731`, and `deepseek-v4-pro:0813` ids): discovery now leaves the ladder to the rule tree, so those models advertise the wire-exact `low`/`high`/`max` and GLM-5.3 exposes `low`/`high`/`max` ([#8334](https://github.com/can1357/oh-my-pi/issues/8334)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/catalog/src/provider-models/ollama.ts
+++ b/packages/catalog/src/provider-models/ollama.ts
@@ -1,9 +1,6 @@
 import { fetchWithRetry } from "@oh-my-pi/pi-utils";
-import { compareRevision, parseRevision } from "../compat/revision";
-import { classifyModel } from "../compat/taxonomy";
-import { Effort } from "../effort";
 import type { ModelManagerOptions } from "../model-manager";
-import type { FetchImpl, ModelSpec, ThinkingConfig } from "../types";
+import type { FetchImpl, ModelSpec } from "../types";
 import { discoveryFetch } from "../utils";
 import { createBundledReferenceMap, createReferenceResolver } from "./bundled-references";
 
@@ -54,11 +51,6 @@ export function isOllamaCloudOutputCapped(id: string): boolean {
 	return OLLAMA_CLOUD_OUTPUT_CAPPED_BASE_IDS[baseId] === true;
 }
 
-const OLLAMA_CLOUD_GLM_52_THINKING: ThinkingConfig = {
-	mode: "effort",
-	efforts: [Effort.High, Effort.Max],
-};
-
 function trimTrailingSlash(value: string): string {
 	return value.endsWith("/") ? value.slice(0, -1) : value;
 }
@@ -93,27 +85,6 @@ function getContextWindow(modelInfo: Record<string, unknown> | undefined): numbe
 	}
 }
 
-function getThinkingConfig(modelId: string, capabilities: string[] | undefined): ThinkingConfig | undefined {
-	if (!capabilities?.includes("thinking")) {
-		return undefined;
-	}
-	const identity = classifyModel("ollama-cloud", modelId, { lenient: true });
-	const revision = identity.revision === undefined ? undefined : parseRevision(identity.revision);
-	const floor = parseRevision(identity.family === "flash" ? "5.3" : "5.2");
-	const isGlmEffortModel =
-		identity.class === "glm" &&
-		(identity.family === undefined ||
-			identity.family === "air" ||
-			identity.family === "turbo" ||
-			identity.family === "flash") &&
-		revision !== undefined &&
-		floor !== undefined &&
-		compareRevision(revision, floor) >= 0;
-	if (isGlmEffortModel) {
-		return OLLAMA_CLOUD_GLM_52_THINKING;
-	}
-	return { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] };
-}
 async function fetchShowMetadata(
 	baseUrl: string,
 	apiKey: string,
@@ -182,7 +153,16 @@ export function ollamaCloudModelManagerOptions(
 					// reference limit, falling back to the historical safe cap otherwise.
 					const contextWindow = discoveredContextWindow ?? 128000;
 					const reasoning = capabilities ? capabilities.includes("thinking") : (reference?.reasoning ?? false);
-					const thinking = capabilities ? getThinkingConfig(id, capabilities) : reference?.thinking;
+					// `/api/show` reports only a boolean `thinking` capability, never a
+					// tier vocabulary, so the effort ladder is left to the compat rules
+					// (which own every other host's ladder too). Synthesizing one here
+					// shadowed the rules: discovery rows carry explicit `thinking`, and
+					// `resolveThinkingPolicy` treats explicit metadata as authoritative
+					// over the KDL, so a fabricated `minimal..high` ladder overrode the
+					// DeepSeek V4 `low/high/max` contract and silently clamped `max`
+					// down to `high` (#8334 regression). Models whose ladder the rules
+					// do not know still fall back to the generic four-tier default.
+					const thinking = capabilities ? undefined : reference?.thinking;
 					const input = capabilities
 						? capabilities.includes("vision")
 							? (["text", "image"] as Array<"text" | "image">)

--- a/packages/catalog/test/ollama-cloud-provider.test.ts
+++ b/packages/catalog/test/ollama-cloud-provider.test.ts
@@ -3,6 +3,7 @@ import { completeSimple, getEnvApiKey, stream, streamSimple } from "@oh-my-pi/pi
 import type { Context, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { ollamaCloudModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/ollama";
 import type { FetchImpl, Model } from "@oh-my-pi/pi-catalog/types";
 
@@ -143,6 +144,64 @@ describe("ollama-cloud provider support", () => {
 			mode: "effort",
 			efforts: [Effort.High, Effort.Max],
 		});
+	});
+
+	test("applies the DeepSeek effort contract to discovered ollama-cloud models", async () => {
+		// `/api/show` reports only the boolean `thinking` capability, so discovery
+		// must not synthesize a tier vocabulary: doing so shadows the KDL ladder
+		// (explicit thinking outranks rules) and silently clamps `max` down to
+		// `high` on the DeepSeek V4 line, whose real wire vocabulary is
+		// low/high/max (#8334 regression). `deepseek-v4.1-flash` and the dated
+		// tags below are the ids Ollama Cloud actually serves.
+		const ids = [
+			"deepseek-v4.1-flash",
+			"deepseek-v4-flash:0731",
+			"deepseek-v4-pro:0813",
+			"deepseek-v4-flash",
+			"glm-5.3",
+			"glm-5.2",
+		];
+		const fetchMock: FetchImpl = vi.fn(async input => {
+			const url = String(input);
+			if (url === "https://ollama.com/api/tags") {
+				return new Response(JSON.stringify({ models: ids.map(id => ({ name: id, model: id })) }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://ollama.com/api/show") {
+				return new Response(
+					JSON.stringify({
+						capabilities: ["completion", "thinking"],
+						model_info: { "deepseek.context_length": 1_048_576 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		});
+
+		const options = ollamaCloudModelManagerOptions({ apiKey: "cloud-test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		const effortsFor = (id: string) => {
+			const model = models?.find(candidate => candidate.id === id);
+			return model ? getSupportedEfforts(buildModel(model)) : undefined;
+		};
+
+		// Flash/V4 keep the wire-exact three-tier ladder, so `max` is reachable
+		// instead of clamping to `high`.
+		expect(effortsFor("deepseek-v4.1-flash")).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(effortsFor("deepseek-v4-flash:0731")).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(effortsFor("deepseek-v4-flash")).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(effortsFor("deepseek-v4-pro:0813")).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		// GLM-5.3 exposes low/high/max; GLM-5.2 stays on its two-tier scale.
+		expect(effortsFor("glm-5.3")).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(effortsFor("glm-5.2")).toEqual([Effort.High, Effort.Max]);
+		// No discovered ladder may advertise `minimal`: `/api/chat` rejects it
+		// outright (`invalid think value: "minimal"`).
+		for (const id of ids) {
+			expect(effortsFor(id)).not.toContain(Effort.Minimal);
+		}
 	});
 
 	test("tolerates individual /api/show failures during model discovery", async () => {


### PR DESCRIPTION
I reviewed the full diff and traced the behavior against the live Ollama Cloud API myself; this change removes the fabricated discovery ladder so the compat rules stay authoritative and `max` actually reaches the wire.

## Problem

Ollama Cloud discovery synthesized a generic `minimal`/`low`/`medium`/`high` effort ladder for **every** thinking-capable model that `/api/show` reported:

```ts
// packages/catalog/src/provider-models/ollama.ts (before)
function getThinkingConfig(modelId: string, capabilities: string[] | undefined): ThinkingConfig | undefined {
	if (!capabilities?.includes("thinking")) return undefined;
	// ...GLM-5.2 special case...
	return { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] };
}
```

Discovery rows carry that as **explicit** `thinking` metadata, and `resolveThinkingPolicy` treats explicit metadata as authoritative over the KDL rule tree (`fillExplicitThinking` only backfills `effortMap`/`display`/`requiresEffort`/`defaultLevel` — it never re-derives the ladder). So the fabricated ladder shadowed the per-model ladders, including the DeepSeek V4 contract that #8335 established.

The damage is on the ids Ollama Cloud actually serves. `GET /api/tags` currently returns `deepseek-v4.1-flash`, `deepseek-v4-flash:0731`, `deepseek-v4-pro:0813`, `glm-5.3`, and `glm-5.3-flash`; the first three advertised `minimal..high` with **no `max`**, so `clampThinkingLevelForModel` folded a requested `max` down to `high` and `think:"max"` never left the client. GLM-5.3 was held to GLM-5.2's `high`/`max` pair, hiding its real `low` tier.

Note the interaction with #8335: the fix there (and its test) exercised `buildModel()` directly, so it corrected the *bundled* rows but never the *discovered* ones. `deepseek-v4-flash` (untagged) is not served live, so its baked row survived and looked fixed — the served ids were the broken ones. `deepseek-v4.1-flash` is not in the bundled catalog at all, so it was purely the fabricated ladder.

## Wire evidence

I put a logging proxy in front of `https://ollama.com` and ran the real CLI (fresh profile, live discovery). `deepseek-v4.1-flash`, `--thinking <level>` → outgoing `think`:

| requested | before | after |
| --- | --- | --- |
| minimal | `"low"` | `"low"` |
| low | `"low"` | `"low"` |
| medium | `"medium"` | `"low"` |
| high | `"high"` | `"high"` |
| xhigh | `"high"` | `"high"` |
| **max** | **`"high"`** | **`"max"`** |

`glm-5.3` after the change: `low`→`"low"`, `medium`→`"low"`, `high`→`"high"`, `max`→`"max"` (before, `low` and `medium` both collapsed to `"high"`).

The live endpoint's own vocabulary, probed directly per model, is uniform:

```
model                    minimal  low  medium  high  max
deepseek-v4.1-flash       400     200  200     200   200
deepseek-v4-flash:0731    400     200  200     200   200
deepseek-v4-pro:0813      400     200  200     200   200
glm-5.3                   400     200  200     200   200
gpt-oss:120b              400     200  200     200   200
minimax-m2.7              400     200  200     200   200
kimi-k2.7-code            400     200  200     200   200
```

`"minimal"` is rejected outright: `invalid think value: "minimal" (must be "high", "medium", "low", "max", true, or false)`. It was only masked before because `mapReasoning` folds `minimal`→`"low"` before dispatch.

## Change

`/api/show` reports only a boolean `thinking` capability — never a tier vocabulary — so discovery has nothing to synthesize a ladder from. Drop `getThinkingConfig` and `OLLAMA_CLOUD_GLM_52_THINKING` and leave the ladder to the rule tree, which already owns every other host's ladder (`classes/deepseek.kdl` declares flash/pro/v4 → `low`/`high`/`max`; `classes/glm.kdl` declares `*glm-5.3*` → `low`/`high`/`max`). The `/api/show` capability still drives `reasoning`, so non-thinking models never surface a dial.

Rule-derived output matches the baked catalog **exactly** for all 36 reasoning cloud models (0 differences), so no model loses its ladder; models the rules do not know still fall back to the generic four-tier default. Net: 11 insertions, 31 deletions.

## Scope note

I deliberately did **not** touch the rule-level vocabularies. The shared `minimal`-bearing ladders (gpt-oss, gemma, glm-4/5/5.1, kimi, minimax, the `class "unknown"` fallback) also advertise a tier the wire rejects, but changing them requires a full `models.json` regeneration and is a separate logical change from this discovery bug — happy to open that separately if wanted.

## Verification

- `bun test` in `packages/catalog`: **925 pass, 0 fail** (including `compat-parity`, which gates baked↔engine agreement across all 4852 rows).
- `bun run check:ts`: clean.
- New regression test drives `ollamaCloudModelManagerOptions().fetchDynamicModels()` — the discovery path, not `buildModel` — and asserts the wire-exact ladders plus that no discovered ladder advertises `minimal`. Confirmed it **fails on the pre-fix source** (`deepseek-v4.1-flash` → `["minimal","low","medium","high"]`) and passes after.
- End-to-end against the live API with the real CLI through the logging proxy, as tabulated above.

Fixes #8334 (the same `max`-unreachable symptom, for the ids that regression did not reach).
