### PR TITLE
fix(install): stop native stderr aborting install.ps1 on PowerShell 5.1

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Windows PowerShell installer (`install.ps1`) aborting on Windows PowerShell 5.1 when bun or git wrote normal progress to stderr: native commands now run with `$ErrorActionPreference` scoped to `Continue` and success is gated on the process exit code, so `$ErrorActionPreference = "Stop"`'s stderr-as-terminating-error behavior no longer kills the install ([#11675](https://github.com/can1357/oh-my-pi/issues/11675)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -26,6 +26,23 @@ if ($NativeArchitecture -notin @("x64", "arm64")) {
 $BinaryName = "omp-windows-$NativeArchitecture.exe"
 $MinimumBunVersion = "1.3.14"
 
+# PowerShell 5.1 raises a terminating NativeCommandError for any line a native
+# executable writes to stderr while $ErrorActionPreference is "Stop", regardless
+# of the process exit code. Tools like bun and git emit normal progress on
+# stderr, so run them with the preference relaxed to "Continue" and let callers
+# gate on $LASTEXITCODE. Global "Stop" stays in effect for the cmdlet-driven
+# operations (Invoke-WebRequest/Invoke-RestMethod) that depend on it.
+function Invoke-Native {
+    param([Parameter(Mandatory = $true)][scriptblock]$Command)
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $Command
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
 function Test-BunInstalled {
     try {
         $null = Get-Command bun -ErrorAction Stop
@@ -169,7 +186,7 @@ function Configure-BashShell {
 
 function Install-Bun {
     Write-Host "Installing bun..."
-    irm bun.sh/install.ps1 | iex
+    Invoke-Native { irm bun.sh/install.ps1 | iex }
     # Refresh PATH
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
     Assert-BunVersion $MinimumBunVersion
@@ -187,19 +204,18 @@ function Install-ViaBun {
 
         try {
             $repoUrl = "https://github.com/$Repo.git"
-            $cloneOk = $false
-            try {
-                git clone --depth 1 --branch $Ref $repoUrl $tmpRoot | Out-Null
-                $cloneOk = $true
-            } catch {
-                $cloneOk = $false
-            }
-
-            if (-not $cloneOk) {
-                git clone $repoUrl $tmpRoot | Out-Null
+            Invoke-Native { git clone --depth 1 --branch $Ref $repoUrl $tmpRoot 2>&1 | Out-Null }
+            if ($LASTEXITCODE -ne 0) {
+                Invoke-Native { git clone $repoUrl $tmpRoot 2>&1 | Out-Null }
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Failed to clone $repoUrl"
+                }
                 Push-Location $tmpRoot
                 try {
-                    git checkout $Ref | Out-Null
+                    Invoke-Native { git checkout $Ref 2>&1 | Out-Null }
+                    if ($LASTEXITCODE -ne 0) {
+                        throw "Failed to checkout $Ref"
+                    }
                 } finally {
                     Pop-Location
                 }
@@ -209,7 +225,7 @@ function Install-ViaBun {
             if (Test-GitLfsInstalled) {
                 Push-Location $tmpRoot
                 try {
-                    git lfs pull | Out-Null
+                    Invoke-Native { git lfs pull 2>&1 | Out-Null }
                 } finally {
                     Pop-Location
                 }
@@ -220,7 +236,7 @@ function Install-ViaBun {
                 throw "Expected package at $packagePath"
             }
 
-            bun install -g $packagePath
+            Invoke-Native { bun install -g $packagePath }
             if ($LASTEXITCODE -ne 0) {
                 throw "Failed to install from $packagePath via bun"
             }
@@ -228,7 +244,7 @@ function Install-ViaBun {
             Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
         }
     } else {
-        bun install -g $Package
+        Invoke-Native { bun install -g $Package }
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to install $Package via bun"
         }


### PR DESCRIPTION
## Repro
On Windows PowerShell 5.1 (Desktop), the documented one-liner `irm https://omp.sh/install.ps1 | iex` fails deterministically (reporter: 3/3, Win11 build 26100, PS 5.1.26100.9444). Running the downloaded script directly surfaces the real culprit:

```
bun : Resolving dependencies
At <path>\install.ps1:231 char:9
+         bun install -g $Package
    + FullyQualifiedErrorId : NativeCommandError
```

## Cause
`scripts/install.ps1` sets `$ErrorActionPreference = "Stop"` process-wide. Under `Stop`, PowerShell 5.1 turns *any* line a native executable writes to stderr into a terminating `NativeCommandError`, regardless of the process exit code. `bun install -g`'s normal `Resolving dependencies` progress goes to stderr, so PowerShell kills the install before the existing `if ($LASTEXITCODE -ne 0)` guard in `Install-ViaBun` ever runs. The `-Ref` source path hits the same trap through `git clone`'s stderr progress (its `try/catch` was actually being driven by that stderr-as-exception behavior). This is distinct from #11531 (closed, unmerged docs workaround): the preference is set *inside* the script, so a fresh subshell does not help.

## Fix
- Add an `Invoke-Native` helper that scopes `$ErrorActionPreference` to `"Continue"` around a native invocation and restores it afterward.
- Route `bun install -g` (both default and `-Ref` paths), the bun bootstrap `irm | iex`, `git clone`/`git checkout`, and `git lfs pull` through it; success is gated on `$LASTEXITCODE` (the `-Ref` clone fallback now branches on the exit code instead of a swallowed exception).
- Global `Stop` stays in effect for the cmdlet-driven downloads (`Invoke-WebRequest`/`Invoke-RestMethod`) that rely on it.

## Verification
Windows PowerShell 5.1 cannot run on the Linux fix worktree, and pwsh 7 removed the stderr-as-terminating-error behavior, so the exact 5.1 stderr trigger is not reproducible here. Verified with pwsh 7.4.6:
- `Parser::ParseFile` on the patched `install.ps1` -> `PARSE OK`.
- Behavioral test of the helper's invariants (using pwsh's `$PSNativeCommandUseErrorActionPreference` exit-code analog of the trap): a bare native failure under `Stop` terminates before the guard; the same call through `Invoke-Native` reaches the guard with `$LASTEXITCODE` propagated correctly through `2>&1 | Out-Null` (0 on success, 7 on real failure); global `Stop` is restored after the helper returns; and the invoked scriptblock resolves enclosing-scope variables (`$Package`).

Fixes #11675