### PR TITLE
fix(settings): clear agent.db settings after config.yml migration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Models whose images are stripped on the wire (`compat.stripImageInput`) now trigger the `describeForTextModels` vision fallback and are skipped when resolving the vision model, instead of silently dropping images ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
+- Legacy `agent.db` settings rows are deleted after a successful `config.yml` migration write, so deleting `config.yml` no longer silently resurrects stale values ([#11568](https://github.com/can1357/oh-my-pi/issues/11568)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1954,6 +1954,11 @@ export class Settings {
 			try {
 				await this.#writeYamlAtomically(this.#configPath, settings);
 				logger.debug("Settings: migrated to config.yml", { path: this.#configPath });
+				try {
+					this.#storage?.clearMigratedSettings();
+				} catch (error) {
+					logger.warn("Settings: failed to clear migrated agent.db settings", { error: String(error) });
+				}
 			} catch {}
 		}
 	}

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -469,6 +469,15 @@ FROM model_usage_legacy
 	}
 
 	/**
+	 * Drops legacy `settings` rows after they have been written to config.yml.
+	 * The table is only a migration source; leaving rows would resurrect values
+	 * if config.yml is later deleted.
+	 */
+	clearMigratedSettings(): void {
+		this.#db.run("DELETE FROM settings");
+	}
+
+	/**
 	 * Records model usage, updating the last-used timestamp.
 	 * @param modelKey - Model key in "provider/modelId" format
 	 */

--- a/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
+++ b/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
@@ -108,11 +108,9 @@ describe("AgentStorage SQLite compatibility", () => {
 				updated_at INTEGER NOT NULL DEFAULT 0
 			);
 		`);
-		seed.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)").run(
-			"theme",
-			'"dark"',
-			LEGACY_TIMESTAMP,
-		);
+		seed
+			.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)")
+			.run("theme", '"dark"', LEGACY_TIMESTAMP);
 		seed.close();
 
 		const storage = await AgentStorage.open(dbPath);

--- a/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
+++ b/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
@@ -96,4 +96,29 @@ describe("AgentStorage SQLite compatibility", () => {
 		expect(storage.getModelUsageOrder()).toEqual(["anthropic/claude-sonnet-4-5"]);
 		expect(readSettingsRows(dbPath)).toEqual([{ key: "theme", value: '"dark"', updated_at: LEGACY_TIMESTAMP }]);
 	});
+
+	it("clears migrated settings rows", async () => {
+		tempDir = TempDir.createSync("@omp-agent-storage-clear-settings-");
+		const dbPath = path.join(tempDir.path(), "agent.db");
+		const seed = new Database(dbPath);
+		seed.exec(`
+			CREATE TABLE settings (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL,
+				updated_at INTEGER NOT NULL DEFAULT 0
+			);
+		`);
+		seed.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)").run(
+			"theme",
+			'"dark"',
+			LEGACY_TIMESTAMP,
+		);
+		seed.close();
+
+		const storage = await AgentStorage.open(dbPath);
+		expect(storage.getSettings()).toEqual({ theme: "dark" });
+		storage.clearMigratedSettings();
+		expect(storage.getSettings()).toBeNull();
+		expect(readSettingsRows(dbPath)).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
@@ -21,7 +22,7 @@ import * as discovery from "@oh-my-pi/pi-coding-agent/discovery";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/tools/image-providers";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
-import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
 import * as fileLock from "@oh-my-pi/pi-utils/file-lock";
 import { YAML } from "bun";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -2192,6 +2193,40 @@ describe("Settings", () => {
 			expect(fs.existsSync(jsonPath)).toBe(false);
 			expect(fs.existsSync(`${jsonPath}.bak`)).toBe(true);
 		});
+
+		it("does not resurrect agent.db settings after config.yml is deleted", async () => {
+			const dbPath = getAgentDbPath(agentDir);
+			const db = new Database(dbPath);
+			db.exec(`
+				CREATE TABLE settings (
+					key TEXT PRIMARY KEY,
+					value TEXT NOT NULL,
+					updated_at INTEGER NOT NULL DEFAULT 0
+				);
+			`);
+			db.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, 1)").run(
+				"symbolPreset",
+				JSON.stringify("ascii"),
+			);
+			db.close();
+
+			const first = await Settings.init({ cwd: projectDir, agentDir });
+			expect(first.get("symbolPreset")).toBe("ascii");
+			expect((await readSettings()).symbolPreset).toBe("ascii");
+
+			const storage = await AgentStorage.open(dbPath);
+			expect(storage.getSettings()).toBeNull();
+
+			await fs.promises.unlink(getConfigPath());
+			AgentStorage.close();
+			resetSettingsForTest();
+
+			const second = await Settings.init({ cwd: projectDir, agentDir });
+			expect(second.get("symbolPreset")).toBe("unicode");
+			expect(second.isConfigured("symbolPreset")).toBe(false);
+			expect(await Bun.file(getConfigPath()).exists()).toBe(false);
+		});
+
 		it("migrates legacy power booleans with system=true to system level", async () => {
 			await writeSettings({
 				power: {


### PR DESCRIPTION
## Summary
- After a successful `config.yml` migration write, delete the legacy `agent.db` `settings` rows that were just copied.
- Deleting `config.yml` is then a real fresh start: the next boot no longer silently rehydrates stale db values.

I reviewed the full diff; the resurrection was leftover `settings` rows being re-merged whenever `config.yml` was missing, and this PR removes that source only after the YAML write succeeds.

Companion of #11569 (write-before-rename / `.bak` recovery). Both PRs touch `#migrateFromLegacy`; merge #11569 first if both are accepted, then rebase this one so `clearMigratedSettings()` still runs only after the durable write.

Fixes #11568

## Test plan
- [x] `bun test test/settings-manager.test.ts --test-name-pattern "does not resurrect agent.db settings"` (1 pass)
- [x] `bun test test/agent-storage-sqlite-compat.test.ts` (3 pass)
- [x] `bun test test/settings-manager.test.ts` (120 pass)
- [x] Seed `agent.db` `symbolPreset=ascii`, migrate, confirm rows gone; delete `config.yml` and reload → default `unicode`, no new YAML


Made with [Cursor](https://cursor.com)