### PR TITLE
fix(ai): hoist Bedrock OpenAI tool-result images

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Amazon Bedrock OpenAI models rejecting image-bearing tool results by sending each image as a sibling user content block ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -924,6 +924,34 @@ function buildSystemPrompt(
 	return blocks;
 }
 
+function buildToolResultBlock(
+	message: ToolResultMessage,
+	model: Model<"bedrock-converse-stream">,
+	hoistedImages: ImageBlockWire[],
+): ToolResultBlockWire {
+	const content: Array<TextBlockWire | ImageBlockWire> = [];
+	for (const block of message.content) {
+		if (block.type === "image") {
+			const image: ImageBlockWire = { image: createImageBlock(block.mimeType, block.data) };
+			if (model.requiresToolResultImageHoisting) {
+				content.push({ text: "(see attached image)" });
+				hoistedImages.push(image);
+			} else {
+				content.push(image);
+			}
+		} else {
+			content.push({ text: block.text.toWellFormed() });
+		}
+	}
+	return {
+		toolResult: {
+			toolUseId: normalizeToolCallId(message.toolCallId),
+			content,
+			status: message.isError ? "error" : "success",
+		},
+	};
+}
+
 function convertMessages(
 	context: Context,
 	model: Model<"bedrock-converse-stream">,
@@ -1022,38 +1050,20 @@ function convertMessages(
 			case "toolResult": {
 				// Collect all consecutive toolResult messages into a single user message —
 				// Bedrock requires all tool results to be in one message.
-				const toolResults: ToolResultBlockWire[] = [];
-				toolResults.push({
-					toolResult: {
-						toolUseId: normalizeToolCallId(m.toolCallId),
-						content: m.content.map(c =>
-							c.type === "image"
-								? { image: createImageBlock(c.mimeType, c.data) }
-								: { text: c.text.toWellFormed() },
-						),
-						status: m.isError ? "error" : "success",
-					},
-				});
+				const contentBlocks: UserContent[] = [];
+				const hoistedImages: ImageBlockWire[] = [];
+				contentBlocks.push(buildToolResultBlock(m, model, hoistedImages));
 
 				let j = i + 1;
 				while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
 					const nextMsg = transformedMessages[j] as ToolResultMessage;
-					toolResults.push({
-						toolResult: {
-							toolUseId: normalizeToolCallId(nextMsg.toolCallId),
-							content: nextMsg.content.map(c =>
-								c.type === "image"
-									? { image: createImageBlock(c.mimeType, c.data) }
-									: { text: c.text.toWellFormed() },
-							),
-							status: nextMsg.isError ? "error" : "success",
-						},
-					});
+					contentBlocks.push(buildToolResultBlock(nextMsg, model, hoistedImages));
 					j++;
 				}
 				i = j - 1;
 
-				result.push({ role: "user", content: toolResults });
+				contentBlocks.push(...hoistedImages);
+				result.push({ role: "user", content: contentBlocks });
 				break;
 			}
 			default:

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/ai/test/bedrock-tool-result-image.test.ts
+++ b/packages/ai/test/bedrock-tool-result-image.test.ts
@@ -124,4 +124,19 @@ describe("Bedrock tool-result image placement", () => {
 		expect(nestedContent.some(block => Reflect.has(objectValue(block, "nested block"), "image"))).toBe(true);
 		expect(content.slice(1).some(block => Reflect.has(objectValue(block, "user block"), "image"))).toBe(false);
 	});
+
+	it("hoists images for opaque OpenAI inference-profile ARNs classified as unknown", async () => {
+		const arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/company-gpt-sol";
+		const target = model(arn);
+		expect(target.identity.class).toBe("unknown");
+		const content = finalUserContent(await capturePayload(target));
+		const toolResultBlock = objectValue(content[0], "tool result block");
+		const nestedContent = arrayField(
+			objectValue(Reflect.get(toolResultBlock, "toolResult"), "tool result"),
+			"content",
+		);
+
+		expect(nestedContent.some(block => Reflect.has(objectValue(block, "nested block"), "image"))).toBe(false);
+		expect(content.slice(1).some(block => Reflect.has(objectValue(block, "user block"), "image"))).toBe(true);
+	});
 });

--- a/packages/ai/test/bedrock-tool-result-image.test.ts
+++ b/packages/ai/test/bedrock-tool-result-image.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { AssistantMessage, Context, Model, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+const PNG_DATA = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+function model(id: string): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400_000,
+		maxTokens: 128_000,
+	});
+}
+
+function assistant(target: Model<"bedrock-converse-stream">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "call_read", name: "read", arguments: { path: "/tmp/t8.png" } }],
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		model: target.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
+function toolResult(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_read",
+		toolName: "read",
+		content: [
+			{ type: "text", text: "Read image file [image/png]" },
+			{ type: "image", data: PNG_DATA, mimeType: "image/png" },
+		],
+		isError: false,
+		timestamp: 2,
+	};
+}
+
+function objectValue(value: unknown, label: string): object {
+	if (typeof value !== "object" || value === null) throw new Error(`Expected ${label} to be an object`);
+	return value;
+}
+
+function arrayField(value: object, key: string): unknown[] {
+	const field: unknown = Reflect.get(value, key);
+	if (!Array.isArray(field)) throw new Error(`Expected ${key} to be an array`);
+	return field;
+}
+
+async function capturePayload(target: Model<"bedrock-converse-stream">): Promise<object> {
+	const context: Context = {
+		messages: [{ role: "user", content: "Read the image.", timestamp: 0 }, assistant(target), toolResult()],
+	};
+	const controller = new AbortController();
+	controller.abort();
+	const { promise, resolve } = Promise.withResolvers<object>();
+	void streamBedrock(target, context, {
+		bearerToken: "test-token",
+		signal: controller.signal,
+		onPayload: payload => resolve(objectValue(payload, "payload")),
+	});
+	return promise;
+}
+
+function finalUserContent(payload: object): unknown[] {
+	const messages = arrayField(payload, "messages");
+	const finalMessage = objectValue(messages.at(-1), "final message");
+	return arrayField(finalMessage, "content");
+}
+
+describe("Bedrock tool-result image placement", () => {
+	it("hoists OpenAI tool-result images into sibling user blocks", async () => {
+		const target = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", "global.openai.gpt-5.6-sol");
+		const content = finalUserContent(await capturePayload(target));
+		const toolResultBlock = objectValue(content[0], "tool result block");
+		const nestedContent = arrayField(
+			objectValue(Reflect.get(toolResultBlock, "toolResult"), "tool result"),
+			"content",
+		);
+		const siblingBlock = objectValue(
+			content.find(block => Reflect.has(objectValue(block, "user block"), "image")),
+			"sibling image block",
+		);
+		const image = objectValue(Reflect.get(siblingBlock, "image"), "image");
+		const source = objectValue(Reflect.get(image, "source"), "image source");
+
+		expect(nestedContent.some(block => Reflect.has(objectValue(block, "nested block"), "image"))).toBe(false);
+		expect(
+			nestedContent.some(
+				block => Reflect.get(objectValue(block, "nested block"), "text") === "Read image file [image/png]",
+			),
+		).toBe(true);
+		expect(content.indexOf(siblingBlock)).toBeGreaterThan(0);
+		expect(Reflect.get(source, "bytes")).toBe(PNG_DATA);
+	});
+
+	it("keeps Claude tool-result images nested", async () => {
+		const content = finalUserContent(await capturePayload(model("global.anthropic.claude-opus-5")));
+		const toolResultBlock = objectValue(content[0], "tool result block");
+		const nestedContent = arrayField(
+			objectValue(Reflect.get(toolResultBlock, "toolResult"), "tool result"),
+			"content",
+		);
+
+		expect(nestedContent.some(block => Reflect.has(objectValue(block, "nested block"), "image"))).toBe(true);
+		expect(content.slice(1).some(block => Reflect.has(objectValue(block, "user block"), "image"))).toBe(false);
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Amazon Bedrock OpenAI models now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
+- Amazon Bedrock OpenAI models, plus unclassified profiles such as opaque application-inference-profile ARNs, now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Amazon Bedrock OpenAI models now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -34,8 +34,8 @@ function isInputModalities(value: unknown): value is ("text" | "image")[] {
  * corrections (`cost-patch`, `limits-patch`, `long-context-cost`,
  * `context-window-floor`) overwrite upstream values; selection metadata
  * (`priority`, `apply-patch-tool-type`, `service-tier-cost`,
- * `requires-cursor-tool-schema-projection`) is rule-owned;
- * `context-promotion-target` fills only when the spec left it unset.
+ * `requires-cursor-tool-schema-projection`, `requires-tool-result-image-hoisting`)
+ * is rule-owned; `context-promotion-target` fills only when the spec left it unset.
  */
 function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: Record<string, unknown>): void {
 	const serviceTierCost = objectPayload(catalog.serviceTierCost);
@@ -62,6 +62,12 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 		model.requiresCursorToolSchemaProjection = true;
 	} else {
 		delete model.requiresCursorToolSchemaProjection;
+	}
+	const requiresToolResultImageHoisting = catalog.requiresToolResultImageHoisting;
+	if (requiresToolResultImageHoisting === true) {
+		model.requiresToolResultImageHoisting = true;
+	} else {
+		delete model.requiresToolResultImageHoisting;
 	}
 	const contextPromotionTarget = catalog.contextPromotionTarget;
 	if (typeof contextPromotionTarget === "string" && model.contextPromotionTarget === undefined) {

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -285,6 +285,11 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 		set: "catalog",
 		shape: "scalar",
 	},
+	"requires-tool-result-image-hoisting": {
+		key: "requiresToolResultImageHoisting",
+		set: "catalog",
+		shape: "scalar",
+	},
 	priority: { key: "priority", set: "catalog", shape: "scalar" },
 	"service-tier-cost": { key: "serviceTierCost", set: "catalog", shape: "object" },
 	"time-based-cost": { key: "timeBased", set: "catalog", shape: "object" },

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7140,10 +7140,13 @@
 				],
 				"thinking": {
 					"mode": "effort"
+				},
+				"catalog": {
+					"requiresToolResultImageHoisting": true
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:19",
+				"source": "providers/amazon-bedrock.kdl:21",
 				"class": "deepseek",
 				"providers": [
 					"amazon-bedrock"
@@ -7161,7 +7164,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:24",
+				"source": "providers/amazon-bedrock.kdl:26",
 				"class": "minimax",
 				"providers": [
 					"amazon-bedrock"
@@ -7172,7 +7175,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:28",
+				"source": "providers/amazon-bedrock.kdl:30",
 				"class": "unknown",
 				"providers": [
 					"amazon-bedrock"
@@ -7188,7 +7191,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:33",
+				"source": "providers/amazon-bedrock.kdl:35",
 				"providers": [
 					"amazon-bedrock"
 				],

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7188,10 +7188,13 @@
 						"high"
 					],
 					"mode": "budget"
+				},
+				"catalog": {
+					"requiresToolResultImageHoisting": true
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:35",
+				"source": "providers/amazon-bedrock.kdl:40",
 				"providers": [
 					"amazon-bedrock"
 				],

--- a/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
+++ b/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
@@ -30,6 +30,11 @@ provider "amazon-bedrock" {
 	class "unknown" {
 		thinking-efforts "minimal" "low" "medium" "high"
 		thinking-mode "budget"
+		// Opaque application-inference-profile ARNs carry no vendor signal, so an
+		// OpenAI-backed profile classifies here and would otherwise nest images in
+		// toolResult content and hit the same rejection. Hoisting is accepted by
+		// every Converse model measured, so it is the safe default for unknowns.
+		requires-tool-result-image-hoisting #true
 	}
 	// residue: taxonomy ranks and exact globs do not isolate these models.
 	models "moonshot.kimi-k2-thinking" {

--- a/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
+++ b/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
@@ -15,6 +15,8 @@ provider "amazon-bedrock" {
 	}
 	class "openai" {
 		thinking-mode "effort"
+		// OpenAI models reject Converse image blocks nested inside toolResult content.
+		requires-tool-result-image-hoisting #true
 	}
 	class "deepseek" {
 		requires-reasoning-content-for-all-assistant-turns #true

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -32218,7 +32218,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"cohere.command-r-v1:0": {
 			"id": "cohere.command-r-v1:0",
@@ -32248,7 +32249,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"deepseek.v3-v1:0": {
 			"id": "deepseek.v3-v1:0",
@@ -33973,7 +33975,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"google.gemma-3-4b-it": {
 			"id": "google.gemma-3-4b-it",
@@ -34004,7 +34007,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -34301,7 +34305,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"meta.llama3-1-70b-instruct-v1:0": {
 			"id": "meta.llama3-1-70b-instruct-v1:0",
@@ -34331,7 +34336,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"meta.llama3-1-8b-instruct-v1:0": {
 			"id": "meta.llama3-1-8b-instruct-v1:0",
@@ -34361,7 +34367,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"minimax.minimax-m2": {
 			"id": "minimax.minimax-m2",
@@ -34854,7 +34861,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"moonshotai.kimi-k2.5": {
 			"id": "moonshotai.kimi-k2.5",
@@ -34895,7 +34903,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"nvidia.nemotron-nano-12b-v2": {
 			"id": "nvidia.nemotron-nano-12b-v2",
@@ -34926,7 +34935,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"nvidia.nemotron-nano-3-30b": {
 			"id": "nvidia.nemotron-nano-3-30b",
@@ -34966,7 +34976,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"nvidia.nemotron-nano-9b-v2": {
 			"id": "nvidia.nemotron-nano-9b-v2",
@@ -34998,7 +35009,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"nvidia.nemotron-super-3-120b": {
 			"id": "nvidia.nemotron-super-3-120b",
@@ -35038,7 +35050,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"openai.gpt-oss-120b": {
 			"id": "openai.gpt-oss-120b",
@@ -36906,7 +36919,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama3-2-1b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-1b-instruct-v1:0",
@@ -36936,7 +36950,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama3-2-3b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-3b-instruct-v1:0",
@@ -36966,7 +36981,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama3-2-90b-instruct-v1:0": {
 			"id": "us.meta.llama3-2-90b-instruct-v1:0",
@@ -36997,7 +37013,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama3-3-70b-instruct-v1:0": {
 			"id": "us.meta.llama3-3-70b-instruct-v1:0",
@@ -37027,7 +37044,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama4-maverick-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-maverick-17b-instruct-v1:0",
@@ -37058,7 +37076,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"us.meta.llama4-scout-17b-instruct-v1:0": {
 			"id": "us.meta.llama4-scout-17b-instruct-v1:0",
@@ -37089,7 +37108,8 @@
 				"supportsLongPromptCacheRetention": false,
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"writer.palmyra-x4-v1:0": {
 			"id": "writer.palmyra-x4-v1:0",
@@ -37129,7 +37149,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"writer.palmyra-x5-v1:0": {
 			"id": "writer.palmyra-x5-v1:0",
@@ -37169,7 +37190,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"xai.grok-4.3": {
 			"id": "xai.grok-4.3",
@@ -37210,7 +37232,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"xai.grok-4.6": {
 			"id": "xai.grok-4.6",
@@ -37251,7 +37274,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"zai.glm-4.7": {
 			"id": "zai.glm-4.7",
@@ -37291,7 +37315,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"zai.glm-4.7-flash": {
 			"id": "zai.glm-4.7-flash",
@@ -37331,7 +37356,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"zai.glm-5": {
 			"id": "zai.glm-5",
@@ -37371,7 +37397,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		}
 	},
 	"anthropic": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -33853,7 +33853,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"global.openai.gpt-5.6-sol": {
 			"id": "global.openai.gpt-5.6-sol",
@@ -33896,7 +33897,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"global.openai.gpt-5.6-terra": {
 			"id": "global.openai.gpt-5.6-terra",
@@ -33939,7 +33941,8 @@
 				"promptCacheMinimumTokens": 0,
 				"promptCacheMaximumCheckpoints": 0,
 				"streamIdleTimeoutMs": 600000
-			}
+			},
+			"requiresToolResultImageHoisting": true
 		},
 		"google.gemma-3-27b-it": {
 			"id": "google.gemma-3-27b-it",

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1090,6 +1090,8 @@ export interface Model<TApi extends Api = Api> {
 	requiresGlyphTokenization?: boolean;
 	/** Whether this model requires Cursor's tool-schema combiner projection. */
 	requiresCursorToolSchemaProjection?: boolean;
+	/** Whether this model requires tool-result images hoisted into sibling user content blocks. */
+	requiresToolResultImageHoisting?: boolean;
 	/**
 	 * Model id to send on the wire when it differs from `id`. Used by catalog
 	 * variants that present one upstream model under several local entries —
@@ -1271,6 +1273,7 @@ export interface ModelSpec<TApi extends Api = Api> extends Omit<
 	| "compatConfig"
 	| "requiresGlyphTokenization"
 	| "requiresCursorToolSchemaProjection"
+	| "requiresToolResultImageHoisting"
 	| "supportsComputerUseConfig"
 > {
 	/** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */


### PR DESCRIPTION
## Repro

The captured Converse payload for `global.openai.gpt-5.6-sol` nested a valid PNG under `toolResult.content`; `bun test packages/ai/test/bedrock-tool-result-image.test.ts` failed with `Expected: false, Received: true` while the Claude control passed. As @srobroek reported: "Because compaction renders large tool output as PNG frames into exactly that position, every subagent whose own tool output is large enough to compact dies."

## Cause

`convertMessages` in `packages/ai/src/providers/amazon-bedrock.ts` encoded every `ToolResultMessage` image directly inside `ToolResultBlockWire.content`. Bedrock Converse accepts that shape for Claude but OpenAI deployments reject it, and the catalog had no model/provider compatibility policy to select the accepted sibling-block encoding.

## Fix

- Add `requiresToolResultImageHoisting` as a generated catalog compatibility axis for OpenAI models on `amazon-bedrock`.
- Replace nested image blocks with `(see attached image)` markers and append the unchanged image blocks after the enclosing message's complete tool-result run.
- Preserve Claude's accepted nested-image shape and cover both paths with serialized-payload regression tests.
- Document the fix in the AI and catalog changelogs.

## Verification

`bun test packages/ai/test/bedrock-*.test.ts` — 58 passed, 0 failed. `bun test packages/catalog/test/generated-policies.test.ts` — 30 passed, 0 failed. `bun check` — passed; the existing unused-variable lint warning in `packages/coding-agent/test/task/executor-subagent-reminders.test.ts` remains non-fatal. The original serialized-payload reproduction now passes for the bundled OpenAI model while the Claude control remains nested.

Fixes #11681