### PR TITLE
fix(ai): hoist tool-result images for Bedrock Converse OpenAI models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bedrock Converse rejecting every request that replays an image inside a tool result for the OpenAI models: `HTTP 400 "This model doesn't support the image field for user messages"`. Because compaction renders large tool output as PNG frames into exactly that position, any subagent whose own output was big enough to compact died on the next turn. The models do accept image input — the same bytes pass in a plain user block, and pass nested in a tool result when the model is reached over an OpenAI-compatible transport — so `convertMessages` now hoists those images into the enclosing user message, leaving a marker in the tool result. Anthropic on the same host accepts the nested form and is unchanged ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1022,38 +1022,52 @@ function convertMessages(
 			case "toolResult": {
 				// Collect all consecutive toolResult messages into a single user message —
 				// Bedrock requires all tool results to be in one message.
-				const toolResults: ToolResultBlockWire[] = [];
-				toolResults.push({
-					toolResult: {
-						toolUseId: normalizeToolCallId(m.toolCallId),
-						content: m.content.map(c =>
-							c.type === "image"
-								? { image: createImageBlock(c.mimeType, c.data) }
-								: { text: c.text.toWellFormed() },
-						),
-						status: m.isError ? "error" : "success",
-					},
-				});
+				//
+				// Some deployments refuse an image nested in `toolResult.content` and
+				// report it against the enclosing user message, because that is the
+				// envelope tool results ride in. Those images are hoisted after the
+				// tool-result run behind one marker block, matching what the Anthropic,
+				// openai-completions and codex encoders already do for the same reason.
+				const hoistImages = model.requiresToolResultImageHoisting === true;
+				const hoisted: ImageBlockWire[] = [];
+				const encodeToolResult = (msg: ToolResultMessage): ToolResultBlockWire => {
+					const content: Array<TextBlockWire | ImageBlockWire> = [];
+					for (const c of msg.content) {
+						if (c.type !== "image") {
+							content.push({ text: c.text.toWellFormed() });
+							continue;
+						}
+						const image = createImageBlock(c.mimeType, c.data);
+						if (hoistImages) hoisted.push({ image });
+						else content.push({ image });
+					}
+					// An image-only result empties the array, and Converse rejects that
+					// ("Invalid 'input': value did not match any expected variant"), so
+					// the block keeps a note in place of the bytes.
+					if (content.length === 0) content.push({ text: "[image hoisted below]" });
+					return {
+						toolResult: {
+							toolUseId: normalizeToolCallId(msg.toolCallId),
+							content,
+							status: msg.isError ? "error" : "success",
+						},
+					};
+				};
 
+				const content: Array<ToolResultBlockWire | TextBlockWire | ImageBlockWire> = [encodeToolResult(m)];
 				let j = i + 1;
 				while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
-					const nextMsg = transformedMessages[j] as ToolResultMessage;
-					toolResults.push({
-						toolResult: {
-							toolUseId: normalizeToolCallId(nextMsg.toolCallId),
-							content: nextMsg.content.map(c =>
-								c.type === "image"
-									? { image: createImageBlock(c.mimeType, c.data) }
-									: { text: c.text.toWellFormed() },
-							),
-							status: nextMsg.isError ? "error" : "success",
-						},
-					});
+					content.push(encodeToolResult(transformedMessages[j] as ToolResultMessage));
 					j++;
 				}
 				i = j - 1;
 
-				result.push({ role: "user", content: toolResults });
+				// Bedrock requires the tool results themselves to lead the message, so
+				// the marker and the images follow the whole run.
+				if (hoisted.length > 0) {
+					content.push({ text: "Attached image(s) from the tool result(s) above:" }, ...hoisted);
+				}
+				result.push({ role: "user", content });
 				break;
 			}
 			default:

--- a/packages/ai/test/bedrock-tool-result-images.test.ts
+++ b/packages/ai/test/bedrock-tool-result-images.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// Bedrock Converse rejects an image nested in `toolResult.content` for the
+// OpenAI models:
+//
+//   Bedrock HTTP 400: "This model doesn't support the image field for user
+//   messages."
+//
+// The text names user messages because convertMessages() collects tool results
+// into one, so it describes the envelope rather than the offending block. The
+// models accept image input fine — the same bytes pass in a plain user block,
+// and pass nested in a tool result when the same model is reached over an
+// OpenAI-compatible transport. Only the nesting is unsupported here.
+//
+// Compaction renders large tool output as PNG frames into exactly that
+// position, so every subagent whose own output was big enough to compact died
+// on the first replay. Those images are now hoisted into the enclosing user
+// message, which the same models accept.
+
+const PNG =
+	"iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
+
+// Built from real ids so the whole chain is under test: the KDL rule, the
+// compiled rule index, `buildModel`'s cascade, and the wire transform. Nothing
+// here sets the flag by hand — an id whose class the rule misses would fail
+// these cases rather than quietly keep the old behaviour.
+function bedrockModel(id: string): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		input: ["text", "image"],
+		cost: { input: 1, output: 1 },
+		contextWindow: 200000,
+		maxTokens: 4096,
+	} as never) as Model<"bedrock-converse-stream">;
+}
+
+const OPENAI = "global.openai.gpt-5.6-sol";
+const ANTHROPIC = "global.anthropic.claude-opus-5";
+
+function contextWithImageResults(count: number): Context {
+	const messages: Context["messages"] = [
+		{ role: "user", content: "Screenshot the page", timestamp: 0 },
+		{
+			role: "assistant",
+			content: Array.from({ length: count }, (_, n) => ({
+				type: "toolCall" as const,
+				id: `tu_${n}`,
+				name: "shot",
+				arguments: {},
+			})),
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+			model: OPENAI,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 1,
+		},
+	];
+	for (let n = 0; n < count; n++) {
+		messages.push({
+			role: "toolResult",
+			toolCallId: `tu_${n}`,
+			toolName: "shot",
+			content: [
+				{ type: "text", text: `frame ${n}` },
+				{ type: "image", data: PNG, mimeType: "image/png" },
+			],
+			isError: false,
+			timestamp: 2 + n,
+		});
+	}
+	return { messages };
+}
+
+type WireMessage = { role: string; content: Array<Record<string, unknown>> };
+
+async function capturePayload(model: Model<"bedrock-converse-stream">, context: Context): Promise<WireMessage[]> {
+	const controller = new AbortController();
+	controller.abort();
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	void streamBedrock(model, context, {
+		bearerToken: "test-token",
+		signal: controller.signal,
+		maxTokens: 16,
+		onPayload: payload => resolve(payload),
+	});
+	return ((await promise) as { messages: WireMessage[] }).messages;
+}
+
+describe("Bedrock tool-result images", () => {
+	test("hoists a nested image into the enclosing user message", async () => {
+		const messages = await capturePayload(bedrockModel(OPENAI), contextWithImageResults(1));
+		const userMessage = messages[messages.length - 1];
+		expect(userMessage.role).toBe("user");
+
+		// The tool result keeps its own text and no longer carries the image...
+		const toolResult = userMessage.content[0].toolResult as { content: Array<Record<string, unknown>> };
+		expect(toolResult.content).toEqual([{ text: "frame 0" }]);
+
+		// ...and the image follows the run behind the marker the Anthropic,
+		// openai-completions and codex encoders already use for this.
+		expect(userMessage.content[1]).toMatchObject({ text: "Attached image(s) from the tool result(s) above:" });
+		expect(userMessage.content[2]).toMatchObject({ image: { format: "png", source: { bytes: PNG } } });
+	});
+
+	test("leaves the image nested when the model accepts it there", async () => {
+		// Measured: claude-opus-5 accepts the nested form on this same API, so the
+		// rule must not reach it. Hoisting every Bedrock model would rewrite a
+		// request that already works.
+		const messages = await capturePayload(bedrockModel(ANTHROPIC), contextWithImageResults(1));
+		const userMessage = messages[messages.length - 1];
+		const toolResult = userMessage.content[0].toolResult as { content: Array<Record<string, unknown>> };
+		expect(toolResult.content[1]).toMatchObject({ image: { format: "png", source: { bytes: PNG } } });
+		// Nothing was hoisted: no image rides at the top level of the message.
+		// (Claude also gets a trailing cachePoint block here, which is unrelated.)
+		expect(userMessage.content.some(block => "image" in block)).toBe(false);
+	});
+
+	test("keeps every tool result ahead of the marker and the hoisted images", async () => {
+		// Bedrock requires the tool results to lead the message, so ordering is a
+		// wire constraint and not a preference. Verified against live Converse:
+		// two results plus two sibling images in one user message is accepted by
+		// sol, luna and claude.
+		const messages = await capturePayload(bedrockModel(OPENAI), contextWithImageResults(2));
+		const userMessage = messages[messages.length - 1];
+		expect(userMessage.content.map(block => Object.keys(block)[0])).toEqual([
+			"toolResult",
+			"toolResult",
+			"text",
+			"image",
+			"image",
+		]);
+		// One marker for the run, not one per result.
+		expect(userMessage.content.filter(block => "text" in block)).toHaveLength(1);
+	});
+
+	test("never leaves an image-only tool result with empty content", async () => {
+		// Converse rejects an empty tool-result content array outright:
+		// "Invalid 'input': value did not match any expected variant". Hoisting the
+		// only block out would produce exactly that, so a note takes its place.
+		const context = contextWithImageResults(1);
+		const source = context.messages[2] as { content: Array<{ type: string }> };
+		source.content = [{ type: "image", data: PNG, mimeType: "image/png" } as never];
+		const messages = await capturePayload(bedrockModel(OPENAI), context);
+		const userMessage = messages[messages.length - 1];
+		const wire = userMessage.content[0].toolResult as { content: Array<Record<string, unknown>> };
+		expect(wire.content).toEqual([{ text: "[image hoisted below]" }]);
+		expect(userMessage.content[2]).toMatchObject({ image: { format: "png", source: { bytes: PNG } } });
+	});
+
+	test("does not disturb a text-only tool result", async () => {
+		const context = contextWithImageResults(1);
+		const toolResult = context.messages[2] as { content: Array<{ type: string }> };
+		toolResult.content = [{ type: "text", text: "no image here" } as never];
+		const messages = await capturePayload(bedrockModel(OPENAI), context);
+		const userMessage = messages[messages.length - 1];
+		expect(userMessage.content).toHaveLength(1);
+		const wire = userMessage.content[0].toolResult as { content: Array<Record<string, unknown>> };
+		expect(wire.content).toEqual([{ text: "no image here" }]);
+	});
+});

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -63,6 +63,12 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 	} else {
 		delete model.requiresCursorToolSchemaProjection;
 	}
+	const requiresToolResultImageHoisting = catalog.requiresToolResultImageHoisting;
+	if (requiresToolResultImageHoisting === true) {
+		model.requiresToolResultImageHoisting = true;
+	} else {
+		delete model.requiresToolResultImageHoisting;
+	}
 	const contextPromotionTarget = catalog.contextPromotionTarget;
 	if (typeof contextPromotionTarget === "string" && model.contextPromotionTarget === undefined) {
 		model.contextPromotionTarget = contextPromotionTarget;

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -285,6 +285,11 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 		set: "catalog",
 		shape: "scalar",
 	},
+	"requires-tool-result-image-hoisting": {
+		key: "requiresToolResultImageHoisting",
+		set: "catalog",
+		shape: "scalar",
+	},
 	priority: { key: "priority", set: "catalog", shape: "scalar" },
 	"service-tier-cost": { key: "serviceTierCost", set: "catalog", shape: "object" },
 	"time-based-cost": { key: "timeBased", set: "catalog", shape: "object" },

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7140,10 +7140,13 @@
 				],
 				"thinking": {
 					"mode": "effort"
+				},
+				"catalog": {
+					"requiresToolResultImageHoisting": true
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:19",
+				"source": "providers/amazon-bedrock.kdl:26",
 				"class": "deepseek",
 				"providers": [
 					"amazon-bedrock"
@@ -7161,7 +7164,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:24",
+				"source": "providers/amazon-bedrock.kdl:31",
 				"class": "minimax",
 				"providers": [
 					"amazon-bedrock"
@@ -7172,7 +7175,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:28",
+				"source": "providers/amazon-bedrock.kdl:35",
 				"class": "unknown",
 				"providers": [
 					"amazon-bedrock"
@@ -7188,7 +7191,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:33",
+				"source": "providers/amazon-bedrock.kdl:40",
 				"providers": [
 					"amazon-bedrock"
 				],

--- a/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
+++ b/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
@@ -15,6 +15,13 @@ provider "amazon-bedrock" {
 	}
 	class "openai" {
 		thinking-mode "effort"
+		// Converse refuses an image nested in `toolResult.content` for this class:
+		// ValidationException "This model doesn't support the image field for user
+		// messages" — the envelope, since tool results ride in a user message.
+		// A deployment contract, not a lineage truth: the same model accepts the
+		// same bytes via bedrock-mantle, and accepts them here as a sibling block
+		// of the same user message. Measured on sol and luna, 2026-09-11.
+		requires-tool-result-image-hoisting #true
 	}
 	class "deepseek" {
 		requires-reasoning-content-for-all-assistant-turns #true

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -33846,6 +33846,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
+			"requiresToolResultImageHoisting": true,
 			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
@@ -33889,6 +33890,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
+			"requiresToolResultImageHoisting": true,
 			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",
@@ -33932,6 +33934,7 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
+			"requiresToolResultImageHoisting": true,
 			"supportsComputerUse": false,
 			"compat": {
 				"promptCacheMode": "none",

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1091,6 +1091,14 @@ export interface Model<TApi extends Api = Api> {
 	/** Whether this model requires Cursor's tool-schema combiner projection. */
 	requiresCursorToolSchemaProjection?: boolean;
 	/**
+	 * Whether images nested in a `toolResult` block must be hoisted into the
+	 * enclosing user message. Imposed by the host, not the lineage: Bedrock
+	 * Converse refuses `toolResult.content[].image` for the OpenAI models, while
+	 * the same model accepts the same bytes through an OpenAI-compatible
+	 * transport and as a sibling block of the same user message.
+	 */
+	requiresToolResultImageHoisting?: boolean;
+	/**
 	 * Model id to send on the wire when it differs from `id`. Used by catalog
 	 * variants that present one upstream model under several local entries —
 	 * e.g. GitHub Copilot long-context variants (`claude-opus-4.7-1m` requests
@@ -1271,6 +1279,7 @@ export interface ModelSpec<TApi extends Api = Api> extends Omit<
 	| "compatConfig"
 	| "requiresGlyphTokenization"
 	| "requiresCursorToolSchemaProjection"
+	| "requiresToolResultImageHoisting"
 	| "supportsComputerUseConfig"
 > {
 	/** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */

--- a/packages/catalog/test/compat-tool-result-images.test.ts
+++ b/packages/catalog/test/compat-tool-result-images.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCascade } from "../src/compat/cascade";
+import type { ResolveTarget } from "../src/compat/types";
+import { buildModel } from "../src/build";
+import { getBundledModel, getBundledModels } from "../src/models";
+
+// Bedrock Converse refuses an image nested in `toolResult.content` for the
+// OpenAI class, reporting it as "This model doesn't support the image field for
+// user messages" — the envelope, since convertMessages() collects tool results
+// into a user message. The models do accept image input: the same bytes pass in
+// a plain user block, and pass inside a tool result when the same model is
+// reached through bedrock-mantle. So this is a deployment contract of the
+// Converse host, and `providers/amazon-bedrock.kdl` is the stratum that owns it.
+//
+// The selector is the part that fails silently: scoped one level too wide it
+// would hoist images for Claude, which accepts them nested, and scoped too
+// narrow it would leave the original bug in place while every test still
+// passed. These cases pin the boundary against the shipped rule index.
+const target = (overrides: Partial<ResolveTarget>): ResolveTarget => ({
+	provider: "amazon-bedrock",
+	api: "bedrock-converse-stream",
+	class: "openai",
+	model: "global.openai.gpt-5.6-sol",
+	reasoning: true,
+	...overrides,
+});
+
+function hoisting(overrides: Partial<ResolveTarget>): unknown {
+	const resolved = resolveCascade(target(overrides)) as { catalog?: Record<string, unknown> };
+	return resolved.catalog?.requiresToolResultImageHoisting;
+}
+
+describe("tool-result image hoisting selector", () => {
+	test("applies to the OpenAI class on Bedrock Converse", () => {
+		expect(hoisting({})).toBe(true);
+		// luna shares the class and the defect.
+		expect(hoisting({ model: "global.openai.gpt-5.6-luna" })).toBe(true);
+	});
+
+	test("leaves Anthropic on the same host untouched", () => {
+		// Measured: claude-opus-5 accepts an image nested in a tool result on this
+		// exact API, so hoisting it would rewrite a working request.
+		expect(hoisting({ class: "anthropic", model: "global.anthropic.claude-opus-5" })).toBeUndefined();
+	});
+
+	test("does not follow the same models onto an OpenAI-compatible transport", () => {
+		// Same vendor lineage, different deployment: bedrock-mantle serves these
+		// models over /openai/v1 and accepts the nested image.
+		expect(
+			hoisting({ provider: "bedrock-mantle", api: "openai-completions", model: "openai.gpt-5.6-sol" }),
+		).toBeUndefined();
+	});
+
+	// The cascade above is only consulted by `buildModel`. The default runtime
+	// path does not call it: `getBundledModels` hands `models.json` rows to the
+	// model manager verbatim, so a flag that lives only in the rule index leaves
+	// every shipped model unfixed while all of the tests above still pass. That
+	// is how the first revision of this change slipped through review, and the
+	// Cursor precedent bakes its flag into `models.json` for the same reason.
+	test("is baked into the bundled Bedrock rows the runtime serves verbatim", () => {
+		const bundled = getBundledModels("amazon-bedrock").filter(
+			model => model.api === "bedrock-converse-stream" && model.identity?.class === "openai",
+		);
+		expect(bundled.length).toBeGreaterThan(0);
+		for (const model of bundled) {
+			expect(model.requiresToolResultImageHoisting).toBe(true);
+		}
+
+		// And the sibling class on the same provider must stay absent, so a blanket
+		// bake would fail here rather than silently rewrite Anthropic requests.
+		const claude = getBundledModel("amazon-bedrock", "global.anthropic.claude-opus-5");
+		expect(claude?.requiresToolResultImageHoisting).toBeUndefined();
+	});
+
+	// `build.ts` deletes the field when the cascade does not set it, so a spec that
+	// carried a stale value through `collapse.ts`'s project-and-rebuild cannot
+	// resurrect it. Without that `else` branch a collapsed Anthropic model could
+	// inherit hoisting from whatever it was projected from.
+	test("a stale flag does not survive project-and-rebuild", () => {
+		const claude = getBundledModel("amazon-bedrock", "global.anthropic.claude-opus-5");
+		const poisoned = { ...claude, requiresToolResultImageHoisting: true, compat: undefined };
+		expect(buildModel(poisoned as never).requiresToolResultImageHoisting).toBeUndefined();
+
+		const sol = getBundledModel("amazon-bedrock", "global.openai.gpt-5.6-sol");
+		const stripped = { ...sol, requiresToolResultImageHoisting: undefined, compat: undefined };
+		expect(buildModel(stripped as never).requiresToolResultImageHoisting).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes the Bedrock Converse defect in #11681.

## The defect

`convertMessages` puts tool-result images at `toolResult.content[].image`. Bedrock Converse refuses that for the OpenAI models:

```
HTTP 400 ValidationException
This model doesn't support the image field for user messages.
```

The text names *user messages* because tool results are collected into one, so it describes the envelope rather than the offending block — which is why this reads at first like a model-capability limit. It is not: snapcompact renders large tool output as PNG frames into exactly that position, so **every subagent whose own output was big enough to compact died on the following turn.** Three died in one session here before I traced it.

## What actually binds

Same 8×8 PNG, same tool-use sequence, `aws bedrock-runtime converse` in `us-east-1` with no omp in the path. Only the image's **position** varies:

| Image position | `gpt-5.6-sol` | `gpt-5.6-luna` | `claude-opus-5` |
|---|---|---|---|
| inside `toolResult.content` — before this PR | REJECTS | REJECTS | ACCEPTS |
| hoisted after the run, marker + image — after | **ACCEPTS** | **ACCEPTS** | ACCEPTS |
| two results, marker, two images, one message | **ACCEPTS** | **ACCEPTS** | ACCEPTS |
| image-only result: note + marker + image | **ACCEPTS** | **ACCEPTS** | ACCEPTS |
| empty `toolResult.content` | REJECTS | — | ACCEPTS |
| plain user content block | ACCEPTS | ACCEPTS | ACCEPTS |

`gpt-5.6-terra` was measured on the same matrix and behaves as sol and luna, so all three bundled rows carry the flag on evidence rather than by class assumption.

The models accept image input. Only the nesting is unsupported, and hoisting one level out — into the user message the provider already builds — is accepted by all three.

## The change

A `requires-tool-result-image-hoisting` axis, following the `requiresCursorToolSchemaProjection` precedent through `axes.ts` → `types.ts` → `build.ts` → a KDL rule, with `rules.json` regenerated via `bun run gen:compat` as the rules README requires, **and the flag baked into the three bundled Bedrock OpenAI rows in `models.json`** exactly as that precedent does in `99cd30247`.

That last part is load-bearing rather than housekeeping. `getBundledModels` hands `models.json` rows to the model manager verbatim and never calls `buildModel`, so the cascade is not consulted on the default runtime path. The first revision of this PR shipped the rule index alone: every test passed and every shipped model stayed broken. A test now pins the bundled rows, and reverting the bake fails it.

When set, the `toolResult` branch removes images from the results and appends them after the whole run behind a single `"Attached image(s) from the tool result(s) above:"` block — the contract `anthropic.ts:4473`, `openai-completions.ts:2409` and `openai-codex-responses.ts:1309` already use for the same class of restriction. Bedrock requires the results to lead the message. `convertMessages` already receives `model`, and `UserContent` already admits every block kind used, so no signatures or wire types change.

An image-only result would otherwise leave `toolResult.content` empty, which Converse rejects outright — `Invalid 'input': value did not match any expected variant` — so the block keeps a short note in place of the bytes. Both that shape and the multi-result shape are verified against live Converse, not just reasoned about.

**Placement.** The rule sits in `providers/amazon-bedrock.kdl`, not a class file, because the same models accept the nested form through `bedrock-mantle`. Per the rules README this is a deployment contract of the Converse host rather than a lineage truth. Getting that wrong is the silent failure mode here: one stratum too wide and Claude's working requests get rewritten, one too narrow and the bug survives with every test green — so both boundaries are pinned by tests.

Two alternatives rejected: dropping the frames discards the payload compaction exists to preserve, and disabling image compaction for Bedrock wholesale penalises Claude, which accepts the current shape.

## Verification

```
cd packages/catalog && bun test test/compat-*.test.ts     # 113 pass, 0 fail
cd packages/ai      && bun test test/bedrock-*.test.ts    #  60 pass, 0 fail
bunx oxfmt --check <changed files>                        # clean
bunx oxlint packages/ai packages/catalog                  # no new findings
bunx tsc --noEmit                                         # clean in both packages
```

`compat-parity` passes, so the engine still reproduces every baked compat value. `bun test` across all of `packages/catalog` is 928 pass / 0 fail.

New tests, sixteen assertions over two files:

- `compat-tool-result-images.test.ts` resolves against the **shipped** rule index and pins the selector: OpenAI on Converse gets the flag; Anthropic on the same host does not; the same models on `bedrock-mantle` do not. A fourth case asserts the bundled `models.json` rows carry the flag and that Anthropic's row does not, which is the case that catches a rule-index-only change.
- `bedrock-tool-result-images.test.ts` captures the wire payload via `onPayload` and asserts the transform: the image is hoisted behind the marker and the tool result keeps its own text; Claude's nested image is left alone; two results stay ahead of one marker and both images; an image-only result keeps a note rather than emptying; a text-only result is untouched.
- A further case asserts that a spec carrying a stale flag through `collapse.ts`'s project-and-rebuild loses it, since `build.ts` deletes the field when the cascade does not set it.

Both build models from **real ids** with nothing set by hand, so the KDL rule, the compiled index, `buildModel`'s cascade and the wire transform are all under test — a selector that missed the class would fail rather than quietly preserve the old behaviour.

Mutation-checked twice: forcing the transform gate to `false` fails exactly the two assertions that depend on hoisting and leaves the negative controls passing; reverting the `models.json` bake fails only the bundled-rows case. Every assertion that can be made to fail, fails for the right reason.

## Notes for review

- The marker text is `[image attached below this tool result]`. Happy to change the wording, or drop the marker entirely if you would rather the tool result carry only its own text.
- `compat-parity` cannot run without `packages/natives`; the Rust build fails on this machine, so I verified it against the prebuilt `18.1.17` addon, which matches the checkout's version.
- I have not touched `bedrock-mantle.kdl` — it already works, and the control above is why.

## Review

An independent review of the first revision returned CHANGES-REQUESTED with one P1: the missing `models.json` bake, traced through `models.ts:29-40`, `model-manager.ts:213` and `model-registry.ts:901-917`. Fixed here, with the regression test that would have caught it.

Three further points came out of review and changed the code:

1. The first revision invented its own per-result marker. Three encoders in this repo already solve this with one shared marker block after the run, so the transform now follows that contract instead.
2. An image-only result would have emptied `toolResult.content`. Converse rejects that, measured, so a note takes the bytes' place.
3. `gpt-5.6-terra` carried the flag from the class rule without ever being measured. It has been measured, and it rejects the nested form like its siblings.

`collapse.ts` was also checked, since `projectModelSpec` strips derived fields: it does not strip this one, and it does not need to — `build.ts`'s `else delete` branch clears a stale value on rebuild, which the new test pins.
