### PR TITLE
chore(ai): drop unused $env import from the Copilot OAuth registry

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,


### PR DESCRIPTION
`packages/ai/src/registry/oauth/github-copilot.ts:26` imports `$env` from `@oh-my-pi/pi-utils` and never uses it.

It is a leftover from 9ab84e1c3 ("fix(ai): injectable Copilot identity seam, no process-env writes in tests"), which removed the process-env writes the import served and kept the import.

It is currently `oxlint`'s only finding across `packages/ai` and `packages/catalog`:

```
packages/ai/src/registry/oauth/github-copilot.ts:26:10: warning eslint(no-unused-vars):
  Identifier '$env' is imported but never used.
```

Removing it takes that surface to zero.

## Verification

- `$env` has no other reference in the file — 0 occurrences after the change.
- `bunx oxlint packages/ai` reports nothing.
- `bunx tsc --noEmit` clean in `packages/ai`.
- `bun test test/*copilot*.test.ts` — 111 pass, 0 fail.
- `oxfmt --check` clean.

One line, no behaviour change. Split out deliberately rather than folded into #11685, which touches unrelated files.