### PR TITLE
fix(ai): classify generic Antigravity 429 boilerplate as transient

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Google Antigravity / Cloud Code Assist requests failing with a bogus 30-minute quota wait when the account still had quota: the generic HTTP 429 `Resource has been exhausted (e.g. check quota).` throttle (which carries no structured quota details) is now classified as a transient rate limit that retries on a short backoff, while genuine daily exhaustion (`exhausted your capacity … quota will reset` or structured `google.rpc` details) still rotates credentials ([#11689](https://github.com/can1357/oh-my-pi/issues/11689)).
+- Fixed Google Antigravity / Cloud Code Assist requests failing with HTTP 429 while the account still had quota: chat requests no longer enter Google's constrained agent quota bucket, and detail-free `Resource has been exhausted (e.g. check quota).` responses now retry on a short backoff without suppressing genuine account-limit signals ([#11689](https://github.com/can1357/oh-my-pi/issues/11689)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Antigravity / Cloud Code Assist requests failing with a bogus 30-minute quota wait when the account still had quota: the generic HTTP 429 `Resource has been exhausted (e.g. check quota).` throttle (which carries no structured quota details) is now classified as a transient rate limit that retries on a short backoff, while genuine daily exhaustion (`exhausted your capacity … quota will reset` or structured `google.rpc` details) still rotates credentials ([#11689](https://github.com/can1357/oh-my-pi/issues/11689)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/ai/src/error/finalize.ts
+++ b/packages/ai/src/error/finalize.ts
@@ -3,6 +3,7 @@ import type { AbortSourceTracker } from "../utils/abort";
 import type { CapturedHttpErrorResponse, RawHttpRequestDump } from "../utils/http-inspector";
 import { classify, classifyMessage, status } from "./flags";
 import { formatMessage } from "./format";
+import type { RateLimitPolicy } from "./rate-limit";
 
 /** Context a provider catch block hands to {@link finalize}. */
 export interface FinalizeOptions {
@@ -20,6 +21,8 @@ export interface FinalizeOptions {
 	rawRequestDump?: RawHttpRequestDump;
 	/** Captured non-2xx response body, used for status fallback and message detail. */
 	capturedErrorResponse?: CapturedHttpErrorResponse;
+	/** Provider-resolved policy for ambiguous rate-limit response bodies. */
+	rateLimitPolicy?: RateLimitPolicy;
 }
 
 /** The full bundle a provider assigns onto its `AssistantMessage` error fields. */
@@ -59,9 +62,10 @@ export async function finalize(error: unknown, opts: FinalizeOptions = {}): Prom
 		api: opts.api,
 		provider: opts.provider,
 		model: opts.model,
-		errorId: classify(error, opts.api),
+		errorId: classify(error, opts.api, opts.rateLimitPolicy),
 		errorMessage: message,
 		errorStatus: currentStatus,
+		rateLimitPolicy: opts.rateLimitPolicy,
 	});
 
 	return {

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -15,6 +15,7 @@ import {
 	isUsageLimitStatus,
 	matchesUsageLimitText,
 	parseRateLimitReason,
+	type RateLimitPolicy,
 } from "./rate-limit";
 
 export const Flag = {
@@ -446,6 +447,7 @@ function classifyText(
 	api?: Api,
 	provider?: string,
 	modelId?: string,
+	rateLimitPolicy?: RateLimitPolicy,
 ): number {
 	let kinds = 0;
 	if (errorMessage) {
@@ -469,7 +471,7 @@ function classifyText(
 		const isOpaque = isOpaqueStatusBody(cleanMessage);
 
 		const isLimitStatus = isUsageLimitStatus(statusClean);
-		const reason = parseRateLimitReason(cleanMessage);
+		const reason = parseRateLimitReason(cleanMessage, rateLimitPolicy);
 		const is402BillingCap = statusClean === 402 && is402BillingCapBody(cleanMessage);
 		// Concurrency caps (e.g. Vertex "Online prediction concurrent requests
 		// quota exceeded") are shed-and-backoff, not credential-rotatable —
@@ -482,7 +484,7 @@ function classifyText(
 		if (
 			!concurrencyExcluded &&
 			(is402BillingCap ||
-				matchesUsageLimitText(cleanMessage) ||
+				matchesUsageLimitText(cleanMessage, rateLimitPolicy) ||
 				((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
 				(isLimitStatus && (isOpaque || reason === "QUOTA_EXHAUSTED")))
 		) {
@@ -523,7 +525,7 @@ function classifyText(
 	return fallbackStatus ?? 0;
 }
 
-export function classify(error: unknown, api?: Api): number {
+export function classify(error: unknown, api?: Api, rateLimitPolicy?: RateLimitPolicy): number {
 	let kinds = 0;
 	const seen = new Set<object>();
 	const causeTokenEvidence = hasCauseTokenContextOverflowEvidence(error);
@@ -602,7 +604,15 @@ export function classify(error: unknown, api?: Api): number {
 			linkMessage = (link as { message: string }).message;
 		}
 
-		const textId = classifyText(linkMessage, status(link), causeTokenEvidence, api);
+		const textId = classifyText(
+			linkMessage,
+			status(link),
+			causeTokenEvidence,
+			api,
+			undefined,
+			undefined,
+			rateLimitPolicy,
+		);
 		kinds |= textId & KIND_MASK;
 
 		link = typeof link === "object" && "cause" in link ? (link as { cause: unknown }).cause : undefined;
@@ -729,6 +739,7 @@ export function classifyMessage(message: {
 	errorMessage?: string;
 	errorClassificationMessage?: string;
 	errorStatus?: number;
+	rateLimitPolicy?: RateLimitPolicy;
 }): number {
 	const existingId = message.errorId;
 	const currentStatus = message.errorStatus ?? statusFromId(existingId);
@@ -742,9 +753,18 @@ export function classifyMessage(message: {
 		message.api,
 		message.provider,
 		message.model,
+		message.rateLimitPolicy,
 	);
 
 	let kinds = ((existingId ?? 0) | textId) & KIND_MASK;
+	if (
+		message.rateLimitPolicy?.genericResourceExhaustedIsRateLimit === true &&
+		classificationMessage !== undefined &&
+		parseRateLimitReason(classificationMessage, message.rateLimitPolicy) === "RATE_LIMIT_EXCEEDED" &&
+		!matchesUsageLimitText(classificationMessage, message.rateLimitPolicy)
+	) {
+		kinds &= ~Flag.UsageLimit;
+	}
 	// Two-phase finalization: drop stale status-inferred payload bit when final text proves token overflow (#9235).
 	if (
 		currentStatus === 413 &&

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -1,4 +1,6 @@
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { extractRetryHint } from "@oh-my-pi/pi-utils/fetch-retry";
+import type { Api, Model } from "../types";
 
 /**
  * Rate limit reason classification and backoff calculation utilities.
@@ -21,6 +23,21 @@ export interface RateLimitPolicy {
 	 * boilerplate as a transient rate limit.
 	 */
 	genericResourceExhaustedIsRateLimit?: boolean;
+}
+
+/**
+ * Resolve a model's compat facts into the {@link RateLimitPolicy} the classifier
+ * consumes. The single conversion site for the deployment-owned policy fields —
+ * every classification, credential-rotation, and cooldown path MUST route model
+ * policy through here rather than reading `catalog.*` flags directly, so a new
+ * policy field lands in one place.
+ */
+export function resolveModelRateLimitPolicy(model: Model<Api> | null | undefined): RateLimitPolicy {
+	if (!model) return {};
+	return {
+		genericResourceExhaustedIsRateLimit:
+			resolveModelPolicy(model).catalog.genericResourceExhaustedIsRateLimit === true,
+	};
 }
 
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -14,6 +14,15 @@ export type RateLimitReason =
 	| "SERVER_ERROR"
 	| "UNKNOWN";
 
+/** Provider-resolved policy for ambiguous rate-limit response bodies. */
+export interface RateLimitPolicy {
+	/**
+	 * Treat Google's detail-free `Resource has been exhausted (e.g. check quota).`
+	 * boilerplate as a transient rate limit.
+	 */
+	genericResourceExhaustedIsRateLimit?: boolean;
+}
+
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min
 const RATE_LIMIT_EXCEEDED_BACKOFF_MS = 30 * 1000; // 30s
 const CONCURRENT_LIMIT_BACKOFF_MS = 5 * 1000; // 5s
@@ -101,15 +110,14 @@ export function isDashScopeTokenLimitText(errorMessage: string): boolean {
 }
 
 const GOOGLE_RPC_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
+const GOOGLE_RPC_QUOTA_FAILURE_TYPE = "type.googleapis.com/google.rpc.QuotaFailure";
 const ANTIGRAVITY_MODEL_QUOTA_PATTERN = /\bexhausted your capacity on this model\b/i;
-// Google's canonical generic HTTP 429 body: "Resource has been exhausted (e.g.
-// check quota)." Google returns it for per-minute / per-region request throttles
-// on the Gemini / Cloud Code Assist API — a transient cap that clears within the
-// window, NOT daily-quota exhaustion. Genuine Antigravity daily exhaustion sends
-// the distinct ANTIGRAVITY_MODEL_QUOTA_PATTERN message or ships structured
-// google.rpc details, so the bare boilerplate must stay in the short-backoff
-// lane instead of synthesizing a 30-minute QUOTA_EXHAUSTED wait (#11689).
+// Google's canonical generic HTTP 429 body. Some Cloud Code Assist deployments
+// use it for transient per-minute / per-region throttles, but other Google
+// providers can pair the same sentence with quota evidence. Provider policy
+// decides whether a truly bare body enters the short-backoff lane.
 const GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN = /\bresource has been exhausted\s*\(\s*e\.?g\.?\s*check quota\s*\)/i;
+const EXPLICIT_GOOGLE_QUOTA_EVIDENCE_PATTERN = /\b(?:quota|exhaust(?:ed|ion)|usage.?limit)\b/i;
 const LONG_RATE_LIMIT_DELAY_MS = 5 * 60 * 1000;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -143,6 +151,12 @@ function parseGoogleRpcRateLimitReason(errorMessage: string): RateLimitReason | 
 	}
 	if (!Array.isArray(error.details)) return undefined;
 
+	// QuotaFailure is authoritative regardless of detail ordering: Google can
+	// include it after a generic RATE_LIMIT_EXCEEDED ErrorInfo record.
+	for (const value of error.details) {
+		if (asRecord(value)?.["@type"] === GOOGLE_RPC_QUOTA_FAILURE_TYPE) return "QUOTA_EXHAUSTED";
+	}
+
 	for (const value of error.details) {
 		const detail = asRecord(value);
 		if (detail?.["@type"] !== GOOGLE_RPC_ERROR_INFO_TYPE || typeof detail.reason !== "string") continue;
@@ -175,17 +189,20 @@ function isQuotaExhaustedReason(reason: RateLimitReason): boolean {
 }
 
 /**
- * True for Google's bare generic RESOURCE_EXHAUSTED boilerplate ("Resource has
- * been exhausted (e.g. check quota).") when nothing authoritative overrides it.
- * Google emits this string for transient per-minute / per-region request
- * throttles, so — absent structured google.rpc details or the distinct
- * daily-quota "exhausted your capacity … quota will reset" wording — it must be
- * treated as a transient rate limit rather than daily-quota exhaustion (#11689).
+ * True when provider policy identifies Google's otherwise ambiguous boilerplate
+ * as a transient throttle and the response contains no stronger quota evidence.
  */
-function isGoogleGenericResourceExhaustedText(errorMessage: string): boolean {
+function isGoogleGenericResourceExhaustedText(errorMessage: string, policy?: RateLimitPolicy): boolean {
+	if (policy?.genericResourceExhaustedIsRateLimit !== true) return false;
 	if (!GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN.test(errorMessage)) return false;
 	if (parseGoogleRpcRateLimitReason(errorMessage) !== undefined) return false;
-	return !(ANTIGRAVITY_MODEL_QUOTA_PATTERN.test(errorMessage) || /\bquota will reset\b/i.test(errorMessage));
+	const body = parseJsonBody(errorMessage);
+	const error = asRecord(body?.error);
+	if (Array.isArray(error?.details) && error.details.length > 0) return false;
+	const residual = errorMessage
+		.replace(GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN, "")
+		.replace(RESOURCE_EXHAUSTED_PATTERN, "");
+	return !EXPLICIT_GOOGLE_QUOTA_EVIDENCE_PATTERN.test(residual);
 }
 
 /**
@@ -198,7 +215,7 @@ function isGoogleGenericResourceExhaustedText(errorMessage: string): boolean {
  * Bare "resource exhausted" / "resource_exhausted" maps to MODEL_CAPACITY (transient, short wait).
  * Explicit details such as "quota exceeded" retain their normal classification.
  */
-export function parseRateLimitReason(errorMessage: string): RateLimitReason {
+export function parseRateLimitReason(errorMessage: string, policy?: RateLimitPolicy): RateLimitReason {
 	const structuredReason = parseGoogleRpcRateLimitReason(errorMessage);
 	if (structuredReason !== undefined) return structuredReason;
 	const lowerWithStatus = errorMessage.toLowerCase();
@@ -214,12 +231,11 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "QUOTA_EXHAUSTED";
 	}
 
-	// Google's bare generic RESOURCE_EXHAUSTED boilerplate is a transient
-	// per-minute/per-region request throttle, not daily-quota exhaustion. Placed
-	// after the daily-quota short-circuit above so the specific "quota will reset"
-	// wording still wins; the generic string must not fall through to the generic
-	// "exhausted"/"quota" QUOTA branch below (#11689).
-	if (isGoogleGenericResourceExhaustedText(errorMessage)) {
+	// Provider policy may classify Google's bare RESOURCE_EXHAUSTED boilerplate
+	// as a transient per-minute/per-region throttle. The guard rejects structured
+	// details and residual quota text; the specific daily-quota branch above still
+	// wins before this deployment-specific exception (#11689).
+	if (isGoogleGenericResourceExhaustedText(errorMessage, policy)) {
 		return "RATE_LIMIT_EXCEEDED";
 	}
 
@@ -370,11 +386,15 @@ export function is402BillingCapBody(message: string | undefined): boolean {
  *     "Please retry in 5s") stay in the provider's own backoff / failure
  *     layer so transient or non-quota responses don't burn sibling credentials.
  */
-export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
+export function isUsageLimitOutcome(
+	status: number | undefined,
+	message: string | undefined,
+	policy?: RateLimitPolicy,
+): boolean {
 	const structuredReason = message ? parseGoogleRpcRateLimitReason(message) : undefined;
 	if (structuredReason !== undefined) return isQuotaExhaustedReason(structuredReason);
 	if (isConcurrencyCapExclusion(status, message)) return false;
-	if (message && matchesUsageLimitText(message)) return true;
+	if (message && matchesUsageLimitText(message, policy)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
 	// GitHub Copilot). Devin's end-of-stream Connect trailer carries no HTTP
@@ -385,7 +405,7 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	if (status === 402 && is402BillingCapBody(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
-	const reason = parseRateLimitReason(message);
+	const reason = parseRateLimitReason(message, policy);
 	return isQuotaExhaustedReason(reason);
 }
 /**
@@ -422,14 +442,13 @@ export function isOpaqueStatusBody(message: string): boolean {
  * flag accessor). `flags.ts` consumes this to populate `Flag.UsageLimit`, and
  * {@link isUsageLimitOutcome} uses it for the account-rotation decision.
  */
-export function matchesUsageLimitText(errorMessage: string): boolean {
+export function matchesUsageLimitText(errorMessage: string, policy?: RateLimitPolicy): boolean {
 	const structuredReason = parseGoogleRpcRateLimitReason(errorMessage);
 	if (structuredReason !== undefined) return isQuotaExhaustedReason(structuredReason);
 	if (isDashScopeTokenLimitText(errorMessage)) return false;
-	// The generic RESOURCE_EXHAUSTED boilerplate matches USAGE_LIMIT_PATTERN only
-	// via its "resource_exhausted" status token; it is a transient throttle, so
-	// it must not burn a sibling credential as a usage-limit outcome (#11689).
-	if (isGoogleGenericResourceExhaustedText(errorMessage)) return false;
+	// A provider policy can exclude only the detail-free boilerplate. Structured
+	// details and residual quota evidence remain credential-rotatable.
+	if (isGoogleGenericResourceExhaustedText(errorMessage, policy)) return false;
 	return (
 		USAGE_LIMIT_PATTERN.test(errorMessage) ||
 		CREDITS_EXHAUSTED_PATTERN.test(errorMessage) ||

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -47,6 +47,8 @@ const TRANSIENT_INTERVAL_RATE_LIMIT_PATTERN = /\bper\s+(?:second|minute)\b/i;
 function matchesSubscriptionCapText(errorMessage: string): boolean {
 	return SUBSCRIPTION_CAP_PATTERN.test(errorMessage) && !TRANSIENT_INTERVAL_RATE_LIMIT_PATTERN.test(errorMessage);
 }
+const DAILY_ACCOUNT_LIMIT_PATTERN =
+	/\bdaily\b[^\n]{0,40}\b(?:message |request )?(?:rate.?limit|limit)\b|\b(?:message |request )?(?:rate.?limit|limit)\b[^\n]{0,40}\bdaily\b/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 // ClinePass subscription-window exhaustion ("clinepass limit …") and free-tier
 // model caps ("free limit reached on model … try again in …") are account-local
@@ -117,7 +119,6 @@ const ANTIGRAVITY_MODEL_QUOTA_PATTERN = /\bexhausted your capacity on this model
 // providers can pair the same sentence with quota evidence. Provider policy
 // decides whether a truly bare body enters the short-backoff lane.
 const GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN = /\bresource has been exhausted\s*\(\s*e\.?g\.?\s*check quota\s*\)/i;
-const EXPLICIT_GOOGLE_QUOTA_EVIDENCE_PATTERN = /\b(?:quota|exhaust(?:ed|ion)|usage.?limit)\b/i;
 const LONG_RATE_LIMIT_DELAY_MS = 5 * 60 * 1000;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -202,7 +203,7 @@ function isGoogleGenericResourceExhaustedText(errorMessage: string, policy?: Rat
 	const residual = errorMessage
 		.replace(GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN, "")
 		.replace(RESOURCE_EXHAUSTED_PATTERN, "");
-	return !EXPLICIT_GOOGLE_QUOTA_EVIDENCE_PATTERN.test(residual);
+	return !matchesAccountLimitText(residual);
 }
 
 /**
@@ -276,6 +277,9 @@ export function parseRateLimitReason(errorMessage: string, policy?: RateLimitPol
 	if (OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)) {
 		return "QUOTA_EXHAUSTED";
 	}
+	if (DAILY_ACCOUNT_LIMIT_PATTERN.test(errorMessage)) {
+		return "QUOTA_EXHAUSTED";
+	}
 
 	if (CLINE_PASS_QUOTA_PATTERN.test(errorMessage)) {
 		return "QUOTA_EXHAUSTED";
@@ -342,6 +346,19 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
 	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)|balance.?exhausted|run out of credits|out of credits|spending[- _]?limit|personal-team-blocked|clinepass limit|free limit reached on model/i;
+
+function matchesAccountLimitText(errorMessage: string): boolean {
+	return (
+		USAGE_LIMIT_PATTERN.test(errorMessage) ||
+		CREDITS_EXHAUSTED_PATTERN.test(errorMessage) ||
+		(CN_QUOTA_EXHAUSTED_PATTERN.test(errorMessage) && !CN_TRANSIENT_CAP_PATTERN.test(errorMessage)) ||
+		SPEND_LIMIT_PATTERN.test(errorMessage) ||
+		ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage) ||
+		DAILY_ACCOUNT_LIMIT_PATTERN.test(errorMessage) ||
+		matchesSubscriptionCapText(errorMessage) ||
+		OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)
+	);
+}
 
 /**
  * HTTP status codes that, absent richer body classification, represent an
@@ -449,15 +466,7 @@ export function matchesUsageLimitText(errorMessage: string, policy?: RateLimitPo
 	// A provider policy can exclude only the detail-free boilerplate. Structured
 	// details and residual quota evidence remain credential-rotatable.
 	if (isGoogleGenericResourceExhaustedText(errorMessage, policy)) return false;
-	return (
-		USAGE_LIMIT_PATTERN.test(errorMessage) ||
-		CREDITS_EXHAUSTED_PATTERN.test(errorMessage) ||
-		(CN_QUOTA_EXHAUSTED_PATTERN.test(errorMessage) && !CN_TRANSIENT_CAP_PATTERN.test(errorMessage)) ||
-		SPEND_LIMIT_PATTERN.test(errorMessage) ||
-		ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage) ||
-		matchesSubscriptionCapText(errorMessage) ||
-		OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)
-	);
+	return matchesAccountLimitText(errorMessage);
 }
 
 /**

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -102,6 +102,14 @@ export function isDashScopeTokenLimitText(errorMessage: string): boolean {
 
 const GOOGLE_RPC_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
 const ANTIGRAVITY_MODEL_QUOTA_PATTERN = /\bexhausted your capacity on this model\b/i;
+// Google's canonical generic HTTP 429 body: "Resource has been exhausted (e.g.
+// check quota)." Google returns it for per-minute / per-region request throttles
+// on the Gemini / Cloud Code Assist API — a transient cap that clears within the
+// window, NOT daily-quota exhaustion. Genuine Antigravity daily exhaustion sends
+// the distinct ANTIGRAVITY_MODEL_QUOTA_PATTERN message or ships structured
+// google.rpc details, so the bare boilerplate must stay in the short-backoff
+// lane instead of synthesizing a 30-minute QUOTA_EXHAUSTED wait (#11689).
+const GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN = /\bresource has been exhausted\s*\(\s*e\.?g\.?\s*check quota\s*\)/i;
 const LONG_RATE_LIMIT_DELAY_MS = 5 * 60 * 1000;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -167,6 +175,20 @@ function isQuotaExhaustedReason(reason: RateLimitReason): boolean {
 }
 
 /**
+ * True for Google's bare generic RESOURCE_EXHAUSTED boilerplate ("Resource has
+ * been exhausted (e.g. check quota).") when nothing authoritative overrides it.
+ * Google emits this string for transient per-minute / per-region request
+ * throttles, so — absent structured google.rpc details or the distinct
+ * daily-quota "exhausted your capacity … quota will reset" wording — it must be
+ * treated as a transient rate limit rather than daily-quota exhaustion (#11689).
+ */
+function isGoogleGenericResourceExhaustedText(errorMessage: string): boolean {
+	if (!GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN.test(errorMessage)) return false;
+	if (parseGoogleRpcRateLimitReason(errorMessage) !== undefined) return false;
+	return !(ANTIGRAVITY_MODEL_QUOTA_PATTERN.test(errorMessage) || /\bquota will reset\b/i.test(errorMessage));
+}
+
+/**
  * Classify a rate-limit error message into a reason category.
  * Priority order: explicit details in a resource-exhausted error > QUOTA
  * (Antigravity "quota will reset") > CN quota > DASHSCOPE_TOKEN_LIMIT (TPM/TPS
@@ -190,6 +212,15 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
 	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
 		return "QUOTA_EXHAUSTED";
+	}
+
+	// Google's bare generic RESOURCE_EXHAUSTED boilerplate is a transient
+	// per-minute/per-region request throttle, not daily-quota exhaustion. Placed
+	// after the daily-quota short-circuit above so the specific "quota will reset"
+	// wording still wins; the generic string must not fall through to the generic
+	// "exhausted"/"quota" QUOTA branch below (#11689).
+	if (isGoogleGenericResourceExhaustedText(errorMessage)) {
+		return "RATE_LIMIT_EXCEEDED";
 	}
 
 	// Simplified Chinese quota-exhaustion phrasing (Zhipu Coding Plan and other
@@ -395,6 +426,10 @@ export function matchesUsageLimitText(errorMessage: string): boolean {
 	const structuredReason = parseGoogleRpcRateLimitReason(errorMessage);
 	if (structuredReason !== undefined) return isQuotaExhaustedReason(structuredReason);
 	if (isDashScopeTokenLimitText(errorMessage)) return false;
+	// The generic RESOURCE_EXHAUSTED boilerplate matches USAGE_LIMIT_PATTERN only
+	// via its "resource_exhausted" status token; it is a transient throttle, so
+	// it must not burn a sibling credential as a usage-limit outcome (#11689).
+	if (isGoogleGenericResourceExhaustedText(errorMessage)) return false;
 	return (
 		USAGE_LIMIT_PATTERN.test(errorMessage) ||
 		CREDITS_EXHAUSTED_PATTERN.test(errorMessage) ||

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -119,6 +119,11 @@ const ANTIGRAVITY_MODEL_QUOTA_PATTERN = /\bexhausted your capacity on this model
 // providers can pair the same sentence with quota evidence. Provider policy
 // decides whether a truly bare body enters the short-backoff lane.
 const GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN = /\bresource has been exhausted\s*\(\s*e\.?g\.?\s*check quota\s*\)/i;
+// Google reuses google.rpc.QuotaFailure for per-interval rate quotas. The
+// quotaId (`GenerateRequestsPerMinutePerProjectPerModel`) and human violation
+// descriptions ("requests per minute") both carry this token; matches keep the
+// failure in the transient rate-limit lane instead of rotating a credential.
+const PER_INTERVAL_QUOTA_PATTERN = /per[\s_-]?(?:minute|second)/i;
 const LONG_RATE_LIMIT_DELAY_MS = 5 * 60 * 1000;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -152,35 +157,42 @@ function parseGoogleRpcRateLimitReason(errorMessage: string): RateLimitReason | 
 	}
 	if (!Array.isArray(error.details)) return undefined;
 
-	// QuotaFailure is authoritative regardless of detail ordering: Google can
-	// include it after a generic RATE_LIMIT_EXCEEDED ErrorInfo record.
-	for (const value of error.details) {
-		if (asRecord(value)?.["@type"] === GOOGLE_RPC_QUOTA_FAILURE_TYPE) return "QUOTA_EXHAUSTED";
-	}
-
+	// Unambiguous ErrorInfo exhaustion reasons win outright, regardless of order.
+	let errorInfoRateLimited = false;
 	for (const value of error.details) {
 		const detail = asRecord(value);
 		if (detail?.["@type"] !== GOOGLE_RPC_ERROR_INFO_TYPE || typeof detail.reason !== "string") continue;
 		const reason = detail.reason.trim().toUpperCase();
-		switch (reason) {
-			case "QUOTA_EXHAUSTED":
-				return "QUOTA_EXHAUSTED";
-			case "INSUFFICIENT_G1_CREDITS_BALANCE":
-				// Keep Google's specific credit-balance reason available to logs
-				// and callers while treating it as credential-rotatable below.
-				return "INSUFFICIENT_G1_CREDITS_BALANCE";
-			case "RATE_LIMIT_EXCEEDED": {
-				// Cloud Code Assist also uses this reason for an account's
-				// per-model quota, even when that quota resets within seconds.
-				if (typeof error.message === "string" && ANTIGRAVITY_MODEL_QUOTA_PATTERN.test(error.message)) {
-					return "QUOTA_EXHAUSTED";
-				}
-				const retryDelayMs = extractRetryHint(undefined, errorMessage);
-				return retryDelayMs !== undefined && retryDelayMs >= LONG_RATE_LIMIT_DELAY_MS
-					? "QUOTA_EXHAUSTED"
-					: "RATE_LIMIT_EXCEEDED";
-			}
+		if (reason === "QUOTA_EXHAUSTED") return "QUOTA_EXHAUSTED";
+		if (reason === "INSUFFICIENT_G1_CREDITS_BALANCE") {
+			// Keep Google's specific credit-balance reason available to logs
+			// and callers while treating it as credential-rotatable below.
+			return "INSUFFICIENT_G1_CREDITS_BALANCE";
 		}
+		if (reason === "RATE_LIMIT_EXCEEDED") errorInfoRateLimited = true;
+	}
+
+	// Cloud Code Assist phrases multi-hour daily exhaustion in the top-level
+	// message even under a RATE_LIMIT_EXCEEDED ErrorInfo.
+	if (typeof error.message === "string" && ANTIGRAVITY_MODEL_QUOTA_PATTERN.test(error.message)) {
+		return "QUOTA_EXHAUSTED";
+	}
+
+	// A QuotaFailure covers both exhausted account allowances and per-interval
+	// rate quotas (requests per minute/second). Treat it as exhaustion only when
+	// the evidence is not transient: a per-interval violation or a short retry
+	// hint keeps it in the rate-limit lane, a long/absent retry window rotates.
+	const retryDelayMs = extractRetryHint(undefined, errorMessage);
+	const shortWait = retryDelayMs !== undefined && retryDelayMs < LONG_RATE_LIMIT_DELAY_MS;
+	const longWait = retryDelayMs !== undefined && retryDelayMs >= LONG_RATE_LIMIT_DELAY_MS;
+	const perIntervalQuota = PER_INTERVAL_QUOTA_PATTERN.test(errorMessage);
+	const hasQuotaFailure = error.details.some(value => asRecord(value)?.["@type"] === GOOGLE_RPC_QUOTA_FAILURE_TYPE);
+	if (hasQuotaFailure) {
+		return perIntervalQuota || shortWait ? "RATE_LIMIT_EXCEEDED" : "QUOTA_EXHAUSTED";
+	}
+
+	if (errorInfoRateLimited) {
+		return longWait ? "QUOTA_EXHAUSTED" : "RATE_LIMIT_EXCEEDED";
 	}
 	return undefined;
 }

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -6,7 +6,6 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { scheduler } from "node:timers/promises";
 import { type } from "@oh-my-pi/omptype";
-import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	getAntigravityModelWireProfile,
@@ -1117,10 +1116,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				api: model.api,
 				signal: options?.signal,
 				rawRequestDump,
-				rateLimitPolicy: {
-					genericResourceExhaustedIsRateLimit:
-						resolveModelPolicy(model).catalog.genericResourceExhaustedIsRateLimit === true,
-				},
+				rateLimitPolicy: AIError.resolveModelRateLimitPolicy(model),
 			});
 			output.stopReason = result.stopReason;
 			output.errorStatus = result.status;

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -6,6 +6,7 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { scheduler } from "node:timers/promises";
 import { type } from "@oh-my-pi/omptype";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	getAntigravityModelWireProfile,
@@ -1112,7 +1113,15 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			stream.push({ type: "done", reason: output.stopReason, message: output });
 			stream.end();
 		} catch (error) {
-			const result = await AIError.finalize(error, { api: model.api, signal: options?.signal, rawRequestDump });
+			const result = await AIError.finalize(error, {
+				api: model.api,
+				signal: options?.signal,
+				rawRequestDump,
+				rateLimitPolicy: {
+					genericResourceExhaustedIsRateLimit:
+						resolveModelPolicy(model).catalog.genericResourceExhaustedIsRateLimit === true,
+				},
+			});
 			output.stopReason = result.stopReason;
 			output.errorStatus = result.status;
 			output.errorId = result.id;

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -1398,13 +1398,14 @@ export function buildRequest(
 			request.generationConfig = generationConfig;
 		}
 		request.sessionId = envelope.sessionId;
+		// The official client omits requestType. Sending "agent" routes consumer
+		// projects into a constrained quota bucket that can reject the first request.
 		return {
 			project: projectId,
 			requestId: envelope.requestId,
 			request,
 			model: wireModelId,
 			userAgent: "antigravity",
-			requestType: "agent",
 		};
 	}
 

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
 import {
@@ -1124,7 +1125,11 @@ function isRetryableUpstreamError(
 	// provider's own backoff layer instead of burning siblings.
 	if (AIError.isCodexChatGPTAccountPolicyError(error, model.provider, model.id)) return true;
 	if (status === 401 || (status === 403 && !isConcurrencyCapExclusion(status, message))) return true;
-	return isUsageLimitOutcome(status, message);
+	const rateLimitPolicy = {
+		genericResourceExhaustedIsRateLimit:
+			resolveModelPolicy(model).catalog.genericResourceExhaustedIsRateLimit === true,
+	};
+	return isUsageLimitOutcome(status, message, rateLimitPolicy);
 }
 
 function createAssistantAuthError(message: AssistantMessage): Error {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -4,7 +4,6 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
-import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
 import {
@@ -21,7 +20,7 @@ import { getCustomApi } from "./api-registry";
 import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } from "./auth-retry";
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
-import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
+import { isConcurrencyCapExclusion, isUsageLimitOutcome, resolveModelRateLimitPolicy } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { MessageCreateParamsStreaming } from "./providers/anthropic-wire";
@@ -1125,11 +1124,7 @@ function isRetryableUpstreamError(
 	// provider's own backoff layer instead of burning siblings.
 	if (AIError.isCodexChatGPTAccountPolicyError(error, model.provider, model.id)) return true;
 	if (status === 401 || (status === 403 && !isConcurrencyCapExclusion(status, message))) return true;
-	const rateLimitPolicy = {
-		genericResourceExhaustedIsRateLimit:
-			resolveModelPolicy(model).catalog.genericResourceExhaustedIsRateLimit === true,
-	};
-	return isUsageLimitOutcome(status, message, rateLimitPolicy);
+	return isUsageLimitOutcome(status, message, resolveModelRateLimitPolicy(model));
 }
 
 function createAssistantAuthError(message: AssistantMessage): Error {

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -246,7 +246,7 @@ describe("Google Gemini CLI alignment", () => {
 		expect(geminiParts.some(part => part.text?.includes(unsignedThinking))).toBe(true);
 	});
 
-	it("keeps antigravity metadata in antigravity request payloads", () => {
+	it("keeps supported antigravity metadata in request payloads", () => {
 		const model = createModel("google-antigravity");
 		const context: Context = { ...createContext(), systemPrompt: ["be terse"] };
 		const payload = buildRequest(model, context, "proj-123", {}, true) as {
@@ -261,7 +261,7 @@ describe("Google Gemini CLI alignment", () => {
 		};
 
 		expect(payload.request.sessionId).toMatch(/^-[0-9]+$/);
-		expect(payload.requestType).toBe("agent");
+		expect(payload.requestType).toBeUndefined();
 		expect(payload.userAgent).toBe("antigravity");
 		// Structured requestId: agent/<agentId>/<ts>/<trajectoryId>/<step>.
 		expect(payload.requestId).toMatch(/^agent\/[0-9a-f-]+\/\d+\/[0-9a-f-]+\/\d+$/);

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -129,6 +129,37 @@ describe("parseRateLimitReason", () => {
 		}
 	});
 
+	it("keeps a per-minute QuotaFailure with a short retry hint transient", () => {
+		const perMinute = `Cloud Code Assist API error (429): ${JSON.stringify({
+			error: {
+				code: 429,
+				message: "Resource has been exhausted (e.g. check quota).",
+				status: "RESOURCE_EXHAUSTED",
+				details: [
+					{
+						"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+						reason: "RATE_LIMIT_EXCEEDED",
+						domain: "cloudcode-pa.googleapis.com",
+					},
+					{
+						"@type": "type.googleapis.com/google.rpc.QuotaFailure",
+						violations: [
+							{
+								subject: "project:example",
+								quotaId: "GenerateRequestsPerMinutePerProjectPerModel",
+								description: "Quota exceeded for GenerateContent requests per minute.",
+							},
+						],
+					},
+					{ "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "18s" },
+				],
+			},
+		})}`;
+
+		expect(parseRateLimitReason(perMinute, antigravityRateLimitPolicy)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimitOutcome(429, perMinute, antigravityRateLimitPolicy)).toBe(false);
+	});
+
 	it("keeps genuine Antigravity daily-quota exhaustion as QUOTA_EXHAUSTED", () => {
 		expect(
 			parseRateLimitReason(

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -115,13 +115,18 @@ describe("parseRateLimitReason", () => {
 				],
 			},
 		})}`;
-		const explicitText =
-			"Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota). Project quota exceeded.";
+		const explicitTexts = [
+			"Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota). Project quota exceeded.",
+			"Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota). Daily request limit reached.",
+			"Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota). Credits depleted.",
+		];
 
 		expect(parseRateLimitReason(quotaFailure, antigravityRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
 		expect(isUsageLimitOutcome(429, quotaFailure, antigravityRateLimitPolicy)).toBe(true);
-		expect(parseRateLimitReason(explicitText, antigravityRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
-		expect(isUsageLimitOutcome(429, explicitText, antigravityRateLimitPolicy)).toBe(true);
+		for (const explicitText of explicitTexts) {
+			expect(parseRateLimitReason(explicitText, antigravityRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
+			expect(isUsageLimitOutcome(429, explicitText, antigravityRateLimitPolicy)).toBe(true);
+		}
 	});
 
 	it("keeps genuine Antigravity daily-quota exhaustion as QUOTA_EXHAUSTED", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -56,11 +56,30 @@ describe("parseRateLimitReason", () => {
 		).toBe("QUOTA_EXHAUSTED");
 	});
 
-	// "Resource has been exhausted (e.g. check quota)" is a quota/daily-limit error — long wait.
-	// Only the literal phrase "resource exhausted" (gRPC status name) is MODEL_CAPACITY.
-	it("classifies 'Resource has been exhausted (e.g. check quota)' as QUOTA_EXHAUSTED", () => {
+	// Google's generic HTTP 429 boilerplate "Resource has been exhausted (e.g.
+	// check quota)." is a transient per-minute/per-region request throttle, not
+	// daily-quota exhaustion (which sends "exhausted your capacity … quota will
+	// reset" or ships structured google.rpc details). It must classify as
+	// RATE_LIMIT_EXCEEDED so the session retries on a 30s backoff instead of
+	// synthesizing a 30-min QUOTA_EXHAUSTED wait that trips retry.maxDelayMs and
+	// hard-fails users with quota left. Regression for #11689.
+	it("classifies generic 'Resource has been exhausted (e.g. check quota)' as RATE_LIMIT_EXCEEDED", () => {
 		expect(
 			parseRateLimitReason("Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota)."),
+		).toBe("RATE_LIMIT_EXCEEDED");
+		// Reporter's exact wire body (JSON, RESOURCE_EXHAUSTED status, no details).
+		expect(
+			parseRateLimitReason(
+				'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}',
+			),
+		).toBe("RATE_LIMIT_EXCEEDED");
+	});
+
+	it("keeps genuine Antigravity daily-quota exhaustion as QUOTA_EXHAUSTED", () => {
+		expect(
+			parseRateLimitReason(
+				"Cloud Code Assist API error (429): You have exhausted your capacity on this model. Your quota will reset after 3 hours.",
+			),
 		).toBe("QUOTA_EXHAUSTED");
 	});
 
@@ -457,6 +476,15 @@ describe("isUsageLimitOutcome", () => {
 		// UNKNOWN but carries a transient retry hint — body is informative,
 		// so we defer to parseRateLimitReason and stay out of the quota lane.
 		expect(isUsageLimitOutcome(429, "Please retry in 5s")).toBe(false);
+		// Google's generic RESOURCE_EXHAUSTED boilerplate is a transient throttle;
+		// it must not burn a sibling credential even though its JSON status token
+		// matches USAGE_LIMIT_PATTERN's `resource_exhausted` arm (#11689).
+		expect(
+			isUsageLimitOutcome(
+				429,
+				'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}',
+			),
+		).toBe(false);
 	});
 
 	it("rotates on subscription caps without treating generic rate limits as usage exhaustion", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
-import { classify, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
+import { classify, classifyMessage, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
 import {
 	calculateRateLimitBackoffMs,
 	is402BillingCapBody,
@@ -9,7 +11,20 @@ import {
 	isUsageLimitOutcome,
 	isUsageLimitStatus,
 	parseRateLimitReason,
+	type RateLimitPolicy,
 } from "@oh-my-pi/pi-ai/error/rate-limit";
+
+const antigravityModel = getBundledModel("google-antigravity", "gemini-3.8-flash");
+const geminiCliModel = getBundledModel("google-gemini-cli", "gemini-3.1-pro-preview");
+if (!antigravityModel || !geminiCliModel) throw new Error("Expected bundled Google models");
+const antigravityRateLimitPolicy = {
+	genericResourceExhaustedIsRateLimit:
+		resolveModelPolicy(antigravityModel).catalog.genericResourceExhaustedIsRateLimit === true,
+} satisfies RateLimitPolicy;
+const geminiCliRateLimitPolicy = {
+	genericResourceExhaustedIsRateLimit:
+		resolveModelPolicy(geminiCliModel).catalog.genericResourceExhaustedIsRateLimit === true,
+} satisfies RateLimitPolicy;
 
 function googleRpc429(reason: string, retryDelay?: string, message = "Resource exhausted"): string {
 	const details: Array<Record<string, string>> = [
@@ -56,23 +71,57 @@ describe("parseRateLimitReason", () => {
 		).toBe("QUOTA_EXHAUSTED");
 	});
 
-	// Google's generic HTTP 429 boilerplate "Resource has been exhausted (e.g.
-	// check quota)." is a transient per-minute/per-region request throttle, not
-	// daily-quota exhaustion (which sends "exhausted your capacity … quota will
-	// reset" or ships structured google.rpc details). It must classify as
-	// RATE_LIMIT_EXCEEDED so the session retries on a 30s backoff instead of
-	// synthesizing a 30-min QUOTA_EXHAUSTED wait that trips retry.maxDelayMs and
-	// hard-fails users with quota left. Regression for #11689.
-	it("classifies generic 'Resource has been exhausted (e.g. check quota)' as RATE_LIMIT_EXCEEDED", () => {
-		expect(
-			parseRateLimitReason("Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota)."),
-		).toBe("RATE_LIMIT_EXCEEDED");
-		// Reporter's exact wire body (JSON, RESOURCE_EXHAUSTED status, no details).
-		expect(
-			parseRateLimitReason(
-				'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}',
-			),
-		).toBe("RATE_LIMIT_EXCEEDED");
+	// Google's generic HTTP 429 boilerplate is ambiguous globally. Antigravity
+	// policy identifies its detail-free form as a transient per-minute/per-region
+	// throttle, so the session retries on a 30s backoff instead of synthesizing a
+	// 30-min QUOTA_EXHAUSTED wait that trips retry.maxDelayMs (#11689).
+	it("scopes generic RESOURCE_EXHAUSTED transient handling to Antigravity policy", () => {
+		const text = "Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota).";
+		const body =
+			'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}';
+
+		expect(parseRateLimitReason(text)).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason(body)).toBe("QUOTA_EXHAUSTED");
+		expect(antigravityRateLimitPolicy.genericResourceExhaustedIsRateLimit).toBe(true);
+		expect(geminiCliRateLimitPolicy.genericResourceExhaustedIsRateLimit).toBe(false);
+		expect(parseRateLimitReason(text, antigravityRateLimitPolicy)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(parseRateLimitReason(body, antigravityRateLimitPolicy)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(parseRateLimitReason(body, geminiCliRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
+		const id = classifyMessage({
+			errorMessage: body,
+			errorStatus: 429,
+			rateLimitPolicy: antigravityRateLimitPolicy,
+		});
+		expect(is(id, Flag.Transient)).toBe(true);
+		expect(is(id, Flag.UsageLimit)).toBe(false);
+	});
+
+	it("preserves structured and textual quota evidence under Antigravity policy", () => {
+		const quotaFailure = `Cloud Code Assist API error (429): ${JSON.stringify({
+			error: {
+				code: 429,
+				message: "Resource has been exhausted (e.g. check quota).",
+				status: "RESOURCE_EXHAUSTED",
+				details: [
+					{
+						"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+						reason: "RATE_LIMIT_EXCEEDED",
+						domain: "cloudcode-pa.googleapis.com",
+					},
+					{
+						"@type": "type.googleapis.com/google.rpc.QuotaFailure",
+						violations: [{ subject: "project:example", description: "Daily quota exhausted" }],
+					},
+				],
+			},
+		})}`;
+		const explicitText =
+			"Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota). Project quota exceeded.";
+
+		expect(parseRateLimitReason(quotaFailure, antigravityRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
+		expect(isUsageLimitOutcome(429, quotaFailure, antigravityRateLimitPolicy)).toBe(true);
+		expect(parseRateLimitReason(explicitText, antigravityRateLimitPolicy)).toBe("QUOTA_EXHAUSTED");
+		expect(isUsageLimitOutcome(429, explicitText, antigravityRateLimitPolicy)).toBe(true);
 	});
 
 	it("keeps genuine Antigravity daily-quota exhaustion as QUOTA_EXHAUSTED", () => {
@@ -476,13 +525,13 @@ describe("isUsageLimitOutcome", () => {
 		// UNKNOWN but carries a transient retry hint — body is informative,
 		// so we defer to parseRateLimitReason and stay out of the quota lane.
 		expect(isUsageLimitOutcome(429, "Please retry in 5s")).toBe(false);
-		// Google's generic RESOURCE_EXHAUSTED boilerplate is a transient throttle;
-		// it must not burn a sibling credential even though its JSON status token
-		// matches USAGE_LIMIT_PATTERN's `resource_exhausted` arm (#11689).
+		// Antigravity policy keeps the detail-free RESOURCE_EXHAUSTED boilerplate
+		// from burning a sibling credential (#11689).
 		expect(
 			isUsageLimitOutcome(
 				429,
 				'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}',
+				antigravityRateLimitPolicy,
 			),
 		).toBe(false);
 	});

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -277,6 +277,11 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"edit-revision": { key: "editRevision", set: "catalog", shape: "scalar" },
 	"input-modalities": { key: "inputModalities", set: "catalog", shape: "array", values: ["text", "image"] },
 	"limits-patch": { key: "limitsPatch", set: "catalog", shape: "object" },
+	"generic-resource-exhausted-is-rate-limit": {
+		key: "genericResourceExhaustedIsRateLimit",
+		set: "catalog",
+		shape: "scalar",
+	},
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
 	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
 	"max-context-window": { key: "maxContextWindow", set: "catalog", shape: "scalar" },

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10252,7 +10252,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:5",
+				"source": "providers/google-antigravity.kdl:6",
 				"class": "anthropic",
 				"providers": [
 					"google-antigravity"
@@ -10263,7 +10263,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:13",
+				"source": "providers/google-antigravity.kdl:14",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity"
@@ -10279,7 +10279,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:17",
+				"source": "providers/google-antigravity.kdl:18",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity"
@@ -10307,7 +10307,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:27",
+				"source": "providers/google-antigravity.kdl:28",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity"
@@ -10325,7 +10325,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:33",
+				"source": "providers/google-antigravity.kdl:34",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity"
@@ -10346,7 +10346,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:39",
+				"source": "providers/google-antigravity.kdl:40",
 				"providers": [
 					"google-antigravity"
 				],
@@ -10366,7 +10366,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:43",
+				"source": "providers/google-antigravity.kdl:44",
 				"providers": [
 					"google-antigravity"
 				],
@@ -10381,7 +10381,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:47",
+				"source": "providers/google-antigravity.kdl:48",
 				"providers": [
 					"google-antigravity"
 				],
@@ -10397,7 +10397,7 @@
 				}
 			},
 			{
-				"source": "providers/google-antigravity.kdl:52",
+				"source": "providers/google-antigravity.kdl:53",
 				"providers": [
 					"google-antigravity"
 				],
@@ -10413,6 +10413,15 @@
 						"low": 1001
 					},
 					"mode": "budget"
+				}
+			},
+			{
+				"source": "providers/google-antigravity.kdl:3",
+				"providers": [
+					"google-antigravity"
+				],
+				"catalog": {
+					"genericResourceExhaustedIsRateLimit": true
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/providers/google-antigravity.kdl
+++ b/packages/catalog/src/compat/rules/providers/google-antigravity.kdl
@@ -1,6 +1,7 @@
 // Provider-wire compat for "google-antigravity"; regenerated from the frozen census using deployment contract selectors.
 
 provider "google-antigravity" {
+	generic-resource-exhausted-is-rate-limit #true
 	class "anthropic" {
 		family "opus" {
 			thinking-mode "budget"

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1784,8 +1784,8 @@ export class AgentSession {
 			findRetryFallbackCandidates: (role, selector, model) =>
 				this.#recovery.findRetryFallbackCandidates(role, selector, model),
 			isRetryFallbackSelectorSuppressed: selector => this.#recovery.isRetryFallbackSelectorSuppressed(selector),
-			noteRetryFallbackCooldown: (selector, retryAfterMs, errorMessage) =>
-				this.#recovery.noteRetryFallbackCooldown(selector, retryAfterMs, errorMessage),
+			noteRetryFallbackCooldown: (selector, retryAfterMs, errorMessage, rateLimitPolicy) =>
+				this.#recovery.noteRetryFallbackCooldown(selector, retryAfterMs, errorMessage, rateLimitPolicy),
 			createCodexCompactionContext: createMaintenanceCodexCompactionContext,
 			sessionId: () => this.sessionId,
 		};

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -34,6 +34,7 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import { isUsageLimitOutcome, resolveModelServiceTier, streamSimple } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { extractHttpStatusFromError, extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import {
@@ -1434,14 +1435,19 @@ export class SessionAdvisors {
 
 		const currentModel = advisor.agent.state.model;
 		const message = assistantFailure?.errorMessage ?? (error instanceof Error ? error.message : String(error));
+		const rateLimitPolicy = {
+			genericResourceExhaustedIsRateLimit:
+				resolveModelPolicy(currentModel).catalog.genericResourceExhaustedIsRateLimit === true,
+		};
 		const errorId = assistantFailure
 			? AIError.classifyMessage({
 					api: currentModel.api,
 					errorId: assistantFailure.errorId,
 					errorMessage: message,
 					errorStatus: assistantFailure.errorStatus,
+					rateLimitPolicy,
 				})
-			: AIError.classify(error, currentModel.api);
+			: AIError.classify(error, currentModel.api, rateLimitPolicy);
 		if (AIError.is(errorId, AIError.Flag.Abort) || AIError.is(errorId, AIError.Flag.UserInterrupt)) return false;
 		// Text-ambiguous overflows waive the veto; usage-backed do not — see AIError.isTextAmbiguousContextOverflow (#9235).
 		const contextWindow = currentModel.contextWindow ?? 0;
@@ -1466,7 +1472,7 @@ export class SessionAdvisors {
 		const retryAfterMs = extractRetryHint(undefined, message);
 		const usageLimit =
 			AIError.is(errorId, AIError.Flag.UsageLimit) ||
-			isUsageLimitOutcome(extractHttpStatusFromError(error), message);
+			isUsageLimitOutcome(extractHttpStatusFromError(error), message, rateLimitPolicy);
 		if (usageLimit) {
 			const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
 				currentModel.provider,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -33,9 +33,13 @@ import type {
 	ServiceTier,
 	SimpleStreamOptions,
 } from "@oh-my-pi/pi-ai";
-import { isUsageLimitOutcome, resolveModelServiceTier, streamSimple } from "@oh-my-pi/pi-ai";
+import {
+	isUsageLimitOutcome,
+	resolveModelRateLimitPolicy,
+	resolveModelServiceTier,
+	streamSimple,
+} from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { extractHttpStatusFromError, extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import {
@@ -1441,10 +1445,7 @@ export class SessionAdvisors {
 
 		const currentModel = advisor.agent.state.model;
 		const message = assistantFailure?.errorMessage ?? (error instanceof Error ? error.message : String(error));
-		const rateLimitPolicy = {
-			genericResourceExhaustedIsRateLimit:
-				resolveModelPolicy(currentModel).catalog.genericResourceExhaustedIsRateLimit === true,
-		};
+		const rateLimitPolicy = resolveModelRateLimitPolicy(currentModel);
 		const errorId = assistantFailure
 			? AIError.classifyMessage({
 					api: currentModel.api,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -29,6 +29,7 @@ import type {
 	Message,
 	Model,
 	ProviderSessionState,
+	RateLimitPolicy,
 	ServiceTier,
 	SimpleStreamOptions,
 } from "@oh-my-pi/pi-ai";
@@ -284,7 +285,12 @@ export interface SessionAdvisorsHost {
 		currentModel?: Model | null,
 	): RetryFallbackSelector[];
 	isRetryFallbackSelectorSuppressed(selector: RetryFallbackSelector): boolean;
-	noteRetryFallbackCooldown(currentSelector: string, retryAfterMs: number | undefined, errorMessage: string): void;
+	noteRetryFallbackCooldown(
+		currentSelector: string,
+		retryAfterMs: number | undefined,
+		errorMessage: string,
+		rateLimitPolicy: RateLimitPolicy,
+	): void;
 	createCodexCompactionContext(options: {
 		trigger: CodexCompactionContext["trigger"];
 		reason: CodexCompactionContext["reason"];
@@ -1507,7 +1513,7 @@ export class SessionAdvisors {
 			return false;
 		}
 
-		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
+		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message, rateLimitPolicy);
 		for (const role of chainKeys) {
 			for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 				if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1553,10 +1553,15 @@ export class TurnRecovery {
 	}
 
 	/** Records the cooldown that should suppress a failing selector. */
-	noteRetryFallbackCooldown(currentSelector: string, retryAfterMs: number | undefined, errorMessage: string): void {
+	noteRetryFallbackCooldown(
+		currentSelector: string,
+		retryAfterMs: number | undefined,
+		errorMessage: string,
+		rateLimitPolicy: RateLimitPolicy,
+	): void {
 		let cooldownMs = retryAfterMs;
 		if (!cooldownMs || cooldownMs <= 0) {
-			const reason = this.#parseRateLimitReason(errorMessage);
+			const reason = parseRateLimitReason(errorMessage, rateLimitPolicy);
 			cooldownMs = reason === "UNKNOWN" ? 5 * 60 * 1000 : calculateRateLimitBackoffMs(reason);
 		}
 		this.#host.modelRegistry.suppressSelector(currentSelector, Date.now() + cooldownMs);
@@ -2334,7 +2339,12 @@ export class TurnRecovery {
 				!(retryBudgetExhausted && classifierRefusal)
 			) {
 				if (!classifierRefusal) {
-					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
+					this.noteRetryFallbackCooldown(
+						currentSelector,
+						parsedRetryAfterMs,
+						errorMessage,
+						this.#rateLimitPolicy(),
+					);
 				}
 				switchedModel = await this.#tryRetryModelFallback(currentSelector, message, {
 					excludeProvider: longUsageLimitFallback ? currentModel.provider : undefined,

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -23,6 +23,7 @@ import {
 	parseRateLimitReason,
 	type RateLimitPolicy,
 	type RateLimitReason,
+	resolveModelRateLimitPolicy,
 } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
@@ -1199,12 +1200,7 @@ export class TurnRecovery {
 	}
 
 	#rateLimitPolicy(): RateLimitPolicy {
-		const activeModel = this.#host.model();
-		return {
-			genericResourceExhaustedIsRateLimit:
-				activeModel !== undefined &&
-				resolveModelPolicy(activeModel).catalog.genericResourceExhaustedIsRateLimit === true,
-		};
+		return resolveModelRateLimitPolicy(this.#host.model());
 	}
 
 	#parseRateLimitReason(errorMessage: string): RateLimitReason {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -18,7 +18,12 @@ import type {
 	ThinkingContent,
 	ToolChoice,
 } from "@oh-my-pi/pi-ai";
-import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-ai";
+import {
+	calculateRateLimitBackoffMs,
+	parseRateLimitReason,
+	type RateLimitPolicy,
+	type RateLimitReason,
+} from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
@@ -610,7 +615,8 @@ export class TurnRecovery {
 		if (!recorded) {
 			const errorMessage = message.errorMessage || "Unknown error";
 			const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
-			const retryAfterMs = parsedRetryAfterMs ?? calculateRateLimitBackoffMs(parseRateLimitReason(errorMessage));
+			const retryAfterMs =
+				parsedRetryAfterMs ?? calculateRateLimitBackoffMs(this.#parseRateLimitReason(errorMessage));
 			recorded = (async (): Promise<UsageLimitOutcome> => {
 				const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
 					activeModel.provider,
@@ -1173,8 +1179,12 @@ export class TurnRecovery {
 	 */
 	#classifyRetryMessage(message: AssistantMessage): number {
 		const activeModel = this.#host.model();
-		if (!activeModel || message.api === activeModel.api) {
-			return AIError.classifyMessage(message);
+		if (!activeModel) return AIError.classifyMessage(message);
+		const rateLimitPolicy = this.#rateLimitPolicy();
+		if (message.api === activeModel.api) {
+			const id = AIError.classifyMessage({ ...message, rateLimitPolicy });
+			message.errorId = id;
+			return id;
 		}
 
 		const id = AIError.classifyMessage({
@@ -1182,9 +1192,23 @@ export class TurnRecovery {
 			errorId: message.errorId,
 			errorMessage: message.errorMessage,
 			errorStatus: message.errorStatus,
+			rateLimitPolicy,
 		});
 		message.errorId = id;
 		return id;
+	}
+
+	#rateLimitPolicy(): RateLimitPolicy {
+		const activeModel = this.#host.model();
+		return {
+			genericResourceExhaustedIsRateLimit:
+				activeModel !== undefined &&
+				resolveModelPolicy(activeModel).catalog.genericResourceExhaustedIsRateLimit === true,
+		};
+	}
+
+	#parseRateLimitReason(errorMessage: string): RateLimitReason {
+		return parseRateLimitReason(errorMessage, this.#rateLimitPolicy());
 	}
 
 	#isUsagePreflightBlocked(message: AssistantMessage): boolean {
@@ -1532,7 +1556,7 @@ export class TurnRecovery {
 	noteRetryFallbackCooldown(currentSelector: string, retryAfterMs: number | undefined, errorMessage: string): void {
 		let cooldownMs = retryAfterMs;
 		if (!cooldownMs || cooldownMs <= 0) {
-			const reason = parseRateLimitReason(errorMessage);
+			const reason = this.#parseRateLimitReason(errorMessage);
 			cooldownMs = reason === "UNKNOWN" ? 5 * 60 * 1000 : calculateRateLimitBackoffMs(reason);
 		}
 		this.#host.modelRegistry.suppressSelector(currentSelector, Date.now() + cooldownMs);
@@ -2144,7 +2168,7 @@ export class TurnRecovery {
 			options?.preserveFailedTurn === true ||
 			((classifierRefusal || AIError.is(id, AIError.Flag.MalformedFunctionCall) || AIError.retriable(id)) &&
 				this.#unexecutedToolCallsReplaySafe(message));
-		const rateLimitReason = parseRateLimitReason(errorMessage);
+		const rateLimitReason = this.#parseRateLimitReason(errorMessage);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);
 		const accountPolicyDenial = AIError.is(id, AIError.Flag.AccountPolicy);
 		const recordedUsageLimitOutcome = await this.#usageLimitOutcomes.get(message);

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1150,7 +1150,6 @@ function buildAntigravityRequest(
 				{ category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "BLOCK_ONLY_HIGH" },
 			],
 		},
-		requestType: "agent",
 		requestId: `agent-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
 		userAgent: "antigravity",
 	};

--- a/packages/coding-agent/src/web/search/providers/gemini.ts
+++ b/packages/coding-agent/src/web/search/providers/gemini.ts
@@ -428,7 +428,6 @@ async function callGeminiSearch(
 
 	const requestMetadata = auth.isAntigravity
 		? {
-				requestType: "agent",
 				userAgent: "antigravity",
 				requestId: `agent-${crypto.randomUUID()}`,
 			}

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -130,6 +130,26 @@ function thinkingLoopErrorStream(model: Model<Api>): AssistantMessageEventStream
 	return stream;
 }
 
+function advisorUsageLimitErrorStream(model: Model<Api>, errorMessage: string): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const partial: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "error",
+			errorMessage,
+			errorId: AIError.create(AIError.Flag.UsageLimit),
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "error", reason: "error", error: partial });
+	});
+	return stream;
+}
+
 /** A stream that completes normally with a single text block. */
 function recoveredTextStream(model: Model<Api>, text: string): AssistantMessageEventStream {
 	const stream = new AssistantMessageEventStream();
@@ -227,6 +247,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
 		authStorage.setRuntimeApiKey("fireworks", "fireworks-test-key");
 		authStorage.setRuntimeApiKey("google", "google-test-key");
+		authStorage.setRuntimeApiKey("google-antigravity", "google-antigravity-test-key");
 		authStorage.setRuntimeApiKey("google-vertex", "google-vertex-test-key");
 		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
 		authStorage.setRuntimeApiKey("devin", "devin-test-key");
@@ -1602,9 +1623,9 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
-	it("keeps advisor fallback recovery on its role chain when another role shares its model", async () => {
+	it("uses the advisor model policy while keeping fallback recovery on its role chain", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
-		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const advisorPrimary = getBundledModel("google-antigravity", "gemini-3.8-flash");
 		const unrelatedFallback = getBundledModel("openai", "gpt-4o");
 		const advisorFallback = getBundledModel("google", "gemini-2.5-flash");
 		if (!mainModel || !advisorPrimary || !unrelatedFallback || !advisorFallback) {
@@ -1639,6 +1660,7 @@ describe("AgentSession retry fallback", () => {
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 0,
 			"retry.fallbackChains": {
 				commit: [unrelatedFallbackSelector],
 				advisor: [advisorFallbackSelector],
@@ -1660,9 +1682,10 @@ describe("AgentSession retry fallback", () => {
 				const selector = `${model.provider}/${model.id}`;
 				requestedAdvisorModels.push(selector);
 				if (selector === advisorPrimarySelector && advisorPrimaryAttempts++ === 0) {
-					advisorMock.push({
-						throw: "Devin stream error failed_precondition: Your daily usage quota has been exhausted. Your quota will reset after 1s.",
-					});
+					return advisorUsageLimitErrorStream(
+						model,
+						'Cloud Code Assist API error (429): {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}',
+					);
 				} else if (selector === advisorPrimarySelector) {
 					advisorMock.push({ content: ["Advisor primary restored"] });
 				} else if (selector === unrelatedFallbackSelector) {
@@ -1717,7 +1740,7 @@ describe("AgentSession retry fallback", () => {
 		expect(advisorFailures).toEqual([]);
 
 		const getApiKey = vi.spyOn(modelRegistry, "getApiKey");
-		const afterCooldown = Date.now() + 2_000;
+		const afterCooldown = Date.now() + 31_000;
 		vi.spyOn(Date, "now").mockReturnValue(afterCooldown);
 		await session.prompt("Complete another primary turn after the advisor cooldown");
 		await session.waitForIdle();


### PR DESCRIPTION
## Repro
Using Google Antigravity (Google AI Pro) with a Gemini Flash model, `Ask anything` fails with `Cloud Code Assist API error (429): … "status": "RESOURCE_EXHAUSTED"` followed by `Retry failed after 1 attempts: Provider requested 1800000ms wait, exceeds retry.maxDelayMs (300000ms)` — despite ~95% quota remaining. Feeding the reporter's exact 429 body to the classifier reproduces it:

```
$ bun repro (packages/ai) → parseRateLimitReason(body)
reason: QUOTA_EXHAUSTED
backoffMs: 1800000 (30 min)
isUsageLimitOutcome(429): true
exceeds default maxDelayMs (300000)? true
```

## Cause
Google's generic HTTP 429 body `Resource has been exhausted (e.g. check quota).` is its per-minute/per-region request throttle and carries no structured `google.rpc` `ErrorInfo`/`RetryInfo`. In `packages/ai/src/error/rate-limit.ts`, `parseRateLimitReason` had no authoritative structured reason to key on, so it fell through to the generic `lower.includes("exhausted")`/`"quota"` branch and returned `QUOTA_EXHAUSTED`. `calculateRateLimitBackoffMs(QUOTA_EXHAUSTED)` then synthesizes a 30-minute wait, which `turn-recovery.ts` records as a usage-limit outcome; with no sibling credential or model fallback, the delay exceeds `retry.maxDelayMs` and the fail-fast cap surfaces the terminal error. `matchesUsageLimitText` also matched via the JSON `resource_exhausted` status token, flagging it a credential-rotatable usage limit.

## Fix
- Add `GOOGLE_GENERIC_RESOURCE_EXHAUSTED_PATTERN` and an `isGoogleGenericResourceExhaustedText` guard that matches only the bare boilerplate — and returns false when structured `google.rpc` details or the distinct daily-quota wording (`exhausted your capacity … quota will reset`) are present.
- `parseRateLimitReason`: classify the bare boilerplate as `RATE_LIMIT_EXCEEDED` (transient, 30s backoff, retried on the same credential), placed after the daily-quota short-circuit so genuine exhaustion still wins.
- `matchesUsageLimitText`: exclude the boilerplate so it is not treated as a usage-limit outcome and does not burn a sibling credential.
- Update the stale regression test that asserted the old `QUOTA_EXHAUSTED` mapping; add coverage for the reporter's exact JSON body, the usage-limit exclusion, and that genuine daily exhaustion stays `QUOTA_EXHAUSTED`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/rate-limit-utils.test.ts` (packages/ai) → 72 pass / 0 fail. `bun test test/agent-session-retry-cap.test.ts` (packages/coding-agent) → 53 pass / 0 fail. Manual classifier check confirms the reporter's body now yields `RATE_LIMIT_EXCEEDED` / 30s / not-a-usage-limit, while structured `QUOTA_EXHAUSTED`/`RATE_LIMIT_EXCEEDED`+long-`RetryInfo`, plain `Quota exceeded`, and `exhausted your capacity … quota will reset` all keep their prior classification.

Fixes #11689