### PR TITLE
fix(export): render nested list markup in HTML transcripts

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/export` HTML now renders bold inline code inside ordered-list items followed by fenced code blocks instead of displaying literal `<strong>` and `<code>` tags ([#11690](https://github.com/can1357/oh-my-pi/issues/11690)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -1589,7 +1589,8 @@
           },
           // Text content: escape HTML tags
           text(token) {
-            return token.tokens ? this.parser.parseInline(token.tokens) : escapeHtmlTags(escapeHtml(token.text));
+            if (token.tokens) return this.parser.parseInline(token.tokens);
+            return token.escaped ? token.text : escapeHtmlTags(escapeHtml(token.text));
           },
           // Inline code: escape HTML
           codespan(token) {

--- a/packages/coding-agent/test/export-html-markdown.test.ts
+++ b/packages/coding-agent/test/export-html-markdown.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import * as vm from "node:vm";
 import { type Element, parseHTML } from "@oh-my-pi/pi-utils/dom";
-import { Marked } from "@oh-my-pi/pi-utils/marked";
 
-const [templateHtml, templateJs] = await Promise.all([
+const [templateHtml, templateJs, markedJs] = await Promise.all([
 	Bun.file(new URL("../src/export/html/template.html", import.meta.url)).text(),
 	Bun.file(new URL("../src/export/html/template.js", import.meta.url)).text(),
+	Bun.file(new URL("../src/export/html/vendor/marked.min.js", import.meta.url)).text(),
 ]);
 
 interface MinimalMessageEntry {
@@ -62,7 +62,6 @@ function renderSession(session: MinimalSession) {
 	const context = vm.createContext({
 		window,
 		document,
-		marked: new Marked(),
 		hljs: {
 			getLanguage: () => false,
 			highlight: () => ({ value: "" }),
@@ -78,6 +77,8 @@ function renderSession(session: MinimalSession) {
 		setTimeout: () => 0,
 		clearTimeout() {},
 	});
+	vm.runInContext(markedJs, context);
+	vm.runInContext("marked = new marked.Marked()", context);
 	vm.runInContext(templateJs, context);
 	return document;
 }
@@ -161,6 +162,21 @@ describe("HTML export Markdown", () => {
 		expect(rendered.querySelector("ul > li > em")?.textContent).toBe("italic");
 		expect(rendered.querySelector("ul > li > code")?.textContent).toBe("code");
 		expect(rendered.querySelector("ol > li > strong")?.textContent).toBe("nested");
+	});
+
+	test("renders bold inline code before indented code blocks in ordered lists", () => {
+		const rendered = renderMarkdown(`1. **\`Crew Ship\`** — description
+   \`\`\`json
+   { "crew": "..." }
+   \`\`\`
+
+2. **\`Hover Ship\`** — description
+   \`\`\`json
+   { "crew": "..." }
+   \`\`\``);
+
+		const names = [...rendered.querySelectorAll("ol > li > p > strong > code")].map(element => element.textContent);
+		expect(names).toEqual(["Crew Ship", "Hover Ship"]);
 	});
 
 	test("renders a deep valid conversation tree without overflowing the call stack", () => {


### PR DESCRIPTION
## Repro

With the export viewer’s pinned `marked@15.0.4`, `bun test packages/coding-agent/test/export-html-markdown.test.ts` rendered an ordered-list item containing `**`Crew Ship`**` immediately before an indented fenced block without any `<strong><code>` element; the pre-fix regression run failed with `Expected: ["Crew Ship", "Hover Ship"]`, `Received: []`.

## Cause

`packages/coding-agent/src/export/html/template.js` reparsed nested inline tokens in `renderer.text`, but marked 15 renders loose-list inline content a second time as a synthetic text token with `escaped: true`. Ignoring that flag sent marked’s generated `<strong>` and `<code>` markup through `escapeHtmlTags(escapeHtml(...))`, exposing those tags as text.

## Fix

- Preserve marked-generated text when the token carries `escaped: true`, while retaining leaf-text escaping.
- Exercise the exact vendored marked 15.0.4 browser parser and cover bold inline code followed by fenced blocks.
- Document the corrected `/export` rendering in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/export-html-*.test.ts` passed: 27 tests, 0 failures. The source CLI also generated a standalone HTML export from the deterministic session fixture successfully; DOM-level coverage verifies both ship names render through `<strong><code>`. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #11690