### PR TITLE
fix(coding-agent): clarify paused-plan guard warning

### DIFF
--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -23,7 +23,6 @@ import {
 	normalizeDomain,
 	normalizeGitHubCopilotEnterpriseDomain,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { $env } from "@oh-my-pi/pi-utils";
 import {
 	resolveCopilotIntegrationIdOverride,
 	wrapFetchForCopilotFallback,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Entering goal or vibe mode while a plan session is paused now warns `Plan mode is paused — run /plan again to fully exit.` instead of the stale `Exit plan mode first.` ([#11692](https://github.com/can1357/oh-my-pi/issues/11692)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3560,12 +3560,25 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
+	/**
+	 * Warn that a plan session blocks entering goal/vibe mode, distinguishing an
+	 * active session from a paused one. A paused session already restored the
+	 * tools/model and cleared the `xd://propose` handler, so "Exit plan mode
+	 * first." reads as stale right after the user toggled plan mode off (#11692);
+	 * point them at the second `/plan` toggle that fully exits instead.
+	 */
+	#warnPlanModeBlocks(): void {
+		this.showWarning(
+			this.planModePaused ? "Plan mode is paused — run /plan again to fully exit." : "Exit plan mode first.",
+		);
+	}
+
 	async #enterGoalMode(options: { objective?: string; resume?: boolean; silent?: boolean }): Promise<void> {
 		if (this.goalModeEnabled) {
 			return;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
-			this.showWarning("Exit plan mode first.");
+			this.#warnPlanModeBlocks();
 			return;
 		}
 		if (this.vibeModeEnabled) {
@@ -4278,7 +4291,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return false;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
-			this.showWarning("Exit plan mode first.");
+			this.#warnPlanModeBlocks();
 			return false;
 		}
 		if (this.goalModeEnabled || this.goalModePaused) {
@@ -4393,7 +4406,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
-			this.showWarning("Exit plan mode first.");
+			this.#warnPlanModeBlocks();
 			return;
 		}
 		if (this.goalModeEnabled || this.goalModePaused) {
@@ -4501,7 +4514,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
 	): Promise<boolean> {
 		if (this.planModeEnabled || this.planModePaused) {
-			this.showWarning("Exit plan mode first.");
+			this.#warnPlanModeBlocks();
 			return false;
 		}
 		if (this.vibeModeEnabled) {
@@ -4544,7 +4557,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	): Promise<boolean> {
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
-				this.showWarning("Exit plan mode first.");
+				this.#warnPlanModeBlocks();
 				return false;
 			}
 			if (this.vibeModeEnabled) {

--- a/packages/coding-agent/test/interactive-mode-plan-paused-guard.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-paused-guard.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Contract: once plan mode is toggled off into the *paused* state, the guards
+ * that block goal/vibe entry must say the plan session is paused (and how to
+ * fully exit) rather than the stale "Exit plan mode first." — which reads as
+ * self-contradictory right after the user just exited plan mode (#11692).
+ *
+ * While the plan session is still *active*, the guard keeps the original
+ * "Exit plan mode first." wording.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("InteractiveMode paused-plan guard message", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		await initTheme();
+		tempDir = TempDir.createSync("@pi-plan-paused-guard-");
+		authStorage = createInMemoryAuthStorage();
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		vi.spyOn(modelRegistry, "getApiKey").mockResolvedValue("test-key");
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: () => {
+					throw new Error("No test stream configured");
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({}),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test", undefined, undefined, undefined, undefined, new EventBus());
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		await session?.dispose();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("warns that plan mode is paused (not 'Exit plan mode first.') when a paused session blocks vibe/goal", async () => {
+		// Enter plan mode, then toggle off — no draft content, so this pauses.
+		await mode.handlePlanModeCommand();
+		expect(mode.planModeEnabled).toBe(true);
+		await mode.handlePlanModeCommand();
+		expect(mode.planModeEnabled).toBe(false);
+		expect(mode.planModePaused).toBe(true);
+
+		const warn = vi.spyOn(mode, "showWarning");
+
+		await mode.handleVibeModeCommand();
+		await mode.handleGoalModeCommand();
+
+		const messages = warn.mock.calls.map(call => call[0]);
+		expect(messages).toEqual([
+			"Plan mode is paused — run /plan again to fully exit.",
+			"Plan mode is paused — run /plan again to fully exit.",
+		]);
+		expect(messages).not.toContain("Exit plan mode first.");
+	});
+
+	it("keeps 'Exit plan mode first.' while the plan session is still active", async () => {
+		await mode.handlePlanModeCommand();
+		expect(mode.planModeEnabled).toBe(true);
+
+		const warn = vi.spyOn(mode, "showWarning");
+
+		await mode.handleVibeModeCommand();
+
+		expect(warn.mock.calls.map(call => call[0])).toEqual(["Exit plan mode first."]);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-plan-paused-guard.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-paused-guard.test.ts
@@ -79,12 +79,14 @@ describe("InteractiveMode paused-plan guard message", () => {
 		await mode.handleVibeModeCommand();
 		await mode.handleGoalModeCommand();
 
-		const messages = warn.mock.calls.map(call => call[0]);
-		expect(messages).toEqual([
-			"Plan mode is paused — run /plan again to fully exit.",
-			"Plan mode is paused — run /plan again to fully exit.",
-		]);
-		expect(messages).not.toContain("Exit plan mode first.");
+		// Both the /vibe and /goal guards fired; a paused blocker must name the
+		// paused state and point at /plan recovery — not the active-mode exit copy.
+		const messages = warn.mock.calls.map(call => String(call[0]));
+		expect(messages).toHaveLength(2);
+		for (const message of messages) {
+			expect(message.toLowerCase()).toContain("paused");
+			expect(message).toContain("/plan");
+		}
 	});
 
 	it("keeps 'Exit plan mode first.' while the plan session is still active", async () => {
@@ -95,6 +97,10 @@ describe("InteractiveMode paused-plan guard message", () => {
 
 		await mode.handleVibeModeCommand();
 
-		expect(warn.mock.calls.map(call => call[0])).toEqual(["Exit plan mode first."]);
+		// Active session: instruct exit, without the paused wording.
+		const messages = warn.mock.calls.map(call => String(call[0]));
+		expect(messages).toHaveLength(1);
+		expect(messages[0].toLowerCase()).toContain("exit plan mode");
+		expect(messages[0].toLowerCase()).not.toContain("paused");
 	});
 });


### PR DESCRIPTION
## Repro
Enter plan mode, then toggle `/plan` off without approving a plan: the status shows `Plan mode paused.` and the plan tools/model are restored (`xd://propose` rejects with "No plan is awaiting approval"). Now try `/goal` or `/vibe` — omp blocks with `Exit plan mode first.`, which reads as stale since the user just exited plan mode. Reproduced by driving `InteractiveMode` directly:

```
ACTIVE planModeEnabled: true
ACTIVE captured: ["Exit plan mode first."]
PAUSED planModePaused: true enabled: false
PAUSED captured: ["Exit plan mode first.","Exit plan mode first."]   # /vibe then /goal
```

## Cause
In `packages/coding-agent/src/modes/interactive-mode.ts`, all five mode guards (`#enterGoalMode`, `handleVibeModeCommand`, `#enterVibeMode`, `handleGoalModeCommand`, `handleGuidedGoalCommand`) test `planModeEnabled || planModePaused` and print the identical `Exit plan mode first.`. A *paused* plan session (`#exitPlanMode({ paused: true })`) already restored tools/model and cleared the proposal handler, so that message contradicts the just-shown `Plan mode paused.` status. The paused three-state toggle itself is deliberate (introduced by #2510).

## Fix
- Add `#warnPlanModeBlocks()` that emits `Plan mode is paused — run /plan again to fully exit.` when the blocker is a paused (not active) session, and keeps `Exit plan mode first.` while the session is active.
- Route all five guard sites through the helper.
- Add `test/interactive-mode-plan-paused-guard.test.ts` covering both the active and paused messages for the goal/vibe guards.
- Changelog entry under `[Unreleased] > Fixed`.

The deliberate paused state and the block itself are unchanged; the reporter's more invasive options (auto-clear on mode switch, exit-means-exit) are behavior changes left for a maintainer decision.

## Verification
`bun check` — green. Behavioral proof by driving `InteractiveMode`: active session warns `Exit plan mode first.`; paused session warns `Plan mode is paused — run /plan again to fully exit.` for both `/vibe` and `/goal`. The new test file's body assertions pass; its `afterEach` `mode.stop()` hits a pre-existing sandbox-only native skew (`vcsDiscover` missing from the read-only prebuilt `.node`) that also breaks the existing `interactive-mode-plan-mode-exit.test.ts` teardown and is unrelated to this diff. Fixes #11692