### PR TITLE
fix(coding-agent): validate compat.stripImageInput in models.yml schema

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `omp models` now reports whether a model's images actually reach the provider, so an id stripped by a text-only catalog rule no longer shows `images: yes` ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
 - Custom `Other` answers are now applied before the Ask dialog becomes interactive again, so the next Enter is no longer discarded ([#11558](https://github.com/can1357/oh-my-pi/pull/11558) by [@schickling-assistant](https://github.com/schickling-assistant)).
 - Explicit per-model price overrides retain their configured flat rates instead of inheriting time-based pricing.
+- Fixed wrong-typed `compat.stripImageInput` in `models.yml` being silently accepted, so the documented vision opt-out is now validated like its neighbours ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
 
 ## [18.1.16] - 2026-09-09
 

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -57,6 +57,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 		"alwaysSendMaxTokens?": "boolean",
 		"strictResponsesPairing?": "boolean",
 		"supportsImageDetailOriginal?": "boolean",
+		"stripImageInput?": "boolean",
 		// anthropic-messages compat flags (same `compat` slot, per-api interpretation)
 		"supportsContextManagement?": "boolean",
 		"supportsEagerToolInputStreaming?": "boolean",

--- a/packages/coding-agent/test/config/models-config-validation.test.ts
+++ b/packages/coding-agent/test/config/models-config-validation.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { OmpErrors } from "@oh-my-pi/omptype";
+import { getModelsConfigSchema } from "@oh-my-pi/pi-coding-agent/config/models-config-schema-bundle";
 import { validateProviderConfiguration } from "@oh-my-pi/pi-coding-agent/config/models-config";
 
 const models = [{ id: "grok-4", api: "openai-completions" as const }];
@@ -31,5 +33,35 @@ describe("validateProviderConfiguration (models-config auth)", () => {
 				"models-config",
 			),
 		).not.toThrow();
+	});
+});
+
+describe("models.yml compat.stripImageInput (#11697)", () => {
+	const schema = getModelsConfigSchema();
+	const configWithModelCompat = (compat: unknown) => ({
+		providers: {
+			p: {
+				baseUrl: "http://x/v1",
+				apiKey: "K",
+				api: "openai-completions" as const,
+				models: [{ id: "m", input: ["text", "image"] as ("text" | "image")[], compat }],
+			},
+		},
+	});
+
+	test("accepts a boolean opt-out and preserves it", () => {
+		const parsed = schema(configWithModelCompat({ stripImageInput: false }));
+		expect(parsed instanceof OmpErrors).toBe(false);
+		if (!(parsed instanceof OmpErrors)) {
+			expect(parsed.providers?.p?.models?.[0]?.compat).toMatchObject({ stripImageInput: false });
+		}
+	});
+
+	test("rejects a wrong-typed opt-out instead of silently ignoring it", () => {
+		const parsed = schema(configWithModelCompat({ stripImageInput: "no" }));
+		expect(parsed instanceof OmpErrors).toBe(true);
+		if (parsed instanceof OmpErrors) {
+			expect(parsed.summary).toContain("stripImageInput");
+		}
 	});
 });


### PR DESCRIPTION
## What

fix for #11697; it type-checks the stripImageInput vision opt-out like its sibling compat keys.

Declares `stripImageInput?: boolean` in `OpenAICompatFields` (`packages/coding-agent/src/config/models-config-schema-bundle.ts`), so model/provider/`modelOverrides`/`whenThinking` compat gets the same type-check as its neighbours. Adds a regression test and CHANGELOG entry.

## Why

Fixes #11697. The documented vision opt-out was consumed by `vision-guard.ts` but absent from the schema, so `stripImageInput: "no"` was silently accepted and the catalog class rule stayed in force.

## Testing

- New `models-config-validation.test.ts`: boolean accepted/preserved, wrong type rejected with `stripImageInput` in summary — fails pre-fix, passes post-fix
- `bun test packages/coding-agent/test/config/models-config-validation.test.ts`: 6 pass
- `bun test packages/ai/test/issue-967-vision-guard.test.ts packages/ai/test/openai-completions-compat.test.ts`: 79 pass
- `bun test packages/coding-agent/test/model-registry.test.ts`: 133 pass
- `models-cli-image-support` failure pre-exists (missing `tool-views.generated.js`), identical with/without this change

---
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
