### PR TITLE
fix(coding-agent): gate image fallback on wire truth (#9697)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Models whose images are stripped on the wire (`compat.stripImageInput`) now trigger the `describeForTextModels` vision fallback and are skipped when resolving the vision model, instead of silently dropping images ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/session/session-provider-boundary.ts
+++ b/packages/coding-agent/src/session/session-provider-boundary.ts
@@ -2,6 +2,7 @@
 
 import type { Agent, AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { CompactionPreparation } from "@oh-my-pi/pi-agent-core/compaction";
+import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import type { AssistantMessage, ImageContent, Message, Model, SimpleStreamOptions, TextContent } from "@oh-my-pi/pi-ai";
 import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
@@ -228,7 +229,7 @@ export class SessionProviderBoundary {
 		const model = this.#host.model();
 		const shouldDescribe =
 			!!model &&
-			!model.input.includes("image") &&
+			!sendsImageInputOnWire(model) &&
 			!this.#host.settings.get("images.blockImages") &&
 			this.#host.settings.get("images.describeForTextModels");
 		if (!shouldDescribe || !model) return undefined;

--- a/packages/coding-agent/src/utils/image-question.ts
+++ b/packages/coding-agent/src/utils/image-question.ts
@@ -1,4 +1,5 @@
 import { instrumentedCompleteSimple, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
+import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { type Api, type AssistantMessage, completeSimple, type Model, type Usage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { extractTextContent } from "../commit/utils";
@@ -51,7 +52,7 @@ export function resolveImageQuestionModel(session: ToolSession): ResolvedImageQu
 	let selectedPattern: string | undefined;
 	for (const pattern of ["@vision", "@default", activeModelPattern]) {
 		const resolved = resolvePattern(pattern);
-		if (resolved?.input.includes("image")) {
+		if (resolved && sendsImageInputOnWire(resolved)) {
 			model = resolved;
 			selectedPattern = pattern;
 			break;
@@ -60,9 +61,9 @@ export function resolveImageQuestionModel(session: ToolSession): ResolvedImageQu
 
 	const activeProvider = resolvePattern(activeModelPattern)?.provider;
 	model ??= availableModels.find(
-		candidate => candidate.provider === activeProvider && candidate.input.includes("image"),
+		candidate => candidate.provider === activeProvider && sendsImageInputOnWire(candidate),
 	);
-	model ??= availableModels.find(candidate => candidate.input.includes("image"));
+	model ??= availableModels.find(candidate => sendsImageInputOnWire(candidate));
 	if (!model) {
 		const textOnly = resolvePattern("@vision") ?? resolvePattern("@default") ?? resolvePattern(activeModelPattern);
 		if (!textOnly) throw new ToolError("Unable to resolve a model for image questions.");

--- a/packages/coding-agent/src/utils/image-vision-fallback.ts
+++ b/packages/coding-agent/src/utils/image-vision-fallback.ts
@@ -18,6 +18,7 @@ import {
 	instrumentedCompleteSimple,
 	resolveTelemetry,
 } from "@oh-my-pi/pi-agent-core";
+import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import type { Api, completeSimple, ImageContent, Model, TextContent } from "@oh-my-pi/pi-ai";
 import { logger, prompt, toError } from "@oh-my-pi/pi-utils";
 import { extractTextContent } from "../commit/utils";
@@ -108,13 +109,13 @@ function resolveVisionModel(deps: DescribeAttachedImagesDeps): Model<Api> | unde
 		if (!pattern) return undefined;
 		const expanded = expandRoleAlias(pattern, deps.settings);
 		const model = resolveModelFromString(expanded, available, preferences);
-		return model?.input.includes("image") ? model : undefined;
+		return model && sendsImageInputOnWire(model) ? model : undefined;
 	};
 	return (
 		resolvePattern("@vision") ??
 		resolvePattern("@default") ??
 		resolvePattern(deps.activeModelString) ??
-		available.find(model => model.input.includes("image"))
+		available.find(model => sendsImageInputOnWire(model))
 	);
 }
 

--- a/packages/coding-agent/test/session/session-provider-boundary-image.test.ts
+++ b/packages/coding-agent/test/session/session-provider-boundary-image.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Api, ImageContent, Model } from "@oh-my-pi/pi-ai";
+import type { ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	SessionProviderBoundary,
+	type SessionProviderBoundaryHost,
+} from "@oh-my-pi/pi-coding-agent/session/session-provider-boundary";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const TINY_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+function makeProxyModel(id: string, compat?: ModelSpec["compat"]): Model<Api> {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "myproxy",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		compat,
+	} as ModelSpec);
+}
+
+function makeHost(active: Model<Api>, artifactsDir: string): SessionProviderBoundaryHost {
+	return {
+		agent: { telemetry: undefined },
+		sessionManager: {},
+		settings: Settings.isolated(),
+		modelRegistry: {
+			getAvailable: () => [],
+		},
+		model: () => active,
+		sessionId: () => "test-session",
+		localProtocolOptions: () => ({ getArtifactsDir: () => artifactsDir, getSessionId: () => "test-session" }),
+	} as unknown as SessionProviderBoundaryHost;
+}
+
+describe("buildImageDescriptionNotice wire truth (#9697)", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = await fs.mkdtemp(path.join(os.tmpdir(), "boundary-wire-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(testDir);
+	});
+
+	it("falls back for a wire-stripped model that declares image input, not for an opted-out one", async () => {
+		const image: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
+		const stripped = makeProxyModel("deepseek-v4-flash", { stripImageInput: true });
+		const notice = await new SessionProviderBoundary(makeHost(stripped, testDir)).buildImageDescriptionNotice([
+			image,
+		]);
+		expect(notice).toBeDefined();
+		expect(JSON.stringify(notice)).toContain("No vision-capable model");
+
+		const optedOut = makeProxyModel("deepseek-v4-flash", { stripImageInput: false });
+		const silent = await new SessionProviderBoundary(makeHost(optedOut, testDir)).buildImageDescriptionNotice([
+			image,
+		]);
+		expect(silent).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/utils/image-question.test.ts
+++ b/packages/coding-agent/test/utils/image-question.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import type { ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { resolveImageQuestionModel } from "@oh-my-pi/pi-coding-agent/utils/image-question";
+
+function makeProxyModel(id: string, compat?: ModelSpec["compat"]): Model<Api> {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "myproxy",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		compat,
+	} as ModelSpec);
+}
+
+function makeSession(active: Model<Api>, available: Model<Api>[]): ToolSession {
+	return {
+		settings: Settings.isolated(),
+		modelRegistry: {
+			getAvailable: () => available,
+		} as unknown as NonNullable<ToolSession["modelRegistry"]>,
+		getModelString: () => `${active.provider}/${active.id}`,
+		getActiveModelString: () => `${active.provider}/${active.id}`,
+	} as unknown as ToolSession;
+}
+
+describe("resolveImageQuestionModel wire truth (#9697)", () => {
+	it("skips a wire-stripped model that declares image input", () => {
+		const stripped = makeProxyModel("deepseek-v4-flash", { stripImageInput: true });
+		const vision = makeProxyModel("qwen-vl", { stripImageInput: false });
+		const resolved = resolveImageQuestionModel(makeSession(stripped, [stripped, vision]));
+		expect(resolved.model.id).toBe("qwen-vl");
+	});
+
+	it("throws instead of returning the stripped model when nothing else can see", () => {
+		const stripped = makeProxyModel("deepseek-v4-flash", { stripImageInput: true });
+		expect(() => resolveImageQuestionModel(makeSession(stripped, [stripped]))).toThrow(
+			"Resolved model myproxy/deepseek-v4-flash does not support image input.",
+		);
+	});
+});

--- a/packages/coding-agent/test/utils/image-vision-fallback.test.ts
+++ b/packages/coding-agent/test/utils/image-vision-fallback.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AssistantMessage, completeSimple, Model } from "@oh-my-pi/pi-ai";
+import type { Api, AssistantMessage, completeSimple, Model } from "@oh-my-pi/pi-ai";
+import type { ModelSpec } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
@@ -57,7 +58,7 @@ function makeCompleteStub(text: string): { calls: unknown[][]; fn: typeof comple
 
 function makeDeps(
 	artifactsDir: string,
-	available: Model<"openai-responses">[],
+	available: Model<Api>[],
 	completeImpl: typeof completeSimple,
 	apiKey: string | undefined = "test-key",
 ): DescribeAttachedImagesDeps {
@@ -148,5 +149,28 @@ describe("describeAttachedImagesForTextModel", () => {
 
 		const paths = blocks.map(b => b.text.match(/path="(local:\/\/[^"]+)"/)![1]);
 		expect(paths[0]).toBe(paths[1]);
+	});
+	it("treats a wire-stripped completions model as text-only when resolving the vision model", async () => {
+		const stripped = buildModel({
+			id: "deepseek-v4-flash",
+			name: "deepseek-v4-flash",
+			api: "openai-completions",
+			provider: "myproxy",
+			baseUrl: "https://proxy.example.com/v1",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+			compat: { stripImageInput: true },
+		} as ModelSpec);
+		const stub = makeCompleteStub("should not be used");
+		const blocks = await describeAttachedImagesForTextModel(
+			[{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }],
+			makeDeps(testDir, [stripped], stub.fn),
+		);
+		expect(stub.calls).toHaveLength(0);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]!.text).toContain("No vision-capable model");
 	});
 });


### PR DESCRIPTION
## What

Wire-stripped models (declared `input: [text, image]` but `compat.stripImageInput: true`) behaved as neither vision nor text-only: the transport replaced images with the placeholder while the describe fallback and vision-model selection still saw declared image support and stayed out. I switched all three gates (`buildImageDescriptionNotice`, `resolveImageQuestionModel`, `resolveVisionModel`) to the shared `sendsImageInputOnWire()` predicate so stripped models get exactly the text-only treatment everywhere.

## Why

Fixes the silent-failure half of #9697. The opt-out itself (`compat.stripImageInput: false`, #11697 schema validation, wire-truth `omp models` column) already shipped; this closes the remaining gap where affected users got a placeholder with no description and no signal.

## Testing

- 4 new regression tests fail pre-fix, pass post-fix (verified via `git stash` A/B).
- Adjacent suites green: `read-image-question` (8), `images-cli` (8), `image-input` (4), ai guard suites (79). `models-cli-image-support` fails identically on clean main (missing generated `tool-views.generated.js` artifact, pre-existing).

---
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)