### PR TITLE
fix(browser): guard abort sends during worker recycling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Eval cell timeouts no longer fatally terminate the session when a browser tab worker is being recycled ([#11707](https://github.com/can1357/oh-my-pi/issues/11707)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -659,7 +659,7 @@ async function runInTabWithSnapshot(
 		}
 	}
 	const abort = (): void => {
-		tab.worker.send({ type: "abort", id });
+		safeSend(tab, { type: "abort", id });
 		for (const ctrl of pending.toolCalls.values()) ctrl.abort(opts.signal?.reason);
 	};
 	if (opts.signal?.aborted) abort();
@@ -1194,7 +1194,7 @@ export function armIdleCloseForOwner(ownerId: string, idleMs: number, retryMs: n
 }
 
 /** Test-only accessor for the module-global tabs map. */
-export function getTabsMapForTest(): ReadonlyMap<string, TabSession> {
+export function getTabsMapForTest(): Map<string, TabSession> {
 	return tabs;
 }
 

--- a/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
+++ b/packages/coding-agent/test/tools/browser-freeze-settle.test.ts
@@ -579,6 +579,47 @@ describe("browser settle — lifecycle freeze via CDP", () => {
 			expect(getTabsMapForTest().has("settle-cancelled")).toBe(true);
 		});
 
+		it("contains a tab-worker termination race when an in-flight run is aborted", async () => {
+			const name = "settle-terminated-worker";
+			const messages: string[] = [];
+			const worker = {
+				mode: "worker",
+				send(message: { type: string }): void {
+					messages.push(message.type);
+					if (message.type === "abort") {
+						throw new DOMException("Worker has been terminated", "InvalidStateError");
+					}
+				},
+				onMessage: (): (() => void) => () => {},
+				onError: (): (() => void) => () => {},
+				terminate: async (): Promise<void> => undefined,
+			};
+			const { tab } = makeStubTab({ name, worker, activateForScreenshot: false });
+			getTabsMapForTest().set(name, tab);
+			const controller = new AbortController();
+
+			try {
+				const run = runInTab(name, {
+					code: "await Promise.withResolvers().promise;",
+					timeoutMs: 60_000,
+					session: makeSession("/tmp"),
+					signal: controller.signal,
+				});
+				await Promise.resolve();
+				expect(messages).toEqual(["run"]);
+				const pending = tab.pending.values().next().value;
+				expect(pending).toBeDefined();
+
+				controller.abort(new ToolAbortError("cell timeout"));
+				pending?.reject(new ToolAbortError("cell timeout"));
+
+				await expect(run).rejects.toThrow("cell timeout");
+				expect(messages).toEqual(["run", "abort"]);
+			} finally {
+				getTabsMapForTest().delete(name);
+			}
+		});
+
 		it("double release is idempotent for concurrent sweep losers", async () => {
 			mockCmuxSocket();
 			const browser = await acquireBrowser(makeKind("settle-idempotent"), { cwd: "/tmp" });


### PR DESCRIPTION
## Repro

On current `main`, start `runInTab` with an abort signal and a worker-backed tab whose terminated worker throws `InvalidStateError` when the abort message is sent, then abort the signal. The reproducer command `bun -e "$REPRO"` (with `REPRO` installing that tab through `getTabsMapForTest()`, calling `runInTab(...)`, and then calling `controller.abort(...)`) exits 1 with `[Uncaught Exception] InvalidStateError: Worker has been terminated`.

## Cause

`packages/coding-agent/src/tools/browser/tab-supervisor.ts` registered an abort listener in `runInTabWithSnapshot()` that called `tab.worker.send(...)` directly. During `recycleTimedOutWorkerTab()`, the old Bun Worker is terminated before its replacement is published, so a concurrent eval-cell timeout could synchronously throw from that abort listener and bypass the normal tool error path.

## Fix

- Route the abort message through the existing state-aware, exception-containing `safeSend()` boundary.
- Make the test-only tab registry accessor mutable so the lifecycle test can install the exact worker state without Chromium.
- Add regression coverage for the in-flight abort/terminated-worker race and document the user-visible fix.

I reproduced the teardown race and kept the production fix at the existing worker-send boundary because that is where Bun's synchronous exception escapes.

## Verification

- `bun test packages/coding-agent/test/tools/browser-freeze-settle.test.ts packages/coding-agent/test/tools/eval-timeout.test.ts` — 34 passed, 10 skipped, 0 failed.
- `bun run check` in `packages/coding-agent` — passed (one pre-existing unused-variable warning in `executor-subagent-reminders.test.ts`).
- Re-ran the worker-backed abort reproducer: it exited 0 and printed `run,abort`; no uncaught exception.
- The pre-publish repository `bun check` gate passed.

Fixes #11707