### PR TITLE
fix(coding-agent): make status test worktree-safe

### DIFF
--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -145,7 +145,7 @@ describe("StatusLineComponent", () => {
 		const placeholder = Bun.stripANSI(statusLine.renderStartupPlaceholder(WIDE_ENOUGH_FOR_COST_SEGMENT, "box"));
 		expect(placeholder.match(/…/g)?.length).toBeGreaterThanOrEqual(3);
 		expect(placeholder).toContain(`${theme.icon.model} …`);
-		expect(placeholder).toContain(`${theme.icon.folder} …`);
+		expect([theme.icon.folder, theme.icon.worktree].some(icon => placeholder.includes(`${icon} …`))).toBe(true);
 		expect(placeholder).toContain("$…");
 		expect(placeholder).not.toContain("Stale Model");
 		expect(placeholder).not.toContain("stale-session");


### PR DESCRIPTION
## Repro
From a linked worktree, `cd packages/coding-agent && bun test test/modes/components/status-line/component.test.ts` reaches the startup-placeholder assertion with `🌳 …`, while the test required `📁 …`; an isolated `bun -e` run of `renderSegment("path", ctx)` with `startupPlaceholder: true`, `stripWorkPrefix: true`, and a linked-worktree context reproduced the mismatch with exit code 1.

## Cause
`StatusLineComponent.#resolveActiveRepoCache()` in `packages/coding-agent/src/modes/components/status-line/component.ts` derives worktree state from the process project directory, and `pathSegment` in `segments.ts` correctly renders `theme.icon.worktree` for that state, but `component.test.ts` hard-coded only `theme.icon.folder`.

## Fix

- Make the test independent of the host checkout.
- Accept either valid startup path icon while preserving every stale model, session, and cost exclusion assertion.

## Verification
`bun test --preload /tmp/omp-status-line-worktree-preload.ts test/modes/components/status-line/component.test.ts` passed 9/9 tests with `vcs.git().linkedWorktree()` forced to a linked-worktree context. `bun test test/status-line-path.test.ts` passed 12/12 tests, the isolated worktree-placeholder check now exits 0 while rendering `🌳 …`, and `bun run check` passed in `packages/coding-agent`.

Fixes #11715