### PR TITLE
test(coding-agent): make status-line placeholder assertion worktree-safe

### DIFF
--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir } from "@oh-my-pi/pi-utils";
 import { createGallerySegmentContext } from "../../../../src/cli/gallery-fixtures/segments";
 import { Settings } from "../../../../src/config/settings";
 import { StatusLineComponent } from "../../../../src/modes/components/status-line/component";
@@ -16,6 +18,11 @@ import { StatusLineTestComponents } from "../../../helpers/status-line";
 // truncation tests that target it directly.
 const WIDE_ENOUGH_FOR_COST_SEGMENT = 400;
 const statusLines = new StatusLineTestComponents();
+
+/** Same linked-worktree check `pathSegment` uses via `resolveWorktreeContext(getProjectDir())`. */
+function startupPathPlaceholderIcon(): string {
+	return vcs.git(getProjectDir())?.linkedWorktree() ? theme.icon.worktree : theme.icon.folder;
+}
 
 function makeSessionWithLastMessage(
 	lastMessage: unknown,
@@ -145,7 +152,7 @@ describe("StatusLineComponent", () => {
 		const placeholder = Bun.stripANSI(statusLine.renderStartupPlaceholder(WIDE_ENOUGH_FOR_COST_SEGMENT, "box"));
 		expect(placeholder.match(/…/g)?.length).toBeGreaterThanOrEqual(3);
 		expect(placeholder).toContain(`${theme.icon.model} …`);
-		expect(placeholder).toContain(`${theme.icon.folder} …`);
+		expect(placeholder).toContain(`${startupPathPlaceholderIcon()} …`);
 		expect(placeholder).toContain("$…");
 		expect(placeholder).not.toContain("Stale Model");
 		expect(placeholder).not.toContain("stale-session");

--- a/packages/coding-agent/test/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/component.test.ts
@@ -19,7 +19,16 @@ import { StatusLineTestComponents } from "../../../helpers/status-line";
 const WIDE_ENOUGH_FOR_COST_SEGMENT = 400;
 const statusLines = new StatusLineTestComponents();
 
-/** Same linked-worktree check `pathSegment` uses via `resolveWorktreeContext(getProjectDir())`. */
+/**
+ * Same linked-worktree check `pathSegment` uses via `resolveWorktreeContext(getProjectDir())`.
+ *
+ * Assumes this checkout has no `activeRepo` (single-direct-child repo).
+ * Production sets `ctx.worktree` to null whenever `activeRepo` is set
+ * (`component.ts` `#resolveActiveRepoCache`), and only then selects
+ * `icon.worktree` when `stripPrefix && ctx.worktree`. This helper does not
+ * re-implement that gate; if `getProjectDir()` ever resolved through an
+ * `activeRepo`, it would predict `worktree` while production renders `folder`.
+ */
 function startupPathPlaceholderIcon(): string {
 	return vcs.git(getProjectDir())?.linkedWorktree() ? theme.icon.worktree : theme.icon.folder;
 }


### PR DESCRIPTION
## Summary
- Status-line startup-placeholder test hard-coded `theme.icon.folder` (📁). In a linked git worktree, `pathSegment` correctly renders `theme.icon.worktree` (🌳) via the same `linkedWorktree()` check as `resolveWorktreeContext(getProjectDir())`, so `bun test` failed for anyone developing in `git worktree add` checkouts.
- The test now picks the icon with that same detection. Production code is unchanged.
- Fixes #11715

## Test plan
- [x] `cd packages/coding-agent && bun test test/modes/components/status-line/component.test.ts` in this linked worktree → 9 pass / 0 fail
- [ ] Same file from the primary checkout should still assert 📁 and pass
- [ ] `bun run test:ts` no longer aborts on this chunk when the suite is started from a worktree


Made with [Cursor](https://cursor.com)