### PR TITLE
fix(session): require positive evidence before moved-project re-root

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `--continue` no longer treats a merely-missing breadcrumb cwd as a project move. Re-root now requires the continue directory to be the same device+inode the breadcrumb recorded (`git worktree move` / same-filesystem `mv`). A cross-filesystem `mv` (copy+unlink, new inode) is intentionally not re-rooted: the session stays in the original bucket, `header.cwd` is not rewritten, and a warn is logged ([#11565](https://github.com/can1357/oh-my-pi/issues/11565)).
 - The `set_steering_mode`, `set_follow_up_mode`, and `set_interrupt_mode` RPC commands are now session-scoped, so a short-lived RPC client no longer silently writes queue-mode fields to the machine-global `config.yml`. The setters still persist by default, so the settings panel and existing callers are unaffected ([#11555](https://github.com/can1357/oh-my-pi/issues/11555)).
 - Hand-authored `*.openapi.json` files can now be edited without disabling generated-file protection globally ([#11674](https://github.com/can1357/oh-my-pi/issues/11674)).
 - `models.yml` now validates the per-model `compat.stripImageInput` opt-out, so a wrong-typed value is rejected like every other declared compat key instead of being silently accepted ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -3096,6 +3096,7 @@ export class SessionManager {
 				// Absence of the recorded cwd is not a move: deleted, unmounted, and
 				// offline paths also fail existsSync. Only re-root when the continue
 				// cwd is the same directory inode the breadcrumb recorded — a rename.
+				// Cross-filesystem `mv` (new inode) is intentionally not a re-root.
 				const looksLikeMovedProject =
 					candidateForMove && hasPositiveMovedProjectEvidence(breadcrumb.cwdIdentity, resolvedCwd);
 				if (looksLikeMovedProject) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -71,6 +71,7 @@ import {
 import { generateId, migrateToCurrentVersion } from "./session-migrations";
 import {
 	computeDefaultSessionDir,
+	hasPositiveMovedProjectEvidence,
 	readTerminalBreadcrumbEntry,
 	resolveManagedSessionRoot,
 	writeTerminalBreadcrumb,
@@ -3064,11 +3065,12 @@ export class SessionManager {
 			if (breadcrumbCwd === resolvedCwd) {
 				chosenSession = breadcrumb.sessionFile;
 			} else {
-				// The terminal's last session started in a different cwd. If that cwd is
-				// gone (worktree move/rename) and this location has no sessions of its
-				// own, re-root the moved session here instead of starting fresh. When an
-				// explicit sessionDir is reused across the move, the stale breadcrumb file
-				// may be the newest entry there; prefer a genuine current-cwd session.
+				// The terminal's last session started in a different cwd. Re-root only
+				// when that cwd is gone *and* this location is the same directory
+				// inode (a worktree move/rename). A missing path alone is not a move.
+				// When an explicit sessionDir is reused across the move, the stale
+				// breadcrumb file may be the newest entry there; prefer a genuine
+				// current-cwd session.
 				let newestInTargetDir = await findMostRecentSession(dir, storage);
 				const breadcrumbFile = path.resolve(breadcrumb.sessionFile);
 				const breadcrumbCwdMissing = !fs.existsSync(breadcrumbCwd);
@@ -3088,11 +3090,16 @@ export class SessionManager {
 					}
 				}
 
-				const looksLikeMovedProject =
+				const candidateForMove =
 					breadcrumbCwdMissing &&
 					(newestInTargetDir === null || (newestIsBreadcrumb && !currentProjectAlreadyHasSession));
+				// Absence of the recorded cwd is not a move: deleted, unmounted, and
+				// offline paths also fail existsSync. Only re-root when the continue
+				// cwd is the same directory inode the breadcrumb recorded — a rename.
+				const looksLikeMovedProject =
+					candidateForMove && hasPositiveMovedProjectEvidence(breadcrumb.cwdIdentity, resolvedCwd);
 				if (looksLikeMovedProject) {
-					logger.info("Re-rooting moved session", { from: breadcrumbCwd, to: resolvedCwd });
+					logger.warn("Re-rooting moved session", { from: breadcrumbCwd, to: resolvedCwd });
 					// Anchor at the gone breadcrumb cwd so the moveTo below relocates the
 					// session: open() now falls back to the launch cwd for a missing
 					// recorded cwd, which would no-op moveTo when it equals `cwd`.
@@ -3101,6 +3108,12 @@ export class SessionManager {
 					});
 					await manager.moveTo(cwd, sessionDir);
 					return manager;
+				}
+				if (candidateForMove) {
+					logger.warn(
+						"Not relocating session: project directory is unavailable and there is no evidence it moved here",
+						{ from: breadcrumbCwd, to: resolvedCwd },
+					);
 				}
 
 				chosenSession = newestInTargetDir;

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -226,6 +226,12 @@ export function readCwdIdentity(cwd: string): CwdIdentity | undefined {
  * True when `targetCwd` is the same directory that `cwdIdentity` was recorded
  * from — i.e. the project was renamed or moved, not merely deleted/unmounted.
  * Missing identity (legacy breadcrumb, or cwd absent at write time) is not evidence.
+ *
+ * Same-filesystem `mv` and `git worktree move` preserve `dev`+`ino` and qualify.
+ * A cross-filesystem `mv` is copy+unlink (new inode, possibly new `dev`) and
+ * therefore returns false — that is intentional. Absence is not a move; we
+ * would rather leave the session in the original bucket than steal it into an
+ * unrelated continue cwd (#11565).
  */
 export function hasPositiveMovedProjectEvidence(cwdIdentity: CwdIdentity | undefined, targetCwd: string): boolean {
 	if (!cwdIdentity) return false;

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -200,6 +200,58 @@ export function computeDefaultSessionDir(
 // Terminal breadcrumbs: maps terminal (TTY) -> last session file for --continue
 // =============================================================================
 
+/** Prefix for the optional cwd device+inode line in a terminal breadcrumb. */
+const CWDSTAT_PREFIX = "cwdstat ";
+
+export interface CwdIdentity {
+	dev: string;
+	ino: string;
+}
+
+/**
+ * Snapshot the directory identity of `cwd` for later move detection.
+ * A later path with the same device+inode is the same directory after rename.
+ */
+export function readCwdIdentity(cwd: string): CwdIdentity | undefined {
+	try {
+		const st = fs.statSync(path.resolve(cwd), { bigint: true });
+		if (!st.isDirectory()) return undefined;
+		return { dev: st.dev.toString(), ino: st.ino.toString() };
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * True when `targetCwd` is the same directory that `cwdIdentity` was recorded
+ * from — i.e. the project was renamed or moved, not merely deleted/unmounted.
+ * Missing identity (legacy breadcrumb, or cwd absent at write time) is not evidence.
+ */
+export function hasPositiveMovedProjectEvidence(cwdIdentity: CwdIdentity | undefined, targetCwd: string): boolean {
+	if (!cwdIdentity) return false;
+	const target = readCwdIdentity(targetCwd);
+	return target !== undefined && target.dev === cwdIdentity.dev && target.ino === cwdIdentity.ino;
+}
+
+function parseBreadcrumbExtras(lines: string[]): {
+	fresh: boolean;
+	cwdIdentity: CwdIdentity | undefined;
+} {
+	let fresh = false;
+	let cwdIdentity: CwdIdentity | undefined;
+	for (const extra of lines.slice(2)) {
+		if (extra === "fresh") {
+			fresh = true;
+			continue;
+		}
+		if (extra.startsWith(CWDSTAT_PREFIX)) {
+			const [dev, ino] = extra.slice(CWDSTAT_PREFIX.length).split(" ");
+			if (dev && ino) cwdIdentity = { dev, ino };
+		}
+	}
+	return { fresh, cwdIdentity };
+}
+
 /**
  * Write a breadcrumb linking the current terminal to a session file.
  * The breadcrumb contains the cwd and session path so --continue can
@@ -213,6 +265,9 @@ export function computeDefaultSessionDir(
  * survive relaunches whose terminal identity changed. Once any lazy session
  * materializes, the caller rewrites the breadcrumb with `fresh:false` so a later
  * external delete is still treated as a genuinely stale crumb.
+ *
+ * When `cwd` exists, the breadcrumb also records its device+inode so
+ * `--continue` can tell a rename/move from a deleted or unmounted path.
  */
 export function writeTerminalBreadcrumb(cwd: string, sessionFile: string, fresh = false): void {
 	const terminalId = getTerminalId();
@@ -220,7 +275,12 @@ export function writeTerminalBreadcrumb(cwd: string, sessionFile: string, fresh 
 
 	const breadcrumbDir = getTerminalSessionsDir();
 	const breadcrumbFile = path.join(breadcrumbDir, terminalId);
-	const content = fresh ? `${cwd}\n${sessionFile}\nfresh\n` : `${cwd}\n${sessionFile}\n`;
+	const extras: string[] = [];
+	if (fresh) extras.push("fresh");
+	const identity = readCwdIdentity(cwd);
+	if (identity) extras.push(`${CWDSTAT_PREFIX}${identity.dev} ${identity.ino}`);
+	const extraBlock = extras.length > 0 ? `${extras.join("\n")}\n` : "";
+	const content = `${cwd}\n${sessionFile}\n${extraBlock}`;
 	// Synchronous + best-effort. Infrequent (session create/switch/reset, never
 	// per-append), and writing in order matters: a lazy fresh-session crumb is
 	// re-stamped non-fresh the instant the session materializes, so an async
@@ -241,6 +301,8 @@ export interface TerminalBreadcrumb {
 	exists: boolean;
 	/** Recorded as a `/new` fresh-session boundary whose JSONL may not exist yet. */
 	fresh: boolean;
+	/** Device+inode of `cwd` when the breadcrumb was written, if that path existed. */
+	cwdIdentity?: CwdIdentity;
 }
 
 /**
@@ -266,13 +328,13 @@ export async function readTerminalBreadcrumbEntry(): Promise<TerminalBreadcrumb 
 
 		const breadcrumbCwd = lines[0];
 		const sessionFile = lines[1];
-		const fresh = lines[2] === "fresh";
+		const { fresh, cwdIdentity } = parseBreadcrumbExtras(lines);
 
 		const stat = fs.statSync(sessionFile, { throwIfNoEntry: false });
 		const exists = stat?.isFile() === true;
 		// A materialized target resumes normally; a missing target is honored only
 		// for a never-written lazy fresh-session boundary.
-		if (exists || fresh) return { cwd: breadcrumbCwd, sessionFile, exists, fresh };
+		if (exists || fresh) return { cwd: breadcrumbCwd, sessionFile, exists, fresh, cwdIdentity };
 	} catch (err) {
 		if (!isEnoent(err)) logger.debug("Terminal breadcrumb read failed", { err });
 		// Breadcrumb doesn't exist or is corrupt — fall through

--- a/packages/coding-agent/test/session-manager/continue-relocation.test.ts
+++ b/packages/coding-agent/test/session-manager/continue-relocation.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import type { SessionHeader } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { writeTerminalBreadcrumb } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
 import { getConfigRootDir, getTerminalSessionsDir, setAgentDir } from "@oh-my-pi/pi-utils";
 
@@ -21,11 +22,14 @@ function getHeader(entries: unknown[]): SessionHeader | undefined {
 function writeBreadcrumb(cwd: string, sessionFile: string): string {
 	const terminalId = getTerminalId();
 	if (!terminalId) throw new Error("Expected a terminal id for breadcrumb test");
-	const dir = getTerminalSessionsDir();
-	fs.mkdirSync(dir, { recursive: true });
-	const file = path.join(dir, terminalId);
-	fs.writeFileSync(file, `${cwd}\n${sessionFile}\n`);
-	return file;
+	writeTerminalBreadcrumb(cwd, sessionFile);
+	return path.join(getTerminalSessionsDir(), terminalId);
+}
+
+/** Simulate `mv` / `git worktree move`: same directory inode at a new path. */
+async function renameProjectDir(from: string, to: string): Promise<void> {
+	await fsp.rm(to, { recursive: true, force: true });
+	await fsp.rename(from, to);
 }
 
 function stripHeaderCwd(file: string): void {
@@ -70,6 +74,62 @@ describe("SessionManager.continueRecent relocation", () => {
 		await fsp.rm(testAgentDir, { recursive: true, force: true });
 	});
 
+	it("does not re-root into an unrelated cwd when the breadcrumb directory is merely missing", async () => {
+		const oldProject = path.join(testAgentDir, "projects", "old-project");
+		const unrelated = path.join(testAgentDir, "elsewhere", "unrelated-project");
+		fs.mkdirSync(oldProject, { recursive: true });
+		fs.mkdirSync(unrelated, { recursive: true });
+
+		const session = SessionManager.create(oldProject);
+		session.appendMessage({ role: "user", content: "original project", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+		const oldFile = session.getSessionFile();
+		if (!oldFile) throw new Error("Expected persisted session file");
+		await session.close();
+
+		writeBreadcrumb(oldProject, oldFile);
+		// Deleted / offline / never-mounted: absence is not evidence of a move.
+		await fsp.rm(oldProject, { recursive: true, force: true });
+
+		const resumed = await SessionManager.continueRecent(unrelated);
+		try {
+			expect(fs.existsSync(oldFile)).toBe(true);
+			expect(resumed.getSessionFile()).not.toBe(oldFile);
+			const oldHeader = getHeader(await loadEntriesFromFile(oldFile));
+			expect(oldHeader?.cwd).toBe(path.resolve(oldProject));
+			expect(oldHeader?.cwd).not.toBe(path.resolve(unrelated));
+			expect(resumed.getCwd()).toBe(path.resolve(unrelated));
+			expect(resumed.getEntries()).toHaveLength(0);
+		} finally {
+			await resumed.close();
+		}
+	});
+
+	it("does not re-root from a two-line breadcrumb that recorded no directory identity", async () => {
+		const session = SessionManager.create(cwdA);
+		session.appendMessage({ role: "user", content: "legacy crumb", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+		const oldFile = session.getSessionFile();
+		if (!oldFile) throw new Error("Expected persisted session file");
+		await session.close();
+
+		const terminalId = getTerminalId();
+		if (!terminalId) throw new Error("Expected a terminal id for breadcrumb test");
+		fs.writeFileSync(path.join(getTerminalSessionsDir(), terminalId), `${cwdA}\n${oldFile}\n`);
+		await renameProjectDir(cwdA, cwdB);
+
+		const resumed = await SessionManager.continueRecent(cwdB);
+		try {
+			expect(fs.existsSync(oldFile)).toBe(true);
+			expect(getHeader(await loadEntriesFromFile(oldFile))?.cwd).toBe(path.resolve(cwdA));
+			expect(resumed.getEntries()).toHaveLength(0);
+		} finally {
+			await resumed.close();
+		}
+	});
+
 	it("re-roots the terminal's session when its directory was moved/renamed", async () => {
 		const session = SessionManager.create(cwdA);
 		session.appendMessage({ role: "user", content: "before move", timestamp: 1 });
@@ -81,8 +141,8 @@ describe("SessionManager.continueRecent relocation", () => {
 
 		// Breadcrumb points at the old session, recorded under the old cwd.
 		writeBreadcrumb(cwdA, oldFile);
-		// Simulate `git worktree move`: the old directory no longer exists.
-		await fsp.rm(cwdA, { recursive: true, force: true });
+		// Real move/rename: the continue cwd is the same directory inode.
+		await renameProjectDir(cwdA, cwdB);
 
 		const resumed = await SessionManager.continueRecent(cwdB);
 		try {
@@ -167,7 +227,7 @@ describe("SessionManager.continueRecent relocation", () => {
 
 		const explicitSessionDir = path.join(testAgentDir, "custom-sessions");
 		writeBreadcrumb(cwdA, oldFile);
-		await fsp.rm(cwdA, { recursive: true, force: true });
+		await renameProjectDir(cwdA, cwdB);
 
 		const resumed = await SessionManager.continueRecent(cwdB, explicitSessionDir);
 		try {
@@ -193,7 +253,7 @@ describe("SessionManager.continueRecent relocation", () => {
 		await session.close();
 
 		writeBreadcrumb(cwdA, oldFile);
-		await fsp.rm(cwdA, { recursive: true, force: true });
+		await renameProjectDir(cwdA, cwdB);
 
 		const resumed = await SessionManager.continueRecent(cwdB, explicitSessionDir);
 		try {
@@ -262,7 +322,7 @@ describe("SessionManager.continueRecent relocation", () => {
 		await moved.close();
 
 		writeBreadcrumb(cwdA, movedFile);
-		await fsp.rm(cwdA, { recursive: true, force: true });
+		await renameProjectDir(cwdA, cwdB);
 
 		const resumed = await SessionManager.continueRecent(cwdB, explicitSessionDir);
 		try {

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import {
+	computeDefaultSessionDir,
+	hasPositiveMovedProjectEvidence,
+	readCwdIdentity,
+} from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 
 const cleanup: string[] = [];
@@ -63,5 +67,21 @@ describe("legacy session directory migration", () => {
 
 		expect(fs.readFileSync(recreated, "utf8")).toBe("older-process-write\n");
 		expect(fs.readFileSync(destination, "utf8")).toBe("canonical\n");
+	});
+});
+
+describe("hasPositiveMovedProjectEvidence", () => {
+	test("is true only when the continue cwd is the same directory inode", () => {
+		const from = makeTempDir("omp-cwd-from-");
+		const sibling = makeTempDir("omp-cwd-unrelated-");
+		const identity = readCwdIdentity(from);
+		expect(identity).toBeDefined();
+		expect(hasPositiveMovedProjectEvidence(identity, sibling)).toBe(false);
+
+		const to = path.join(path.dirname(from), `${path.basename(from)}-renamed`);
+		fs.renameSync(from, to);
+		cleanup.push(to);
+		expect(hasPositiveMovedProjectEvidence(identity, to)).toBe(true);
+		expect(hasPositiveMovedProjectEvidence(undefined, to)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- `--continue` treated a missing breadcrumb cwd (`!existsSync`) as a project move, so resuming from an unrelated directory relocated the old session jsonl and rewrote `header.cwd`.
- Breadcrumbs now record cwd `dev+ino`. Re-root only when the continue directory is that same inode (a real rename/move). Deleted, unmounted, or offline paths stay in the original bucket; `header.cwd` is not rewritten; a warn is logged.
- Legacy two-line breadcrumbs without identity no longer guess a move.
- Fixes #11565

## Test plan
- [x] Focused continue-relocation / session-paths / breadcrumb / move-to: 38 pass
- [x] RED: unrelated cwd + deleted breadcrumb cwd → jsonl not moved, `header.cwd` unchanged
- [x] GREEN: real `rename` still re-roots
- [ ] Manual: `--continue` from another project after deleting the old directory must not steal the session


Made with [Cursor](https://cursor.com)