### PR TITLE
test(ai): align OAuth cache_control assertions with 1h retention default

### DIFF
--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1678,7 +1678,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.tools?.[0]?.strict).toBe(true);
 		expect(payload.tools?.[0]?.eager_input_streaming).toBe(true);
 		// Sole tool is also the last tool, so it carries the head breakpoint.
-		expect(payload.tools?.[0]?.cache_control).toEqual({ type: "ephemeral" });
+		expect(payload.tools?.[0]?.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 	});
 
 	it("breakpoints the last tool definition so the stable head gets its own cache entry", async () => {
@@ -1706,15 +1706,16 @@ describe("Anthropic request fingerprint alignment", () => {
 		// single prefix, so earlier markers would spend breakpoints for nothing.
 		expect(payload.tools?.[0]?.cache_control).toBeUndefined();
 		expect(payload.tools?.[1]?.cache_control).toBeUndefined();
-		expect(payload.tools?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
+		expect(payload.tools?.at(-1)?.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
 		// The trailing message window is untouched; the OAuth identity block carries its
 		// own breakpoint, while caller system blocks stay uncached.
 		const content = payload.messages?.at(-1)?.content;
 		expect(Array.isArray(content) ? content.at(-1)?.cache_control : undefined).toEqual({
 			type: "ephemeral",
+			ttl: "1h",
 		});
-		expect(payload.system?.[1]?.cache_control).toEqual({ type: "ephemeral" });
+		expect(payload.system?.[1]?.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 		expect(payload.system?.[2]?.cache_control).toBeUndefined();
 		// Anthropic rejects a fifth breakpoint, so the total must stay in budget.
 		const marked = (blocks: Array<{ cache_control?: unknown }> | undefined) =>


### PR DESCRIPTION
## Repro
On `main`, two tests in `packages/ai/test/anthropic-alignment.test.ts` fail:
`keeps OAuth tool names behind the proxy prefix with eager streaming and strict flags` and `breakpoints the last tool definition so the stable head gets its own cache entry`. Both assert `cache_control` equals `{ type: "ephemeral" }`. Reproduce with `cd packages/ai && bun test test/anthropic-alignment.test.ts -t "fingerprint alignment"`.

## Cause
#11667 (`6019d73540`) changed `getCacheControl` in `packages/ai/src/providers/anthropic.ts` so an OAuth request with a `supportsLongCacheRetention` model defaults to `long` retention (`defaultRetention = isOAuthToken && model.compat.supportsLongCacheRetention ? "long" : "short"`), emitting `{ type: "ephemeral", ttl: "1h" }`. That single `cacheControl` object is applied to the last tool, the OAuth system identity block, and the trailing message block. The feature PR did not update these assertions, which capture OAuth payloads (`captureAnthropicPayload` defaults `isOAuth: true`).

## Fix
- Update the sole-tool assertion to `{ type: "ephemeral", ttl: "1h" }`.
- Update the last-tool, trailing-message, and `system[1]` assertions in the breakpoint test to the same 1h contract; the "only the last tool is marked" invariant and breakpoint budget checks are unchanged.

## Verification
`cd packages/ai && bun test test/anthropic-alignment.test.ts -t "fingerprint alignment"` → 96 pass, 0 fail. Fixes #11721