### PR TITLE
fix(ai): cache working Copilot integration identity per credential

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,12 +5,16 @@
 ### Fixed
 
 - GitHub Copilot Enterprise requests keep the Copilot CLI identity accepted by private Enterprise endpoints, and Business requests denied with HTTP 400 `model_not_supported` now retry once as the Copilot CLI (matching the existing 403 fallback), restoring models that 18.1.17 rejected as unsupported ([#11669](https://github.com/can1357/oh-my-pi/issues/11669)).
+- GitHub Copilot streams remember the working `Copilot-Integration-Id` per credential after a denied chat identity retries as the Copilot CLI, so later streams start at the working shape instead of replaying the denial ([#11669](https://github.com/can1357/oh-my-pi/issues/11669)).
+
 ### Changed
 
 - Defaulted Anthropic OAuth requests to 1h prompt-cache retention where supported, matching Claude Code subscriber behavior and preventing cache expiry during idle intervals ([#11667](https://github.com/can1357/oh-my-pi/pull/11667) by [@camjac251](https://github.com/camjac251)).
+
 ### Added
 
 - Added historical decimation prompt-cache breakpoints every 15 user turns on Anthropic requests, so long conversations retain stable cached prefixes during branching, rewinds, and session resume ([#11665](https://github.com/can1357/oh-my-pi/pull/11665) by [@camjac251](https://github.com/camjac251)).
+
 ### Fixed
 
 - Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -110,6 +110,8 @@ import {
 } from "./claude-code-fingerprint";
 import {
 	buildCopilotDynamicHeaders,
+	getCachedCopilotIntegrationId,
+	getCopilotIntegrationCacheKey,
 	hasCopilotVisionInput,
 	resolveCopilotRequestIdentity,
 	resolveGitHubCopilotBaseUrl,
@@ -2030,6 +2032,8 @@ const streamAnthropicOnce = (
 			// (and any consumer awaiting `result()`) hanging forever.
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
 			const copilotApiKey = model.provider === "github-copilot" ? parseGitHubCopilotApiKey(apiKey) : undefined;
+			const copilotCacheKey =
+				model.provider === "github-copilot" ? getCopilotIntegrationCacheKey(apiKey) : undefined;
 			const copilotDynamicHeaders = copilotApiKey
 				? buildCopilotDynamicHeaders({
 						messages: context.messages,
@@ -2039,6 +2043,7 @@ const streamAnthropicOnce = (
 						integrationId: resolveCopilotRequestIdentity(options?.headers),
 						initiatorOverride: options?.initiatorOverride,
 						enterpriseUrl: copilotApiKey.enterpriseUrl,
+						cachedIntegrationId: getCachedCopilotIntegrationId(copilotCacheKey),
 					})
 				: undefined;
 			if (copilotDynamicHeaders?.premiumRequests !== undefined) {
@@ -3295,7 +3300,12 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			maxRetries: 5,
 			maxRetryDelayMs,
 			defaultHeaders,
-			fetch: wrapFetchForCopilotFallback(cchFetch, true, resolveCopilotRequestIdentity(headers)),
+			fetch: wrapFetchForCopilotFallback(
+				cchFetch,
+				true,
+				resolveCopilotRequestIdentity(headers),
+				getCopilotIntegrationCacheKey(apiKey),
+			),
 			fetchOptions,
 		};
 	}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2032,8 +2032,12 @@ const streamAnthropicOnce = (
 			// (and any consumer awaiting `result()`) hanging forever.
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
 			const copilotApiKey = model.provider === "github-copilot" ? parseGitHubCopilotApiKey(apiKey) : undefined;
+			const copilotBaseUrl =
+				model.provider === "github-copilot"
+					? (resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com")
+					: undefined;
 			const copilotCacheKey =
-				model.provider === "github-copilot" ? getCopilotIntegrationCacheKey(apiKey) : undefined;
+				model.provider === "github-copilot" ? getCopilotIntegrationCacheKey(apiKey, copilotBaseUrl) : undefined;
 			const copilotDynamicHeaders = copilotApiKey
 				? buildCopilotDynamicHeaders({
 						messages: context.messages,
@@ -2049,7 +2053,7 @@ const streamAnthropicOnce = (
 			if (copilotDynamicHeaders?.premiumRequests !== undefined) {
 				output.usage.premiumRequests = copilotDynamicHeaders.premiumRequests;
 			}
-			const baseUrl = resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com";
+			const baseUrl = copilotBaseUrl ?? resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com";
 			const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 			const providerSessionState = getAnthropicProviderSessionState(
 				options?.providerSessionState,
@@ -3304,7 +3308,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 				cchFetch,
 				true,
 				resolveCopilotRequestIdentity(headers),
-				getCopilotIntegrationCacheKey(apiKey),
+				getCopilotIntegrationCacheKey(apiKey, baseUrl),
 			),
 			fetchOptions,
 		};

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1248,6 +1248,14 @@ export type AnthropicClientOptionsArgs = {
 	fetch?: FetchImpl;
 	maxRetryDelayMs?: number;
 	sessionId?: string;
+	/** Working-identity cache key for this credential+host; undefined off the Copilot path. */
+	copilotCacheKey?: string;
+	/**
+	 * Build-time cache provenance for the wrapper: the cached value the
+	 * outgoing headers were built from, or `null` when the cache was empty at
+	 * build. `undefined` rereads the cache at dispatch.
+	 */
+	copilotCacheSnapshot?: string | null;
 };
 
 export type AnthropicClientOptionsResult = {
@@ -2038,6 +2046,8 @@ const streamAnthropicOnce = (
 					: undefined;
 			const copilotCacheKey =
 				model.provider === "github-copilot" ? getCopilotIntegrationCacheKey(apiKey, copilotBaseUrl) : undefined;
+			const copilotCached =
+				model.provider === "github-copilot" ? getCachedCopilotIntegrationId(copilotCacheKey) : undefined;
 			const copilotDynamicHeaders = copilotApiKey
 				? buildCopilotDynamicHeaders({
 						messages: context.messages,
@@ -2047,7 +2057,7 @@ const streamAnthropicOnce = (
 						integrationId: resolveCopilotRequestIdentity(options?.headers),
 						initiatorOverride: options?.initiatorOverride,
 						enterpriseUrl: copilotApiKey.enterpriseUrl,
-						cachedIntegrationId: getCachedCopilotIntegrationId(copilotCacheKey),
+						cachedIntegrationId: copilotCached,
 					})
 				: undefined;
 			if (copilotDynamicHeaders?.premiumRequests !== undefined) {
@@ -2198,6 +2208,8 @@ const streamAnthropicOnce = (
 					thinkingDisplay: options?.thinkingDisplay,
 					fetch: options?.fetch,
 					maxRetryDelayMs: options?.maxRetryDelayMs,
+					copilotCacheKey,
+					copilotCacheSnapshot: copilotCached ?? null,
 					sessionId:
 						options?.sessionId ??
 						extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
@@ -3229,6 +3241,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		maxRetryDelayMs,
 		sessionId,
 		disableStrictTools: disableStrictToolsOverride,
+		copilotCacheKey,
+		copilotCacheSnapshot,
 	} = args;
 	const compat = model.compat;
 	const disableStrictTools = disableStrictToolsOverride ?? compat.disableStrictTools;
@@ -3308,7 +3322,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 				cchFetch,
 				true,
 				resolveCopilotRequestIdentity(headers),
-				getCopilotIntegrationCacheKey(apiKey, baseUrl),
+				copilotCacheKey ?? getCopilotIntegrationCacheKey(apiKey, baseUrl),
+				copilotCacheSnapshot,
 			),
 			fetchOptions,
 		};

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -177,32 +177,40 @@ async function isCopilotIdentityDenied(response: Response): Promise<boolean> {
  * body is drained before reissuing, and the retry carries the CLI identity so
  * the guard passes it through: at most two requests, never a loop.
  *
- * When `cacheKey` is set, the retry identity that clears the gate is
- * remembered via `rememberCopilotWorkingIntegrationId`, so later streams for
- * the same credential start at the working shape. A cached CLI start that is
- * itself denied (stale after an org-policy flip) retries once as chat and
- * relearns. Only a 2xx retry proves its identity: 401s deny every identity
- * equally, other 4xx are never identity-retried, and 408/429/5xx are
- * transport-retryable — the transport resends the *original* headers, so
- * recording a retryable response would pin the wrong shape and break the
- * resend's own reverse retry. Inconclusive retries leave the cache unchanged.
+ * When `cacheKey` is set, a 2xx retry remembers its identity via
+ * `rememberCopilotWorkingIntegrationId`, so later streams for the same
+ * credential start at the working shape. A cached CLI start that is itself
+ * denied (stale after an org-policy flip) retries once as chat and relearns.
+ * Only a 2xx retry proves its identity — 401s deny every identity equally and
+ * 408/429/5xx are transport-retryable (the transport resends the *original*
+ * headers), so those must never be recorded as working. Any non-2xx retry
+ * clears the entry instead: the next stream rediscovers rather than pinning a
+ * shape that just failed.
  */
 export function wrapFetchForCopilotFallback(
 	base: FetchImpl | undefined,
 	enabled: boolean,
 	integrationId?: unknown,
 	cacheKey?: string,
+	/**
+	 * Build-time cache provenance: the exact cached value the outgoing headers
+	 * were built from. `undefined` rereads the cache at dispatch (direct
+	 * callers); `null` pins "cache was empty at build" so a sibling learning
+	 * mid-flight cannot change this request's retry decision.
+	 */
+	cacheSnapshot?: string | null,
 ): FetchImpl {
 	const inner = base ?? fetch;
 	if (!enabled) return inner;
 	const cliIntegrationId = COPILOT_CAPI_IDENTITY_HEADERS["Copilot-Integration-Id"];
 	return async (input, init) => {
-		// Snapshot before dispatch: a concurrent stream can relearn the cache
-		// while this request is in flight, and the reverse retry below must be
-		// decided by what this request started as — not by what a sibling
-		// learned mid-flight. Without this, two stale-CLI streams racing would
-		// let the first relearn chat and the second then skip its own retry.
-		const cachedBeforeRequest = getCachedCopilotIntegrationId(cacheKey);
+		// Provenance fallback for direct callers: without a build-time value,
+		// snapshot at dispatch — still before any await in this invocation, so
+		// a concurrent stream cannot interleave between the snapshot and use.
+		const cachedBeforeRequest =
+			cacheSnapshot === undefined
+				? getCachedCopilotIntegrationId(cacheKey)
+				: normalizeCopilotIntegrationId(cacheSnapshot);
 		const response = await inner(input, init);
 		if (response.status !== 403 && response.status !== 400) return response;
 		if (input instanceof Request) return response;
@@ -220,8 +228,9 @@ export function wrapFetchForCopilotFallback(
 				const retryHeaders = new Headers(outgoing);
 				retryHeaders.set("Copilot-Integration-Id", cliIntegrationId);
 				const retry = await inner(input, { ...init, headers: retryHeaders });
-				if (cacheKey && retry.ok) {
-					rememberCopilotWorkingIntegrationId(cacheKey, cliIntegrationId);
+				if (cacheKey) {
+					if (retry.ok) rememberCopilotWorkingIntegrationId(cacheKey, cliIntegrationId);
+					else clearCopilotIntegrationCache(cacheKey);
 				}
 				return retry;
 			}
@@ -239,11 +248,8 @@ export function wrapFetchForCopilotFallback(
 				const retryHeaders = new Headers(outgoing);
 				retryHeaders.set("Copilot-Integration-Id", COPILOT_CHAT_INTEGRATION_ID);
 				const retry = await inner(input, { ...init, headers: retryHeaders });
-				if (retry.ok) {
-					rememberCopilotWorkingIntegrationId(cacheKey, COPILOT_CHAT_INTEGRATION_ID);
-				} else if (await isCopilotIdentityDenied(retry)) {
-					clearCopilotIntegrationCache(cacheKey);
-				}
+				if (retry.ok) rememberCopilotWorkingIntegrationId(cacheKey, COPILOT_CHAT_INTEGRATION_ID);
+				else clearCopilotIntegrationCache(cacheKey);
 				return retry;
 			}
 			return response;

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -5,6 +5,7 @@ import {
 	normalizeCopilotIntegrationId,
 	parseGitHubCopilotApiKey,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { $env, logger } from "@oh-my-pi/pi-utils";
 import type { FetchImpl, Message } from "../types";
 /**
@@ -87,42 +88,56 @@ export function resolveCopilotRequestIdentity(
  * headers bypass the cache entirely — a pin is never second-guessed.
  */
 const COPILOT_WORKING_INTEGRATION_CACHE_LIMIT = 50;
-const copilotWorkingIntegrationCache = new Map<string, string>();
+const copilotWorkingIntegrationCache = new LRUCache<string, string>({ max: COPILOT_WORKING_INTEGRATION_CACHE_LIMIT });
 
 /**
- * Stable cache key for a raw Copilot API key envelope. Hashes the bearer with
- * `Bun.hash` (repo-approved hashing API; same credential-scoped pattern as the
- * GitLab Duo and Codex account keys) so token bytes never sit in the map as
- * keys; enterprise/business routing inputs participate so the same token on
- * two hosts does not share an entry.
+ * Normalize the effective request host for cache isolation. Custom
+ * `model.baseUrl` values survive `resolveGitHubCopilotBaseUrl`, so two proxies
+ * fronting different org policies must not share a learned identity even when
+ * the token envelope matches.
  */
-export function getCopilotIntegrationCacheKey(apiKeyRaw: string | undefined): string | undefined {
+function normalizeCopilotCacheBaseUrl(baseUrl: string | undefined): string {
+	const trimmed = baseUrl?.trim().replace(/\/+$/, "") ?? "";
+	if (!trimmed) return "";
+	try {
+		const url = new URL(trimmed);
+		return `${url.protocol}//${url.host.toLowerCase()}${url.pathname.replace(/\/+$/, "")}${url.search}${url.hash}`;
+	} catch {
+		return trimmed.toLowerCase();
+	}
+}
+
+/**
+ * Stable cache key for a raw Copilot API key envelope on one effective host.
+ * Hashes the bearer with `Bun.hash` (repo-approved hashing API; same
+ * credential-scoped pattern as the GitLab Duo and Codex account keys) so token
+ * bytes never sit in the map as keys; enterprise/business routing inputs and
+ * the normalized effective base URL participate so the same token on two hosts
+ * does not share an entry.
+ */
+export function getCopilotIntegrationCacheKey(apiKeyRaw: string | undefined, baseUrl?: string): string | undefined {
 	if (!apiKeyRaw) return undefined;
 	const trimmed = apiKeyRaw.trim();
 	if (!trimmed) return undefined;
 	const parsed = parseGitHubCopilotApiKey(trimmed);
 	if (!parsed.accessToken) return undefined;
 	const fingerprint = Bun.hash(parsed.accessToken).toString(36);
-	return `${parsed.enterpriseUrl ?? ""}\0${parsed.apiEndpoint ?? ""}\0${fingerprint}`;
+	return `${parsed.enterpriseUrl ?? ""}\0${parsed.apiEndpoint ?? ""}\0${normalizeCopilotCacheBaseUrl(baseUrl)}\0${fingerprint}`;
 }
+
 /** Cached working identity for a cache key, if one was learned. */
 export function getCachedCopilotIntegrationId(cacheKey: string | undefined): string | undefined {
 	if (!cacheKey) return undefined;
 	return normalizeCopilotIntegrationId(copilotWorkingIntegrationCache.get(cacheKey));
 }
 
-/** Remember the identity that cleared the identity gate for a credential. */
+/**
+ * Remember the identity that cleared the identity gate for a credential.
+ * Every store refreshes recency, so hot credentials survive eviction.
+ */
 export function rememberCopilotWorkingIntegrationId(cacheKey: string | undefined, integrationId: unknown): void {
 	const normalized = normalizeCopilotIntegrationId(integrationId);
 	if (!cacheKey || !normalized) return;
-	if (copilotWorkingIntegrationCache.get(cacheKey) === normalized) return;
-	if (
-		copilotWorkingIntegrationCache.size >= COPILOT_WORKING_INTEGRATION_CACHE_LIMIT &&
-		!copilotWorkingIntegrationCache.has(cacheKey)
-	) {
-		const oldest = copilotWorkingIntegrationCache.keys().next();
-		if (!oldest.done) copilotWorkingIntegrationCache.delete(oldest.value);
-	}
 	copilotWorkingIntegrationCache.set(cacheKey, normalized);
 }
 
@@ -149,16 +164,6 @@ async function isCopilotIdentityDenied(response: Response): Promise<boolean> {
 }
 
 /**
- * True when a retry response proves its identity cleared the gate: not denied
- * and not an auth failure. 401s never cache — a bad token denies every
- * identity equally and must not pin one.
- */
-async function isCopilotWorkingIdentityProven(response: Response): Promise<boolean> {
-	if (response.status === 401) return false;
-	return !(await isCopilotIdentityDenied(response));
-}
-
-/**
  * Reissue Copilot client-identity denials once with the other surface.
  *
  * Chat is the default surface (`COPILOT_CHAT_INTEGRATION_ID`) because Business
@@ -172,10 +177,15 @@ async function isCopilotWorkingIdentityProven(response: Response): Promise<boole
  * body is drained before reissuing, and the retry carries the CLI identity so
  * the guard passes it through: at most two requests, never a loop.
  *
- * When `cacheKey` is set, the CLI retry that clears the gate is remembered via
- * `rememberCopilotWorkingIntegrationId`, so later streams for the same
- * credential start at the working shape. A cached CLI start that is itself
- * denied (stale after an org-policy flip) retries once as chat and relearns.
+ * When `cacheKey` is set, the retry identity that clears the gate is
+ * remembered via `rememberCopilotWorkingIntegrationId`, so later streams for
+ * the same credential start at the working shape. A cached CLI start that is
+ * itself denied (stale after an org-policy flip) retries once as chat and
+ * relearns. Only a 2xx retry proves its identity: 401s deny every identity
+ * equally, other 4xx are never identity-retried, and 408/429/5xx are
+ * transport-retryable — the transport resends the *original* headers, so
+ * recording a retryable response would pin the wrong shape and break the
+ * resend's own reverse retry. Inconclusive retries leave the cache unchanged.
  */
 export function wrapFetchForCopilotFallback(
 	base: FetchImpl | undefined,
@@ -210,7 +220,7 @@ export function wrapFetchForCopilotFallback(
 				const retryHeaders = new Headers(outgoing);
 				retryHeaders.set("Copilot-Integration-Id", cliIntegrationId);
 				const retry = await inner(input, { ...init, headers: retryHeaders });
-				if (cacheKey && (await isCopilotWorkingIdentityProven(retry))) {
+				if (cacheKey && retry.ok) {
 					rememberCopilotWorkingIntegrationId(cacheKey, cliIntegrationId);
 				}
 				return retry;
@@ -229,9 +239,9 @@ export function wrapFetchForCopilotFallback(
 				const retryHeaders = new Headers(outgoing);
 				retryHeaders.set("Copilot-Integration-Id", COPILOT_CHAT_INTEGRATION_ID);
 				const retry = await inner(input, { ...init, headers: retryHeaders });
-				if (await isCopilotWorkingIdentityProven(retry)) {
+				if (retry.ok) {
 					rememberCopilotWorkingIntegrationId(cacheKey, COPILOT_CHAT_INTEGRATION_ID);
-				} else {
+				} else if (await isCopilotIdentityDenied(retry)) {
 					clearCopilotIntegrationCache(cacheKey);
 				}
 				return retry;

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
 	COPILOT_CAPI_IDENTITY_HEADERS,
 	COPILOT_CHAT_INTEGRATION_ID,
@@ -72,9 +73,93 @@ export function resolveCopilotRequestIdentity(
 		resolveCopilotIntegrationIdOverride(env)
 	);
 }
+/**
+ * Working `Copilot-Integration-Id` learned per credential.
+ *
+ * Business orgs that reject the chat-surface default pay one extra round-trip
+ * per stream until the working shape is known (issue #11669, follow-up). The
+ * cache remembers the identity that last cleared the identity gate so later
+ * streams start there instead of replaying the denial. Enterprise credentials
+ * already default to the CLI identity, so they only consult the cache when a
+ * prior reverse retry learned chat.
+ *
+ * Process-local only: a stale entry costs at most one reverse retry, which
+ * relearns the working shape. Explicit `COPILOT_INTEGRATION_ID` and caller
+ * headers bypass the cache entirely — a pin is never second-guessed.
+ */
+const COPILOT_WORKING_INTEGRATION_CACHE_LIMIT = 50;
+const copilotWorkingIntegrationCache = new Map<string, string>();
 
 /**
- * Reissue chat-surface Copilot denials once as the Copilot CLI.
+ * Stable cache key for a raw Copilot API key envelope. Hashes the bearer so
+ * token bytes never sit in the map as keys; enterprise/business routing inputs
+ * participate so the same token on two hosts does not share an entry.
+ */
+export function getCopilotIntegrationCacheKey(apiKeyRaw: string | undefined): string | undefined {
+	if (!apiKeyRaw) return undefined;
+	const trimmed = apiKeyRaw.trim();
+	if (!trimmed) return undefined;
+	const parsed = parseGitHubCopilotApiKey(trimmed);
+	if (!parsed.accessToken) return undefined;
+	const fingerprint = createHash("sha256").update(parsed.accessToken).digest("base64url");
+	return `${parsed.enterpriseUrl ?? ""}\0${parsed.apiEndpoint ?? ""}\0${fingerprint}`;
+}
+
+/** Cached working identity for a cache key, if one was learned. */
+export function getCachedCopilotIntegrationId(cacheKey: string | undefined): string | undefined {
+	if (!cacheKey) return undefined;
+	return normalizeCopilotIntegrationId(copilotWorkingIntegrationCache.get(cacheKey));
+}
+
+/** Remember the identity that cleared the identity gate for a credential. */
+export function rememberCopilotWorkingIntegrationId(cacheKey: string | undefined, integrationId: unknown): void {
+	const normalized = normalizeCopilotIntegrationId(integrationId);
+	if (!cacheKey || !normalized) return;
+	if (copilotWorkingIntegrationCache.get(cacheKey) === normalized) return;
+	if (
+		copilotWorkingIntegrationCache.size >= COPILOT_WORKING_INTEGRATION_CACHE_LIMIT &&
+		!copilotWorkingIntegrationCache.has(cacheKey)
+	) {
+		const oldest = copilotWorkingIntegrationCache.keys().next();
+		if (!oldest.done) copilotWorkingIntegrationCache.delete(oldest.value);
+	}
+	copilotWorkingIntegrationCache.set(cacheKey, normalized);
+}
+
+/** Clear one cached identity, or the whole cache when no key is given. */
+export function clearCopilotIntegrationCache(cacheKey?: string): void {
+	if (cacheKey === undefined) copilotWorkingIntegrationCache.clear();
+	else copilotWorkingIntegrationCache.delete(cacheKey);
+}
+
+/**
+ * True when a response is a client-identity denial: HTTP 403, or HTTP 400
+ * carrying `code: "model_not_supported"`. Reads a clone so the caller's body
+ * stays intact. Unreadable 400s are not denials.
+ */
+async function isCopilotIdentityDenied(response: Response): Promise<boolean> {
+	if (response.status === 403) return true;
+	if (response.status !== 400) return false;
+	try {
+		const body = (await response.clone().json()) as { error?: { code?: unknown } } | null;
+		return body?.error?.code === "model_not_supported";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * True when a retry response proves its identity cleared the gate: not denied
+ * and not an auth failure. 401s never cache — a bad token denies every
+ * identity equally and must not pin one.
+ */
+async function isCopilotWorkingIdentityProven(response: Response): Promise<boolean> {
+	if (response.status === 401) return false;
+	return !(await isCopilotIdentityDenied(response));
+}
+
+/**
+ * Reissue Copilot client-identity denials once with the other surface.
  *
  * Chat is the default surface (`COPILOT_CHAT_INTEGRATION_ID`) because Business
  * organizations that gate premium models per client surface commonly allow
@@ -86,41 +171,68 @@ export function resolveCopilotRequestIdentity(
  * explicit identity — an explicit choice is never second-guessed. The denied
  * body is drained before reissuing, and the retry carries the CLI identity so
  * the guard passes it through: at most two requests, never a loop.
+ *
+ * When `cacheKey` is set, the CLI retry that clears the gate is remembered via
+ * `rememberCopilotWorkingIntegrationId`, so later streams for the same
+ * credential start at the working shape. A cached CLI start that is itself
+ * denied (stale after an org-policy flip) retries once as chat and relearns.
  */
 export function wrapFetchForCopilotFallback(
 	base: FetchImpl | undefined,
 	enabled: boolean,
 	integrationId?: unknown,
+	cacheKey?: string,
 ): FetchImpl {
 	const inner = base ?? fetch;
 	if (!enabled) return inner;
+	const cliIntegrationId = COPILOT_CAPI_IDENTITY_HEADERS["Copilot-Integration-Id"];
 	return async (input, init) => {
 		const response = await inner(input, init);
 		if (response.status !== 403 && response.status !== 400) return response;
 		if (input instanceof Request) return response;
 		if (normalizeCopilotIntegrationId(integrationId) !== undefined) return response;
 		const outgoing = new Headers(init?.headers);
-		if (outgoing.get("Copilot-Integration-Id") !== COPILOT_CHAT_INTEGRATION_ID) {
+		const outgoingId = outgoing.get("Copilot-Integration-Id");
+		if (outgoingId === COPILOT_CHAT_INTEGRATION_ID) {
+			if (await isCopilotIdentityDenied(response)) {
+				try {
+					await response.arrayBuffer();
+				} catch {}
+				logger.warn(
+					`GitHub Copilot chat identity denied (HTTP ${response.status}); retrying once as the Copilot CLI`,
+				);
+				const retryHeaders = new Headers(outgoing);
+				retryHeaders.set("Copilot-Integration-Id", cliIntegrationId);
+				const retry = await inner(input, { ...init, headers: retryHeaders });
+				if (cacheKey && (await isCopilotWorkingIdentityProven(retry))) {
+					rememberCopilotWorkingIntegrationId(cacheKey, cliIntegrationId);
+				}
+				return retry;
+			}
 			return response;
 		}
-		if (response.status === 400) {
-			// A 400 is only the client-identity denial when its body carries
-			// `code: "model_not_supported"`; read a clone so an unrelated 400
-			// (which must not retry) reaches the caller with its body intact.
-			let identityDenied = false;
-			try {
-				const body = (await response.clone().json()) as { error?: { code?: unknown } } | null;
-				identityDenied = body?.error?.code === "model_not_supported";
-			} catch {}
-			if (!identityDenied) return response;
+		if (outgoingId === cliIntegrationId && cacheKey) {
+			if (getCachedCopilotIntegrationId(cacheKey) !== cliIntegrationId) return response;
+			if (await isCopilotIdentityDenied(response)) {
+				try {
+					await response.arrayBuffer();
+				} catch {}
+				logger.warn(
+					`GitHub Copilot CLI identity denied (HTTP ${response.status}); retrying once as ${COPILOT_CHAT_INTEGRATION_ID}`,
+				);
+				const retryHeaders = new Headers(outgoing);
+				retryHeaders.set("Copilot-Integration-Id", COPILOT_CHAT_INTEGRATION_ID);
+				const retry = await inner(input, { ...init, headers: retryHeaders });
+				if (await isCopilotWorkingIdentityProven(retry)) {
+					rememberCopilotWorkingIntegrationId(cacheKey, COPILOT_CHAT_INTEGRATION_ID);
+				} else {
+					clearCopilotIntegrationCache(cacheKey);
+				}
+				return retry;
+			}
+			return response;
 		}
-		try {
-			await response.arrayBuffer();
-		} catch {}
-		logger.warn(`GitHub Copilot chat identity denied (HTTP ${response.status}); retrying once as the Copilot CLI`);
-		const retryHeaders = new Headers(outgoing);
-		retryHeaders.set("Copilot-Integration-Id", COPILOT_CAPI_IDENTITY_HEADERS["Copilot-Integration-Id"]);
-		return inner(input, { ...init, headers: retryHeaders });
+		return response;
 	};
 }
 export function inferCopilotInitiator(messages: unknown[]): CopilotInitiator {
@@ -222,6 +334,8 @@ export function buildCopilotDynamicHeaders(params: {
 	enterpriseUrl?: string;
 	/** Raw explicit identity; validated here, chat default when absent/invalid. */
 	integrationId?: unknown;
+	/** Learned working identity for this credential; explicit still wins, then this, then the defaults. */
+	cachedIntegrationId?: unknown;
 }): CopilotDynamicHeaders {
 	const initiator =
 		params.initiatorOverride ?? getCopilotInitiatorOverride(params.headers) ?? inferCopilotInitiator(params.messages);
@@ -232,6 +346,7 @@ export function buildCopilotDynamicHeaders(params: {
 	};
 	headers["Copilot-Integration-Id"] =
 		normalizeCopilotIntegrationId(params.integrationId) ??
+		normalizeCopilotIntegrationId(params.cachedIntegrationId) ??
 		(params.enterpriseUrl ? COPILOT_CAPI_IDENTITY_HEADERS["Copilot-Integration-Id"] : COPILOT_CHAT_INTEGRATION_ID);
 
 	if (params.hasImages) {

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
 	COPILOT_CAPI_IDENTITY_HEADERS,
 	COPILOT_CHAT_INTEGRATION_ID,
@@ -91,9 +90,11 @@ const COPILOT_WORKING_INTEGRATION_CACHE_LIMIT = 50;
 const copilotWorkingIntegrationCache = new Map<string, string>();
 
 /**
- * Stable cache key for a raw Copilot API key envelope. Hashes the bearer so
- * token bytes never sit in the map as keys; enterprise/business routing inputs
- * participate so the same token on two hosts does not share an entry.
+ * Stable cache key for a raw Copilot API key envelope. Hashes the bearer with
+ * `Bun.hash` (repo-approved hashing API; same credential-scoped pattern as the
+ * GitLab Duo and Codex account keys) so token bytes never sit in the map as
+ * keys; enterprise/business routing inputs participate so the same token on
+ * two hosts does not share an entry.
  */
 export function getCopilotIntegrationCacheKey(apiKeyRaw: string | undefined): string | undefined {
 	if (!apiKeyRaw) return undefined;
@@ -101,10 +102,9 @@ export function getCopilotIntegrationCacheKey(apiKeyRaw: string | undefined): st
 	if (!trimmed) return undefined;
 	const parsed = parseGitHubCopilotApiKey(trimmed);
 	if (!parsed.accessToken) return undefined;
-	const fingerprint = createHash("sha256").update(parsed.accessToken).digest("base64url");
+	const fingerprint = Bun.hash(parsed.accessToken).toString(36);
 	return `${parsed.enterpriseUrl ?? ""}\0${parsed.apiEndpoint ?? ""}\0${fingerprint}`;
 }
-
 /** Cached working identity for a cache key, if one was learned. */
 export function getCachedCopilotIntegrationId(cacheKey: string | undefined): string | undefined {
 	if (!cacheKey) return undefined;
@@ -187,6 +187,12 @@ export function wrapFetchForCopilotFallback(
 	if (!enabled) return inner;
 	const cliIntegrationId = COPILOT_CAPI_IDENTITY_HEADERS["Copilot-Integration-Id"];
 	return async (input, init) => {
+		// Snapshot before dispatch: a concurrent stream can relearn the cache
+		// while this request is in flight, and the reverse retry below must be
+		// decided by what this request started as — not by what a sibling
+		// learned mid-flight. Without this, two stale-CLI streams racing would
+		// let the first relearn chat and the second then skip its own retry.
+		const cachedBeforeRequest = getCachedCopilotIntegrationId(cacheKey);
 		const response = await inner(input, init);
 		if (response.status !== 403 && response.status !== 400) return response;
 		if (input instanceof Request) return response;
@@ -212,7 +218,7 @@ export function wrapFetchForCopilotFallback(
 			return response;
 		}
 		if (outgoingId === cliIntegrationId && cacheKey) {
-			if (getCachedCopilotIntegrationId(cacheKey) !== cliIntegrationId) return response;
+			if (cachedBeforeRequest !== cliIntegrationId) return response;
 			if (await isCopilotIdentityDenied(response)) {
 				try {
 					await response.arrayBuffer();

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -78,11 +78,7 @@ import {
 	rememberOpenAIReasoningEffortFallback,
 	resolveOpenAIReasoningEffortFallback,
 } from "./openai-reasoning-fallback";
-import {
-	getCopilotIntegrationCacheKey,
-	resolveCopilotRequestIdentity,
-	wrapFetchForCopilotFallback,
-} from "./github-copilot-headers";
+import { resolveCopilotRequestIdentity, wrapFetchForCopilotFallback } from "./github-copilot-headers";
 import {
 	applyChatCompletionsReasoningParams,
 	applyChatCompletionsToolStream,
@@ -729,7 +725,15 @@ const streamOpenAICompletionsOnce = (
 				getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, model.compat.streamFirstEventTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
-			const { copilotPremiumRequests, baseUrl, headers, query, requestHeaders } = createRequestSetup(
+			const {
+				copilotPremiumRequests,
+				baseUrl,
+				headers,
+				query,
+				requestHeaders,
+				copilotCacheKey,
+				copilotCacheSnapshot,
+			} = createRequestSetup(
 				model,
 				context,
 				apiKey,
@@ -800,12 +804,12 @@ const streamOpenAICompletionsOnce = (
 						url: completionsUrl,
 						headers: headersWithTimeout,
 						body: params,
-						signal: requestSignal,
 						fetch: wrapFetchForCopilotFallback(
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
-							getCopilotIntegrationCacheKey(apiKey, baseUrl),
+							copilotCacheKey,
+							copilotCacheSnapshot,
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport retries.
 						// The first-event watchdog above aborts `requestSignal`, which

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -78,7 +78,11 @@ import {
 	rememberOpenAIReasoningEffortFallback,
 	resolveOpenAIReasoningEffortFallback,
 } from "./openai-reasoning-fallback";
-import { resolveCopilotRequestIdentity, wrapFetchForCopilotFallback } from "./github-copilot-headers";
+import {
+	getCopilotIntegrationCacheKey,
+	resolveCopilotRequestIdentity,
+	wrapFetchForCopilotFallback,
+} from "./github-copilot-headers";
 import {
 	applyChatCompletionsReasoningParams,
 	applyChatCompletionsToolStream,
@@ -801,6 +805,7 @@ const streamOpenAICompletionsOnce = (
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
+							getCopilotIntegrationCacheKey(apiKey),
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport retries.
 						// The first-event watchdog above aborts `requestSignal`, which

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -805,7 +805,7 @@ const streamOpenAICompletionsOnce = (
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
-							getCopilotIntegrationCacheKey(apiKey),
+							getCopilotIntegrationCacheKey(apiKey, baseUrl),
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport retries.
 						// The first-event watchdog above aborts `requestSignal`, which

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -576,7 +576,7 @@ const streamOpenAIResponsesOnce = (
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
-							getCopilotIntegrationCacheKey(apiKey),
+							getCopilotIntegrationCacheKey(apiKey, baseUrl),
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport
 						// retries; the first-event watchdog aborts `requestSignal`,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -64,11 +64,7 @@ import {
 	rememberOpenAIReasoningEffortFallback,
 	resolveOpenAIReasoningEffortFallback,
 } from "./openai-reasoning-fallback";
-import {
-	getCopilotIntegrationCacheKey,
-	resolveCopilotRequestIdentity,
-	wrapFetchForCopilotFallback,
-} from "./github-copilot-headers";
+import { resolveCopilotRequestIdentity, wrapFetchForCopilotFallback } from "./github-copilot-headers";
 import type {
 	Tool as OpenAITool,
 	ReasoningEffort,
@@ -458,14 +454,15 @@ const streamOpenAIResponsesOnce = (
 			const routingSessionId = getOpenAIResponsesRoutingSessionId(options);
 			const promptCacheSessionId = getOpenAIPromptCacheKey(options);
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const { headers, copilotPremiumRequests, baseUrl } = resolveOpenAIRequestSetup(model, {
-				apiKey,
-				extraHeaders: options?.headers,
-				initiatorOverride: options?.initiatorOverride,
-				messages: context.messages,
-				sessionId: options?.sessionId ?? routingSessionId,
-				promptCacheSessionId,
-			});
+			const { headers, copilotPremiumRequests, baseUrl, copilotCacheKey, copilotCacheSnapshot } =
+				resolveOpenAIRequestSetup(model, {
+					apiKey,
+					extraHeaders: options?.headers,
+					initiatorOverride: options?.initiatorOverride,
+					messages: context.messages,
+					sessionId: options?.sessionId ?? routingSessionId,
+					promptCacheSessionId,
+				});
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
 			const strictToolsScope = getOpenAIStrictToolsScope(model, baseUrl);
@@ -571,12 +568,12 @@ const streamOpenAIResponsesOnce = (
 						url: requestUrl,
 						headers: headersWithTimeout,
 						body: requestParams,
-						signal: requestSignal,
 						fetch: wrapFetchForCopilotFallback(
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
-							getCopilotIntegrationCacheKey(apiKey, baseUrl),
+							copilotCacheKey,
+							copilotCacheSnapshot,
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport
 						// retries; the first-event watchdog aborts `requestSignal`,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -64,7 +64,11 @@ import {
 	rememberOpenAIReasoningEffortFallback,
 	resolveOpenAIReasoningEffortFallback,
 } from "./openai-reasoning-fallback";
-import { resolveCopilotRequestIdentity, wrapFetchForCopilotFallback } from "./github-copilot-headers";
+import {
+	getCopilotIntegrationCacheKey,
+	resolveCopilotRequestIdentity,
+	wrapFetchForCopilotFallback,
+} from "./github-copilot-headers";
 import type {
 	Tool as OpenAITool,
 	ReasoningEffort,
@@ -572,6 +576,7 @@ const streamOpenAIResponsesOnce = (
 							options?.fetch,
 							model.provider === "github-copilot",
 							resolveCopilotRequestIdentity(options?.headers),
+							getCopilotIntegrationCacheKey(apiKey),
 						),
 						// Transient 408/429/5xx get Retry-After-aware transport
 						// retries; the first-event watchdog aborts `requestSignal`,

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -257,7 +257,8 @@ export function resolveOpenAIRequestSetup(
 	if (model.provider === "github-copilot") {
 		const copilotApiKey = parseGitHubCopilotApiKey(rawApiKey);
 		apiKey = copilotApiKey.accessToken;
-		const copilotCacheKey = getCopilotIntegrationCacheKey(rawApiKey);
+		const copilotBaseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
+		const copilotCacheKey = getCopilotIntegrationCacheKey(rawApiKey, copilotBaseUrl);
 		const copilot = buildCopilotDynamicHeaders({
 			messages: options.messages,
 			hasImages: hasCopilotVisionInput(options.messages),
@@ -270,7 +271,7 @@ export function resolveOpenAIRequestSetup(
 		});
 		Object.assign(headers, copilot.headers);
 		copilotPremiumRequests = copilot.premiumRequests;
-		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
+		baseUrl = copilotBaseUrl;
 	}
 
 	if (model.provider === "alibaba-token-plan") {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -92,6 +92,8 @@ import { getOpenRouterHeaders } from "../utils/openrouter-headers";
 import { isForcedToolChoice } from "../utils/tool-choice";
 import {
 	buildCopilotDynamicHeaders,
+	getCachedCopilotIntegrationId,
+	getCopilotIntegrationCacheKey,
 	hasCopilotVisionInput,
 	resolveGitHubCopilotBaseUrl,
 } from "./github-copilot-headers";
@@ -255,6 +257,7 @@ export function resolveOpenAIRequestSetup(
 	if (model.provider === "github-copilot") {
 		const copilotApiKey = parseGitHubCopilotApiKey(rawApiKey);
 		apiKey = copilotApiKey.accessToken;
+		const copilotCacheKey = getCopilotIntegrationCacheKey(rawApiKey);
 		const copilot = buildCopilotDynamicHeaders({
 			messages: options.messages,
 			hasImages: hasCopilotVisionInput(options.messages),
@@ -263,6 +266,7 @@ export function resolveOpenAIRequestSetup(
 			initiatorOverride: options.initiatorOverride,
 			enterpriseUrl: copilotApiKey.enterpriseUrl,
 			integrationId: resolveCopilotRequestIdentity(options.extraHeaders),
+			cachedIntegrationId: getCachedCopilotIntegrationId(copilotCacheKey),
 		});
 		Object.assign(headers, copilot.headers);
 		copilotPremiumRequests = copilot.premiumRequests;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -185,6 +185,14 @@ export interface OpenAIRequestSetup {
 	headers: Record<string, string>;
 	query: Record<string, string> | undefined;
 	requestHeaders: Record<string, string>;
+	/** Working-identity cache key for this credential+host; undefined off the Copilot path. */
+	copilotCacheKey: string | undefined;
+	/**
+	 * Build-time cache provenance for the wrapper: the cached value the
+	 * outgoing headers were built from, or `null` when the cache was empty at
+	 * build. `undefined` off the Copilot path (wrapper rereads at dispatch).
+	 */
+	copilotCacheSnapshot: string | null | undefined;
 }
 
 function normalizeSakanaRequestBaseUrl(baseUrl: string | undefined): string | undefined {
@@ -237,6 +245,8 @@ export function resolveOpenAIRequestSetup(
 	}
 
 	let copilotPremiumRequests: number | undefined;
+	let copilotCacheKey: string | undefined;
+	let copilotCacheSnapshot: string | null | undefined;
 	let baseUrl = model.baseUrl;
 	if (model.provider === "moonshot") {
 		// Bundled `moonshot` catalog models hardcode the international endpoint
@@ -258,7 +268,8 @@ export function resolveOpenAIRequestSetup(
 		const copilotApiKey = parseGitHubCopilotApiKey(rawApiKey);
 		apiKey = copilotApiKey.accessToken;
 		const copilotBaseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
-		const copilotCacheKey = getCopilotIntegrationCacheKey(rawApiKey, copilotBaseUrl);
+		copilotCacheKey = getCopilotIntegrationCacheKey(rawApiKey, copilotBaseUrl);
+		const copilotCached = getCachedCopilotIntegrationId(copilotCacheKey);
 		const copilot = buildCopilotDynamicHeaders({
 			messages: options.messages,
 			hasImages: hasCopilotVisionInput(options.messages),
@@ -267,11 +278,12 @@ export function resolveOpenAIRequestSetup(
 			initiatorOverride: options.initiatorOverride,
 			enterpriseUrl: copilotApiKey.enterpriseUrl,
 			integrationId: resolveCopilotRequestIdentity(options.extraHeaders),
-			cachedIntegrationId: getCachedCopilotIntegrationId(copilotCacheKey),
+			cachedIntegrationId: copilotCached,
 		});
 		Object.assign(headers, copilot.headers);
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = copilotBaseUrl;
+		copilotCacheSnapshot = copilotCached ?? null;
 	}
 
 	if (model.provider === "alibaba-token-plan") {
@@ -336,7 +348,7 @@ export function resolveOpenAIRequestSetup(
 	if (apiKey !== NO_AUTH_SENTINEL) {
 		headers.Authorization ??= `Bearer ${apiKey}`;
 	}
-	return { copilotPremiumRequests, baseUrl, headers, query, requestHeaders };
+	return { copilotPremiumRequests, baseUrl, headers, query, requestHeaders, copilotCacheKey, copilotCacheSnapshot };
 }
 
 export function applyOpenAIServiceTier(

--- a/packages/ai/test/github-copilot-headers.test.ts
+++ b/packages/ai/test/github-copilot-headers.test.ts
@@ -561,6 +561,17 @@ describe("copilot working integration cache", () => {
 		expect(getCopilotIntegrationCacheKey("   ")).toBeUndefined();
 	});
 
+	it("isolates the same token across effective hosts", () => {
+		const token = "ghu_shared_proxy_token";
+		const hostA = getCopilotIntegrationCacheKey(token, "https://proxy-a.example")!;
+		const hostB = getCopilotIntegrationCacheKey(token, "https://proxy-b.example")!;
+		expect(hostA).not.toBe(hostB);
+		expect(getCopilotIntegrationCacheKey(token, "https://proxy-a.example/")).toBe(hostA);
+		rememberCopilotWorkingIntegrationId(hostA, "copilot-developer-cli");
+		expect(getCachedCopilotIntegrationId(hostA)).toBe("copilot-developer-cli");
+		expect(getCachedCopilotIntegrationId(hostB)).toBeUndefined();
+	});
+
 	it("remembers and clears the working shape per credential", () => {
 		const key = getCopilotIntegrationCacheKey("ghu_cache_roundtrip")!;
 		expect(getCachedCopilotIntegrationId(key)).toBeUndefined();
@@ -738,5 +749,52 @@ describe("wrapFetchForCopilotFallback working-identity cache", () => {
 			denied,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves the cache unchanged when the CLI retry is indeterminate", async () => {
+		const cacheKey = "test-working-shape-forward-indeterminate";
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
+			if (outgoing === COPILOT_CHAT_INTEGRATION_ID) return new Response("{}", { status: 403 });
+			return new Response("{}", { status: 500 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		const result = await wrapped(chatUrl, {
+			headers: {
+				Authorization: "Bearer ghu_test",
+				"Copilot-Integration-Id": COPILOT_CHAT_INTEGRATION_ID,
+			},
+		});
+		expect(result.status).toBe(500);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
+	});
+
+	it("keeps reverse-retrying while chat retries stay indeterminate", async () => {
+		const cacheKey = "test-working-shape-reverse-indeterminate";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		const seen: (string | null)[] = [];
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
+			seen.push(outgoing);
+			// CLI is identity-denied; chat hits a transport-retryable 500 the
+			// transport will resend with the original CLI headers.
+			return outgoing === "copilot-developer-cli"
+				? new Response("{}", { status: 403 })
+				: new Response("{}", { status: 500 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		const cliRequest = {
+			headers: { "Copilot-Integration-Id": "copilot-developer-cli" },
+		};
+		const first = await wrapped(chatUrl, cliRequest);
+		expect(first.status).toBe(500);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-developer-cli");
+		// Transport resend with the original CLI headers must reverse-retry
+		// again instead of surfacing the CLI denial as terminal.
+		const second = await wrapped(chatUrl, cliRequest);
+		expect(second.status).toBe(500);
+		expect(seen).toEqual(["copilot-developer-cli", "copilot-chat", "copilot-developer-cli", "copilot-chat"]);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-developer-cli");
 	});
 });

--- a/packages/ai/test/github-copilot-headers.test.ts
+++ b/packages/ai/test/github-copilot-headers.test.ts
@@ -751,8 +751,9 @@ describe("wrapFetchForCopilotFallback working-identity cache", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("leaves the cache unchanged when the CLI retry is indeterminate", async () => {
+	it("clears the cache when the CLI retry fails", async () => {
 		const cacheKey = "test-working-shape-forward-indeterminate";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-chat");
 		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
 			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
 			if (outgoing === COPILOT_CHAT_INTEGRATION_ID) return new Response("{}", { status: 403 });
@@ -770,9 +771,14 @@ describe("wrapFetchForCopilotFallback working-identity cache", () => {
 		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
 	});
 
-	it("keeps reverse-retrying while chat retries stay indeterminate", async () => {
+	it("keeps reverse-retrying across transport resends and clears on failure", async () => {
 		const cacheKey = "test-working-shape-reverse-indeterminate";
 		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		// Build-time provenance, as threaded by the transports: the resend
+		// below reuses the headers (and snapshot) built before the first
+		// attempt, so it must reverse-retry even though the failed first
+		// attempt already invalidated the shared entry.
+		const snapshot = getCachedCopilotIntegrationId(cacheKey);
 		const seen: (string | null)[] = [];
 		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
 			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
@@ -783,18 +789,78 @@ describe("wrapFetchForCopilotFallback working-identity cache", () => {
 				? new Response("{}", { status: 403 })
 				: new Response("{}", { status: 500 });
 		});
-		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
 		const cliRequest = {
 			headers: { "Copilot-Integration-Id": "copilot-developer-cli" },
 		};
-		const first = await wrapped(chatUrl, cliRequest);
+		const first = await wrapFetchForCopilotFallback(
+			fetchMock as unknown as typeof fetch,
+			true,
+			undefined,
+			cacheKey,
+			snapshot,
+		)(chatUrl, cliRequest);
 		expect(first.status).toBe(500);
-		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-developer-cli");
-		// Transport resend with the original CLI headers must reverse-retry
-		// again instead of surfacing the CLI denial as terminal.
-		const second = await wrapped(chatUrl, cliRequest);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
+		const second = await wrapFetchForCopilotFallback(
+			fetchMock as unknown as typeof fetch,
+			true,
+			undefined,
+			cacheKey,
+			snapshot,
+		)(chatUrl, cliRequest);
 		expect(second.status).toBe(500);
 		expect(seen).toEqual(["copilot-developer-cli", "copilot-chat", "copilot-developer-cli", "copilot-chat"]);
-		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-developer-cli");
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
+	});
+
+	it("honors build-time provenance over a sibling's mid-flight relearn", async () => {
+		const cacheKey = "test-working-shape-provenance";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		// Headers built from the cached CLI; a sibling relearns chat before
+		// this request dispatches. Without the build-time snapshot the wrapper
+		// would see chat, skip its reverse retry, and surface the CLI denial
+		// even though chat works.
+		const snapshot = getCachedCopilotIntegrationId(cacheKey);
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-chat");
+		const seen: (string | null)[] = [];
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
+			seen.push(outgoing);
+			return outgoing === "copilot-developer-cli"
+				? new Response("{}", { status: 403 })
+				: new Response("{}", { status: 200 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(
+			fetchMock as unknown as typeof fetch,
+			true,
+			undefined,
+			cacheKey,
+			snapshot,
+		);
+		const result = await wrapped(chatUrl, { headers: { "Copilot-Integration-Id": "copilot-developer-cli" } });
+		expect(result.status).toBe(200);
+		expect(seen).toEqual(["copilot-developer-cli", "copilot-chat"]);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-chat");
+	});
+
+	it("treats a null snapshot as default-built and skips reverse retry", async () => {
+		const cacheKey = "test-working-shape-null-snapshot";
+		const denied = new Response("{}", { status: 403 });
+		const fetchMock = vi.fn(async () => denied);
+		// `null` pins "cache was empty at build" (e.g. Enterprise default):
+		// a sibling learning afterwards must not turn this default-built
+		// request into a reverse retry.
+		const wrapped = wrapFetchForCopilotFallback(
+			fetchMock as unknown as typeof fetch,
+			true,
+			undefined,
+			cacheKey,
+			null,
+		);
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		await expect(wrapped(chatUrl, { headers: { "Copilot-Integration-Id": "copilot-developer-cli" } })).resolves.toBe(
+			denied,
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/ai/test/github-copilot-headers.test.ts
+++ b/packages/ai/test/github-copilot-headers.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
 	buildCopilotDynamicHeaders,
+	clearCopilotIntegrationCache,
+	getCachedCopilotIntegrationId,
+	getCopilotIntegrationCacheKey,
 	getCopilotInitiatorOverride,
 	getCopilotPremiumMultiplier,
 	hasCopilotVisionInput,
 	inferCopilotInitiator,
+	rememberCopilotWorkingIntegrationId,
 	resolveCopilotIntegrationIdOverride,
 	resolveCopilotRequestIdentity,
 	wrapFetchForCopilotFallback,
@@ -535,5 +539,181 @@ describe("wrapFetchForCopilotFallback", () => {
 		await expect(wrapped(request)).resolves.toBe(denied);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(denied.bodyUsed).toBe(false);
+	});
+});
+
+describe("copilot working integration cache", () => {
+	afterEach(() => {
+		clearCopilotIntegrationCache();
+		vi.restoreAllMocks();
+	});
+
+	it("keys credentials by bearer hash with routing inputs, never raw bytes", () => {
+		const personal = getCopilotIntegrationCacheKey("ghu_personal_token")!;
+		expect(getCopilotIntegrationCacheKey("ghu_personal_token")).toBe(personal);
+		expect(personal).not.toContain("ghu_personal_token");
+		expect(getCopilotIntegrationCacheKey("ghu_other_token")).not.toBe(personal);
+		const enterprise = getCopilotIntegrationCacheKey(
+			JSON.stringify({ token: "ghu_personal_token", enterpriseUrl: "ghe.example.com" }),
+		)!;
+		expect(enterprise).not.toBe(personal);
+		expect(getCopilotIntegrationCacheKey(undefined)).toBeUndefined();
+		expect(getCopilotIntegrationCacheKey("   ")).toBeUndefined();
+	});
+
+	it("remembers and clears the working shape per credential", () => {
+		const key = getCopilotIntegrationCacheKey("ghu_cache_roundtrip")!;
+		expect(getCachedCopilotIntegrationId(key)).toBeUndefined();
+		rememberCopilotWorkingIntegrationId(key, "copilot-developer-cli");
+		expect(getCachedCopilotIntegrationId(key)).toBe("copilot-developer-cli");
+		rememberCopilotWorkingIntegrationId(key, "not an id\r\ninjected");
+		expect(getCachedCopilotIntegrationId(key)).toBe("copilot-developer-cli");
+		clearCopilotIntegrationCache(key);
+		expect(getCachedCopilotIntegrationId(key)).toBeUndefined();
+	});
+
+	it("prefers cached working shape over defaults but never over explicit", () => {
+		expect(
+			buildCopilotDynamicHeaders({ messages: [], hasImages: false, cachedIntegrationId: "copilot-developer-cli" })
+				.headers["Copilot-Integration-Id"],
+		).toBe("copilot-developer-cli");
+		expect(
+			buildCopilotDynamicHeaders({
+				messages: [],
+				hasImages: false,
+				integrationId: "vscode-chat",
+				cachedIntegrationId: "copilot-developer-cli",
+			}).headers["Copilot-Integration-Id"],
+		).toBe("vscode-chat");
+		expect(
+			buildCopilotDynamicHeaders({ messages: [], hasImages: false, cachedIntegrationId: "bad\r\nid" }).headers[
+				"Copilot-Integration-Id"
+			],
+		).toBe("copilot-chat");
+	});
+
+	it("lets a learned chat shape override the Enterprise CLI default", () => {
+		expect(
+			buildCopilotDynamicHeaders({
+				messages: [],
+				hasImages: false,
+				enterpriseUrl: "ghe.example.com",
+				cachedIntegrationId: "copilot-chat",
+			}).headers["Copilot-Integration-Id"],
+		).toBe("copilot-chat");
+	});
+});
+
+describe("wrapFetchForCopilotFallback working-identity cache", () => {
+	const chatUrl = "https://api.githubcopilot.com/chat/completions";
+	afterEach(() => {
+		clearCopilotIntegrationCache();
+		vi.restoreAllMocks();
+	});
+
+	function chatRequest(init?: RequestInit): [string, RequestInit | undefined] {
+		return [
+			chatUrl,
+			{
+				...init,
+				headers: {
+					Authorization: "Bearer ghu_test",
+					"Copilot-Integration-Id": COPILOT_CHAT_INTEGRATION_ID,
+				},
+			},
+		];
+	}
+
+	it("remembers CLI after a chat denial clears on retry", async () => {
+		const cacheKey = "test-working-shape-forward";
+		let calls = 0;
+		const fetchMock = vi.fn(async () => {
+			calls++;
+			if (calls === 1) return new Response("{}", { status: 403 });
+			return new Response("{}", { status: 200 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		const result = await wrapped(...chatRequest());
+		expect(result.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-developer-cli");
+	});
+
+	it("leaves the cache empty when the CLI retry stays denied", async () => {
+		const cacheKey = "test-working-shape-still-denied";
+		const fetchMock = vi.fn(async () => new Response("{}", { status: 403 }));
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		await wrapped(...chatRequest());
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
+	});
+
+	it("never caches on auth failure and never retries an explicit pin", async () => {
+		const authKey = "test-working-shape-401";
+		let calls = 0;
+		const authMock = vi.fn(async () => {
+			calls++;
+			return new Response("{}", { status: calls === 1 ? 403 : 401 });
+		});
+		await wrapFetchForCopilotFallback(
+			authMock as unknown as typeof fetch,
+			true,
+			undefined,
+			authKey,
+		)(...chatRequest());
+		expect(getCachedCopilotIntegrationId(authKey)).toBeUndefined();
+
+		const pinKey = "test-working-shape-pinned";
+		const denied = new Response("{}", { status: 403 });
+		const pinMock = vi.fn(async () => denied);
+		const pinned = wrapFetchForCopilotFallback(pinMock as unknown as typeof fetch, true, "vscode-chat", pinKey);
+		await expect(pinned(...chatRequest())).resolves.toBe(denied);
+		expect(pinMock).toHaveBeenCalledTimes(1);
+		expect(getCachedCopilotIntegrationId(pinKey)).toBeUndefined();
+	});
+
+	it("retries a stale cached CLI as chat and relearns", async () => {
+		const cacheKey = "test-working-shape-reverse";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		const seen: (string | null)[] = [];
+		let calls = 0;
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			calls++;
+			seen.push(new Headers(init?.headers).get("Copilot-Integration-Id"));
+			if (calls === 1) return new Response("{}", { status: 403 });
+			return new Response("{}", { status: 200 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		const result = await wrapped(chatUrl, {
+			headers: { "Copilot-Integration-Id": "copilot-developer-cli" },
+		});
+		expect(result.status).toBe(200);
+		expect(seen).toEqual(["copilot-developer-cli", "copilot-chat"]);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-chat");
+	});
+
+	it("clears a cached CLI both sides deny", async () => {
+		const cacheKey = "test-working-shape-reverse-denied";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		const fetchMock = vi.fn(async () => new Response("{}", { status: 403 }));
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		await wrapped(chatUrl, { headers: { "Copilot-Integration-Id": "copilot-developer-cli" } });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getCachedCopilotIntegrationId(cacheKey)).toBeUndefined();
+	});
+
+	it("leaves an uncached CLI denial terminal", async () => {
+		const denied = new Response("{}", { status: 403 });
+		const fetchMock = vi.fn(async () => denied);
+		const wrapped = wrapFetchForCopilotFallback(
+			fetchMock as unknown as typeof fetch,
+			true,
+			undefined,
+			"test-working-shape-uncached-cli",
+		);
+		await expect(wrapped(chatUrl, { headers: { "Copilot-Integration-Id": "copilot-developer-cli" } })).resolves.toBe(
+			denied,
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/ai/test/github-copilot-headers.test.ts
+++ b/packages/ai/test/github-copilot-headers.test.ts
@@ -692,6 +692,29 @@ describe("wrapFetchForCopilotFallback working-identity cache", () => {
 		expect(getCachedCopilotIntegrationId(cacheKey)).toBe("copilot-chat");
 	});
 
+	it("retries a stale cached CLI even when a sibling relearns mid-flight", async () => {
+		const cacheKey = "test-working-shape-reverse-race";
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");
+		const seen: (string | null)[] = [];
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			const outgoing = new Headers(init?.headers).get("Copilot-Integration-Id");
+			seen.push(outgoing);
+			return outgoing === "copilot-developer-cli"
+				? new Response("{}", { status: 403 })
+				: new Response("{}", { status: 200 });
+		});
+		const wrapped = wrapFetchForCopilotFallback(fetchMock as unknown as typeof fetch, true, undefined, cacheKey);
+		// The wrapper snapshots the cached CLI synchronously on invocation, so a
+		// sibling stream relearning chat between dispatch and denial must not
+		// cancel this request's own reverse retry — otherwise it would surface a
+		// denial even though chat works.
+		const second = wrapped(chatUrl, { headers: { "Copilot-Integration-Id": "copilot-developer-cli" } });
+		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-chat");
+		const result = await second;
+		expect(result.status).toBe(200);
+		expect(seen).toEqual(["copilot-developer-cli", "copilot-chat"]);
+	});
+
 	it("clears a cached CLI both sides deny", async () => {
 		const cacheKey = "test-working-shape-reverse-denied";
 		rememberCopilotWorkingIntegrationId(cacheKey, "copilot-developer-cli");

--- a/packages/ai/test/github-copilot-openai-base-url.test.ts
+++ b/packages/ai/test/github-copilot-openai-base-url.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { clearCopilotIntegrationCache } from "@oh-my-pi/pi-ai/providers/github-copilot-headers";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 afterEach(() => {
+	clearCopilotIntegrationCache();
 	vi.restoreAllMocks();
 });
 
@@ -364,5 +366,56 @@ describe("GitHub Copilot OpenAI transport base URL", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(requestedInitiators[0]).toBe("agent");
+	});
+});
+
+describe("GitHub Copilot working-identity cache across streams", () => {
+	function chatCompletionsSse(): Response {
+		const chunk = (delta: unknown, finishReason: string | null) =>
+			JSON.stringify({
+				id: "chatcmpl-working-shape",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "gpt-4o",
+				choices: [{ index: 0, delta, finish_reason: finishReason }],
+			});
+		return new Response(
+			`data: ${chunk({ role: "assistant", content: "ok" }, null)}\n\ndata: ${chunk({}, "stop")}\n\ndata: [DONE]\n\n`,
+			{ status: 200, headers: { "content-type": "text/event-stream" } },
+		);
+	}
+
+	it("starts the second stream at the learned CLI shape without a chat denial", async () => {
+		const cacheApiKey = "ghu_test_working_shape_transport";
+		const seenIntegrationIds: (string | null)[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const integrationId = getRequestHeader(input, init, "Copilot-Integration-Id");
+			seenIntegrationIds.push(integrationId);
+			if (integrationId === "copilot-chat") {
+				return new Response(JSON.stringify({ error: { message: "denied" } }), {
+					status: 403,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			return chatCompletionsSse();
+		});
+
+		const model = getBundledModel("github-copilot", "gpt-4o") as Model<"openai-completions">;
+		const first = await streamOpenAICompletions(model, testContext, {
+			apiKey: cacheApiKey,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(first.stopReason).toBe("stop");
+		expect(seenIntegrationIds).toEqual(["copilot-chat", "copilot-developer-cli"]);
+
+		const second = await streamOpenAICompletions(model, testContext, {
+			apiKey: cacheApiKey,
+			fetch: fetchMock as unknown as typeof fetch,
+		}).result();
+
+		expect(second.stopReason).toBe("stop");
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(seenIntegrationIds).toEqual(["copilot-chat", "copilot-developer-cli", "copilot-developer-cli"]);
 	});
 });


### PR DESCRIPTION
## What

follow up to https://github.com/can1357/oh-my-pi/pull/11670/, cache working shape for github copilot

Remembers the `Copilot-Integration-Id` that clears the identity gate per credential and effective host (`Bun.hash` bearer fingerprint + enterprise/business routing inputs + normalized effective base URL, never raw token bytes) in the central `LRUCache`. Later OpenAI chat-completions/Responses and Anthropic streams start at the learned shape; a stale cached CLI that gets denied retries once as chat and relearns. Only a 2xx retry proves its identity — any failed retry clears the entry so the next stream rediscovers instead of pinning a failing shape. Transports thread the build-time snapshot to the wrapper, so a sibling relearning between header construction (before the `onPayload` await) and dispatch cannot cancel this request's own reverse retry. Explicit `COPILOT_INTEGRATION_ID`/caller headers still bypass the cache entirely.

## Why

Follow-up to #11670 per reviewer thread: every new chat whose working surface is not the default pays one extra round-trip (chat denial → CLI retry). Enterprise already defaults to CLI; Business/personal credentials that need CLI replay the denial on each stream. Caching the working shape removes the repeat retry while a reverse retry handles org-policy flips.

## Testing

- `bun test packages/ai/test/github-copilot*` — 130 passed, 0 failed (cache unit tests, cross-host isolation, indeterminate/invalidation sequences, build-time provenance races, and a transport test proving the second stream sends `copilot-developer-cli` upfront).
- Adjacent suites (`anthropic-alignment`, `alibaba-token-plan`, `coreweave-project-header`) — 111 passed, 0 failed.
- `bunx oxlint` and `bunx oxfmt` clean on all touched files.
- Full `bun check` not run (Rust stage unrelated to this TS-only change); scoped lint/format + focused package tests above are the verification.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)