### PR TITLE
fix(read): hyperlink grouped read tree rows like standalone rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Hand-authored `*.openapi.json` files can now be edited without disabling generated-file protection globally ([#11674](https://github.com/can1357/oh-my-pi/issues/11674)).
 - `models.yml` now validates the per-model `compat.stripImageInput` opt-out, so a wrong-typed value is rejected like every other declared compat key instead of being silently accepted ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
 - `/mcp reload` now distinguishes servers still connecting after the bounded reload window instead of reporting a healthy asynchronous reload as zero active servers ([#11639](https://github.com/can1357/oh-my-pi/issues/11639)).
+- File paths in the compact grouped `Read (N)` tree are now clickable OSC 8 hyperlinks, matching standalone Read rows; delimited reads carry a resolved link target per row so both live output and rebuilt transcripts link correctly ([#11732](https://github.com/can1357/oh-my-pi/issues/11732)).
 ### Changed
 
 - The `providers.cacheRetention` `auto` setting now keeps Anthropic OAuth subscriber sessions on 1h prompt-cache retention and API keys on 5m, instead of 5m for both ([#11667](https://github.com/can1357/oh-my-pi/pull/11667) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -87,6 +87,7 @@ type ReadToolResultDetails = {
 	};
 	conflictCount?: number;
 	displayReadTargets?: unknown;
+	displayReadTargetLinks?: unknown;
 	displayContent?: {
 		text?: string;
 		startLine?: number;
@@ -111,10 +112,13 @@ function getSuffixResolution(details: ReadToolResultDetails | undefined): ReadTo
 	return { from: details.suffixResolution.from, to: details.suffixResolution.to };
 }
 
+/** One display path recovered from a delimited read, paired with the resolved fs link target for its row. */
+type ReadDisplayPathSpec = { path: string; linkPath?: string };
+
 type ReadEntry = {
 	toolCallId: string;
 	path: string;
-	displayPaths?: string[];
+	displayPaths?: ReadDisplayPathSpec[];
 	linkPath?: string;
 	status: "pending" | "success" | "warning" | "error";
 	correctedFrom?: string;
@@ -159,12 +163,17 @@ const READ_STATUS_RANK: Record<ReadEntry["status"], number> = {
 
 const URL_LIKE_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
-function getDisplayReadTargets(details: ReadToolResultDetails | undefined): string[] | undefined {
+function getDisplayReadTargets(details: ReadToolResultDetails | undefined): ReadDisplayPathSpec[] | undefined {
 	if (!Array.isArray(details?.displayReadTargets)) return undefined;
-	const targets = details.displayReadTargets
-		.filter((target): target is string => typeof target === "string")
-		.map(target => target.trim())
-		.filter(target => target.length > 0);
+	const links = Array.isArray(details.displayReadTargetLinks) ? details.displayReadTargetLinks : undefined;
+	const targets: ReadDisplayPathSpec[] = [];
+	details.displayReadTargets.forEach((raw, index) => {
+		if (typeof raw !== "string") return;
+		const path = raw.trim();
+		if (!path) return;
+		const link = links?.[index];
+		targets.push({ path, linkPath: typeof link === "string" && link.length > 0 ? link : undefined });
+	});
 	return targets.length > 0 ? targets : undefined;
 }
 
@@ -591,15 +600,17 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#displayTargetsForEntries(entries: ReadEntry[]): ReadDisplayTarget[] {
 		const targets: ReadDisplayTarget[] = [];
 		for (const entry of entries) {
-			const pathSpecs = entry.displayPaths ?? splitReadDisplayPathSpecs(entry.path);
+			const pathSpecs: ReadDisplayPathSpec[] =
+				entry.displayPaths ?? splitReadDisplayPathSpecs(entry.path).map(path => ({ path }));
 			const useEntryLinkPath = pathSpecs.length === 1;
 			for (const pathSpec of pathSpecs) {
-				const split = splitPathAndSel(pathSpec);
-				const linkPath = readTargetLinkPath(split.path, useEntryLinkPath ? entry.linkPath : undefined);
+				const split = splitPathAndSel(pathSpec.path);
+				const entryLinkPath = pathSpec.linkPath ?? (useEntryLinkPath ? entry.linkPath : undefined);
+				const linkPath = readTargetLinkPath(split.path, entryLinkPath);
 				for (const selector of splitSelectorDisplayParts(split.sel)) {
 					targets.push({
 						entry,
-						targetPath: selector ? `${split.path}:${selector}` : pathSpec,
+						targetPath: selector ? `${split.path}:${selector}` : pathSpec.path,
 						basePath: split.path,
 						linkPath,
 						selector,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -818,8 +818,17 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		for (const part of parts) {
 			try {
 				const result = await this.execute("read-delimited-part", { path: part }, signal);
-				displayReadTargets.push(result.details?.suffixResolution?.to ?? part);
-				displayReadTargetLinks.push(readDetailsLinkPath(result.details));
+				const nestedTargets = result.details?.displayReadTargets;
+				if (nestedTargets?.length) {
+					const nestedLinks = result.details?.displayReadTargetLinks;
+					for (const [index, target] of nestedTargets.entries()) {
+						displayReadTargets.push(target);
+						displayReadTargetLinks.push(nestedLinks?.[index] ?? null);
+					}
+				} else {
+					displayReadTargets.push(result.details?.suffixResolution?.to ?? part);
+					displayReadTargetLinks.push(readDetailsLinkPath(result.details));
+				}
 				for (const block of result.content) {
 					if (block.type === "text") {
 						appendText(block.text);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -658,8 +658,25 @@ export interface ReadToolDetails {
 	conflictCount?: number;
 	/** Paths recovered from a delimited read argument; used only by the TUI to render one call as multiple read rows. */
 	displayReadTargets?: string[];
+	/**
+	 * Resolved filesystem link target for each {@link displayReadTargets} entry, aligned by index; `null` when a
+	 * delimited part has no linkable fs path. Lets the TUI hyperlink each grouped row the same way a standalone read row is.
+	 */
+	displayReadTargetLinks?: Array<string | null>;
 }
 type ReadParams = ReadToolInput;
+
+/**
+ * Resolve the filesystem path a read result should hyperlink to: the explicit
+ * `resolvedPath` when the read corrected/resolved the input, else the absolute
+ * path plain-file reads record only in `meta.source`. Returns `null` for
+ * URL/internal sources that are not fs paths.
+ */
+function readDetailsLinkPath(details: ReadToolDetails | undefined): string | null {
+	if (typeof details?.resolvedPath === "string") return details.resolvedPath;
+	const source = details?.meta?.source;
+	return source?.type === "path" && typeof source.value === "string" ? source.value : null;
+}
 
 /** Identical reads tolerated before the loop hint is appended. */
 const REPEAT_READ_HINT_THRESHOLD = 3;
@@ -787,6 +804,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const notes = [notice];
 		const content: Array<TextContent | ImageContent> = [];
 		const displayReadTargets: string[] = [];
+		const displayReadTargetLinks: Array<string | null> = [];
 		let pendingText = notice;
 		const flushText = () => {
 			if (pendingText.length === 0) return;
@@ -801,6 +819,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			try {
 				const result = await this.execute("read-delimited-part", { path: part }, signal);
 				displayReadTargets.push(result.details?.suffixResolution?.to ?? part);
+				displayReadTargetLinks.push(readDetailsLinkPath(result.details));
 				for (const block of result.content) {
 					if (block.type === "text") {
 						appendText(block.text);
@@ -815,12 +834,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				const errorNote = `Could not read ${part}: ${message}`;
 				notes.push(errorNote);
 				displayReadTargets.push(part);
+				displayReadTargetLinks.push(null);
 				appendText(`[${errorNote}]`);
 			}
 		}
 		flushText();
 
-		return toolResult<ReadToolDetails>({ notes, displayReadTargets }).content(content).done();
+		return toolResult<ReadToolDetails>({ notes, displayReadTargets, displayReadTargetLinks }).content(content).done();
 	}
 
 	/**

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -215,6 +215,35 @@ describe("ReadToolGroupComponent", () => {
 		expect(plain).toContain(`${themeModule.theme.tree.last} ${twoPath}`);
 	});
 
+	it("links every grouped delimited row from result-provided link paths", () => {
+		settings.override("tui.hyperlinks", "always");
+		const component = new ReadToolGroupComponent();
+		const oneLink = path.resolve("/workspace/src/one.ts");
+		const twoLink = path.resolve("/workspace/src/two.ts");
+		component.updateArgs({ path: "src/one.ts:1-5, src/two.ts:9-12" }, "read-grouped-link");
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "combined" }],
+				details: {
+					displayReadTargets: ["src/one.ts:1-5", "src/two.ts:9-12"],
+					displayReadTargetLinks: [oneLink, twoLink],
+				},
+			},
+			false,
+			"read-grouped-link",
+		);
+
+		const rendered = component.render(120).join("\n");
+
+		const oneUri = new URL(url.pathToFileURL(oneLink).href);
+		oneUri.searchParams.set("line", "1");
+		const twoUri = new URL(url.pathToFileURL(twoLink).href);
+		twoUri.searchParams.set("line", "9");
+		expect(Bun.stripANSI(rendered)).toContain("Read (2)");
+		expect(extractLinkUris(rendered)).toEqual(expect.arrayContaining([oneUri.href, twoUri.href]));
+		expect(extractLinkTexts(rendered)).toEqual(expect.arrayContaining(["src/one.ts", "src/two.ts"]));
+	});
+
 	it("renders warning previews with warning styling instead of success styling", () => {
 		const component = new ReadToolGroupComponent({ showContentPreview: true });
 		const examplePath = path.resolve("/tmp/example.ts");

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -538,6 +538,31 @@ describe("tool path arrays", () => {
 		]);
 	});
 
+	it("flattens nested mixed-delimiter read targets and links", async () => {
+		const tools = await createTools(createTestSession(tempDir, { hasEditTool: false }));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		const result = await tool.execute("read-mixed-delimited", {
+			path: "apps/grep.txt, packages/grep.txt; phases/grep.txt",
+		});
+		const text = getText(result);
+		const details = result.details as
+			| { displayReadTargets?: string[]; displayReadTargetLinks?: Array<string | null> }
+			| undefined;
+
+		expect(text).toContain("shared-needle apps");
+		expect(text).toContain("shared-needle packages");
+		expect(text).toContain("shared-needle phases");
+		expect(details?.displayReadTargets).toEqual(["apps/grep.txt", "packages/grep.txt", "phases/grep.txt"]);
+		expect(details?.displayReadTargetLinks).toEqual([
+			path.join(tempDir, "apps", "grep.txt"),
+			path.join(tempDir, "packages", "grep.txt"),
+			path.join(tempDir, "phases", "grep.txt"),
+		]);
+	});
+
 	it("read treats semicolon lists as explicit scope before fuzzy suffix recovery", async () => {
 		const decoyRoot = path.join(tempDir, "decoy");
 		const decoyPath = path.join(decoyRoot, "apps", "grep.txt; packages", "grep.txt");

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -525,12 +525,17 @@ describe("tool path arrays", () => {
 			path: "apps/grep.txt, packages/grep.txt",
 		});
 		const text = getText(result);
-		const details = result.details as { notes?: string[] } | undefined;
+		const details = result.details as { notes?: string[]; displayReadTargetLinks?: Array<string | null> } | undefined;
 
 		expect(text).toContain("Note: interpreted as 2 paths: apps/grep.txt, packages/grep.txt");
 		expect(text).toContain("shared-needle apps");
 		expect(text).toContain("shared-needle packages");
 		expect(details?.notes).toEqual(["Note: interpreted as 2 paths: apps/grep.txt, packages/grep.txt"]);
+		// Each grouped row must carry a resolved fs link target so the TUI hyperlinks it like a standalone read row (#11732).
+		expect(details?.displayReadTargetLinks).toEqual([
+			path.join(tempDir, "apps", "grep.txt"),
+			path.join(tempDir, "packages", "grep.txt"),
+		]);
 	});
 
 	it("read treats semicolon lists as explicit scope before fuzzy suffix recovery", async () => {
@@ -569,7 +574,7 @@ describe("tool path arrays", () => {
 			path: "missing.txt, packages/grep.txt",
 		});
 		const text = getText(result);
-		const details = result.details as { notes?: string[] } | undefined;
+		const details = result.details as { notes?: string[]; displayReadTargetLinks?: Array<string | null> } | undefined;
 
 		expect(text).toContain("Note: interpreted as 2 paths: missing.txt, packages/grep.txt");
 		expect(text).toContain("shared-needle packages");
@@ -578,6 +583,8 @@ describe("tool path arrays", () => {
 			"Note: interpreted as 2 paths: missing.txt, packages/grep.txt",
 			"Could not read missing.txt: Path 'missing.txt' not found",
 		]);
+		// Alignment contract: an unreadable part gets a null link, the readable peer keeps its resolved fs path (#11732).
+		expect(details?.displayReadTargetLinks).toEqual([null, path.join(tempDir, "packages", "grep.txt")]);
 	});
 
 	it("ast_grep accepts quoted path and glob filters", async () => {


### PR DESCRIPTION
## Repro
With the compact grouped Read summary (`read.toolResultPreview: false`), file paths in a `Read (N)` tree are not clickable OSC 8 hyperlinks, while a standalone `Read <path>` row of the same relative path links correctly. Rendering `ReadToolGroupComponent` with hyperlinks forced on and extracting the OSC 8 link display texts shows:

```
STANDALONE clickable paths: ["src/Foo/Renderer.cs"]
GROUPED clickable paths: []
```

The standalone row links; every grouped row drops the link, with or without line-range selectors.

## Cause
A plain-file read records its absolute path in `meta.source`, which `read-tool-group.ts` turns into the OSC 8 link target. A delimited/grouped read (`ReadTool.#tryReadDelimitedPaths`) instead returned only `displayReadTargets` — the *relative* display strings the model typed — with no per-target resolved path. In `#displayTargetsForEntries`, `readTargetLinkPath` can only link an absolute or internal-URL path, so relative grouped rows got no `linkPath` and `fileHyperlink` was skipped.

## Fix
- `read.ts`: add `ReadToolDetails.displayReadTargetLinks` and populate it in `#tryReadDelimitedPaths` — the resolved fs link path per delimited target (`null` when a part is unreadable), derived from each part's `resolvedPath`/`meta.source` via the new `readDetailsLinkPath` helper. Kept index-aligned with `displayReadTargets`.
- `read-tool-group.ts`: `getDisplayReadTargets` now zips each display target with its link path into `ReadDisplayPathSpec`; `#displayTargetsForEntries` uses the per-spec link path (falling back to the single-entry link path), so each tree row hyperlinks like a standalone row. Works for both live output and rebuilt transcripts since the field is persisted in `details`.
- CHANGELOG entry under Fixed.

## Verification
`bun test test/read-tool-group.test.ts` (32 pass) — includes a new test asserting every grouped delimited row emits the expected `file://` URI with its line selector and links the base path. Added tool-contract assertions in `test/tools/grep-path-lists.test.ts` that the delimited read result carries `displayReadTargetLinks` resolving to each part's absolute path (and `null` for an unreadable peer); these exercise the read tool's snapshot path which requires the `@oh-my-pi/pi-natives` addon, unbuildable in this sandbox (missing `cmake`), so they run in CI rather than locally. `bunx tsgo -p tsconfig.json --noEmit` passes. `Fixes #11732`