### PR TITLE
fix(coding-agent): rotate credentials on long-retry-after rate limits

### DIFF
--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -89,6 +89,31 @@ const PREMATURE_STREAM_CLOSE_ERROR_RE =
 const IMMUTABLE_ANTHROPIC_THINKING_ERROR_PATTERN =
 	/messages\.\d+\.content\.\d+.*\b(?:thinking|redacted_thinking)\b.*\blatest assistant message cannot be modified\b/is;
 
+/**
+ * A rate-limit whose provider-requested wait dwarfs any transient per-minute
+ * cap is really an account/usage cap in disguise. Anthropic tier weekly caps
+ * (Fable/Mythos/Opus/Sonnet) surface as a generic `429 rate_limit_error`
+ * rather than `usage_limit_reached`, so the central classifier tags them
+ * `Transient`, not `UsageLimit`. Left as transient, recovery sleeps the
+ * multi-hour `retry-after` and fails at `retry.maxDelayMs` instead of rotating
+ * to a healthy sibling account.
+ *
+ * Kept deliberately narrow: only fires for a transient (non-usage-limit)
+ * rate-limit whose parsed retry-after exceeds `maxDelayMs` — the longest we
+ * would ever sleep-and-retry the same account — so genuine per-minute limits
+ * (retry-after of seconds) keep their existing shed-and-backoff behavior.
+ */
+export function isRotatableRateLimitCap(
+	errorKindId: number,
+	parsedRetryAfterMs: number | undefined,
+	maxDelayMs: number,
+): boolean {
+	if (AIError.is(errorKindId, AIError.Flag.UsageLimit)) return false;
+	if (!AIError.is(errorKindId, AIError.Flag.Transient)) return false;
+	if (parsedRetryAfterMs === undefined || maxDelayMs <= 0) return false;
+	return parsedRetryAfterMs > maxDelayMs;
+}
+
 function hasNonWhitespace(value: string): boolean {
 	return NON_WHITESPACE_RE.test(value);
 }
@@ -604,12 +629,22 @@ export class TurnRecovery {
 		if (message.stopReason !== "error") return false;
 		const id = this.#classifyRetryMessage(message);
 		const activeModel = this.#host.model();
-		if (!activeModel || !AIError.is(id, AIError.Flag.UsageLimit)) return false;
+		if (!activeModel) return false;
+		const errorMessage = message.errorMessage || "Unknown error";
+		const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
+		// A long-`retry-after` rate-limit is an account cap in disguise (e.g.
+		// Anthropic tier weekly caps return a generic `rate_limit_error`, not
+		// `usage_limit_reached`); route it through credential rotation instead
+		// of sleeping the multi-hour window and failing at `retry.maxDelayMs`.
+		const rotatableRateLimitCap = isRotatableRateLimitCap(
+			id,
+			parsedRetryAfterMs,
+			this.#host.settings.getGroup("retry").maxDelayMs,
+		);
+		if (!AIError.is(id, AIError.Flag.UsageLimit) && !rotatableRateLimitCap) return false;
 
 		let recorded = this.#usageLimitOutcomes.get(message);
 		if (!recorded) {
-			const errorMessage = message.errorMessage || "Unknown error";
-			const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
 			const retryAfterMs = parsedRetryAfterMs ?? calculateRateLimitBackoffMs(parseRateLimitReason(errorMessage));
 			recorded = (async (): Promise<UsageLimitOutcome> => {
 				const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(

--- a/packages/coding-agent/test/turn-recovery-rate-limit-cap.test.ts
+++ b/packages/coding-agent/test/turn-recovery-rate-limit-cap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { isRotatableRateLimitCap } from "@oh-my-pi/pi-coding-agent/session/turn-recovery";
+
+const MAX_DELAY_MS = 300_000;
+const transient = AIError.create(AIError.Flag.Transient);
+const usageLimit = AIError.create(AIError.Flag.UsageLimit);
+const usageLimitTransient = AIError.create(AIError.Flag.UsageLimit, AIError.Flag.Transient);
+const authFailed = AIError.create(AIError.Flag.AuthFailed);
+
+describe("isRotatableRateLimitCap", () => {
+	it("routes a transient rate-limit whose retry-after exceeds maxDelayMs into rotation", () => {
+		// Anthropic tier weekly caps surface as a generic `rate_limit_error`
+		// (classified Transient) with a multi-hour retry-after.
+		expect(isRotatableRateLimitCap(transient, 60_690_000, MAX_DELAY_MS)).toBe(true);
+	});
+
+	it("leaves a genuine per-minute rate-limit as transient shed-and-backoff", () => {
+		expect(isRotatableRateLimitCap(transient, 30_000, MAX_DELAY_MS)).toBe(false);
+	});
+
+	it("does not fire at exactly maxDelayMs (strictly greater)", () => {
+		expect(isRotatableRateLimitCap(transient, MAX_DELAY_MS, MAX_DELAY_MS)).toBe(false);
+	});
+
+	it("does not fire without a parsed retry-after", () => {
+		expect(isRotatableRateLimitCap(transient, undefined, MAX_DELAY_MS)).toBe(false);
+	});
+
+	it("defers to the existing usage-limit path when already flagged UsageLimit", () => {
+		expect(isRotatableRateLimitCap(usageLimit, 60_690_000, MAX_DELAY_MS)).toBe(false);
+		expect(isRotatableRateLimitCap(usageLimitTransient, 60_690_000, MAX_DELAY_MS)).toBe(false);
+	});
+
+	it("ignores non-transient errors", () => {
+		expect(isRotatableRateLimitCap(authFailed, 60_690_000, MAX_DELAY_MS)).toBe(false);
+		expect(isRotatableRateLimitCap(0, 60_690_000, MAX_DELAY_MS)).toBe(false);
+	});
+
+	it("is disabled when maxDelayMs is non-positive", () => {
+		expect(isRotatableRateLimitCap(transient, 60_690_000, 0)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What & why

When one of my two Anthropic accounts hits a **tier weekly cap** (e.g. Fable),
OMP kept hitting the exhausted account and failing the turn instead of switching
to my other account that still had quota. It turns out to be a classification
gap: Anthropic returns that cap as a generic `429 rate_limit_error` (not
`usage_limit_reached`), so the central classifier flags it `Transient`, and
`TurnRecovery.recordUsageLimitOutcome` short-circuits before ever calling
`markUsageLimitReached`. Recovery then treats the multi-hour `retry-after` as a
transient wait, exceeds `retry.maxDelayMs`, and gives up — no rotation.

This change routes a transient (non-usage-limit) rate-limit whose parsed
`retry-after` is longer than `retry.maxDelayMs` — the longest we would ever
sleep-and-retry the same account — into the existing usage-limit path, so
`markUsageLimitReached` blocks the exhausted credential and rotates to a healthy
sibling. Genuine per-minute limits (retry-after of seconds) are untouched.

## Root cause

- `packages/ai/src/error/flags.ts`: a `ProviderHttpError` with
  `code === "rate_limit_error"` maps to `Flag.Transient`, and a bare `429`
  without `Flag.UsageLimit` also maps to `Flag.Transient`. The message
  ("This request would exceed your account's rate limit…") doesn't match
  `USAGE_LIMIT_PATTERN`, and the status is `429` (not `403`), so the
  `UsageLimit` arm in `classifyText` never fires.
- `packages/coding-agent/src/session/turn-recovery.ts`:
  `recordUsageLimitOutcome` returns early on `!AIError.is(id, UsageLimit)`, so
  `markUsageLimitReached` (which blocks the account and reports sibling
  availability) is never called. Recovery then adopts the multi-hour
  `retry-after` and trips the `maxDelayMs` fail-fast.

## Fix

- New narrow, pure predicate `isRotatableRateLimitCap(errorKindId,
  parsedRetryAfterMs, maxDelayMs)`.
- `recordUsageLimitOutcome` now proceeds when the error is `UsageLimit` **or** a
  rotatable long-retry-after rate-limit cap.

## Reproduction (before this change)

Two Anthropic accounts on the same provider — account A's Fable weekly is
exhausted, account B has headroom:

- `omp dry-balance anthropic/claude-fable-5 --bench` → account A returns
  `429 rate_limit_error` (`retry-after` ≈ 17h), account B succeeds.
- A Fable turn that lands on account A fails with:
  `Error: Retry failed after 1 attempts: Provider requested 60690779ms wait, exceeds retry.maxDelayMs (300000ms).`
  It never rotates to account B.

## Verification

- New unit test `packages/coding-agent/test/turn-recovery-rate-limit-cap.test.ts`
  (7 cases) covers the decision boundary (long vs short retry-after, the
  `> maxDelayMs` strict bound, missing retry-after, already-`UsageLimit`,
  non-transient, and `maxDelayMs <= 0`).
- Existing `turn-recovery-replay-unsafe.test.ts` still passes (67/67).
- `oxfmt --check` and `oxlint` are clean on the changed files.
- Caveat: I could not rebuild the full binary in my checkout (missing
  `pi_natives` native addon), so I verified the new decision logic via the unit
  test plus the live reproduction above; CI exercises the end-to-end path.
