### PR TITLE
fix(coding-agent): make `free` a searchable model fact

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 
+### Fixed
+
+- Searching `free` in the model picker now finds every zero-cost model, not just the ones with `free` in their id.
+
 ## [18.1.11] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -374,16 +374,36 @@ export function formatRoleChip(role: string, assignment: RoleAssignment, setting
 	return theme.fg(info.color ?? "muted", `${theme.status.enabled} ${label}`) + suffix;
 }
 
+/** Both token legs at zero cost — the condition {@link formatCostPair} renders as `free`. */
+function isFreeModel(model: Model): boolean {
+	const cost = model.cost;
+	return !cost || (cost.input <= 0 && cost.output <= 0);
+}
+
 /** `$in/out` per-million cost pair; `free` when both legs are zero. */
 function formatCostPair(model: Model): string {
+	if (isFreeModel(model)) return "free";
 	const cost = model.cost;
-	if (!cost || (cost.input <= 0 && cost.output <= 0)) return "free";
 	const fmt = (n: number): string => {
 		if (n <= 0) return "0";
 		const s = n >= 100 ? String(Math.round(n)) : n >= 10 ? n.toFixed(1) : n.toFixed(2);
 		return s.replace(/\.?0+$/, "");
 	};
 	return `$${fmt(cost.input)}/${fmt(cost.output)}`;
+}
+
+/**
+ * The fuzzy haystack for a model row: the displayed `provider/id`, plus `free`
+ * for zero-cost models so the cost column's own word is searchable even when
+ * the id never says it (openrouter suffixes `:free`; nvidia does not).
+ *
+ * Must stay a pure function of the item — never of the query. `fuzzyRank`
+ * caches match indices keyed on this string and stops admitting new entries
+ * past its cap, so a query-dependent haystack would thrash that cache.
+ */
+export function modelSearchText({ provider, id, model }: ModelBrowserItem): string {
+	const base = `${provider}/${id}`;
+	return isFreeModel(model) ? `${base} free` : base;
 }
 
 /** Provider-supplied blurb, flattened to a single renderable detail-line cell. */
@@ -722,10 +742,10 @@ export class ModelBrowser implements Component {
 		const query = this.#searchInput.getValue();
 		let items: ModelBrowserItem[];
 		if (query.trim()) {
-			// Match against the displayed "provider/id" string so the user can
-			// type what they see: bare names, provider prefixes, or scoped
-			// queries all flow through the same fuzzy matcher.
-			const ranked = fuzzyRank(this.#baseItems, query, ({ provider, id }) => `${provider}/${id}`);
+			// Match against the displayed row text so the user can type what
+			// they see: bare names, provider prefixes, scoped queries, and the
+			// cost column's `free` all flow through the same fuzzy matcher.
+			const ranked = fuzzyRank(this.#baseItems, query, modelSearchText);
 			const matches = ranked.map(result => result.item);
 			if (this.#preserveQueryOrder) {
 				items = matches;

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -38,6 +38,7 @@ import {
 	buildBrowserItems,
 	ModelBrowser,
 	type ModelBrowserItem,
+	modelSearchText,
 	type RoleAssignments,
 	resolveRoleAssignments,
 	sortModelItems,
@@ -655,7 +656,7 @@ export class ModelHubComponent implements Component {
 			this.#composeEntries();
 			return;
 		}
-		const matches = fuzzyFilter(this.#availableItems, query, ({ provider, id }) => `${provider}/${id}`);
+		const matches = fuzzyFilter(this.#availableItems, query, modelSearchText);
 		const counts = new Map<string, number>();
 		for (const item of matches) {
 			counts.set(item.provider, (counts.get(item.provider) ?? 0) + 1);

--- a/packages/coding-agent/test/model-browser.test.ts
+++ b/packages/coding-agent/test/model-browser.test.ts
@@ -12,7 +12,8 @@ import {
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 /** Optional presentation metadata a catalog or discovery source may attach. */
-type NativeMetadata = Pick<Model, "description" | "isNew" | "isBeta" | "isRecommended" | "int" | "tps">;
+type NativeMetadata = Pick<Model, "description" | "isNew" | "isBeta" | "isRecommended" | "int" | "tps"> &
+	Partial<Pick<Model, "cost">>;
 
 function makeModel(provider: string, id: string, metadata?: NativeMetadata): Model {
 	return buildModel({
@@ -141,6 +142,60 @@ describe("ModelBrowser search ranking", () => {
 		browser.setQuery("muse");
 
 		expect(browser.getSelected()?.selector).toBe("fireworks/muse-glimmer-30b");
+	});
+
+	test("typing free finds a zero-cost model whose id never says free", () => {
+		// Regression: the cost column renders "free" for zero-cost models, but
+		// the haystack was only "provider/id" — so nvidia's genuinely free
+		// models were unfindable while openrouter's ":free" ids matched by
+		// accident of naming.
+		const browser = makeBrowser(
+			[
+				makeModel("nvidia", "nemotron-3-nano"),
+				makeModel("anthropic", "claude-sonnet-4-5", {
+					cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+				}),
+			],
+			[],
+		);
+
+		browser.setQuery("free");
+
+		expect(browser.visibleCount).toBe(1);
+		expect(browser.getSelected()?.selector).toBe("nvidia/nemotron-3-nano");
+	});
+
+	test("an id that literally says free outranks a model that is merely free", () => {
+		// Both match; the contiguous-literal tier must keep the ":free" id on
+		// top rather than collapsing every zero-cost model into one tier.
+		const browser = makeBrowser(
+			[makeModel("nvidia", "nemotron-3-nano"), makeModel("kilo", "liquid/lfm-2.5-2.6b:free")],
+			[],
+		);
+
+		browser.setQuery("free");
+
+		expect(browser.visibleCount).toBe(2);
+		expect(browser.getSelected()?.selector).toBe("kilo/liquid/lfm-2.5-2.6b:free");
+	});
+
+	test("the cost keyword composes with multi-token search", () => {
+		// The keyword is appended as its own word, so it survives AND-token
+		// matching — narrowing a model name by cost, not just a bare "free".
+		const browser = makeBrowser(
+			[
+				makeModel("nvidia", "moonshotai/kimi-k3"),
+				makeModel("moonshot", "moonshotai/kimi-k3", {
+					cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+				}),
+			],
+			[],
+		);
+
+		browser.setQuery("kimi k3 free");
+
+		expect(browser.visibleCount).toBe(1);
+		expect(browser.getSelected()?.selector).toBe("nvidia/moonshotai/kimi-k3");
 	});
 });
 

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -28,7 +28,7 @@ function footerLine(lines: readonly string[]): string {
 	return stripVTControlCharacters(lines[lines.length - 2] ?? "");
 }
 
-function makeModel(provider: string, id: string, contextWindow = 128_000): Model {
+function makeModel(provider: string, id: string, contextWindow = 128_000, cost?: Model["cost"]): Model {
 	return buildModel({
 		id,
 		name: id,
@@ -37,7 +37,7 @@ function makeModel(provider: string, id: string, contextWindow = 128_000): Model
 		baseUrl: "https://example.com",
 		reasoning: false,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		cost: cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens: 1024,
 	});
@@ -285,6 +285,32 @@ describe("ModelHub", () => {
 			hub.handleInput(UP); // skips Roles → wraps to prov-a
 			expect(normalize(hub.render(220))).toContain("prov-a ·");
 			expect(footerLine(hub.render(220))).not.toContain("→ roles");
+		});
+
+		test("provider sidebar counts agree with the free keyword", () => {
+			// Regression: the sidebar counts come from the hub's own filter, so
+			// if only the browser learned the cost keyword a free provider would
+			// render 0, gray out, and drop out of the scope hop while its rows
+			// were still listed.
+			const { hub } = createHub({
+				models: [
+					makeModel("nvidia", "nemotron-3-nano"),
+					makeModel("anthropic", "claude-sonnet-4-5", 128_000, {
+						input: 3,
+						output: 15,
+						cacheRead: 0.3,
+						cacheWrite: 3.75,
+					}),
+				],
+			});
+			installTestTheme();
+
+			for (const ch of "free") hub.handleInput(ch);
+
+			const rendered = normalize(hub.render(220));
+			expect(rendered).toContain("All models 1");
+			expect(rendered).toContain("nvidia 1");
+			expect(rendered).toContain("anthropic 0");
 		});
 	});
 


### PR DESCRIPTION
# What

The model picker shows free in the cost column when the model is free, as expected, but you can’t search by the price (or free-ness). So when I type “free kimi” in the search bar, it only shows the free Kimi 2.6 from OpenRouter, just because it has “:free” in its name. It doesn’t show the free Kimi K3 from Nvidia because it doesn’t have “free” in its name.

Checked against shipped models:

| | count |
|---|---|
| models | 4781 |
| zero-cost | 1684 |
| with the word "free" in the id | 156 |
| free but unfindable by typing `free` | **1528** |

nvidia alone contributes 164 of the invisible ones. (Love you Nvidia <3)

## Fix

Append `free` to the search haystack for free models, sharing a single
predicate with `formatCostPair` so the column and the search can't drift apart
again.

This follows the same pattern already used everywhere else, `oauth-selector.ts` appends `logged in authenticated` / `unavailable`, and
`settings-list.ts` and `hook-selector.ts` do the same.

Both call sites are updated together, which matters: the hub's filter feeds the
per-provider sidebar counts. Updating only the browser would leave a provider
reading `0`, grayed out, and skipped by the scope hop while its rows were
plainly visible in the list.

`modelSearchTier` is deliberately left alone. It reads `id`/`selector` only,
which is what keeps the 156 literal `:free` ids ranked above the 1528 computed
matches instead of collapsing everything into one tier.

## Verification

I ran the picker on this branch (`bun run dev`, then `/models`) with my own
provider config and typed `free kimi`, which is the search that prompted this
in the first place.

Before, that query gave me one row: `openrouter/moonshotai/kimi-k2.6:free`, the
only free Kimi with "free" in its id.

Now it gives 7: that same OpenRouter row plus all six of Nvidia's free Kimi
models — `kimi-k2-instruct`, `kimi-k2-instruct-0905`, `kimi-k2-thinking`,
`kimi-k2.5`, `kimi-k2.6`, and `kimi-k3`, which is ranked first. Every row's
cost column reads `free`. The provider sidebar agrees: `All models 7`, with
`nvidia 6` and `openrouter 1`, and nvidia is no longer grayed out or skipped by
the scope hop.

Run against the real matcher and the shipped catalog. Note these are
catalog-wide counts across every provider — the picker only lists providers you
have configured, so any individual user sees a subset of these:

| query | before | after | paid models admitted |
|---|---|---|---|
| `free` | 157 | 1684 | **0** |
| `free kimi` | 5 | 43 | **0** |
| `kimi k3 free` | 1 | 8 | **0** |
| `sonnet` | 136 | 136 | — |
| `opus` | 215 | 215 | — |
| `gpt` | 1533 | 1533 | — |
| `glm` | 355 | 355 | — |
| `haiku` | 43 | 43 | — |

No paid model is shown by either widening query, and unrelated queries are
unchanged. Driving the real `ModelBrowser` over the full catalog returns 1684
rows for `free` with all of the top 12 being literal `:free` ids, so the
ranking split survives.

Because the injection is a pure suffix, every existing word keeps its offset and
`compact` position, a score can only move if a query token fuzzy-matches the
word `free`.

## Tests

Four added:

- `model-browser`: a zero-cost model whose id never says "free" is now found
- `model-browser`: an id that literally says `:free` still outranks one that is
  merely free
- `model-browser`: the keyword composes with multi-token search (`kimi k3 free`)
- `model-hub`: the provider sidebar counts agree with the keyword

The hub test is the one that catches a half-applied change — reverting only the
hub call site makes it fail with exactly the symptom described above (`nvidia 0`,
grayed, while its row is listed).

## Notes

One quirk left alone deliberately: `openrouter/auto` and `openrouter/auto-beta`
ship `{input: -1000000, output: -1000000}` as a variable-pricing sentinel.
Because the test is `<= 0` they already render as "free" today, and now they're
searchable as such. Two rows out of 4781. Keeping `<= 0` verbatim means this PR
ships with zero display-behavior delta — search simply agrees with what the
screen already says. Worth a separate fix via a `classifyModelCost` returning
`free | variable | priced`; sharing the predicate here makes that a one-site
change later.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
