### PR TITLE
fix: bound Cursor caches, harden session dispose paths

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Fixed
 
 - Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).
+- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever.
+- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable.
 - Fixed Amazon Bedrock OpenAI models rejecting image-bearing tool results by sending each image as a sibling user content block ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,8 +8,8 @@
 ### Fixed
 
 - Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).
-- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever.
-- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable.
+- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
+- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
 - Fixed Amazon Bedrock OpenAI models rejecting image-bearing tool results by sending each image as a sibling user content block ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1422,8 +1422,11 @@ export class AuthStorage {
 		// failures must never block construction.
 		try {
 			this.#store.cleanExpiredCache();
-		} catch {
-			// Best-effort.
+		} catch (err) {
+			// Best-effort hygiene: a corrupted cache at init is non-fatal, but log
+			// it so a re-query hitting the same corruption is traceable. The block
+			// store below latches its own init-time corruption separately.
+			logger.warn("cleanExpiredCache failed during AuthStorage init", { error: String(err) });
 		}
 		try {
 			this.#store.cleanExpiredCredentialBlocks?.(Date.now());

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -169,6 +169,7 @@ import {
 	parseStreamingJsonThrottled,
 	sanitizeText,
 } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -322,9 +323,31 @@ const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
 const CURSOR_MODEL_NOT_FOUND_PATTERN = /^(?:Connect error not_found:|gRPC error 5:)/i;
 const NOT_IMPLEMENTED = `Not implemented by this client`;
 
-const conversationStateCache = new Map<string, ConversationStateStructure>();
+/**
+ * Cap on per-conversation state retained process-wide. Cursor caches one
+ * {@link ConversationStateStructure} plus its blob store per conversationId;
+ * without a bound, a long-lived daemon (omp daemon, collab session) would
+ * hold every conversation it ever touched forever. 64 covers active working
+ * set; the LRU evicts least-recently-used under pressure.
+ */
+const CURSOR_CONVERSATION_CACHE_MAX = 64;
+
+/** Bounded dedup cap for one-shot warning keys (low per-entry cost). */
+const CURSOR_DEDUP_CACHE_MAX = 256;
+
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
-const warnedCursorKimiK3ReplayMessages = new Set<string>();
+const conversationStateCache = new LRUCache<string, ConversationStateStructure>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+	// Tie blob-store lifetime to conversation-state eviction: the blob store
+	// is populated and read alongside the state (same conversationId key), so
+	// it must not outlive the state entry that owns it.
+	dispose: (_value, key) => {
+		conversationBlobStores.delete(key);
+	},
+});
+const warnedCursorKimiK3ReplayMessages = new LRUCache<string, true>({
+	max: CURSOR_DEDUP_CACHE_MAX,
+});
 /**
  * Base conversation id → rotated wire id (#8345). Cursor's backend can pin a
  * per-conversation rejection (bare `resource_exhausted`, zero tokens) to one
@@ -334,9 +357,15 @@ const warnedCursorKimiK3ReplayMessages = new Set<string>();
  * is not hidden. After the rotated id completes a turn, a later poison of
  * that id is allowed to rotate again.
  */
-const rotatedConversationIds = new Map<string, string>();
-const successfulRotatedConversationIds = new Set<string>();
-const freshRotatedConversationIds = new Set<string>();
+const rotatedConversationIds = new LRUCache<string, string>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
+const successfulRotatedConversationIds = new LRUCache<string, true>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
+const freshRotatedConversationIds = new LRUCache<string, true>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
 
 export interface CursorOptions extends StreamOptions {
 	customSystemPrompt?: string;
@@ -942,7 +971,7 @@ function streamCursorWithWireMode(
 			heartbeatTimer = setInterval(sendHeartbeat, 5000);
 			await h2Completion.promise;
 			if (conversationId && baseConversationId && conversationId !== baseConversationId) {
-				successfulRotatedConversationIds.add(conversationId);
+				successfulRotatedConversationIds.set(conversationId, true);
 				freshRotatedConversationIds.delete(conversationId);
 			}
 			// The transport is done, but a handler decoded from the last chunk may
@@ -1048,7 +1077,7 @@ function streamCursorWithWireMode(
 				const rotated = crypto.randomUUID();
 				if (currentRotated) successfulRotatedConversationIds.delete(currentRotated);
 				rotatedConversationIds.set(baseConversationId, rotated);
-				freshRotatedConversationIds.add(rotated);
+				freshRotatedConversationIds.set(rotated, true);
 				logger.debug("cursor conversation rotated", {
 					base: baseConversationId,
 					from: conversationId,
@@ -4829,7 +4858,7 @@ function assertCursorKimiK3HistoryReplayable(
 		newlyWarnedKeys.push(warningKey);
 	}
 	if (missingThinkingTurns.length === 0) return;
-	for (const key of newlyWarnedKeys) warnedCursorKimiK3ReplayMessages.add(key);
+	for (const key of newlyWarnedKeys) warnedCursorKimiK3ReplayMessages.set(key, true);
 	logger.warn(
 		`Cursor kimi-k3 history contains same-model assistant turn(s) ${missingThinkingTurns.join(", ")} without thinking blocks; replaying those spans without reasoning may make generation less stable`,
 		{ model: targetModelId, assistantTurns: missingThinkingTurns },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting.
+- Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -859,6 +859,15 @@ export class AgentSession {
 
 	#endInFlight(onSettled?: () => void | Promise<void>): void {
 		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);
+		// An endInFlight with no matching beginInFlight is a bug: the clamp below
+		// prevents a negative count, but the mismatched release would drop the
+		// power assertion and flush agent_end early. Surface it in dev/test so a
+		// missing beginInFlight surfaces instead of silently corrupting in-flight state.
+		if (this.#promptInFlightCount === 0 && !isBunTestRuntime()) {
+			logger.warn("endInFlight called without a matching beginInFlight", {
+				promptGeneration: this.#promptGeneration,
+			});
+		}
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount !== 0) return;
 		this.yieldQueue.requestIdleFlush();
@@ -889,7 +898,7 @@ export class AgentSession {
 	 *  Runs whenever the session settles; the guard makes it a no-op when the
 	 *  queue was consumed normally or a new turn already started. */
 	#drainStrandedQueuedMessages(): void {
-		if (this.#abortInProgress) return;
+		if (this.#isDisposed || this.#abortInProgress) return;
 		// Session transitions (newSession/`/new`, compact, model-switch, session-switch,
 		// dispose) call #disconnectFromAgent() BEFORE `await abort()`, so abort's own
 		// finally lands here with no listener attached. Auto-resuming now would snapshot
@@ -4522,6 +4531,7 @@ export class AgentSession {
 		this.agent.hasIrcInterrupts = undefined;
 		this.#advisors.stopRuntime();
 		this.#eval.beginDispose();
+		this.#lazyContextRefreshed.clear();
 	}
 
 	/**


### PR DESCRIPTION
## What

Bounded five module-level Cursor conversation caches that grew without limit for the process lifetime, and hardened three AgentSession/AuthStorage dispose and error-logging paths.

I reviewed the full diff. The Cursor provider held every conversation it ever touched in unbounded Maps/Sets; bounding them with LRU eviction (cap 64 conversations / 256 dedup keys) stops a long-lived daemon from leaking memory indefinitely while preserving the existing rotation/replay semantics. The blob-store Map entries are driven by the conversationStateCache dispose callback so they evict together with their owning state entry.

## Why

A code review (`docs/code-review-astra.md` in this branch) flagged the unbounded module-level collections as the highest-impact leak: an `omp daemon` or collab session accumulates one ConversationStateStructure + blob store per conversationId and never drops them. The review also flagged three smaller correctness/hygiene issues: an empty catch in the AuthStorage constructor swallowing init-time corruption, `#lazyContextRefreshed` never cleared on dispose, and `#endInFlight`/`#drainStrandedQueuedMessages` lacking guards against disposed/underflowed state.

Addresses `docs/code-review-astra.md` sections 2.1–2.4, 3.2, 4.2, 4.3, 4.4.

## Testing

- `tsgo --noEmit` on both `packages/ai` and `packages/coding-agent` → clean.
- `oxlint` + `oxfmt --check` on all three changed source files → clean.
- `bun test` cursor suite (6 files, 42 tests including `cursor-conversation-rotate` which exercises the rotation Maps/Sets → LRUCache): all pass. The LRU cap (64) is far above what the tests use (2–4 conversations); `.add()` → `.set(key, true)` is API-compatible.
- `bun test` full auth-storage suite (26 files, 325 tests): all pass.
- `bun test` agent-session tests touching the changed paths (`session-teardown`, `advisor-suppression`, `retry-cap`, `title-generation-dispose`, `session-exit-diagnostics` — 95 tests): all pass.
- Reproduced a regression during development: an edit accidentally dropped the existing `#abortInProgress` guard from `#drainStrandedQueuedMessages`, which broke `agent-session-advisor-suppression`. Restored it alongside the new `#isDisposed` check; all tests pass.

Note: the `pi-natives` native addon does not build from source on this host (wayland-client 0.31.15 fails against the pinned nightly toolchain), so I used the prebuilt addon from npm — the same approach CI uses — to run the test suite.

---

- [x] \`bun check\` passes
- [x] Tested locally
- [ ] CHANGELOG updated with the required attribution (will add PR link after number is assigned)