### PR TITLE
fix(coding-agent): harvest the reporting turn for data-less subagent yields

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Models whose images are stripped on the wire (`compat.stripImageInput`) now trigger the `describeForTextModels` vision fallback and are skipped when resolving the vision model, instead of silently dropping images ([#9697](https://github.com/can1357/oh-my-pi/issues/9697)).
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
+- Subagents (including `/vibe` workers) that write their report in one turn and then finalize with a data-less `yield` in the next no longer come back as `SYSTEM WARNING: Subagent called yield with null data` stapled to accumulated narration. The finalize now harvests the last turn that actually reported — prose with no further work started — so mid-run narration can never surface as a final result either ([#11746](https://github.com/can1357/oh-my-pi/pull/11746) by [@oldschoola](https://github.com/oldschoola)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/prompts/system/subagent-yield-reminder.md
+++ b/packages/coding-agent/src/prompts/system/subagent-yield-reminder.md
@@ -4,7 +4,7 @@ Request budget crossed; in-flight turn stopped → forced wrap-up. MUST call `yi
 
 - Consolidate all gathered value; mark remaining gaps incomplete, do not investigate further.
 - Do NOT call another tool or resume assignment.
-- Terminal `yield` only: omit `type`, report in `data`; or `type: string` to finalize from last assistant turn.
+- Terminal `yield` only: report in `data`, `type` omitted. Data-less `type: string` ONLY when that report is already written out as prose this turn.
 </system-reminder>
 {{else}}
 <system-reminder>
@@ -13,7 +13,7 @@ Last turn had no tool call → session idle. Reminder {{retryCount}} of {{maxRet
 Every turn MUST end with a tool call. First applicable:
 1. **Resume work** — assignment incomplete and not recording an incremental section: call next intended tool (edit, write, bash, search, etc.). NEVER treat this reminder as forced stop.
 2. **Yield incremental section** — only if useful: call `yield` with non-empty `type: string[]`; matching sections accumulate; task continues.
-3. **Yield success** — only if genuinely complete: terminal `yield`; omit `type` for single final structured result in `data`; use `type: string` to finalize from last assistant turn when data omitted.
+3. **Yield success** — only if genuinely complete: terminal `yield` carrying the report in `data`, `type` omitted. Data-less `type: string` finalizes from your last assistant turn and keeps no structure — use it ONLY when that turn already spells the report out in prose.
 4. **Yield error** — only for a real, concrete, nameable blocker (missing file, unavailable API, contradictory spec): describe attempts and exact blocker. NEVER fabricate a "forced immediate-yield" or "system reminder required termination" reason; reminder not a blocker.
 
 Default option 1 unless work done, blocked, or ready for an incremental section.

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1071,6 +1071,11 @@ interface SubagentRunMonitor {
 	/** Best-effort capture of the last assistant text for cancelled-run salvage. */
 	captureSalvage(session: AgentSession): void;
 	lastAssistantSalvageText(): string | undefined;
+	/**
+	 * Text of the last assistant turn that read as a report — prose, with no
+	 * further work started. Source for `yield`'s data-less finalize.
+	 */
+	lastReportTurnText(): string | undefined;
 	/** Final raw output: end-of-run assistant text when available, else accumulated chunks. */
 	rawOutput(): string;
 	scheduleProgress(flush?: boolean): void;
@@ -1161,6 +1166,15 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let terminalError: string | undefined;
 	let consecutiveYieldToolErrors = 0;
 	let lastAssistantSalvageText: string | undefined;
+	// Text of the most recent assistant turn that READ AS A REPORT: it carried
+	// prose and started no further work (no tool call, or only the terminal
+	// `yield`). This — not merely the last assistant message — is what a
+	// data-less `yield` finalize harvests. Both the idle reminder and the
+	// budget wrap-up tell a finished subagent to finalize "from last assistant
+	// turn", and models routinely comply one turn later, so the finalize turn
+	// itself is usually text-less. Turns that started more work are excluded on
+	// purpose: mid-run narration must never surface as a final result.
+	let lastReportTurnText: string | undefined;
 	let activeSessionAbortPromise: Promise<void> | undefined;
 
 	const abortActiveSession = (): Promise<void> => {
@@ -1666,18 +1680,31 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 					const eventContent = isRecord(event) && "content" in event ? event.content : undefined;
 					const messageContent = getMessageContent(event.message) || eventContent;
 					if (messageContent && Array.isArray(messageContent)) {
+						const turnText: string[] = [];
+						let startedMoreWork = false;
 						for (const block of messageContent) {
 							if (!isRecord(block)) continue;
 							if (block.type === "text" && typeof block.text === "string") {
 								outputChunks.push(block.text);
+								if (block.text) turnText.push(block.text);
 								continue;
 							}
 							if (block.type !== "toolCall" || typeof block.name !== "string") continue;
-							if (block.name === "yield" && !yieldCalled) {
-								yieldCallPending = true;
-								flushProgress = true;
+							if (block.name === "yield") {
+								if (!yieldCalled) {
+									yieldCallPending = true;
+									flushProgress = true;
+								}
+								continue;
 							}
+							startedMoreWork = true;
 						}
+						// Report turns only: prose plus nothing but (optionally) the
+						// terminal `yield`. A turn that kicked off more work is
+						// narration; harvesting it would hand the parent a stale
+						// mid-run fragment as the subagent's final answer.
+						const text = turnText.join("\n");
+						if (!startedMoreWork && text.trim()) lastReportTurnText = text;
 					}
 					if (softRequestBudget > 0 && !abortSent && !yieldCallPending) {
 						const stopThreshold = softRequestBudget * 1.5;
@@ -1930,6 +1957,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		attach,
 		captureSalvage,
 		lastAssistantSalvageText: () => lastAssistantSalvageText,
+		lastReportTurnText: () => lastReportTurnText,
 		rawOutput: () => (finalOutputChunks.length > 0 ? finalOutputChunks.join("") : outputChunks.join("")),
 		scheduleProgress,
 		finish: () => {
@@ -2286,7 +2314,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 			outputSchema: args.outputSchema,
 			outputSchemaMode: args.outputSchemaMode,
 			outputSchemaSource: args.outputSchemaSource,
-			lastAssistantText: monitor.lastAssistantSalvageText(),
+			lastAssistantText: monitor.lastReportTurnText(),
 		});
 	} finally {
 		popLoopPhase();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1699,12 +1699,16 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							}
 							startedMoreWork = true;
 						}
-						// Report turns only: prose plus nothing but (optionally) the
-						// terminal `yield`. A turn that kicked off more work is
-						// narration; harvesting it would hand the parent a stale
-						// mid-run fragment as the subagent's final answer.
+						// Only the report turn immediately preceding the finalize is
+						// harvestable. A turn that started more work invalidates any
+						// earlier candidate: the model took the reminder's "resume
+						// work" path, so that prose predates the work and is no longer
+						// a description of the finished assignment. Skipping the
+						// update alone would leave it harvestable and hand the parent
+						// stale narration as the completed result.
 						const text = turnText.join("\n");
-						if (!startedMoreWork && text.trim()) lastReportTurnText = text;
+						if (startedMoreWork) lastReportTurnText = undefined;
+						else if (text.trim()) lastReportTurnText = text;
 					}
 					if (softRequestBudget > 0 && !abortSent && !yieldCallPending) {
 						const stopThreshold = softRequestBudget * 1.5;

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -666,6 +666,60 @@ describe("runSubprocess yield reminders", () => {
 		expect(result.output).not.toBe(narration);
 	});
 
+	it("invalidates an earlier report turn once the subagent resumes work", async () => {
+		// The reminder's option 1 is "resume work", so a prose-only idle turn is
+		// routinely followed by more tool calls. Skipping the capture on those
+		// turns is not enough — the earlier prose must be invalidated, or a
+		// text-less finalize many turns later harvests a report written before
+		// all that work and passes it off as the completed result (PR #11746
+		// review).
+		const staleReport = "Everything is done; nothing left to change.";
+		const session = createMockSession(({ promptIndex, emit, state }) => {
+			if (promptIndex === 1) {
+				const reporting = createAssistantStopMessage(staleReport);
+				state.messages.push(reporting);
+				emit({ type: "message_end", message: reporting });
+				return;
+			}
+			if (promptIndex === 2) {
+				const resumed: AssistantMessage = {
+					...createAssistantStopMessage(""),
+					content: [
+						{ type: "text", text: "Actually one more fix." },
+						{ type: "toolCall", id: "tool-resume", name: "bash", arguments: { command: "bun test" } },
+					],
+					stopReason: "toolUse",
+				};
+				state.messages.push(resumed);
+				emit({ type: "message_end", message: resumed });
+				return;
+			}
+			const finalize: AssistantMessage = {
+				...createAssistantStopMessage(""),
+				content: [{ type: "toolCall", id: "tool-late", name: "yield", arguments: { type: "result" } }],
+				stopReason: "toolUse",
+			};
+			state.messages.push(finalize);
+			emit({ type: "message_end", message: finalize });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-late",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", type: "result", useLastTurn: true },
+				},
+				isError: false,
+			});
+		});
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-resumed-work" });
+		expect(result.output).toContain("SYSTEM WARNING: Subagent called yield with null data.");
+		expect(result.output).not.toBe(staleReport);
+	});
+
 	it("retries when yield tool returns an error before succeeding", async () => {
 		const prompts: string[] = [];
 		const session = createMockSession(({ text, promptIndex, emit, state }) => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -577,6 +577,95 @@ describe("runSubprocess yield reminders", () => {
 		expect(result.output).toContain("SYSTEM WARNING: Subagent called yield with null data.");
 	});
 
+	it("finalizes from the reporting turn when the data-less yield lands in its own turn", async () => {
+		// The idle reminder instructs a complete subagent to finalize with
+		// `type: string` "from last assistant turn". Models comply across two
+		// turns: prose report first, then a text-less turn carrying only the bare
+		// `yield`. Sampling the salvage text once at end-of-run saw that empty
+		// finalize turn, so `useLastTurn` resolved to nothing and the parent got
+		// "null data" stapled onto accumulated narration instead of the report
+		// (muse-spark-1.3 on the `lumbridge-fixups` subagent).
+		const report = "All four tasks done on content/lumbridge-pass; PR #139 updated in place.";
+		const session = createMockSession(({ promptIndex, emit, state }) => {
+			if (promptIndex === 1) {
+				const assistant = createAssistantStopMessage(report);
+				state.messages.push(assistant);
+				emit({ type: "message_end", message: assistant });
+				return;
+			}
+			const finalize: AssistantMessage = {
+				...createAssistantStopMessage(""),
+				content: [{ type: "toolCall", id: "tool-finalize", name: "yield", arguments: { type: "result" } }],
+				stopReason: "toolUse",
+			};
+			state.messages.push(finalize);
+			emit({ type: "message_end", message: finalize });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-finalize",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", type: "result", useLastTurn: true },
+				},
+				isError: false,
+			});
+		});
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-last-turn-finalize" });
+		expect(result.output).toBe(report);
+		expect(result.output).not.toContain("SYSTEM WARNING");
+	});
+
+	it("never harvests mid-work narration as the final result", async () => {
+		// Counterpart to the test above: the report turn is the one that started
+		// no further work. A turn that narrated and then called a tool is mid-run
+		// chatter, so a later data-less finalize must NOT harvest it — handing the
+		// parent a stale fragment as the subagent's answer is worse than saying
+		// the report is missing.
+		const narration = "Checking the failing test first.";
+		const session = createMockSession(({ promptIndex, emit, state }) => {
+			if (promptIndex === 1) {
+				const working: AssistantMessage = {
+					...createAssistantStopMessage(""),
+					content: [
+						{ type: "text", text: narration },
+						{ type: "toolCall", id: "tool-bash", name: "bash", arguments: { command: "bun test" } },
+					],
+					stopReason: "toolUse",
+				};
+				state.messages.push(working);
+				emit({ type: "message_end", message: working });
+				return;
+			}
+			const finalize: AssistantMessage = {
+				...createAssistantStopMessage(""),
+				content: [{ type: "toolCall", id: "tool-bare", name: "yield", arguments: { type: "result" } }],
+				stopReason: "toolUse",
+			};
+			state.messages.push(finalize);
+			emit({ type: "message_end", message: finalize });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-bare",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", type: "result", useLastTurn: true },
+				},
+				isError: false,
+			});
+		});
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-no-stale-harvest" });
+		expect(result.output).toContain("SYSTEM WARNING: Subagent called yield with null data.");
+		expect(result.output).not.toBe(narration);
+	});
+
 	it("retries when yield tool returns an error before succeeding", async () => {
 		const prompts: string[] = [];
 		const session = createMockSession(({ text, promptIndex, emit, state }) => {


### PR DESCRIPTION
## What

I ran into this with a `/vibe` worker on muse-spark-1.3: it finished the job, wrote the whole report out as prose, then closed the subagent with a bare `yield {"type":"result"}` — and what came back to me was a "called yield with null data" warning instead of the report it had just written. The idle reminder literally tells it to finalize from the last assistant turn, so the model did what it was told; the harness was reading the wrong turn. This makes the finalize read the turn that actually reported, with a guard so it can't pick up mid-run narration instead.

A subagent that finalizes with a data-less `yield {"type":"result"}` is documented to have its last assistant turn become the raw final result (`packages/coding-agent/src/prompts/tools/yield.md`). The run monitor resolved that from `session.getLastAssistantMessage()`, sampled once at teardown — which is, by construction, the turn carrying the `yield` tool call. That turn is usually text-less, because both the idle reminder ladder and the budget wrap-up tell a finished subagent to finalize "from last assistant turn", and models comply on the *next* turn.

So the harvest resolved to nothing: `missingData` flipped true and the parent received `SYSTEM WARNING: Subagent called yield with null data` prepended to concatenated mid-run narration, with `structuredOutput` marked `invalid` (a hard `schema_violation` under strict mode).

This tracks `lastReportTurnText` as turns complete, scoped to turns that carried prose and **started no further work** (no tool call, or only the terminal `yield`). Turns that kicked off more work are excluded, so mid-run narration can never surface as a final result. `lastAssistantSalvageText` is left untouched, so cancelled-run salvage keeps its existing semantics.

Both branches of `subagent-yield-reminder.md` now lead with a data-bearing submit, demoting the data-less finalize to an explicit fallback.

## Why

Observed on a `/vibe` worker (`vibe_spawn cli=good`, model `muse-code/muse-spark-1.3-contributor`). The worker wrote its full report as prose, the `Last turn had no tool call → session idle. Reminder 1 of 3` nudge fired, and it answered with a bare `yield {"type":"result"}` on a turn containing only empty thinking blocks — exactly what reminder option 3 instructs. Its `<id>.md` artifact then opened with:

```
SYSTEM WARNING: Subagent called yield with null data.

<the actual report, which was present all along>
```

The model followed the documented contract; the harness did not honor it. Vibe workers run as task-executor subagents (`src/vibe/runtime.ts`), so they share this path — the fix applies to `runSubprocess` and to `runSubagentFollowUpTurn`, which drives every subsequent vibe turn.

## Testing

The original failure was observed in an **on-disk session transcript from a prior `/vibe` run** (the artifact quoted above) — it was not re-reproduced against a live model here. Verification is at the harness level: three regression tests in `test/task/executor-subagent-reminders.test.ts` drive scripted `AgentSessionEvent` sequences through `runSubprocess`, reconstructing the turn shapes that trigger the bug and the two near misses around it. Each test was proven load-bearing by neutralizing its own mechanism in `executor.ts` and re-running — the quoted failures below are those runs:

1. **`finalizes from the reporting turn when the data-less yield lands in its own turn`** — turn 1 emits the report with no tool call; turn 2 emits only the `yield` tool call with no text. Asserts the report is the result, with no warning.
   With the capture disabled, this reproduces the original artifact byte-for-byte:
   ```
   - "All four tasks done ..."
   + "SYSTEM WARNING: Subagent called yield with null data.
   +
   + All four tasks done ..."
   ```

2. **`never harvests mid-work narration as the final result`** — turn 1 narrates *and* calls `bash`; turn 2 bare-yields. Asserts the null-data warning is surfaced rather than the stale fragment being passed off as the answer.
   With the scoping removed, the parent silently receives `"Checking the failing test first."` as the subagent's final result at exit 0 — the failure this guard exists to prevent:
   ```
   Expected to contain: "SYSTEM WARNING: Subagent called yield with null data."
   Received: "Checking the failing test first."
   ```

3. **`invalidates an earlier report turn once the subagent resumes work`** *(added in response to the P1 review)* — turn 1 is prose-only; turn 2 takes the reminder's "resume work" path with a `bash` call; turn 3 bare-yields. Asserts the null-data warning rather than the pre-work prose.
   With the clear reverted to skip-only, the parent silently receives a report written *before* all the intervening work, at exit 0:
   ```
   Expected to contain: "SYSTEM WARNING: Subagent called yield with null data."
   Received: "Everything is done; nothing left to change."
   ```

Suite: `bun test test/task test/tools` → **2759 pass, 0 fail** (3071 across 224 files).
`bun check`: passes on this branch's contents.

> [!NOTE]
> For reviewers: a repo-wide `bun check` in my working tree exits 1, but every error comes from an untracked local file (`packages/coding-agent/src/config/profiles.ts`) that is unrelated to this change and **not part of this PR**. I confirmed the branch itself is clean by moving that file aside and re-running the full check, which passed — so a clean checkout of this branch sees no errors.

Prompt change exercised directly by rendering `subagent-yield-reminder.md` through `prompt.render` for both the `budgetStop` and idle branches, confirming they render with no unsubstituted `{{` handles.

### Not included

A related but separate defect was found and deliberately left out to keep this to one logical change: a subagent that never calls `yield` at all, with no output schema, is silently accepted at `executor.ts:799` and returns `outputChunks.join("")` — every assistant text block in the run, concatenated — to its parent as a successful result. Fixing that changes whether such runs start failing, which deserves its own discussion.

---

- [x] `bun check` passes
- [ ] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
