### PR TITLE
fix(utils): drain ACP inbound requests on clean stdin EOF

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ACP JSON-RPC now drains accepted inbound requests on clean stdin EOF before resolving `closed`, so in-flight methods such as `session/new` still receive a success or explicit error response instead of being dropped on exit 0 ([#11567](https://github.com/can1357/oh-my-pi/issues/11567)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/utils/src/acp/transport.ts
+++ b/packages/utils/src/acp/transport.ts
@@ -205,7 +205,7 @@ export class RpcConnection {
 	async #drainInbound(): Promise<void> {
 		if (this.#inbound.size === 0) return;
 		const drained = Promise.allSettled(this.#inbound).then(() => {});
-		let timer: ReturnType<typeof setTimeout> | undefined;
+		let timer: Timer | undefined;
 		const timedOut = await Promise.race([
 			drained.then(() => false),
 			new Promise<boolean>(resolve => {

--- a/packages/utils/src/acp/transport.ts
+++ b/packages/utils/src/acp/transport.ts
@@ -108,10 +108,15 @@ function createStandardError(
 type Dispatcher = (method: string, params: unknown, notification: boolean) => MaybePromise<unknown>;
 type Pending = { resolve(value: unknown): void; reject(reason: unknown): void };
 
+/** Bound on clean-EOF inbound drain so `closed` cannot hang if a handler never settles. */
+const INBOUND_DRAIN_TIMEOUT_MS = 30_000;
+
 /** Correlated bidirectional JSON-RPC connection. */
 export class RpcConnection {
 	#nextId = 0;
 	#pending = new Map<JsonRpcId, Pending>();
+	#inbound = new Set<Promise<void>>();
+	#openInboundIds = new Set<JsonRpcId>();
 	#writable: WritableStream<AnyMessage>;
 	#writeTail: Promise<void> = Promise.resolve();
 	#abort = new AbortController();
@@ -179,14 +184,43 @@ export class RpcConnection {
 			while (true) {
 				const next = await reader.read();
 				if (next.done) break;
-				void this.#handle(next.value).catch(error => this.close(error));
+				this.#dispatch(next.value);
 			}
+			await this.#drainInbound();
 			this.close();
 		} catch (error) {
 			this.close(error);
 		} finally {
 			reader.releaseLock();
 		}
+	}
+
+	#dispatch(message: AnyMessage): void {
+		if ("method" in message && "id" in message) this.#openInboundIds.add(message.id);
+		const task = this.#handle(message).catch(error => this.close(error));
+		this.#inbound.add(task);
+		void task.finally(() => this.#inbound.delete(task));
+	}
+
+	async #drainInbound(): Promise<void> {
+		if (this.#inbound.size === 0) return;
+		const drained = Promise.allSettled(this.#inbound).then(() => {});
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timedOut = await Promise.race([
+			drained.then(() => false),
+			new Promise<boolean>(resolve => {
+				timer = setTimeout(() => resolve(true), INBOUND_DRAIN_TIMEOUT_MS);
+			}),
+		]);
+		if (timer !== undefined) clearTimeout(timer);
+		if (!timedOut) return;
+		const error = RequestError.internalError(undefined, "Inbound request drain timed out").toErrorResponse();
+		await Promise.allSettled([...this.#openInboundIds].map(id => this.#respond(id, { error })));
+	}
+
+	#respond(id: JsonRpcId, body: { result: unknown } | { error: ErrorResponse }): Promise<void> {
+		if (!this.#openInboundIds.delete(id)) return Promise.resolve();
+		return this.#write({ jsonrpc: "2.0", id, ...body });
 	}
 
 	async #handle(message: AnyMessage): Promise<void> {
@@ -210,13 +244,13 @@ export class RpcConnection {
 		}
 		try {
 			const result = await this.#dispatcher(message.method, message.params, false);
-			await this.#write({ jsonrpc: "2.0", id: message.id, result: result ?? {} });
+			await this.#respond(message.id, { result: result ?? {} });
 		} catch (error) {
 			const protocolError =
 				error instanceof RequestError
 					? error
 					: RequestError.internalError({ details: error instanceof Error ? error.message : String(error) });
-			await this.#write({ jsonrpc: "2.0", id: message.id, error: protocolError.toErrorResponse() });
+			await this.#respond(message.id, { error: protocolError.toErrorResponse() });
 		}
 	}
 }

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -103,6 +103,66 @@ describe("ACP JSON-RPC transport", () => {
 		writer.releaseLock();
 		reader.releaseLock();
 	});
+	it("drains accepted inbound requests before resolving closed on clean EOF", async () => {
+		const inbound = new TransformStream<AnyMessage, AnyMessage>();
+		const outbound = new TransformStream<AnyMessage, AnyMessage>();
+		const sessionStarted = Promise.withResolvers<void>();
+		const releaseSession = Promise.withResolvers<void>();
+		const connection = new RpcConnection(
+			{ writable: outbound.writable, readable: inbound.readable },
+			async method => {
+				if (method === "initialize") return { protocolVersion: 1 };
+				if (method === "session/new") {
+					sessionStarted.resolve();
+					await releaseSession.promise;
+					return { sessionId: "session-1" };
+				}
+				throw RequestError.methodNotFound(method);
+			},
+		);
+		const writer = inbound.writable.getWriter();
+		const reader = outbound.readable.getReader();
+		await writer.write({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+		await writer.write({ jsonrpc: "2.0", id: 2, method: "session/new", params: {} });
+		await sessionStarted.promise;
+		await writer.close();
+
+		const initialize = await reader.read();
+		expect(initialize.done).toBe(false);
+		expect(initialize.value).toEqual({ jsonrpc: "2.0", id: 1, result: { protocolVersion: 1 } });
+
+		const closedBeforeDrain = await Promise.race([
+			connection.closed.then(() => true),
+			new Promise<boolean>(resolve => setTimeout(() => resolve(false), 25)),
+		]);
+		expect(closedBeforeDrain).toBe(false);
+
+		releaseSession.resolve();
+		const created = await reader.read();
+		expect(created.done).toBe(false);
+		expect(created.value).toEqual({ jsonrpc: "2.0", id: 2, result: { sessionId: "session-1" } });
+		await connection.closed;
+		reader.releaseLock();
+	});
+
+	it("still fail-fast closes on read errors without waiting for inbound handlers", async () => {
+		const inbound = new TransformStream<AnyMessage, AnyMessage>();
+		const outbound = new TransformStream<AnyMessage, AnyMessage>();
+		const started = Promise.withResolvers<void>();
+		const hold = Promise.withResolvers<void>();
+		const connection = new RpcConnection({ writable: outbound.writable, readable: inbound.readable }, async () => {
+			started.resolve();
+			await hold.promise;
+			return {};
+		});
+		const writer = inbound.writable.getWriter();
+		await writer.write({ jsonrpc: "2.0", id: 1, method: "slow" });
+		await started.promise;
+		await writer.abort(new Error("broken pipe"));
+		await connection.closed;
+		hold.resolve();
+	});
+
 	it("matches the SDK error-code fixtures", () => {
 		expect([
 			RequestError.parseError().toErrorResponse(),


### PR DESCRIPTION
## Summary
- `RpcConnection` now tracks accepted inbound `#handle` tasks and drains them on clean stdin EOF **before** aborting, so `await connection.closed` already waits for in-flight JSON-RPC responses.
- Leftover inbound request IDs that cannot finish within 30s still get an explicit JSON-RPC error instead of silence; `close(error)` stays fail-fast.
- `acp-mode.ts` is unchanged: ACP stdio teardown already waits on `connection.closed`.

Fixes #11567.

## Test plan
- [x] `export PATH="$HOME/.bun/bin:$PATH" && bun test packages/utils/test/acp.test.ts` — 8 pass
- [ ] Repro: `printf '<initialize>\n<session/new>\n' | omp --mode acp` should answer both accepted requests (or return an explicit JSON-RPC error for the second), then exit 0
- [ ] Confirm an aborted/errored transport still fail-fast closes without waiting for inbound handlers


Made with [Cursor](https://cursor.com)