### PR TITLE
feat(rpc): add completed child message subscription

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -129,7 +129,7 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_todos", phases: TodoPhase[] }`
 - `{ id?, type: "set_host_tools", tools: RpcHostToolDefinition[] }`
 - `{ id?, type: "set_host_uri_schemes", schemes: RpcHostUriSchemeDefinition[] }`
-- `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "events" }`
+- `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "messages" | "events" }`
 - `{ id?, type: "get_subagents" }`
 - `{ id?, type: "get_subagent_messages", subagentId?: string, sessionFile?: string, fromByte?: number }`
 
@@ -527,7 +527,10 @@ Subagent forwarding defaults to `"off"`. `set_subagent_subscription` selects:
 
 - `"off"`: no forwarded subagent frames
 - `"progress"`: lifecycle and progress frames
+- `"messages"`: lifecycle, progress, and completed child messages (`subagent_event` with `payload.event.type: "message_end"`), including all message roles
 - `"events"`: lifecycle, progress, and full subagent event frames
+
+Use `"messages"` when a client needs completed child transcripts without partial-message updates, tool-stream updates, or repeated turn/agent message aggregates. These events are filtered before RPC encoding. Progress frames, parent-session events, and persisted child transcripts are unchanged. This reduces forwarded traffic; it does not bound completed-message size or total queued output.
 
 `get_subagents` returns the registry snapshot sorted by subagent index and id.
 `get_subagent_messages` selects a transcript by `subagentId` or `sessionFile`;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- RPC clients can subscribe to completed child messages and progress with the `messages` subagent subscription level.
+- RPC clients can subscribe to completed child messages and progress with the `messages` subagent subscription level ([#11751](https://github.com/can1357/oh-my-pi/pull/11751) by [@numman-ali](https://github.com/numman-ali)).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- RPC clients can subscribe to completed child messages and progress with the `messages` subagent subscription level.
+
 ### Fixed
 
 - The `set_steering_mode`, `set_follow_up_mode`, and `set_interrupt_mode` RPC commands are now session-scoped, so a short-lived RPC client no longer silently writes queue-mode fields to the machine-global `config.yml`. The setters still persist by default, so the settings panel and existing callers are unaffected ([#11555](https://github.com/can1357/oh-my-pi/issues/11555)).

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -537,7 +537,7 @@ export class RpcClient {
 	}
 
 	/**
-	 * Subscribe to subagent lifecycle frames after setSubagentSubscription("progress" | "events").
+	 * Subscribe to subagent lifecycle frames after setSubagentSubscription("progress" | "messages" | "events").
 	 */
 	onSubagentLifecycle(listener: RpcSubagentLifecycleListener): () => void {
 		this.#subagentLifecycleListeners.add(listener);
@@ -545,7 +545,7 @@ export class RpcClient {
 	}
 
 	/**
-	 * Subscribe to aggregated subagent progress frames after setSubagentSubscription("progress" | "events").
+	 * Subscribe to aggregated subagent progress frames after setSubagentSubscription("progress" | "messages" | "events").
 	 */
 	onSubagentProgress(listener: RpcSubagentProgressListener): () => void {
 		this.#subagentProgressListeners.add(listener);
@@ -553,7 +553,8 @@ export class RpcClient {
 	}
 
 	/**
-	 * Subscribe to raw subagent session events. Call setSubagentSubscription(\"events\") to enable them server-side.
+	 * Subscribe to subagent session events. Call setSubagentSubscription("messages") for completed
+	 * message_end events of every role, or setSubagentSubscription("events") for all raw session events.
 	 */
 	onSubagentEvent(listener: RpcSubagentEventListener): () => void {
 		this.#subagentEventListeners.add(listener);
@@ -659,7 +660,9 @@ export class RpcClient {
 
 	/**
 	 * Configure subagent frames emitted by the RPC server. Servers default to "off".
-	 * "progress" emits lifecycle/progress frames; "events" additionally emits raw subagent session events.
+	 * "progress" emits lifecycle/progress frames.
+	 * "messages" additionally emits completed message_end events of every role, without intermediate snapshots.
+	 * "events" emits lifecycle/progress frames and all raw subagent session events.
 	 */
 	async setSubagentSubscription(level: RpcSubagentSubscriptionLevel): Promise<RpcSubagentSubscriptionLevel> {
 		const response = await this.#send({ type: "set_subagent_subscription", level });

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -616,7 +616,7 @@ function shouldEmitRpcTitles(): boolean {
 }
 
 function isSubagentSubscriptionLevel(value: unknown): value is RpcSubagentSubscriptionLevel {
-	return value === "off" || value === "progress" || value === "events";
+	return value === "off" || value === "progress" || value === "messages" || value === "events";
 }
 
 /** Sends an RPC select request while retaining aligned option descriptions. */

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -241,7 +241,9 @@ export class RpcSubagentRegistry {
 
 	handleEvent(payload: SubagentEventPayload): void {
 		if (this.#staleSubagentIds.has(payload.id)) return;
-		if (this.#subscriptionLevel !== "events") return;
+		if (this.#subscriptionLevel !== "events") {
+			if (this.#subscriptionLevel !== "messages" || payload.event.type !== "message_end") return;
+		}
 		this.#output({ type: "subagent_event", payload } satisfies RpcSubagentEventFrame);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -162,7 +162,7 @@ export interface RpcHandoffResult {
 	savedPath?: string;
 }
 
-export type RpcSubagentSubscriptionLevel = "off" | "progress" | "events";
+export type RpcSubagentSubscriptionLevel = "off" | "progress" | "messages" | "events";
 
 export interface RpcSubagentSnapshot {
 	id: string;

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/task";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
 
 const tempPaths: string[] = [];
 
@@ -171,6 +172,152 @@ describe("RPC subagent registry", () => {
 		]);
 
 		registry.dispose();
+	});
+
+	test("messages subscribers retain completed roles and progress without streaming or aggregate events", () => {
+		const frames: RpcSubagentFrame[] = [];
+		const eventBus = new EventBus();
+		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
+		registry.setSubscriptionLevel("messages");
+		const lifecycle: SubagentLifecyclePayload = {
+			id: "SubagentA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+		};
+		const progress: SubagentProgressPayload = {
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			task: "Do work",
+			assignment: "Implement work",
+			progress: createProgress(),
+		};
+		const assistant = createAssistantMessage("ABC");
+		const completed: SubagentEventPayload[] = [
+			{
+				id: "SubagentA",
+				event: { type: "message_end", message: { role: "user", content: "Request", timestamp: 1 } },
+			},
+			{ id: "SubagentA", event: { type: "message_end", message: assistant } },
+			{
+				id: "SubagentA",
+				event: {
+					type: "message_end",
+					message: {
+						role: "toolResult",
+						toolCallId: "call-1",
+						toolName: "read",
+						content: [{ type: "text", text: "Result" }],
+						isError: false,
+						timestamp: 2,
+					},
+				},
+			},
+		];
+		const discarded: SubagentEventPayload[] = [
+			{ id: "SubagentA", event: { type: "message_start", message: assistant } },
+			{
+				id: "SubagentA",
+				event: {
+					type: "tool_execution_update",
+					toolCallId: "call-1",
+					toolName: "read",
+					args: {},
+					partialResult: "partial",
+				},
+			},
+			{ id: "SubagentA", event: { type: "turn_end", message: assistant, toolResults: [] } },
+			{ id: "SubagentA", event: { type: "agent_end", messages: [assistant] } },
+		];
+		try {
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, lifecycle);
+			eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, progress);
+			for (const payload of discarded) eventBus.emit(TASK_SUBAGENT_EVENT_CHANNEL, payload);
+			for (const payload of completed) eventBus.emit(TASK_SUBAGENT_EVENT_CHANNEL, payload);
+			const terminal = { ...lifecycle, status: "completed" } satisfies SubagentLifecyclePayload;
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, terminal);
+			expect(frames).toEqual([
+				{ type: "subagent_lifecycle", payload: lifecycle },
+				{ type: "subagent_progress", payload: progress },
+				...completed.map(payload => ({ type: "subagent_event" as const, payload })),
+				{ type: "subagent_lifecycle", payload: terminal },
+			]);
+		} finally {
+			registry.dispose();
+		}
+	});
+
+	test("messages subscribers never serialize growing partial snapshots while events subscribers still receive them", () => {
+		const frames: string[] = [];
+		const registry = new RpcSubagentRegistry(new EventBus(), frame => frames.push(JSON.stringify(frame)));
+		let serializedPartials = 0;
+		const updates: SubagentEventPayload[] = ["A", "AB", "ABC"].map((text, index) => {
+			const message = Object.assign(createAssistantMessage(text), {
+				toJSON() {
+					serializedPartials++;
+					return createAssistantMessage(text);
+				},
+			});
+			return {
+				id: "SubagentA",
+				event: {
+					type: "message_update",
+					message,
+					assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: text[index], partial: message },
+				},
+			};
+		});
+		try {
+			registry.setSubscriptionLevel("messages");
+			for (const update of updates) registry.handleEvent(update);
+			expect(frames).toEqual([]);
+			expect(serializedPartials).toBe(0);
+			registry.setSubscriptionLevel("events");
+			for (const update of updates) registry.handleEvent(update);
+			expect(frames.map(frame => JSON.parse(frame).payload.event.message.content[0].text)).toEqual([
+				"A",
+				"AB",
+				"ABC",
+			]);
+			expect(serializedPartials).toBe(6);
+		} finally {
+			registry.dispose();
+		}
+	});
+
+	test("messages subscribers receive late completed messages until their RPC session is cleared", () => {
+		const frames: RpcSubagentFrame[] = [];
+		const registry = new RpcSubagentRegistry(new EventBus(), frame => frames.push(frame));
+		registry.setSubscriptionLevel("messages");
+		const lifecycle: SubagentLifecyclePayload = {
+			id: "SubagentA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			sessionFile: "/tmp/subagent.jsonl",
+		};
+		const completed: SubagentEventPayload = {
+			id: "SubagentA",
+			event: { type: "message_end", message: createAssistantMessage("Final") },
+		};
+		try {
+			registry.handleLifecycle(lifecycle);
+			registry.handleLifecycle({ ...lifecycle, status: "aborted" });
+			registry.handleEvent(completed);
+			expect(frames.at(-1)).toEqual({ type: "subagent_event", payload: completed });
+			frames.length = 0;
+			registry.clear();
+			registry.handleEvent(completed);
+			expect(frames).toEqual([]);
+			registry.handleLifecycle(lifecycle);
+			registry.handleEvent(completed);
+			expect(frames.map(frame => frame.type)).toEqual(["subagent_lifecycle", "subagent_event"]);
+		} finally {
+			registry.dispose();
+		}
 	});
 
 	test("clears stale snapshots when the active RPC session changes", () => {
@@ -362,6 +509,22 @@ describe("readRpcSubagentTranscript", () => {
 });
 
 describe("RpcClient subagent frames", () => {
+	test("the native RPC server accepts the completed-message subscription", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-messages-"));
+		tempPaths.push(dir);
+		using client = new RpcClient({
+			cliPath: path.join(import.meta.dir, "../src/cli.ts"),
+			cwd: dir,
+			env: { PI_CODING_AGENT_DIR: dir },
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			args: ["--no-extensions", "--no-skills", "--no-tools", "--no-session"],
+		});
+		await client.start();
+		await expect(client.setSubagentSubscription("messages")).resolves.toBe("messages");
+		await expect(client.setSubagentSubscription("events")).resolves.toBe("events");
+	});
+
 	test("dispatches subagent frames and session-specific events", async () => {
 		const scriptPath = path.join(os.tmpdir(), `omp-rpc-subagent-client-${Date.now()}.js`);
 		tempPaths.push(scriptPath);


### PR DESCRIPTION
## What

Add `messages` to `set_subagent_subscription`. It forwards completed child messages of every role plus lifecycle and progress, filtering other child events before RPC encoding. Existing subscription levels retain their behavior.

Contributor note:

I use RPC mode heavily with a mesh server, when reading child sessions the RAM grew heavily as it was additive messages on each read, whereas it would be more performant and suitable to subscribe to the latest message. Tested it locally, and provided evidence of change is resource usage in this approach.

## Why

A client retaining completed child transcripts currently receives every growing snapshot: `A`, then `AB`, then `ABC`, even when it only needs the final message. This mode avoids that repeated encoding and transport while retaining the completed transcript and progress. It does not impose a memory limit or change full-event backpressure.

## Testing

Source checkout prerequisite: run `bun run gen:tool-views` from the repository root to generate the ignored HTML tool-view bundle imported by the RPC dependency graph. The root `prepare` script also runs this generator; installs that skip scripts need the explicit step. After regenerating the bundle, all 16 RPC tests and the coding-agent lint, formatting and type checks passed again with the client documentation update.

- Root `bun run check` and coding-agent `bun run check` passed (lint, formatting and types). The standard root script skipped Rust checks outside CI because no Rust files changed.
- `bun test packages/coding-agent/test/rpc-subagents.test.ts`: 16 passed, including real native CLI subscription negotiation without a model request.
- New tests cover completed roles, lifecycle/progress, suppression before serialization, unchanged full events, and late/stale child handling. Restoring the three original source files makes three of the four new tests fail; patched source was restored afterward.
- Tested on macOS arm64 with official Bun 1.4.0 and the official 18.1.17 native addon. No main-native source build or Rust execution was performed.

A separate deterministic local transport fixture used two child agents, each emitting 100 KiB of reasoning and 60 KiB of visible text, with no external model calls. Both arms used the same patched, compiled OMP 18.1.4 executable and the same RPC reader; only the selected subscription changed. These were single sequential runs (`events` first) on macOS arm64 with Bun 1.3.14, separate from the upstream-main Bun 1.4.0 checks above.

| Measurement | `events` | `messages` |
| --- | ---: | ---: |
| Maximum observed OMP RSS | 774.5 MiB | 584.0 MiB |
| Cumulative RPC wire bytes | 227,370,143 | 4,692,294 |

Both arms completed and produced identical captured completed-child history: six messages, comprising two user, two assistant, and two tool messages. Cumulative wire traffic fell by 97.94%. RSS was sampled every 100 ms; these observations are not peak or capacity guarantees, and the mode does not bound completed-message size or aggregate queued output.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)

🤖 Generated with [Codex](https://openai.com/codex/) (model: gpt-6-astra)
