### PR TITLE
fix(mcp): allow spaces in MCP server names

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Hand-authored `*.openapi.json` files can now be edited without disabling generated-file protection globally ([#11674](https://github.com/can1357/oh-my-pi/issues/11674)).
 - `models.yml` now validates the per-model `compat.stripImageInput` opt-out, so a wrong-typed value is rejected like every other declared compat key instead of being silently accepted ([#11697](https://github.com/can1357/oh-my-pi/issues/11697)).
 - `/mcp reload` now distinguishes servers still connecting after the bounded reload window instead of reporting a healthy asynchronous reload as zero active servers ([#11639](https://github.com/can1357/oh-my-pi/issues/11639)).
+- MCP server names may now contain spaces, so human-friendly display labels like `MaaS Slack` survive `/mcp reauth` write-back instead of being rejected by the config writer ([#11731](https://github.com/can1357/oh-my-pi/issues/11731)).
 ### Changed
 
 - The `providers.cacheRetention` `auto` setting now keeps Anthropic OAuth subscriber sessions on 1h prompt-cache retention and API keys on 5m, instead of 5m for both ([#11667](https://github.com/can1357/oh-my-pi/pull/11667) by [@camjac251](https://github.com/camjac251)).

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -90,13 +90,15 @@ export function validateServerName(name: string): string | undefined {
 	if (name.length > 100) {
 		return "Server name is too long (max 100 characters)";
 	}
-	// Check for invalid characters. Colon is allowed so namespaced plugin servers
-	// (e.g. "cloudflare:cloudflare-api" from a Claude Code marketplace plugin) can
-	// be persisted: the runtime already accepts colons in server names (tool names
-	// sanitize them via createMCPToolName) and `/mcp reauth` writes such names back
-	// as a user-config override that shadows the discovered entry.
-	if (!/^[a-zA-Z0-9_.:-]+$/.test(name)) {
-		return "Server name can only contain letters, numbers, dash, underscore, dot, and colon";
+	// Check for invalid characters. Colons and spaces are allowed so namespaced
+	// plugin servers (e.g. "cloudflare:cloudflare-api" from a Claude Code
+	// marketplace plugin) and human display labels (e.g. "MaaS Slack") can be
+	// persisted: the runtime already accepts them in server names (tool names
+	// sanitize them via createMCPToolName, ownership matches on the raw name) and
+	// `/mcp reauth` writes such names back as a user-config override that shadows
+	// the discovered entry.
+	if (!/^[a-zA-Z0-9_.: -]+$/.test(name)) {
+		return "Server name can only contain letters, numbers, dash, underscore, dot, colon, and space";
 	}
 	return undefined;
 }

--- a/packages/coding-agent/test/mcp-discovered-server-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-discovered-server-reauth.test.ts
@@ -77,8 +77,10 @@ describe("MCP discovered-server reauth", () => {
 	describe("config writer persists namespaced plugin server names", () => {
 		it("validateServerName accepts a colon-namespaced name", () => {
 			expect(validateServerName(NAMESPACED_NAME)).toBeUndefined();
-			// Sanity: genuinely invalid characters are still rejected.
-			expect(validateServerName("has space")).toBeDefined();
+			// Colons and spaces are allowed (namespaced plugins + display labels);
+			// sanity: genuinely invalid characters are still rejected.
+			expect(validateServerName("has space")).toBeUndefined();
+			expect(validateServerName("has/slash")).toBeDefined();
 		});
 
 		it("updateMCPServer round-trips a namespaced HTTP server with an oauth auth block", async () => {

--- a/packages/coding-agent/test/mcp/config-writer.test.ts
+++ b/packages/coding-agent/test/mcp/config-writer.test.ts
@@ -2,7 +2,32 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { addMCPServer, readDisabledServers, readMCPConfigFile, setServerDisabled } from "../../src/mcp/config-writer";
+import {
+	addMCPServer,
+	readDisabledServers,
+	readMCPConfigFile,
+	setServerDisabled,
+	validateServerName,
+} from "../../src/mcp/config-writer";
+import { createMCPToolName } from "../../src/mcp/tool-bridge";
+
+describe("validateServerName", () => {
+	it("accepts human display labels with spaces (#11731)", () => {
+		expect(validateServerName("MaaS Slack")).toBeUndefined();
+	});
+
+	it("still accepts namespaced colon names and rejects unsupported characters", () => {
+		expect(validateServerName("cloudflare:cloudflare-api")).toBeUndefined();
+		expect(validateServerName("bad/name")).toBeDefined();
+		expect(validateServerName("")).toBeDefined();
+	});
+
+	it("sanitizes a spaced server name into a valid tool identifier", () => {
+		// Ownership uses the raw name; tool names are lossy-sanitized, so a space
+		// never yields an invalid tool identifier.
+		expect(createMCPToolName("MaaS Slack", "send")).toMatch(/^[a-zA-Z0-9_-]+$/);
+	});
+});
 
 describe("config-writer concurrent mutations", () => {
 	let dir: string;
@@ -25,6 +50,12 @@ describe("config-writer concurrent mutations", () => {
 
 		const config = await readMCPConfigFile(filePath);
 		expect(Object.keys(config.mcpServers ?? {}).sort()).toEqual(["alpha", "bravo"]);
+	});
+
+	it("persists a server name containing spaces (#11731)", async () => {
+		await addMCPServer(filePath, "MaaS Slack", { type: "stdio", command: "s" });
+		const config = await readMCPConfigFile(filePath);
+		expect(Object.keys(config.mcpServers ?? {})).toContain("MaaS Slack");
 	});
 
 	it("preserves both denylist edits when disable calls race", async () => {


### PR DESCRIPTION
## Summary

`validateServerName` restricted MCP server names to `[a-zA-Z0-9_.:-]`, so a human-friendly display label such as **`MaaS Slack`** was rejected. This surfaced through `/mcp reauth`: reauthenticating a discovered server writes its config back via `addMCPServer` → `validateServerName`, which then failed for any name containing a space.

Fixes #11731.

## Change

Relax the validation charset to also allow a space, and update the error message to match:

```diff
-if (!/^[a-zA-Z0-9_.:-]+$/.test(name)) {
-    return "Server name can only contain letters, numbers, dash, underscore, dot, and colon";
+if (!/^[a-zA-Z0-9_.: -]+$/.test(name)) {
+    return "Server name can only contain letters, numbers, dash, underscore, dot, colon, and space";
 }
```

## Why this is safe

A space behaves exactly like the already-allowed colon:

- **Tool names** — `createMCPToolName` (via `sanitizeMCPToolNamePart`) lossily replaces any non-`[a-z0-9_]` run with `_`, so `MaaS Slack` yields a valid tool identifier; no space ever reaches a tool name.
- **Ownership / lookup** — server ownership matches on the raw `mcpServerName`, so the stored name round-trips unchanged.
- **Persistence** — `/mcp reauth` writes the name as a user-config override that shadows the discovered entry, identical to the colon-namespaced plugin case.

The empty-name and length (≤100) checks are unchanged.

## Tests

- `validateServerName` now accepts `"MaaS Slack"`, still accepts colon-namespaced names, and still rejects genuinely invalid input (`has/slash`, empty).
- `createMCPToolName("MaaS Slack", …)` is asserted to produce a valid tool identifier.
- `addMCPServer` round-trips a spaced server name to disk.
- Updated the existing reauth test whose "invalid" sanity example was a space (now intentionally allowed) to use `/`.

`bun test test/mcp/config-writer.test.ts test/mcp-discovered-server-reauth.test.ts` → 11 pass. `oxfmt --check` and `oxlint` are clean on the changed files, and `check:types` reports no new errors.
