### PR TITLE
fix(ai): repair three typecheck failures on main

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -4731,7 +4731,7 @@ export function convertAnthropicMessages(
 		dropAllThinking?: boolean;
 		droppedThinkingBlocks?: ReadonlySet<string>;
 	},
-): AnthropicMessageParam[] {
+): Array<AnthropicMessageParam & ConversationalUserCarrier> {
 	// Indices of params emitted from `developer` messages. After the main pass,
 	// the ones whose placement satisfies Anthropic's mid-conversation rules are
 	// upgraded from the `user` role to the authoritative `system` role.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -811,6 +811,7 @@ const streamOpenAICompletionsOnce = (
 							copilotCacheKey,
 							copilotCacheSnapshot,
 						),
+						signal: requestSignal,
 						// Transient 408/429/5xx get Retry-After-aware transport retries.
 						// The first-event watchdog above aborts `requestSignal`, which
 						// bounds every attempt and backoff sleep — retries cannot

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -575,6 +575,7 @@ const streamOpenAIResponsesOnce = (
 							copilotCacheKey,
 							copilotCacheSnapshot,
 						),
+						signal: requestSignal,
 						// Transient 408/429/5xx get Retry-After-aware transport
 						// retries; the first-event watchdog aborts `requestSignal`,
 						// so retries cannot extend the caller's deadline.

--- a/packages/ai/test/anthropic-server-compaction.test.ts
+++ b/packages/ai/test/anthropic-server-compaction.test.ts
@@ -15,6 +15,7 @@
  *     endpoints without context management keep the text.
  *   • The empty-completion retry does not re-issue a compaction pause.
  */
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
 	convertAnthropicMessages,
 	streamAnthropic,
@@ -816,6 +817,7 @@ describe("anthropic server-side compaction replay", () => {
 					role: "toolResult",
 					toolCallId: "toolu_1",
 					toolName: "read",
+					isError: false,
 					content: [{ type: "text", text: "file bytes" }],
 					timestamp: 3,
 				},

--- a/packages/coding-agent/src/secrets/message-transform.ts
+++ b/packages/coding-agent/src/secrets/message-transform.ts
@@ -283,7 +283,11 @@ export function obfuscateMessages(obfuscator: SecretObfuscator, messages: Messag
 		let current = message;
 		const compactionPayload = anthropicCompactionPayload(current);
 		const compactionFiles = anthropicCompactionFilesText(current);
-		if (compactionPayload !== undefined && compactionFiles !== undefined) {
+		if (
+			compactionPayload !== undefined &&
+			compactionFiles !== undefined &&
+			(current.role === "user" || current.role === "developer" || current.role === "assistant")
+		) {
 			const filesText = obfuscator.obfuscate(compactionFiles, sharedRegexSecretValues);
 			if (filesText !== compactionFiles) {
 				current = { ...current, providerPayload: { ...compactionPayload, filesText } };

--- a/packages/coding-agent/test/compaction-speculation.test.ts
+++ b/packages/coding-agent/test/compaction-speculation.test.ts
@@ -331,7 +331,9 @@ describe("async speculative compaction", () => {
 			obfuscatePreparationForProvider: preparation => ({ ...preparation, previousSummary: "MARKED PREVIOUS" }),
 			convertToLlmForSideRequest: messages =>
 				messages.map(message =>
-					typeof message.content === "string" ? { ...message, content: `MARKED:${message.content}` } : message,
+					"content" in message && typeof message.content === "string"
+						? { ...message, content: `MARKED:${message.content}` }
+						: message,
 				) as never,
 		});
 		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({

--- a/packages/coding-agent/test/secrets-obfuscator.test.ts
+++ b/packages/coding-agent/test/secrets-obfuscator.test.ts
@@ -275,7 +275,8 @@ describe("SecretObfuscator regex behavior", () => {
 		};
 
 		const [obfuscated] = obfuscateMessages(obfuscator, [message]);
-		const payload = obfuscated?.providerPayload;
+		if (obfuscated?.role !== "user") throw new Error("expected user message");
+		const payload = obfuscated.providerPayload;
 		if (payload?.type !== "anthropicCompaction") throw new Error("expected compaction payload");
 		// The metadata takes the same boundary as the summary text...
 		expect(payload.filesText).not.toContain(secret);


### PR DESCRIPTION
## Repro
`main` at db038d5bee fails typechecking in three spots (tests still pass at runtime). Reproduce with:

```
cd packages/ai && bun run check:types
cd ../coding-agent && bun run check:types
```

The first run reports `signal` missing on the `postOpenAIStream` calls plus the whole `anthropic-server-compaction.test.ts` failing to resolve its test globals; the second reports `providerPayload`/`content` read off the wrong union members.

## Cause
- `openai-completions.ts:803` / `openai-responses.ts:567` — b7fccdb16b precomputed the copilot cache-key args and dropped the adjacent `signal: requestSignal,` line, so `postOpenAIStream` no longer receives the abort signal the first-event watchdog fires; the object also stopped satisfying the required `signal` field of `OpenAIStreamRequestInit`.
- `test/anthropic-server-compaction.test.ts` (added in 32f8baa994) never imports `afterEach`/`vi`/`describe`/`it`/`expect` from `bun:test`, its `toolResult` literal omits the required `isError`, and its replay assertions compare against `[kConversationalUser]`, which `convertAnthropicMessages` attaches at runtime but did not declare on its return type.
- `src/secrets/message-transform.ts:289` spreads `{ ...current, providerPayload }` while `current` is still the whole `Message` union (where `ToolResultMessage` carries `providerMetadata`); `test/secrets-obfuscator.test.ts` and `test/compaction-speculation.test.ts` read `.providerPayload`/`.content` off `Message`/`AgentMessage` members that don't declare them.

## Fix
- Restore `signal: requestSignal,` in both `postOpenAIStream` calls.
- Declare `convertAnthropicMessages` to return `Array<AnthropicMessageParam & ConversationalUserCarrier>`, reflecting the `[kConversationalUser]` marker it already writes.
- Import the `bun:test` globals in `anthropic-server-compaction.test.ts` and add `isError: false` to the `toolResult` literal.
- Narrow to the payload-carrying roles before the `providerPayload` spread in `message-transform.ts`, and narrow the two tests' `Message`/`AgentMessage` reads to members that declare the accessed field.

## Verification
- `cd packages/ai && bun run check:types` → clean.
- `cd packages/coding-agent && bun run check:types` → clean.
- `bun test test/anthropic-server-compaction.test.ts` → 26 pass, 0 fail.
- `bun test test/secrets-obfuscator.test.ts test/compaction-speculation.test.ts` → 164 pass, 0 fail.

Fixes #11764