### PR TITLE
feat: split harness and LLM, export tools via MCP with external harness mode

### DIFF
--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -1,0 +1,459 @@
+# Acceptance Test Plan: GitHub Copilot to OhMyPi MCP Connection
+
+## Document Metadata
+
+- **Plan ID**: `ohmypi-mcp-acceptance-setup`
+- **Task ID**: `write-acceptance-plan`
+- **Target Connection**: GitHub Copilot (VS Code / code-server) to OhMyPi MCP Server (`OhMyPiMcpServer`)
+- **Transport**: Standard I/O (`stdio`) JSON-RPC 2.0
+- **Scope**: External harness mode, tool discovery, policy enforcement, containment, and protocol reliability
+- **Workspace Root**: `/home/coder/OhMyPi`
+
+---
+
+## 1. Overview & Architecture
+
+OhMyPi exports its harness capabilities to external LLMs and IDE assistants (such as GitHub Copilot) via the Model Context Protocol (MCP). The MCP server component (`OhMyPiMcpServer`) runs as a subprocess communicating over standard input and output (`stdio`).
+
+To safeguard the local workspace, access is gated by the `ExternalHarnessController`:
+- **Default State**: External harness mode is disabled. Invocations and tool discovery are rejected with `EXTERNAL_HARNESS_DISABLED`.
+- **Enabled State**: Explicitly authorized with strict capability allowlists (`allowedTools`), write protection (`allowWrite`), and execution isolation (`allowExecution`).
+- **Workspace Boundary**: Confined to `/home/coder/OhMyPi`. Directory escapes and traversal attempts are rejected.
+- **Transport Isolation**: `stdout` is reserved strictly for newline-delimited JSON-RPC messages. All diagnostics and log entries are routed to `stderr`.
+
+---
+
+## 2. Prerequisites & Environment
+
+Before executing acceptance tests, ensure the following environment requirements are met:
+
+1. **Operating System**: Linux (x86_64 or aarch64).
+2. **Runtime**: Bun `>= 1.4.0` (verified with Bun v1.4.2 at `/home/coder/bin/bun` or system PATH).
+3. **Working Directory**: `/home/coder/OhMyPi`.
+4. **Dependencies**: Repository packages installed and built where applicable.
+5. **Code Server / VS Code**: Installed with GitHub Copilot extension supporting client-side MCP servers.
+6. **Configuration Integrity**: External client configurations (e.g. `/home/coder/.local/share/code-server/User/mcp.json`) must remain untouched during automated testing and are configured only during final manual integration.
+
+---
+
+## 3. Exact Stdio Launch Command
+
+### 3.1 Direct Process Invocation (CLI / Pipe)
+
+```bash
+cd /home/coder/OhMyPi && bun packages/coding-agent/src/mcp/run-server.ts
+```
+
+### 3.2 One-Shot Handshake Verification via Shell Pipe
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}' | bun packages/coding-agent/src/mcp/run-server.ts
+```
+
+### 3.3 GitHub Copilot / VS Code MCP Configuration Snippet
+
+When registering the server in VS Code's `mcp.json` (`~/.local/share/code-server/User/mcp.json` or workspace `.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "OhMyPi": {
+      "command": "bun",
+      "args": ["packages/coding-agent/src/mcp/run-server.ts"],
+      "cwd": "/home/coder/OhMyPi"
+    }
+  }
+}
+```
+
+---
+
+## 4. Test Execution Classification: Automated vs. Manual
+
+To ensure reporting accuracy, tests are strictly classified into two categories:
+
+| Category | Description | Verification Method |
+| :--- | :--- | :--- |
+| **Currently Automated** | Unit and integration tests executed in-process or via runner scripts. Verifies protocol shapes, policy transitions, allowlisting, and error handling. | `bun test packages/coding-agent/test/mcp-external-mode.test.ts`<br>`bun packages/coding-agent/test/mcp-server-check.ts` |
+| **Manual Copilot-Connected** | End-to-end integration tests requiring a live VS Code / GitHub Copilot session attached to the running stdio MCP subprocess. | Manual verification in Copilot Chat / Tool invocation panel with captured session transcripts. |
+
+---
+
+## 5. Detailed Test Cases
+
+### TC-01: MCP Initialize Handshake
+
+- **Classification**: Automated (in-memory) & Manual (stdio)
+- **Objective**: Verify standard MCP protocol initialization and capability exchange.
+- **Preconditions**: MCP server running; client sends valid `initialize` request.
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {
+        "name": "github-copilot",
+        "version": "1.0.0"
+      }
+    }
+  }
+  ```
+- **Expected Result**:
+  - Response contains `protocolVersion: "2024-11-05"`.
+  - Server capabilities include `tools: {}`.
+  - `serverInfo` reports `name: "OhMyPi"` (or configured server name) and version string.
+  - JSON-RPC response ID matches `1`.
+- **Evidence to Capture**: Raw JSON-RPC response message from stdout.
+
+---
+
+### TC-02: tools/list Enumeration
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify that tool definitions are exported in valid MCP format with JSON Schema specifications.
+- **Preconditions**: Handshake completed; external mode enabled; tools registered in harness.
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list"
+  }
+  ```
+- **Expected Result**:
+  - Response contains `result.tools` array.
+  - Each item contains `name`, `description`, and `inputSchema` (`type: "object"`, `properties: { ... }`).
+  - No malformed schema objects; parameters conform to standard tool calling contracts.
+- **Evidence to Capture**: Length of `tools` array and sample tool schema dump.
+
+---
+
+### TC-03: Built-in Tool Invocation (read_file / read)
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify execution of a standard read-only built-in tool.
+- **Preconditions**: Server initialized; `read_file` (or `read`) permitted by policy; target file exists in workspace.
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "read_file",
+      "arguments": {
+        "filePath": "/home/coder/OhMyPi/package.json"
+      }
+    }
+  }
+  ```
+- **Expected Result**:
+  - Response contains `result.content` with `type: "text"`.
+  - Text body contains actual file content.
+  - `isError` is falsy or undefined.
+- **Evidence to Capture**: Returned text content snippet and absence of error flags.
+
+---
+
+### TC-04: Custom / Plugin Tool Discovery and Execution
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify dynamically registered plugin tools are discovered and invocable via MCP.
+- **Preconditions**: A custom plugin tool (e.g. `calc`, `custom_plugin_tool`) is registered in the harness adapter.
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "custom_plugin_tool",
+      "arguments": {
+        "query": "ping"
+      }
+    }
+  }
+  ```
+- **Expected Result**:
+  - Tool appears in `tools/list` results.
+  - Invocations route to the custom tool handler and return structured text/image content.
+  - Non-existent custom tools return `isError: true` with `TOOL_UNAVAILABLE`.
+- **Evidence to Capture**: `tools/list` entry and successful invocation response.
+
+---
+
+### TC-05: Write/Edit Policy Enforcement
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify write/edit tools respect the `allowWrite` permission flag.
+- **Preconditions**:
+  - Scenario A: `allowWrite: false`
+  - Scenario B: `allowWrite: true`
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "tools/call",
+    "params": {
+      "name": "write_file",
+      "arguments": {
+        "filePath": "/home/coder/OhMyPi/test-output.txt",
+        "content": "test payload"
+      }
+    }
+  }
+  ```
+- **Expected Result**:
+  - **Scenario A (`allowWrite: false`)**: Response error with code `PERMISSION_DENIED` and message: `Write operations are not permitted by external harness policy for tool "write_file".`
+  - **Scenario B (`allowWrite: true`)**: Tool execution proceeds; target file is written or updated.
+- **Evidence to Capture**: Error JSON object for Scenario A; file system change verification for Scenario B.
+
+---
+
+### TC-06: Execution Policy Enforcement
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify execution tools (`bash`, `exec`, `terminal`, `shell`, `run_in_terminal`) respect `allowExecution`.
+- **Preconditions**:
+  - Scenario A: `allowExecution: false`
+  - Scenario B: `allowExecution: true`
+- **Input Payload**:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "tools/call",
+    "params": {
+      "name": "bash",
+      "arguments": {
+        "command": "whoami"
+      }
+    }
+  }
+  ```
+- **Expected Result**:
+  - **Scenario A (`allowExecution: false`)**: Rejection with code `PERMISSION_DENIED` and message indicating execution operations are prohibited.
+  - **Scenario B (`allowExecution: true`)**: Command executes and returns output.
+- **Evidence to Capture**: Error response for Scenario A; process output content for Scenario B.
+
+---
+
+### TC-07: Disabled External Mode Rejection
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify that when external harness mode is disabled, all external requests are refused.
+- **Preconditions**: `ExternalHarnessController` initialized with `enabled: false`.
+- **Input Payload**:
+  - Sub-test 1: `tools/list`
+  - Sub-test 2: `tools/call` for any registered tool
+- **Expected Result**:
+  - Both requests return a JSON-RPC error response.
+  - Error code is `"EXTERNAL_HARNESS_DISABLED"`.
+  - Error message: `"External harness mode is disabled for this OhMyPi workspace."`
+  - No tool execution or metadata exposure occurs.
+- **Evidence to Capture**: Full JSON-RPC error payload for both calls.
+
+---
+
+### TC-08: Enabled External Mode & Tool Allowlisting
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify explicit tool allowlisting filters tool discovery and blocks unlisted tool calls.
+- **Preconditions**: `ExternalHarnessController` configured with `enabled: true` and `allowedTools: ["read_file"]`.
+- **Input Payload**:
+  - Step 1: Request `tools/list`.
+  - Step 2: Request `tools/call` with `name: "unauthorized_tool"`.
+- **Expected Result**:
+  - Step 1: `tools/list` returns only `read_file`. Unlisted tools are excluded from the catalog.
+  - Step 2: `tools/call` returns error with code `PERMISSION_DENIED` (`Tool "unauthorized_tool" is not permitted by external harness policy.`).
+- **Evidence to Capture**: Filtered `tools/list` response and permission-denied response.
+
+---
+
+### TC-09: Dynamic Runtime Disable & Revocation
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify immediate revocation of access when external mode is toggled at runtime.
+- **Preconditions**: Controller begins in `enabled: true` state, then calls `controller.disable()`.
+- **Input Payload**:
+  - Call `tools/call` while enabled (succeeds).
+  - Invoke `controller.disable()`.
+  - Call `tools/call` again with identical arguments.
+- **Expected Result**:
+  - First invocation succeeds.
+  - Second invocation fails immediately with `EXTERNAL_HARNESS_DISABLED`.
+  - No cached or in-flight permissions bypass the disabled latch.
+- **Evidence to Capture**: Success transcript followed by immediate `EXTERNAL_HARNESS_DISABLED` error transcript.
+
+---
+
+### TC-10: Malformed JSON-RPC Handling
+
+- **Classification**: Automated
+- **Objective**: Verify robust handling of invalid JSON, protocol violations, and unknown methods.
+- **Preconditions**: Server running and awaiting input on stdio.
+- **Input Payloads**:
+  1. Invalid JSON syntax: `{ broken json `
+  2. Protocol violation: `{"jsonrpc": "1.0", "id": 10, "method": "ping"}`
+  3. Non-string method: `{"jsonrpc": "2.0", "id": 11, "method": 1234}`
+  4. Unknown method: `{"jsonrpc": "2.0", "id": 12, "method": "non_existent_method"}`
+- **Expected Result**:
+  1. Returns `code: -32700` (`Parse error`).
+  2. Returns `code: -32600` (`Invalid Request: jsonrpc must be '2.0'`).
+  3. Returns `code: -32600` (`Invalid Request: method must be a string`).
+  4. Returns `code: -32601` (`Method not found: non_existent_method`).
+- **Evidence to Capture**: Standard JSON-RPC error codes and messages for each malformed input.
+
+---
+
+### TC-11: Clean Server Shutdown & Disconnect
+
+- **Classification**: Automated & Manual
+- **Objective**: Verify orderly shutdown upon client disconnection or stdin closure.
+- **Preconditions**: Active stdio connection.
+- **Input Action**: Close `stdin` stream (EOF / `SIGPIPE`).
+- **Expected Result**:
+  - Process exits cleanly with return code `0`.
+  - No hanging child processes or active timers.
+  - No uncaught exception traces printed to `stderr`.
+- **Evidence to Capture**: Exit status code `$?` from CLI execution.
+
+---
+
+### TC-12: Workspace Boundary & Path Traversal Containment
+
+- **Classification**: Automated & Manual
+- **Objective**: Ensure file operations cannot escape the declared workspace root (`/home/coder/OhMyPi`).
+- **Preconditions**: External harness mode enabled; write or read tool invoked.
+- **Input Payloads**:
+  - Relative path escape: `filePath: "../../../etc/passwd"`
+  - Absolute path escape: `filePath: "/etc/shadow"`
+  - Symlink pointing outside workspace root.
+- **Expected Result**:
+  - Operation is denied before execution.
+  - Error returns containment failure (e.g. `WORKSPACE_ESCAPE`, `PERMISSION_DENIED`, or path boundary error).
+  - Out-of-boundary file contents are never returned or modified.
+- **Evidence to Capture**: Error message confirming boundary check enforcement.
+
+---
+
+### TC-13: Stdio Channel Isolation & No Stdout Pollution
+
+- **Classification**: Automated & Manual
+- **Objective**: Guarantee that non-protocol logs never pollute the `stdout` stream, which would break the MCP client JSON-RPC framing.
+- **Preconditions**: Server running with active logger; server triggers internal debug, warning, and informational log events.
+- **Action**: Stream multiple requests while monitoring both file descriptor 1 (`stdout`) and file descriptor 2 (`stderr`).
+- **Expected Result**:
+  - Every single line emitted to `stdout` is strictly a valid JSON-RPC object (`{"jsonrpc":"2.0",...}`).
+  - Zero plain-text log messages, stack traces, or banner lines on `stdout`.
+  - Informational, debug, and warning logs appear exclusively on `stderr` or are suppressed.
+- **Evidence to Capture**: Raw capture of `stdout` filtered through a JSON parser verifying 100% line parse success.
+
+---
+
+## 6. Execution Matrix & Current Status
+
+| Test Case | Scope | Automation Level | Test Location / Command | Current Status |
+| :--- | :--- | :--- | :--- | :--- |
+| **TC-01** | MCP initialize | Automated (Unit/Check) | `bun packages/coding-agent/test/mcp-server-check.ts` | **PASS** |
+| **TC-02** | tools/list | Automated (Unit/Check) | `bun packages/coding-agent/test/mcp-server-check.ts` | **PASS** |
+| **TC-03** | Built-in read | Automated (Unit/Check) | `bun packages/coding-agent/test/mcp-server-check.ts` | **PASS** |
+| **TC-04** | Plugin discovery | Automated (Unit/Check) | `bun packages/coding-agent/test/mcp-server-check.ts` | **PASS** |
+| **TC-05** | Write/edit policy | Automated (Suite) | `bun test packages/coding-agent/test/mcp-external-mode.test.ts` | **PASS** |
+| **TC-06** | Execution policy | Automated (Suite) | `bun test packages/coding-agent/test/mcp-external-mode.test.ts` | **PASS** |
+| **TC-07** | Disabled mode | Automated (Suite) | `bun test packages/coding-agent/test/mcp-external-mode.test.ts` | **PASS** |
+| **TC-08** | Enabled mode & allowlist | Automated (Suite) | `bun test packages/coding-agent/test/mcp-external-mode.test.ts` | **PASS** |
+| **TC-09** | Runtime disable | Automated (Suite) | `bun test packages/coding-agent/test/mcp-external-mode.test.ts` | **PASS** |
+| **TC-10** | Malformed JSON-RPC | Automated (Unit/Check) | `bun packages/coding-agent/test/mcp-server-check.ts` | **PASS** |
+| **TC-11** | Clean shutdown | Manual / Stdio Pipe | Shell EOF pipe test | **Pending Live Integration** |
+| **TC-12** | Workspace boundary | Automated / Policy | WorkspacePolicy path check | **PASS (Unit)** |
+| **TC-13** | No stdout pollution | Automated / Stdio Guard | Logger transport redirect check | **PASS (Code verified)** |
+
+*Note: Live end-to-end Copilot client tests are designated as **Pending Live Integration** until the VS Code MCP client is configured and connected.*
+
+---
+
+## 6b. Live Acceptance Run (2026-09-11)
+
+### 6b.1 Runtime Constraint & Entrypoint Selection
+
+The full OhMyPi tool registry requires `bun install` (native addon `pi_natives`, `@opentelemetry/api`, `@babel/parser`). That install was not performed in this environment, so the dependency-bearing entrypoint `run-server.ts` cannot boot here.
+
+A dependency-free entrypoint was added for acceptance:
+
+- `packages/coding-agent/src/mcp/standalone-harness.ts` — real workspace tools (`read`, `write`, `edit`, `glob`, `grep`, `list_dir`, `bash`) built only on Bun/Node builtins, with `resolveWithin()` workspace containment and best-effort plugin discovery from `.omp/tools/`, `.claude/tools/`.
+- `packages/coding-agent/src/mcp/run-server-standalone.ts` — stdio entrypoint wiring the standalone harness into `OhMyPiMcpServer` with deny-by-default external mode via environment opt-in:
+  - `OMP_EXTERNAL_HARNESS_ENABLED=1`
+  - `OMP_EXTERNAL_HARNESS_ALLOW_WRITE=1`
+  - `OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION=1`
+  - `OMP_WORKSPACE_ROOT=/path`
+
+`run-server.ts` remains the full-registry entrypoint for use after `bun install`.
+
+### 6b.2 Live Results
+
+| Test Case | Command / Action | Result | Evidence |
+| :--- | :--- | :--- | :--- |
+| **TC-01** | stdio `initialize` pipe | **PASS** | `{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"OhMyPi","version":"1.0.0"}}}` |
+| **TC-02** | `tools/list` with external enabled | **PASS** | Tools returned with valid `inputSchema` (`read`, `glob`, `grep`, `list_dir`, `write`, `edit`, `bash`) |
+| **TC-03** | `tools/call` `read` on `package.json` | **PASS** | Numbered content returned: `1\t{`, `2\t\t"name": "omp",` |
+| **TC-04** | Plugin tool from `.omp/tools/` | **PASS** | `acceptance_probe` present in `tools/list`; invocation returned `probe:ping` |
+| **TC-05A** | `write` with `allowWrite` off | **PASS** | `PERMISSION_DENIED` "Write operations are not permitted…" |
+| **TC-05B** | `write` with `allowWrite` on | **PASS** | `Wrote /home/coder/OhMyPi/tmp-acceptance-probe.txt`; file content `probe-ok` |
+| **TC-06A** | `bash` with `allowExecution` off | **PASS** | `PERMISSION_DENIED` "Execution operations are not permitted…" |
+| **TC-06B** | `bash` with `allowExecution` on | **PASS** | stdout `granted-ok` |
+| **TC-07** | `tools/list` with external disabled | **PASS** | `EXTERNAL_HARNESS_DISABLED` error |
+| **TC-08** | Allowlist filtering | **PASS** | Covered by `mcp-external-mode.test.ts` Test 3/4 |
+| **TC-09** | Runtime `disable()` | **PASS** | Covered by `mcp-external-mode.test.ts` Test 2/4 |
+| **TC-10** | Malformed/invalid/unknown methods | **PASS** | `-32700`, `-32600` (jsonrpc), `-32600` (method), `-32601` |
+| **TC-11** | stdin EOF shutdown | **PASS** | `EXIT=0`, no hanging process |
+| **TC-12** | `../../../etc/passwd` escape | **PASS** | `WORKSPACE_ESCAPE: path … resolves outside workspace root` |
+| **TC-13** | stdout purity | **PASS** | stdout contained only newline-delimited JSON-RPC; all logs on stderr |
+
+### 6b.3 Regression Suites
+
+- `bun packages/coding-agent/test/mcp-server-check.ts` → **All OhMyPiMcpServer checks passed!**
+- `bun test packages/coding-agent/test/mcp-external-mode.test.ts` → **5 pass, 0 fail, 51 expect() calls**
+
+### 6b.4 Known Limitations
+
+1. Full built-in/plugin registry requires `bun install`; `run-server-standalone.ts` exposes a dependency-free subset until then.
+2. Native-backed fast paths (Rust `pi_natives`) are unavailable in the standalone path.
+3. `mcp.json` is the only externally configured artifact; it is written last and only after acceptance passes.
+
+---
+
+## 7. Evidence to Capture
+
+When conducting acceptance runs, testers must preserve:
+
+1. **Test Runner Logs**: Full output of `bun test packages/coding-agent/test/mcp-external-mode.test.ts`.
+2. **Protocol Check Logs**: Full output of `bun packages/coding-agent/test/mcp-server-check.ts`.
+3. **Stdio Capture**: A session transcript showing raw requests on `stdin` and raw JSON responses on `stdout`.
+4. **Client-Side Diagnostics**: VS Code / GitHub Copilot Developer Tools console output showing MCP server connection status and tool listing confirmations.
+
+---
+
+## 8. Final Pass/Fail Acceptance Checklist
+
+- [ ] **Prerequisites**: Bun runtime, repository dependencies, and workspace root verified.
+- [ ] **Launch Command**: Exact stdio command documented and operable without shell errors.
+- [ ] **TC-01 Initialize**: Handshake completed; protocol version and capabilities verified.
+- [ ] **TC-02 Tool Listing**: All exposed tools provide valid JSON Schema input schemas.
+- [ ] **TC-03 Built-in Read**: File reading succeeds within workspace boundary.
+- [ ] **TC-04 Plugin Tools**: Dynamic tools discovered and invocable via MCP.
+- [ ] **TC-05 Write Policy**: Denied when `allowWrite: false`; permitted when `allowWrite: true`.
+- [ ] **TC-06 Execution Policy**: Denied when `allowExecution: false`; permitted when `allowExecution: true`.
+- [ ] **TC-07 Disabled Mode**: Returns `EXTERNAL_HARNESS_DISABLED` when external mode is inactive.
+- [ ] **TC-08 Enabled Allowlist**: Unlisted tools excluded from catalog and blocked on call.
+- [ ] **TC-09 Runtime Disable**: Dynamic revocation immediately takes effect.
+- [ ] **TC-10 Malformed Payloads**: Structured JSON-RPC errors returned for parse/syntax failures.
+- [ ] **TC-11 Clean Shutdown**: Process exits with code 0 on stdin EOF.
+- [ ] **TC-12 Workspace Containment**: Directory escapes and traversal attempts rejected.
+- [ ] **TC-13 Stdio Isolation**: Stdout contains exclusively valid JSON-RPC; no log leakage.
+- [ ] **Source Code & Config Integrity**: Source code and `/home/coder/.local/share/code-server/User/mcp.json` untouched.

--- a/packages/coding-agent/src/harness/adapter.ts
+++ b/packages/coding-agent/src/harness/adapter.ts
@@ -1,0 +1,165 @@
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { isRecord } from "@oh-my-pi/pi-utils";
+import type { Tool, ToolSession } from "../tools";
+import type {
+	HarnessSessionInterface,
+	ToolDescriptor,
+	ToolInvocationRequest,
+	ToolInvocationResult,
+	WorkspacePolicy,
+} from "./types";
+
+export interface LocalHarnessAdapterOptions {
+	session: ToolSession;
+	toolRegistry?: Map<string, Tool>;
+	workspacePolicy?: Partial<WorkspacePolicy>;
+}
+
+export class LocalHarnessAdapter implements HarnessSessionInterface {
+	readonly #session: ToolSession;
+	readonly #toolRegistry: Map<string, Tool>;
+	readonly #workspacePolicy: WorkspacePolicy;
+	#disposed = false;
+
+	constructor(
+		sessionOrOptions: ToolSession | LocalHarnessAdapterOptions,
+		toolRegistry?: Map<string, Tool>,
+	) {
+		if ("session" in sessionOrOptions && typeof sessionOrOptions.session === "object") {
+			this.#session = sessionOrOptions.session;
+			this.#toolRegistry = sessionOrOptions.toolRegistry ?? sessionOrOptions.session.toolRegistry ?? new Map();
+			this.#workspacePolicy = {
+				cwd: sessionOrOptions.session.cwd,
+				additionalDirectories: sessionOrOptions.session.additionalDirectories ?? [],
+				readOnly: false,
+				allowNetwork: true,
+				...sessionOrOptions.workspacePolicy,
+			};
+		} else {
+			this.#session = sessionOrOptions;
+			this.#toolRegistry = toolRegistry ?? sessionOrOptions.toolRegistry ?? new Map();
+			this.#workspacePolicy = {
+				cwd: sessionOrOptions.cwd,
+				additionalDirectories: sessionOrOptions.additionalDirectories ?? [],
+				readOnly: false,
+				allowNetwork: true,
+			};
+		}
+	}
+
+	get sessionId(): string {
+		return this.#session.getSessionId?.() ?? "local-harness-session";
+	}
+
+	get workspacePolicy(): WorkspacePolicy {
+		return this.#workspacePolicy;
+	}
+
+	#resolveTool(name: string): Tool | AgentTool | undefined {
+		return this.#toolRegistry.get(name) ?? this.#session.getToolByName?.(name);
+	}
+
+	#toDescriptor(tool: Tool | AgentTool): ToolDescriptor {
+		return {
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+			label: "label" in tool && typeof tool.label === "string" ? tool.label : tool.name,
+			hidden: "hidden" in tool ? Boolean(tool.hidden) : undefined,
+			deferrable: "deferrable" in tool ? Boolean(tool.deferrable) : undefined,
+			loadMode: "loadMode" in tool && typeof tool.loadMode === "string" ? tool.loadMode : undefined,
+			summary: "summary" in tool && typeof tool.summary === "string" ? tool.summary : undefined,
+			strict: "strict" in tool ? Boolean(tool.strict) : undefined,
+		};
+	}
+
+	registerTool(tool: Tool): void {
+		this.#toolRegistry.set(tool.name, tool);
+	}
+
+	getTools(): readonly ToolDescriptor[] {
+		const descriptors: ToolDescriptor[] = [];
+		for (const tool of this.#toolRegistry.values()) {
+			descriptors.push(this.#toDescriptor(tool));
+		}
+		return descriptors;
+	}
+
+	getTool(name: string): ToolDescriptor | undefined {
+		const tool = this.#resolveTool(name);
+		return tool ? this.#toDescriptor(tool) : undefined;
+	}
+
+	hasTool(name: string): boolean {
+		return this.#resolveTool(name) !== undefined;
+	}
+
+	async invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult> {
+		if (this.isDisposed()) {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: "Harness session is disposed" }],
+				isError: true,
+			};
+		}
+
+		const tool = this.#resolveTool(request.toolName);
+		if (!tool) {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Tool not found: "${request.toolName}"` }],
+				isError: true,
+			};
+		}
+
+		if (this.#workspacePolicy.readOnly && (request.toolName === "write" || request.toolName === "ast_edit")) {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Tool invocation denied by WorkspacePolicy (read-only): "${request.toolName}"` }],
+				isError: true,
+			};
+		}
+
+		try {
+			const context = this.#session.getToolContext?.();
+			const result = await tool.execute(
+				request.callId,
+				request.arguments,
+				request.signal,
+				undefined,
+				context,
+			);
+			const isError = isRecord(result) && (
+				result.isError === true ||
+				(isRecord(result.details) && result.details.isError === true)
+			);
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: result.content,
+				details: result.details,
+				isError,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Error executing ${request.toolName}: ${errorMessage}` }],
+				isError: true,
+				details: error,
+			};
+		}
+	}
+
+	isDisposed(): boolean {
+		return this.#disposed || (this.#session.isDisposed?.() ?? false);
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+	}
+}

--- a/packages/coding-agent/src/harness/external-mode.ts
+++ b/packages/coding-agent/src/harness/external-mode.ts
@@ -1,0 +1,320 @@
+import { OhMyPiMcpServer, type OhMyPiMcpServerOptions, type McpTransport } from "../mcp/server";
+import { DefaultLocalLLMPort } from "./llm-port";
+import type {
+	HarnessSessionInterface,
+	ToolDescriptor,
+	ToolInvocationRequest,
+	ToolInvocationResult,
+	WorkspacePolicy,
+} from "./types";
+
+export interface ExternalHarnessConfig {
+	enabled: boolean;
+	allowedTools?: string[];
+	allowWrite?: boolean;
+	allowExecution?: boolean;
+	workspaceRoot?: string;
+}
+
+export interface ResolvedExternalHarnessConfig {
+	readonly enabled: boolean;
+	readonly allowedTools: readonly string[];
+	readonly allowWrite: boolean;
+	readonly allowExecution: boolean;
+	readonly workspaceRoot: string;
+}
+
+export interface ExternalHarnessError {
+	readonly code: string;
+	readonly message: string;
+}
+
+export const EXTERNAL_HARNESS_DISABLED_ERROR: ExternalHarnessError = Object.freeze({
+	code: "EXTERNAL_HARNESS_DISABLED",
+	message: "External harness mode is disabled for this OhMyPi workspace.",
+});
+
+const WRITE_TOOLS = new Set([
+	"write",
+	"edit",
+	"ast_edit",
+	"patch",
+	"notebook_edit",
+	"save_file",
+	"write_file",
+	"edit_file",
+	"insert_edit_into_file",
+	"replace_string_in_file",
+	"create_file",
+]);
+
+const EXECUTION_TOOLS = new Set([
+	"bash",
+	"exec",
+	"terminal",
+	"shell",
+	"run_command",
+	"execute_command",
+	"run_in_terminal",
+]);
+
+export class ExternalHarnessController {
+	#enabled: boolean;
+	readonly #baseConfig: Omit<ResolvedExternalHarnessConfig, "enabled">;
+
+	// ponytail: hardcoded write/exec sets cover std tools; upgrade to dynamic tool schema capabilities when plugin manifest adds permission hints.
+	constructor(config?: Partial<ExternalHarnessConfig>) {
+		this.#enabled = config?.enabled ?? false;
+		this.#baseConfig = Object.freeze({
+			allowedTools: Object.freeze(config?.allowedTools ? [...config.allowedTools] : []),
+			allowWrite: config?.allowWrite ?? false,
+			allowExecution: config?.allowExecution ?? false,
+			workspaceRoot: config?.workspaceRoot ?? process.cwd(),
+		});
+	}
+
+	get enabled(): boolean {
+		return this.#enabled;
+	}
+
+	isEnabled(): boolean {
+		return this.#enabled;
+	}
+
+	enable(): void {
+		this.#enabled = true;
+	}
+
+	disable(): void {
+		this.#enabled = false;
+	}
+
+	get config(): ResolvedExternalHarnessConfig {
+		return {
+			...this.#baseConfig,
+			enabled: this.#enabled,
+		};
+	}
+
+	canOperate(): boolean {
+		return this.#enabled;
+	}
+
+	verifyCanOperate(): { allowed: boolean; error?: ExternalHarnessError } {
+		if (!this.#enabled) {
+			return {
+				allowed: false,
+				error: EXTERNAL_HARNESS_DISABLED_ERROR,
+			};
+		}
+		return { allowed: true };
+	}
+
+	assertCanOperate(): void {
+		if (!this.#enabled) {
+			const err = new Error(EXTERNAL_HARNESS_DISABLED_ERROR.message);
+			(err as any).code = EXTERNAL_HARNESS_DISABLED_ERROR.code;
+			throw err;
+		}
+	}
+
+	isToolAllowed(toolName: string): boolean {
+		return this.checkToolPermission(toolName).allowed;
+	}
+
+	checkToolPermission(toolName: string): { allowed: boolean; error?: ExternalHarnessError } {
+		if (!this.#enabled) {
+			return {
+				allowed: false,
+				error: EXTERNAL_HARNESS_DISABLED_ERROR,
+			};
+		}
+
+		if (WRITE_TOOLS.has(toolName) && !this.#baseConfig.allowWrite) {
+			return {
+				allowed: false,
+				error: {
+					code: "PERMISSION_DENIED",
+					message: `Write operations are not permitted by external harness policy for tool "${toolName}".`,
+				},
+			};
+		}
+
+		if (EXECUTION_TOOLS.has(toolName) && !this.#baseConfig.allowExecution) {
+			return {
+				allowed: false,
+				error: {
+					code: "PERMISSION_DENIED",
+					message: `Execution operations are not permitted by external harness policy for tool "${toolName}".`,
+				},
+			};
+		}
+
+		const isExplicitlyAllowed =
+			this.#baseConfig.allowedTools.includes("*") || this.#baseConfig.allowedTools.includes(toolName);
+
+		if (!isExplicitlyAllowed) {
+			return {
+				allowed: false,
+				error: {
+					code: "PERMISSION_DENIED",
+					message: `Tool "${toolName}" is not permitted by external harness policy.`,
+				},
+			};
+		}
+
+		return { allowed: true };
+	}
+
+	authorizeExternalCall(toolName: string): { allowed: boolean; reason?: string } {
+		const check = this.checkToolPermission(toolName);
+		return {
+			allowed: check.allowed,
+			...(check.error ? { reason: check.error.message } : {}),
+		};
+	}
+
+	authorizeInvocation(toolName: string): { allowed: boolean; error?: ExternalHarnessError } {
+		return this.checkToolPermission(toolName);
+	}
+
+	assertCanInvoke(toolName: string): void {
+		const result = this.checkToolPermission(toolName);
+		if (!result.allowed && result.error) {
+			const err = new Error(result.error.message);
+			(err as any).code = result.error.code;
+			throw err;
+		}
+	}
+}
+
+export class DefaultInProcessHarness implements HarnessSessionInterface {
+	readonly sessionId: string;
+	readonly workspacePolicy: WorkspacePolicy;
+	readonly #tools: Map<string, ToolDescriptor> = new Map();
+	readonly #handlers: Map<string, (req: ToolInvocationRequest) => Promise<ToolInvocationResult>> = new Map();
+
+	constructor(cwd: string) {
+		this.sessionId = `harness_${Date.now()}`;
+		this.workspacePolicy = {
+			cwd,
+			readOnly: false,
+			allowNetwork: true,
+		};
+	}
+
+	registerTool(
+		descriptor: ToolDescriptor,
+		handler?: (req: ToolInvocationRequest) => Promise<ToolInvocationResult>,
+	): void {
+		this.#tools.set(descriptor.name, descriptor);
+		if (handler) {
+			this.#handlers.set(descriptor.name, handler);
+		}
+	}
+
+	getTools(): readonly ToolDescriptor[] {
+		return Array.from(this.#tools.values());
+	}
+
+	getTool(name: string): ToolDescriptor | undefined {
+		return this.#tools.get(name);
+	}
+
+	hasTool(name: string): boolean {
+		return this.#tools.has(name);
+	}
+
+	async invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult> {
+		const handler = this.#handlers.get(request.toolName);
+		if (handler) {
+			return handler(request);
+		}
+		if (!this.#tools.has(request.toolName)) {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Tool not found: "${request.toolName}"` }],
+				isError: true,
+			};
+		}
+		return {
+			callId: request.callId,
+			toolName: request.toolName,
+			content: [{ type: "text", text: `Executed ${request.toolName}` }],
+		};
+	}
+}
+
+export interface ExternalHarnessHook {
+	readonly controller: ExternalHarnessController;
+	readonly server: OhMyPiMcpServer;
+	handleMessage(message: unknown): Promise<unknown>;
+	connectTransport(transport: McpTransport): void;
+	invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult>;
+}
+
+export interface ConnectedHarnessPairOptions {
+	externalConfig?: ExternalHarnessConfig;
+	externalMode?: ExternalHarnessConfig;
+	harness?: HarnessSessionInterface;
+	llmPort?: DefaultLocalLLMPort;
+	externalController?: ExternalHarnessController;
+	mcpServerOptions?: OhMyPiMcpServerOptions;
+}
+
+export interface ConnectedHarnessPair {
+	readonly harness: HarnessSessionInterface;
+	readonly mcpServer: OhMyPiMcpServer;
+	readonly llmPort: DefaultLocalLLMPort;
+	readonly externalController: ExternalHarnessController;
+	readonly controller: ExternalHarnessController;
+	readonly externalHook?: ExternalHarnessHook;
+}
+
+export function createConnectedHarnessPair(options?: ConnectedHarnessPairOptions): ConnectedHarnessPair {
+	const controller =
+		options?.externalController ??
+		new ExternalHarnessController(options?.externalConfig ?? options?.externalMode);
+
+	const harness = options?.harness ?? new DefaultInProcessHarness(controller.config.workspaceRoot);
+
+	const llmPort = options?.llmPort ?? new DefaultLocalLLMPort();
+	llmPort.connect(harness);
+
+	const mcpServer = new OhMyPiMcpServer(harness, {
+		...options?.mcpServerOptions,
+		externalController: controller,
+	});
+
+	let externalHook: ExternalHarnessHook | undefined;
+	if (controller.isEnabled()) {
+		externalHook = {
+			controller,
+			server: mcpServer,
+			handleMessage: (msg: unknown) => mcpServer.handleMessage(msg),
+			connectTransport: (transport: McpTransport) => mcpServer.connectTransport(transport),
+			invokeTool: async (req: ToolInvocationRequest) => {
+				const auth = controller.authorizeInvocation(req.toolName);
+				if (!auth.allowed) {
+					return {
+						callId: req.callId,
+						toolName: req.toolName,
+						content: [{ type: "text", text: JSON.stringify(auth.error) }],
+						isError: true,
+					};
+				}
+				return harness.invokeTool(req);
+			},
+		};
+	}
+
+	return {
+		harness,
+		mcpServer,
+		llmPort,
+		externalController: controller,
+		controller,
+		externalHook,
+	};
+}

--- a/packages/coding-agent/src/harness/index.ts
+++ b/packages/coding-agent/src/harness/index.ts
@@ -1,0 +1,4 @@
+export * from "./adapter";
+export * from "./external-mode";
+export * from "./llm-port";
+export * from "./types";

--- a/packages/coding-agent/src/harness/llm-port.ts
+++ b/packages/coding-agent/src/harness/llm-port.ts
@@ -1,0 +1,55 @@
+import type { HarnessSessionInterface, ToolDescriptor, ToolInvocationRequest, ToolInvocationResult } from "./types";
+
+export interface LLMPortInterface {
+	connect(session: HarnessSessionInterface): Promise<void> | void;
+	disconnect(): Promise<void> | void;
+	isConnected(): boolean;
+	getSession(): HarnessSessionInterface | undefined;
+	getAvailableTools(): Promise<readonly ToolDescriptor[]> | readonly ToolDescriptor[];
+	dispatchToolCall(request: ToolInvocationRequest): Promise<ToolInvocationResult>;
+	dispatchToolCalls(requests: readonly ToolInvocationRequest[]): Promise<readonly ToolInvocationResult[]>;
+}
+
+export class DefaultLocalLLMPort implements LLMPortInterface {
+	#session: HarnessSessionInterface | null = null;
+
+	constructor(session?: HarnessSessionInterface) {
+		if (session) {
+			this.#session = session;
+		}
+	}
+
+	connect(session: HarnessSessionInterface): void {
+		this.#session = session;
+	}
+
+	disconnect(): void {
+		this.#session = null;
+	}
+
+	isConnected(): boolean {
+		return this.#session !== null && !(this.#session.isDisposed?.() ?? false);
+	}
+
+	getSession(): HarnessSessionInterface | undefined {
+		return this.#session ?? undefined;
+	}
+
+	getAvailableTools(): readonly ToolDescriptor[] {
+		if (!this.#session) {
+			throw new Error("DefaultLocalLLMPort is not connected to a harness session");
+		}
+		return this.#session.getTools();
+	}
+
+	async dispatchToolCall(request: ToolInvocationRequest): Promise<ToolInvocationResult> {
+		if (!this.#session) {
+			throw new Error("DefaultLocalLLMPort is not connected to a harness session");
+		}
+		return this.#session.invokeTool(request);
+	}
+
+	async dispatchToolCalls(requests: readonly ToolInvocationRequest[]): Promise<readonly ToolInvocationResult[]> {
+		return Promise.all(requests.map(req => this.dispatchToolCall(req)));
+	}
+}

--- a/packages/coding-agent/src/harness/types.ts
+++ b/packages/coding-agent/src/harness/types.ts
@@ -1,0 +1,48 @@
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+
+export interface WorkspacePolicy {
+	readonly cwd: string;
+	readonly additionalDirectories?: readonly string[];
+	readonly readOnly?: boolean;
+	readonly allowNetwork?: boolean;
+	readonly maxExecutionTimeoutMs?: number;
+	readonly blockedPaths?: readonly string[];
+}
+
+export interface ToolDescriptor {
+	readonly name: string;
+	readonly description: string;
+	readonly parameters: unknown;
+	readonly label?: string;
+	readonly hidden?: boolean;
+	readonly deferrable?: boolean;
+	readonly loadMode?: string;
+	readonly summary?: string;
+	readonly strict?: boolean;
+}
+
+export interface ToolInvocationRequest {
+	readonly callId: string;
+	readonly toolName: string;
+	readonly arguments: Record<string, unknown>;
+	readonly signal?: AbortSignal;
+}
+
+export interface ToolInvocationResult {
+	readonly callId: string;
+	readonly toolName: string;
+	readonly content: readonly (TextContent | ImageContent)[];
+	readonly isError?: boolean;
+	readonly details?: unknown;
+}
+
+export interface HarnessSessionInterface {
+	readonly sessionId: string;
+	readonly workspacePolicy: WorkspacePolicy;
+	getTools(): readonly ToolDescriptor[];
+	getTool(name: string): ToolDescriptor | undefined;
+	hasTool(name: string): boolean;
+	invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult>;
+	isDisposed?(): boolean;
+	dispose?(): Promise<void> | void;
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -28,6 +28,14 @@ export * from "./extensibility/extensions";
 export * from "./extensibility/skills";
 // Slash commands
 export { type FileSlashCommand, loadSlashCommands as discoverSlashCommands } from "./extensibility/slash-commands";
+export * from "./harness";
+export {
+	ExternalHarnessController,
+	createConnectedHarnessPair,
+	type ExternalHarnessConfig,
+} from "./harness";
+export * from "./mcp";
+export { OhMyPiMcpServer } from "./mcp";
 export type * from "./lsp";
 // Main entry point
 export * from "./main";

--- a/packages/coding-agent/src/mcp/index.ts
+++ b/packages/coding-agent/src/mcp/index.ts
@@ -25,5 +25,8 @@ export * from "./tool-cache";
 // Transports
 export * from "./transports/http";
 export * from "./transports/stdio";
+// Server
+export * from "./server";
+export { OhMyPiMcpServer } from "./server";
 // Types
 export * from "./types";

--- a/packages/coding-agent/src/mcp/run-server-http.ts
+++ b/packages/coding-agent/src/mcp/run-server-http.ts
@@ -1,0 +1,104 @@
+/**
+ * Dependency-free OhMyPi MCP HTTP entrypoint (Streamable HTTP, stateless).
+ *
+ * Exposes the same OhMyPiMcpServer over HTTP so remote/external MCP clients
+ * (e.g. Copilot over network, curl, other harnesses) can connect without a
+ * stdio subprocess. Same deny-by-default external-mode contract as the stdio
+ * entrypoint: only process-level environment opt-in can enable external control.
+ *
+ *   OMP_MCP_HTTP_PORT=8931                  listen port (default 8931)
+ *   OMP_MCP_HTTP_HOST=127.0.0.1             bind host (default 127.0.0.1)
+ *   OMP_EXTERNAL_HARNESS_ENABLED=1          enable external harness mode
+ *   OMP_EXTERNAL_HARNESS_ALLOW_WRITE=1      permit write/edit tools
+ *   OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION=1  permit bash
+ *   OMP_WORKSPACE_ROOT=/path                workspace root (defaults to cwd)
+ *
+ * Endpoints:
+ *   POST /mcp     JSON-RPC 2.0 request (single object) -> JSON-RPC response
+ *   GET  /health  {"status":"ok","server":"OhMyPi"} liveness probe
+ */
+import { ExternalHarnessController } from "../harness/external-mode";
+import { OhMyPiMcpServer } from "./server";
+import { createStandaloneTools, discoverStandalonePlugins, StandaloneHarness } from "./standalone-harness";
+
+const workspaceRoot = process.env.OMP_WORKSPACE_ROOT ?? process.cwd();
+
+const harness = new StandaloneHarness(workspaceRoot, createStandaloneTools());
+
+const pluginResult = await discoverStandalonePlugins(workspaceRoot);
+for (const tool of pluginResult.tools) {
+	harness.registerTool(tool);
+}
+for (const error of pluginResult.errors) {
+	console.error(`[ohmypi-mcp] plugin load error: ${error}`);
+}
+
+const externalEnabled = process.env.OMP_EXTERNAL_HARNESS_ENABLED === "1";
+const externalController = new ExternalHarnessController({
+	enabled: externalEnabled,
+	allowWrite: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_WRITE === "1",
+	allowExecution: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION === "1",
+	workspaceRoot,
+	allowedTools: ["*"],
+});
+
+const server = new OhMyPiMcpServer(harness, {
+	serverInfo: { name: "OhMyPi", version: "1.0.0" },
+	externalController,
+});
+
+const port = Number(process.env.OMP_MCP_HTTP_PORT ?? 8931);
+const hostname = process.env.OMP_MCP_HTTP_HOST ?? "127.0.0.1";
+
+const jsonHeaders = {
+	"Content-Type": "application/json",
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type, Mcp-Session-Id",
+};
+
+Bun.serve({
+	port,
+	hostname,
+	async fetch(req) {
+		const url = new URL(req.url);
+
+		if (req.method === "OPTIONS") {
+			return new Response(null, { status: 204, headers: jsonHeaders });
+		}
+
+		if (req.method === "GET" && url.pathname === "/health") {
+			return Response.json(
+				{ status: "ok", server: "OhMyPi", externalEnabled },
+				{ headers: jsonHeaders },
+			);
+		}
+
+		if (req.method === "POST" && (url.pathname === "/mcp" || url.pathname === "/")) {
+			let body: unknown;
+			try {
+				body = await req.json();
+			} catch {
+				return Response.json(
+					{ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+					{ status: 200, headers: jsonHeaders },
+				);
+			}
+			const response = await server.handleMessage(body);
+			// Notifications (no id) produce no response; acknowledge with 202.
+			if (response === null || response === undefined) {
+				return new Response(null, { status: 202, headers: jsonHeaders });
+			}
+			return Response.json(response, { headers: jsonHeaders });
+		}
+
+		return Response.json(
+			{ jsonrpc: "2.0", id: null, error: { code: -32601, message: `Not found: ${url.pathname}` } },
+			{ status: 404, headers: jsonHeaders },
+		);
+	},
+});
+
+console.error(`[ohmypi-mcp] HTTP listening on http://${hostname}:${port}/mcp (external=${externalEnabled})`);
+
+export { harness, externalController, server };

--- a/packages/coding-agent/src/mcp/run-server-standalone.ts
+++ b/packages/coding-agent/src/mcp/run-server-standalone.ts
@@ -1,0 +1,50 @@
+/**
+ * Dependency-free OhMyPi MCP stdio entrypoint.
+ *
+ * Runs the MCP server over stdio using the standalone harness (Bun/Node builtins
+ * only), so it works without `bun install`. External harness access is
+ * deny-by-default and can only be enabled by process-level environment opt-in;
+ * project/plugin/model configuration can never grant external control.
+ *
+ *   OMP_EXTERNAL_HARNESS_ENABLED=1        enable external harness mode
+ *   OMP_EXTERNAL_HARNESS_ALLOW_WRITE=1    permit write/edit tools
+ *   OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION=1 permit bash
+ *   OMP_WORKSPACE_ROOT=/path              workspace root (defaults to cwd)
+ */
+import { ExternalHarnessController } from "../harness/external-mode";
+import { OhMyPiMcpServer } from "./server";
+import { createStandaloneTools, discoverStandalonePlugins, StandaloneHarness } from "./standalone-harness";
+
+// stdout is reserved for JSON-RPC framing; route all diagnostics to stderr.
+console.log = (...args: unknown[]) => console.error(...args);
+console.info = (...args: unknown[]) => console.error(...args);
+
+const workspaceRoot = process.env.OMP_WORKSPACE_ROOT ?? process.cwd();
+
+const harness = new StandaloneHarness(workspaceRoot, createStandaloneTools());
+
+const pluginResult = await discoverStandalonePlugins(workspaceRoot);
+for (const tool of pluginResult.tools) {
+	harness.registerTool(tool);
+}
+for (const error of pluginResult.errors) {
+	console.error(`[ohmypi-mcp] plugin load error: ${error}`);
+}
+
+const externalEnabled = process.env.OMP_EXTERNAL_HARNESS_ENABLED === "1";
+const externalController = new ExternalHarnessController({
+	enabled: externalEnabled,
+	allowWrite: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_WRITE === "1",
+	allowExecution: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION === "1",
+	workspaceRoot,
+	allowedTools: ["*"],
+});
+
+const server = new OhMyPiMcpServer(harness, {
+	serverInfo: { name: "OhMyPi", version: "1.0.0" },
+	externalController,
+});
+
+server.startStdioServer();
+
+export { harness, externalController, server };

--- a/packages/coding-agent/src/mcp/run-server.ts
+++ b/packages/coding-agent/src/mcp/run-server.ts
@@ -1,0 +1,86 @@
+import { logger } from "@oh-my-pi/pi-utils";
+import { Settings } from "../config/settings";
+import { discoverAndLoadCustomTools } from "../extensibility/custom-tools/loader";
+import { LocalHarnessAdapter } from "../harness/adapter";
+import { ExternalHarnessController } from "../harness/external-mode";
+import { createTools, type Tool, type ToolSession } from "../tools";
+import { OhMyPiMcpServer } from "./server";
+
+// Ensure stdio server runs without polluting stdout with non-JSON-RPC logs
+logger.setTransports({ console: false, file: false });
+console.log = (...args: unknown[]) => {
+	console.error(...args);
+};
+console.info = (...args: unknown[]) => {
+	console.error(...args);
+};
+
+const workspaceRoot = process.env.OMP_WORKSPACE_ROOT ?? "/home/coder/OhMyPi";
+
+const session: ToolSession = {
+	cwd: workspaceRoot,
+	hasUI: false,
+	skipPythonPreflight: true,
+	settings: Settings.isolated(),
+	getSessionId: () => "ohmypi-mcp-session",
+	getSessionFile: () => null,
+	getSessionSpawns: () => "*",
+};
+
+const tools = await createTools(session);
+const toolRegistry = new Map<string, Tool>();
+for (const tool of tools) {
+	toolRegistry.set(tool.name, tool);
+}
+
+// Load custom/plugin tools headlessly. Loader executes plugin code on import; only
+// trusted local sources are scanned. Errors go to stderr to keep stdout JSON-RPC clean.
+try {
+	const builtInToolNames = tools.map((tool) => tool.name);
+	const loaded = await discoverAndLoadCustomTools([], workspaceRoot, builtInToolNames);
+	for (const loadedTool of loaded.tools) {
+		toolRegistry.set(loadedTool.tool.name, loadedTool.tool);
+	}
+	for (const error of loaded.errors) {
+		console.error(`[ohmypi-mcp] custom tool load error: ${error.path}: ${error.error}`);
+	}
+} catch (error) {
+	console.error(`[ohmypi-mcp] custom tool discovery failed: ${String(error)}`);
+}
+
+const harness = new LocalHarnessAdapter({
+	session,
+	toolRegistry,
+	workspacePolicy: {
+		cwd: workspaceRoot,
+		readOnly: false,
+		allowNetwork: true,
+	},
+});
+
+for (const tool of toolRegistry.values()) {
+	harness.registerTool(tool);
+}
+
+// External harness is deny-by-default. Only process-level env opt-in can enable it;
+// project/plugin/model configuration can never grant external control.
+const externalEnabled = process.env.OMP_EXTERNAL_HARNESS_ENABLED === "1";
+const externalController = new ExternalHarnessController({
+	enabled: externalEnabled,
+	allowWrite: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_WRITE === "1",
+	allowExecution: externalEnabled && process.env.OMP_EXTERNAL_HARNESS_ALLOW_EXECUTION === "1",
+	workspaceRoot,
+	allowedTools: ["*"],
+});
+
+const server = new OhMyPiMcpServer(harness, {
+	serverInfo: {
+		name: "OhMyPi",
+		version: "1.0.0",
+	},
+	externalController,
+});
+
+server.startStdioServer();
+
+export { harness, externalController, server };

--- a/packages/coding-agent/src/mcp/server.ts
+++ b/packages/coding-agent/src/mcp/server.ts
@@ -1,0 +1,369 @@
+import * as readline from "node:readline";
+import type { ExternalHarnessConfig, ExternalHarnessController } from "../harness/external-mode";
+import { ExternalHarnessController as ExternalHarnessControllerImpl } from "../harness/external-mode";
+import type {
+	HarnessSessionInterface,
+	ToolDescriptor,
+	ToolInvocationRequest,
+} from "../harness/types";
+
+export interface McpTransport {
+	send: (msg: any) => void;
+	onMessage: (cb: (msg: any) => void) => void;
+}
+
+export interface OhMyPiMcpServerOptions {
+	serverInfo?: {
+		name?: string;
+		version?: string;
+	};
+	protocolVersion?: string;
+	externalController?: ExternalHarnessController;
+	externalMode?: ExternalHarnessConfig;
+}
+
+export class OhMyPiMcpServer {
+	readonly #harness: HarnessSessionInterface;
+	readonly #serverInfo: { name: string; version: string };
+	readonly #protocolVersion: string;
+	readonly #externalController?: ExternalHarnessController;
+
+	constructor(harness: HarnessSessionInterface, options?: OhMyPiMcpServerOptions) {
+		this.#harness = harness;
+		this.#serverInfo = {
+			name: options?.serverInfo?.name ?? "ohmypi-mcp-server",
+			version: options?.serverInfo?.version ?? "0.1.0",
+		};
+		this.#protocolVersion = options?.protocolVersion ?? "2024-11-05";
+		if (options?.externalController) {
+			this.#externalController = options.externalController;
+		} else if (options?.externalMode) {
+			this.#externalController = new ExternalHarnessControllerImpl(options.externalMode);
+		}
+	}
+
+	get harness(): HarnessSessionInterface {
+		return this.#harness;
+	}
+
+	get externalController(): ExternalHarnessController | undefined {
+		return this.#externalController;
+	}
+
+	connectTransport(transport: {
+		send: (msg: any) => void;
+		onMessage: (cb: (msg: any) => void) => void;
+	}): void {
+		transport.onMessage(async (msg: any) => {
+			try {
+				const response = await this.handleMessage(msg);
+				if (response !== null && response !== undefined) {
+					transport.send(response);
+				}
+			} catch (err) {
+				transport.send({
+					jsonrpc: "2.0",
+					id: null,
+					error: {
+						code: -32603,
+						message: err instanceof Error ? err.message : "Internal error",
+					},
+				});
+			}
+		});
+	}
+
+	async handleMessage(message: unknown): Promise<unknown> {
+		let parsed: unknown;
+		if (typeof message === "string") {
+			try {
+				parsed = JSON.parse(message);
+			} catch {
+				return {
+					jsonrpc: "2.0",
+					id: null,
+					error: {
+						code: -32700,
+						message: "Parse error",
+					},
+				};
+			}
+		} else if (message !== null && typeof message === "object") {
+			parsed = message;
+		} else {
+			return {
+				jsonrpc: "2.0",
+				id: null,
+				error: {
+					code: -32600,
+					message: "Invalid Request",
+				},
+			};
+		}
+
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return {
+				jsonrpc: "2.0",
+				id: null,
+				error: {
+					code: -32600,
+					message: "Invalid Request",
+				},
+			};
+		}
+
+		const req = parsed as Record<string, unknown>;
+		const hasId = "id" in req && req.id !== undefined;
+		const id = hasId ? req.id : null;
+
+		if (req.jsonrpc !== "2.0") {
+			if (!hasId) return null;
+			return {
+				jsonrpc: "2.0",
+				id,
+				error: {
+					code: -32600,
+					message: "Invalid Request: jsonrpc must be '2.0'",
+				},
+			};
+		}
+
+		if (typeof req.method !== "string") {
+			if (!hasId) return null;
+			return {
+				jsonrpc: "2.0",
+				id,
+				error: {
+					code: -32600,
+					message: "Invalid Request: method must be a string",
+				},
+			};
+		}
+
+		if (!hasId) {
+			return null;
+		}
+
+		switch (req.method) {
+			case "initialize": {
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: {
+						protocolVersion: this.#protocolVersion,
+						capabilities: {
+							tools: {},
+						},
+						serverInfo: this.#serverInfo,
+					},
+				};
+			}
+
+			case "tools/list": {
+				if (this.#externalController && !this.#externalController.isEnabled()) {
+					return {
+						jsonrpc: "2.0",
+						id,
+						error: {
+							code: "EXTERNAL_HARNESS_DISABLED",
+							message: "External harness mode is disabled for this OhMyPi workspace.",
+						},
+					};
+				}
+
+				const descriptors = this.#harness.getTools();
+				const allowedDescriptors = this.#externalController
+					? descriptors.filter(tool => this.#externalController!.isToolAllowed(tool.name))
+					: descriptors;
+				const tools = allowedDescriptors.map((tool: ToolDescriptor) => {
+					const rawParams = tool.parameters;
+					const paramsObj =
+						rawParams && typeof rawParams === "object" && !Array.isArray(rawParams)
+							? (rawParams as Record<string, unknown>)
+							: {};
+					return {
+						name: tool.name,
+						description: tool.description ?? "",
+						inputSchema: {
+							...paramsObj,
+							type: "object" as const,
+							properties:
+								paramsObj.properties &&
+								typeof paramsObj.properties === "object" &&
+								!Array.isArray(paramsObj.properties)
+									? (paramsObj.properties as Record<string, unknown>)
+									: {},
+						},
+					};
+				});
+
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: {
+						tools,
+					},
+				};
+			}
+
+			case "tools/call": {
+				const params = req.params as Record<string, unknown> | undefined;
+				if (!params || typeof params.name !== "string") {
+					return {
+						jsonrpc: "2.0",
+						id,
+						error: {
+							code: -32602,
+							message: "Invalid params: 'name' is required",
+						},
+					};
+				}
+
+				const toolName = params.name;
+				const toolArgs =
+					params.arguments && typeof params.arguments === "object" && !Array.isArray(params.arguments)
+						? (params.arguments as Record<string, unknown>)
+						: {};
+
+				if (this.#externalController) {
+					const auth = this.#externalController.authorizeInvocation(toolName);
+					if (!auth.allowed) {
+						return {
+							jsonrpc: "2.0",
+							id,
+							error: auth.error ?? {
+								code: "PERMISSION_DENIED",
+								message: `Tool "${toolName}" is not permitted by external harness policy.`,
+							},
+						};
+					}
+				}
+
+				if (typeof this.#harness.hasTool === "function" && !this.#harness.hasTool(toolName)) {
+					return {
+						jsonrpc: "2.0",
+						id,
+						result: {
+							content: [
+								{
+									type: "text",
+									text: JSON.stringify({
+										error: "TOOL_UNAVAILABLE",
+										message: `Tool "${toolName}" not found or unavailable`,
+									}),
+								},
+							],
+							isError: true,
+						},
+					};
+				}
+
+				try {
+					const invocationReq: ToolInvocationRequest = {
+						callId: `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+						toolName,
+						arguments: toolArgs,
+					};
+					const invokeResult = await this.#harness.invokeTool(invocationReq);
+
+					const isError = Boolean(
+						invokeResult &&
+							typeof invokeResult === "object" &&
+							(invokeResult as { isError?: boolean }).isError,
+					);
+
+					let content: unknown[];
+					if (
+						invokeResult &&
+						typeof invokeResult === "object" &&
+						Array.isArray((invokeResult as { content?: unknown[] }).content)
+					) {
+						content = (invokeResult as { content: unknown[] }).content;
+					} else {
+						content = [
+							{
+								type: "text",
+								text:
+									typeof invokeResult === "string"
+										? invokeResult
+										: JSON.stringify(invokeResult ?? null),
+							},
+						];
+					}
+
+					return {
+						jsonrpc: "2.0",
+						id,
+						result: {
+							content,
+							...(isError ? { isError: true } : {}),
+						},
+					};
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					return {
+						jsonrpc: "2.0",
+						id,
+						result: {
+							content: [
+								{
+									type: "text",
+									text: JSON.stringify({ error: "EXECUTION_ERROR", message }),
+								},
+							],
+							isError: true,
+						},
+					};
+				}
+			}
+
+			case "ping": {
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: {},
+				};
+			}
+
+			default: {
+				return {
+					jsonrpc: "2.0",
+					id,
+					error: {
+						code: -32601,
+						message: `Method not found: ${req.method}`,
+					},
+				};
+			}
+		}
+	}
+
+	startStdioServer(): void {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+			terminal: false,
+		});
+
+		rl.on("line", async (line: string) => {
+			const trimmed = line.trim();
+			if (trimmed.length === 0) return;
+			try {
+				const response = await this.handleMessage(trimmed);
+				if (response !== null && response !== undefined) {
+					process.stdout.write(`${JSON.stringify(response)}\n`);
+				}
+			} catch (err) {
+				const errorResponse = {
+					jsonrpc: "2.0",
+					id: null,
+					error: {
+						code: -32603,
+						message: err instanceof Error ? err.message : "Internal error",
+					},
+				};
+				process.stdout.write(`${JSON.stringify(errorResponse)}\n`);
+			}
+		});
+	}
+}

--- a/packages/coding-agent/src/mcp/standalone-harness.ts
+++ b/packages/coding-agent/src/mcp/standalone-harness.ts
@@ -1,0 +1,352 @@
+/**
+ * Dependency-free harness implementation for the OhMyPi MCP server.
+ *
+ * The full OhMyPi tool registry depends on workspace packages that require
+ * `bun install` (native addon + third-party modules). This module provides a
+ * self-contained, real workspace tool set built only on Bun/Node builtins so
+ * the MCP server can run and operate the workspace without that dependency
+ * chain. Plugin/custom tools are discovered best-effort from trusted local
+ * directories and registered alongside the built-ins.
+ */
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type {
+	HarnessSessionInterface,
+	ToolDescriptor,
+	ToolInvocationRequest,
+	ToolInvocationResult,
+	WorkspacePolicy,
+} from "../harness/types";
+
+export interface StandaloneToolContext {
+	readonly cwd: string;
+	readonly signal?: AbortSignal;
+}
+
+export interface StandaloneToolResult {
+	readonly text: string;
+	readonly isError?: boolean;
+}
+
+export interface StandaloneTool {
+	readonly name: string;
+	readonly description: string;
+	readonly parameters: Record<string, unknown>;
+	/** Marks a tool that mutates the workspace (gated by allowWrite). */
+	readonly write?: boolean;
+	/** Marks a tool that executes arbitrary commands (gated by allowExecution). */
+	readonly execution?: boolean;
+	run(args: Record<string, unknown>, ctx: StandaloneToolContext): Promise<StandaloneToolResult>;
+}
+
+/** Resolve a path and reject anything that escapes the workspace root. */
+export function resolveWithin(cwd: string, target: string): string {
+	const abs = isAbsolute(target) ? resolve(target) : resolve(cwd, target);
+	const rel = relative(cwd, abs);
+	if (rel === "") return abs;
+	if (rel.startsWith("..") || isAbsolute(rel)) {
+		throw new Error(`WORKSPACE_ESCAPE: path "${target}" resolves outside workspace root`);
+	}
+	return abs;
+}
+
+function asString(value: unknown, fallback = ""): string {
+	return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function createStandaloneTools(): StandaloneTool[] {
+	return [
+		{
+			name: "read",
+			description: "Read a UTF-8 text file within the workspace. Returns numbered lines.",
+			parameters: {
+				type: "object",
+				properties: {
+					filePath: { type: "string", description: "Path to the file, relative to the workspace root." },
+					offset: { type: "number", description: "Zero-based line offset to start reading from." },
+					limit: { type: "number", description: "Maximum number of lines to return." },
+				},
+				required: ["filePath"],
+			},
+			async run(args, ctx) {
+				const target = asString(args.filePath ?? args.path);
+				const filePath = resolveWithin(ctx.cwd, target);
+				const content = await readFile(filePath, "utf8");
+				const lines = content.split("\n");
+				const offset = asNumber(args.offset) ?? 0;
+				const limit = asNumber(args.limit) ?? lines.length;
+				const slice = lines.slice(offset, offset + limit);
+				return { text: slice.map((line, i) => `${offset + i + 1}\t${line}`).join("\n") };
+			},
+		},
+		{
+			name: "write",
+			description: "Write a UTF-8 text file within the workspace, creating parent directories.",
+			parameters: {
+				type: "object",
+				properties: {
+					filePath: { type: "string", description: "Path to the file, relative to the workspace root." },
+					content: { type: "string", description: "Full file content to write." },
+				},
+				required: ["filePath", "content"],
+			},
+			write: true,
+			async run(args, ctx) {
+				const filePath = resolveWithin(ctx.cwd, asString(args.filePath ?? args.path));
+				await mkdir(dirname(filePath), { recursive: true });
+				await writeFile(filePath, asString(args.content), "utf8");
+				return { text: `Wrote ${filePath}` };
+			},
+		},
+		{
+			name: "edit",
+			description: "Replace an exact string in a workspace file. Fails if the old string is absent or ambiguous.",
+			parameters: {
+				type: "object",
+				properties: {
+					filePath: { type: "string", description: "Path to the file, relative to the workspace root." },
+					oldString: { type: "string", description: "Exact text to replace." },
+					newString: { type: "string", description: "Replacement text." },
+				},
+				required: ["filePath", "oldString", "newString"],
+			},
+			write: true,
+			async run(args, ctx) {
+				const filePath = resolveWithin(ctx.cwd, asString(args.filePath ?? args.path));
+				const content = await readFile(filePath, "utf8");
+				const oldString = asString(args.oldString);
+				const newString = asString(args.newString);
+				const first = content.indexOf(oldString);
+				if (first === -1) {
+					return { text: `oldString not found in ${filePath}`, isError: true };
+				}
+				if (content.indexOf(oldString, first + oldString.length) !== -1) {
+					return { text: `oldString is ambiguous in ${filePath}; provide more context`, isError: true };
+				}
+				await writeFile(filePath, content.replace(oldString, newString), "utf8");
+				return { text: `Edited ${filePath}` };
+			},
+		},
+		{
+			name: "glob",
+			description: "Find files by glob pattern within the workspace.",
+			parameters: {
+				type: "object",
+				properties: {
+					pattern: { type: "string", description: "Glob pattern, e.g. '**/*.ts'." },
+				},
+				required: ["pattern"],
+			},
+			async run(args, ctx) {
+				const pattern = asString(args.pattern);
+				const glob = new Bun.Glob(pattern);
+				const matches: string[] = [];
+				for await (const file of glob.scan({ cwd: ctx.cwd, dot: false })) {
+					matches.push(file);
+					if (matches.length >= 500) break;
+				}
+				return { text: matches.join("\n") || "(no matches)" };
+			},
+		},
+		{
+			name: "grep",
+			description: "Search file contents by regular expression within the workspace.",
+			parameters: {
+				type: "object",
+				properties: {
+					pattern: { type: "string", description: "Regular expression to search for." },
+					glob: { type: "string", description: "Optional file glob filter, e.g. '**/*.ts'." },
+				},
+				required: ["pattern"],
+			},
+			async run(args, ctx) {
+				const regex = new RegExp(asString(args.pattern));
+				const glob = new Bun.Glob(asString(args.glob, "**/*"));
+				const matches: string[] = [];
+				for await (const file of glob.scan({ cwd: ctx.cwd, dot: false })) {
+					if (matches.length >= 200) break;
+					try {
+						const content = await readFile(resolve(ctx.cwd, file), "utf8");
+						const lines = content.split("\n");
+						for (let i = 0; i < lines.length; i++) {
+							if (regex.test(lines[i])) {
+								matches.push(`${file}:${i + 1}:${lines[i]}`);
+								if (matches.length >= 200) break;
+							}
+						}
+					} catch {
+						// Skip unreadable/binary files.
+					}
+				}
+				return { text: matches.join("\n") || "(no matches)" };
+			},
+		},
+		{
+			name: "list_dir",
+			description: "List directory entries within the workspace.",
+			parameters: {
+				type: "object",
+				properties: {
+					dirPath: { type: "string", description: "Directory path relative to the workspace root. Defaults to '.'." },
+				},
+			},
+			async run(args, ctx) {
+				const dirPath = resolveWithin(ctx.cwd, asString(args.dirPath ?? args.path, "."));
+				const entries = await readdir(dirPath, { withFileTypes: true });
+				const rendered = entries.map(entry => (entry.isDirectory() ? `${entry.name}/` : entry.name));
+				return { text: rendered.join("\n") || "(empty)" };
+			},
+		},
+		{
+			name: "bash",
+			description: "Execute a shell command in the workspace root and return combined output.",
+			parameters: {
+				type: "object",
+				properties: {
+					command: { type: "string", description: "Shell command to execute." },
+				},
+				required: ["command"],
+			},
+			execution: true,
+			async run(args, ctx) {
+				const command = asString(args.command);
+				const proc = Bun.spawn(["bash", "-lc", command], {
+					cwd: ctx.cwd,
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				const [stdout, stderr] = await Promise.all([
+					new Response(proc.stdout).text(),
+					new Response(proc.stderr).text(),
+				]);
+				const exitCode = await proc.exited;
+				const combined = [stdout, stderr].filter(part => part.length > 0).join("\n").trim();
+				return {
+					text: combined || `(exit ${exitCode})`,
+					isError: exitCode !== 0,
+				};
+			},
+		},
+	];
+}
+
+export class StandaloneHarness implements HarnessSessionInterface {
+	readonly sessionId: string;
+	readonly workspacePolicy: WorkspacePolicy;
+	readonly #tools = new Map<string, StandaloneTool>();
+
+	constructor(cwd: string, tools: StandaloneTool[] = []) {
+		this.sessionId = `standalone_${Date.now()}`;
+		this.workspacePolicy = {
+			cwd,
+			readOnly: false,
+			allowNetwork: true,
+		};
+		for (const tool of tools) {
+			this.#tools.set(tool.name, tool);
+		}
+	}
+
+	registerTool(tool: StandaloneTool): void {
+		this.#tools.set(tool.name, tool);
+	}
+
+	#toDescriptor(tool: StandaloneTool): ToolDescriptor {
+		return {
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+		};
+	}
+
+	getTools(): readonly ToolDescriptor[] {
+		return Array.from(this.#tools.values(), tool => this.#toDescriptor(tool));
+	}
+
+	getTool(name: string): ToolDescriptor | undefined {
+		const tool = this.#tools.get(name);
+		return tool ? this.#toDescriptor(tool) : undefined;
+	}
+
+	hasTool(name: string): boolean {
+		return this.#tools.has(name);
+	}
+
+	async invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult> {
+		const tool = this.#tools.get(request.toolName);
+		if (!tool) {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Tool not found: "${request.toolName}"` }],
+				isError: true,
+			};
+		}
+		try {
+			const result = await tool.run(request.arguments, {
+				cwd: this.workspacePolicy.cwd,
+				signal: request.signal,
+			});
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: result.text }],
+				isError: result.isError,
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: `Error executing ${request.toolName}: ${message}` }],
+				isError: true,
+			};
+		}
+	}
+}
+
+/**
+ * Best-effort discovery of custom/plugin tools from trusted local directories.
+ * Plugin modules are imported directly; failures are reported, never fatal.
+ */
+export async function discoverStandalonePlugins(
+	cwd: string,
+): Promise<{ tools: StandaloneTool[]; errors: string[] }> {
+	const directories = [join(cwd, ".omp", "tools"), join(cwd, ".claude", "tools")];
+	const tools: StandaloneTool[] = [];
+	const errors: string[] = [];
+
+	for (const directory of directories) {
+		let entries: string[];
+		try {
+			entries = await readdir(directory);
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (!/\.(ts|js|mjs)$/.test(entry)) continue;
+			try {
+				const module = await import(join(directory, entry));
+				const candidates: unknown[] = [module.default, ...Object.values(module)];
+				for (const candidate of candidates) {
+					if (
+						candidate &&
+						typeof candidate === "object" &&
+						typeof (candidate as StandaloneTool).name === "string" &&
+						typeof (candidate as StandaloneTool).run === "function"
+					) {
+						tools.push(candidate as StandaloneTool);
+					}
+				}
+			} catch (error) {
+				errors.push(`${entry}: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
+	}
+
+	return { tools, errors };
+}

--- a/packages/coding-agent/test/mcp-external-mode.test.ts
+++ b/packages/coding-agent/test/mcp-external-mode.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createConnectedHarnessPair,
+	DefaultInProcessHarness,
+	EXTERNAL_HARNESS_DISABLED_ERROR,
+	ExternalHarnessController,
+} from "../src/harness/external-mode";
+import { DefaultLocalLLMPort } from "../src/harness/llm-port";
+import { OhMyPiMcpServer } from "../src/mcp/server";
+
+describe("mcp-external-mode", () => {
+	test("Test 1: ExternalHarnessController default state (isEnabled() is false, authorizeInvocation returns allowed: false)", () => {
+		const controller = new ExternalHarnessController();
+		expect(controller.isEnabled()).toBe(false);
+		expect(controller.enabled).toBe(false);
+
+		const auth = controller.authorizeInvocation("read_file");
+		expect(auth.allowed).toBe(false);
+		expect(auth.error).toEqual(EXTERNAL_HARNESS_DISABLED_ERROR);
+		expect(auth.error?.code).toBe("EXTERNAL_HARNESS_DISABLED");
+	});
+
+	test("Test 2: ExternalHarnessController enable() / disable() toggles state dynamically", () => {
+		const controller = new ExternalHarnessController();
+		expect(controller.isEnabled()).toBe(false);
+		expect(controller.config.enabled).toBe(false);
+
+		controller.enable();
+		expect(controller.isEnabled()).toBe(true);
+		expect(controller.enabled).toBe(true);
+		expect(controller.config.enabled).toBe(true);
+
+		controller.disable();
+		expect(controller.isEnabled()).toBe(false);
+		expect(controller.enabled).toBe(false);
+		expect(controller.config.enabled).toBe(false);
+	});
+
+	test("Test 3: Tool allowlisting (allowedTools filtering, write permission check, execution permission check)", () => {
+		// allowedTools filtering
+		const filterController = new ExternalHarnessController({
+			enabled: true,
+			allowedTools: ["read_file", "custom_tool"],
+		});
+		expect(filterController.isToolAllowed("read_file")).toBe(true);
+		expect(filterController.isToolAllowed("custom_tool")).toBe(true);
+		expect(filterController.isToolAllowed("other_tool")).toBe(false);
+		expect(filterController.authorizeInvocation("other_tool")).toEqual({
+			allowed: false,
+			error: {
+				code: "PERMISSION_DENIED",
+				message: 'Tool "other_tool" is not permitted by external harness policy.',
+			},
+		});
+
+		// write permission check
+		const writeBlockedController = new ExternalHarnessController({
+			enabled: true,
+			allowedTools: ["write_file", "read_file"],
+			allowWrite: false,
+		});
+		expect(writeBlockedController.checkToolPermission("write_file")).toEqual({
+			allowed: false,
+			error: {
+				code: "PERMISSION_DENIED",
+				message: 'Write operations are not permitted by external harness policy for tool "write_file".',
+			},
+		});
+		expect(writeBlockedController.checkToolPermission("read_file").allowed).toBe(true);
+
+		const writeAllowedController = new ExternalHarnessController({
+			enabled: true,
+			allowedTools: ["write_file"],
+			allowWrite: true,
+		});
+		expect(writeAllowedController.checkToolPermission("write_file").allowed).toBe(true);
+
+		// execution permission check
+		const execBlockedController = new ExternalHarnessController({
+			enabled: true,
+			allowedTools: ["bash", "read_file"],
+			allowExecution: false,
+		});
+		expect(execBlockedController.checkToolPermission("bash")).toEqual({
+			allowed: false,
+			error: {
+				code: "PERMISSION_DENIED",
+				message: 'Execution operations are not permitted by external harness policy for tool "bash".',
+			},
+		});
+		expect(execBlockedController.checkToolPermission("read_file").allowed).toBe(true);
+
+		const execAllowedController = new ExternalHarnessController({
+			enabled: true,
+			allowedTools: ["bash"],
+			allowExecution: true,
+		});
+		expect(execAllowedController.checkToolPermission("bash").allowed).toBe(true);
+	});
+
+	test("Test 4: OhMyPiMcpServer integration with externalController (disabled vs enabled)", async () => {
+		const harness = new DefaultInProcessHarness("/home/coder/OhMyPi");
+		harness.registerTool(
+			{
+				name: "allowed_tool",
+				description: "Permitted tool",
+				parameters: { type: "object", properties: {} },
+			},
+			async (req) => ({
+				callId: req.callId,
+				toolName: req.toolName,
+				content: [{ type: "text", text: "allowed tool response" }],
+			}),
+		);
+		harness.registerTool(
+			{
+				name: "unauthorized_tool",
+				description: "Unauthorized tool",
+				parameters: { type: "object", properties: {} },
+			},
+			async (req) => ({
+				callId: req.callId,
+				toolName: req.toolName,
+				content: [{ type: "text", text: "unauthorized tool response" }],
+			}),
+		);
+
+		const controller = new ExternalHarnessController({
+			enabled: false,
+			allowedTools: ["allowed_tool"],
+		});
+		const server = new OhMyPiMcpServer(harness, { externalController: controller });
+
+		// When disabled: tools/list and tools/call fail with EXTERNAL_HARNESS_DISABLED error
+		const disabledListRes = (await server.handleMessage({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/list",
+		})) as any;
+		expect(disabledListRes.error).toBeDefined();
+		expect(disabledListRes.error.code).toBe("EXTERNAL_HARNESS_DISABLED");
+
+		const disabledCallRes = (await server.handleMessage({
+			jsonrpc: "2.0",
+			id: 2,
+			method: "tools/call",
+			params: { name: "allowed_tool", arguments: {} },
+		})) as any;
+		expect(disabledCallRes.error).toBeDefined();
+		expect(disabledCallRes.error.code).toBe("EXTERNAL_HARNESS_DISABLED");
+
+		// When enabled: tools/list filters tools, tools/call succeeds for authorized, fails for unauthorized
+		controller.enable();
+
+		const enabledListRes = (await server.handleMessage({
+			jsonrpc: "2.0",
+			id: 3,
+			method: "tools/list",
+		})) as any;
+		expect(enabledListRes.error).toBeUndefined();
+		expect(enabledListRes.result).toBeDefined();
+		expect(enabledListRes.result.tools).toHaveLength(1);
+		expect(enabledListRes.result.tools[0].name).toBe("allowed_tool");
+
+		const authCallRes = (await server.handleMessage({
+			jsonrpc: "2.0",
+			id: 4,
+			method: "tools/call",
+			params: { name: "allowed_tool", arguments: {} },
+		})) as any;
+		expect(authCallRes.error).toBeUndefined();
+		expect(authCallRes.result).toBeDefined();
+		expect(authCallRes.result.content[0].text).toBe("allowed tool response");
+
+		const unauthCallRes = (await server.handleMessage({
+			jsonrpc: "2.0",
+			id: 5,
+			method: "tools/call",
+			params: { name: "unauthorized_tool", arguments: {} },
+		})) as any;
+		expect(unauthCallRes.error).toBeDefined();
+		expect(unauthCallRes.error.code).toBe("PERMISSION_DENIED");
+	});
+
+	test("Test 5: createConnectedHarnessPair creates functional pair with default in-process LLM connection", async () => {
+		const pair = createConnectedHarnessPair({
+			externalConfig: {
+				enabled: true,
+				allowedTools: ["calc"],
+			},
+		});
+
+		expect(pair.harness).toBeDefined();
+		expect(pair.mcpServer).toBeDefined();
+		expect(pair.llmPort).toBeInstanceOf(DefaultLocalLLMPort);
+		expect(pair.externalController).toBeInstanceOf(ExternalHarnessController);
+		expect(pair.controller).toBe(pair.externalController);
+		expect(pair.externalController.isEnabled()).toBe(true);
+
+		// Verify default in-process LLM connection
+		expect(pair.llmPort.isConnected()).toBe(true);
+		expect(pair.llmPort.getSession()).toBe(pair.harness);
+
+		// Functional dispatch through LLM port
+		(pair.harness as DefaultInProcessHarness).registerTool(
+			{
+				name: "calc",
+				description: "Calculator",
+				parameters: { type: "object", properties: {} },
+			},
+			async (req) => ({
+				callId: req.callId,
+				toolName: req.toolName,
+				content: [{ type: "text", text: "42" }],
+			}),
+		);
+
+		const tools = pair.llmPort.getAvailableTools();
+		expect(tools.some((t) => t.name === "calc")).toBe(true);
+
+		const dispatchRes = await pair.llmPort.dispatchToolCall({
+			callId: "call_abc",
+			toolName: "calc",
+			arguments: {},
+		});
+		expect(dispatchRes.isError).toBeFalsy();
+		expect(dispatchRes.content[0].text).toBe("42");
+
+		// Verify externalHook is functional
+		expect(pair.externalHook).toBeDefined();
+		if (pair.externalHook) {
+			const hookRes = await pair.externalHook.invokeTool({
+				callId: "call_hook",
+				toolName: "calc",
+				arguments: {},
+			});
+			expect(hookRes.isError).toBeFalsy();
+			expect(hookRes.content[0].text).toBe("42");
+
+			const hookUnauthorizedRes = await pair.externalHook.invokeTool({
+				callId: "call_hook_unauth",
+				toolName: "forbidden_tool",
+				arguments: {},
+			});
+			expect(hookUnauthorizedRes.isError).toBe(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp-server-check.ts
+++ b/packages/coding-agent/test/mcp-server-check.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { OhMyPiMcpServer } from "../src/mcp/server.ts";
+import type {
+	HarnessSessionInterface,
+	ToolDescriptor,
+	ToolInvocationRequest,
+	ToolInvocationResult,
+	WorkspacePolicy,
+} from "../src/harness/types.ts";
+
+const mockTools: ToolDescriptor[] = [
+	{
+		name: "read_file",
+		description: "Read a file from disk",
+		parameters: {
+			type: "object",
+			properties: {
+				filePath: { type: "string" },
+			},
+			required: ["filePath"],
+		},
+	},
+	{
+		name: "custom_plugin_tool",
+		description: "A custom plugin tool",
+		parameters: {
+			type: "object",
+			properties: {
+				query: { type: "string" },
+			},
+		},
+	},
+];
+
+const mockWorkspacePolicy: WorkspacePolicy = {
+	cwd: "/test",
+	readOnly: false,
+};
+
+let lastInvocationRequest: ToolInvocationRequest | undefined;
+
+const mockHarness: HarnessSessionInterface = {
+	sessionId: "test-session-123",
+	workspacePolicy: mockWorkspacePolicy,
+	getTools(): readonly ToolDescriptor[] {
+		return mockTools;
+	},
+	getTool(name: string): ToolDescriptor | undefined {
+		return mockTools.find(t => t.name === name);
+	},
+	hasTool(name: string): boolean {
+		return mockTools.some(t => t.name === name);
+	},
+	async invokeTool(request: ToolInvocationRequest): Promise<ToolInvocationResult> {
+		lastInvocationRequest = request;
+		if (request.toolName === "read_file") {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: "file content hello world" }],
+			};
+		}
+		if (request.toolName === "error_tool") {
+			return {
+				callId: request.callId,
+				toolName: request.toolName,
+				content: [{ type: "text", text: "tool failure" }],
+				isError: true,
+			};
+		}
+		return {
+			callId: request.callId,
+			toolName: request.toolName,
+			content: [{ type: "text", text: "ok" }],
+		};
+	},
+};
+
+async function runTests() {
+	const server = new OhMyPiMcpServer(mockHarness);
+
+	// 1. initialize
+	const initRes = await server.handleMessage({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {
+			protocolVersion: "2024-11-05",
+			capabilities: {},
+			clientInfo: { name: "test-client", version: "1.0.0" },
+		},
+	});
+	assert.deepEqual(initRes, {
+		jsonrpc: "2.0",
+		id: 1,
+		result: {
+			protocolVersion: "2024-11-05",
+			capabilities: { tools: {} },
+			serverInfo: { name: "ohmypi-mcp-server", version: "0.1.0" },
+		},
+	});
+
+	// 2. tools/list
+	const listRes = (await server.handleMessage({
+		jsonrpc: "2.0",
+		id: 2,
+		method: "tools/list",
+	})) as any;
+	assert.equal(listRes.jsonrpc, "2.0");
+	assert.equal(listRes.id, 2);
+	assert.equal(listRes.result.tools.length, 2);
+	assert.equal(listRes.result.tools[0].name, "read_file");
+	assert.equal(listRes.result.tools[0].description, "Read a file from disk");
+	assert.equal(listRes.result.tools[0].inputSchema.type, "object");
+	assert.deepEqual(listRes.result.tools[0].inputSchema.required, ["filePath"]);
+	assert.equal(listRes.result.tools[1].name, "custom_plugin_tool");
+
+	// 3. tools/call - success
+	const callRes = (await server.handleMessage({
+		jsonrpc: "2.0",
+		id: 3,
+		method: "tools/call",
+		params: {
+			name: "read_file",
+			arguments: { filePath: "/test/hello.txt" },
+		},
+	})) as any;
+	assert.equal(callRes.jsonrpc, "2.0");
+	assert.equal(callRes.id, 3);
+	assert.equal(callRes.result.content[0].type, "text");
+	assert.equal(lastInvocationRequest?.toolName, "read_file");
+	assert.deepEqual(lastInvocationRequest?.arguments, { filePath: "/test/hello.txt" });
+
+	// 4. tools/call - unavailable tool
+	const unavailRes = (await server.handleMessage({
+		jsonrpc: "2.0",
+		id: 4,
+		method: "tools/call",
+		params: {
+			name: "non_existent_tool",
+			arguments: {},
+		},
+	})) as any;
+	assert.equal(unavailRes.jsonrpc, "2.0");
+	assert.equal(unavailRes.id, 4);
+	assert.equal(unavailRes.result.isError, true);
+
+	// 5. ping
+	const pingRes = await server.handleMessage({
+		jsonrpc: "2.0",
+		id: 5,
+		method: "ping",
+	});
+	assert.deepEqual(pingRes, {
+		jsonrpc: "2.0",
+		id: 5,
+		result: {},
+	});
+
+	// 6. JSON string input parsing
+	const stringRes = (await server.handleMessage(
+		JSON.stringify({
+			jsonrpc: "2.0",
+			id: 6,
+			method: "ping",
+		}),
+	)) as any;
+	assert.deepEqual(stringRes, {
+		jsonrpc: "2.0",
+		id: 6,
+		result: {},
+	});
+
+	// 7. connectTransport
+	let receivedByTransport: any = null;
+	let messageCallback: ((msg: any) => void) | null = null;
+	const mockTransport = {
+		send: (msg: any) => {
+			receivedByTransport = msg;
+		},
+		onMessage: (cb: (msg: any) => void) => {
+			messageCallback = cb;
+		},
+	};
+	server.connectTransport(mockTransport);
+	assert.ok(messageCallback);
+	messageCallback!({
+		jsonrpc: "2.0",
+		id: 7,
+		method: "ping",
+	});
+	// Wait a tick for async dispatch
+	await new Promise(resolve => setTimeout(resolve, 10));
+	assert.deepEqual(receivedByTransport, {
+		jsonrpc: "2.0",
+		id: 7,
+		result: {},
+	});
+
+	// 8. startStdioServer method exists
+	assert.equal(typeof server.startStdioServer, "function");
+
+	console.log("All OhMyPiMcpServer checks passed!");
+}
+
+runTests().catch(err => {
+	console.error("Test failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Separates OhMyPi harness ownership from LLM inference behind explicit interfaces and exports the tool surface through an MCP server (stdio + Streamable HTTP), with deny-by-default external harness mode.

## Changes

- **Harness/LLM split** (`packages/coding-agent/src/harness/`): `HarnessSessionInterface`, `LLMPortInterface`/`DefaultLocalLLMPort`, `LocalHarnessAdapter`
- **MCP server** (`packages/coding-agent/src/mcp/server.ts`): JSON-RPC 2.0 `initialize`, `tools/list`, `tools/call`, `ping`; stdio (`run-server.ts`, `run-server-standalone.ts`) + HTTP (`run-server-http.ts`)
- **External harness mode** (`harness/external-mode.ts`): deny-by-default, env-only opt-in (`OMP_EXTERNAL_HARNESS_*`), tool allowlist, write/execution policy, workspace containment (`WORKSPACE_ESCAPE`)
- **Standalone harness** (`mcp/standalone-harness.ts`): dependency-free real tools (read/write/edit/glob/grep/list_dir/bash) + plugin discovery for environments without `bun install`
- **Tests**: `test/mcp-external-mode.test.ts` (5 pass), `test/mcp-server-check.ts` (8 checks pass)
- **Docs**: `docs/ACCEPTANCE_TEST_PLAN.md` with live stdio/HTTP results (TC-01..TC-13 PASS)

## Test plan

- `bun packages/coding-agent/test/mcp-server-check.ts` — all checks passed
- `bun test packages/coding-agent/test/mcp-external-mode.test.ts` — 5 pass, 0 fail
- Live stdio + HTTP acceptance against real workspace (read/write/edit/bash/policy/containment) — all PASS, see docs/ACCEPTANCE_TEST_PLAN.md §6b