### PR TITLE
fix(catalog): keep image input on OpenCode Go DeepSeek Flash lanes

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `supports-server-compaction` compat axis (`compat.supportsServerCompaction`): whether a model line accepts Anthropic server-side compaction (`compact-2026-01-12`). Class rules enable it for Opus 4.6+, Sonnet 4.6+, and Fable/Mythos 5 on every Anthropic-messages host; the default is `false`.
 ### Fixed
 
+- OpenCode Go's DeepSeek Flash lanes (`deepseek-flash`, `deepseek-v4.1-flash`) accept image input. The gateway serves them with vision despite the IDs carrying no vision suffix, so the class-wide `strip-image-input` rule was dropping attachments the endpoint reads.
 - Amazon Bedrock OpenAI models, plus unclassified profiles such as opaque application-inference-profile ARNs, now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `supports-server-compaction` compat axis (`compat.supportsServerCompaction`): whether a model line accepts Anthropic server-side compaction (`compact-2026-01-12`). Class rules enable it for Opus 4.6+, Sonnet 4.6+, and Fable/Mythos 5 on every Anthropic-messages host; the default is `false`.
 ### Fixed
 
-- OpenCode Go's DeepSeek Flash lanes (`deepseek-flash`, `deepseek-v4.1-flash`) now declare image input. The gateway serves them with vision despite the IDs carrying no vision suffix, so the class-wide `strip-image-input` rule was dropping attachments the endpoint reads; the modality is declared too, since live discovery seeds these lanes text-only.
+- OpenCode Go's DeepSeek Flash lanes (`deepseek-flash`, `deepseek-v4.1-flash`) now declare image input. The gateway serves them with vision despite the IDs carrying no vision suffix, so the class-wide `strip-image-input` rule was dropping attachments the endpoint reads; the modality is declared too, since live discovery seeds these lanes text-only ([#11774](https://github.com/can1357/oh-my-pi/pull/11774) by [@STRML](https://github.com/STRML)).
 - Amazon Bedrock OpenAI models, plus unclassified profiles such as opaque application-inference-profile ARNs, now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 - DeepSeek V4.1 Flash requests now honor the documented 384K output maximum instead of being capped at 64K ([#11769](https://github.com/can1357/oh-my-pi/issues/11769)).
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `supports-server-compaction` compat axis (`compat.supportsServerCompaction`): whether a model line accepts Anthropic server-side compaction (`compact-2026-01-12`). Class rules enable it for Opus 4.6+, Sonnet 4.6+, and Fable/Mythos 5 on every Anthropic-messages host; the default is `false`.
 ### Fixed
 
-- OpenCode Go's DeepSeek Flash lanes (`deepseek-flash`, `deepseek-v4.1-flash`) accept image input. The gateway serves them with vision despite the IDs carrying no vision suffix, so the class-wide `strip-image-input` rule was dropping attachments the endpoint reads.
+- OpenCode Go's DeepSeek Flash lanes (`deepseek-flash`, `deepseek-v4.1-flash`) now declare image input. The gateway serves them with vision despite the IDs carrying no vision suffix, so the class-wide `strip-image-input` rule was dropping attachments the endpoint reads; the modality is declared too, since live discovery seeds these lanes text-only.
 - Amazon Bedrock OpenAI models, plus unclassified profiles such as opaque application-inference-profile ARNs, now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -13026,7 +13026,26 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:15",
+				"source": "providers/opencode-go.kdl:7",
+				"providers": [
+					"opencode-go"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "deepseek-flash"
+					},
+					{
+						"kind": "exact",
+						"value": "deepseek-v4.1-flash"
+					}
+				],
+				"wire": {
+					"stripImageInput": false
+				}
+			},
+			{
+				"source": "providers/opencode-go.kdl:21",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -13037,7 +13056,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:13",
+				"source": "providers/opencode-go.kdl:19",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -13047,7 +13066,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:20",
+				"source": "providers/opencode-go.kdl:26",
 				"providers": [
 					"opencode-go"
 				],
@@ -13062,7 +13081,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:26",
+				"source": "providers/opencode-go.kdl:32",
 				"providers": [
 					"opencode-go"
 				],
@@ -13084,7 +13103,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:32",
+				"source": "providers/opencode-go.kdl:38",
 				"class": "glm",
 				"providers": [
 					"opencode-go"
@@ -13094,7 +13113,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:35",
+				"source": "providers/opencode-go.kdl:41",
 				"class": "kimi",
 				"providers": [
 					"opencode-go"
@@ -13104,7 +13123,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:39",
+				"source": "providers/opencode-go.kdl:45",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13115,7 +13134,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:38",
+				"source": "providers/opencode-go.kdl:44",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13125,7 +13144,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:46",
+				"source": "providers/opencode-go.kdl:52",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13151,7 +13170,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:50",
+				"source": "providers/opencode-go.kdl:56",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13177,7 +13196,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:56",
+				"source": "providers/opencode-go.kdl:62",
 				"providers": [
 					"opencode-go"
 				],
@@ -13202,7 +13221,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:61",
+				"source": "providers/opencode-go.kdl:67",
 				"providers": [
 					"opencode-go"
 				],
@@ -13222,7 +13241,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:66",
+				"source": "providers/opencode-go.kdl:72",
 				"providers": [
 					"opencode-go"
 				],
@@ -13244,7 +13263,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:71",
+				"source": "providers/opencode-go.kdl:77",
 				"providers": [
 					"opencode-go"
 				],
@@ -13265,7 +13284,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:75",
+				"source": "providers/opencode-go.kdl:81",
 				"providers": [
 					"opencode-go"
 				],
@@ -13292,7 +13311,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:79",
+				"source": "providers/opencode-go.kdl:85",
 				"providers": [
 					"opencode-go"
 				],
@@ -13314,7 +13333,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:84",
+				"source": "providers/opencode-go.kdl:90",
 				"providers": [
 					"opencode-go"
 				],
@@ -13329,7 +13348,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:88",
+				"source": "providers/opencode-go.kdl:94",
 				"providers": [
 					"opencode-go"
 				],

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -13026,7 +13026,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:7",
+				"source": "providers/opencode-go.kdl:10",
 				"providers": [
 					"opencode-go"
 				],
@@ -13042,10 +13042,16 @@
 				],
 				"wire": {
 					"stripImageInput": false
+				},
+				"catalog": {
+					"inputModalities": [
+						"text",
+						"image"
+					]
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:21",
+				"source": "providers/opencode-go.kdl:25",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -13056,7 +13062,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:19",
+				"source": "providers/opencode-go.kdl:23",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -13066,7 +13072,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:26",
+				"source": "providers/opencode-go.kdl:30",
 				"providers": [
 					"opencode-go"
 				],
@@ -13081,7 +13087,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:32",
+				"source": "providers/opencode-go.kdl:36",
 				"providers": [
 					"opencode-go"
 				],
@@ -13103,7 +13109,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:38",
+				"source": "providers/opencode-go.kdl:42",
 				"class": "glm",
 				"providers": [
 					"opencode-go"
@@ -13113,7 +13119,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:41",
+				"source": "providers/opencode-go.kdl:45",
 				"class": "kimi",
 				"providers": [
 					"opencode-go"
@@ -13123,7 +13129,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:45",
+				"source": "providers/opencode-go.kdl:49",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13134,7 +13140,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:44",
+				"source": "providers/opencode-go.kdl:48",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -13144,7 +13150,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:52",
+				"source": "providers/opencode-go.kdl:56",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13170,7 +13176,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:56",
+				"source": "providers/opencode-go.kdl:60",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -13196,7 +13202,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:62",
+				"source": "providers/opencode-go.kdl:66",
 				"providers": [
 					"opencode-go"
 				],
@@ -13221,7 +13227,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:67",
+				"source": "providers/opencode-go.kdl:71",
 				"providers": [
 					"opencode-go"
 				],
@@ -13241,7 +13247,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:72",
+				"source": "providers/opencode-go.kdl:76",
 				"providers": [
 					"opencode-go"
 				],
@@ -13263,7 +13269,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:77",
+				"source": "providers/opencode-go.kdl:81",
 				"providers": [
 					"opencode-go"
 				],
@@ -13284,7 +13290,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:81",
+				"source": "providers/opencode-go.kdl:85",
 				"providers": [
 					"opencode-go"
 				],
@@ -13311,7 +13317,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:85",
+				"source": "providers/opencode-go.kdl:89",
 				"providers": [
 					"opencode-go"
 				],
@@ -13333,7 +13339,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:90",
+				"source": "providers/opencode-go.kdl:94",
 				"providers": [
 					"opencode-go"
 				],
@@ -13348,7 +13354,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:94",
+				"source": "providers/opencode-go.kdl:98",
 				"providers": [
 					"opencode-go"
 				],

--- a/packages/catalog/src/compat/rules/providers/opencode-go.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-go.kdl
@@ -4,7 +4,11 @@ provider "opencode-go" {
 	// The Flash lanes accept images despite their IDs lacking a vision suffix;
 	// verified against the gateway (unguessable pixel-rendered text read back
 	// verbatim). Mirrors the OpenRouter carve-out for deepseek-v4.1-flash.
+	// The modality is declared here as well: live gateway discovery seeds
+	// `input: ["text"]`, and the wire guard requires the declared modality, so
+	// clearing `strip-image-input` alone would leave the lane text-only.
 	models "deepseek-flash" "deepseek-v4.1-flash" {
+		input-modalities "text" "image"
 		strip-image-input #false
 	}
 	// Replaces the OpenCode reasoning-model whenThinking fallback object.

--- a/packages/catalog/src/compat/rules/providers/opencode-go.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-go.kdl
@@ -1,6 +1,12 @@
 // Provider-wire compat for "opencode-go"; regenerated from the frozen census using deployment contract selectors.
 
 provider "opencode-go" {
+	// The Flash lanes accept images despite their IDs lacking a vision suffix;
+	// verified against the gateway (unguessable pixel-rendered text read back
+	// verbatim). Mirrors the OpenRouter carve-out for deepseek-v4.1-flash.
+	models "deepseek-flash" "deepseek-v4.1-flash" {
+		strip-image-input #false
+	}
 	// Replaces the OpenCode reasoning-model whenThinking fallback object.
 	when-thinking {
 		requires-reasoning-content-for-tool-calls #true

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { sendsImageInputOnWire } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
@@ -913,14 +914,16 @@ describe("OpenCode provider discovery", () => {
 		expect(policy.catalog).toMatchObject({ longUsageLimitFallback: true });
 	});
 
-	test("keeps image input on the OpenCode Go DeepSeek Flash lanes", () => {
+	test("serves image input on the OpenCode Go DeepSeek Flash lanes", () => {
 		// The deepseek class rule strips image input for the whole lineage, which
 		// is right for the DeepSeek API but wrong for this gateway: both Flash
 		// lanes accept image_url and read an unguessable pixel-rendered string
-		// back verbatim (user-verified against the live gateway, 2026-09-11).
-		// Mirrors the OpenRouter carve-out for deepseek-v4.1-flash.
-		const spec = (id: string) =>
-			({
+		// back verbatim (live gateway, 2026-09-11). The rule declares the
+		// modality as well as clearing the strip, because live discovery seeds
+		// `input: ["text"]` and the wire guard requires the declared modality —
+		// clearing the strip alone would leave the lane text-only.
+		const discovered = (id: string) =>
+			buildModel({
 				id,
 				name: id,
 				api: "openai-completions",
@@ -931,13 +934,17 @@ describe("OpenCode provider discovery", () => {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 1_048_576,
 				maxTokens: 384_000,
-			}) satisfies ModelSpec<"openai-completions">;
+			});
 
 		for (const id of ["deepseek-flash", "deepseek-v4.1-flash"]) {
-			expect(resolveModelPolicy(spec(id)).compat.stripImageInput).toBe(false);
+			const model = discovered(id);
+			expect(model.input).toContain("image");
+			expect(sendsImageInputOnWire(model)).toBe(true);
 		}
 		// The plain V4 Flash lane carries no such evidence and stays text-only.
-		expect(resolveModelPolicy(spec("deepseek-v4-flash")).compat.stripImageInput).toBe(true);
+		const plain = discovered("deepseek-v4-flash");
+		expect(plain.input).toEqual(["text"]);
+		expect(sendsImageInputOnWire(plain)).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -912,6 +912,33 @@ describe("OpenCode provider discovery", () => {
 
 		expect(policy.catalog).toMatchObject({ longUsageLimitFallback: true });
 	});
+
+	test("keeps image input on the OpenCode Go DeepSeek Flash lanes", () => {
+		// The deepseek class rule strips image input for the whole lineage, which
+		// is right for the DeepSeek API but wrong for this gateway: both Flash
+		// lanes accept image_url and read an unguessable pixel-rendered string
+		// back verbatim (user-verified against the live gateway, 2026-09-11).
+		// Mirrors the OpenRouter carve-out for deepseek-v4.1-flash.
+		const spec = (id: string) =>
+			({
+				id,
+				name: id,
+				api: "openai-completions",
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1_048_576,
+				maxTokens: 384_000,
+			}) satisfies ModelSpec<"openai-completions">;
+
+		for (const id of ["deepseek-flash", "deepseek-v4.1-flash"]) {
+			expect(resolveModelPolicy(spec(id)).compat.stripImageInput).toBe(false);
+		}
+		// The plain V4 Flash lane carries no such evidence and stays text-only.
+		expect(resolveModelPolicy(spec("deepseek-v4-flash")).compat.stripImageInput).toBe(true);
+	});
 });
 
 describe("issue #10416 — retired bare opencode provider", () => {


### PR DESCRIPTION
## What

The OpenCode Go gateway serves both DeepSeek Flash lanes with vision, but the DeepSeek class rule strips image input for the entire lineage, so attachments never reach the model.

`packages/catalog/src/compat/rules/classes/deepseek.kdl` carves out ids carrying a `vision` or `ocr` token. The gateway's `deepseek-flash` and `deepseek-v4.1-flash` carry neither, so they inherited the strip even though they read images correctly.

This adds the provider-scoped carve-out that `providers/openrouter.kdl` already carries for the same reason ("V4.1 Flash accepts images despite its ID lacking a vision suffix").

Fixes #11773.

## Why both axes

Clearing the transport guard is not sufficient on its own. `sendsImageInputOnWire` and `isOpenAICompletionsVisionSupported` require `model.input` to carry `"image"` before they ever consult `compat.stripImageInput`, and live gateway discovery seeds these ids `input: ["text"]`. The rule therefore declares `input-modalities "text" "image"` alongside `strip-image-input #false`. (Thanks to the review on the first revision, which caught the incomplete rule.)

## Evidence

POST to `https://opencode.ai/zen/go/v1/chat/completions` with an `image_url` data part, for the same ids omp resolves. The image is a random 7-letter word plus a random 5-digit code rendered as pixels, so no prompt text could produce the answer:

```
challenge text = 'LEFNWDY 98743'
[200] deepseek-flash                 MATCH     'LEFNWDY 98743'
[200] deepseek-v4-flash-vision-exp   MATCH     'LEFNWDY 98743'
[200] deepseek-v4.1-flash            MATCH     'LEFNWDY 98743'
[403] deepseek-v4-pro                RegionError (China-only, not testable)
```

## Scope

4 files, +88 / -18, branched from `upstream/main` (`upstream/main` merged in after #11775 landed):

- `src/compat/rules/providers/opencode-go.kdl` — the carve-out
- `src/compat/rules.json` — regenerated via `bun run gen:compat`, and confirmed byte-stable against a fresh compile after the merge
- `test/opencode-provider.test.ts` — regression test
- `CHANGELOG.md`

## Deliberately unchanged

- `opencode-go/deepseek-v4-flash` keeps the class strip. It answers a RegionError when addressed directly, so there is no evidence either way.
- `deepseek/deepseek-flash` (the DeepSeek API) keeps the strip.
- `opencode-zen` is untouched: it is a separate gateway and I have no credential to test it.

## Verification

The test drives `buildModel` from a discovery-shaped spec (`input: ["text"]`, provider `opencode-go`) and asserts both the materialized modality and `sendsImageInputOnWire`:

```
$ bun test -t "serves image input on the OpenCode Go DeepSeek Flash lanes"
1 pass
```

Mutation-checked: deleting only the `input-modalities` line fails it with

```
Expected to contain: "image"
Received: [ "text" ]
```

so the test cannot pass on the incomplete rule.

```
$ cd packages/catalog && bun test
928 pass, 0 fail, 4219 expect() calls
$ cd packages/catalog && bun run check
oxlint + oxfmt + tsgo clean
$ bun run dev models opencode-go
| deepseek-flash               | 1M | 384K | ... | yes |
| deepseek-v4-flash            | 1M | 384K | ... | no  |
| deepseek-v4-flash-vision-exp | 1M | 384K | ... | yes |
| deepseek-v4-pro              | 1M | 384K | ... | no  |
| deepseek-v4.1-flash          | 1M | 384K | ... | yes |
```
