### PR TITLE
fix(catalog): honor DeepSeek Flash output limits

### DIFF
--- a/packages/ai/test/openai-max-output-tokens-cap.test.ts
+++ b/packages/ai/test/openai-max-output-tokens-cap.test.ts
@@ -210,6 +210,15 @@ describe("OpenAI-family output-token cap", () => {
 		expect(body.max_output_tokens).toBe(2_048);
 	});
 
+	it.each(["deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"])(
+		"lets first-party DeepSeek %s requests use the documented 384k output cap",
+		async id => {
+			const model = getBundledModel("deepseek", id) as Model<"openai-completions">;
+			const body = await captureCompletionsBody(model, model.maxTokens ?? undefined);
+			expect(body.max_tokens).toBe(384_000);
+		},
+	);
+
 	it("clamps non-aggregator completions output to the 64k ceiling", async () => {
 		const body = await captureCompletionsBody(directCompletionsModel(131_072), 131_072);
 		expect(body.max_completion_tokens ?? body.max_tokens).toBe(OPENAI_MAX_OUTPUT_TOKENS);

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Amazon Bedrock OpenAI models, plus unclassified profiles such as opaque application-inference-profile ARNs, now carry the compatibility policy required to preserve image-bearing tool results ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
+- DeepSeek V4.1 Flash requests now honor the documented 384K output maximum instead of being capped at 64K ([#11769](https://github.com/can1357/oh-my-pi/issues/11769)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -9671,6 +9671,9 @@
 						"value": "deepseek-v4-flash-vision-exp"
 					}
 				],
+				"wire": {
+					"clampOutputToModelMax": true
+				},
 				"catalog": {
 					"timeBased": {
 						"offPeakMultiplier": 0.5,
@@ -9696,7 +9699,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:44",
+				"source": "providers/deepseek.kdl:45",
 				"providers": [
 					"deepseek"
 				],
@@ -9714,7 +9717,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:51",
+				"source": "providers/deepseek.kdl:52",
 				"providers": [
 					"deepseek"
 				],
@@ -9758,7 +9761,7 @@
 				}
 			},
 			{
-				"source": "providers/deepseek.kdl:84",
+				"source": "providers/deepseek.kdl:85",
 				"providers": [
 					"deepseek"
 				],

--- a/packages/catalog/src/compat/rules/providers/deepseek.kdl
+++ b/packages/catalog/src/compat/rules/providers/deepseek.kdl
@@ -16,6 +16,7 @@ provider "deepseek" {
 	// bare alias carries no family, and the retired `v4-flash`/`-vision-exp` ids
 	// are still accepted and billed at the Flash card.
 	models "deepseek-flash" "deepseek-v4-flash" "deepseek-v4-flash-vision-exp" {
+		clamp-output-to-model-max #true
 		time-based-cost {
 			off-peak-multiplier 0.5
 			peak-windows {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -76194,7 +76194,7 @@
 				"dropThinkingWhenReasoningEffort": false,
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
+				"clampOutputToModelMax": true,
 				"stripImageInput": true,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
@@ -76250,6 +76250,20 @@
 			"maxTokens": 384000,
 			"int": 51.8,
 			"tps": 140,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76299,7 +76313,7 @@
 				"dropThinkingWhenReasoningEffort": false,
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
+				"clampOutputToModelMax": true,
 				"stripImageInput": true,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
@@ -76359,7 +76373,7 @@
 					"dropThinkingWhenReasoningEffort": false,
 					"nativeKimiK3Reasoning": false,
 					"zaiReasoningEffortDialect": false,
-					"clampOutputToModelMax": false,
+					"clampOutputToModelMax": true,
 					"stripImageInput": true,
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
@@ -76367,20 +76381,6 @@
 					"supportsPromptCacheKey": false
 				}
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "deepseek",
-				"family": "flash"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false,
@@ -76443,6 +76443,20 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "deepseek",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -76492,7 +76506,7 @@
 				"dropThinkingWhenReasoningEffort": false,
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
+				"clampOutputToModelMax": true,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "deepseek",
 				"rejectRootObjectUnion": false,
@@ -76552,7 +76566,7 @@
 					"dropThinkingWhenReasoningEffort": false,
 					"nativeKimiK3Reasoning": false,
 					"zaiReasoningEffortDialect": false,
-					"clampOutputToModelMax": false,
+					"clampOutputToModelMax": true,
 					"stripImageInput": false,
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
@@ -76560,20 +76574,6 @@
 					"supportsPromptCacheKey": false
 				}
 			},
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"high",
-					"max"
-				]
-			},
-			"identity": {
-				"class": "deepseek",
-				"family": "flash"
-			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"supportsDeveloperRole": false,


### PR DESCRIPTION
## Repro
A wire-level `streamSimple` request using `getBundledModel("deepseek", "deepseek-flash")` with `maxTokens: 384000` reproduced the mismatch: the catalog reported `384000`, `compat.clampOutputToModelMax` was `false`, and the serialized body contained `max_tokens: 64000`.

## Cause
`packages/catalog/src/compat/rules/providers/deepseek.kdl` supplied the documented 384K catalog limit for first-party DeepSeek Flash but did not set `clamp-output-to-model-max`; `resolveOpenAICompletionsOutputClamp` therefore retained the generic 64K OpenAI-compatible guard.

## Fix
- Enable `clamp-output-to-model-max` for `deepseek-flash` and its two retired first-party aliases.
- Regenerate the compiled compat policy and bundled model rows.
- Cover all three accepted IDs at the serialized Chat Completions request boundary.
- Document the user-visible correction in the catalog changelog.

## Verification
`bun test packages/ai/test/openai-max-output-tokens-cap.test.ts packages/catalog/test/generated-policies.test.ts` passed: 44 tests, 0 failures. Re-running the original wire probe produced `catalogMaxTokens: 384000`, `clampOutputToModelMax: true`, and `wireMaxTokens: 384000`. The pre-publish gate also completed successfully.

Fixes #11769