### PR TITLE
fix(ai): exercise DeepSeek KDL rule in output-cap test

### DIFF
--- a/packages/ai/test/openai-max-output-tokens-cap.test.ts
+++ b/packages/ai/test/openai-max-output-tokens-cap.test.ts
@@ -162,6 +162,23 @@ function directCompletionsModel(maxTokens: number): Model<"openai-completions"> 
 	});
 }
 
+// First-party DeepSeek Flash: synthetic spec exercises the KDL clamp rule via
+// buildModel instead of the bundled snapshot.
+function deepseekFlashModel(id: string): Model<"openai-completions"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "deepseek",
+		baseUrl: "https://api.deepseek.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+	});
+}
+
 // Kimi via OpenRouter stays exempt from the omit (TPM rate limits need max_tokens).
 function kimiOpenRouterModel(maxTokens: number): Model<"openai-completions"> {
 	return buildModel({
@@ -213,7 +230,7 @@ describe("OpenAI-family output-token cap", () => {
 	it.each(["deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"])(
 		"lets first-party DeepSeek %s requests use the documented 384k output cap",
 		async id => {
-			const model = getBundledModel("deepseek", id) as Model<"openai-completions">;
+			const model = deepseekFlashModel(id);
 			const body = await captureCompletionsBody(model, model.maxTokens ?? undefined);
 			expect(body.max_tokens).toBe(384_000);
 		},


### PR DESCRIPTION
## What

I reworked the DeepSeek Flash wire test to build synthetic ModelSpecs through buildModel instead of reading the bundled snapshot, so the coverage now exercises the deepseek.kdl clamp rule directly.

## Why

Follow-up to #11775 addressing the Codex P1 nit (https://github.com/can1357/oh-my-pi/pull/11775#discussion_r3992253712): getBundledModel reads the already-generated models.json, so the test could keep passing on a stale snapshot even if the KDL selector stopped applying.

## Testing

- bun test packages/ai/test/openai-max-output-tokens-cap.test.ts: 14 pass, 0 fail
- bun check passes
- Verified via a buildModel probe that clampOutputToModelMax is true for exactly deepseek-flash, deepseek-v4-flash, deepseek-v4-flash-vision-exp and false for deepseek-v4-pro / deepseek-chat
- No CHANGELOG: test-only, no user-facing change

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)