### PR TITLE
fix(vcs): run whole-worktree status and untracked listing in a subprocess

### DIFF
--- a/crates/pi-vcs/src/git/cli.rs
+++ b/crates/pi-vcs/src/git/cli.rs
@@ -35,7 +35,7 @@ pub const SYNC_TIMEOUT: Duration = Duration::from_secs(5);
 pub const OUTPUT_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
 const TERMINATE_GRACE: Duration = Duration::from_secs(5);
-const TRUNCATION_MARKER: &str = "\n[git subprocess output truncated after 8 MiB]\n";
+const TRUNCATION_MARKER: &str = "\n[git subprocess output truncated at the capture limit]\n";
 
 /// Captured result of a completed git invocation.
 #[derive(Debug, Clone)]
@@ -91,11 +91,47 @@ fn hardened_args(args: &[String], read_only: bool) -> Vec<String> {
 	out
 }
 
+/// Environment sink for the two command builders. `std::process::Command` and
+/// `tokio::process::Command` share no trait, and duplicating the contract per
+/// builder is how the synchronous path silently lost the `LC_ALL` removal that
+/// [`is_dubious_ownership`] depends on.
+trait EnvSink {
+	fn set(&mut self, key: &str, value: &str);
+	fn unset(&mut self, key: &str);
+}
+
+impl EnvSink for std::process::Command {
+	fn set(&mut self, key: &str, value: &str) {
+		self.env(key, value);
+	}
+
+	fn unset(&mut self, key: &str) {
+		self.env_remove(key);
+	}
+}
+
+impl EnvSink for tokio::process::Command {
+	fn set(&mut self, key: &str, value: &str) {
+		self.env(key, value);
+	}
+
+	fn unset(&mut self, key: &str) {
+		self.env_remove(key);
+	}
+}
+
 /// Apply the non-interactive environment contract to a command builder:
-/// prompts rejected, editors disabled, ambient repo-location overrides
-/// stripped, `LC_MESSAGES=C` for parseable errors while preserving a UTF-8
-/// character locale.
-fn apply_env(cmd: &mut tokio::process::Command) {
+/// prompts rejected, editors disabled, ambient repo-location and pathspec
+/// overrides stripped, `LC_MESSAGES=C` for parseable errors while preserving a
+/// UTF-8 character locale. `LC_ALL` must go: it outranks `LC_MESSAGES`, so
+/// leaving it inherited would hand back localized diagnostics.
+///
+/// The `*_PATHSPECS` variables are global pathspec modes, so an inherited
+/// `GIT_LITERAL_PATHSPECS=1` would make the `:(literal)` magic this crate
+/// builds match a filename containing that prefix (i.e. nothing), and
+/// `GIT_ICASE_PATHSPECS=1` would match case variants the caller did not ask
+/// for. Explicit magic is only explicit once they are gone.
+fn apply_env(cmd: &mut impl EnvSink) {
 	for stripped in [
 		"GIT_DIR",
 		"GIT_COMMON_DIR",
@@ -103,22 +139,26 @@ fn apply_env(cmd: &mut tokio::process::Command) {
 		"GIT_INDEX_FILE",
 		"GIT_OBJECT_DIRECTORY",
 		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		"GIT_LITERAL_PATHSPECS",
+		"GIT_GLOB_PATHSPECS",
+		"GIT_NOGLOB_PATHSPECS",
+		"GIT_ICASE_PATHSPECS",
 	] {
-		cmd.env_remove(stripped);
+		cmd.unset(stripped);
 	}
 	if let Some(lc_all) = std::env::var_os("LC_ALL") {
 		let lc_all = lc_all.to_string_lossy().into_owned();
 		if is_utf8_locale(&lc_all) {
-			cmd.env("LC_CTYPE", lc_all);
+			cmd.set("LC_CTYPE", &lc_all);
 		}
 	}
-	cmd.env_remove("LC_ALL");
-	cmd.env("LC_MESSAGES", "C");
-	cmd.env("GIT_OPTIONAL_LOCKS", "0");
-	cmd.env("GIT_ASKPASS", "true");
-	cmd.env("GIT_EDITOR", "true");
-	cmd.env("GIT_TERMINAL_PROMPT", "0");
-	cmd.env("SSH_ASKPASS", "false");
+	cmd.unset("LC_ALL");
+	cmd.set("LC_MESSAGES", "C");
+	cmd.set("GIT_OPTIONAL_LOCKS", "0");
+	cmd.set("GIT_ASKPASS", "true");
+	cmd.set("GIT_EDITOR", "true");
+	cmd.set("GIT_TERMINAL_PROMPT", "0");
+	cmd.set("SSH_ASKPASS", "false");
 }
 
 /// Loose match for a UTF-8 character locale (`en_US.UTF-8`, `C.utf8`, …).
@@ -211,11 +251,59 @@ pub(crate) fn is_spawn_failure(err: &Error) -> bool {
 	matches!(err, Error::Backend { context: "git spawn", .. })
 }
 
+/// Whether captured output hit [`OUTPUT_LIMIT_BYTES`] and therefore lost
+/// bytes. Callers whose output is a value rather than a diagnostic (path
+/// lists) must retry in-process or fail, never return the short result.
+pub(crate) fn is_truncated(text: &str) -> bool {
+	text.ends_with(TRUNCATION_MARKER)
+}
+
+/// Whether git refused the checkout under its `safe.directory` ownership
+/// check (`fatal: detected dubious ownership`, exit 128), which happens
+/// whenever the process user differs from the checkout owner — a
+/// host-mounted repository inside a container is the common case.
+///
+/// `open::open_options` opens user-chosen checkouts with `Trust::Full` on
+/// purpose, so the in-process walk has no such objection: a caller with a
+/// gitoxide fallback must take it rather than surface an error the
+/// library-backed path would never have produced.
+///
+/// [`apply_env`] pins `LC_MESSAGES=C` and drops the `LC_ALL` that would
+/// outrank it, so the English wording is what git emits. `safe.directory` is
+/// matched as well: it is a config key, so it survives translation even if a
+/// host manages to localize the diagnostic anyway.
+pub(crate) fn is_dubious_ownership(err: &Error) -> bool {
+	matches!(
+		err,
+		Error::Cli { exit_code: 128, stderr, .. }
+			if stderr.contains("dubious ownership") || stderr.contains("safe.directory")
+	)
+}
+
+/// Whether `err` describes a CLI that could not do the work at all while the
+/// in-process gitoxide path still can.
+pub(crate) fn prefers_in_process(err: &Error) -> bool {
+	is_spawn_failure(err) || is_dubious_ownership(err)
+}
+
 /// Synchronous bounded runner with a caller-chosen deadline; render paths pass
 /// [`SYNC_TIMEOUT`] so a stalled git cannot freeze the UI. Stdout/stderr are
 /// drained concurrently with capped retention, so output larger than the OS
 /// pipe buffer can never stall the child into a spurious timeout.
 pub(crate) fn run_sync(cwd: &Path, args: &[String], timeout: Duration) -> Result<CliOutput> {
+	run_sync_capped(cwd, args, timeout, OUTPUT_LIMIT_BYTES)
+}
+
+/// [`run_sync`] with an explicit retention cap. The cap is a parameter rather
+/// than a constant read inside the reader threads so a test can exercise the
+/// truncation contract on one call without lowering the limit for every other
+/// invocation in the process.
+pub(crate) fn run_sync_capped(
+	cwd: &Path,
+	args: &[String],
+	timeout: Duration,
+	limit: usize,
+) -> Result<CliOutput> {
 	let argv = hardened_args(args, true);
 	let mut cmd = std::process::Command::new("git");
 	cmd.args(&argv)
@@ -223,25 +311,10 @@ pub(crate) fn run_sync(cwd: &Path, args: &[String], timeout: Duration) -> Result
 		.stdin(Stdio::null())
 		.stdout(Stdio::piped())
 		.stderr(Stdio::piped());
-	// The sync and async builders expose the same env API surface; reuse the
-	// async configurator through a tokio wrapper would allocate a runtime, so
-	// mirror the pins directly.
-	for stripped in [
-		"GIT_DIR",
-		"GIT_COMMON_DIR",
-		"GIT_WORK_TREE",
-		"GIT_INDEX_FILE",
-		"GIT_OBJECT_DIRECTORY",
-		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-	] {
-		cmd.env_remove(stripped);
-	}
-	cmd.env("LC_MESSAGES", "C");
-	cmd.env("GIT_OPTIONAL_LOCKS", "0");
-	cmd.env("GIT_TERMINAL_PROMPT", "0");
+	apply_env(&mut cmd);
 	let mut child = cmd.spawn().map_err(|err| spawn_error(cwd, err))?;
-	let stdout = spawn_sync_reader("git-cli-stdout", child.stdout.take());
-	let stderr = spawn_sync_reader("git-cli-stderr", child.stderr.take());
+	let stdout = spawn_sync_reader("git-cli-stdout", child.stdout.take(), limit);
+	let stderr = spawn_sync_reader("git-cli-stderr", child.stderr.take(), limit);
 
 	let deadline = std::time::Instant::now() + timeout;
 	let status = loop {
@@ -274,17 +347,18 @@ pub(crate) fn run_sync(cwd: &Path, args: &[String], timeout: Duration) -> Result
 fn spawn_sync_reader(
 	name: &'static str,
 	stream: Option<impl std::io::Read + Send + 'static>,
+	limit: usize,
 ) -> Option<std::thread::JoinHandle<String>> {
 	let stream = stream?;
 	std::thread::Builder::new()
 		.name(name.into())
-		.spawn(move || read_capped_sync(stream))
+		.spawn(move || read_capped_sync(stream, limit))
 		.ok()
 }
 
-/// Synchronous mirror of [`read_capped`]: cap retention at
-/// [`OUTPUT_LIMIT_BYTES`] while draining to EOF so the child never blocks.
-fn read_capped_sync(mut stream: impl std::io::Read) -> String {
+/// Synchronous mirror of [`read_capped`]: cap retention at `limit` while
+/// draining to EOF so the child never blocks.
+fn read_capped_sync(mut stream: impl std::io::Read, limit: usize) -> String {
 	let mut retained: Vec<u8> = Vec::new();
 	let mut buf = [0u8; 8 * 1024];
 	let mut truncated = false;
@@ -296,7 +370,7 @@ fn read_capped_sync(mut stream: impl std::io::Read) -> String {
 		if truncated {
 			continue;
 		}
-		let remaining = OUTPUT_LIMIT_BYTES - retained.len();
+		let remaining = limit - retained.len();
 		if n <= remaining {
 			retained.extend_from_slice(&buf[..n]);
 		} else {
@@ -487,4 +561,88 @@ pub async fn clone(
 		}
 	}
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Set on the re-executed child; carries the fixture repository it should
+	/// probe. Its presence is what tells the test body which side it is on.
+	const ENV_PROBE_REPO: &str = "PI_VCS_TEST_ENV_PROBE_REPO";
+
+	/// Asks git to report the ambient variables it was started with. A `!`-alias
+	/// is the only way to make git print its own environment.
+	const ENV_PROBE_ALIAS: &str = r#"!printf 'LC_ALL=[%s] LC_CTYPE=[%s] LC_MESSAGES=[%s] LITERAL=[%s] ICASE=[%s]' "$LC_ALL" "$LC_CTYPE" "$LC_MESSAGES" "$GIT_LITERAL_PATHSPECS" "$GIT_ICASE_PATHSPECS""#;
+
+	/// Two guarantees this crate builds on top of, both of which depend on what
+	/// the child process actually receives:
+	///
+	/// - The ownership fallback reads git's diagnostic, and `LC_ALL` outranks
+	///   `LC_MESSAGES`, so an inherited one hands back a translated message that
+	///   [`is_dubious_ownership`] cannot match.
+	/// - The `:(literal)` magic this crate builds is only explicit once the
+	///   global pathspec modes are gone; `GIT_LITERAL_PATHSPECS=1` would turn
+	///   the prefix into filename text and match nothing.
+	///
+	/// Asserted through [`run_sync`] rather than [`apply_env`] directly, because
+	/// the regression this covers was the synchronous builder not calling the
+	/// helper. The variables have to be present before the process starts, and
+	/// `set_var` in a running test binary is observable by every other thread,
+	/// so the probe runs in a re-executed copy of this test binary spawned with
+	/// them already in its environment.
+	#[test]
+	fn sync_runner_pins_message_locale_and_scrubs_pathspec_modes() {
+		if let Some(repo) = std::env::var_os(ENV_PROBE_REPO) {
+			let out = run_sync(
+				Path::new(&repo),
+				&["-c".to_owned(), format!("alias.envprobe={ENV_PROBE_ALIAS}"), "envprobe".to_owned()],
+				SYNC_TIMEOUT,
+			)
+			.expect("run alias");
+
+			assert_eq!(out.exit_code, 0, "alias failed: {out:?}");
+			assert!(out.stdout.contains("LC_ALL=[]"), "LC_ALL leaked: {out:?}");
+			assert!(out.stdout.contains("LC_MESSAGES=[C]"), "messages not pinned: {out:?}");
+			// The character locale is preserved so paths keep round-tripping as
+			// UTF-8; only the message locale is forced.
+			assert!(
+				out.stdout.contains("LC_CTYPE=[fr_FR.UTF-8]"),
+				"UTF-8 character locale dropped: {out:?}"
+			);
+			assert!(out.stdout.contains("LITERAL=[]"), "literal pathspec mode leaked: {out:?}");
+			assert!(out.stdout.contains("ICASE=[]"), "icase pathspec mode leaked: {out:?}");
+			return;
+		}
+
+		let dir = tempfile::tempdir().expect("tempdir");
+		let init = std::process::Command::new("git")
+			.args(["init", "-q", "-b", "main"])
+			.current_dir(dir.path())
+			.status()
+			.expect("spawn git init");
+		assert!(init.success(), "git init failed");
+
+		let name = format!(
+			"{}::sync_runner_pins_message_locale_and_scrubs_pathspec_modes",
+			module_path!()
+				.split_once("::")
+				.expect("crate-qualified module path")
+				.1
+		);
+		let child = std::process::Command::new(std::env::current_exe().expect("test binary"))
+			.args(["--exact", &name, "--nocapture", "--test-threads=1"])
+			.env(ENV_PROBE_REPO, dir.path())
+			.env("LC_ALL", "fr_FR.UTF-8")
+			.env("GIT_LITERAL_PATHSPECS", "1")
+			.env("GIT_ICASE_PATHSPECS", "1")
+			.output()
+			.expect("re-exec test binary");
+		assert!(
+			child.status.success(),
+			"environment probe failed:\n{}{}",
+			String::from_utf8_lossy(&child.stdout),
+			String::from_utf8_lossy(&child.stderr)
+		);
+	}
 }

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -19,6 +19,10 @@ use crate::{
 	},
 };
 
+/// Bytes retained from a porcelain capture that only has to answer "any change
+/// at all?". One status entry is enough; a few KiB leaves room for long paths.
+const DIRTY_PROBE_CAPTURE_LIMIT: usize = 4 * 1024;
+
 impl GitRepo {
 	/// Resolve the repository HEAD, preserving an unborn symbolic branch.
 	pub fn head(&self) -> Result<HeadState> {
@@ -180,47 +184,22 @@ impl GitRepo {
 
 	/// Whether default porcelain status reports a staged, unstaged, or untracked
 	/// change.
+	///
+	/// Runs the same subprocess as [`Self::status_porcelain`] rather than its
+	/// own in-process walk: this is a whole-worktree status with no pathspec,
+	/// the exact shape whose peak memory and worker-thread spawn failures
+	/// belong out of process (see [`Self::status_porcelain`]). Measured on a
+	/// clean 4 GiB worktree the subprocess is also faster than the in-process
+	/// walk, which no longer gets to stop at the first change.
+	///
+	/// The answer is a boolean, so the capture is capped at the first entries
+	/// and the rest of the output is dropped as it arrives — a worktree with
+	/// 100k untracked paths cannot make this allocate megabytes to decide
+	/// `true`.
 	pub fn is_dirty(&self) -> Result<bool> {
-		let options = StatusOptions::default();
-		if self.is_reftable() {
-			return self
-				.status_porcelain(&options)
-				.map(|status| !status.is_empty());
-		}
-		let repo = self.gix()?;
-		let platform = status_with_fresh_index(&repo, "git status")?
-			.untracked_files(gix::status::UntrackedFiles::Collapsed);
-		let iter = platform
-			.into_iter(options.pathspecs.iter().map(|path| path.as_bytes().into()))
-			.map_err(|err| Error::backend("git status", err))?;
-		use gix::status::{Item, index_worktree, plumbing::index_as_worktree::EntryStatus};
-		for item in iter {
-			let item = item.map_err(|err| Error::backend("git status", err))?;
-			match item {
-				Item::TreeIndex(_) | Item::IndexWorktree(index_worktree::Item::Rewrite { .. }) => {
-					return Ok(true);
-				},
-				Item::IndexWorktree(index_worktree::Item::Modification { status, .. })
-					if !matches!(status, EntryStatus::NeedsUpdate(_)) =>
-				{
-					return Ok(true);
-				},
-				Item::IndexWorktree(index_worktree::Item::DirectoryContents { entry, .. })
-					if entry.status == gix::dir::entry::Status::Untracked
-						&& (entry.disk_kind != Some(gix::dir::entry::Kind::Directory)
-							|| dir_contains_file(
-								&self
-									.info()
-									.repo_root
-									.join(bytes_to_path(entry.rela_path.as_bstr())),
-							)) =>
-				{
-					return Ok(true);
-				},
-				_ => {},
-			}
-		}
-		Ok(false)
+		self
+			.status_porcelain_capped(&StatusOptions::default(), DIRTY_PROBE_CAPTURE_LIMIT)
+			.map(|status| !status.is_empty())
 	}
 
 	/// Render git status in porcelain-v1 form.
@@ -232,10 +211,18 @@ impl GitRepo {
 	/// worker-thread spawn (`.expect("valid name")`) and pins gigabytes of
 	/// committed memory until process exit. A subprocess bounds that blast
 	/// radius: its memory returns to the OS when it exits and failure is an
-	/// exit code, not a panic. Hosts without a git binary fall back to the
-	/// in-process gitoxide walk (never for reftable repos, which are
-	/// unreadable in-process).
+	/// exit code, not a panic. Hosts without a git binary — and checkouts git
+	/// refuses under its `safe.directory` ownership check, which gitoxide opens
+	/// with `Trust::Full` regardless — fall back to the in-process walk (never
+	/// for reftable repos, which are unreadable in-process).
 	pub fn status_porcelain(&self, options: &StatusOptions) -> Result<String> {
+		self.status_porcelain_capped(options, super::cli::OUTPUT_LIMIT_BYTES)
+	}
+
+	/// [`Self::status_porcelain`] with an explicit retention cap for the
+	/// subprocess capture. The in-process fallback ignores the cap: it builds
+	/// the rendering itself and has nothing to drain.
+	fn status_porcelain_capped(&self, options: &StatusOptions, limit: usize) -> Result<String> {
 		let mut args = vec!["status".to_owned(), "--porcelain".to_owned()];
 		args.push(match options.untracked {
 			UntrackedMode::No => "--untracked-files=no".to_owned(),
@@ -249,8 +236,8 @@ impl GitRepo {
 			args.push("--".to_owned());
 			args.extend(options.pathspecs.iter().cloned());
 		}
-		match cli_text_owned(self.root(), &args, super::cli::COMMAND_TIMEOUT) {
-			Err(err) if !self.is_reftable() && super::cli::is_spawn_failure(&err) => {
+		match cli_text_owned_capped(self.root(), &args, super::cli::COMMAND_TIMEOUT, limit) {
+			Err(err) if !self.is_reftable() && super::cli::prefers_in_process(&err) => {
 				self.status_porcelain_gix(options)
 			},
 			result => result,
@@ -709,14 +696,24 @@ impl GitRepo {
 		self.ls_files_at_paths(others, exclude_standard, &BTreeSet::new())
 	}
 
+	/// Untracked listing (`others`) is a whole-worktree walk, the same shape
+	/// [`Self::status_porcelain`] moved into a subprocess so its peak memory and
+	/// worker-thread spawn failures stay outside this process. The in-process
+	/// gitoxide walk below covers the three cases the subprocess cannot: no git
+	/// binary, a checkout git refuses under its `safe.directory` ownership check
+	/// that gitoxide opens with `Trust::Full`, and output too large to capture.
+	/// Tracked listing is a bounded index read and stays in-process (reftable
+	/// repos excepted: unreadable in-process).
+	/// `-z` keeps paths raw — the newline form quotes non-ASCII names, which the
+	/// gitoxide path does not.
 	pub(crate) fn ls_files_at_paths(
 		&self,
 		others: bool,
 		exclude_standard: bool,
 		paths: &BTreeSet<String>,
 	) -> Result<Vec<String>> {
-		if self.is_reftable() {
-			let mut args = vec!["ls-files".to_owned()];
+		if self.is_reftable() || others {
+			let mut args = vec!["ls-files".to_owned(), "-z".to_owned()];
 			if others {
 				args.push("--others".to_owned());
 			}
@@ -727,11 +724,37 @@ impl GitRepo {
 				args.push("--".to_owned());
 				args.extend(paths.iter().map(|path| literal_pathspec(path)));
 			}
-			return Ok(cli_text_owned(self.root(), &args, super::cli::SYNC_TIMEOUT)?
-				.lines()
-				.filter(|line| !line.is_empty())
-				.map(str::to_owned)
-				.collect());
+			// A whole-worktree walk legitimately outlives the interactive
+			// deadline; the index read does not.
+			let timeout = if others {
+				super::cli::COMMAND_TIMEOUT
+			} else {
+				super::cli::SYNC_TIMEOUT
+			};
+			match cli_text_owned_capped(self.root(), &args, timeout, path_list_capture_limit()) {
+				// The subprocess capture is capped, and this output is the
+				// return value rather than a diagnostic: a short list would
+				// silently hide paths, so re-run the walk in-process. Reftable
+				Ok(text) if super::cli::is_truncated(&text) => {
+					if self.is_reftable() {
+						return Err(Error::backend(
+							"git ls-files",
+							"path list exceeded the subprocess capture limit",
+						));
+					}
+				},
+				Ok(text) => {
+					return Ok(text
+						.split('\0')
+						.filter(|path| !path.is_empty())
+						.map(str::to_owned)
+						.collect());
+				},
+				Err(err) if self.is_reftable() || !super::cli::prefers_in_process(&err) => {
+					return Err(err);
+				},
+				Err(_) => {},
+			}
 		}
 		if !others {
 			let repo = self.gix()?;
@@ -1044,6 +1067,34 @@ fn cli_text_owned(cwd: &Path, args: &[String], timeout: std::time::Duration) -> 
 		.into_checked(args)?
 		.stdout)
 }
+
+/// [`cli_text_owned`] with an explicit retention cap, for reads whose output is
+/// the return value rather than a diagnostic.
+fn cli_text_owned_capped(
+	cwd: &Path,
+	args: &[String],
+	timeout: std::time::Duration,
+	limit: usize,
+) -> Result<String> {
+	Ok(super::cli::run_sync_capped(cwd, args, timeout, limit)?
+		.into_checked(args)?
+		.stdout)
+}
+
+/// Retention cap for path-list captures.
+///
+/// A thread-local in test builds: the walk runs on the calling thread, so a
+/// test lowers the cap for its own invocations without truncating captures in
+/// tests running concurrently.
+#[cfg(test)]
+fn path_list_capture_limit() -> usize {
+	tests::CAPTURE_LIMIT.get()
+}
+
+#[cfg(not(test))]
+const fn path_list_capture_limit() -> usize {
+	super::cli::OUTPUT_LIMIT_BYTES
+}
 fn cli_lines(cwd: &Path, args: &[&str]) -> Result<Vec<String>> {
 	Ok(cli_text(cwd, args)?
 		.lines()
@@ -1256,6 +1307,131 @@ mod tests {
 		fs::write(cwd.join(name), contents)?;
 		git(cwd, &["add", name])?;
 		git(cwd, &["commit", "-m", subject])?;
+		Ok(())
+	}
+
+	thread_local! {
+		/// Retention cap consulted by [`path_list_capture_limit`]; per-thread so
+		/// lowering it here cannot truncate captures in concurrent tests.
+		pub(super) static CAPTURE_LIMIT: std::cell::Cell<usize> =
+			const { std::cell::Cell::new(super::super::cli::OUTPUT_LIMIT_BYTES) };
+	}
+
+	/// Run `f` with the path-list capture cap lowered to `limit`.
+	fn with_capture_limit<R>(limit: usize, f: impl FnOnce() -> R) -> R {
+		struct Restore(usize);
+		impl Drop for Restore {
+			fn drop(&mut self) {
+				CAPTURE_LIMIT.set(self.0);
+			}
+		}
+		let _restore = Restore(CAPTURE_LIMIT.get());
+		CAPTURE_LIMIT.set(limit);
+		f()
+	}
+
+	/// Create `count` untracked files whose combined path bytes exceed any small
+	/// capture cap, and return them in the order git reports.
+	fn untracked_fixture(
+		root: &Path,
+		count: usize,
+	) -> std::result::Result<Vec<String>, Box<dyn std::error::Error>> {
+		let mut expected = Vec::with_capacity(count);
+		for index in 0..count {
+			let name = format!("{}-{index:03}.txt", "u".repeat(40));
+			fs::write(root.join(&name), "x")?;
+			expected.push(name);
+		}
+		expected.sort();
+		Ok(expected)
+	}
+
+	#[test]
+	fn is_dirty_answers_from_a_capped_capture() -> TestResult {
+		let (dir, repo) = repo()?;
+		let root = dir.path();
+		commit(root, "tracked", "tracked\n", "tracked")?;
+		assert!(!repo.is_dirty()?);
+
+		// Enough entries that the porcelain rendering outgrows
+		// DIRTY_PROBE_CAPTURE_LIMIT, so the answer has to survive a capture that
+		// was cut short rather than depend on reading the whole listing.
+		untracked_fixture(root, 150)?;
+		let full = repo.status_porcelain(&StatusOptions::default())?;
+		assert!(
+			full.len() > DIRTY_PROBE_CAPTURE_LIMIT,
+			"fixture must outgrow the probe cap, got {} bytes",
+			full.len()
+		);
+		assert!(repo.is_dirty()?);
+		Ok(())
+	}
+
+	#[test]
+	fn ls_files_returns_every_untracked_path_when_the_capture_truncates() -> TestResult {
+		let (dir, repo) = repo()?;
+		let root = dir.path();
+		commit(root, "tracked", "tracked\n", "tracked")?;
+		let expected = untracked_fixture(root, 60)?;
+		// Pin the precondition: at this cap the subprocess capture really is cut
+		// short, so the equality below is evidence of the in-process retry and
+		// not of a capture that happened to fit.
+		let capped = cli_text_owned_capped(
+			root,
+			&["ls-files".to_owned(), "-z".to_owned(), "--others".to_owned()],
+			super::super::cli::SYNC_TIMEOUT,
+			256,
+		)?;
+		assert!(super::super::cli::is_truncated(&capped), "fixture must overflow the cap");
+
+		let listed = with_capture_limit(256, || repo.ls_files(true, true))?;
+		assert_eq!(listed, expected);
+		Ok(())
+	}
+
+	/// Initialize a reftable repository, or report that this git cannot.
+	///
+	/// `--ref-format` arrived in git 2.45. There is no way to fake the fixture
+	/// on an older binary: writing `extensions.refstorage = reftable` by hand
+	/// makes git reject the repository outright, so every command in the test
+	/// would fail for the wrong reason.
+	fn init_reftable(root: &Path) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+		let out = Command::new("git")
+			.current_dir(root)
+			.args(["init", "-q", "-b", "main", "--ref-format=reftable"])
+			.output()?;
+		if out.status.success() {
+			return Ok(true);
+		}
+		let stderr = String::from_utf8_lossy(&out.stderr);
+		if stderr.contains("ref-format") {
+			eprintln!("skipping reftable coverage: this git has no --ref-format ({})", stderr.trim());
+			return Ok(false);
+		}
+		Err(format!("git init --ref-format=reftable failed: {stderr}").into())
+	}
+
+	#[test]
+	fn reftable_ls_files_errors_rather_than_returning_a_truncated_prefix() -> TestResult {
+		let dir = tempfile::tempdir()?;
+		let root = dir.path();
+		if !init_reftable(root)? {
+			return Ok(());
+		}
+		git(root, &["config", "user.name", "Test User"])?;
+		git(root, &["config", "user.email", "test@example.com"])?;
+		let repo = GitRepo::require(root)?;
+		assert!(repo.is_reftable(), "fixture must use reftable ref storage");
+		let expected = untracked_fixture(root, 60)?;
+
+		// Uncapped, the reftable repo reads through the same CLI path.
+		assert_eq!(repo.ls_files(true, true)?, expected);
+
+		// Capped, there is no in-process walk to fall back to, so a short list
+		// must surface as an error instead of a silent prefix.
+		let err = with_capture_limit(256, || repo.ls_files(true, true))
+			.expect_err("truncated reftable listing must fail");
+		assert!(err.to_string().contains("capture limit"), "unexpected error: {err}");
 		Ok(())
 	}
 


### PR DESCRIPTION
## What broke

Six `native-panic-*.log` files from one host, three processes, inside 12 seconds. Each process emitted the same pair:

```
thread:   gix_status::index_as_worktree
location: gix-features-0.48.1/src/parallel/in_parallel.rs:83:22
message:  valid name: Os { code: 1455, kind: Uncategorized,
            message: "The paging file is too small for this operation to complete." }

thread:   gix::status::index_worktree::producer
location: gix-status-0.32.0/src/index_as_worktree_with_renames/mod.rs:333:86
message:  no panic: Any { .. }
```

`CreateThread` failed with `ERROR_COMMITMENT_LIMIT` while gitoxide was spawning a status worker. gix does `.expect("valid name")` there, so a recoverable OS resource failure becomes a panic; the second log is that panic re-raised on the producer thread. gix spawned the thread, so it carries no `blocking_task_panic_scope` and `crash_handler` classifies it `Fatal` and dumps to stderr.

## What this changes

`status_porcelain` already documents this failure and runs the git CLI for it. `is_dirty` and untracked `ls_files` were the two remaining whole-worktree reads still walking in-process.

- `is_dirty` shares the porcelain subprocess. It loses its first-change short circuit and is still faster in every fixture measured. The answer is a boolean, so its capture is capped at `DIRTY_PROBE_CAPTURE_LIMIT` and the rest is dropped as it arrives — 100k untracked paths cannot make it allocate megabytes to decide `true`.
- Untracked `ls-files` runs `git ls-files -z --others [--exclude-standard]` with `COMMAND_TIMEOUT`, not `SYNC_TIMEOUT`: a whole-tree walk legitimately outlives the interactive deadline. Tracked listing is a bounded index read and stays in-process.
- `-z` also drops the quoting the newline form applies to non-ASCII paths, which the gitoxide path never did, so reftable repos stop returning quoted names.

The in-process walk stays reachable for exactly the cases the subprocess cannot serve, via `cli::prefers_in_process`:

| case | predicate |
|---|---|
| no git binary | `is_spawn_failure` (unchanged) |
| checkout git refuses under `safe.directory` | `is_dubious_ownership` — exit 128 plus the `LC_MESSAGES=C`-pinned text |
| output too large to capture | `is_truncated`, path list only |

`open_options` opens user-chosen checkouts with `Trust::Full` on purpose, so the library-backed path has no ownership objection. This also repairs `status_porcelain`, which has been CLI-first for longer than this change and failed the same way on host-mounted container checkouts.

A spawn that fails *because* the host is out of commit is deliberately **not** in that set: `spawn_error` maps everything but `NotFound` to `Error::Io`, so the walk that panics is not re-entered under the very condition that made it panic.

The 8 MiB capture cap would silently shorten a path list, unlike a diagnostic, so truncation drives an in-process retry; a reftable repo has no in-process walk and errors instead. The cap is now a parameter of the sync runner (`run_sync_capped`) rather than a constant read inside the reader threads, so one call can be capped without shrinking every other capture in the process, and the path-list cap resolves through a test-only thread-local.

## Measured

Release build, peak commit charge via `PROCESS_MEMORY_COUNTERS.PeakPagefileUsage`, throwaway probe (not committed):

| fixture | before | after |
|---|---|---|
| clean 4 GiB worktree, mtimes bumped — `is_dirty` | 116 ms / 5.7 MB | 25 ms / 1.0 MB |
| 40 000 untracked — `is_dirty` | 68 ms / 1.7 MB | 45 ms / 1.0 MB |
| 40 000 untracked — `ls-files` | 47 ms / 5.7 MB | 56 ms / 1.0 MB |
| 48 001 untracked, 9.3 MB of path bytes — `ls-files` | 151 ms / 14.5 MB | 336 ms / 38.6 MB |

The last row is the cap tripping: the subprocess result is discarded and the in-process walk re-runs, returning all 48 001 paths with `ünïcødé-ファイル.txt` unquoted. Two walks, so ~2× time and memory, bounded, and only past 8 MiB of path bytes.

Ownership fallback verified against the real refusal using git's own `GIT_TEST_ASSUME_DIFFERENT_OWNER=1`:

```
CLI: exit=128 fatal: detected dubious ownership in repository at '.../ownprobe'

before  is_dirty=Err(Cli{128})  ls_files=Err(Cli{128})  status_porcelain=Err(Cli{128})
after   is_dirty=Ok(true)       ls_files=Ok(["untracked.txt"])
        status_porcelain=Ok(" M tracked.txt\n?? untracked.txt\n")
```

## Tests

Three regression tests, each checked to fail against the bug it covers (guard disabled / cap raised), not just to pass:

- `ls_files_returns_every_untracked_path_when_the_capture_truncates` — asserts the raw capped capture really is cut short as a precondition, then that all 60 paths come back.
- `reftable_ls_files_errors_rather_than_returning_a_truncated_prefix` — `git init --ref-format=reftable` (needs git ≥ 2.45); uncapped returns all 60, capped must error rather than return a prefix.
- `is_dirty_answers_from_a_capped_capture` — fixture outgrows `DIRTY_PROBE_CAPTURE_LIMIT`, so the boolean has to survive a capture that was cut short.

No automated test for the ownership fallback: forcing it needs a second UID or a process-wide `GIT_TEST_ASSUME_DIFFERENT_OWNER`, and `std::env::set_var` in a parallel test binary would break every other test's CLI invocation. Covered by the verification above.

## Scope

I could not reproduce GB-scale in-process usage in any shape — gix streams its hashes and the dirwalk is cheap. A thread spawn failing at the commit limit means the host was already there, so this PR removes exposure to a panic under that condition; it does not claim to be the fix for whatever exhausted commit on that machine.

Not addressed here:

- The upstream `.expect("valid name")` in `gix-features` — a recoverable spawn failure panicking across a library boundary. Every gix consumer inherits it; this is the underlying defect.
- Remaining in-process gix walks (`diff.rs` tracked diff, `clean`, the fallbacks). The only levers are `thread_limit = 1`, which single-threads every large diff, or `catch_unwind` at the pi-vcs boundary, which does not suppress the stderr dump because the hook runs on the gix thread first.
- The thread-local recovery scope in `crash_handler.rs`. gix spawns raw threads; a process-global counter would mislabel genuinely fatal panics.

## Validation

`cargo test -p pi-vcs`: 46 passed, 5 failed — byte-identical to the same command on `origin/main` with this commit reverted (pre-existing Windows UNC-path and `patch_apply` failures on my host; @roboomp's Linux run of `CI=1 bun run test:rs` saw 2770/2771 with one unrelated author-name assertion). `cargo clippy -p pi-vcs --all-targets`: only the pre-existing `git_diff` dead-code warning. `bun run fmt:rs` clean. Workspace `lint:rs` cannot run on this host (`pi-voice`'s opus build script needs Ninja), and no CI checks have reported on this branch, so Bazel remains unexercised.
