### PR TITLE
fix(auth): propagate broker credential changes to long-lived clients

### DIFF
--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -541,15 +541,13 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#applyStreamEvent(event: SnapshotStreamEvent): void {
 		switch (event.kind) {
 			case "snapshot": {
-				// Strip the discriminator so we store the wire-shape SnapshotResponse.
+				// The first frame of every SSE connection is a full authoritative
+				// snapshot. Always adopt it as the new generation baseline: the
+				// broker's in-memory generation counter resets on restart and may
+				// therefore be lower than the previous stream's last value.
+				// Subsequent entry/removal frames remain guarded against reordering
+				// relative to this new baseline below.
 				const { kind: _kind, ...snapshot } = event;
-				if (snapshot.generation < this.#generation) {
-					logger.debug("auth-broker stream snapshot older than local; ignoring", {
-						local: this.#generation,
-						incoming: snapshot.generation,
-					});
-					return;
-				}
 				this.#applySnapshot(snapshot, snapshot.generation);
 				return;
 			}

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -256,12 +256,17 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#snapshotReceivedAt = Date.now();
 	#generation = 0;
 	/**
-	 * Generation last reported as "seen" by {@link pollExternalChanges}. Seeded
-	 * from the initial snapshot so the first poll after a broker-side change
-	 * (delivered by the background SSE/long-poll loop, which advances
-	 * `#generation`) returns true and drives an {@link AuthStorage} reload.
+	 * Content fingerprint of the credential set in {@link #snapshot} (id +
+	 * provider + credential material), recomputed after every snapshot mutation.
+	 * Drives {@link #credentialRevision} independently of the broker's numeric
+	 * generation, which is an in-memory counter that resets when the broker
+	 * process restarts and so cannot be trusted for change detection.
 	 */
-	#acknowledgedGeneration = 0;
+	#credentialFingerprint = "";
+	/** Monotonic local counter bumped whenever {@link #credentialFingerprint} changes. */
+	#credentialRevision = 0;
+	/** Revision last reported as "seen" by {@link pollExternalChanges}; seeded from the initial snapshot. */
+	#acknowledgedRevision = 0;
 	#usageOverlays: Map<string, UsageReport> = new Map();
 	#backgroundAbort = new AbortController();
 	readonly #backgroundIdleMs: number;
@@ -307,7 +312,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			? new Map([...opts.accountPool].map(([provider, identities]) => [provider, new Set(identities)]))
 			: undefined;
 		this.#applySnapshot(opts.initialSnapshot ?? emptySnapshot(), opts.initialSnapshot?.generation ?? 0);
-		this.#acknowledgedGeneration = this.#generation;
+		this.#acknowledgedRevision = this.#credentialRevision;
 		this.#onSnapshot = opts.onSnapshot;
 		void this.#runBackground();
 	}
@@ -333,6 +338,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		this.#snapshot = { ...snapshot, credentials };
 		this.#generation = generation;
 		this.#snapshotReceivedAt = nowMs;
+		this.#refreshCredentialRevision();
 		const onSnapshot = this.#onSnapshot;
 		if (!onSnapshot) return;
 		try {
@@ -340,6 +346,34 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		} catch (error) {
 			logger.debug("auth-broker snapshot callback failed", { error: String(error) });
 		}
+	}
+
+	/**
+	 * Recompute the credential-content fingerprint and bump
+	 * {@link #credentialRevision} when it changes. Called after every snapshot
+	 * mutation so {@link pollExternalChanges} detects add/remove/replace even
+	 * when the broker's numeric generation repeats (e.g. after a broker
+	 * restart resets its in-memory counter).
+	 */
+	#refreshCredentialRevision(): void {
+		const fingerprint = this.#computeCredentialFingerprint();
+		if (fingerprint === this.#credentialFingerprint) return;
+		this.#credentialFingerprint = fingerprint;
+		this.#credentialRevision += 1;
+	}
+
+	/**
+	 * Order-independent digest of the routable credential material — exactly the
+	 * fields {@link listAuthCredentials} exposes (id, provider, credential). A
+	 * token rotation or an add/remove changes it; credential blocks and usage
+	 * overlays do not.
+	 */
+	#computeCredentialFingerprint(): string {
+		const parts = this.#snapshot.credentials.map(
+			entry => `${entry.id}\u0000${entry.provider}\u0000${JSON.stringify(entry.credential)}`,
+		);
+		parts.sort();
+		return parts.join("\u0001");
 	}
 	#protectNewSnapshotBlocks(previous: readonly SnapshotEntry[], next: readonly SnapshotEntry[], nowMs: number): void {
 		const previousBlocksByKey = new Map<string, string>();
@@ -556,6 +590,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		this.#snapshot = { ...this.#snapshot, generation, serverNowMs, refresher, credentials };
 		this.#generation = generation;
 		this.#snapshotReceivedAt = Date.now();
+		this.#refreshCredentialRevision();
 	}
 
 	#removeStreamCredential(
@@ -572,6 +607,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		this.#snapshot = { ...this.#snapshot, generation, serverNowMs, refresher, credentials };
 		this.#generation = generation;
 		this.#snapshotReceivedAt = Date.now();
+		this.#refreshCredentialRevision();
 	}
 
 	/** Re-hydrate the in-memory snapshot from the broker. */
@@ -588,17 +624,20 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	 * clients (notably `auth-gateway serve`) pick up logins/logouts made by
 	 * another process without a restart.
 	 *
-	 * `#generation` is advanced only by the background SSE/long-poll loop
-	 * (`#applySnapshot`/`#applyStreamEntry`/`#removeStreamCredential`), so a move
-	 * past the last acknowledged generation means the broker's credential set
-	 * changed. Records foreground activity first: a low-traffic client's
-	 * background sync parks after `#backgroundIdleMs`, and without this wakeup it
-	 * would never fetch the new generation to report in the first place.
+	 * Compares a local content revision, not the broker's numeric generation:
+	 * generation is an in-memory counter that resets when the broker process
+	 * restarts, so a reconnecting stream can deliver a different credential set
+	 * under a repeated (or lower) generation. {@link #refreshCredentialRevision}
+	 * bumps the revision whenever the applied credential material actually
+	 * changes, catching those cases too. Records foreground activity first: a
+	 * low-traffic client's background sync parks after `#backgroundIdleMs`, and
+	 * without this wakeup it would never fetch the new snapshot to report in the
+	 * first place.
 	 */
 	pollExternalChanges(): boolean {
 		this.#noteActivity();
-		if (this.#generation === this.#acknowledgedGeneration) return false;
-		this.#acknowledgedGeneration = this.#generation;
+		if (this.#credentialRevision === this.#acknowledgedRevision) return false;
+		this.#acknowledgedRevision = this.#credentialRevision;
 		return true;
 	}
 

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -255,6 +255,13 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#snapshot: SnapshotResponse = emptySnapshot();
 	#snapshotReceivedAt = Date.now();
 	#generation = 0;
+	/**
+	 * Generation last reported as "seen" by {@link pollExternalChanges}. Seeded
+	 * from the initial snapshot so the first poll after a broker-side change
+	 * (delivered by the background SSE/long-poll loop, which advances
+	 * `#generation`) returns true and drives an {@link AuthStorage} reload.
+	 */
+	#acknowledgedGeneration = 0;
 	#usageOverlays: Map<string, UsageReport> = new Map();
 	#backgroundAbort = new AbortController();
 	readonly #backgroundIdleMs: number;
@@ -300,6 +307,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			? new Map([...opts.accountPool].map(([provider, identities]) => [provider, new Set(identities)]))
 			: undefined;
 		this.#applySnapshot(opts.initialSnapshot ?? emptySnapshot(), opts.initialSnapshot?.generation ?? 0);
+		this.#acknowledgedGeneration = this.#generation;
 		this.#onSnapshot = opts.onSnapshot;
 		void this.#runBackground();
 	}
@@ -572,6 +580,26 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		const result = await this.#client.fetchSnapshot();
 		if (result.status === 200) this.#applySnapshot(result.snapshot, result.generation);
 		return this.#snapshot;
+	}
+
+	/**
+	 * Stateful probe for broker-side credential changes, mirroring
+	 * {@link SqliteAuthCredentialStore.pollExternalChanges} so long-lived broker
+	 * clients (notably `auth-gateway serve`) pick up logins/logouts made by
+	 * another process without a restart.
+	 *
+	 * `#generation` is advanced only by the background SSE/long-poll loop
+	 * (`#applySnapshot`/`#applyStreamEntry`/`#removeStreamCredential`), so a move
+	 * past the last acknowledged generation means the broker's credential set
+	 * changed. Records foreground activity first: a low-traffic client's
+	 * background sync parks after `#backgroundIdleMs`, and without this wakeup it
+	 * would never fetch the new generation to report in the first place.
+	 */
+	pollExternalChanges(): boolean {
+		this.#noteActivity();
+		if (this.#generation === this.#acknowledgedGeneration) return false;
+		this.#acknowledgedGeneration = this.#generation;
+		return true;
 	}
 
 	listAuthCredentials(provider?: string): StoredAuthCredential[] {

--- a/packages/ai/test/auth-broker-remote-store.test.ts
+++ b/packages/ai/test/auth-broker-remote-store.test.ts
@@ -112,6 +112,52 @@ describe("RemoteAuthCredentialStore SSE integration", () => {
 		expect(remote!.snapshot.credentials[0].id).not.toBe(bId);
 	});
 
+	test("pollExternalChanges reports broker-side changes so a wrapping AuthStorage reloads", async () => {
+		const client = new AuthBrokerClient({ url: handle!.url, token });
+		// Mirror `auth-gateway serve`'s boot: fetch the initial snapshot so the
+		// store seeds its acknowledged generation, then wrap the broker-backed
+		// store in its own AuthStorage whose credential view only refreshes on
+		// reload().
+		const initial = await client.fetchSnapshot();
+		if (initial.status !== 200) throw new Error("expected initial broker snapshot");
+		remote = new RemoteAuthCredentialStore({ client, initialSnapshot: initial.snapshot });
+		const gatewayStorage = new AuthStorage(remote, { sourceLabel: `broker ${handle!.url}` });
+		try {
+			await gatewayStorage.reload();
+			await waitUntil(() => remote!.snapshot.credentials.length === 1);
+			// Boot generation is acknowledged: no spurious reload before any change.
+			expect(await gatewayStorage.pollExternalChanges()).toBe(false);
+			expect(gatewayStorage.exportSnapshot().credentials.map(c => c.provider)).toEqual(["anthropic"]);
+
+			// Another process logs in a new provider; the change reaches the remote
+			// store over SSE.
+			storage!.upsertCredential("deepseek", { type: "api_key", key: "sk-repro" });
+			await waitUntil(() => remote!.snapshot.credentials.some(c => c.provider === "deepseek"));
+
+			// The poll now reports the change and the reload widens the gateway view.
+			expect(await gatewayStorage.pollExternalChanges()).toBe(true);
+			expect(
+				gatewayStorage
+					.exportSnapshot()
+					.credentials.map(c => c.provider)
+					.sort(),
+			).toEqual(["anthropic", "deepseek"]);
+			// One true per observed change: an unchanged generation reports false.
+			expect(await gatewayStorage.pollExternalChanges()).toBe(false);
+
+			// A logout in another process removes the credential over SSE, and the
+			// next poll drops it from the gateway view.
+			const deepseekId = remote!.snapshot.credentials.find(c => c.provider === "deepseek")?.id;
+			expect(deepseekId).toBeDefined();
+			expect(storage!.disableCredentialById(deepseekId!, "logged out by test")).toBe(true);
+			await waitUntil(() => !remote!.snapshot.credentials.some(c => c.provider === "deepseek"));
+			expect(await gatewayStorage.pollExternalChanges()).toBe(true);
+			expect(gatewayStorage.exportSnapshot().credentials.map(c => c.provider)).toEqual(["anthropic"]);
+		} finally {
+			gatewayStorage.close();
+		}
+	});
+
 	test("batches observed usage and reports it to the broker as per-install client usage", async () => {
 		const client = new AuthBrokerClient({ url: handle!.url, token });
 		remote = new RemoteAuthCredentialStore({ client, observedUsageFlushMs: 25 });

--- a/packages/ai/test/auth-broker-remote-store.test.ts
+++ b/packages/ai/test/auth-broker-remote-store.test.ts
@@ -7,6 +7,7 @@ import {
 	AuthBrokerClient,
 	type AuthBrokerServerHandle,
 	discoverAuthStorage,
+	type FetchSnapshotResult,
 	RemoteAuthCredentialStore,
 	type SnapshotResponse,
 	startAuthBroker,
@@ -451,5 +452,81 @@ describe("RemoteAuthCredentialStore SSE integration", () => {
 				}
 			},
 		);
+	});
+});
+
+/**
+ * Snapshot builder for the fake-client tests: only `id`/`provider`/`credential`
+ * feed the content fingerprint, so the credential key is what drives change
+ * detection.
+ */
+function buildApiKeySnapshot(
+	generation: number,
+	creds: { id: number; provider: string; key: string }[],
+): SnapshotResponse {
+	return {
+		generation,
+		generatedAt: Date.now(),
+		serverNowMs: Date.now(),
+		refresher: { enabled: false, intervalMs: 0, skewMs: 0, nextSweepInMs: 0 },
+		credentials: creds.map(c => ({
+			id: c.id,
+			provider: c.provider,
+			credential: { type: "api_key", key: c.key },
+			identityKey: null,
+			rotatesInMs: null,
+		})),
+	};
+}
+
+/**
+ * Minimal broker client that serves a test-controlled snapshot. Background
+ * long-poll calls (which pass `ifGenerationGt`) always report "unchanged" so
+ * the manual `refreshSnapshot()` is the sole driver, keeping the test
+ * deterministic.
+ */
+class FakeBrokerClient {
+	current: SnapshotResponse;
+	constructor(initial: SnapshotResponse) {
+		this.current = initial;
+	}
+	async fetchSnapshot(opts: { ifGenerationGt?: number } = {}): Promise<FetchSnapshotResult> {
+		if (opts.ifGenerationGt !== undefined) return { status: 304, generation: this.current.generation };
+		return { status: 200, snapshot: this.current, generation: this.current.generation };
+	}
+}
+
+describe("RemoteAuthCredentialStore.pollExternalChanges content revision", () => {
+	test("detects a replaced credential even when the broker generation repeats", async () => {
+		const initial = buildApiKeySnapshot(5, [{ id: 1, provider: "deepseek", key: "sk-old" }]);
+		const client = new FakeBrokerClient(initial);
+		const store = new RemoteAuthCredentialStore({
+			client: client as unknown as AuthBrokerClient,
+			initialSnapshot: initial,
+			streamSnapshots: false,
+			backgroundIdleMs: 0,
+		});
+		try {
+			// Boot state is acknowledged: nothing to report yet.
+			expect(store.pollExternalChanges()).toBe(false);
+
+			// An identical re-fetch (same generation, same content) stays quiet.
+			client.current = buildApiKeySnapshot(5, [{ id: 1, provider: "deepseek", key: "sk-old" }]);
+			await store.refreshSnapshot();
+			expect(store.pollExternalChanges()).toBe(false);
+
+			// The broker restarts and replaces the credential's key while its
+			// in-memory generation counter lands back on the acknowledged value 5.
+			// A generation-equality check would miss this; the content revision
+			// catches it.
+			client.current = buildApiKeySnapshot(5, [{ id: 1, provider: "deepseek", key: "sk-new" }]);
+			await store.refreshSnapshot();
+			expect(store.snapshot.generation).toBe(5);
+			expect(store.pollExternalChanges()).toBe(true);
+			// One true per observed change.
+			expect(store.pollExternalChanges()).toBe(false);
+		} finally {
+			store.close();
+		}
 	});
 });

--- a/packages/ai/test/auth-broker-remote-store.test.ts
+++ b/packages/ai/test/auth-broker-remote-store.test.ts
@@ -159,6 +159,77 @@ describe("RemoteAuthCredentialStore SSE integration", () => {
 		}
 	});
 
+	test("accepts a lower-generation authoritative snapshot after broker restart", async () => {
+		const client = new AuthBrokerClient({ url: handle!.url, token });
+		const initial = await client.fetchSnapshot();
+		if (initial.status !== 200) throw new Error("expected initial broker snapshot");
+		remote = new RemoteAuthCredentialStore({ client, initialSnapshot: initial.snapshot });
+		const gatewayStorage = new AuthStorage(remote, { sourceLabel: `broker ${handle!.url}` });
+		try {
+			await gatewayStorage.reload();
+
+			// Drive the original broker above the generation its replacement will
+			// start at, then acknowledge that complete credential view.
+			storage!.upsertCredential("deepseek", { type: "api_key", key: "sk-deepseek" });
+			storage!.upsertCredential("openai", { type: "api_key", key: "sk-openai" });
+			storage!.upsertCredential("xai", { type: "api_key", key: "sk-xai" });
+			await waitUntil(() => remote!.snapshot.credentials.length === 4);
+			const previousGeneration = remote.snapshot.generation;
+			expect(await gatewayStorage.pollExternalChanges()).toBe(true);
+			expect(await gatewayStorage.pollExternalChanges()).toBe(false);
+
+			// Stop the broker, replace its persisted credential set, and boot a
+			// fresh AuthStorage whose in-memory generation starts below the
+			// client's previously acknowledged value.
+			const brokerUrl = new URL(handle!.url);
+			const bind = `${brokerUrl.hostname}:${brokerUrl.port}`;
+			await handle!.close();
+			storage!.close();
+
+			store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+			for (const provider of ["anthropic", "deepseek", "openai", "xai"]) {
+				store.deleteProvider(provider);
+			}
+			store.saveApiKey("google", "sk-restarted");
+			storage = new AuthStorage(store);
+			await storage.reload();
+			expect(storage.getGeneration()).toBeLessThan(previousGeneration);
+			handle = startAuthBroker({
+				storage,
+				bind,
+				bearerTokens: [token],
+				disableRefresher: true,
+			});
+
+			// The reconnect's first SSE frame is authoritative despite its lower
+			// generation. The wrapping AuthStorage must reload that content.
+			await waitUntil(
+				() =>
+					remote!.snapshot.generation < previousGeneration &&
+					remote!.snapshot.credentials.length === 1 &&
+					remote!.snapshot.credentials[0]?.provider === "google",
+				4_000,
+			);
+			expect(await gatewayStorage.pollExternalChanges()).toBe(true);
+			expect(gatewayStorage.exportSnapshot().credentials.map(c => c.provider)).toEqual(["google"]);
+
+			// Incremental events are now ordered against the replacement
+			// baseline, not the previous broker process's higher generation.
+			storage!.upsertCredential("deepseek", { type: "api_key", key: "sk-after-restart" });
+			await waitUntil(() => remote!.snapshot.credentials.some(c => c.provider === "deepseek"));
+			expect(remote.snapshot.generation).toBeLessThan(previousGeneration);
+			expect(await gatewayStorage.pollExternalChanges()).toBe(true);
+			expect(
+				gatewayStorage
+					.exportSnapshot()
+					.credentials.map(c => c.provider)
+					.sort(),
+			).toEqual(["deepseek", "google"]);
+		} finally {
+			gatewayStorage.close();
+		}
+	});
+
 	test("batches observed usage and reports it to the broker as per-install client usage", async () => {
 		const client = new AuthBrokerClient({ url: handle!.url, token });
 		remote = new RemoteAuthCredentialStore({ client, observedUsageFlushMs: 25 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Provider-native compaction (OpenAI Responses compact, Anthropic server-side compaction) re-issues the system prompt the live turn actually sent — a per-turn `before_agent_start` override included — instead of the rebuilt base prompt, and advisor compaction sends the advisor's own prompt instead of the generic summarizer prompt, so the request reads the live request's cached prefix.
+- `omp auth-gateway serve` now picks up credential logins and logouts made by another process within ~10s instead of serving its boot-time credential set until restart: broker-backed clients implement `pollExternalChanges()`, and the gateway polls it to reload credentials and rebuild its served catalog so a newly-logged-in provider becomes routable and a logged-out one stops being advertised and used ([#11781](https://github.com/can1357/oh-my-pi/issues/11781)).
 ### Fixed
 
 - The `set_steering_mode`, `set_follow_up_mode`, and `set_interrupt_mode` RPC commands are now session-scoped, so a short-lived RPC client no longer silently writes queue-mode fields to the machine-global `config.yml`. The setters still persist by default, so the settings panel and existing callers are unaffected ([#11555](https://github.com/can1357/oh-my-pi/issues/11555)).

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -179,6 +179,40 @@ export function indexModelsByRequestId(
 	return modelById;
 }
 
+/**
+ * Serialize catalog rebuilds so `registry.refresh()` passes never overlap,
+ * while guaranteeing a forced rebuild requested mid-flight runs a forced pass
+ * afterward. Without the follow-up pass a credential change arriving during a
+ * weaker cached rebuild would piggyback on it and miss an account-scoped
+ * catalog change. Non-forced requests during an in-flight rebuild simply
+ * coalesce onto it. Returns `rebuild(force?)`; its promise resolves once the
+ * catalog reflects that call's requirement.
+ */
+export function createSerializedRebuilder(run: (force: boolean) => Promise<void>): (force?: boolean) => Promise<void> {
+	let inFlight: Promise<void> | null = null;
+	let forcedQueued = false;
+	const rebuild = (force = false): Promise<void> => {
+		if (inFlight) {
+			if (force) forcedQueued = true;
+			return inFlight;
+		}
+		inFlight = (async () => {
+			try {
+				await run(force);
+				while (forcedQueued) {
+					forcedQueued = false;
+					await run(true);
+				}
+			} finally {
+				inFlight = null;
+				forcedQueued = false;
+			}
+		})();
+		return inFlight;
+	};
+	return rebuild;
+}
+
 async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	const brokerConfig = await resolveAuthBrokerConfig();
 	if (!brokerConfig) {
@@ -230,23 +264,17 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 		return providers;
 	};
 	let modelById = new Map<string, Model<Api>>();
-	// Rebuild the served catalog behind a `registry.refresh()` pass (a
-	// first-time provider has no cached models) and re-index against the current
-	// credential set. A single in-flight guard coalesces the periodic model
-	// refresh and the credential-sync poll; a failed rebuild keeps the previous
-	// catalog.
-	let rebuildInFlight: Promise<void> | null = null;
-	const rebuildCatalog = (): Promise<void> => {
-		rebuildInFlight ??= (async () => {
-			try {
-				await registry.refresh();
-				modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds());
-			} finally {
-				rebuildInFlight = null;
-			}
-		})();
-		return rebuildInFlight;
-	};
+	// Rebuild the served catalog (a `registry.refresh()` pass, then re-index
+	// against the current credential set). Credential-triggered rebuilds force
+	// `online` discovery: an account added to or removed from an
+	// already-authenticated provider (e.g. Codex, whose discovery unions
+	// per-account catalogs) leaves that provider's model cache fresh, so the
+	// default `online-if-uncached` pass would skip the fetch and miss the change
+	// for up to a cache TTL. Periodic rebuilds stay cached.
+	const rebuildCatalog = createSerializedRebuilder(async force => {
+		await registry.refresh(force ? "online" : "online-if-uncached");
+		modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds());
+	});
 	await rebuildCatalog();
 
 	const handle = startAuthGateway({
@@ -282,12 +310,13 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	// Poll the broker-backed store for credential changes made by another
 	// process (host `login`/`logout`). `pollExternalChanges()` reloads the
 	// storage's credential view so selection stops 401ing (or stops using a
-	// removed credential); rebuilding the catalog then updates `/v1/models` and
-	// `resolveModel`. `unref()` for the same reason as above.
+	// removed credential); the forced rebuild then refetches account-scoped
+	// catalogs and updates `/v1/models` and `resolveModel`. `unref()` for the
+	// same reason as above.
 	const credentialSync = setInterval(() => {
 		void (async () => {
 			try {
-				if (await storage.pollExternalChanges()) await rebuildCatalog();
+				if (await storage.pollExternalChanges()) await rebuildCatalog(true);
 			} catch (error) {
 				logger.warn("auth-gateway credential sync failed", {
 					error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -150,6 +150,17 @@ async function fetchBrokerSnapshot(client: AuthBrokerClient): Promise<SnapshotRe
 const CATALOG_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
+ * How often a long-lived `serve` polls the broker-backed store for credential
+ * changes made by another process (a `login`/`logout` on the host). Kept below
+ * {@link RemoteAuthCredentialStore}'s background idle window so the poll's
+ * activity ping keeps the snapshot stream warm and new generations arrive
+ * promptly. When the poll reports a change, the served catalog is rebuilt so a
+ * newly-credentialed provider becomes routable and a removed one stops being
+ * advertised.
+ */
+const CREDENTIAL_SYNC_INTERVAL_MS = 10 * 1000;
+
+/**
  * Index resolvable models by the request ids clients may send: the
  * provider-qualified `provider/id` (always) and the bare `id` (first-write-wins
  * fallback for legacy clients). Scoped to providers the gateway holds broker
@@ -208,12 +219,35 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	// shadow broker credentials. Format handlers ask `resolveModel` to translate
 	// a client-requested `model` field into a pi-ai `Model<Api>` before dispatch;
 	// `listModels` powers `/v1/models`.
-	const snapshot = storage.exportSnapshot();
-	const providersWithCreds = new Set<string>();
-	for (const entry of snapshot.credentials) providersWithCreds.add(entry.provider);
 	const registry = new ModelRegistry(storage, undefined, { ignoreLocalModelConfig: true });
-	await registry.refresh();
-	let modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
+	// Providers the gateway can route right now, derived live from the store on
+	// every rebuild. Captured once at boot it would freeze the served catalog:
+	// a provider logged in later stays unroutable and one logged out keeps being
+	// advertised until restart.
+	const providersWithCreds = (): Set<string> => {
+		const providers = new Set<string>();
+		for (const entry of storage.exportSnapshot().credentials) providers.add(entry.provider);
+		return providers;
+	};
+	let modelById = new Map<string, Model<Api>>();
+	// Rebuild the served catalog behind a `registry.refresh()` pass (a
+	// first-time provider has no cached models) and re-index against the current
+	// credential set. A single in-flight guard coalesces the periodic model
+	// refresh and the credential-sync poll; a failed rebuild keeps the previous
+	// catalog.
+	let rebuildInFlight: Promise<void> | null = null;
+	const rebuildCatalog = (): Promise<void> => {
+		rebuildInFlight ??= (async () => {
+			try {
+				await registry.refresh();
+				modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds());
+			} finally {
+				rebuildInFlight = null;
+			}
+		})();
+		return rebuildInFlight;
+	};
+	await rebuildCatalog();
 
 	const handle = startAuthGateway({
 		storage,
@@ -232,22 +266,36 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	process.stdout.write(`upstream broker: ${brokerConfig.url}\n`);
 
 	// `serve` is long-lived: rebuild the catalog periodically so models
-	// discovered after boot become routable without a restart. A failed refresh
-	// keeps serving the previous catalog. `unref()` so the timer never keeps the
-	// process alive on its own.
+	// discovered after boot (for providers we already hold credentials for)
+	// become routable without a restart. A failed rebuild keeps serving the
+	// previous catalog. `unref()` so the timer never keeps the process alive on
+	// its own.
 	const catalogRefresh = setInterval(() => {
-		void registry
-			.refresh()
-			.then(() => {
-				modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
-			})
-			.catch(error => {
-				logger.warn("auth-gateway catalog refresh failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
+		void rebuildCatalog().catch(error => {
+			logger.warn("auth-gateway catalog refresh failed", {
+				error: error instanceof Error ? error.message : String(error),
 			});
+		});
 	}, CATALOG_REFRESH_INTERVAL_MS);
 	catalogRefresh.unref();
+
+	// Poll the broker-backed store for credential changes made by another
+	// process (host `login`/`logout`). `pollExternalChanges()` reloads the
+	// storage's credential view so selection stops 401ing (or stops using a
+	// removed credential); rebuilding the catalog then updates `/v1/models` and
+	// `resolveModel`. `unref()` for the same reason as above.
+	const credentialSync = setInterval(() => {
+		void (async () => {
+			try {
+				if (await storage.pollExternalChanges()) await rebuildCatalog();
+			} catch (error) {
+				logger.warn("auth-gateway credential sync failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		})();
+	}, CREDENTIAL_SYNC_INTERVAL_MS);
+	credentialSync.unref();
 
 	const stopped = Promise.withResolvers<void>();
 	let shutdownStarted = false;
@@ -256,6 +304,7 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 		shutdownStarted = true;
 		process.stdout.write(`\nReceived ${signal}, shutting down...\n`);
 		clearInterval(catalogRefresh);
+		clearInterval(credentialSync);
 		let closeError: unknown;
 		try {
 			await handle.close();

--- a/packages/coding-agent/test/cli/auth-gateway-catalog.test.ts
+++ b/packages/coding-agent/test/cli/auth-gateway-catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { TempDir } from "@oh-my-pi/pi-utils";
-import { indexModelsByRequestId } from "../../src/cli/auth-gateway-cli";
+import { createSerializedRebuilder, indexModelsByRequestId } from "../../src/cli/auth-gateway-cli";
 import { ModelRegistry } from "../../src/config/model-registry";
 
 function stubAuthStorage(configKeys?: string[]): AuthStorage {
@@ -107,5 +107,58 @@ describe("indexModelsByRequestId (auth-gateway catalog)", () => {
 
 		expect(index.get(`anthropic/${anthropicModel.id}`)).toBeDefined();
 		expect(index.get(`${foreignModel.provider}/${foreignModel.id}`)).toBeUndefined();
+	});
+});
+
+describe("createSerializedRebuilder", () => {
+	// Deferred `run` gate so tests drive completion without wall-clock timers.
+	function makeRun() {
+		const calls: boolean[] = [];
+		const gates: PromiseWithResolvers<void>[] = [];
+		const run = (force: boolean): Promise<void> => {
+			calls.push(force);
+			const gate = Promise.withResolvers<void>();
+			gates.push(gate);
+			return gate.promise;
+		};
+		return { calls, gates, run };
+	}
+	// Flush queued microtasks so a resolved gate lets the serialized loop advance.
+	async function flush(): Promise<void> {
+		for (let i = 0; i < 8; i++) await Promise.resolve();
+	}
+
+	test("runs a forced pass when a forced rebuild is requested mid-flight", async () => {
+		const { calls, gates, run } = makeRun();
+		const rebuild = createSerializedRebuilder(run);
+
+		const first = rebuild(false);
+		expect(calls).toEqual([false]);
+
+		// A credential-triggered forced rebuild arrives while the cached pass runs.
+		rebuild(true);
+		expect(calls).toEqual([false]); // coalesced, not started yet
+
+		gates[0].resolve();
+		await flush();
+		// The forced follow-up pass must run so the account change is not missed.
+		expect(calls).toEqual([false, true]);
+
+		gates[1].resolve();
+		await first;
+		expect(calls).toEqual([false, true]);
+	});
+
+	test("coalesces a non-forced rebuild without an extra pass", async () => {
+		const { calls, gates, run } = makeRun();
+		const rebuild = createSerializedRebuilder(run);
+
+		const first = rebuild(false);
+		rebuild(false); // coalesces onto the in-flight pass
+		expect(calls).toEqual([false]);
+
+		gates[0].resolve();
+		await first;
+		expect(calls).toEqual([false]); // no redundant follow-up
 	});
 });


### PR DESCRIPTION
## Repro
A long-lived broker client — `omp auth-gateway serve` — never notices credential changes made by another process, serving its boot-time credential set and provider list until restart. Reproduced in-process against a real broker + `RemoteAuthCredentialStore`, mirroring the gateway's stack (broker-backed store wrapped in its own `AuthStorage`): after another process logs in a provider, the store's own `#snapshot` picks it up over SSE, but `AuthStorage.pollExternalChanges()` returns `false` and `exportSnapshot()` still shows zero providers. The reporter's shell repro (`auth-gateway serve` + a second process inserting into `agent.db`) shows `/v1/models` frozen at 0 and requests returning `401 No credential available` / `Unknown model` until the gateway restarts.

## Cause
`RemoteAuthCredentialStore` (`packages/ai/src/auth-broker/remote-store.ts`) implemented no `pollExternalChanges()`, so `AuthStorage.pollExternalChanges()` (`packages/ai/src/auth-storage.ts:1483-1484`) short-circuits on the optional call and never `reload()`s `AuthStorage.#data` — the view credential selection actually reads — even though the store's background SSE/long-poll loop keeps `#snapshot` current and advances `#generation` on every change (`#applySnapshot`/`#applyStreamEntry`/`#removeStreamCredential`). Separately, `runServe` (`packages/coding-agent/src/cli/auth-gateway-cli.ts:212-216`) captured `providersWithCreds` once from `exportSnapshot()` at boot and reused that frozen set in the 15-minute catalog rebuild (`:238-249`), so a provider gained or lost after boot never enters or leaves the served catalog.

## Fix
- `RemoteAuthCredentialStore.pollExternalChanges()`: compares `#generation` against a `#acknowledgedGeneration` seeded from the initial snapshot, reporting true once per broker-side change; calls `#noteActivity()` first so a low-traffic client's parked background sync resumes and actually fetches the new generation.
- `runServe`: derives `providersWithCreds` live from the store on every rebuild instead of capturing it at boot; factors catalog rebuild into a single-in-flight `rebuildCatalog()` (refresh + re-index) shared by the periodic model refresh; adds a 10s credential-sync poll that calls `storage.pollExternalChanges()` (reloading credential selection so it stops 401ing / stops using removed credentials) and rebuilds the catalog on change (updating `/v1/models` and `resolveModel`). The new interval is `unref()`'d and cleared on shutdown.
- Changelog entry under `packages/coding-agent`.

## Verification
`bun test test/auth-broker-remote-store.test.ts` (packages/ai) — 10 pass, including the new regression that mirrors the gateway stack and asserts login propagation, logout propagation, boot-generation acknowledgement, and one-true-per-change idempotence. `bun test test/cli/auth-gateway-catalog.test.ts test/auth-gateway-account-pool.test.ts` (packages/coding-agent) — 4 pass. `bun check` passes (TS + format). Fixes #11781