### PR TITLE
fix(ci): run workspace typechecks sequentially to avoid OOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"test:scripts": "bun test scripts/ci-test-ts.test.ts scripts/ci-release-build-binaries.test.ts scripts/musl-release.test.ts scripts/ci-release-publish.test.ts scripts/release.test.ts",
 		"test:rs": "bun scripts/run-rs-task.ts test:rs",
 		"check": "bun run --parallel check:ts check:rs",
-		"check:ts": "bun run check:tools && bun run --workspaces --if-present check",
+		"check:ts": "bun run check:tools && bun run --workspaces --sequential --if-present check",
 		"check:tools": "oxlint . && oxfmt --check 'packages/*/src/**/*.{ts,tsx}' 'packages/*/{test,bench,examples,scripts}/**/*.ts' 'packages/*/*.ts' 'scripts/**/*.ts'",
 		"check:rs": "bun scripts/run-rs-task.ts check:rs",
 		"lint": "bun run --parallel lint:ts lint:rs",


### PR DESCRIPTION
Main CI fails in `Lint, type check & web build`:`bun run ci:check:full` with the pi-coding-agent `check:types` (tsgo) SIGKILLed, exit 137.

Root cause: f18f8d70 removed `--sequential` from root `check:ts`, so `bun run --workspaces --if-present check` launches ~15 concurrent tsgo processes. On the memory-constrained kata runner this OOMs (runs 34641414028, 34644998093, 34645362466). The run immediately before the regression (34640284050, sequential) passed the check job.

Fix: restore `--sequential` so one workspace typecheck runs at a time. Verified locally: `bun run ci:check:full` exits 0, all 16 workspace checks complete.