### PR TITLE
fix(debug): avoid heap snapshot string limits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/coding-agent/src/debug/profiler.ts
+++ b/packages/coding-agent/src/debug/profiler.ts
@@ -147,8 +147,9 @@ export async function startCpuProfile(): Promise<ProfilerSession> {
 	};
 }
 
+/** Binary V8 heap snapshot content ready for archive serialization. */
 export interface HeapSnapshot {
-	data: string;
+	data: Uint8Array;
 }
 
 /**
@@ -159,8 +160,11 @@ export function generateHeapSnapshotData(): HeapSnapshot {
 	// Force GC before snapshot
 	Bun.gc(true);
 
-	// Use V8 format for Chrome DevTools compatibility
-	const snapshot = Bun.generateHeapSnapshot("v8");
+	// Use binary V8 output to avoid JavaScript's maximum string length.
+	const snapshot = new Uint8Array(Bun.generateHeapSnapshot("v8", "arraybuffer"));
+	if (snapshot.byteLength === 0) {
+		throw new Error("Bun generated an empty heap snapshot");
+	}
 
 	return {
 		data: snapshot,

--- a/packages/coding-agent/src/debug/report-bundle.ts
+++ b/packages/coding-agent/src/debug/report-bundle.ts
@@ -89,7 +89,7 @@ export async function createReportBundle(options: ReportBundleOptions): Promise<
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 	const outputPath = path.join(reportsDir, `omp-report-${timestamp}.tar.gz`);
 
-	const data: Record<string, string> = {};
+	const data: Record<string, string | Uint8Array> = {};
 	const files: string[] = [];
 
 	// Collect system info
@@ -174,7 +174,7 @@ export async function createReportBundle(options: ReportBundleOptions): Promise<
 
 /** Recursively add every file under a directory to the archive. */
 async function addDirectoryToArchive(
-	data: Record<string, string>,
+	data: Record<string, string | Uint8Array>,
 	files: string[],
 	dirPath: string,
 	archivePrefix: string,

--- a/packages/coding-agent/test/debug/profiler.test.ts
+++ b/packages/coding-agent/test/debug/profiler.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { startCpuProfile } from "@oh-my-pi/pi-coding-agent/debug/profiler";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { generateHeapSnapshotData, startCpuProfile } from "@oh-my-pi/pi-coding-agent/debug/profiler";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("startCpuProfile", () => {
 	// Regression: `node:v8` `setFlagsFromString` throws on Bun
@@ -20,5 +24,13 @@ describe("startCpuProfile", () => {
 		expect(parsed.nodes.length).toBeGreaterThan(0);
 		expect(typeof profile.markdown).toBe("string");
 		expect(profile.markdown.length).toBeGreaterThan(0);
+	});
+});
+
+describe("generateHeapSnapshotData", () => {
+	it("rejects an empty snapshot instead of reporting success", () => {
+		vi.spyOn(Bun, "generateHeapSnapshot").mockReturnValue(new ArrayBuffer(0));
+
+		expect(() => generateHeapSnapshotData()).toThrow("Bun generated an empty heap snapshot");
 	});
 });


### PR DESCRIPTION
## Repro

On current `main`, an isolated Bun probe stubbed `Bun.generateHeapSnapshot("v8")` to return the observed empty output, then called `generateHeapSnapshotData()` and `createReportBundle()`; `XDG_STATE_HOME=/tmp/omp-11785-repro-state bun -e '<probe>'` exited 0 with `{"helperBytes":0,"reportedFiles":["system.json","env.json","heap.heapsnapshot"],"archivedBytes":0}`.

## Cause

`generateHeapSnapshotData()` in `packages/coding-agent/src/debug/profiler.ts` requested Bun's string-form V8 snapshot, which can exceed JavaScript's maximum string length, and did not reject an empty result. `createReportBundle()` in `packages/coding-agent/src/debug/report-bundle.ts` then unconditionally counted and archived that empty value.

## Fix

- Request Bun's `arraybuffer` heap-snapshot encoding and retain it as a zero-copy `Uint8Array` view.
- Reject zero-byte snapshot output before report bundle creation so `/debug` surfaces the existing failure path instead of claiming success.
- Allow report bundles to archive binary snapshot data and add regression coverage plus the attributed changelog entry.

## Verification

`bun test packages/coding-agent/test/debug` passed 103 tests. The original empty-output probe now reports `Bun generated an empty heap snapshot` with no bundle created. A real binary-snapshot smoke run generated and archived 1,804,421 bytes with matching member size and valid heap-snapshot JSON. `bun check` passed.

Fixes #11785