### PR TITLE
fix(mcp): release obsolete tools after reconnect

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -242,6 +242,23 @@ export class SessionTools {
 	#promptModelKey: string | undefined;
 	#rebuildSystemPrompt: SessionToolsOptions["rebuildSystemPrompt"];
 	#getMcpServerInstructions: SessionToolsOptions["getMcpServerInstructions"];
+	/**
+	 * Session-lifetime factory shared by every custom-tool wrapper. Defining it
+	 * outside the refresh frame prevents wrappers from retaining rollback maps
+	 * from earlier MCP generations through a shared lexical environment.
+	 */
+	readonly #getCustomToolContext = (): CustomToolContext => ({
+		sessionManager: this.#host.sessionManager,
+		modelRegistry: this.#host.modelRegistry,
+		model: this.#host.model(),
+		isIdle: () => !this.#host.isStreaming(),
+		hasQueuedMessages: () => this.#host.queuedMessageCount() > 0,
+		abort: () => {
+			this.#host.agent.abort();
+		},
+		settings: this.#host.settings,
+		localProtocolOptions: this.#host.localProtocolOptions(),
+	});
 	#setActiveToolNames: SessionToolsOptions["setActiveToolNames"];
 	#ensureWriteRegistered: SessionToolsOptions["ensureWriteRegistered"];
 	#isDeviceOnlyWrite: SessionToolsOptions["isDeviceOnlyWrite"];
@@ -1631,22 +1648,11 @@ export class SessionTools {
 			this.#mcpManagerToolNames = previousMcpManagerToolNames;
 		};
 
-		const getCustomToolContext = (): CustomToolContext => ({
-			sessionManager: this.#host.sessionManager,
-			modelRegistry: this.#host.modelRegistry,
-			model: this.#host.model(),
-			isIdle: () => !this.#host.isStreaming(),
-			hasQueuedMessages: () => this.#host.queuedMessageCount() > 0,
-			abort: () => {
-				this.#host.agent.abort();
-			},
-			settings: this.#host.settings,
-			localProtocolOptions: this.#host.localProtocolOptions(),
-		});
-
 		const extensionRunner = this.#host.extensionRunner();
 		const managerTools = deduplicateMCPToolsByName(mcpTools).map(customTool => {
-			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
+			const wrapped = wrapToolWithMetaNotice(
+				CustomToolAdapter.wrap(customTool, this.#getCustomToolContext) as AgentTool,
+			);
 			return (extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped) as AgentTool;
 		});
 		const managerToolSet = new Set(managerTools);
@@ -1675,7 +1681,13 @@ export class SessionTools {
 		];
 		try {
 			await this.#applyActiveToolsByName(nextActive);
-			if (this.#host.isDisposed()) restorePreviousMcpTools();
+			if (this.#host.isDisposed()) {
+				restorePreviousMcpTools();
+			} else {
+				// The settled mutation promise may retain this async frame; drop
+				// rollback references as soon as the new generation commits.
+				previousMcpTools.clear();
+			}
 		} catch (error) {
 			restorePreviousMcpTools();
 			throw error;

--- a/packages/coding-agent/test/fixtures/mcp-refresh-retention-probe.ts
+++ b/packages/coding-agent/test/fixtures/mcp-refresh-retention-probe.ts
@@ -1,0 +1,93 @@
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { MCPTool } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
+import type { MCPServerConnection, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SessionTools, type SessionToolsHost } from "@oh-my-pi/pi-coding-agent/session/session-tools";
+
+interface V8HeapSnapshot {
+	snapshot: {
+		meta: {
+			node_fields: string[];
+			node_types: Array<string | string[]>;
+		};
+	};
+	nodes: number[];
+	strings: string[];
+}
+
+const TOOL_COUNT = 50;
+const REFRESH_COUNT = 20;
+
+function alphabeticIndex(index: number): string {
+	let result = "";
+	do {
+		result = String.fromCharCode(97 + (index % 26)) + result;
+		index = Math.floor(index / 26) - 1;
+	} while (index >= 0);
+	return result;
+}
+
+const definitions: MCPToolDefinition[] = Array.from({ length: TOOL_COUNT }, (_, index) => ({
+	name: `noop_${alphabeticIndex(index)}`,
+	description: `No-op tool ${index}`,
+	inputSchema: {
+		type: "object",
+		properties: { query: { type: "string" } },
+		required: ["query"],
+	},
+}));
+const agent = new Agent();
+const settings = Settings.isolated();
+const host: SessionToolsHost = {
+	agent,
+	sessionManager: SessionManager.inMemory(),
+	settings,
+	effectiveExtensionRoots: () => ({}) as never,
+	modelRegistry: {} as never,
+	extensionRunner: () => undefined,
+	clientBridge: () => undefined,
+	agentKind: () => "main",
+	isDisposed: () => false,
+	isStreaming: () => false,
+	queuedMessageCount: () => 0,
+	planModeEnabled: () => false,
+	model: () => undefined,
+	memoryBackendSession: () => ({}) as never,
+	clearInheritedProviderPromptCacheKey: () => {},
+	clearMemoryPromotionSnapshot: () => {},
+	captureMemoryPromotionSnapshot: () => {},
+	emitNotice: () => {},
+	notifyCommandMetadataChanged: () => {},
+	localProtocolOptions: () => ({}),
+};
+const sessionTools = new SessionTools(host, {
+	baseSystemPrompt: [],
+	rebuildSystemPrompt: async toolNames => ({ systemPrompt: [toolNames.join(",")] }),
+});
+const connection = { name: "alpha" } as MCPServerConnection;
+
+for (let refresh = 0; refresh < REFRESH_COUNT; refresh++) {
+	await sessionTools.refreshMCPTools(MCPTool.fromTools(connection, definitions));
+}
+
+Bun.gc(true);
+const heap = JSON.parse(Bun.generateHeapSnapshot("v8")) as V8HeapSnapshot;
+const { node_fields: nodeFields, node_types: nodeTypes } = heap.snapshot.meta;
+const typeOffset = nodeFields.indexOf("type");
+const nameOffset = nodeFields.indexOf("name");
+const typeNames = nodeTypes[typeOffset];
+if (typeOffset < 0 || nameOffset < 0 || !Array.isArray(typeNames)) {
+	throw new Error("Unexpected V8 heap snapshot schema");
+}
+
+let mcpTools = 0;
+let adapters = 0;
+for (let nodeOffset = 0; nodeOffset < heap.nodes.length; nodeOffset += nodeFields.length) {
+	if (typeNames[heap.nodes[nodeOffset + typeOffset]!] !== "object") continue;
+	const name = heap.strings[heap.nodes[nodeOffset + nameOffset]!];
+	if (name === "MCPTool") mcpTools++;
+	else if (name === "CustomToolAdapter") adapters++;
+}
+
+process.stdout.write(JSON.stringify({ toolCount: TOOL_COUNT, mcpTools, adapters }));

--- a/packages/coding-agent/test/mcp-refresh-retention.test.ts
+++ b/packages/coding-agent/test/mcp-refresh-retention.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+
+interface ProbeResult {
+	toolCount: number;
+	mcpTools: number;
+	adapters: number;
+}
+
+const probePath = path.join(import.meta.dir, "fixtures", "mcp-refresh-retention-probe.ts");
+
+test("MCP refresh releases obsolete tool wrapper generations", async () => {
+	const proc = Bun.spawn([process.execPath, probePath], {
+		cwd: path.join(import.meta.dir, "../../.."),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	const result = JSON.parse(stdout) as ProbeResult;
+	expect(result.mcpTools).toBe(result.toolCount);
+	expect(result.adapters).toBe(result.toolCount);
+}, 30_000);


### PR DESCRIPTION
## Repro
A source-level harness repeatedly called the real `SessionTools.refreshMCPTools` path with 500 freshly constructed `MCPTool` objects per generation, then forced GC and sampled `bun:jsc` heap stats: `cd packages/coding-agent && CYCLES=280 TOOLS=500 bun leak-session-tools.ts`. Before the fix, 280 refreshes grew heap from 25.0 MB to 165.5 MB, `GetterSetter` from 2,368 to 516,448, and `JSLexicalEnvironment` from 4,516 to 562,279; a three-generation snapshot retained all 150/150 `MCPTool` objects. The committed regression probe reproduces the same contract with `bun test test/mcp-refresh-retention.test.ts`.

## Cause
`SessionTools.#applyMCPToolRefresh` created `getCustomToolContext` inside each refresh frame and passed it to every `CustomToolAdapter`. Each live adapter retained that shared lexical environment, including the rollback `previousMcpTools` map. The current tool generation therefore held the prior wrapper generation, whose context closure held the generation before it, forming an unbounded chain. The settled registry-mutation frame could also keep one committed rollback map alive.

## Fix
- Move the custom-tool context factory to one session-lifetime `SessionTools` field, so wrappers capture only the session owner rather than refresh-local rollback state.
- Clear `previousMcpTools` immediately after a successful refresh commit while preserving it through rollback/disposal paths.
- Add a subprocess heap-snapshot probe asserting that 20 refreshes retain exactly one generation of 50 `MCPTool` and `CustomToolAdapter` objects.
- Document the reconnect memory fix in the coding-agent changelog.

## Verification
`bun test test/mcp-refresh-retention.test.ts test/agent-session-tool-rebuild-skip.test.ts` passes: 41 tests, 180 assertions. `bun check` passes. Re-running the 500-tool/280-refresh churn held heap flat at 25.0–25.5 MB with stable `GetterSetter` (2,368), `JSLexicalEnvironment` (~4,518), and `Function` (~17,119) counts. Fixes #11784