### PR TITLE
fix(coding-agent): exit cleanly on Ctrl-C during guarded extension load

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Ctrl+C during an in-flight extension/hook load now exits cleanly instead of raising an `ExtensionExitError` unhandled-rejection storm: host-owned hard exits route through the hardened `postmortem.exitProcess`, which reinstalls the guard-shadowed `process.exit`/`process.reallyExit` primitives before terminating ([#11789](https://github.com/can1357/oh-my-pi/issues/11789)).
+- Ctrl+C during an in-flight extension/hook load now exits cleanly instead of raising an `ExtensionExitError` unhandled-rejection storm ([#11789](https://github.com/can1357/oh-my-pi/issues/11789)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ctrl+C during an in-flight extension/hook load now exits cleanly instead of raising an `ExtensionExitError` unhandled-rejection storm: host-owned hard exits route through the hardened `postmortem.exitProcess`, which reinstalls the guard-shadowed `process.exit`/`process.reallyExit` primitives before terminating ([#11789](https://github.com/can1357/oh-my-pi/issues/11789)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -16,6 +16,7 @@ import {
 	type ViewportSize,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
+import { postmortem } from "@oh-my-pi/pi-utils";
 import { CustomEditor } from "./components/custom-editor";
 import { type AnimationFrame, TranscriptContainer } from "./components/transcript-container";
 import { type LspServerInfo, type RecentSession, WelcomeComponent } from "./components/welcome";
@@ -262,7 +263,10 @@ export class Composer implements TerminalFrameProvider {
 
 	constructor(options: ComposerOptions = {}) {
 		if (typeof theme === "undefined") initThemeSync();
-		this.#exit = options.exit ?? (code => process.exit(code));
+		// Host-owned hard exit: route through postmortem so a double-Ctrl-C during
+		// an open extension-load guard window exits cleanly instead of throwing
+		// ExtensionExitError through the guarded process.exit (#11789).
+		this.#exit = options.exit ?? (code => postmortem.exitProcess(code));
 		this.#now = options.now ?? Date.now;
 		this.#preferences = { ...COMPOSER_DEFAULTS, ...options.preferences };
 		this.#statusSnapshot = options.status;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -8,7 +8,7 @@ import {
 	type PasteOptions,
 	type SlashCommand,
 } from "@oh-my-pi/pi-tui";
-import { isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, postmortem, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
 import { AskDialogComponent } from "../../modes/components/ask-dialog";
@@ -1265,7 +1265,10 @@ export class InputController {
 		// common case; this is the defense-in-depth ladder for everything
 		// else. See issue #2600.
 		if (this.ctx.isShuttingDown) {
-			process.exit(130); // 128 + SIGINT
+			// Route through postmortem: this hard-abort can fire while an
+			// extension-load guard window is open, where raw process.exit is a
+			// throwing ExtensionExitError stub (#11789).
+			postmortem.exitProcess(130); // 128 + SIGINT
 		}
 
 		const now = Date.now();

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the public `postmortem.exitProcess()` utility for host-owned hard exits that must bypass temporary process-exit guards ([#11789](https://github.com/can1357/oh-my-pi/issues/11789)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -60,6 +60,26 @@ export const NATIVE_PROCESS_EXIT = Symbol.for("omp.postmortem.nativeProcessExit"
 type HardExitFn = (code?: number) => never;
 
 /**
+ * Walk a guarded exit primitive down to the native it shadows.
+ *
+ * `withHostGuard` stamps each throwing replacement with the primitive it
+ * shadows under {@link NATIVE_PROCESS_EXIT}; nested guard windows stack, so a
+ * single unwrap can still land on another throwing stub. Follow the chain
+ * (cycle-guarded) until a link carries no stamp — that link is native.
+ */
+function nativeHardExit(fn: HardExitFn | undefined): HardExitFn | undefined {
+	let current = fn;
+	const seen = new Set<HardExitFn>();
+	while (typeof current === "function" && !seen.has(current)) {
+		seen.add(current);
+		const behind = Reflect.get(current, NATIVE_PROCESS_EXIT);
+		if (typeof behind !== "function") return current;
+		current = behind as HardExitFn;
+	}
+	return typeof current === "function" ? current : undefined;
+}
+
+/**
  * Hard-exit the process through the native primitive, resolved on every call.
  *
  * The native exit is deliberately re-resolved here rather than bound at module
@@ -70,14 +90,30 @@ type HardExitFn = (code?: number) => never;
  * init could freeze the throwing stub forever and turn every later shutdown
  * (SIGHUP/SIGINT/fatal) into an unhandled-rejection loop (#7393). When the
  * guard is active the stub carries the native exit under
- * {@link NATIVE_PROCESS_EXIT}; unwrapping it lets a mid-guard signal still exit
- * (#6488). Otherwise the current `process.reallyExit`/`process.exit` is native.
+ * {@link NATIVE_PROCESS_EXIT} (#6488).
+ *
+ * Both globals are reinstalled to their natives before exiting: Bun's
+ * `process.exit` re-reads `process.reallyExit` at call time, so exiting through
+ * one primitive while its sibling still holds the throwing stub re-enters the
+ * guard and loops the rejection storm (#11789). After restoring, `reallyExit`
+ * (the low-level primitive) is preferred; `process.exit` and finally `SIGKILL`
+ * are fallbacks so a poisoned or absent chain can never leave the process alive.
  */
-function exitProcess(code: number): never {
-	const current: HardExitFn = typeof process.reallyExit === "function" ? process.reallyExit : process.exit;
-	const behind = Reflect.get(current, NATIVE_PROCESS_EXIT);
-	const nativeExit = typeof behind === "function" ? (behind as HardExitFn) : current;
-	return nativeExit.call(process, code) as never;
+export function exitProcess(code: number): never {
+	const reallyExit = nativeHardExit(typeof process.reallyExit === "function" ? process.reallyExit : undefined);
+	const exit = nativeHardExit(process.exit as HardExitFn);
+	if (reallyExit) process.reallyExit = reallyExit as typeof process.reallyExit;
+	if (exit) process.exit = exit as typeof process.exit;
+	try {
+		reallyExit?.call(process, code);
+	} catch {}
+	try {
+		exit?.call(process, code);
+	} catch {}
+	try {
+		process.kill(process.pid, "SIGKILL");
+	} catch {}
+	throw new Error(`exitProcess(${code}) failed to terminate the process`);
 }
 let cleanupPromise: Promise<void> | undefined;
 let stdioDisconnectRegistrations = 0;

--- a/packages/utils/test/postmortem-guard-exit.test.ts
+++ b/packages/utils/test/postmortem-guard-exit.test.ts
@@ -52,7 +52,7 @@ if (process.argv.includes(directFlag)) {
 	const err = new Error("Module called process.exit(130) during guarded extension/hook loading");
 	err.name = "ExtensionExitError";
 	void Promise.reject(err);
-	await new Promise<never>(() => {});
+	await Promise.withResolvers<never>().promise;
 }
 
 if (!process.argv.includes(directFlag) && !process.argv.includes(fatalFlag)) {

--- a/packages/utils/test/postmortem-guard-exit.test.ts
+++ b/packages/utils/test/postmortem-guard-exit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { postmortem } from "@oh-my-pi/pi-utils";
+
+// Regression for #11789: host-owned hard exits (composer double-Ctrl-C,
+// input-controller stuck-teardown) can fire while an extension-load
+// `withHostGuard` window has swapped process.exit/process.reallyExit for stubs
+// that throw ExtensionExitError. `postmortem.exitProcess` must terminate the
+// process through the native primitive even when the exit chain is poisoned by
+// nested guard stubs, instead of re-entering the guard and looping the
+// unhandled-rejection storm.
+
+const NATIVE = postmortem.NATIVE_PROCESS_EXIT;
+const directFlag = "--guard-exit-direct-child";
+const fatalFlag = "--guard-exit-fatal-child";
+
+/**
+ * Install a two-level poisoned exit chain: each global becomes
+ * `outerStub -> innerStub -> native`. A single unwrap lands on `innerStub`
+ * (still a throwing stub); only a full chain walk reaches native.
+ */
+function poisonExitChain(): void {
+	const stub = (message: string) =>
+		((_code?: number) => {
+			const err = new Error(message);
+			err.name = "ExtensionExitError";
+			throw err;
+		}) as (code?: number) => never;
+
+	if (typeof process.reallyExit === "function") {
+		const inner = stub("inner reallyExit stub");
+		Reflect.set(inner, NATIVE, process.reallyExit);
+		const outer = stub("outer reallyExit stub");
+		Reflect.set(outer, NATIVE, inner);
+		process.reallyExit = outer as typeof process.reallyExit;
+	}
+	const innerExit = stub("inner exit stub");
+	Reflect.set(innerExit, NATIVE, process.exit);
+	const outerExit = stub("outer exit stub");
+	Reflect.set(outerExit, NATIVE, innerExit);
+	process.exit = outerExit as typeof process.exit;
+}
+
+if (process.argv.includes(directFlag)) {
+	// Host callsite behavior: a hard exit issued while the guard chain is poisoned.
+	poisonExitChain();
+	postmortem.exitProcess(130);
+	process.stderr.write("REACHED-END\n");
+} else if (process.argv.includes(fatalFlag)) {
+	// Raw guard throw reaching the global fatal handler, whose exitProcess(1) must
+	// terminate cleanly rather than re-throwing into an unhandled-rejection loop.
+	poisonExitChain();
+	const err = new Error("Module called process.exit(130) during guarded extension/hook loading");
+	err.name = "ExtensionExitError";
+	void Promise.reject(err);
+	await new Promise<never>(() => {});
+}
+
+if (!process.argv.includes(directFlag) && !process.argv.includes(fatalFlag)) {
+	describe("postmortem guard-window exit (#11789)", () => {
+		it("exports a hard-exit primitive host callsites can route through", () => {
+			expect(typeof postmortem.exitProcess).toBe("function");
+		});
+
+		it("exits with the requested code through a poisoned guard chain", async () => {
+			const child = Bun.spawn([process.execPath, "run", import.meta.path, directFlag], {
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stdout, stderr] = await Promise.all([
+				child.exited,
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+			]);
+			expect(exitCode).toBe(130);
+			expect(stdout).toBe("");
+			expect(stderr).not.toContain("REACHED-END");
+			expect(stderr).not.toContain("ExtensionExitError");
+		});
+
+		it("bounds the fatal path to a single rejection instead of an ExtensionExitError storm", async () => {
+			// The fix guarantees a bounded exit; an unfixed exitProcess re-throws and
+			// loops, in which case the child never exits and bun's per-test timeout
+			// surfaces the regression. No wall-clock watchdog is needed here.
+			const child = Bun.spawn([process.execPath, "run", import.meta.path, fatalFlag], {
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			try {
+				const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+				const rejections = stderr.split("[Unhandled Rejection]").length - 1;
+				expect(exitCode).toBe(1);
+				expect(rejections).toBe(1);
+				expect(stderr).toContain("ExtensionExitError");
+			} finally {
+				child.kill();
+				await child.exited;
+			}
+		});
+	});
+}


### PR DESCRIPTION
## Repro
Start omp with a project extension whose top level is `await Bun.sleep(4000)` and press Ctrl-C twice inside the load window. While `withHostGuard` holds the extension-load window open, `process.exit`/`process.reallyExit` are throwing `ExtensionExitError` stubs. The Composer double-Ctrl-C quit path (and the input-controller stuck-teardown hard-abort) call raw `process.exit`, which throws through the guard. Faithful repro (open a guard window, then a host quit path calls `process.exit(130)`):

```
[Unhandled Rejection] ExtensionExitError: Module called process.exit(130) during guarded extension/hook loading
    at ge (repro.ts:8)
    at hostDoubleCtrlC (repro.ts:17)
    at processTicksAndRejections (native)
EXITCODE=1
```

Instead of a clean quit (exit 130) the process prints a spurious unhandled rejection and exits 1. On Bun builds where the native exit chain is nested/poisoned (the reporter's environment) the fatal handler's `exitProcess(1)` itself lands on a throwing stub and re-throws, looping the storm (~1900 lines, external kill required).

## Cause
Two host-owned exit callsites bypass `postmortem.exitProcess`: `packages/coding-agent/src/modes/composer.ts` (`this.#exit = options.exit ?? (code => process.exit(code))`, the `#handleInterrupt` → `#requestExit(130)` path) and `packages/coding-agent/src/modes/controllers/input-controller.ts` (`handleCtrlC` hard-abort `process.exit(130)`). Their raw `process.exit` is the guard's throwing stub during an extension load. The unhandled-rejection fatal path routes to `postmortem.exitProcess` (`packages/utils/src/postmortem.ts`), but its single `NATIVE_PROCESS_EXIT` unwrap is not chain-safe: Bun's `process.exit` re-reads `process.reallyExit` at call time, so exiting through one primitive while the sibling still holds the throwing stub re-enters the guard. This is the host-side counterpart of #6488 (extension-owned exits, fixed by #6493) and #7393 (lazy-init capture, fixed by #7395).

## Fix
- `packages/utils/src/postmortem.ts`: harden and export `exitProcess`. New `nativeHardExit` walks each exit chain (cycle-guarded) to the native it shadows; `exitProcess` reinstalls the guard-shadowed `process.exit`/`process.reallyExit` before terminating, prefers low-level `reallyExit`, falls back to `process.exit`, and SIGKILLs as a last resort so a poisoned or absent chain can never leave the process alive.
- `packages/coding-agent/src/modes/composer.ts`: default `#exit` now routes through `postmortem.exitProcess`.
- `packages/coding-agent/src/modes/controllers/input-controller.ts`: the Ctrl-C stuck-teardown hard-abort routes through `postmortem.exitProcess`.
- `packages/utils/test/postmortem-guard-exit.test.ts`: poisoned-chain child probes asserting a bounded exit with the requested code and a single rejection (no storm).
- CHANGELOG entry under `[Unreleased]`.

## Verification
`bun test packages/utils/test/postmortem-guard-exit.test.ts` → 3 pass (direct exit through a poisoned chain exits 130 with no `ExtensionExitError`; the fatal path is bounded to a single `[Unhandled Rejection]` and exit 1). Existing `postmortem-epipe`/`postmortem-cleanup-error` suites: 27 pass. `bun run check:types` clean for `pi-utils` and `pi-coding-agent`; oxlint + oxfmt clean on all changed files. Manually confirmed the current single-unwrap throws on a 2-level chain while the hardened version exits 130. The `test/startup-composer.test.ts` / `test/input-controller-*.test.ts` full-file runs surface pre-existing failures unrelated to this diff (a missing `src/export/html/tool-views.generated.js` build artifact, then Settings-singleton cross-test contamination); the individual affected tests pass in isolation. Fixes #11789