### PR TITLE
fix(ai): drop fabricated id from synthesized Responses reasoning items

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed OpenRouter reasoning models (e.g. Meta Muse Spark) rejecting every turn with `400 Provider returned error` after the session history contains a tool-call turn from another provider, by no longer sending a fabricated reasoning item id.
+- Fixed OpenRouter reasoning models (e.g. Meta Muse Spark) rejecting every turn with `400 Provider returned error` after the session history contains a tool-call turn from another provider, by no longer sending a fabricated reasoning item id ([#11791](https://github.com/can1357/oh-my-pi/pull/11791) by [@brndnmtthws](https://github.com/brndnmtthws)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Codex OAuth login now accepts valid account tokens that expose an email but omit `chatgpt_account_id`, without fabricating a workspace header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
 - Fixed Muse Code login failing when Meta returns no assigned subscription tier (`subs_tier_id`/`subs_tier_name` as null); sign-in now succeeds and usage is reported without a tier ([#11843](https://github.com/can1357/oh-my-pi/pull/11843) by [@John-Cusack](https://github.com/John-Cusack)).
 
+### Fixed
+
+- Fixed OpenRouter reasoning models (e.g. Meta Muse Spark) rejecting every turn with `400 Provider returned error` after the session history contains a tool-call turn from another provider, by no longer sending a fabricated reasoning item id.
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -14,10 +14,6 @@
 
 - Codex OAuth login now accepts valid account tokens that expose an email but omit `chatgpt_account_id`, without fabricating a workspace header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
 - Fixed Muse Code login failing when Meta returns no assigned subscription tier (`subs_tier_id`/`subs_tier_name` as null); sign-in now succeeds and usage is reported without a tier ([#11843](https://github.com/can1357/oh-my-pi/pull/11843) by [@John-Cusack](https://github.com/John-Cusack)).
-
-### Fixed
-
-- Fixed OpenRouter reasoning models (e.g. Meta Muse Spark) rejecting every turn with `400 Provider returned error` after the session history contains a tool-call turn from another provider, by no longer sending a fabricated reasoning item id.
 - Fixed OpenRouter reasoning models (e.g. Meta Muse Spark) rejecting every turn with `400 Provider returned error` after the session history contains a tool-call turn from another provider, by no longer sending a fabricated reasoning item id ([#11791](https://github.com/can1357/oh-my-pi/pull/11791) by [@brndnmtthws](https://github.com/brndnmtthws)).
 
 ## [18.1.18] - 2026-09-11

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -2308,19 +2308,22 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 		// reasoning dropped by compaction/archive budget) the carried text is
 		// empty — and DeepSeek-family targets reject an empty `reasoning_text`
 		// exactly like a missing item (#10690), so substitute a non-empty
-		// placeholder. The `id` still prefers a surviving upstream item id.
+		// placeholder. The `id` is only set when an upstream item id survived:
+		// providers that validate reasoning ids against their own store (Meta via
+		// OpenRouter) reject a fabricated `rs_…` with "Referenced reasoning item
+		// … was not found or has expired", and the targets that need the item
+		// (DeepSeek, Kimi, Meta) all accept it without an id.
 		const carriedReasoningText = carriedReasoningTexts.join("\n");
 		const reasoningText =
 			carriedReasoningText.length > 0 ? carriedReasoningText : SYNTHETIC_REASONING_REPLAY_PLACEHOLDER;
-		const reasoningId =
-			synthesizedReasoningItemId ?? `rs_${Bun.hash(`${model.id}:${msgIndex}:${reasoningText}`).toString(36)}`;
-		const reasoningItem: ResponseReasoningItem = {
+		const reasoningItem = {
 			type: "reasoning",
-			id: reasoningId,
+			...(synthesizedReasoningItemId ? { id: synthesizedReasoningItemId } : {}),
 			summary: [],
 			content: [{ type: "reasoning_text", text: reasoningText }],
-		};
-		outputItems.unshift(reasoningItem);
+		} satisfies Omit<ResponseReasoningItem, "id"> & Partial<Pick<ResponseReasoningItem, "id">>;
+		// The vendored SDK type marks `id` required; the wire accepts its absence.
+		outputItems.unshift(reasoningItem as ResponseReasoningItem);
 	}
 
 	return outputItems;

--- a/packages/ai/test/openai-responses-openrouter.test.ts
+++ b/packages/ai/test/openai-responses-openrouter.test.ts
@@ -496,6 +496,66 @@ describe("OpenRouter Responses request shape", () => {
 
 		expect(bodies[1]?.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "continue" }] }]);
 	});
+
+	it("synthesizes the required reasoning item without a fabricated id for foreign tool-call history", async () => {
+		// Meta (via OpenRouter Responses) validates reasoning ids against its own
+		// store and rejects a minted `rs_…` with "Referenced reasoning item … was
+		// not found or has expired", failing every turn once a Claude/Bedrock or
+		// DeepSeek turn with a tool call sits in the history.
+		const usage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		const foreignTurn: AssistantMessage = {
+			role: "assistant",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+			model: "global.anthropic.claude-fable-5-1",
+			stopReason: "toolUse",
+			usage,
+			content: [
+				{ type: "text", text: "<thinking>\nCheck the build.\n</thinking>\nRunning cargo check." },
+				{
+					type: "toolCall",
+					id: "tooluse_1PyTNHRXRnPxuFbunJ5ham",
+					name: "bash",
+					arguments: { command: "cargo check" },
+				},
+			],
+			timestamp: 1,
+		};
+		const history: Context = {
+			messages: [
+				{ role: "user", content: "check", timestamp: 0 },
+				foreignTurn,
+				{
+					role: "toolResult",
+					toolCallId: "tooluse_1PyTNHRXRnPxuFbunJ5ham",
+					toolName: "bash",
+					content: [{ type: "text", text: "Finished" }],
+					isError: false,
+					timestamp: 2,
+				},
+				{ role: "user", content: "continue", timestamp: 3 },
+			],
+		};
+		const body = await capturePseudoResponsesRequest(
+			buildOpenRouterModel({ id: "meta/muse-spark-1.3", reasoning: true }),
+			{ reasoning: Effort.Medium },
+			history,
+		);
+		const input = body.input as Array<Record<string, unknown>>;
+		const reasoning = input.filter(item => item.type === "reasoning");
+		expect(reasoning).toHaveLength(1);
+		expect(reasoning[0]).not.toHaveProperty("id");
+		expect(input.findIndex(item => item.type === "reasoning")).toBeLessThan(
+			input.findIndex(item => item.type === "function_call"),
+		);
+	});
 });
 
 async function captureDirectResponsesRequest(


### PR DESCRIPTION
## What

This fixes 400 errors returned by Muse Spark 1.3 on openrouter.

`convertResponsesAssistantMessage` synthesizes a `reasoning` item for replayed assistant turns when the target requires one (`requiresReasoningContentForToolCalls`, which is on for every reasoning model routed through OpenRouter) and no native reasoning item survived. It minted `id: rs_<Bun.hash(...)>` for that item. Meta's Responses endpoint validates reasoning ids against its own store and rejects the fabricated one, so the item now carries an `id` only when a real upstream item id survived; DeepSeek, Kimi and Meta (via OpenRouter) all accept the id-less item.

## Why

Any session containing a tool-call turn from another provider (e.g. Claude on Bedrock, DeepSeek) fails permanently once switched to `meta/muse-spark-1.3*`:

```
400 Provider returned error
→ Referenced reasoning item 'rs_221n7fgv8xprc' was not found or has expired.
```

OpenRouter surfaces only the outer message; the inner one is visible when the captured `~/.omp/logs/http-400-requests/*.json` body is replayed with curl.

## Testing

- Reproduced with the captured 400 bodies via curl: as-sent → 400; same body with the synthetic item's `id` removed → 200 (`meta/muse-spark-1.3`, `deepseek/deepseek-v4.1-flash` and `moonshotai/kimi-k2.6` via OpenRouter all accept the id-less item).
- Resumed the failing session (Claude/Bedrock history → `meta/muse-spark-1.3-contributor`) with the patched source (`bun --cwd=packages/coding-agent src/cli.ts -p --resume …`): the turn completes and no new http-400 capture is written.
- Replayed the second failing session (1368 input items: 17 synthesized placeholders + 188 native `encrypted_content` reasoning items) with only the placeholder ids dropped → 200.
- New regression test in `packages/ai/test/openai-responses-openrouter.test.ts` fails before the fix (`Received value: "rs_1rtned5t0h5l2"`) and passes after; the #10690 upstream-id case still passes.
- `bun run check` and `bun test` in `packages/ai`: 4610 pass, 0 fail.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution (if user-facing; internal issue fixes use issue links, external contributions add the PR link and contributor credit after creation)
