### PR TITLE
fix(coding-agent): export findCutPoint and sessionEntryToContextMessages from legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
+- The legacy `@earendil-works/pi-coding-agent` shim now exports `findCutPoint` (adapted to upstream Pi's tokenizer-less 4-arg signature) and `sessionEntryToContextMessages`, so extensions targeting upstream Pi 0.84.2's compaction/session APIs (e.g. NVlabs/SoL-Pi) install instead of failing validation ([#11796](https://github.com/can1357/oh-my-pi/issues/11796)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -22,6 +22,13 @@ import {
 	type MessageCountOptions,
 	Tokenizer,
 } from "@oh-my-pi/pi-agent-core";
+import { findCutPoint as computeCutPoint, type CutPointResult } from "@oh-my-pi/pi-agent-core/compaction";
+import type { SessionEntry as CompactionSessionEntry } from "@oh-my-pi/pi-agent-core/compaction/entries";
+import {
+	createBranchSummaryMessage,
+	createCompactionSummaryMessage,
+	createCustomMessage,
+} from "@oh-my-pi/pi-agent-core/compaction/messages";
 import { type AuthCredential, SqliteAuthCredentialStore, type TSchema } from "@oh-my-pi/pi-ai";
 import { piEscapeRegexLiteral, piJoinPath } from "@oh-my-pi/pi-ai/providers/cursor-pi-args";
 import { getKeybindings, type Keybinding, Text } from "@oh-my-pi/pi-tui";
@@ -52,6 +59,7 @@ import {
 	truncateHead,
 	truncateTail,
 } from "../session/streaming-output";
+import type { SessionEntry } from "../session/session-entries";
 import type { Tool, ToolSession } from "../tools";
 import { BashTool } from "../tools/bash";
 import { GlobTool } from "../tools/glob";
@@ -1504,6 +1512,53 @@ const legacyTokenizer = new Tokenizer();
  */
 export function estimateTokens(message: AgentMessage, tokenizer?: Tokenizer, options?: MessageCountOptions): number {
 	return (tokenizer ?? legacyTokenizer).countMessage(message, options);
+}
+
+// Legacy pi's `@earendil-works/pi-coding-agent` also exported `findCutPoint` and
+// `sessionEntryToContextMessages` from its package root (upstream Pi 0.84.2
+// public API). In omp `findCutPoint` moved to `@oh-my-pi/pi-agent-core/compaction`
+// AND grew a required `Tokenizer` parameter, and `sessionEntryToContextMessages`
+// has no canonical equivalent, so neither reaches the barrel below and legacy
+// extensions importing them (e.g. NVlabs/SoL-Pi's online-context-compact) fail
+// Bun's static export check during validation (issue #11796).
+
+/**
+ * Legacy `findCutPoint(entries, startIndex, endIndex, keepRecentTokens)` export.
+ * The canonical helper now requires an explicit `Tokenizer`; legacy callers use
+ * the tokenizer-less 4-arg shape, so adapt it with the shared model-agnostic
+ * tokenizer (mirroring `estimateTokens`). A raw re-export would instead misread
+ * the caller's `startIndex` as the tokenizer argument at runtime.
+ */
+export function findCutPoint(
+	entries: SessionEntry[],
+	startIndex: number,
+	endIndex: number,
+	keepRecentTokens: number,
+): CutPointResult {
+	// The coding-agent `SessionEntry` union is a superset of the compaction
+	// module's (the package split makes them nominally distinct); findCutPoint
+	// only walks message entries, so the extra variants are inert.
+	return computeCutPoint(entries as CompactionSessionEntry[], legacyTokenizer, startIndex, endIndex, keepRecentTokens);
+}
+
+/**
+ * Legacy `sessionEntryToContextMessages(entry)` export: project one session entry
+ * into its LLM/runtime messages. Plain custom/state entries do not participate in
+ * context and yield `[]`. omp's `buildSessionContext` only projects whole branches,
+ * so this ports upstream Pi's per-entry mapper.
+ */
+export function sessionEntryToContextMessages(entry: SessionEntry): AgentMessage[] {
+	if (entry.type === "message") return [entry.message];
+	if (entry.type === "custom_message") {
+		return [createCustomMessage(entry.customType, entry.content, entry.display, entry.details, entry.timestamp)];
+	}
+	if (entry.type === "branch_summary" && entry.summary) {
+		return [createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp)];
+	}
+	if (entry.type === "compaction") {
+		return [createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp)];
+	}
+	return [];
 }
 
 // Same barrel gap for two more legacy package-root exports: pi re-exported the

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -3,9 +3,10 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
-import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	calculateCost,
 	getBundledModel,
@@ -31,16 +32,16 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 // `@sinclair/typebox` is served from.
 installLegacyPiSpecifierShim();
 
-// Own the mock-API registration under a source ID unique to this file so
-// cleanup removes only our entry — clearing the shared registry would drop
-// registrations other suites own at module scope (e.g.
-// session-manager/workspace-prompt-refresh.test.ts), failing them by schedule.
-const MOCK_API_SOURCE_ID = "legacy-pi-ai-type-remap.test";
+// Use a unique API name as well as a unique source ID: registrations are keyed
+// by API name, so registering the shared `mock` API would replace another
+// suite's module-scoped owner before source-scoped cleanup could run.
+const COMPLETE_API = "legacy-pi-ai-type-remap-complete";
+const COMPLETE_API_SOURCE_ID = "legacy-pi-ai-type-remap.test";
 const tempRoots: string[] = [];
 
 afterEach(() => {
 	vi.restoreAllMocks();
-	unregisterCustomApis(MOCK_API_SOURCE_ID);
+	unregisterCustomApis(COMPLETE_API_SOURCE_ID);
 });
 
 afterAll(async () => {
@@ -396,10 +397,53 @@ it("runs the legacy pi-ai compat `complete` export with SoL-Pi's reducer call sh
 			options?: SimpleStreamOptions & { timeoutMs?: number },
 		) => Promise<AssistantMessage>;
 	};
-	registerMockApi(MOCK_API_SOURCE_ID);
-	const mock = createMockModel({ responses: [{ content: ["reduced output"] }] });
+	let callCount = 0;
+	let capturedOptions: SimpleStreamOptions | undefined;
+	registerCustomApi(
+		COMPLETE_API,
+		(model, _context, options) => {
+			callCount++;
+			capturedOptions = options;
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "reduced output" }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: {
+						input: 1,
+						output: 2,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 3,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				stream.push({ type: "start", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		},
+		COMPLETE_API_SOURCE_ID,
+	);
+	const model = buildModel({
+		id: "reducer",
+		name: "Reducer",
+		api: COMPLETE_API,
+		provider: "legacy-pi-ai-type-remap",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 4096,
+		maxTokens: 1024,
+	});
 	const response = await loaded.completeCompat(
-		mock.model,
+		model,
 		{
 			systemPrompt: "Reduce",
 			messages: [{ role: "user", content: [{ type: "text", text: "payload" }], timestamp: 0 }],
@@ -417,8 +461,8 @@ it("runs the legacy pi-ai compat `complete` export with SoL-Pi's reducer call sh
 	expect(loaded.schema.safeParse("red").success).toBe(true);
 	expect(loaded.schema.safeParse("blue").success).toBe(false);
 	expect(response.content).toEqual([{ type: "text", text: "reduced output" }]);
-	expect(mock.calls).toHaveLength(1);
-	expect(mock.calls[0]?.options).toMatchObject({
+	expect(callCount).toBe(1);
+	expect(capturedOptions).toMatchObject({
 		apiKey: "test-key",
 		cacheRetention: "none",
 		maxTokens: 321,

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import {
@@ -31,17 +31,22 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 // `@sinclair/typebox` is served from.
 installLegacyPiSpecifierShim();
 
+// Own the mock-API registration under a source ID unique to this file so
+// cleanup removes only our entry — clearing the shared registry would drop
+// registrations other suites own at module scope (e.g.
+// session-manager/workspace-prompt-refresh.test.ts), failing them by schedule.
+const MOCK_API_SOURCE_ID = "legacy-pi-ai-type-remap.test";
 const tempRoots: string[] = [];
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	unregisterCustomApis(MOCK_API_SOURCE_ID);
 });
 
 afterAll(async () => {
 	for (const dir of tempRoots) {
 		await removeWithRetries(dir);
 	}
-	clearCustomApis();
 });
 
 async function writeFixtureExtension(source: string): Promise<string> {
@@ -391,7 +396,7 @@ it("runs the legacy pi-ai compat `complete` export with SoL-Pi's reducer call sh
 			options?: SimpleStreamOptions & { timeoutMs?: number },
 		) => Promise<AssistantMessage>;
 	};
-	registerMockApi();
+	registerMockApi(MOCK_API_SOURCE_ID);
 	const mock = createMockModel({ responses: [{ content: ["reduced output"] }] });
 	const response = await loaded.completeCompat(
 		mock.model,

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -3,6 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import {
 	calculateCost,
 	getBundledModel,
@@ -38,6 +41,7 @@ afterAll(async () => {
 	for (const dir of tempRoots) {
 		await removeWithRetries(dir);
 	}
+	clearCustomApis();
 });
 
 async function writeFixtureExtension(source: string): Promise<string> {
@@ -67,25 +71,6 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 		expect(loaded.schema.safeParse({ name: "ok" }).success).toBe(true);
 		expect(loaded.schema.safeParse({}).success).toBe(false);
 		expect(loaded.schema.safeParse({ name: "ok", extra: 1 }).success).toBe(false);
-	});
-
-	it("redirects the legacy pi-ai compat entrypoint through the root compatibility shim", async () => {
-		const entry = await writeFixtureExtension(
-			[
-				'import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";',
-				'export const schema = StringEnum(["red", "green"] as const);',
-				"export const completeType = typeof complete;",
-				"export type LegacyModel = Model;",
-			].join("\n"),
-		);
-
-		const loaded = (await loadLegacyPiModule(entry)) as {
-			schema: { safeParse: (input: unknown) => { success: boolean } };
-			completeType: string;
-		};
-		expect(loaded.schema.safeParse("red").success).toBe(true);
-		expect(loaded.schema.safeParse("blue").success).toBe(false);
-		expect(loaded.completeType).toBe("function");
 	});
 
 	it('redirects `import { Type } from "@oh-my-pi/pi-ai"` for plugins published against the canonical scope', async () => {
@@ -386,5 +371,52 @@ describe("legacy pi package root remaps (issue #1474)", () => {
 		const loaded = (await loadLegacyPiModule(entry)) as { probe: () => boolean };
 		expect(typeof loaded.probe).toBe("function");
 		expect(canonicalLookupSeen).toBe(true);
+	});
+});
+it("runs the legacy pi-ai compat `complete` export with SoL-Pi's reducer call shape", async () => {
+	const entry = await writeFixtureExtension(
+		[
+			'import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";',
+			'export const schema = StringEnum(["red", "green"] as const);',
+			"export const completeCompat = complete;",
+			"export type LegacyModel = Model;",
+		].join("\n"),
+	);
+
+	const loaded = (await loadLegacyPiModule(entry)) as {
+		schema: { safeParse: (input: unknown) => { success: boolean } };
+		completeCompat: (
+			model: Model<Api>,
+			context: { systemPrompt?: string; messages: Context["messages"] },
+			options?: SimpleStreamOptions & { timeoutMs?: number },
+		) => Promise<AssistantMessage>;
+	};
+	registerMockApi();
+	const mock = createMockModel({ responses: [{ content: ["reduced output"] }] });
+	const response = await loaded.completeCompat(
+		mock.model,
+		{
+			systemPrompt: "Reduce",
+			messages: [{ role: "user", content: [{ type: "text", text: "payload" }], timestamp: 0 }],
+		},
+		{
+			apiKey: "test-key",
+			cacheRetention: "none",
+			maxTokens: 321,
+			sessionId: "sol-pi-run",
+			signal: AbortSignal.timeout(1000),
+			timeoutMs: 1000,
+		},
+	);
+
+	expect(loaded.schema.safeParse("red").success).toBe(true);
+	expect(loaded.schema.safeParse("blue").success).toBe(false);
+	expect(response.content).toEqual([{ type: "text", text: "reduced output" }]);
+	expect(mock.calls).toHaveLength(1);
+	expect(mock.calls[0]?.options).toMatchObject({
+		apiKey: "test-key",
+		cacheRetention: "none",
+		maxTokens: 321,
+		sessionId: "sol-pi-run",
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
@@ -5,6 +5,9 @@ import {
 	calculateContextTokens,
 	compact,
 	estimateTokens,
+	findCutPoint,
+	type SessionEntry,
+	sessionEntryToContextMessages,
 	serializeConversation,
 } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 
@@ -59,5 +62,83 @@ describe("legacy shim compaction helpers", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 		expect(calculateContextTokens(usage)).toBe(115);
+	});
+});
+
+// Issue #11796: `omp install git:github.com/NVlabs/SoL-Pi` failed Bun's static
+// export check because the shim never forwarded `findCutPoint`. omp's canonical
+// `findCutPoint` also grew a required `Tokenizer` parameter, so the shim exposes
+// an upstream-signature (tokenizer-less, 4-arg) wrapper backed by the shared
+// model-agnostic tokenizer — a raw re-export would misread `startIndex` as the
+// tokenizer and throw at runtime.
+describe("legacy shim findCutPoint", () => {
+	const entries: SessionEntry[] = [
+		{
+			type: "message",
+			id: "a",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			message: { role: "user", content: "alpha", timestamp: 0 },
+		},
+		{
+			type: "message",
+			id: "b",
+			parentId: "a",
+			timestamp: new Date(1000).toISOString(),
+			message: { role: "user", content: "beta", timestamp: 1000 },
+		},
+	];
+
+	it("accepts the upstream tokenizer-less 4-arg call shape and keeps all entries under a large budget", () => {
+		const result = findCutPoint(entries, 0, entries.length, 50_000);
+		// A raw re-export would pass `startIndex` (0) where the canonical helper
+		// expects a Tokenizer and throw on `.countMessage`; reaching a numeric
+		// cut index proves the wrapper injected the tokenizer.
+		expect(result.firstKeptEntryIndex).toBe(0);
+		expect(result.isSplitTurn).toBe(false);
+	});
+});
+
+// Issue #11796: SoL-Pi's online-context-compact also imports
+// `sessionEntryToContextMessages`, absent from omp entirely, so it would fail the
+// same static check right after `findCutPoint`. The shim ports upstream Pi's
+// per-entry projector.
+describe("legacy shim sessionEntryToContextMessages", () => {
+	it("projects a message entry to its underlying message", () => {
+		const message = { role: "user" as const, content: "hi", timestamp: 0 };
+		const entry: SessionEntry = {
+			type: "message",
+			id: "m",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			message,
+		};
+		expect(sessionEntryToContextMessages(entry)).toEqual([message]);
+	});
+
+	it("projects a compaction entry to a single compaction-summary message", () => {
+		const entry: SessionEntry = {
+			type: "compaction",
+			id: "c",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "did stuff",
+			firstKeptEntryId: "a",
+			tokensBefore: 1234,
+		};
+		const messages = sessionEntryToContextMessages(entry);
+		expect(messages).toHaveLength(1);
+		expect(messages[0].role).toBe("compactionSummary");
+	});
+
+	it("yields no messages for state-only entries", () => {
+		const entry: SessionEntry = {
+			type: "model_change",
+			id: "mc",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			model: "anthropic/x",
+		};
+		expect(sessionEntryToContextMessages(entry)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Repro
`omp install git:github.com/NVlabs/SoL-Pi` fails at extension validation with `Export named 'findCutPoint' not found in module 'omp-legacy-pi-bundled:@oh-my-pi/pi-coding-agent'`. SoL-Pi's `online-context-compact` extension imports `findCutPoint` and `sessionEntryToContextMessages` from `@earendil-works/pi-coding-agent` (upstream Pi 0.84.2 public API), which omp aliases to `legacy-pi-coding-agent-shim.ts`. Enumerating every runtime-value SoL-Pi imports from that package against the shim's export surface shows two gaps:

```
OK       getAgentDir / CONFIG_DIR_NAME / buildSessionContext / estimateTokens
OK       createBashToolDefinition / createEditToolDefinition / createWriteToolDefinition
MISSING  findCutPoint
MISSING  sessionEntryToContextMessages
```

## Cause
The shim (`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts`) forwards several upstream compaction helpers (`calculateContextTokens`, `compact`, `serializeConversation`, `estimateTokens`) but not `findCutPoint`; and `sessionEntryToContextMessages` has no omp equivalent at all (omp's `buildSessionContext` only projects whole branches). Additionally, omp's canonical `findCutPoint` (`@oh-my-pi/pi-agent-core/compaction`) grew a required `tokenizer` parameter — `findCutPoint(entries, tokenizer, startIndex, endIndex, keepRecentTokens)` — while SoL-Pi calls the upstream tokenizer-less shape `findCutPoint(path, startIndex, path.length, keepRecentTokens)`, so a raw re-export would install but then misread `startIndex` as the tokenizer at runtime.

## Fix
- Add an upstream-signature (4-arg, tokenizer-less) `findCutPoint` wrapper to the shim, backed by the shared model-agnostic `legacyTokenizer` — same adaptation pattern as the existing `estimateTokens` export.
- Port upstream Pi's per-entry `sessionEntryToContextMessages` projector into the shim (message -> `[message]`, custom_message/branch_summary/compaction -> their created messages, state-only entries -> `[]`), reusing omp's `createCustomMessage`/`createBranchSummaryMessage`/`createCompactionSummaryMessage`.
- Add regression tests pinning both exports through the public package specifier, including the tokenizer-less call shape and per-entry projection.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts` — 9 pass / 0 fail. `bun run check:types` (packages/coding-agent) — 0 errors. A pre-fix export probe reported 2 missing exports (exit 1); post-fix it reports 0 (exit 0). Fixes #11796