### PR TITLE
fix(ai): recognize camelcase reasoning-effort errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI-compatible endpoints that report `ReasoningEffort` in CamelCase now trigger effort-downgrade retries instead of terminating turns with HTTP 400 ([#11804](https://github.com/can1357/oh-my-pi/issues/11804)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/ai/src/providers/openai-reasoning-fallback.ts
+++ b/packages/ai/src/providers/openai-reasoning-fallback.ts
@@ -187,7 +187,7 @@ function collectMessageParts(error: unknown, captured: CapturedHttpErrorResponse
  * the same rejection with `Supported values are: …`, so value lists count too.
  */
 const REASONING_EFFORT_FIELD_PATTERN =
-	/reasoning[_. ]effort|reasoning value|(?:valid|supported|allowed) (?:levels?|values?)/i;
+	/reasoning[_. ]?effort|reasoning value|(?:valid|supported|allowed) (?:levels?|values?)/i;
 
 function mentionsReasoningEffort(error: unknown, captured: CapturedHttpErrorResponse | undefined): boolean {
 	const param = capturedStringField(captured, "param");
@@ -224,17 +224,17 @@ interface EffortRejectionSignal {
 	rejectedMatches: boolean;
 }
 
-const EFFORT_FIELD_PATTERN = /reasoning[_. ]effort|reasoning value/i;
+const EFFORT_FIELD_PATTERN = /reasoning[_. ]?effort|reasoning value/i;
 const ALLOWED_LEVELS_PATTERN = /(?:valid|supported|allowed) levels?/i;
 
 /** Fielded rejection verdicts in any word order: verdict-first, field-first, or bare mention plus verdict. */
 function messageCarriesEffortVerdict(message: string): boolean {
 	return (
-		/invalid[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(message) ||
-		/(?:reasoning[_. ]effort|reasoning value)[^\n]*(?:invalid|unsupported|not supported|not permitted|must be|expected|unknown|unexpected|unrecognized)/i.test(
+		/invalid[^\n]*(?:reasoning[_. ]?effort|reasoning value)/i.test(message) ||
+		/(?:reasoning[_. ]?effort|reasoning value)[^\n]*(?:invalid|unsupported|not supported|not permitted|must be|expected|unknown|unexpected|unrecognized)/i.test(
 			message,
 		) ||
-		/(?:unsupported|not supported|not permitted|unknown|unexpected|unrecognized|extra)[^\n]*(?:reasoning[_. ]effort|reasoning value)/i.test(
+		/(?:unsupported|not supported|not permitted|unknown|unexpected|unrecognized|extra)[^\n]*(?:reasoning[_. ]?effort|reasoning value)/i.test(
 			message,
 		)
 	);
@@ -367,7 +367,7 @@ function nearestEnabledReasoningFallback(currentEffort: string, allowed: Set<str
  * supported`).
  */
 const TEMPLATE_KWARG_EFFORT_PATTERN =
-	/chat_template_kwargs[^\n]{0,120}reasoning[_. ]effort|reasoning[_. ]effort[^\n]{0,120}chat_template_kwargs/i;
+	/chat_template_kwargs[^\n]{0,120}reasoning[_. ]?effort|reasoning[_. ]?effort[^\n]{0,120}chat_template_kwargs/i;
 const FIELD_REJECTION_PATTERN =
 	/invalid|unsupported|not supported|not permitted|unknown|unexpected|unrecognized|rejected|extra input/i;
 

--- a/packages/ai/test/openai-reasoning-effort-fallback.test.ts
+++ b/packages/ai/test/openai-reasoning-effort-fallback.test.ts
@@ -82,6 +82,14 @@ function invalidReasoningResponse(param: "reasoning_effort" | "reasoning.effort"
 		{ status: 400, headers: { "content-type": "application/json" } },
 	);
 }
+
+function camelCaseReasoningEffortResponse(): Response {
+	const message = "field ReasoningEffort invalid, should be one of: low, medium, high, xhigh, none";
+	return new Response(JSON.stringify({ error: { message, type: "invalid_request_error" } }), {
+		status: 400,
+		headers: { "content-type": "application/json" },
+	});
+}
 function invalidMediumReasoningResponse(): Response {
 	return new Response(
 		JSON.stringify({
@@ -169,10 +177,10 @@ function templateKwargRejectionResponse(): Response {
 	return new Response(
 		JSON.stringify({
 			error: {
-				message: "chat_template_kwargs.reasoning_effort is not supported",
+				message: "chat_template_kwargs.ReasoningEffort is not supported",
 				type: "invalid_request_error",
 				code: "unknown_parameter",
-				param: "chat_template_kwargs.reasoning_effort",
+				param: "chat_template_kwargs.ReasoningEffort",
 			},
 		}),
 		{ status: 400, headers: { "content-type": "application/json" } },
@@ -354,6 +362,27 @@ describe("OpenAI reasoning effort fallback retry", () => {
 
 		expect(result.stopReason).toBe("stop");
 		expect(bodies.map(body => body.reasoning_effort)).toEqual(["xhigh", "max"]);
+	});
+
+	it("retries CamelCase ReasoningEffort rejections with the nearest supported tier", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const body = parseJsonBody(init);
+				bodies.push(body);
+				return bodies.length === 1 ? camelCaseReasoningEffortResponse() : createChatSseResponse();
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const result = await streamOpenAICompletions(createCompletionsModel(), testContext, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			reasoning: "xhigh",
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies.map(body => body.reasoning_effort)).toEqual(["xhigh", "high"]);
 	});
 
 	it("retries Responses xhigh as provider max and stores the successful fallback params", async () => {


### PR DESCRIPTION
## Repro

On current `main`, invoke `resolveOpenAIReasoningEffortFallback` with the reported 400 and an `xhigh` request: `bun -e 'import { resolveOpenAIReasoningEffortFallback as resolve } from "./packages/ai/src/providers/openai-reasoning-fallback.ts"; const message = "field ReasoningEffort invalid, should be one of: low, medium, high, xhigh, none"; console.log(resolve(new Error(message), { status: 400, bodyText: message, bodyJson: { error: { message, type: "invalid_request_error" } } }, { reasoning_effort: "xhigh" }));'`. Before the fix it prints `undefined`; the equivalent `reasoning_effort` wording returns `high`.

## Cause

`packages/ai/src/providers/openai-reasoning-fallback.ts` required a separator in every reasoning-effort field matcher (`reasoning[_. ]effort`). CamelCase `ReasoningEffort` therefore failed both `mentionsReasoningEffort` and `messageCarriesEffortVerdict`, preventing the existing allowed-value parser and downgrade ladder from running.

## Fix

- Accept zero or one separator in the field, verdict, and template-kwarg matchers.
- Cover the reported OpenAI Completions 400 end to end, including the retry from `xhigh` to `high`.
- Exercise CamelCase template-kwarg rejection detection and document the user-visible recovery.

## Verification

`bun test packages/ai/test/openai-reasoning-effort-fallback.test.ts` passes: 17 tests, 0 failures. The original direct resolver reproduction now returns `high`; the successful push also passed the repository `bun check` pre-publish gate.

Fixes #11804