### PR TITLE
fix(ai): retry statusless stream-drop diagnostics on both recovery paths

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed statusless stream-drop diagnostics (stream disconnected/closed before `response.completed`, upstream stream interrupted or ended before its terminal chunk, socket disconnected before the secure TLS handshake) classifying as terminal errors, so they now retry like their status-tagged twins instead of settling the turn ([#11805](https://github.com/can1357/oh-my-pi/issues/11805)).
+
 ## [18.1.18] - 2026-09-11
 
 ### Added

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -503,21 +503,24 @@ function classifyText(
 		}
 		if (isTimeoutText(errorMessage)) kinds |= Flag.Transient | Flag.Timeout;
 		else if (isTransientErrorText(errorMessage)) kinds |= Flag.Transient;
-		// A stream truncation or forwarded Codex HTTP body-read failure may not
-		// match TRANSIENT_TRANSPORT_PATTERN. Flag it explicitly so AIError.retriable and
-		// the turn-recovery layer treat it as retryable, matching the provider
-		// retry path (isProviderRetryableError). Separate `if` (not chained onto
-		// the else-if) so a timeout whose text also reads as a truncation keeps
-		// Flag.Timeout alongside Flag.Transient. The string arm applies the strict
-		// STREAM_PARSE_DIAGNOSTIC_PATTERN, per the rationale on isTransientStreamParseError.
-		// Skip a truncation phrase that rides on a terminal 4xx (e.g. a malformed
-		// request rejected as "400 unexpected EOF"): that is a deterministic client
-		// error that replays identically, so keep it terminal. classify() carries
-		// the outer terminal status down the cause chain so a wrapped truncation
-		// (ProviderHttpError 400 → cause "unexpected EOF") is caught here too.
+		// A stream truncation, transport-level stream drop, or forwarded Codex HTTP
+		// body-read failure may not match TRANSIENT_TRANSPORT_PATTERN. Flag it
+		// explicitly so AIError.retriable and the turn-recovery layer treat it as
+		// retryable, matching the provider retry path (isProviderRetryableError).
+		// Separate `if` (not chained onto the else-if) so a timeout whose text also
+		// reads as a truncation keeps Flag.Timeout alongside Flag.Transient. The
+		// string arm applies the strict STREAM_PARSE_DIAGNOSTIC_PATTERN, per the
+		// rationale on isTransientStreamParseError. Skip a phrase that rides on a
+		// terminal 4xx (e.g. a malformed request rejected as "400 unexpected EOF"):
+		// that is a deterministic client error that replays identically, so keep it
+		// terminal. classify() carries the outer terminal status down the cause
+		// chain so a wrapped truncation (ProviderHttpError 400 → cause "unexpected
+		// EOF") is caught here too.
 		if (
 			!isTerminalClientErrorStatus(statusClean) &&
-			(isTransientStreamParseError(errorMessage) || CODEX_HTTP_BODY_READ_ERROR_PATTERN.test(errorMessage))
+			(isTransientStreamParseError(errorMessage) ||
+				isTransientStreamDropError(errorMessage) ||
+				CODEX_HTTP_BODY_READ_ERROR_PATTERN.test(errorMessage))
 		) {
 			kinds |= Flag.Transient;
 		}
@@ -869,6 +872,31 @@ const STREAM_EVENT_ORDER_PATTERN = /stream event order|before message_start/i;
 export function isTransientStreamParseError(error: unknown): boolean {
 	if (typeof error === "string") return STREAM_PARSE_DIAGNOSTIC_PATTERN.test(error);
 	return error instanceof Error && STREAM_PARSE_TRUNCATION_PATTERN.test(error.message);
+}
+
+/**
+ * Transport-level stream drops: the connection or upstream stream ended before a
+ * terminal event, with no JSON-parse signal and no retryable status attached.
+ *
+ * Distinct from {@link STREAM_PARSE_TRUNCATION_PATTERN} (mid-body JSON
+ * truncation) — these name the transport itself dropping (proxy/gateway closing
+ * the SSE stream, socket dying before the TLS handshake completes). The wording
+ * is the statusless twin of a `408 stream disconnected`, which the status path
+ * already retries; an identical replay recovers it, so callers under a
+ * non-terminal status treat it as transient (#11805).
+ */
+const STREAM_DROP_PATTERN =
+	/stream disconnected before completion|stream closed before response\.completed|stream was interrupted|stream ended before terminal (?:chunk|completion event)|socket disconnected before secure tls connection/i;
+
+/**
+ * Transport stream-drop diagnostic (see {@link STREAM_DROP_PATTERN}). Unlike
+ * {@link isTransientStreamParseError}, one pattern serves both the live `Error`
+ * and the persisted-string forms: the phrasings are high-signal enough to trust
+ * detached from a transport `Error`.
+ */
+export function isTransientStreamDropError(error: unknown): boolean {
+	if (typeof error === "string") return STREAM_DROP_PATTERN.test(error);
+	return error instanceof Error && STREAM_DROP_PATTERN.test(error.message);
 }
 
 /** Any malformed stream-envelope error (prefix-tagged or out-of-order events). */

--- a/packages/ai/src/error/retryable.ts
+++ b/packages/ai/src/error/retryable.ts
@@ -2,6 +2,7 @@ import { isRetryableError, isUnexpectedSocketCloseMessage } from "@oh-my-pi/pi-u
 import {
 	CODEX_HTTP_BODY_READ_ERROR_PATTERN,
 	isRetryableStreamEnvelopeError,
+	isTransientStreamDropError,
 	isTransientStreamParseError,
 	isUsageLimit,
 	status,
@@ -55,6 +56,7 @@ export function isProviderRetryableError(error: unknown): boolean {
 		CODEX_HTTP_BODY_READ_ERROR_PATTERN.test(msg) ||
 		PROVIDER_TRANSIENT_EXTRA_PATTERN.test(msg) ||
 		isTransientStreamParseError(error) ||
+		isTransientStreamDropError(error) ||
 		isRetryableStreamEnvelopeError(error)
 	) {
 		return true;

--- a/packages/ai/test/error-id.test.ts
+++ b/packages/ai/test/error-id.test.ts
@@ -143,6 +143,26 @@ describe("error-id classification", () => {
 		}
 	});
 
+	it.each([
+		"stream error: stream disconnected before completion: stream closed before response.completed",
+		"Upstream response stream was interrupted",
+		"Upstream stream ended before terminal chunk",
+		"Client network socket disconnected before secure TLS connection was established",
+	])("classifies statusless stream-drop families as transient + retryable on both paths: %s", errorMessage => {
+		const id = AIError.classifyMessage(message({ errorMessage }));
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(id)).toBe(true);
+		expect(AIError.isProviderRetryableError(new Error(errorMessage))).toBe(true);
+	});
+
+	it("keeps a stream-drop phrase riding on a terminal 4xx terminal", () => {
+		const errorMessage = "stream closed before response.completed";
+		const id = AIError.classifyMessage(message({ errorStatus: 400, errorMessage }));
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(false);
+		expect(AIError.retriable(id)).toBe(false);
+		expect(AIError.isProviderRetryableError(new AIError.ProviderHttpError(errorMessage, 400))).toBe(false);
+	});
+
 	it("keeps Flag.Timeout when a timeout message also reads as a truncation", () => {
 		const id = AIError.classifyMessage(message({ errorMessage: "read timed out: unexpected EOF" }));
 		expect(AIError.is(id, AIError.Flag.Timeout)).toBe(true);


### PR DESCRIPTION
## Repro
Four transport-drop diagnostics settle terminal on both recovery paths — the turn path (`AIError.retriable(classifyMessage(...))`) and the provider path (`isProviderRetryableError(new Error(...))`) — even though an immediate replay recovers them. Running a classifier probe against `main`:

```
{"msg":"stream error: stream disconnected before complet","turnRetriable":false,"provRetriable":false}
{"msg":"Upstream response stream was interrupted","turnRetriable":false,"provRetriable":false}
{"msg":"Upstream stream ended before terminal chunk","turnRetriable":false,"provRetriable":false}
{"msg":"Client network socket disconnected before secure","turnRetriable":false,"provRetriable":false}
provider retries 408-status twin: true
provider retries statusless : false
```

The status-tagged twin (`408 stream disconnected`) is retried while the statusless twin — identical wording — is not: the wording carries the signal but nothing consumes it when no status is attached.

## Cause
`TRANSIENT_TRANSPORT_PATTERN` and `isTransientStreamParseError` in `packages/ai/src/error/flags.ts` have no arm for these transport-level stream-drop phrasings (stream disconnected/closed before `response.completed`, upstream stream interrupted/ended before its terminal chunk, socket disconnected before the secure TLS handshake). With no match, `classifyText` (turn path) and `isProviderRetryableError` (provider path) both fall through to terminal. Same classification gap as the bare-`unexpected EOF` case fixed in #11745/#11747.

## Fix
- Added `STREAM_DROP_PATTERN` + exported `isTransientStreamDropError(error)` in `flags.ts` — one pattern serves both the live `Error` and persisted-string forms (the phrasings are high-signal enough to trust detached from a transport `Error`).
- Consulted it in `classifyText` under the existing `!isTerminalClientErrorStatus(statusClean)` guard, so a drop phrase riding on a terminal 4xx (e.g. `400 stream closed before response.completed`) stays terminal while `408`/`429`/statusless variants flip to `Flag.Transient`.
- Consulted it in `isProviderRetryableError` (`retryable.ts`), which already guards non-408/429 4xx before message matching.
- Certificate-verification failures are deliberately left terminal: they are host/CA state (TLS-inspecting proxy / missing CA), consistent with the existing `isProviderRetryableError("tls: failed to verify certificate") === false` policy. Whether they should surface as an actionable setup error is a maintainer design call (see #10466).
- Added regression tests and a `packages/ai/CHANGELOG.md` entry.

## Verification
`bun test test/error-id.test.ts test/anthropic-retry.test.ts test/error-aierr.test.ts test/overflow-utils.test.ts` — 115 pass / 0 fail. New `it.each` proves each of the four families is transient + retryable on both paths; a companion test proves `400 stream closed before response.completed` stays terminal on both paths. Manual classifier probe against the fixed source flips all four statusless families to `turn:true, prov:true` while the 4xx guard holds. Fixes #11805.