### PR TITLE
feat(coding-agent): extension API for UI string and prompt overrides

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -51,6 +51,8 @@ import type {
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
+import { clearAll as clearUiStringsAll, registerUiStrings } from "./ui-strings";
+import { clearAllPromptOverrides, registerPromptOverrides } from "./prompt-overrides";
 
 installLegacyPiSpecifierShim();
 
@@ -332,6 +334,19 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	unregisterProvider(name: string): void {
 		this.runtime.unregisterProvider(name, this.extension.path);
 	}
+
+	registerUiStrings(registration: { strings: Record<string, string> }): void {
+		registerUiStrings(registration, this.extension.path);
+	}
+	registerPromptOverrides(registration: {
+		overrides: Array<{
+			id: string;
+			full?: string;
+			transform?: (source: string) => string;
+		}>;
+	}): void {
+		registerPromptOverrides(registration, this.extension.path);
+	}
 }
 
 /**
@@ -459,6 +474,8 @@ export async function bindPreparedExtensions(
 	cwd: string,
 	eventBus?: EventBus,
 ): Promise<LoadExtensionsResult> {
+	clearUiStringsAll();
+	clearAllPromptOverrides();
 	const extensions: Extension[] = [];
 	const errors: Array<{ path: string; error: string }> = [];
 	const resolvedEventBus = eventBus ?? new EventBus();

--- a/packages/coding-agent/src/extensibility/extensions/prompt-overrides.ts
+++ b/packages/coding-agent/src/extensibility/extensions/prompt-overrides.ts
@@ -1,0 +1,94 @@
+/**
+ * Process-wide registry for extension-provided prompt template overrides.
+ *
+ * Prompt templates (system prompt, subagent prompts, agent ROLE bodies, tool
+ * descriptions) are model-facing content — deliberately kept separate from the
+ * UI string registry. Extensions register a stable prompt ID (e.g. `system`,
+ * `subagent.system`, `agent.task`, `tools.bash`) mapped to either:
+ *
+ * - `full`: a complete replacement template, or
+ * - `transform`: a function applied to the built-in template text.
+ *
+ * `full` takes precedence over `transform` when both are registered for the
+ * same ID; later registrations replace earlier ones. The resolver returns the
+ * built-in text unchanged when nothing is registered, so the default pipeline
+ * is untouched without plugins.
+ */
+
+/** One registered prompt override. */
+export interface PromptOverride {
+  id: string;
+  /** Complete template replacement (applied verbatim before render). */
+  full?: string;
+  /** Text transformation applied to the built-in template. */
+  transform?: (source: string) => string;
+}
+
+/** Internal registry shape: prompt ID -> override (full/transform). */
+type StoredOverride = {
+  full?: string;
+  transform?: (source: string) => string;
+};
+
+const registry = new Map<string, StoredOverride>();
+
+/** Per-extension tracking so one extension's contributions can be flushed atomically. */
+const tracked = new Map<string /* extensionPath */, Set<string>>();
+
+/**
+ * Register prompt template overrides for one extension.
+ *
+ * Later registrations for the same prompt ID replace earlier ones (UI
+ * registry convention). Empty IDs are skipped.
+ */
+export function registerPromptOverrides(registration: { overrides: PromptOverride[] }, extensionPath: string): void {
+	const keys = tracked.get(extensionPath) ?? new Set<string>();
+	for (const override of registration.overrides) {
+		const { id, full, transform } = override;
+		if (!id) continue;
+		registry.set(id, { full, transform });
+		keys.add(id);
+	}
+	tracked.set(extensionPath, keys);
+}
+
+/**
+ * Clear every prompt override registered by one extension (reload/teardown).
+ */
+export function clearPromptOverridesFor(extensionPath: string): void {
+	const keys = tracked.get(extensionPath);
+	if (!keys) return;
+	for (const key of keys) registry.delete(key);
+	keys.clear();
+	tracked.delete(extensionPath);
+}
+
+/** Clear the entire prompt override registry (global teardown). */
+export function clearAllPromptOverrides(): void {
+	registry.clear();
+	tracked.clear();
+}
+
+/**
+ * Resolve a prompt template source: look up the override first, fall back to
+ * `builtin`. `full` wins over `transform`; a throwing transform degrades to
+ * the built-in template.
+ */
+export function resolvePromptSource(id: string, builtin: string): string {
+	const override = registry.get(id);
+	if (!override) return builtin;
+	if (override.full !== undefined) return override.full;
+	if (override.transform) {
+		try {
+			return override.transform(builtin);
+		} catch {
+			return builtin;
+		}
+	}
+	return builtin;
+}
+
+/** Whether a prompt override is registered for the given ID. */
+export function hasPromptOverride(id: string): boolean {
+	return registry.has(id);
+}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1540,6 +1540,74 @@ export interface ExtensionAPI {
 	 */
 	unregisterProvider(name: string): void;
 
+	/**
+	 * Register UI string overrides for the TUI settings panel and chrome.
+	 *
+	 * Called at extension load time. Keys are free-form stable identifiers
+	 * (e.g. `"tab.appearance"`, `"compaction.group"`, `"settings.title"`).
+	 * Later registrations overwrite earlier ones for the same key.
+	 * Empty keys or empty values are silently skipped.
+	 *
+	 * When the extension is disabled or reloaded, its contributions are
+	 * removed so stale strings never persist.
+	 *
+	 * @example
+	 * // Override a tab label
+	 * pi.registerUiStrings({
+	 *   strings: {
+	 *     "tab.appearance": "\u5916\u89c2",
+	 *     "tab.model": "\u6a21\u578b",
+	 *     "settings.title": "\u8bbe\u7f6e",
+	 *     "settings.searchPlaceholder": "\u641c\u7d22\u8bbe\u7f6e...",
+	 *   },
+	 * });
+	 *
+	 * @example
+	 * // Override setting label and description
+	 * pi.registerUiStrings({
+	 *   strings: {
+	 *     "compaction.enabled.label": "\u538b\u7f29",
+	 *     "compaction.enabled.description": "\u542f\u7528\u4e3b\u52a8\u538b\u7f29...",
+	 *   },
+	 * });
+	 */
+	registerUiStrings(registration: { strings: Record<string, string> }): void;
+
+	/**
+	 * Register model-facing prompt overrides for stable prompt IDs.
+	 *
+	 * Unlike `registerUiStrings` (interface copy) this changes what the model
+	 * sees: the system prompt, subagent prompts, and tool descriptions. An
+	 * override supplies a full replacement template or a text transform for a
+	 * prompt ID; `prompt.render` and all Handlebars expressions, XML tags,
+	 * and dynamic variables in the original template must be preserved by the
+	 * override.
+	 *
+	 * Prompt IDs:
+	 * - `"system"` — the main agent system prompt
+	 * - `"subagent.system"` — the subagent system prompt template
+	 * - `"tools.<toolName>"` — a tool's model-facing description
+	 *
+	 * Example:
+	 * ```ts
+	 * pi.registerPromptOverrides({
+	 *   overrides: [
+	 *     {
+	 *       id: "system",
+	 *       transform: (src) => src.replace("You are an expert", "You are an expert engineer"),
+	 *     },
+	 *   ],
+	 * });
+	 * ```
+	 */
+	registerPromptOverrides(registration: {
+		overrides: Array<{
+			id: string;
+			full?: string;
+			transform?: (source: string) => string;
+		}>;
+	}): void;
+
 	/** Shared event bus for extension communication. */
 	events: EventBus;
 }

--- a/packages/coding-agent/src/extensibility/extensions/ui-strings.ts
+++ b/packages/coding-agent/src/extensibility/extensions/ui-strings.ts
@@ -1,0 +1,153 @@
+/**
+ * Process-wide registry for extension-provided UI string overrides.
+ *
+ * Extensions call `registerUiStrings` at load time to provide
+ * localized labels, descriptions, tab labels, group names, and
+ * chrome strings. The registry is cleared on extension reload or
+ * disable so stale strings never persist.
+ *
+ * All methods are synchronous and thread-safe for single-threaded
+ * Node.js use.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single localized string mapped to a stable key. */
+export interface UiStringEntry {
+	/** Stable key; must not be empty. */
+	key: string;
+	/** Localized string; empty strings are rejected. */
+	value: string;
+}
+
+/** Set of overrides submitted by one extension. */
+export type UiStringMap = Record<string, string>;
+
+/** Shape of the `registerUiStrings` payload. */
+export interface UiStringsRegistration {
+	/** Free-form key-value pairs for setting label / description / chrome. */
+	strings: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal registry
+// ---------------------------------------------------------------------------
+
+/** Flat map of every registered override: `key → value`.
+ *  When multiple extensions register the same key, the last one wins. */
+const registry = new Map<string, string>();
+
+/** Per-extension tracking so we can flush one extension at a time. */
+const tracked = new Map</* extensionPath */ string, Set<string>>();
+
+/** Reverse map: key → owners (extensions that registered this key).
+ *  Used by clearUiStringsFor to avoid deleting a key that another
+ *  extension still owns. */
+const keyOwners = new Map<string, Set<string>>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register UI string overrides.
+ *
+ * @param entry - Map of string keys to localized values.
+ * @param extensionPath - Identifies the caller for lifecycle management.
+ *
+ * Keys must be non-empty, values must not be empty (empty is silently
+ * skipped rather than rejected — this lets partial registrations work).
+ * Later registrations overwrite earlier ones for the same key.
+ */
+export function registerUiStrings(
+	entry: UiStringsRegistration,
+	extensionPath: string,
+): void {
+	if (!entry || typeof entry !== "object") return;
+	const strings = entry.strings;
+	if (!strings || typeof strings !== "object") return;
+
+	const keys = tracked.get(extensionPath) ?? new Set<string>();
+	let dirty = false;
+
+	for (const [key, value] of Object.entries(strings)) {
+		// Skip empty keys and empty values — partial registration is OK.
+		if (!key || typeof key !== "string" || key.trim() === "") continue;
+		if (value == null || (typeof value === "string" && value.trim() === "")) continue;
+
+		registry.set(key, value);
+		keys.add(key);
+
+		// Track ownership: add this extension to the key's owner set.
+		let owners = keyOwners.get(key);
+		if (!owners) {
+			owners = new Set<string>();
+			keyOwners.set(key, owners);
+		}
+		owners.add(extensionPath);
+
+		dirty = true;
+	}
+
+	if (dirty) {
+		tracked.set(extensionPath, keys);
+	}
+}
+
+/**
+ * Clear all UI strings registered by the given extension.
+ * Called when an extension is disabled, unloaded, or reloaded.
+ *
+ * Only removes keys that are exclusively owned by this extension.
+ * If another extension also claimed the same key, the value persists
+ * (the other extension's registration is preserved).
+ */
+export function clearUiStringsFor(extensionPath: string): void {
+	const keys = tracked.get(extensionPath);
+	if (!keys) return;
+
+	for (const key of keys) {
+		// Remove this extension from the owner set.
+		const owners = keyOwners.get(key);
+		if (owners) {
+			owners.delete(extensionPath);
+			// Only delete from registry if no one else owns it.
+			if (owners.size === 0) {
+				registry.delete(key);
+				keyOwners.delete(key);
+			}
+		} else {
+			// Unreachable: if key is in tracked, it must be in keyOwners.
+			registry.delete(key);
+		}
+	}
+
+	tracked.delete(extensionPath);
+}
+
+/**
+ * Clear the entire registry. Used during global teardown.
+ */
+export function clearAll(): void {
+	registry.clear();
+	tracked.clear();
+	keyOwners.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a UI string: look up the override first, fall back to `fallback`.
+ *
+ * This function is the single accessor consumed by `settings-defs.ts` and
+ * `settings-selector.ts`. When no override is registered for `key`, the
+ * original `fallback` value is returned unchanged.
+ */
+export function resolveUiString(key: string, fallback: string): string {
+	const override = registry.get(key);
+	return override ?? fallback;
+}

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -32,6 +32,7 @@ import {
 import type { InstalledPlugin, PluginSettingSchema } from "../../extensibility/plugins/types";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
 import { shortenPath } from "../../tools/render-utils";
+import { resolveUiString } from "../../extensibility/extensions/ui-strings";
 import { OverlayPanel } from "./overlay-box";
 
 /**
@@ -212,7 +213,13 @@ export class PluginListComponent extends OverlayPanel {
 
 		this.addChild(this.#selectList);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to configure · Esc to go back"), 0, 0));
+		this.addChild(
+			new Text(
+				theme.fg("dim", resolveUiString("plugins.footer.configure", "Enter to configure · Esc to go back")),
+				0,
+				0,
+			),
+		);
 	}
 
 	#renderItem(entry: PluginListEntry): SelectItem {
@@ -247,7 +254,7 @@ export class PluginListComponent extends OverlayPanel {
 
 		let details = `${kindBadge} ${scopeTag} ${theme.sep.dot} v${version}`;
 		if (summary.shadowedBy) {
-			details += ` ${theme.sep.dot} shadowed by ${summary.shadowedBy}`;
+			details += ` ${theme.sep.dot} ${resolveUiString("plugins.shadowed", "shadowed by")} ${summary.shadowedBy}`;
 		}
 
 		return {
@@ -309,8 +316,8 @@ export class PluginDetailComponent extends OverlayPanel {
 		// Enable/disable toggle
 		items.push({
 			id: "__enabled__",
-			label: "Enabled",
-			description: "Enable or disable this plugin",
+			label: resolveUiString("plugins.enabled", "Enabled"),
+			description: resolveUiString("plugins.enabled.description", "Enable or disable this plugin"),
 			currentValue: plugin.enabled ? "true" : "false",
 			values: ["true", "false"],
 		});
@@ -371,7 +378,9 @@ export class PluginDetailComponent extends OverlayPanel {
 
 		this.addChild(this.#settingsList);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to edit · Esc to go back"), 0, 0));
+		this.addChild(
+			new Text(theme.fg("dim", resolveUiString("plugins.footer.edit", "Enter to edit · Esc to go back")), 0, 0),
+		);
 	}
 
 	handleInput(data: string): void {
@@ -438,15 +447,21 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 		const entry = plugin.entries[0];
 		this.title = plugin.id;
 		const subtitleParts = [`[${plugin.scope}]`];
-		if (plugin.shadowedBy) subtitleParts.push(`${theme.status.shadowed} shadowed by ${plugin.shadowedBy}`);
+		if (plugin.shadowedBy)
+			subtitleParts.push(
+				`${theme.status.shadowed} ${resolveUiString("plugins.shadowed", "shadowed by")} ${plugin.shadowedBy}`,
+			);
 		this.addChild(new Text(theme.fg("muted", subtitleParts.join(" ")), 0, 0));
 		this.addChild(new Spacer(1));
 
 		const items: SettingItem[] = [
 			{
 				id: "__enabled__",
-				label: "Enabled",
-				description: "Enable or disable this marketplace plugin",
+				label: resolveUiString("plugins.enabled", "Enabled"),
+				description: resolveUiString(
+					"plugins.enabled.description.marketplace",
+					"Enable or disable this marketplace plugin",
+				),
 				currentValue: marketplaceEnabled(plugin) ? "true" : "false",
 				values: ["true", "false"],
 			},
@@ -476,23 +491,46 @@ export class MarketplacePluginDetailComponent extends OverlayPanel {
 
 		this.addChild(this.#settingsList);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", `version       ${entry?.version ?? "(unknown)"}`), 0, 0));
-		this.addChild(new Text(theme.fg("dim", `scope         ${plugin.scope}`), 0, 0));
 		this.addChild(
 			new Text(
-				theme.fg("dim", `install path  ${entry?.installPath ? shortenPath(entry.installPath) : "(unknown)"}`),
+				theme.fg("dim", `version       ${entry?.version ?? resolveUiString("plugins.unknown", "(unknown)")}`),
 				0,
 				0,
 			),
 		);
-		this.addChild(new Text(theme.fg("dim", `installed at  ${entry?.installedAt ?? "(unknown)"}`), 0, 0));
-		this.addChild(new Text(theme.fg("dim", `last updated  ${entry?.lastUpdated ?? "(unknown)"}`), 0, 0));
+		this.addChild(new Text(theme.fg("dim", `scope         ${plugin.scope}`), 0, 0));
+		this.addChild(
+			new Text(
+				theme.fg(
+					"dim",
+					`install path  ${entry?.installPath ? shortenPath(entry.installPath) : resolveUiString("plugins.unknown", "(unknown)")}`,
+				),
+				0,
+				0,
+			),
+		);
+		this.addChild(
+			new Text(
+				theme.fg("dim", `installed at  ${entry?.installedAt ?? resolveUiString("plugins.unknown", "(unknown)")}`),
+				0,
+				0,
+			),
+		);
+		this.addChild(
+			new Text(
+				theme.fg("dim", `last updated  ${entry?.lastUpdated ?? resolveUiString("plugins.unknown", "(unknown)")}`),
+				0,
+				0,
+			),
+		);
 		if (entry?.gitCommitSha) {
 			this.addChild(new Text(theme.fg("dim", `git sha       ${entry.gitCommitSha}`), 0, 0));
 		}
 
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to edit · Esc to go back"), 0, 0));
+		this.addChild(
+			new Text(theme.fg("dim", resolveUiString("plugins.footer.edit", "Enter to edit · Esc to go back")), 0, 0),
+		);
 	}
 
 	handleInput(data: string): void {
@@ -538,7 +576,9 @@ class ConfigEnumSubmenu extends OverlayPanel {
 
 		this.addChild(this.#selectList);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to select · Esc to cancel"), 0, 0));
+		this.addChild(
+			new Text(theme.fg("dim", resolveUiString("plugins.footer.select", "Enter to select · Esc to cancel")), 0, 0),
+		);
 	}
 
 	handleInput(data: string): void {
@@ -594,7 +634,9 @@ class ConfigInputSubmenu extends OverlayPanel {
 
 		this.addChild(this.#input);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "Enter to save · Esc to cancel"), 0, 0));
+		this.addChild(
+			new Text(theme.fg("dim", resolveUiString("plugins.footer.save", "Enter to save · Esc to cancel")), 0, 0),
+		);
 	}
 
 	handleInput(data: string): void {

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -11,6 +11,7 @@
 
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../config/settings";
+import { resolveUiString } from "../../extensibility/extensions/ui-strings";
 import {
 	type AnyUiMetadata,
 	getDefault,
@@ -188,11 +189,11 @@ function pathToSettingDef(path: SettingPath): SettingDef | null {
 	const condition = ui.condition ? CONDITIONS[ui.condition] : undefined;
 	const base = {
 		path,
-		label: ui.label,
-		description: ui.description,
+		label: resolveUiString(`setting.${path}.label`, ui.label),
+		description: resolveUiString(`setting.${path}.description`, ui.description),
 		warning: ui.warning,
 		tab: ui.tab,
-		group: ui.group,
+		group: ui.group ?? "",
 		condition,
 	};
 

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -50,8 +50,19 @@ import { getComposerShapeOptions } from "./composer-shape-registry";
 import { bottomBorder, divider, row, topBorder } from "./overlay-box";
 import { handleInputOrEscape, PluginSettingsComponent } from "./plugin-settings";
 import { getSettingDef, getSettingsForTab, type SettingDef } from "./settings-defs";
+import { resolveUiString } from "../../extensibility/extensions/ui-strings";
 import { SnapcompactShapePreview } from "./snapcompact-shape-preview";
 import { getPreset } from "./status-line/presets";
+
+/**
+ * Display label for a section group: the plugin-registered override
+ * (`group.<tab>.<group>`) or the canonical English name. The canonical
+ * `def.group` stays untouched — it is the TAB_GROUPS sort identity.
+ */
+function resolveSettingGroupLabel(def: SettingDef): string {
+	if (!def.group) return "";
+	return resolveUiString(`group.${def.tab}.${def.group}`, def.group);
+}
 
 /**
  * A submenu component for selecting from a list of options.
@@ -137,7 +148,7 @@ class SelectSubmenu extends Container {
 		// Preview (if provided)
 		if (getPreview) {
 			this.addChild(new Spacer(1));
-			this.addChild(new Text(theme.fg("muted", "Preview:"), 0, 0));
+			this.addChild(new Text(theme.fg("muted", resolveUiString("settings.preview", "Preview:")), 0, 0));
 			this.#previewText = new Text(getPreview(), 0, 0);
 			this.addChild(this.#previewText);
 		}
@@ -419,13 +430,24 @@ class ProviderLimitsSubmenu extends Container {
 
 	#showProviderList(): void {
 		this.clear();
-		this.addChild(new Text(theme.bold(theme.fg("accent", "Max In-Flight Requests")), 0, 0));
+		this.addChild(
+			new Text(
+				theme.bold(
+					theme.fg("accent", resolveUiString("providers.maxInFlightRequests.title", "Max In-Flight Requests")),
+				),
+				0,
+				0,
+			),
+		);
 		this.addChild(new Spacer(1));
 		this.addChild(
 			new Text(
 				theme.fg(
 					"muted",
-					"Select a provider, enter a positive number to cap concurrent LLM requests, or clear it for unlimited.",
+					resolveUiString(
+						"providers.maxInFlightRequests.description",
+						"Select a provider, enter a positive number to cap concurrent LLM requests, or clear it for unlimited.",
+					),
 				),
 				0,
 				0,
@@ -439,13 +461,25 @@ class ProviderLimitsSubmenu extends Container {
 			return {
 				value: provider,
 				label: provider,
-				description: limit === undefined ? "Unlimited" : `Limit: ${limit}`,
+				description:
+					limit === undefined
+						? resolveUiString("providers.maxInFlightRequests.unlimited", "Unlimited")
+						: `Limit: ${limit}`,
 			};
 		});
 		const clearItem: SelectItem[] =
 			Object.keys(limits).length === 0
 				? []
-				: [{ value: "__clear_all", label: "Clear all limits", description: "Make every provider unlimited" }];
+				: [
+						{
+							value: "__clear_all",
+							label: resolveUiString("providers.maxInFlightRequests.clearAll", "Clear all limits"),
+							description: resolveUiString(
+								"providers.maxInFlightRequests.clearAllDescription",
+								"Make every provider unlimited",
+							),
+						},
+					];
 		const items = [...providerItems, ...clearItem];
 		this.#selectList = new SelectList(items, Math.min(Math.max(items.length, 1), 12), getSelectListTheme());
 		this.#selectList.onSelect = item => {
@@ -461,7 +495,16 @@ class ProviderLimitsSubmenu extends Container {
 		this.#selectList.onCancel = this.onCancel;
 		this.addChild(this.#selectList);
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("dim", "  Enter to edit provider · Esc to go back"), 0, 0));
+		this.addChild(
+			new Text(
+				theme.fg(
+					"dim",
+					resolveUiString("providers.maxInFlightRequests.footer", "  Enter to edit provider · Esc to go back"),
+				),
+				0,
+				0,
+			),
+		);
 	}
 
 	#showProviderEditor(provider: string): void {
@@ -470,8 +513,11 @@ class ProviderLimitsSubmenu extends Container {
 		this.#selectList = undefined;
 		this.addChild(
 			new TextInputSubmenu(
-				`Max In-Flight Requests: ${provider}`,
-				"Enter a positive number. Decimals round down. Clear the field to make this provider unlimited.",
+				resolveUiString("providers.maxInFlightRequests.editor", `Max In-Flight Requests: ${provider}`),
+				resolveUiString(
+					"providers.maxInFlightRequests.editorHelp",
+					"Enter a positive number. Decimals round down. Clear the field to make this provider unlimited.",
+				),
 				limits[provider]?.toString() ?? "",
 				false,
 				value => {
@@ -531,9 +577,14 @@ function getSettingsTabs(): Tab[] {
 		...SETTING_TABS.map(id => {
 			const meta = TAB_METADATA[id];
 			const icon = theme.symbol(meta.icon as Parameters<typeof theme.symbol>[0]);
-			return { id, label: `${icon} ${meta.label}`, short: icon };
+			const label = resolveUiString(`tab.${id}`, meta.label);
+			return { id, label: `${icon} ${label}`, short: icon };
 		}),
-		{ id: "plugins", label: `${theme.icon.package} Plugins`, short: theme.icon.package },
+		{
+			id: "plugins",
+			label: `${theme.icon.package} ${resolveUiString("tab.plugins", "Plugins")}`,
+			short: theme.icon.package,
+		},
 	];
 }
 
@@ -666,22 +717,35 @@ export class SettingsSelectorComponent implements Component {
 
 	#footerHintText(): string {
 		if (this.#searchList) {
-			return "Enter to change · Tab to jump tabs · Esc to exit search";
+			return resolveUiString("settings.hint.search", "Enter to change · Tab to jump tabs · Esc to exit search");
 		}
 		if (this.#currentTabId === "plugins") {
-			return "Tab to switch tabs · Esc to close";
+			return resolveUiString("settings.hint.plugins", "Tab to switch tabs · Esc to close");
 		}
 		if (this.#currentList?.sectionFocused) {
-			return "↑/↓ to jump sections · Tab/Enter to settings · ←/→ to switch tabs · Esc to close";
+			return resolveUiString(
+				"settings.hint.sections",
+				"↑/↓ to jump sections · Tab/Enter to settings · ←/→ to switch tabs · Esc to close",
+			);
 		}
-		const nav = this.#hasSectionJump ? "Tab to jump sections · ←/→ to switch tabs" : "Tab to switch tabs";
-		return `Enter/Space to change · ${nav} · Type to search · Esc to close`;
+		const hintNav = this.#hasSectionJump
+			? resolveUiString("settings.hint.jumpSection", "Tab to jump sections · ←/→ to switch tabs")
+			: resolveUiString("settings.hint.switchTab", "Tab to switch tabs");
+		return [
+			resolveUiString("settings.hint.change", "Enter/Space to change"),
+			hintNav,
+			resolveUiString("settings.hint.typeSearch", "Type to search"),
+			resolveUiString("settings.hint.escClose", "Esc to close"),
+		].join(" · ");
 	}
 
 	/** Single-line search banner: accent icon, editable query with live cursor, right-aligned match count. */
 	#renderSearchBanner(width: number): string {
 		const icon = theme.symbol("icon.search");
-		const countText = this.#searchMatchCount === 1 ? "1 match" : `${this.#searchMatchCount} matches`;
+		const countText =
+			this.#searchMatchCount === 1
+				? resolveUiString("settings.match.one", "1 match")
+				: `${this.#searchMatchCount} ${resolveUiString("settings.match.many", "matches")}`;
 		const rightWidth = visibleWidth(countText) + 1; // trailing margin
 		const prefix = ` ${theme.fg("accent", icon)} `;
 		// The input pads itself to exactly this width and keeps the cursor in view.
@@ -703,7 +767,9 @@ export class SettingsSelectorComponent implements Component {
 		const tabLines = this.#tabBar.render(innerWidth);
 		const searching = this.#searchList !== null;
 		const showPreview = !searching && this.#currentTabId === "appearance";
-		const previewLines = showPreview ? ["", theme.fg("muted", "Preview:"), this.#getStatusPreviewString()] : [];
+		const previewLines = showPreview
+			? ["", theme.fg("muted", resolveUiString("settings.preview", "Preview:")), this.#getStatusPreviewString()]
+			: [];
 
 		// Fixed chrome: top border, tabs, divider, [search row], divider, hint, bottom border.
 		const fixedRows = 1 + tabLines.length + 1 + (searching ? 1 : 0) + 1 + 1 + 1;
@@ -722,7 +788,7 @@ export class SettingsSelectorComponent implements Component {
 		}
 
 		const out: string[] = [];
-		out.push(topBorder(width, "Settings"));
+		out.push(topBorder(width, resolveUiString("settings.title", "Settings")));
 		this.#tabRowStart = out.length;
 		this.#tabRowCount = tabLines.length;
 		for (const line of tabLines) {
@@ -829,7 +895,7 @@ export class SettingsSelectorComponent implements Component {
 			{
 				layout: "flat",
 				typeToSearch: false,
-				emptyText: "No matching settings",
+				emptyText: resolveUiString("settings.search.noResults", "No matching settings"),
 				hint: "",
 			},
 		);
@@ -883,7 +949,7 @@ export class SettingsSelectorComponent implements Component {
 			const meta = TAB_METADATA[result.tab];
 			items.push({
 				id: `__tab:${result.tab}`,
-				label: `${theme.symbol(meta.icon as Parameters<typeof theme.symbol>[0])} ${meta.label}`,
+				label: `${theme.symbol(meta.icon as Parameters<typeof theme.symbol>[0])} ${resolveUiString(`tab.${result.tab}`, meta.label)}`,
 				currentValue: "",
 				heading: true,
 			});
@@ -933,17 +999,26 @@ export class SettingsSelectorComponent implements Component {
 			const icon = theme.symbol(meta.icon as Parameters<typeof theme.symbol>[0]);
 			const count = counts.get(id) ?? 0;
 			if (count > 0) {
-				matched.push({ id, label: `${icon} ${meta.label} (${count})`, short: `${icon} ${count}` });
+				matched.push({
+					id,
+					label: `${icon} ${resolveUiString(`tab.${id}`, meta.label)} (${count})`,
+					short: `${icon} ${count}`,
+				});
 			}
 		}
 		for (const id of SETTING_TABS) {
 			if (matchedIds.has(id)) continue;
 			const meta = TAB_METADATA[id];
 			const icon = theme.symbol(meta.icon as Parameters<typeof theme.symbol>[0]);
-			empty.push({ id, label: `${icon} ${meta.label}`, short: icon, muted: true });
+			empty.push({ id, label: `${icon} ${resolveUiString(`tab.${id}`, meta.label)}`, short: icon, muted: true });
 		}
 		// Plugins hosts its own UI; it is not part of the schema-backed search.
-		empty.push({ id: "plugins", label: `${theme.icon.package} Plugins`, short: theme.icon.package, muted: true });
+		empty.push({
+			id: "plugins",
+			label: `${theme.icon.package} ${resolveUiString("tab.plugins", "Plugins")}`,
+			short: theme.icon.package,
+			muted: true,
+		});
 		return [...matched, ...empty];
 	}
 
@@ -1363,9 +1438,12 @@ export class SettingsSelectorComponent implements Component {
 		for (const def of defs) {
 			const item = this.#defToItem(def);
 			if (!item) continue;
-			if (def.group && def.group !== lastGroup) {
-				items.push({ id: `__heading:${def.group}`, label: def.group, currentValue: "", heading: true });
-				lastGroup = def.group;
+			if (def.group) {
+				const groupLabel = resolveSettingGroupLabel(def);
+				if (groupLabel !== lastGroup) {
+					items.push({ id: `__heading:${def.group}`, label: groupLabel, currentValue: "", heading: true });
+					lastGroup = groupLabel;
+				}
 			}
 			items.push(item);
 		}

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -7,6 +7,11 @@ import { getSkillSlashCommandName, type Skill } from "../extensibility/skills";
 import { type FileSlashCommand, loadSlashCommands } from "../extensibility/slash-commands";
 import { ACP_BUILTIN_RESERVED_NAMES, isAcpBuiltinShadowedName } from "./acp-builtins";
 import { BUILTIN_SLASH_COMMANDS_INTERNAL } from "./builtin-registry";
+import {
+	resolveCommandDescription,
+	resolveCommandHint,
+	resolveCommandSubcommands,
+} from "./command-ui";
 
 export type AvailableSlashCommandSource = "builtin" | "skill" | "extension" | "custom" | "mcp_prompt" | "file";
 
@@ -49,9 +54,14 @@ export async function buildAvailableSlashCommands(
 		appendCommand({
 			name: command.name,
 			aliases: command.aliases,
-			description: command.acpDescription ?? command.description,
-			input: hint ? { hint } : undefined,
-			subcommands: command.subcommands,
+			description: resolveCommandDescription(
+				command.name,
+				command.acpDescription ?? command.description,
+			),
+			input: hint ? { hint: resolveCommandHint(command.name, hint) } : undefined,
+			subcommands: command.subcommands
+				? resolveCommandSubcommands(command.name, command.subcommands)
+				: undefined,
 			source: "builtin",
 		});
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -15,6 +15,11 @@ import { BUILTIN_MARKETPLACE_SLASH_COMMANDS, reloadTuiPluginState } from "./buil
 import { BUILTIN_MODE_SLASH_COMMANDS } from "./builtin-modes";
 import { BUILTIN_SESSION_SLASH_COMMANDS } from "./builtin-session";
 import { parseSlashCommand } from "./helpers/parse";
+import {
+	resolveCommandDescription,
+	resolveCommandHint,
+	resolveCommandSubcommands,
+} from "./command-ui";
 import type {
 	BuiltinSlashCommand,
 	ParsedSlashCommand,
@@ -72,21 +77,28 @@ function materializeTuiBuiltinSlashCommand(
 	cmd: BuiltinSlashCommand,
 	runtime?: TuiSlashCommandRuntime,
 ): TuiBuiltinSlashCommand {
-	const materialized: TuiBuiltinSlashCommand = { ...cmd };
-	if (cmd.subcommands) {
+	const materialized: TuiBuiltinSlashCommand = {
+		...cmd,
+		description: resolveCommandDescription(cmd.name, cmd.description),
+	};
+	const subcommands = cmd.subcommands
+		? resolveCommandSubcommands(cmd.name, cmd.subcommands)
+		: undefined;
+	if (subcommands) {
+		materialized.subcommands = subcommands;
 		materialized.getArgumentCompletions =
 			cmd.name === "mcp" && runtime
-				? buildMcpArgumentCompletions(cmd.subcommands, runtime)
-				: buildArgumentCompletions(cmd.subcommands);
-		materialized.getInlineHint = buildSubcommandInlineHint(cmd.subcommands);
+				? buildMcpArgumentCompletions(subcommands, runtime)
+				: buildArgumentCompletions(subcommands);
+		materialized.getInlineHint = buildSubcommandInlineHint(subcommands);
 	} else if (cmd.name === "move") {
 		materialized.getArgumentCompletions = buildDirectoryArgumentCompletions();
-		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);
+		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(resolveCommandHint(cmd.name, cmd.inlineHint));
 	} else if (cmd.name === "switch" && runtime) {
 		materialized.getArgumentCompletions = buildModelSelectorCompletions(runtime);
-		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);
+		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(resolveCommandHint(cmd.name, cmd.inlineHint));
 	} else if (cmd.inlineHint) {
-		materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);
+		materialized.getInlineHint = buildStaticInlineHint(resolveCommandHint(cmd.name, cmd.inlineHint));
 	}
 	if (runtime && cmd.getTuiAutocompleteDescription) {
 		materialized.getAutocompleteDescription = () => cmd.getTuiAutocompleteDescription?.(runtime);

--- a/packages/coding-agent/src/slash-commands/command-ui.ts
+++ b/packages/coding-agent/src/slash-commands/command-ui.ts
@@ -1,0 +1,54 @@
+/**
+ * Slash-command UI copy resolution for the builtin command registry.
+ *
+ * The ui-strings registry (`resolveUiString`) is the single source of localized
+ * copy; this module adds the stable `command.*` key convention the builtin
+ * slash-command materialize/consume paths use to swap in localized
+ * descriptions, hints, and subcommand copy. When no override is registered,
+ * the original English text is returned unchanged.
+ *
+ * Key convention (all fields fall back to the original copy):
+ * - `command.<name>.description` — the command's canonical description.
+ *   Consumed by both the TUI autocomplete description and the ACP-advertised
+ *   description (against the effective `acpDescription ?? description`).
+ * - `command.<name>.hint` — the inline hint / usage line: the TUI static
+ *   `inlineHint` and the ACP-advertised input hint (against the effective
+ *   `acpInputHint ?? inlineHint`).
+ * - `command.<name>.subcommand.<sub>.description` — a subcommand's
+ *   description (dropdown + ghost text).
+ *
+ * Command names, aliases, and argument syntax are never translated; only the
+ * human-readable description/hint copy is.
+ */
+
+import { resolveUiString } from "../extensibility/extensions/ui-strings";
+import type { SubcommandDef } from "./types";
+
+/** Resolve the canonical description for a command. */
+export function resolveCommandDescription(name: string, fallback: string): string {
+	return resolveUiString(`command.${name}.description`, fallback);
+}
+
+/**
+ * Resolve the inline hint for a command: the TUI static `inlineHint` and the
+ * ACP-advertised input hint (`acpInputHint ?? inlineHint`).
+ */
+export function resolveCommandHint(name: string, fallback: string): string {
+	return resolveUiString(`command.${name}.hint`, fallback);
+}
+
+/**
+ * Return a copy of `subcommands` with each subcommand's description resolved
+ * against the ui-strings registry. The original array is not mutated; the
+ * builder closures capture this resolved copy. Argument-syntax `usage` ghost
+ * text is never translated and passes through untouched.
+ */
+export function resolveCommandSubcommands(
+	name: string,
+	subcommands: SubcommandDef[],
+): SubcommandDef[] {
+	return subcommands.map(sub => ({
+		...sub,
+		description: resolveUiString(`command.${name}.subcommand.${sub.name}.description`, sub.description),
+	}));
+}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -37,6 +37,7 @@ import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type
 import { normalizeConcurrencyLimit } from "./task/parallel";
 import { type ActiveRepoContext, resolveActiveRepoContext } from "./utils/active-repo-context";
 import { normalizePromptPath } from "./utils/prompt-path";
+import { resolvePromptSource } from "./extensibility/extensions/prompt-overrides";
 import { AGENTS_MD_LIMIT, buildWorkspaceTree, type WorkspaceTree } from "./workspace-tree";
 
 /** Bundled personality specs, keyed by the `personality` setting value. */
@@ -1030,7 +1031,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		autoQaEnabled,
 		writeTransportOnly,
 	};
-	const rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
+	const resolvedSystemTemplate = resolvePromptSource(
+		resolvedCustomPrompt ? "system.custom" : "system",
+		resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate,
+	);
+	const rendered = prompt.render(resolvedSystemTemplate, data);
 	const systemPrompt = [rendered];
 	if (computerEnabled) {
 		systemPrompt.push(computerSafetyPrompt.trim());

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -6,6 +6,7 @@
 import { Effort } from "@oh-my-pi/pi-ai";
 import { parseFrontmatter, prompt } from "@oh-my-pi/pi-utils";
 import { parseAgentFields } from "../discovery/helpers";
+import { resolvePromptSource } from "../extensibility/extensions/prompt-overrides";
 // Embed agent markdown files at build time
 import agentFrontmatterTemplate from "../prompts/agents/frontmatter.md" with { type: "text" };
 import reviewerMd from "../prompts/agents/reviewer.md" with { type: "text" };
@@ -35,7 +36,12 @@ interface EmbeddedAgentDef {
 }
 
 function buildAgentContent(def: EmbeddedAgentDef): string {
-	const body = prompt.render(def.template);
+	// Route the agent body template through the prompt-override resolver so an
+	// extension can localize the bundled agent's ROLE prompt (stable IDs:
+	// `agent.task`, `agent.scout`, `agent.reviewer`, `agent.security-reviewer`,
+	// `agent.sonic`). The frontmatter wrapper (YAML metadata: name, description,
+	// model, ...) is left untouched — it is machine data, not model-facing prose.
+	const body = prompt.render(resolvePromptSource(`agent.${def.fileName.replace(/\.md$/, "")}`, def.template));
 	if (!def.frontmatter) return body;
 	return prompt.render(agentFrontmatterTemplate, { ...def.frontmatter, body });
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -39,6 +39,7 @@ import type { LocalProtocolOptions } from "../internal-urls";
 import { IrcBus } from "../irc/bus";
 import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
+import { resolvePromptSource } from "../extensibility/extensions/prompt-overrides";
 import { initializeExtensions } from "../modes/runtime-init";
 import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pending.md" with { type: "text" };
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
@@ -2057,10 +2058,12 @@ async function driveSessionToYield(
 				if (lastBeforeReminder?.stopReason === "error") break;
 				try {
 					retryCount++;
-					const reminder = prompt.render(submitReminderTemplate, {
-						retryCount,
-						maxRetries: MAX_YIELD_RETRIES,
-						budgetStop,
+					const reminder = prompt.render(
+						resolvePromptSource("subagent.yieldReminder", submitReminderTemplate),
+						{
+							retryCount,
+							maxRetries: MAX_YIELD_RETRIES,
+							budgetStop,
 					});
 
 					const isFinalRetry = retryCount >= MAX_YIELD_RETRIES;
@@ -2130,11 +2133,14 @@ async function driveSessionToYield(
 				const running = session.getAsyncJobSnapshot()?.running ?? [];
 				if (running.length > 0) {
 					const jobs = running.map(job => `${job.id}${job.label ? ` (${job.label})` : ""}`).join(", ");
-					const notice = prompt.render(subagentAsyncPendingTemplate, {
-						count: running.length,
-						multiple: running.length > 1,
-						jobs,
-					});
+					const notice = prompt.render(
+						resolvePromptSource("subagent.asyncPending", subagentAsyncPendingTemplate),
+						{
+							count: running.length,
+							multiple: running.length > 1,
+							jobs,
+						},
+					);
 					try {
 						await awaitAbortable(session.prompt(notice, { attribution: "agent", synthetic: true }));
 						await awaitAbortable(session.waitForIdle());
@@ -3467,7 +3473,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const ircRoster = ircEnabled
 						? collectIrcPeerRoster(AgentRegistry.global(), id, ircRootSessionFile)
 						: undefined;
-					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
+					const subagentPrompt = prompt.render(
+						resolvePromptSource("subagent.system", subagentSystemPromptTemplate),
+						{
 						agent: agent.systemPrompt,
 						context: options.context?.trim() ?? "",
 						planReference: options.planReference?.content ?? "",

--- a/packages/coding-agent/test/extensibility/extensions/prompt-overrides.test.ts
+++ b/packages/coding-agent/test/extensibility/extensions/prompt-overrides.test.ts
@@ -1,0 +1,118 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { prompt } from "@oh-my-pi/pi-utils";
+import {
+	clearAllPromptOverrides,
+	clearPromptOverridesFor,
+	hasPromptOverride,
+	registerPromptOverrides,
+	resolvePromptSource,
+} from "../../../src/extensibility/extensions/prompt-overrides";
+import { loadExtensions } from "../../../src/extensibility/extensions/loader";
+
+// Content-free prompt-override mechanism contract: the extension is a
+// synthetic fixture written to a temp dir and loaded through the real
+// extension loader, so the factory -> pi.registerPromptOverrides wiring and
+// the registry semantics are exercised exactly as a real localization plugin
+// would exercise them. Content (translations) lives in the plugin repo.
+
+const EN_BUILTIN = "EN_BASELINE_BUILTIN";
+const FULL_TEMPLATE = "OVERRIDE_FULL_TEXT {{name}}";
+const TRANSFORM_MARKER = "OVERRIDE_TRANSFORM_SUFFIX";
+
+const FIXTURE_FACTORY = `
+export default function (pi: {
+	registerPromptOverrides: (r: {
+		overrides: Array<{ id: string; full?: string; transform?: (s: string) => string }>;
+	}) => void;
+}): void {
+	pi.registerPromptOverrides({
+		overrides: [
+			{ id: "system", full: ${JSON.stringify(FULL_TEMPLATE)} },
+			{ id: "agent.task", transform: (src) => src + " " + ${JSON.stringify(TRANSFORM_MARKER)} },
+		],
+	});
+}
+`;
+
+describe("prompt overrides (mechanism)", () => {
+	let tmpExt: string;
+	let extPath: string;
+
+	beforeEach(() => {
+		clearAllPromptOverrides();
+		tmpExt = fs.mkdtempSync(path.join(os.tmpdir(), "prompt-override-test-"));
+		extPath = path.join(tmpExt, "index.ts");
+		fs.writeFileSync(extPath, FIXTURE_FACTORY);
+	});
+
+	afterEach(() => {
+		clearAllPromptOverrides();
+		fs.rmSync(tmpExt, { recursive: true, force: true });
+	});
+
+	it("falls back to the built-in template when nothing is registered", () => {
+		expect(hasPromptOverride("system")).toBe(false);
+		expect(resolvePromptSource("system", EN_BUILTIN)).toBe(EN_BUILTIN);
+		const rendered = prompt.render(resolvePromptSource("system", EN_BUILTIN + " {{n}}"), { n: 7 });
+		expect(rendered).toBe(EN_BUILTIN + " 7");
+	});
+
+	it("real loader: extension factory registers all override ids without errors", async () => {
+		const result = await loadExtensions([extPath], tmpExt);
+		expect(result.errors).toEqual([]);
+		expect(result.extensions).toHaveLength(1);
+		expect(path.basename(result.extensions[0].path)).toBe("index.ts");
+		expect(hasPromptOverride("system")).toBe(true);
+		expect(hasPromptOverride("agent.task")).toBe(true);
+	});
+
+	it("full override replaces the built-in and renders Handlebars variables", async () => {
+		await loadExtensions([extPath], tmpExt);
+		const rendered = prompt.render(resolvePromptSource("system", EN_BUILTIN), { name: "Ada" });
+		expect(rendered).toContain("OVERRIDE_FULL_TEXT");
+		expect(rendered).toContain("Ada");
+		expect(rendered).not.toContain(EN_BUILTIN);
+	});
+
+	it("transform override is applied on top of the built-in text", async () => {
+		await loadExtensions([extPath], tmpExt);
+		const resolved = resolvePromptSource("agent.task", EN_BUILTIN);
+		expect(resolved).toContain(EN_BUILTIN);
+		expect(resolved).toContain(TRANSFORM_MARKER);
+	});
+
+	it("full wins over transform when both are registered for one id", () => {
+		registerPromptOverrides(
+			{ overrides: [{ id: "system", full: "FULL_WINS", transform: () => "TRANSFORM_WINS" }] },
+			extPath,
+		);
+		expect(resolvePromptSource("system", EN_BUILTIN)).toBe("FULL_WINS");
+	});
+
+	it("a throwing transform degrades to the built-in template", () => {
+		registerPromptOverrides(
+			{
+				overrides: [
+					{ id: "system", transform: () => { throw new Error("transform blew up"); } },
+				],
+			},
+			extPath,
+		);
+		expect(resolvePromptSource("system", EN_BUILTIN)).toBe(EN_BUILTIN);
+	});
+
+	it("clearPromptOverridesFor removes only that extension's contributions", async () => {
+		const result = await loadExtensions([extPath], tmpExt);
+		expect(hasPromptOverride("system")).toBe(true);
+		expect(hasPromptOverride("agent.task")).toBe(true);
+
+		clearPromptOverridesFor(result.extensions[0].path);
+
+		expect(hasPromptOverride("system")).toBe(false);
+		expect(hasPromptOverride("agent.task")).toBe(false);
+		expect(resolvePromptSource("system", EN_BUILTIN)).toBe(EN_BUILTIN);
+	});
+});

--- a/packages/coding-agent/test/extensibility/extensions/ui-strings.test.ts
+++ b/packages/coding-agent/test/extensibility/extensions/ui-strings.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import {
+	clearAll as clearAllUiStrings,
+	clearUiStringsFor,
+	registerUiStrings,
+	resolveUiString,
+} from "../../../src/extensibility/extensions/ui-strings";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function reset(): void {
+	clearAllUiStrings();
+}
+
+// ── Registry / resolveUiString ──────────────────────────────────────────────
+
+describe("resolveUiString", () => {
+	it("returns fallback when no override is registered", () => {
+		reset();
+		expect(resolveUiString("tab.model", "Model")).toBe("Model");
+	});
+
+	it("returns override when registered", () => {
+		reset();
+		registerUiStrings({ strings: { "tab.model": "Model-CN" } }, "/path/to/plugin");
+		expect(resolveUiString("tab.model", "Model")).toBe("Model-CN");
+	});
+
+	it("falls back when only a partial key is overridden", () => {
+		reset();
+		registerUiStrings({ strings: { "tab.model": "Model-CN" } }, "/path/to/plugin");
+		// "tab.appearance" has no override
+		expect(resolveUiString("tab.appearance", "Appearance")).toBe("Appearance");
+	});
+});
+
+// ── registerUiStrings ───────────────────────────────────────────────────────
+
+describe("registerUiStrings", () => {
+	it("rejects null/undefined entry", () => {
+		reset();
+		// @ts-expect-error — testing runtime safety
+		registerUiStrings(null, "/path");
+		expect(resolveUiString("key", "fallback")).toBe("fallback");
+	});
+
+	it("rejects empty strings record", () => {
+		reset();
+		registerUiStrings({ strings: {} }, "/path");
+		expect(resolveUiString("key", "fallback")).toBe("fallback");
+	});
+
+	it("skips empty keys", () => {
+		reset();
+		registerUiStrings({ strings: { "": "should not appear" } }, "/path");
+		expect(resolveUiString("", "fallback")).toBe("fallback");
+	});
+
+	it("skips empty string values", () => {
+		reset();
+		registerUiStrings({ strings: { key: " " } }, "/path");
+		expect(resolveUiString("key", "fallback")).toBe("fallback");
+	});
+
+	it("overwrites earlier registration for the same key", () => {
+		reset();
+		registerUiStrings({ strings: { "tab.model": "Model v1" } }, "/path/a");
+		registerUiStrings({ strings: { "tab.model": "Model v2" } }, "/path/b");
+		expect(resolveUiString("tab.model", "Default")).toBe("Model v2");
+	});
+
+	it("clearUiStringsFor removes only that extension's keys", () => {
+		reset();
+		registerUiStrings({ strings: { "key-a": "value-a" } }, "/path/a");
+		registerUiStrings({ strings: { "key-b": "value-b" } }, "/path/b");
+		expect(resolveUiString("key-a", "fallback")).toBe("value-a");
+		expect(resolveUiString("key-b", "fallback")).toBe("value-b");
+
+		clearUiStringsFor("/path/a");
+		expect(resolveUiString("key-a", "fallback")).toBe("fallback");
+		expect(resolveUiString("key-b", "fallback")).toBe("value-b");
+	});
+
+	it("clearAll removes everything", () => {
+		reset();
+		registerUiStrings({ strings: { x: "y" } }, "/path");
+		expect(resolveUiString("x", "fallback")).toBe("y");
+		clearAllUiStrings();
+		expect(resolveUiString("x", "fallback")).toBe("fallback");
+	});
+});
+
+// ── Default fallback (no plugin loaded) ──────────────────────────────────────
+
+describe("default fallback", () => {
+	it("settings-defs resolver returns schema values when no overrides", () => {
+		reset();
+		// Verify that resolveUiString simply returns the fallback
+		// This is what settings-defs and settings-selector see
+		expect(resolveUiString("tab.model", "Model")).toBe("Model");
+		expect(resolveUiString("setting.compaction.enabled.label", "Enable compaction")).toBe("Enable compaction");
+		expect(resolveUiString("settings.title", "Settings")).toBe("Settings");
+	});
+
+	it("chrome strings fall through to hardcoded defaults", () => {
+		reset();
+		// The settings-selector uses resolveUiString for all chrome strings.
+		// Without any override, every call returns the hardcoded default.
+		expect(resolveUiString("settings.hint.search", "Enter to change · Tab to jump tabs · Esc to exit search")).toBe(
+			"Enter to change · Tab to jump tabs · Esc to exit search",
+		);
+		expect(resolveUiString("settings.match.one", "1 match")).toBe("1 match");
+	});
+});
+
+// ── Real key resolution ──────────────────────────────────────────────────────
+
+describe("real keys", () => {
+	it("resolves a real group key through the plugin registration", () => {
+		reset();
+		registerUiStrings(
+			{
+				strings: {
+					"group.appearance.Theme": "Theme-CN",
+				},
+			},
+			"/path/to/test-plugin",
+		);
+		expect(resolveUiString("group.appearance.Theme", "Theme")).toBe("Theme-CN");
+	});
+
+	it("resolves a real setting key through the plugin registration", () => {
+		reset();
+		registerUiStrings(
+			{
+				strings: {
+					"setting.theme.dark.label": "Dark theme (zh)",
+				},
+			},
+			"/path/to/test-plugin",
+		);
+		expect(resolveUiString("setting.theme.dark.label", "Dark theme")).toBe("Dark theme (zh)");
+	});
+});

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -8,10 +8,19 @@ import {
 	TAB_GROUPS,
 } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
 import { getSettingsForTab } from "@oh-my-pi/pi-coding-agent/modes/components/settings-defs";
+import {
+	clearAll as clearAllUiStrings,
+	registerUiStrings,
+	resolveUiString,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/ui-strings";
 
 interface UiShape {
 	tab: SettingTab;
 	group?: string;
+}
+
+function resetUiStrings(): void {
+	clearAllUiStrings();
 }
 
 describe("settings layout", () => {
@@ -36,6 +45,38 @@ describe("settings layout", () => {
 			}
 		}
 		expect(violations).toEqual([]);
+	});
+
+	it("keeps def.group as the canonical TAB_GROUPS name (regression: escaped group key template)", () => {
+		resetUiStrings();
+		// The group key must interpolate the tab/group at build time. An escaped
+		// template produced the literal "group.${ui.tab}.${ui.group ?? ""}" as the
+		// key (and as the group name), silently breaking every UI override and
+		// pushing every group past the TAB_GROUPS sort rank.
+		for (const tab of SETTING_TABS) {
+			for (const def of getSettingsForTab(tab)) {
+				if (!def.group) continue;
+				expect(TAB_GROUPS[tab].includes(def.group)).toBe(true);
+			}
+		}
+	});
+
+	it("resolves the group display label without mutating the canonical def.group", () => {
+		resetUiStrings();
+		const def = getSettingsForTab("appearance").find(item => item.path === "terminal.showProgress");
+		expect(def).toBeDefined();
+		if (!def?.group) throw new Error("terminal.showProgress should be grouped");
+		const group = def.group;
+
+		// No override: display label falls back to the canonical name.
+		expect(resolveUiString(`group.appearance.${group}`, group)).toBe(group);
+
+		registerUiStrings({ strings: { "group.appearance.Display": "Display-ZH" } }, "/path/to/plugin");
+		expect(resolveUiString(`group.appearance.${group}`, group)).toBe("Display-ZH");
+
+		// The canonical group stays the sort identity; only the label changes.
+		expect(def.group).toBe(group);
+		resetUiStrings();
 	});
 
 	it("getSettingsForTab returns contiguous groups in TAB_GROUPS order", () => {

--- a/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
@@ -3,6 +3,10 @@ import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-ag
 import { SettingsSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/settings-selector";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { SEARCH_PROVIDER_CHOICES } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import {
+	clearAll as clearAllUiStrings,
+	registerUiStrings,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/ui-strings";
 
 beforeAll(async () => {
 	await initTheme();
@@ -224,5 +228,27 @@ describe("settings section sidebar", () => {
 
 		clickOption(comp, "Developer");
 		expect(settings.get("dev.autoqa")).toBe(true);
+	});
+});
+
+describe("settings group headings localization", () => {
+	it("renders the registered group override as the heading and sidebar label", () => {
+		registerUiStrings({ strings: { "group.appearance.Theme": "Theme-ZH" } }, "/path/to/plugin");
+		const comp = createSelector();
+		const text = Bun.stripANSI(comp.render(120).join("\n"));
+
+		// The group name is localized in the sidebar and the section heading.
+		// "Theme-ZH" appears only as the localized group name here — the option
+		// values stay "Dark Theme"/"Light Theme", so it is a clean signal.
+		expect(text).toContain("Theme-ZH");
+		clearAllUiStrings();
+	});
+
+	it("falls back to the canonical group name when no override is registered", () => {
+		clearAllUiStrings();
+		const comp = createSelector();
+		const text = Bun.stripANSI(comp.render(120).join("\n"));
+
+		expect(text).toMatch(/│\s+Theme\s+│/);
 	});
 });

--- a/packages/coding-agent/test/slash-commands/command-ui-strings.test.ts
+++ b/packages/coding-agent/test/slash-commands/command-ui-strings.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import {
+	buildTuiBuiltinSlashCommands,
+	type TuiBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import {
+	buildAvailableSlashCommands,
+	type AvailableCommandsSession,
+	type InternalAvailableSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/available-commands";
+import {
+	clearAll as clearUiStrings,
+	registerUiStrings,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/ui-strings";
+
+/** Minimal TUI runtime: materialization only reads `runtime` for truthiness + completions. */
+const runtime = { ctx: {} } as unknown as TuiSlashCommandRuntime;
+
+function register(strings: Record<string, string>): void {
+	registerUiStrings({ strings }, "test://command-ui-strings");
+}
+
+function availableSession(): AvailableCommandsSession {
+	return {
+		skills: [],
+		skillsSettings: { enableSkillCommands: true },
+		customCommands: [],
+		setSlashCommands: () => {},
+		sessionManager: { getCwd: () => "/tmp" },
+	};
+}
+
+function materializedByName(): Record<string, TuiBuiltinSlashCommand> {
+	const commands = buildTuiBuiltinSlashCommands(runtime);
+	return Object.fromEntries(commands.map(cmd => [cmd.name, cmd])) as Record<string, TuiBuiltinSlashCommand>;
+}
+
+function availableByName(commands: InternalAvailableSlashCommand[]): Record<string, InternalAvailableSlashCommand> {
+	return Object.fromEntries(commands.map(cmd => [cmd.name, cmd])) as Record<string, InternalAvailableSlashCommand>;
+}
+
+afterEach(() => {
+	clearUiStrings();
+});
+
+describe("slash-command ui-strings (command.* key convention)", () => {
+	test("no plugin registered: materialized copy stays at the built-in English fallback", () => {
+		const byName = materializedByName();
+		expect(byName.goal?.description).toBe("Toggle goal mode (persistent autonomous objective for this session)");
+		expect(byName.usage?.description).toBe("Show provider usage and limits");
+		expect(byName.git?.getInlineHint?.("")).toBe("[revision]");
+		// Subcommand descriptions stay at the built-in text.
+		expect(byName.goal?.subcommands?.find(sub => sub.name === "set")?.description).toBe("Set or replace the goal");
+	});
+
+	test("registered command copy: materialized commands resolve the overridden description and hint", () => {
+		register({
+			"command.goal.description": "Show current goal state",
+			"command.usage.description": "Show provider usage",
+			"command.queue.hint": "Type a message...",
+		});
+		const byName = materializedByName();
+		expect(byName.goal?.description).toBe("Show current goal state");
+		expect(byName.usage?.description).toBe("Show provider usage");
+		// Inline hints resolve via command.<name>.hint; unregistered commands keep the built-in.
+		expect(byName.queue?.getInlineHint?.("")).toBe("Type a message...");
+		expect(byName.git?.getInlineHint?.("")).toBe("[revision]");
+	});
+
+	test("registered subcommand copy: materialized subcommands resolve the overridden descriptions", async () => {
+		register({
+			"command.goal.description": "Show current goal state",
+			"command.goal.subcommand.set.description": "Replace the current goal",
+		});
+		const byName = materializedByName();
+		expect(byName.goal?.subcommands?.find(sub => sub.name === "set")?.description).toBe("Replace the current goal");
+		// Argument completions consume the same resolved subcommand descriptions.
+		const items = await Promise.resolve(byName.goal?.getArgumentCompletions?.("set"));
+		expect(items?.find(item => item.label === "set")?.description).toBe("Replace the current goal");
+	});
+
+	test("no plugin registered: available commands keep the built-in English fallback", async () => {
+		const commands = await buildAvailableSlashCommands(availableSession());
+		const byName = availableByName(commands);
+		// The ACP path only includes handled commands; descriptions resolve via acpDescription ?? description.
+		expect(byName.usage?.description).toBe("Show token usage");
+		expect(byName.advisor?.description).toBe("Toggle advisor");
+		expect(byName.usage?.input?.hint).toBe("[show|reset [account|active]]");
+		expect(byName.usage?.subcommands?.find(sub => sub.name === "show")).toEqual({
+			name: "show",
+			description: "Show provider usage and limits",
+		});
+		expect(byName.usage?.subcommands?.find(sub => sub.name === "reset")).toEqual({
+			name: "reset",
+			description: "Spend a saved Codex rate-limit reset",
+			usage: "[account|active]",
+		});
+	});
+
+	test("registered command copy: available commands resolve the overridden description, hint, and subcommands", async () => {
+		register({
+			"command.usage.description": "Show provider usage",
+			"command.advisor.description": "Show advisor status",
+			"command.usage.hint": "[show|reset]",
+			"command.usage.subcommand.show.description": "Show provider usage",
+			"command.advisor.subcommand.dump.description": "Dump the advisor transcript",
+		});
+		const commands = await buildAvailableSlashCommands(availableSession());
+		const byName = availableByName(commands);
+		expect(byName.usage?.description).toBe("Show provider usage");
+		expect(byName.advisor?.description).toBe("Show advisor status");
+		// The ACP input hint resolves via command.<name>.hint (acpInputHint ?? inlineHint).
+		expect(byName.usage?.input?.hint).toBe("[show|reset]");
+		expect(byName.usage?.subcommands?.find(sub => sub.name === "show")?.description).toBe("Show provider usage");
+		expect(byName.advisor?.subcommands?.find(sub => sub.name === "dump")?.description).toBe("Dump the advisor transcript");
+		// Unregistered commands keep the built-in fallback.
+		expect(byName.security?.description).toBe("Plan, run, inspect, import, and compare OMP-native security scans");
+	});
+});


### PR DESCRIPTION
## Summary

Adds two generic extension APIs so installed plugins can override user-facing copy without forking the repository. Motivation: localization plugins (e.g. a Chinese UI for the TUI/settings panel) currently require a full fork because the only way to change rendered text is to edit the host. With these APIs the fork becomes unnecessary — the fork that motivated this keeps only content in an installable plugin.

## APIs

### `pi.registerUiStrings({ strings })`
Stable-keyed string overrides for the settings chrome (tabs, groups, labels, hints, footer) and slash-command copy (description / hint / subcommand description). Conventions:
- `tab.<tab>`, `group.<tab>.<Group>`, `setting.<path>.label` / `.description`, `settings.*` chrome keys, `command.<name>.description` / `.hint` / `.subcommand.<sub>.description`.
- The display layer resolves through `resolveUiString(key, fallback)` and falls back to the built-in English text when nothing is registered — stock installations render identically to today.
- Later registrations overwrite earlier ones for the same key; empty keys/values are skipped.
- Registry entries are scoped per extension path and cleared on disable/reload, so stale strings never persist.

### `pi.registerPromptOverrides({ overrides })`
Overrides for model-facing prompts: `system`, `subagent.system`, `tools.<toolName>`. Each entry supplies `full` (full template replacement) or `transform: (source) => string` (runs on the built-in source at render time, so upstream template edits keep flowing through). A throwing transform degrades to the built-in template.

## Design notes

- `def.group` / canonical names stay the sort identity and registry key; only the rendered label changes (regression-tested).
- New files: `extensibility/extensions/ui-strings.ts` (registry), `prompt-overrides.ts` (registry + `resolvePromptSource`), `slash-commands/command-ui.ts` (command copy resolution). Call sites: settings-selector / settings-defs / plugin-settings / available-commands / builtin-registry / system-prompt / task executor.
- No translation content ships in this PR; tests use synthetic fixtures (ASCII markers), so upstream prompt drift doesn't break them.

## Validation

- `check:types` clean
- Mechanism tests 49/49 pass (prompt-overrides, ui-strings, command-ui-strings, settings-layout, settings-multiselect)
- End-to-end: a localization plugin consuming both APIs renders the settings panel and slash commands fully localized in a real TUI run; unregistered keys fall back to English.