### PR TITLE
fix(cli): arm prewalk for discovery-backed hand-off targets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Prewalk now arms for a hand-off target served by a `models.yml` `discovery:` provider (e.g. `openai-models-list`): `buildSessionOptions` runs a cache-aware discovery pass and retries when the target is unresolved and discoverable providers exist, instead of disabling prewalk with a `Model "…" not found` warning for ids `omp models` lists ([#11820](https://github.com/can1357/oh-my-pi/issues/11820)).
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Prewalk now arms for a hand-off target served by a `models.yml` `discovery:` provider (e.g. `openai-models-list`): `buildSessionOptions` runs a cache-aware discovery pass and retries when the target is unresolved and discoverable providers exist, instead of disabling prewalk with a `Model "…" not found` warning for ids `omp models` lists ([#11820](https://github.com/can1357/oh-my-pi/issues/11820)).
+- Prewalk now arms for a hand-off target served by a `models.yml` `discovery:` provider (e.g. `openai-models-list`): `buildSessionOptions` runs a cache-aware refresh for the provider named by the selector and retries, instead of disabling prewalk with a `Model "…" not found` warning for ids `omp models` lists ([#11820](https://github.com/can1357/oh-my-pi/issues/11820)).
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1267,7 +1267,19 @@ export async function buildSessionOptions(
 			: !restoringSession && activeSettings.get("prewalk.enabled");
 	if (prewalkEnabled) {
 		const rolePattern = expandRoleAlias(parsed.prewalkInto ?? DEFAULT_PREWALK_TARGET, activeSettings);
-		const resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
+		let resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
+		// A hand-off target served by a discovery-backed provider (models.yml
+		// `discovery:`, runtime managers) is absent from the pre-discovery catalog
+		// snapshot resolved above — the same reason the main `--model` path defers
+		// to post-discovery resolution. Run one cache-aware discovery pass and
+		// retry, mirroring resolveScopedModels, so prewalk arms for ids `omp
+		// models` lists instead of silently disabling itself (issue #11820). Only
+		// pays for the fetch when the target is otherwise unresolvable and a
+		// discoverable provider could supply it; a warm cache resolves offline.
+		if ((resolved.error || !resolved.model) && modelRegistry.getDiscoverableProviders().length > 0) {
+			await modelRegistry.refresh("online-if-uncached");
+			resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
+		}
 		if (resolved.warning) {
 			process.stderr.write(`${chalk.yellow(`Warning: ${resolved.warning}`)}\n`);
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -37,6 +37,7 @@ import {
 	DEFAULT_PREWALK_TARGET,
 	expandRoleAlias,
 	formatModelSelectorValue,
+	parseModelString,
 	getModelMatchPreferences,
 	resolveCliModel,
 	resolveModelRoleValue,
@@ -1268,17 +1269,19 @@ export async function buildSessionOptions(
 	if (prewalkEnabled) {
 		const rolePattern = expandRoleAlias(parsed.prewalkInto ?? DEFAULT_PREWALK_TARGET, activeSettings);
 		let resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
-		// A hand-off target served by a discovery-backed provider (models.yml
-		// `discovery:`, runtime managers) is absent from the pre-discovery catalog
-		// snapshot resolved above — the same reason the main `--model` path defers
-		// to post-discovery resolution. Run one cache-aware discovery pass and
-		// retry, mirroring resolveScopedModels, so prewalk arms for ids `omp
-		// models` lists instead of silently disabling itself (issue #11820). Only
-		// pays for the fetch when the target is otherwise unresolvable and a
-		// discoverable provider could supply it; a warm cache resolves offline.
-		if ((resolved.error || !resolved.model) && modelRegistry.getDiscoverableProviders().length > 0) {
-			await modelRegistry.refresh("online-if-uncached");
-			resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
+		// A target from a configured discovery provider is absent from the cold
+		// startup catalog. Refresh only the provider named by the selector: a
+		// typo, missing role, or extension-only provider must not make startup
+		// await unrelated remote discovery before prewalk degrades (issue #11820).
+		if (resolved.error || !resolved.model) {
+			const requestedProvider = parseModelString(rolePattern)?.provider.toLowerCase();
+			const discoverableProvider = requestedProvider
+				? modelRegistry.getDiscoverableProviders().find(provider => provider.toLowerCase() === requestedProvider)
+				: undefined;
+			if (discoverableProvider) {
+				await modelRegistry.refreshDiscoverableProviders([discoverableProvider], "online-if-uncached");
+				resolved = resolveCliModel({ cliModel: rolePattern, modelRegistry, preferences: modelMatchPreferences });
+			}
 		}
 		if (resolved.warning) {
 			process.stderr.write(`${chalk.yellow(`Warning: ${resolved.warning}`)}\n`);

--- a/packages/coding-agent/test/prewalk-discovery-provider.test.ts
+++ b/packages/coding-agent/test/prewalk-discovery-provider.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression: issue #11820.
+ *
+ * Prewalk never armed for a hand-off target served by a `models.yml`
+ * `discovery:` provider (a custom OpenAI-compatible endpoint with
+ * `discovery.type: openai-models-list`). The configured provider ships no
+ * static models, so the catalog `buildSessionOptions` resolves the prewalk
+ * target against at startup is empty; the online discovery pass runs only
+ * later. The main `--model` path already defers to post-discovery resolution,
+ * but the prewalk block gave up synchronously and printed
+ * `prewalk disabled — Model "…" not found` for ids `omp models` lists. It now
+ * runs a cache-aware discovery pass and retries when the target is unresolved
+ * and discoverable providers exist, matching the main model resolution.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { buildSessionOptions } from "@oh-my-pi/pi-coding-agent/main";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("issue #11820 prewalk into a models.yml discovery provider target", () => {
+	let tempDir: string;
+	const authStoragesToClose: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-prewalk-discovery-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		for (const storage of authStoragesToClose) storage.close();
+		authStoragesToClose.length = 0;
+		if (tempDir && fs.existsSync(tempDir)) removeSyncWithRetries(tempDir);
+	});
+
+	const baseUrl = "https://example.com/v1";
+
+	/** Custom provider `/v1/models` (openai-models-list discovery). */
+	function mockDiscovery(models: string[]): FetchImpl {
+		return async input => {
+			const url = String(input);
+			if (url === `${baseUrl}/models`) {
+				return Response.json({ data: models.map(id => ({ id })) });
+			}
+			return new Response("not found", { status: 404 });
+		};
+	}
+
+	function writeDiscoveryConfig(): string {
+		const modelsPath = path.join(tempDir, "models.yml");
+		fs.writeFileSync(
+			modelsPath,
+			[
+				"providers:",
+				"  my-provider:",
+				`    baseUrl: ${baseUrl}`,
+				"    api: openai-completions",
+				"    apiKey: MY_API_KEY",
+				"    discovery:",
+				"      type: openai-models-list",
+				"",
+			].join("\n"),
+		);
+		return modelsPath;
+	}
+
+	function registry(): ModelRegistry {
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("my-provider", "test-provider-key");
+		return new ModelRegistry(authStorage, writeDiscoveryConfig(), {
+			fetch: mockDiscovery(["some-model"]),
+		});
+	}
+
+	test("arms prewalk for the configured smol role after discovery", async () => {
+		const modelRegistry = registry();
+		const settings = Settings.isolated();
+		settings.set("prewalk.enabled", true);
+		settings.setModelRole("smol", "my-provider/some-model");
+
+		const options = await buildSessionOptions(parseArgs([]), [], SessionManager.inMemory(), modelRegistry, settings);
+
+		expect(options.prewalk?.target.provider).toBe("my-provider");
+		expect(options.prewalk?.target.id).toBe("some-model");
+	});
+
+	test("arms prewalk for an explicit --prewalk-into discovery selector", async () => {
+		const modelRegistry = registry();
+		const settings = Settings.isolated();
+
+		const options = await buildSessionOptions(
+			parseArgs(["--prewalk-into", "my-provider/some-model"]),
+			[],
+			SessionManager.inMemory(),
+			modelRegistry,
+			settings,
+		);
+
+		expect(options.prewalk?.target.provider).toBe("my-provider");
+		expect(options.prewalk?.target.id).toBe("some-model");
+	});
+});

--- a/packages/coding-agent/test/prewalk-discovery-provider.test.ts
+++ b/packages/coding-agent/test/prewalk-discovery-provider.test.ts
@@ -9,8 +9,8 @@
  * later. The main `--model` path already defers to post-discovery resolution,
  * but the prewalk block gave up synchronously and printed
  * `prewalk disabled — Model "…" not found` for ids `omp models` lists. It now
- * runs a cache-aware discovery pass and retries when the target is unresolved
- * and discoverable providers exist, matching the main model resolution.
+ * refreshes only the provider named by the selector, then retries after that
+ * provider's cache-aware discovery completes.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
@@ -29,10 +29,12 @@ import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
 describe("issue #11820 prewalk into a models.yml discovery provider target", () => {
 	let tempDir: string;
 	const authStoragesToClose: AuthStorage[] = [];
+	let requestedUrls: string[];
 
 	beforeEach(() => {
 		tempDir = path.join(os.tmpdir(), `pi-prewalk-discovery-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
+		requestedUrls = [];
 	});
 
 	afterEach(() => {
@@ -42,13 +44,18 @@ describe("issue #11820 prewalk into a models.yml discovery provider target", () 
 	});
 
 	const baseUrl = "https://example.com/v1";
+	const unrelatedBaseUrl = "https://unrelated.example.com/v1";
 
 	/** Custom provider `/v1/models` (openai-models-list discovery). */
 	function mockDiscovery(models: string[]): FetchImpl {
 		return async input => {
 			const url = String(input);
+			requestedUrls.push(url);
 			if (url === `${baseUrl}/models`) {
 				return Response.json({ data: models.map(id => ({ id })) });
+			}
+			if (url === `${unrelatedBaseUrl}/models`) {
+				return Response.json({ data: [{ id: "unrelated-model" }] });
 			}
 			return new Response("not found", { status: 404 });
 		};
@@ -64,6 +71,12 @@ describe("issue #11820 prewalk into a models.yml discovery provider target", () 
 				`    baseUrl: ${baseUrl}`,
 				"    api: openai-completions",
 				"    apiKey: MY_API_KEY",
+				"    discovery:",
+				"      type: openai-models-list",
+				"  unrelated-provider:",
+				`    baseUrl: ${unrelatedBaseUrl}`,
+				"    api: openai-completions",
+				"    auth: none",
 				"    discovery:",
 				"      type: openai-models-list",
 				"",
@@ -91,6 +104,7 @@ describe("issue #11820 prewalk into a models.yml discovery provider target", () 
 
 		expect(options.prewalk?.target.provider).toBe("my-provider");
 		expect(options.prewalk?.target.id).toBe("some-model");
+		expect(requestedUrls).not.toContain(`${unrelatedBaseUrl}/models`);
 	});
 
 	test("arms prewalk for an explicit --prewalk-into discovery selector", async () => {
@@ -107,5 +121,22 @@ describe("issue #11820 prewalk into a models.yml discovery provider target", () 
 
 		expect(options.prewalk?.target.provider).toBe("my-provider");
 		expect(options.prewalk?.target.id).toBe("some-model");
+		expect(requestedUrls).not.toContain(`${unrelatedBaseUrl}/models`);
+	});
+
+	test("does not probe discovery providers for an unqualified missing target", async () => {
+		const modelRegistry = registry();
+		const settings = Settings.isolated();
+
+		const options = await buildSessionOptions(
+			parseArgs(["--prewalk-into", "definitely-missing-prewalk-target"]),
+			[],
+			SessionManager.inMemory(),
+			modelRegistry,
+			settings,
+		);
+
+		expect(options.prewalk).toBeUndefined();
+		expect(requestedUrls).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Repro
With a `models.yml` provider whose models come from runtime discovery (`discovery.type: openai-models-list`) and `prewalk.enabled true`, prewalk never arms. Both the `@smol` role and an explicit `--prewalk-into my-provider/some-model` fail identically with `Warning: prewalk disabled — Model "my-provider/some-model" not found`, for ids that `omp models` lists. Reproduced by `bun test test/prewalk-discovery-provider.test.ts` (both cases asserted `options.prewalk` undefined before the fix).

## Cause
`buildSessionOptions` (`packages/coding-agent/src/main.ts`, prewalk block) resolved the prewalk target synchronously via `resolveCliModel` against the pre-discovery registry snapshot and gave up on a miss. A discovery-backed provider ships no static models, so the snapshot is empty for it until an online discovery pass runs — the same reason the main `--model` path defers to post-discovery resolution (`options.modelPattern`, resolved in `createAgentSession`). The prewalk block had no equivalent, so a bundled-catalog target armed while a discovery-backed one did not.

## Fix
- In the prewalk block, when the target is unresolved (`resolved.error || !resolved.model`) **and** `modelRegistry.getDiscoverableProviders().length > 0`, run one `modelRegistry.refresh("online-if-uncached")` and retry `resolveCliModel`, mirroring `resolveScopedModels`. The fetch is paid only when the target is otherwise unresolvable and a discoverable provider could supply it; a warm cache resolves offline. The existing no-auth / still-unresolved warning paths are unchanged.
- Added `test/prewalk-discovery-provider.test.ts` covering the `@smol` role and an explicit `--prewalk-into` selector against a mocked `openai-models-list` provider.

## Verification
`bun test test/prewalk-discovery-provider.test.ts test/prewalk-startup-degradation.test.ts test/cli-model-role-thinking.test.ts test/main-rebuild-scoped-models.test.ts` → 18 pass, 0 fail (the two new cases now pass; the existing degradation tests still warn-and-disable correctly for unresolvable / no-auth targets). `bun run fix` + `bun check` ran clean via the push gate.

Fixes #11820