### PR TITLE
fix(session): drop stale tool-roster notice after prompt rebuild

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,20 @@
 - Fixed the Windows installer failing on Windows PowerShell 5.1: OS architecture detection no longer depends on the .NET `RuntimeInformation` type that only resolves reliably on PowerShell 7, and the script now requires PowerShell 5.1+ with a clear upgrade message instead of failing cryptically ([#11905](https://github.com/can1357/oh-my-pi/pull/11905) by [@h4vc](https://github.com/h4vc)).
 - Speculative reads now infer the summary language from the requested path while reading the resolved target, so cross-language symlinks summarize exactly like ordinary reads ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
 - The structural summary cache now keys on the parser language path, so one file read through different extensions no longer reuses a stale summary ([#11892](https://github.com/can1357/oh-my-pi/pull/11892) by [@h4vc](https://github.com/h4vc)).
+- Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+### Added
+
+- Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.
+- Added `f follow up` in BTW history to continue a selected side conversation with an English input prompt, persistent multi-turn history, and no changes to the main conversation.
+- Completed inline BTW answers now support `f follow up` directly; history uses `Tab` for pane navigation and `Enter` or `f` to start a follow-up.
+- Marketplace plugins that share a repository root now load only their declared skills instead of every skill in the repository ([#11513](https://github.com/can1357/oh-my-pi/issues/11513)).
+- Codex web search now accepts valid email-only OAuth credentials without requiring or fabricating a `ChatGPT-Account-Id` header ([#11847](https://github.com/can1357/oh-my-pi/pull/11847) by [@nguyennguyenit](https://github.com/nguyennguyenit)).
+- Sessions now stay alive when their working directory is removed instead of crashing while preparing shell tools ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
+- MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
+- `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
+- Sloppy-mode edits now drop a copied `[N more lines in ...]` read notice the same way they already drop the other read-metadata rows, so a pasted projection can no longer leak into the matched pattern or the written text ([#11797](https://github.com/can1357/oh-my-pi/pull/11797) by [@vasyza](https://github.com/vasyza)).
+- `/usage` now honors a provider's configured `baseUrl` when checking credentials before any model has been discovered, so a proxy-scoped API key is no longer sent to the provider's canonical host ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
+- Cycling models with Ctrl+P no longer injects a spurious tool-roster notice that made the model believe still-callable tools had been removed; a prompt rebuild now discards the queued delta it already reflects ([#11824](https://github.com/can1357/oh-my-pi/issues/11824)).
 
 ## [18.1.18] - 2026-09-11
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6580,42 +6580,37 @@ export class AgentSession {
 				}
 			}
 
-			// Deferred notices can carry substantial inline xd:// docs. Preview them
-			// in a copy so context maintenance sees the request's true size without
-			// consuming deltas that a maintenance-triggered rebuild may supersede.
+			// Only the xd:// mount notice can carry substantial inline docs (up to
+			// XDEV_DOCS_TOTAL_BUDGET), so preview it in a copy and let context
+			// maintenance see the request's true size without consuming a delta a
+			// rebuild may supersede. The tool-roster notice is a tiny name list with
+			// no budget impact, so it is not previewed here — it must always ship
+			// alongside the schema change it describes (see below).
 			const previewXdevMountNotice = isUserQueuedMessage(message)
 				? this.#tools.peekPendingXdevMountNotice({ baseCatalogDelivered: baseXdevCatalogDelivered })
 				: undefined;
-			const previewToolRosterNotice = isUserQueuedMessage(message)
-				? this.#tools.peekPendingToolRosterNotice()
-				: undefined;
-			const maintenanceMessages =
-				previewXdevMountNotice?.notice || previewToolRosterNotice?.notice ? [...messages] : messages;
-			if (maintenanceMessages !== messages) {
-				maintenanceMessages.splice(
-					xdevMountNoticeIndex,
-					0,
-					...(previewXdevMountNotice?.notice ? [previewXdevMountNotice.notice] : []),
-					...(previewToolRosterNotice?.notice ? [previewToolRosterNotice.notice] : []),
-				);
+			const maintenanceMessages = previewXdevMountNotice?.notice ? [...messages] : messages;
+			if (maintenanceMessages !== messages && previewXdevMountNotice?.notice) {
+				maintenanceMessages.splice(xdevMountNoticeIndex, 0, previewXdevMountNotice.notice);
 			}
 			await this.#maintenance.runPrePromptCompactionIfNeeded(maintenanceMessages);
 			if (this.#promptGeneration !== generation) {
 				return false;
 			}
-			// Consume only the revisions maintenance estimated. Any delta or catalog
-			// mutation during the await invalidates its preview, leaving the complete
-			// coalesced change pending for the next user turn instead of adding
-			// unbudgeted notice content after the final context check.
+			// Consume the xd:// notice only when its previewed revision still holds:
+			// a mount delta (or catalog rebuild) during the await invalidates it and
+			// defers the whole coalesced change to the next turn so its unbudgeted
+			// docs never bypass the context check. The roster notice is re-derived
+			// from the live delta here and always delivered, keeping the model's
+			// stated availability in lockstep with the wire tool list even when a
+			// roster change landed during maintenance.
 			const xdevMountNotice = previewXdevMountNotice
 				? this.#tools.takePendingXdevMountNotice({
 						baseCatalogDelivered: baseXdevCatalogDelivered,
 						expectedRevision: previewXdevMountNotice.revision,
 					})
 				: undefined;
-			const toolRosterNotice = previewToolRosterNotice
-				? this.#tools.takePendingToolRosterNotice({ expectedRevision: previewToolRosterNotice.revision })
-				: undefined;
+			const toolRosterNotice = isUserQueuedMessage(message) ? this.#tools.takePendingToolRosterNotice() : undefined;
 			if (xdevMountNotice || toolRosterNotice) {
 				messages.splice(
 					xdevMountNoticeIndex,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6479,12 +6479,10 @@ export class AgentSession {
 
 			// Pending tool-roster and xd:// deltas accompany the next user-authored
 			// prompt, never an agent-initiated continuation. Reserve their pre-user
-			// position now, but consume them only after before_agent_start and
-			// pre-prompt compaction run: both can rebuild the base prompt (an
-			// extension systemPrompt override, or a context-promotion/summary
-			// rebuild), and a rebuild renders the complete roster while clearing the
-			// queued roster delta. Consuming earlier would splice a notice the
-			// rebuilt prompt already subsumes, sending a contradictory pair.
+			// position now. Non-consuming previews count toward pre-prompt context
+			// maintenance, while the live deltas are consumed only after maintenance:
+			// promotion/summary can rebuild the base prompt and clear a roster delta
+			// it subsumes, avoiding a contradictory materialized notice.
 			const xdevMountNoticeIndex = messages.length;
 			messages.push(message);
 			// Inject any pending "nextTurn" messages as context alongside the user message
@@ -6582,12 +6580,30 @@ export class AgentSession {
 				}
 			}
 
-			await this.#maintenance.runPrePromptCompactionIfNeeded(messages);
+			// Deferred notices can carry substantial inline xd:// docs. Preview them
+			// in a copy so context maintenance sees the request's true size without
+			// consuming deltas that a maintenance-triggered rebuild may supersede.
+			const previewXdevMountNotice = isUserQueuedMessage(message)
+				? this.#tools.peekPendingXdevMountNotice(baseXdevCatalogDelivered)
+				: undefined;
+			const previewToolRosterNotice = isUserQueuedMessage(message)
+				? this.#tools.peekPendingToolRosterNotice()
+				: undefined;
+			const maintenanceMessages = previewXdevMountNotice || previewToolRosterNotice ? [...messages] : messages;
+			if (maintenanceMessages !== messages) {
+				maintenanceMessages.splice(
+					xdevMountNoticeIndex,
+					0,
+					...(previewXdevMountNotice ? [previewXdevMountNotice] : []),
+					...(previewToolRosterNotice ? [previewToolRosterNotice] : []),
+				);
+			}
+			await this.#maintenance.runPrePromptCompactionIfNeeded(maintenanceMessages);
 			if (this.#promptGeneration !== generation) {
 				return false;
 			}
-			// Consumed here — after pre-prompt compaction — so a promotion/summary
-			// rebuild has already cleared any queued roster delta it now reflects.
+			// Consume only after maintenance so a promotion/summary rebuild has
+			// already cleared any queued roster delta it now reflects.
 			const xdevMountNotice = isUserQueuedMessage(message)
 				? this.#tools.takePendingXdevMountNotice(baseXdevCatalogDelivered)
 				: undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6584,30 +6584,38 @@ export class AgentSession {
 			// in a copy so context maintenance sees the request's true size without
 			// consuming deltas that a maintenance-triggered rebuild may supersede.
 			const previewXdevMountNotice = isUserQueuedMessage(message)
-				? this.#tools.peekPendingXdevMountNotice(baseXdevCatalogDelivered)
+				? this.#tools.peekPendingXdevMountNotice({ baseCatalogDelivered: baseXdevCatalogDelivered })
 				: undefined;
 			const previewToolRosterNotice = isUserQueuedMessage(message)
 				? this.#tools.peekPendingToolRosterNotice()
 				: undefined;
-			const maintenanceMessages = previewXdevMountNotice || previewToolRosterNotice ? [...messages] : messages;
+			const maintenanceMessages =
+				previewXdevMountNotice?.notice || previewToolRosterNotice?.notice ? [...messages] : messages;
 			if (maintenanceMessages !== messages) {
 				maintenanceMessages.splice(
 					xdevMountNoticeIndex,
 					0,
-					...(previewXdevMountNotice ? [previewXdevMountNotice] : []),
-					...(previewToolRosterNotice ? [previewToolRosterNotice] : []),
+					...(previewXdevMountNotice?.notice ? [previewXdevMountNotice.notice] : []),
+					...(previewToolRosterNotice?.notice ? [previewToolRosterNotice.notice] : []),
 				);
 			}
 			await this.#maintenance.runPrePromptCompactionIfNeeded(maintenanceMessages);
 			if (this.#promptGeneration !== generation) {
 				return false;
 			}
-			// Consume only after maintenance so a promotion/summary rebuild has
-			// already cleared any queued roster delta it now reflects.
-			const xdevMountNotice = isUserQueuedMessage(message)
-				? this.#tools.takePendingXdevMountNotice(baseXdevCatalogDelivered)
+			// Consume only the revisions maintenance estimated. Any delta or catalog
+			// mutation during the await invalidates its preview, leaving the complete
+			// coalesced change pending for the next user turn instead of adding
+			// unbudgeted notice content after the final context check.
+			const xdevMountNotice = previewXdevMountNotice
+				? this.#tools.takePendingXdevMountNotice({
+						baseCatalogDelivered: baseXdevCatalogDelivered,
+						expectedRevision: previewXdevMountNotice.revision,
+					})
 				: undefined;
-			const toolRosterNotice = isUserQueuedMessage(message) ? this.#tools.takePendingToolRosterNotice() : undefined;
+			const toolRosterNotice = previewToolRosterNotice
+				? this.#tools.takePendingToolRosterNotice({ expectedRevision: previewToolRosterNotice.revision })
+				: undefined;
 			if (xdevMountNotice || toolRosterNotice) {
 				messages.splice(
 					xdevMountNoticeIndex,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6607,7 +6607,6 @@ export class AgentSession {
 			const xdevMountNotice = previewXdevMountNotice
 				? this.#tools.takePendingXdevMountNotice({
 						baseCatalogDelivered: baseXdevCatalogDelivered,
-						expectedRevision: previewXdevMountNotice.revision,
 						expectedContentKey: previewXdevMountNotice.contentKey,
 					})
 				: undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6597,13 +6597,13 @@ export class AgentSession {
 			if (this.#promptGeneration !== generation) {
 				return false;
 			}
-			// Consume the xd:// notice only when its previewed revision still holds:
-			// a mount delta (or catalog rebuild) during the await invalidates it and
-			// defers the whole coalesced change to the next turn so its unbudgeted
-			// docs never bypass the context check. The roster notice is re-derived
-			// from the live delta here and always delivered, keeping the model's
-			// stated availability in lockstep with the wire tool list even when a
-			// roster change landed during maintenance.
+			// Consume the xd:// notice only when its previewed revision still holds.
+			// A mount delta or catalog rebuild during the await invalidates it: any
+			// additions carried by the delivered base are recorded as announced,
+			// while remaining notice content waits for the next context check.
+			// The roster notice is re-derived from the live delta here and always
+			// delivered, keeping the model's stated availability in lockstep with
+			// the wire tool list even when a roster change landed during maintenance.
 			const xdevMountNotice = previewXdevMountNotice
 				? this.#tools.takePendingXdevMountNotice({
 						baseCatalogDelivered: baseXdevCatalogDelivered,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6479,8 +6479,12 @@ export class AgentSession {
 
 			// Pending tool-roster and xd:// deltas accompany the next user-authored
 			// prompt, never an agent-initiated continuation. Reserve their pre-user
-			// position, but consume xd:// only after before_agent_start determines
-			// whether the final provider prompt still carries the base catalog.
+			// position now, but consume them only after before_agent_start and
+			// pre-prompt compaction run: both can rebuild the base prompt (an
+			// extension systemPrompt override, or a context-promotion/summary
+			// rebuild), and a rebuild renders the complete roster while clearing the
+			// queued roster delta. Consuming earlier would splice a notice the
+			// rebuilt prompt already subsumes, sending a contradictory pair.
 			const xdevMountNoticeIndex = messages.length;
 			messages.push(message);
 			// Inject any pending "nextTurn" messages as context alongside the user message
@@ -6577,6 +6581,13 @@ export class AgentSession {
 					return false;
 				}
 			}
+
+			await this.#maintenance.runPrePromptCompactionIfNeeded(messages);
+			if (this.#promptGeneration !== generation) {
+				return false;
+			}
+			// Consumed here — after pre-prompt compaction — so a promotion/summary
+			// rebuild has already cleared any queued roster delta it now reflects.
 			const xdevMountNotice = isUserQueuedMessage(message)
 				? this.#tools.takePendingXdevMountNotice(baseXdevCatalogDelivered)
 				: undefined;
@@ -6588,11 +6599,6 @@ export class AgentSession {
 					...(xdevMountNotice ? [xdevMountNotice] : []),
 					...(toolRosterNotice ? [toolRosterNotice] : []),
 				);
-			}
-
-			await this.#maintenance.runPrePromptCompactionIfNeeded(messages);
-			if (this.#promptGeneration !== generation) {
-				return false;
 			}
 
 			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6611,7 +6611,9 @@ export class AgentSession {
 						expectedContentKey: previewXdevMountNotice.contentKey,
 					})
 				: undefined;
-			const toolRosterNotice = isUserQueuedMessage(message) ? this.#tools.takePendingToolRosterNotice() : undefined;
+			const toolRosterNotice = isUserQueuedMessage(message)
+				? this.#tools.takePendingToolRosterNotice({ baseDelivered: baseXdevCatalogDelivered })
+				: undefined;
 			if (xdevMountNotice || toolRosterNotice) {
 				messages.splice(
 					xdevMountNoticeIndex,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6608,6 +6608,7 @@ export class AgentSession {
 				? this.#tools.takePendingXdevMountNotice({
 						baseCatalogDelivered: baseXdevCatalogDelivered,
 						expectedRevision: previewXdevMountNotice.revision,
+						expectedContentKey: previewXdevMountNotice.contentKey,
 					})
 				: undefined;
 			const toolRosterNotice = isUserQueuedMessage(message) ? this.#tools.takePendingToolRosterNotice() : undefined;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -180,9 +180,19 @@ const XDEV_MOUNT_NOTICE_MESSAGE_TYPE = "xdev-mount-notice";
  * (and re-splice a redundant developer message that busts the provider
  * prompt-cache prefix).
  */
+interface ToolRosterNoticeDetails {
+	added: string[];
+	removed: string[];
+}
+
 interface XdevMountNoticeDetails {
 	added: string[];
 	removed: string[];
+}
+
+interface XdevMountNoticeProjection {
+	notice: CustomMessage<XdevMountNoticeDetails> | undefined;
+	announcedMounts: Set<string>;
 }
 
 /** Owns tool registration, presentation, prompt rebuilding, skills, and permissions. */
@@ -1226,11 +1236,21 @@ export class SessionTools {
 		}
 	}
 
+	/** Previews the hidden provider-visible roster notice without consuming its pending delta. */
+	peekPendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
+		return this.#buildPendingToolRosterNotice();
+	}
+
 	/** Consumes the hidden notice for provider-visible tool-roster changes. */
-	takePendingToolRosterNotice(): CustomMessage<{ added: string[]; removed: string[] }> | undefined {
+	takePendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
+		const notice = this.#buildPendingToolRosterNotice();
+		if (notice) this.#pendingToolRosterDelta = undefined;
+		return notice;
+	}
+
+	#buildPendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
 		const pending = this.#pendingToolRosterDelta;
 		if (!pending) return undefined;
-		this.#pendingToolRosterDelta = undefined;
 		const added = [...pending.added];
 		const removed = [...pending.removed];
 		return {
@@ -1247,12 +1267,25 @@ export class SessionTools {
 		};
 	}
 
+	/** Previews the hidden `xd://` mount notice without consuming or announcing its pending delta. */
+	peekPendingXdevMountNotice(baseCatalogDelivered: boolean): CustomMessage<XdevMountNoticeDetails> | undefined {
+		return this.#projectPendingXdevMountNotice(baseCatalogDelivered)?.notice;
+	}
+
 	/** Consumes the hidden notice for unannounced `xd://` mount changes. */
 	takePendingXdevMountNotice(baseCatalogDelivered: boolean): CustomMessage<XdevMountNoticeDetails> | undefined {
+		const projection = this.#projectPendingXdevMountNotice(baseCatalogDelivered);
+		if (!projection) return undefined;
+		this.#pendingXdevMountDelta = undefined;
+		this.#announcedMounts = projection.announcedMounts;
+		return projection.notice;
+	}
+
+	#projectPendingXdevMountNotice(baseCatalogDelivered: boolean): XdevMountNoticeProjection | undefined {
 		const pending = this.#pendingXdevMountDelta;
 		if (!pending) return undefined;
-		this.#pendingXdevMountDelta = undefined;
 		this.#ensureAnnouncedMountsSeeded();
+		const announcedMounts = new Set(this.#announcedMounts);
 		// A pending add for a device the outgoing base prompt already lists in its
 		// catalog needs no notice line — but only when the final provider prompt
 		// still carries that base catalog. A `before_agent_start` replacement drops
@@ -1263,7 +1296,7 @@ export class SessionTools {
 		// any request is sent (issue #7139 reviews).
 		if (baseCatalogDelivered) {
 			for (const name of pending.added) {
-				if (this.#basePromptXdevNames.has(name)) this.#announcedMounts.add(name);
+				if (this.#basePromptXdevNames.has(name)) announcedMounts.add(name);
 			}
 		}
 		// Only announce a net change relative to what the model already knows (from
@@ -1271,9 +1304,13 @@ export class SessionTools {
 		// device — the common resume/reconnect case — and an unmount for a device
 		// it was never told about are both suppressed, keeping the provider prompt
 		// cache prefix byte-stable across resumes.
-		const addedNames = [...pending.added].filter(name => !this.#announcedMounts.has(name));
-		const removedNames = [...pending.removed].filter(name => this.#announcedMounts.has(name));
-		if (addedNames.length === 0 && removedNames.length === 0) return undefined;
+		const addedNames = [...pending.added].filter(name => !announcedMounts.has(name));
+		const removedNames = [...pending.removed].filter(name => announcedMounts.has(name));
+		for (const name of addedNames) announcedMounts.add(name);
+		for (const name of removedNames) announcedMounts.delete(name);
+		if (addedNames.length === 0 && removedNames.length === 0) {
+			return { notice: undefined, announcedMounts };
+		}
 		const summaries = new Map(this.#xdev ? xdevEntries(this.#xdev).map(entry => [entry.name, entry.summary]) : []);
 		const added = addedNames.map(name => ({ name, summary: summaries.get(name) ?? "" }));
 		const removed = removedNames.map(name => ({ name }));
@@ -1285,16 +1322,17 @@ export class SessionTools {
 					this.#host.settings.get("tools.xdevInlineDevices"),
 				)
 			: "";
-		for (const name of addedNames) this.#announcedMounts.add(name);
-		for (const name of removedNames) this.#announcedMounts.delete(name);
 		return {
-			role: "custom",
-			customType: XDEV_MOUNT_NOTICE_MESSAGE_TYPE,
-			content: prompt.render(xdevMountNoticePrompt, { added, removed, docs }),
-			details: { added: addedNames, removed: removedNames },
-			attribution: "agent",
-			display: false,
-			timestamp: Date.now(),
+			notice: {
+				role: "custom",
+				customType: XDEV_MOUNT_NOTICE_MESSAGE_TYPE,
+				content: prompt.render(xdevMountNoticePrompt, { added, removed, docs }),
+				details: { added: addedNames, removed: removedNames },
+				attribution: "agent",
+				display: false,
+				timestamp: Date.now(),
+			},
+			announcedMounts,
 		};
 	}
 

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -215,7 +215,6 @@ export class SessionTools {
 	#xdev: XdevState | undefined;
 	#pendingToolRosterDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
-	#toolRosterDeltaRevision = 0;
 	#xdevMountDeltaRevision = 0;
 	/**
 	 * Dynamic (`xd://`) devices the model has already been told are mounted.
@@ -1103,7 +1102,7 @@ export class SessionTools {
 				// rebuilt base off the wire (see {@link #applyAgentSystemPrompt}), so
 				// keep the delta then — the notice is the only channel carrying the
 				// roster change on this turn.
-				if (this.#turnSystemPromptOverride === undefined) this.#clearPendingToolRosterDelta();
+				if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
 			} else if (frozenSignature) {
 				this.#notifyToolRosterDelta(previousActiveToolNames, appliedNames);
 				this.#lastAppliedToolSignature = frozenSignature;
@@ -1147,13 +1146,6 @@ export class SessionTools {
 			if (!pending.added.delete(name)) pending.removed.add(name);
 		}
 		this.#pendingToolRosterDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
-		this.#toolRosterDeltaRevision++;
-	}
-
-	#clearPendingToolRosterDelta(): void {
-		if (!this.#pendingToolRosterDelta) return;
-		this.#pendingToolRosterDelta = undefined;
-		this.#toolRosterDeltaRevision++;
 	}
 
 	/**
@@ -1262,19 +1254,17 @@ export class SessionTools {
 		}
 	}
 
-	/** Previews the hidden provider-visible roster notice and its immutable pending revision. */
-	peekPendingToolRosterNotice(): PendingNoticePreview<ToolRosterNoticeDetails> | undefined {
+	/**
+	 * Consumes the hidden provider-visible roster notice for the current pending
+	 * delta. Unlike the xd:// mount notice this carries no meaningful payload (a
+	 * short tool-name list), so it is never previewed or deferred for context
+	 * budgeting: it is re-derived from the live delta after pre-prompt maintenance
+	 * and always delivered alongside the schema change it describes, keeping the
+	 * model's stated availability in lockstep with the wire tool list.
+	 */
+	takePendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
 		const notice = this.#buildPendingToolRosterNotice();
-		return notice ? { notice, revision: this.#toolRosterDeltaRevision } : undefined;
-	}
-
-	/** Consumes the roster notice only when no delta mutation followed its preview. */
-	takePendingToolRosterNotice(options: {
-		expectedRevision: number;
-	}): CustomMessage<ToolRosterNoticeDetails> | undefined {
-		if (options.expectedRevision !== this.#toolRosterDeltaRevision) return undefined;
-		const notice = this.#buildPendingToolRosterNotice();
-		if (notice) this.#clearPendingToolRosterDelta();
+		if (notice) this.#pendingToolRosterDelta = undefined;
 		return notice;
 	}
 
@@ -1591,7 +1581,7 @@ export class SessionTools {
 		// `before_agent_start` override keeps the rebuilt base off the wire (see
 		// {@link #applyAgentSystemPrompt}), so keep the delta then so
 		// takePendingToolRosterNotice() still surfaces the change on this turn.
-		if (this.#turnSystemPromptOverride === undefined) this.#clearPendingToolRosterDelta();
+		if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -192,13 +192,11 @@ interface XdevMountNoticeDetails {
 
 interface PendingNoticePreview<T> {
 	notice: CustomMessage<T> | undefined;
-	revision: number;
 	/**
-	 * Fingerprint of the previewed notice's rendered content. Guards against
-	 * changes the {@link SessionTools.#xdevMountDeltaRevision} counter misses —
-	 * chiefly a same-named MCP tool reconnecting with a new schema during the
-	 * maintenance await, which rewrites the inline docs without moving the mount
-	 * set or the schema-excluding applied-tool signature.
+	 * Exact rendered content included in the context estimate. Re-projecting and
+	 * comparing this key after maintenance catches every semantically relevant
+	 * change — mount membership, base-catalog suppression, summaries, and schemas
+	 * — without false-invalidating a byte-identical notice after a hidden rebuild.
 	 */
 	contentKey: string;
 }
@@ -223,7 +221,6 @@ export class SessionTools {
 	#xdev: XdevState | undefined;
 	#pendingToolRosterDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
-	#xdevMountDeltaRevision = 0;
 	/**
 	 * Whether the current {@link #baseSystemPrompt} already renders the roster the
 	 * pending delta describes — true after a full rebuild, false after a frozen
@@ -1146,11 +1143,6 @@ export class SessionTools {
 
 	#setBasePromptXdevNames(names: readonly string[] | undefined): void {
 		this.#basePromptXdevNames = new Set(names);
-		// A rebuild can change which pending additions the final base catalog
-		// already announces. Invalidate the projection; the post-maintenance take
-		// records additions carried by a delivered base and defers only the
-		// remaining notice payload.
-		if (this.#pendingXdevMountDelta) this.#xdevMountDeltaRevision++;
 	}
 
 	#notifyToolRosterDelta(previousActiveToolNames: readonly string[], appliedNames: readonly string[]): void {
@@ -1200,7 +1192,6 @@ export class SessionTools {
 			if (!pending.added.delete(name)) pending.removed.add(name);
 		}
 		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
-		this.#xdevMountDeltaRevision++;
 		if (this.#host.settings.get("startup.quiet")) return;
 		const parts: string[] = [];
 		if (addedNames.length > 0) parts.push(`mounted ${addedNames.join(", ")}`);
@@ -1321,7 +1312,7 @@ export class SessionTools {
 		};
 	}
 
-	/** Previews the hidden `xd://` mount notice, its pending revision, and a content fingerprint. */
+	/** Previews the hidden `xd://` mount notice and its rendered-content fingerprint. */
 	peekPendingXdevMountNotice(options: {
 		baseCatalogDelivered: boolean;
 	}): PendingNoticePreview<XdevMountNoticeDetails> | undefined {
@@ -1329,38 +1320,34 @@ export class SessionTools {
 		if (!projection) return undefined;
 		return {
 			notice: projection.notice,
-			revision: this.#xdevMountDeltaRevision,
 			contentKey: this.#xdevNoticeContentKey(projection.notice),
 		};
 	}
 
-	/** Consumes the mount notice only when no delta, catalog, or schema change followed its preview. */
+	/**
+	 * Consumes the mount notice only when its rendered content still matches the
+	 * preview included in the context estimate.
+	 */
 	takePendingXdevMountNotice(options: {
 		baseCatalogDelivered: boolean;
-		expectedRevision: number;
 		expectedContentKey: string;
 	}): CustomMessage<XdevMountNoticeDetails> | undefined {
-		if (options.expectedRevision !== this.#xdevMountDeltaRevision) {
-			// Maintenance may have rebuilt and delivered the base catalog after the
-			// preview. Commit additions carried by that prompt before deferring the
-			// remaining delta; a later unmount must not cancel an addition the model
-			// has already seen.
+		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
+		if (!projection) return undefined;
+		const contentMatches = this.#xdevNoticeContentKey(projection.notice) === options.expectedContentKey;
+		if (!contentMatches) {
+			// Changed rendered content can follow mount/catalog changes or a
+			// same-named MCP tool reconnect whose schema replacement does not change
+			// mount membership or the applied-tool signature.
+			// If maintenance delivered a rebuilt base, commit additions carried by
+			// that prompt before deferring the remaining notice content.
 			if (options.baseCatalogDelivered) this.#recordBasePromptXdevAdditions();
 			return undefined;
 		}
-		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
-		if (!projection) return undefined;
-		if (this.#xdevNoticeContentKey(projection.notice) !== options.expectedContentKey) {
-			// The rendered notice changed after the only context estimate without
-			// moving the revision — a same-named MCP tool reconnecting with a new
-			// schema during the await rewrites the inline docs (up to
-			// XDEV_DOCS_TOTAL_BUDGET). Defer the whole notice to the next user turn,
-			// which re-previews it against a fresh estimate, rather than delivering
-			// unbudgeted docs now.
-			return undefined;
-		}
+		// A hidden base rebuild can leave the projected notice byte-identical. The
+		// exact content was already budgeted, so consume it rather than withholding
+		// both the catalog and its availability notice from this request.
 		this.#pendingXdevMountDelta = undefined;
-		this.#xdevMountDeltaRevision++;
 		this.#announcedMounts = projection.announcedMounts;
 		return projection.notice;
 	}
@@ -1386,7 +1373,6 @@ export class SessionTools {
 		}
 		if (!changed) return;
 		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
-		this.#xdevMountDeltaRevision++;
 	}
 
 	#projectPendingXdevMountNotice(baseCatalogDelivered: boolean): XdevMountNoticeProjection | undefined {

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -193,6 +193,14 @@ interface XdevMountNoticeDetails {
 interface PendingNoticePreview<T> {
 	notice: CustomMessage<T> | undefined;
 	revision: number;
+	/**
+	 * Fingerprint of the previewed notice's rendered content. Guards against
+	 * changes the {@link SessionTools.#xdevMountDeltaRevision} counter misses —
+	 * chiefly a same-named MCP tool reconnecting with a new schema during the
+	 * maintenance await, which rewrites the inline docs without moving the mount
+	 * set or the schema-excluding applied-tool signature.
+	 */
+	contentKey: string;
 }
 
 interface XdevMountNoticeProjection {
@@ -1288,18 +1296,24 @@ export class SessionTools {
 		};
 	}
 
-	/** Previews the hidden `xd://` mount notice and its immutable pending revision. */
+	/** Previews the hidden `xd://` mount notice, its pending revision, and a content fingerprint. */
 	peekPendingXdevMountNotice(options: {
 		baseCatalogDelivered: boolean;
 	}): PendingNoticePreview<XdevMountNoticeDetails> | undefined {
 		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
-		return projection ? { notice: projection.notice, revision: this.#xdevMountDeltaRevision } : undefined;
+		if (!projection) return undefined;
+		return {
+			notice: projection.notice,
+			revision: this.#xdevMountDeltaRevision,
+			contentKey: this.#xdevNoticeContentKey(projection.notice),
+		};
 	}
 
-	/** Consumes the mount notice only when no delta or catalog mutation followed its preview. */
+	/** Consumes the mount notice only when no delta, catalog, or schema change followed its preview. */
 	takePendingXdevMountNotice(options: {
 		baseCatalogDelivered: boolean;
 		expectedRevision: number;
+		expectedContentKey: string;
 	}): CustomMessage<XdevMountNoticeDetails> | undefined {
 		if (options.expectedRevision !== this.#xdevMountDeltaRevision) {
 			// Maintenance may have rebuilt and delivered the base catalog after the
@@ -1311,10 +1325,27 @@ export class SessionTools {
 		}
 		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
 		if (!projection) return undefined;
+		if (this.#xdevNoticeContentKey(projection.notice) !== options.expectedContentKey) {
+			// The rendered notice changed after the only context estimate without
+			// moving the revision — a same-named MCP tool reconnecting with a new
+			// schema during the await rewrites the inline docs (up to
+			// XDEV_DOCS_TOTAL_BUDGET). Defer the whole notice to the next user turn,
+			// which re-previews it against a fresh estimate, rather than delivering
+			// unbudgeted docs now.
+			return undefined;
+		}
 		this.#pendingXdevMountDelta = undefined;
 		this.#xdevMountDeltaRevision++;
 		this.#announcedMounts = projection.announcedMounts;
 		return projection.notice;
+	}
+
+	/** Stable fingerprint of a mount notice's rendered text, ignoring its timestamp. */
+	#xdevNoticeContentKey(notice: CustomMessage<XdevMountNoticeDetails> | undefined): string {
+		if (!notice) return "";
+		const { content } = notice;
+		if (typeof content === "string") return content;
+		return content.map(part => (part.type === "text" ? part.text : "")).join("\u0000");
 	}
 
 	#recordBasePromptXdevAdditions(): void {

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -225,6 +225,16 @@ export class SessionTools {
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	#xdevMountDeltaRevision = 0;
 	/**
+	 * Whether the current {@link #baseSystemPrompt} already renders the roster the
+	 * pending delta describes — true after a full rebuild, false after a frozen
+	 * (prefix-preserving) apply queues a change the base did not re-render. The
+	 * delta is subsumed only when such a base is the prompt actually delivered, a
+	 * decision {@link takePendingToolRosterNotice} defers to send time because a
+	 * per-turn `before_agent_start` override (registered after some rebuilds) can
+	 * still keep the rebuilt base off the wire.
+	 */
+	#basePromptReflectsRosterDelta = false;
+	/**
 	 * Dynamic (`xd://`) devices the model has already been told are mounted.
 	 * Seeded lazily from persisted history on resume (see
 	 * {@link #ensureAnnouncedMountsSeeded}) and updated as notices are emitted, so
@@ -1105,12 +1115,14 @@ export class SessionTools {
 				this.#promptModelKey = this.#currentPromptModelKey();
 				this.#setBasePromptXdevNames(rebuiltXdevCatalogNames);
 				// The rebuilt prompt renders the complete current roster, so a delta
-				// queued by an earlier frozen apply is subsumed once that prompt is the
-				// one delivered. A per-turn `before_agent_start` override keeps the
-				// rebuilt base off the wire (see {@link #applyAgentSystemPrompt}), so
-				// keep the delta then — the notice is the only channel carrying the
-				// roster change on this turn.
-				if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
+				// queued by an earlier frozen apply is subsumed once that base is the
+				// prompt actually delivered. Whether it is — a per-turn
+				// `before_agent_start` override can still hide it — is unknown here
+				// (the override may be registered after this rebuild, e.g. a memory
+				// backend's beforeAgentStartPrompt refresh), so mark the base as
+				// carrying the roster and let `takePendingToolRosterNotice` decide at
+				// send time.
+				this.#basePromptReflectsRosterDelta = true;
 			} else if (frozenSignature) {
 				this.#notifyToolRosterDelta(previousActiveToolNames, appliedNames);
 				this.#lastAppliedToolSignature = frozenSignature;
@@ -1155,6 +1167,9 @@ export class SessionTools {
 			if (!pending.added.delete(name)) pending.removed.add(name);
 		}
 		this.#pendingToolRosterDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
+		// A frozen apply changed the roster without re-rendering the base prompt, so
+		// the base no longer reflects the pending delta.
+		this.#basePromptReflectsRosterDelta = false;
 	}
 
 	/**
@@ -1265,15 +1280,25 @@ export class SessionTools {
 
 	/**
 	 * Consumes the hidden provider-visible roster notice for the current pending
-	 * delta. Unlike the xd:// mount notice this carries no meaningful payload (a
-	 * short tool-name list), so it is never previewed or deferred for context
-	 * budgeting: it is re-derived from the live delta after pre-prompt maintenance
-	 * and always delivered alongside the schema change it describes, keeping the
-	 * model's stated availability in lockstep with the wire tool list.
+	 * delta. This carries no meaningful payload (a short tool-name list), so it is
+	 * never previewed or deferred for context budgeting: it is re-derived from the
+	 * live delta after pre-prompt maintenance, keeping the model's stated
+	 * availability in lockstep with the wire tool list.
+	 *
+	 * The notice is suppressed only when the prompt actually delivered this turn is
+	 * a rebuilt base that already renders the full roster (`baseDelivered` and
+	 * {@link #basePromptReflectsRosterDelta}). A per-turn `before_agent_start`
+	 * override that hides the rebuilt base leaves `baseDelivered` false, so the
+	 * notice still ships — the only channel carrying the change on that turn.
 	 */
-	takePendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
-		const notice = this.#buildPendingToolRosterNotice();
-		if (notice) this.#pendingToolRosterDelta = undefined;
+	takePendingToolRosterNotice(options: {
+		baseDelivered: boolean;
+	}): CustomMessage<ToolRosterNoticeDetails> | undefined {
+		if (!this.#pendingToolRosterDelta) return undefined;
+		const subsumed = options.baseDelivered && this.#basePromptReflectsRosterDelta;
+		const notice = subsumed ? undefined : this.#buildPendingToolRosterNotice();
+		this.#pendingToolRosterDelta = undefined;
+		this.#basePromptReflectsRosterDelta = false;
 		return notice;
 	}
 
@@ -1630,13 +1655,14 @@ export class SessionTools {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
 		this.#applyAgentSystemPrompt(this.#baseSystemPrompt);
-		// An explicit rebuild re-renders the complete current roster, so a delta
-		// queued by an earlier frozen apply (e.g. a Code Mode boundary crossed
-		// mid model-cycle) is subsumed once that base is delivered. A per-turn
-		// `before_agent_start` override keeps the rebuilt base off the wire (see
-		// {@link #applyAgentSystemPrompt}), so keep the delta then so
-		// takePendingToolRosterNotice() still surfaces the change on this turn.
-		if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
+		// The rebuilt prompt renders the complete current roster, so a delta queued
+		// by an earlier frozen apply (e.g. a Code Mode boundary crossed mid
+		// model-cycle) is subsumed once this base is the prompt actually delivered.
+		// A per-turn `before_agent_start` override — which may be registered after
+		// this refresh, e.g. a memory backend's beforeAgentStartPrompt injection —
+		// can still hide it, so mark the base as carrying the roster and let
+		// `takePendingToolRosterNotice` decide at send time.
+		this.#basePromptReflectsRosterDelta = true;
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -190,6 +190,11 @@ interface XdevMountNoticeDetails {
 	removed: string[];
 }
 
+interface PendingNoticePreview<T> {
+	notice: CustomMessage<T> | undefined;
+	revision: number;
+}
+
 interface XdevMountNoticeProjection {
 	notice: CustomMessage<XdevMountNoticeDetails> | undefined;
 	announcedMounts: Set<string>;
@@ -210,6 +215,8 @@ export class SessionTools {
 	#xdev: XdevState | undefined;
 	#pendingToolRosterDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
+	#toolRosterDeltaRevision = 0;
+	#xdevMountDeltaRevision = 0;
 	/**
 	 * Dynamic (`xd://`) devices the model has already been told are mounted.
 	 * Seeded lazily from persisted history on resume (see
@@ -1089,14 +1096,14 @@ export class SessionTools {
 				this.#applyAgentSystemPrompt(this.#baseSystemPrompt);
 				this.#lastAppliedToolSignature = rebuiltSignature;
 				this.#promptModelKey = this.#currentPromptModelKey();
-				this.#basePromptXdevNames = new Set(rebuiltXdevCatalogNames);
+				this.#setBasePromptXdevNames(rebuiltXdevCatalogNames);
 				// The rebuilt prompt renders the complete current roster, so a delta
 				// queued by an earlier frozen apply is subsumed once that prompt is the
 				// one delivered. A per-turn `before_agent_start` override keeps the
 				// rebuilt base off the wire (see {@link #applyAgentSystemPrompt}), so
 				// keep the delta then — the notice is the only channel carrying the
 				// roster change on this turn.
-				if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
+				if (this.#turnSystemPromptOverride === undefined) this.#clearPendingToolRosterDelta();
 			} else if (frozenSignature) {
 				this.#notifyToolRosterDelta(previousActiveToolNames, appliedNames);
 				this.#lastAppliedToolSignature = frozenSignature;
@@ -1118,6 +1125,14 @@ export class SessionTools {
 		for (const name of names) mountedNames.add(name);
 	}
 
+	#setBasePromptXdevNames(names: readonly string[] | undefined): void {
+		this.#basePromptXdevNames = new Set(names);
+		// A rebuild can change whether the final base catalog suppresses a mount
+		// notice. Invalidate any pre-maintenance projection so it is recomputed on
+		// the next user turn rather than growing after the completed estimate.
+		if (this.#pendingXdevMountDelta) this.#xdevMountDeltaRevision++;
+	}
+
 	#notifyToolRosterDelta(previousActiveToolNames: readonly string[], appliedNames: readonly string[]): void {
 		const previous = new Set(previousActiveToolNames);
 		const current = new Set(appliedNames);
@@ -1132,6 +1147,13 @@ export class SessionTools {
 			if (!pending.added.delete(name)) pending.removed.add(name);
 		}
 		this.#pendingToolRosterDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
+		this.#toolRosterDeltaRevision++;
+	}
+
+	#clearPendingToolRosterDelta(): void {
+		if (!this.#pendingToolRosterDelta) return;
+		this.#pendingToolRosterDelta = undefined;
+		this.#toolRosterDeltaRevision++;
 	}
 
 	/**
@@ -1162,6 +1184,7 @@ export class SessionTools {
 			if (!pending.added.delete(name)) pending.removed.add(name);
 		}
 		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
+		this.#xdevMountDeltaRevision++;
 		if (this.#host.settings.get("startup.quiet")) return;
 		const parts: string[] = [];
 		if (addedNames.length > 0) parts.push(`mounted ${addedNames.join(", ")}`);
@@ -1239,15 +1262,19 @@ export class SessionTools {
 		}
 	}
 
-	/** Previews the hidden provider-visible roster notice without consuming its pending delta. */
-	peekPendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
-		return this.#buildPendingToolRosterNotice();
+	/** Previews the hidden provider-visible roster notice and its immutable pending revision. */
+	peekPendingToolRosterNotice(): PendingNoticePreview<ToolRosterNoticeDetails> | undefined {
+		const notice = this.#buildPendingToolRosterNotice();
+		return notice ? { notice, revision: this.#toolRosterDeltaRevision } : undefined;
 	}
 
-	/** Consumes the hidden notice for provider-visible tool-roster changes. */
-	takePendingToolRosterNotice(): CustomMessage<ToolRosterNoticeDetails> | undefined {
+	/** Consumes the roster notice only when no delta mutation followed its preview. */
+	takePendingToolRosterNotice(options: {
+		expectedRevision: number;
+	}): CustomMessage<ToolRosterNoticeDetails> | undefined {
+		if (options.expectedRevision !== this.#toolRosterDeltaRevision) return undefined;
 		const notice = this.#buildPendingToolRosterNotice();
-		if (notice) this.#pendingToolRosterDelta = undefined;
+		if (notice) this.#clearPendingToolRosterDelta();
 		return notice;
 	}
 
@@ -1270,16 +1297,24 @@ export class SessionTools {
 		};
 	}
 
-	/** Previews the hidden `xd://` mount notice without consuming or announcing its pending delta. */
-	peekPendingXdevMountNotice(baseCatalogDelivered: boolean): CustomMessage<XdevMountNoticeDetails> | undefined {
-		return this.#projectPendingXdevMountNotice(baseCatalogDelivered)?.notice;
+	/** Previews the hidden `xd://` mount notice and its immutable pending revision. */
+	peekPendingXdevMountNotice(options: {
+		baseCatalogDelivered: boolean;
+	}): PendingNoticePreview<XdevMountNoticeDetails> | undefined {
+		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
+		return projection ? { notice: projection.notice, revision: this.#xdevMountDeltaRevision } : undefined;
 	}
 
-	/** Consumes the hidden notice for unannounced `xd://` mount changes. */
-	takePendingXdevMountNotice(baseCatalogDelivered: boolean): CustomMessage<XdevMountNoticeDetails> | undefined {
-		const projection = this.#projectPendingXdevMountNotice(baseCatalogDelivered);
+	/** Consumes the mount notice only when no delta or catalog mutation followed its preview. */
+	takePendingXdevMountNotice(options: {
+		baseCatalogDelivered: boolean;
+		expectedRevision: number;
+	}): CustomMessage<XdevMountNoticeDetails> | undefined {
+		if (options.expectedRevision !== this.#xdevMountDeltaRevision) return undefined;
+		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
 		if (!projection) return undefined;
 		this.#pendingXdevMountDelta = undefined;
+		this.#xdevMountDeltaRevision++;
 		this.#announcedMounts = projection.announcedMounts;
 		return projection.notice;
 	}
@@ -1541,7 +1576,7 @@ export class SessionTools {
 		const built = await this.#rebuildSystemPrompt(promptToolNames, this.#toolRegistry, { directToolNames });
 		if (this.#host.isDisposed()) return;
 		this.#baseSystemPrompt = built.systemPrompt;
-		this.#basePromptXdevNames = new Set(built.xdevCatalogNames);
+		this.#setBasePromptXdevNames(built.xdevCatalogNames);
 		this.#host.clearMemoryPromotionSnapshot();
 		if (
 			previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||
@@ -1556,7 +1591,7 @@ export class SessionTools {
 		// `before_agent_start` override keeps the rebuilt base off the wire (see
 		// {@link #applyAgentSystemPrompt}), so keep the delta then so
 		// takePendingToolRosterNotice() still surfaces the change on this turn.
-		if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
+		if (this.#turnSystemPromptOverride === undefined) this.#clearPendingToolRosterDelta();
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1090,10 +1090,13 @@ export class SessionTools {
 				this.#lastAppliedToolSignature = rebuiltSignature;
 				this.#promptModelKey = this.#currentPromptModelKey();
 				this.#basePromptXdevNames = new Set(rebuiltXdevCatalogNames);
-				// The rebuilt prompt renders the complete current roster, so any delta
-				// queued by an earlier frozen apply is now subsumed and must not also
-				// ride along as a notice.
-				this.#pendingToolRosterDelta = undefined;
+				// The rebuilt prompt renders the complete current roster, so a delta
+				// queued by an earlier frozen apply is subsumed once that prompt is the
+				// one delivered. A per-turn `before_agent_start` override keeps the
+				// rebuilt base off the wire (see {@link #applyAgentSystemPrompt}), so
+				// keep the delta then — the notice is the only channel carrying the
+				// roster change on this turn.
+				if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
 			} else if (frozenSignature) {
 				this.#notifyToolRosterDelta(previousActiveToolNames, appliedNames);
 				this.#lastAppliedToolSignature = frozenSignature;
@@ -1549,8 +1552,11 @@ export class SessionTools {
 		this.#applyAgentSystemPrompt(this.#baseSystemPrompt);
 		// An explicit rebuild re-renders the complete current roster, so a delta
 		// queued by an earlier frozen apply (e.g. a Code Mode boundary crossed
-		// mid model-cycle) is subsumed here and must not also surface as a notice.
-		this.#pendingToolRosterDelta = undefined;
+		// mid model-cycle) is subsumed once that base is delivered. A per-turn
+		// `before_agent_start` override keeps the rebuilt base off the wire (see
+		// {@link #applyAgentSystemPrompt}), so keep the delta then so
+		// takePendingToolRosterNotice() still surfaces the change on this turn.
+		if (this.#turnSystemPromptOverride === undefined) this.#pendingToolRosterDelta = undefined;
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1080,6 +1080,10 @@ export class SessionTools {
 				this.#lastAppliedToolSignature = rebuiltSignature;
 				this.#promptModelKey = this.#currentPromptModelKey();
 				this.#basePromptXdevNames = new Set(rebuiltXdevCatalogNames);
+				// The rebuilt prompt renders the complete current roster, so any delta
+				// queued by an earlier frozen apply is now subsumed and must not also
+				// ride along as a notice.
+				this.#pendingToolRosterDelta = undefined;
 			} else if (frozenSignature) {
 				this.#notifyToolRosterDelta(previousActiveToolNames, appliedNames);
 				this.#lastAppliedToolSignature = frozenSignature;
@@ -1505,6 +1509,10 @@ export class SessionTools {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
 		this.#applyAgentSystemPrompt(this.#baseSystemPrompt);
+		// An explicit rebuild re-renders the complete current roster, so a delta
+		// queued by an earlier frozen apply (e.g. a Code Mode boundary crossed
+		// mid model-cycle) is subsumed here and must not also surface as a notice.
+		this.#pendingToolRosterDelta = undefined;
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1126,9 +1126,10 @@ export class SessionTools {
 
 	#setBasePromptXdevNames(names: readonly string[] | undefined): void {
 		this.#basePromptXdevNames = new Set(names);
-		// A rebuild can change whether the final base catalog suppresses a mount
-		// notice. Invalidate any pre-maintenance projection so it is recomputed on
-		// the next user turn rather than growing after the completed estimate.
+		// A rebuild can change which pending additions the final base catalog
+		// already announces. Invalidate the projection; the post-maintenance take
+		// records additions carried by a delivered base and defers only the
+		// remaining notice payload.
 		if (this.#pendingXdevMountDelta) this.#xdevMountDeltaRevision++;
 	}
 
@@ -1300,13 +1301,36 @@ export class SessionTools {
 		baseCatalogDelivered: boolean;
 		expectedRevision: number;
 	}): CustomMessage<XdevMountNoticeDetails> | undefined {
-		if (options.expectedRevision !== this.#xdevMountDeltaRevision) return undefined;
+		if (options.expectedRevision !== this.#xdevMountDeltaRevision) {
+			// Maintenance may have rebuilt and delivered the base catalog after the
+			// preview. Commit additions carried by that prompt before deferring the
+			// remaining delta; a later unmount must not cancel an addition the model
+			// has already seen.
+			if (options.baseCatalogDelivered) this.#recordBasePromptXdevAdditions();
+			return undefined;
+		}
 		const projection = this.#projectPendingXdevMountNotice(options.baseCatalogDelivered);
 		if (!projection) return undefined;
 		this.#pendingXdevMountDelta = undefined;
 		this.#xdevMountDeltaRevision++;
 		this.#announcedMounts = projection.announcedMounts;
 		return projection.notice;
+	}
+
+	#recordBasePromptXdevAdditions(): void {
+		const pending = this.#pendingXdevMountDelta;
+		if (!pending) return;
+		this.#ensureAnnouncedMountsSeeded();
+		let changed = false;
+		for (const name of pending.added) {
+			if (!this.#basePromptXdevNames.has(name)) continue;
+			pending.added.delete(name);
+			this.#announcedMounts.add(name);
+			changed = true;
+		}
+		if (!changed) return;
+		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
+		this.#xdevMountDeltaRevision++;
 	}
 
 	#projectPendingXdevMountNotice(baseCatalogDelivered: boolean): XdevMountNoticeProjection | undefined {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1000,6 +1000,40 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(notices[0]).toContain("## Schema");
 	});
 
+	it("defers a mount delta queued after its pre-prompt preview", async () => {
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }, { content: ["ok"] }],
+		});
+		session.settings.set("tools.xdevDocs", "builtins");
+		session.settings.set("tools.xdevInlineDevices", ["mcp__nucleus_*"]);
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const fetch = createMcpCustomTool("mcp__nucleus_fetch", "nucleus", "fetch", "Fetch nucleus");
+		await session.refreshMCPTools([search]);
+
+		// The first prompt previews search for context maintenance. Fetch arrives
+		// during that await, after the only context-size check; consuming the now
+		// larger notice would add unbudgeted inline docs to this request.
+		const maintenanceSpy = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementationOnce(async () => {
+				await session.refreshMCPTools([search, fetch]);
+			});
+		await session.prompt("first");
+
+		expect(mountNoticesIn(contexts[0])).toHaveLength(0);
+		maintenanceSpy.mockRestore();
+
+		// The complete coalesced delta survives and is previewed afresh on the next
+		// user turn, so both devices and their inline docs are delivered together.
+		await session.prompt("second");
+		const notices = mountNoticesIn(contexts[1]);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("xd://mcp__nucleus_search");
+		expect(notices[0]).toContain("xd://mcp__nucleus_fetch");
+		expect(notices[0]).toContain("## Schema");
+	});
+
 	it("drops a mount delta that cancels out before the next prompt", async () => {
 		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
 			xdev: createTestXdevState(),

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -9,6 +9,7 @@ import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { type CustomMessage, convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionMaintenance } from "@oh-my-pi/pi-coding-agent/session/session-maintenance";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
 	collectMountedMCPToolRoutes,
@@ -66,7 +67,7 @@ function createMcpCustomTool(name: string, serverName: string, mcpToolName: stri
 }
 
 /** Rendered xd:// mount notices within one provider call's messages. */
-function mountNoticesIn(messages: Message[]): string[] {
+function mountNoticesIn(messages: readonly (AgentMessage | Message)[]): string[] {
 	return messages.flatMap(message => {
 		const { content } = message;
 		const text =
@@ -972,9 +973,20 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		session.settings.set("tools.xdevDocs", "builtins");
 		session.settings.set("tools.xdevInlineDevices", ["mcp__nucleus_*"]);
 		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const maintenanceMessages: AgentMessage[][] = [];
+		const maintenanceSpy = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementation(async messages => {
+				maintenanceMessages.push([...messages]);
+			});
 
 		await session.refreshMCPTools([search]);
 		await session.prompt("hello");
+		expect(maintenanceSpy).toHaveBeenCalledTimes(1);
+		const estimatedNotices = mountNoticesIn(maintenanceMessages[0] ?? []);
+		expect(estimatedNotices).toHaveLength(1);
+		expect(estimatedNotices[0]).toContain("## mcp__nucleus_search");
+		expect(estimatedNotices[0]).toContain("## Schema");
 
 		const notices = mountNoticesIn(contexts[0]);
 		expect(notices).toHaveLength(1);

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1034,6 +1034,44 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(notices[0]).toContain("## Schema");
 	});
 
+	it("defers a mount notice whose docs change via a same-name schema replacement", async () => {
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }, { content: ["ok"] }],
+		});
+		session.settings.set("tools.xdevDocs", "builtins");
+		session.settings.set("tools.xdevInlineDevices", ["mcp__nucleus_*"]);
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const searchReconnected = createMcpCustomTool(
+			"mcp__nucleus_search",
+			"nucleus",
+			"search",
+			"Search nucleus, now reconnected with a different documented schema",
+		);
+		await session.refreshMCPTools([search]);
+
+		// The preview estimates the notice for the original schema. During the await
+		// a same-named tool reconnects with different docs: the mount set and the
+		// schema-excluding applied signature are unchanged, so the revision never
+		// moves, but the rendered docs differ. The notice must defer rather than
+		// slip its (potentially XDEV_DOCS_TOTAL_BUDGET-sized) docs past the estimate.
+		const maintenanceSpy = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementationOnce(async () => {
+				await session.refreshMCPTools([searchReconnected]);
+			});
+		await session.prompt("first");
+		expect(mountNoticesIn(contexts[0])).toHaveLength(0);
+		maintenanceSpy.mockRestore();
+
+		// The next user turn re-previews against the new schema and delivers it.
+		await session.prompt("second");
+		const notices = mountNoticesIn(contexts[1]);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("xd://mcp__nucleus_search");
+		expect(notices[0]).toContain("reconnected with a different documented schema");
+	});
+
 	it("drops a mount delta that cancels out before the next prompt", async () => {
 		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
 			xdev: createTestXdevState(),

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1154,6 +1154,40 @@ These tools became available:
 		).toHaveLength(0);
 	});
 
+	it("announces an unmount after a maintenance rebuild delivered the pending addition", async () => {
+		const { session, contexts, systemPrompts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }, { content: ["ok"] }],
+			exposeXdevCatalog: true,
+		});
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		await session.refreshMCPTools([search]);
+
+		// The pending addition is previewed, then maintenance rebuilds the base
+		// catalog before delivery. The rebuild carries the device to the provider
+		// but invalidates the preview revision.
+		const rebuildDuringMaintenance = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementationOnce(async () => {
+				await session.refreshBaseSystemPrompt();
+			});
+		await session.prompt("first");
+		expect(rebuildDuringMaintenance).toHaveBeenCalledTimes(1);
+		expect(systemPrompts[0]?.join("\n")).toContain("mcp__nucleus_search");
+		expect(mountNoticesIn(contexts[0] ?? [])).toHaveLength(0);
+		rebuildDuringMaintenance.mockRestore();
+
+		// Since the model learned the device from the delivered base, a subsequent
+		// unmount must produce a removal notice rather than cancelling the stale
+		// pending addition as though it had never been announced.
+		await session.refreshMCPTools([]);
+		await session.prompt("second");
+		const notices = mountNoticesIn(contexts[1] ?? []);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("Unmounted; writes fail:");
+		expect(notices[0]).toContain("xd://mcp__nucleus_search");
+	});
+
 	it("keeps the mount notice when before_agent_start replaces the catalog prompt (#7139)", async () => {
 		const replacementPrompt = ["extension replacement"];
 		const { session, contexts, systemPrompts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -67,7 +67,7 @@ function createMcpCustomTool(name: string, serverName: string, mcpToolName: stri
 }
 
 /** Rendered xd:// mount notices within one provider call's messages. */
-function mountNoticesIn(messages: readonly (AgentMessage | Message)[]): string[] {
+function mountNoticesIn(messages: readonly Message[]): string[] {
 	return messages.flatMap(message => {
 		const { content } = message;
 		const text =
@@ -983,10 +983,16 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		await session.prompt("hello");
 		expect(maintenanceSpy).toHaveBeenCalledTimes(1);
-		const estimatedNotices = mountNoticesIn(maintenanceMessages[0] ?? []);
-		expect(estimatedNotices).toHaveLength(1);
-		expect(estimatedNotices[0]).toContain("## mcp__nucleus_search");
-		expect(estimatedNotices[0]).toContain("## Schema");
+		const estimatedNotice = (maintenanceMessages[0] ?? []).find(
+			(message): message is CustomMessage => message.role === "custom" && message.customType === "xdev-mount-notice",
+		);
+		expect(estimatedNotice).toBeDefined();
+		const estimatedText =
+			typeof estimatedNotice?.content === "string"
+				? estimatedNotice.content
+				: (estimatedNotice?.content ?? []).flatMap(part => (part.type === "text" ? [part.text] : [])).join("");
+		expect(estimatedText).toContain("## mcp__nucleus_search");
+		expect(estimatedText).toContain("## Schema");
 
 		const notices = mountNoticesIn(contexts[0]);
 		expect(notices).toHaveLength(1);

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1237,11 +1237,20 @@ These tools became available:
 		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
 
 		// The base prompt rebuild exposes the device, but the per-turn extension
-		// replaces that prompt before the provider call. The mount notice is now
-		// the only channel making the newly mounted device visible on this turn.
+		// replaces that prompt before the provider call. A second rebuild during
+		// maintenance advances the internal catalog revision, yet remains hidden by
+		// the same override and leaves the budgeted notice byte-identical. That
+		// notice is the only channel making the newly mounted device visible on this
+		// turn, so the revision change alone must not defer it.
 		await session.refreshMCPTools([search]);
+		const hiddenRebuild = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementationOnce(async () => {
+				await session.refreshBaseSystemPrompt();
+			});
 		await session.prompt("hi");
 
+		expect(hiddenRebuild).toHaveBeenCalledTimes(1);
 		expect(systemPrompts[0]).toEqual(replacementPrompt);
 		const notices = mountNoticesIn(contexts[0]);
 		expect(notices).toHaveLength(1);

--- a/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
+++ b/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
@@ -277,6 +277,34 @@ describe("prefix-bound tool roster changes", () => {
 		expect(providerText(harness.contexts[1])).toContain("Now available: bash.");
 	});
 
+	it("keeps the roster notice when a rebuild precedes a turn override", async () => {
+		const override = ["per-turn override prompt"];
+		const harness = newSession(createPrefixBindingModel(), { beforeAgentStartSystemPrompt: override });
+		sessions.push(harness.session);
+		await harness.session.setActiveToolPresentation(["read"], []);
+		await harness.session.prompt("first");
+
+		// A prefix-bound roster change freezes the prompt and queues a hidden delta.
+		await harness.session.setActiveToolPresentation(["read", "bash"], []);
+		// A rebuild happens while no override is registered yet — modelling a memory
+		// backend's beforeAgentStartPrompt refresh, which runs inside
+		// buildSystemPromptForAgentStart before emitBeforeAgentStart sets the
+		// per-turn override. The rebuilt base must not clear the delta outright: the
+		// override registered moments later hides that base from the wire.
+		await harness.session.refreshBaseSystemPrompt();
+
+		await harness.session.prompt("second");
+
+		// The override hid the rebuilt base, so the provider never saw the roster there.
+		expect(harness.systemPrompts[1]).toEqual(override);
+		// The notice is the only channel carrying the change, so it must survive.
+		const notices = harness.session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "tool-roster-notice",
+		);
+		expect(notices).toHaveLength(1);
+		expect(providerText(harness.contexts[1])).toContain("Now available: bash.");
+	});
+
 	it("delivers a roster notice for a change queued during pre-prompt maintenance", async () => {
 		const harness = newSession(createPrefixBindingModel());
 		sessions.push(harness.session);

--- a/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
+++ b/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
@@ -5,6 +5,7 @@ import type { Message, Model } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionMaintenance } from "@oh-my-pi/pi-coding-agent/session/session-maintenance";
@@ -56,10 +57,11 @@ function createTool(name: string): AgentTool {
 interface TestSession {
 	session: AgentSession;
 	contexts: Message[][];
+	systemPrompts: string[][];
 	rebuild: Mock<(toolNames: string[]) => Promise<string>>;
 }
 
-function newSession(model: Model): TestSession {
+function newSession(model: Model, options: { beforeAgentStartSystemPrompt?: string[] } = {}): TestSession {
 	const read = createTool("read");
 	const bash = createTool("bash");
 	const toolRegistry = new Map<string, AgentTool>([
@@ -68,6 +70,7 @@ function newSession(model: Model): TestSession {
 	]);
 	const mock = createMockModel({ responses: [{ content: ["ok"] }, { content: ["ok"] }] });
 	const contexts: Message[][] = [];
+	const systemPrompts: string[][] = [];
 	const rebuilder = {
 		async rebuildSystemPrompt(toolNames: string[]): Promise<string> {
 			return `tools:${toolNames.join(",")}`;
@@ -80,6 +83,7 @@ function newSession(model: Model): TestSession {
 		convertToLlm,
 		streamFn: (requestModel, context, streamOptions) => {
 			contexts.push([...context.messages]);
+			systemPrompts.push([...(context.systemPrompt ?? [])]);
 			return mock.stream(requestModel, context, streamOptions);
 		},
 	});
@@ -90,11 +94,17 @@ function newSession(model: Model): TestSession {
 		modelRegistry: { getApiKey: async () => "test-key" } as never,
 		toolRegistry,
 		builtInToolNames: ["read", "bash"],
+		extensionRunner: options.beforeAgentStartSystemPrompt
+			? ({
+					emitBeforeAgentStart: async () => ({ systemPrompt: options.beforeAgentStartSystemPrompt }),
+					emit: async () => undefined,
+				} as unknown as ExtensionRunner)
+			: undefined,
 		rebuildSystemPrompt: async toolNames => ({
 			systemPrompt: [await rebuilder.rebuildSystemPrompt(toolNames)],
 		}),
 	});
-	return { session, contexts, rebuild };
+	return { session, contexts, systemPrompts, rebuild };
 }
 
 function providerText(messages: Message[]): string {
@@ -232,5 +242,38 @@ describe("prefix-bound tool roster changes", () => {
 		expect(notices).toHaveLength(0);
 		const secondRequest = providerText(harness.contexts[1]);
 		expect(secondRequest).not.toContain("Tool availability changed.");
+	});
+
+	it("keeps the roster notice when a turn override hides the rebuilt base", async () => {
+		const override = ["per-turn override prompt"];
+		const harness = newSession(createPrefixBindingModel(), { beforeAgentStartSystemPrompt: override });
+		sessions.push(harness.session);
+		await harness.session.setActiveToolPresentation(["read"], []);
+		await harness.session.prompt("first");
+
+		// A prefix-bound roster change freezes the prompt and queues a hidden delta.
+		await harness.session.setActiveToolPresentation(["read", "bash"], []);
+
+		// A before_agent_start override is active for the turn, so a mid-prompt
+		// rebuild (here a promotion/summary rebuild) re-renders the base but never
+		// puts it on the wire — the override stays. The queued delta must survive
+		// that rebuild so the notice remains the only channel carrying the change.
+		const rebuildDuringCompaction = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementation(async () => {
+				await harness.session.refreshBaseSystemPrompt();
+			});
+
+		await harness.session.prompt("second");
+
+		expect(rebuildDuringCompaction).toHaveBeenCalledTimes(1);
+		// The provider saw the override, not the rebuilt roster.
+		expect(harness.systemPrompts[1]).toEqual(override);
+		// So the notice must still be delivered.
+		const notices = harness.session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "tool-roster-notice",
+		);
+		expect(notices).toHaveLength(1);
+		expect(providerText(harness.contexts[1])).toContain("Now available: bash.");
 	});
 });

--- a/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
+++ b/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
@@ -7,6 +7,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionMaintenance } from "@oh-my-pi/pi-coding-agent/session/session-maintenance";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 
 function createPrefixBindingModel(): Model<"anthropic-messages"> {
@@ -198,5 +199,38 @@ describe("prefix-bound tool roster changes", () => {
 		const secondRequest = providerText(harness.contexts[1]);
 		expect(secondRequest).not.toContain("Tool availability changed.");
 		expect(harness.session.agent.state.systemPrompt).toEqual(["tools:read,bash"]);
+	});
+
+	it("does not ship a roster notice when a rebuild clears the delta during pre-prompt compaction", async () => {
+		const harness = newSession(createPrefixBindingModel());
+		sessions.push(harness.session);
+		await harness.session.setActiveToolPresentation(["read"], []);
+		await harness.session.prompt("first");
+
+		// A prefix-bound roster change freezes the prompt and queues a hidden delta
+		// that survives to the next prompt (no rebuild behind it).
+		await harness.session.setActiveToolPresentation(["read", "bash"], []);
+
+		// The pre-prompt maintenance pass can rebuild the base prompt mid-prompt
+		// (context promotion switches the model -> syncAfterModelChange, or a
+		// summary compaction), which re-renders the complete roster and clears the
+		// queued delta. The roster notice is consumed after that pass, so it must
+		// see the cleared delta and emit nothing — the outgoing request must never
+		// carry both a rebuilt roster and a contradicting notice.
+		const rebuildDuringCompaction = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementation(async () => {
+				await harness.session.refreshBaseSystemPrompt();
+			});
+
+		await harness.session.prompt("second");
+
+		expect(rebuildDuringCompaction).toHaveBeenCalledTimes(1);
+		const notices = harness.session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "tool-roster-notice",
+		);
+		expect(notices).toHaveLength(0);
+		const secondRequest = providerText(harness.contexts[1]);
+		expect(secondRequest).not.toContain("Tool availability changed.");
 	});
 });

--- a/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
+++ b/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
@@ -276,4 +276,31 @@ describe("prefix-bound tool roster changes", () => {
 		expect(notices).toHaveLength(1);
 		expect(providerText(harness.contexts[1])).toContain("Now available: bash.");
 	});
+
+	it("delivers a roster notice for a change queued during pre-prompt maintenance", async () => {
+		const harness = newSession(createPrefixBindingModel());
+		sessions.push(harness.session);
+		await harness.session.setActiveToolPresentation(["read"], []);
+		await harness.session.prompt("first");
+
+		// The tool list changes mid-maintenance (e.g. an MCP refresh landing during
+		// the await). The roster notice carries no context-budget risk, so it must
+		// ship this turn alongside the schema change rather than deferring — a
+		// deferred notice would leave the wire tool list and stated availability out
+		// of sync, the same divergence as the original bug.
+		const rosterChangeDuringMaintenance = vi
+			.spyOn(SessionMaintenance.prototype, "runPrePromptCompactionIfNeeded")
+			.mockImplementationOnce(async () => {
+				await harness.session.setActiveToolPresentation(["read", "bash"], []);
+			});
+
+		await harness.session.prompt("second");
+
+		expect(rosterChangeDuringMaintenance).toHaveBeenCalledTimes(1);
+		const notices = harness.session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "tool-roster-notice",
+		);
+		expect(notices).toHaveLength(1);
+		expect(providerText(harness.contexts[1])).toContain("Now available: bash.");
+	});
 });

--- a/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
+++ b/packages/coding-agent/test/prefix-binding-tool-roster.test.ts
@@ -176,4 +176,27 @@ describe("prefix-bound tool roster changes", () => {
 		expect(harness.rebuild).toHaveBeenCalledTimes(rebuildsBeforeRosterChange + 1);
 		expect(harness.session.agent.state.systemPrompt).toEqual(["tools:read,bash"]);
 	});
+
+	it("drops a pending roster notice once the base prompt is rebuilt afterward", async () => {
+		const harness = newSession(createPrefixBindingModel());
+		sessions.push(harness.session);
+		await harness.session.setActiveToolPresentation(["read"], []);
+		await harness.session.prompt("first");
+
+		// A prefix-bound roster change freezes the prompt and queues a hidden delta.
+		await harness.session.setActiveToolPresentation(["read", "bash"], []);
+		// A later full rebuild (e.g. the model-cycle round trip's syncAfterModelChange)
+		// re-renders the complete roster, subsuming the queued delta.
+		await harness.session.refreshBaseSystemPrompt();
+
+		await harness.session.prompt("second");
+
+		const notices = harness.session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "tool-roster-notice",
+		);
+		expect(notices).toHaveLength(0);
+		const secondRequest = providerText(harness.contexts[1]);
+		expect(secondRequest).not.toContain("Tool availability changed.");
+		expect(harness.session.agent.state.systemPrompt).toEqual(["tools:read,bash"]);
+	});
 });


### PR DESCRIPTION
## Repro
Cycling models with Ctrl+P over a round trip that crosses a Code Mode boundary (e.g. a scoped set with a prefix-binding Anthropic model and an openai-codex code-mode model, `providers.openai-codex.codeMode: auto`) makes the next user turn receive a hidden `<system-notice>` announcing already-active tools as "now available." The model reads the unlisted tools as removed and stops calling them for the rest of the session. Reproduced in-process against `test/prefix-binding-tool-roster.test.ts`: a prefix-bound roster change (frozen apply) followed by a base-prompt rebuild still delivers a `tool-roster-notice`.

## Cause
A round-trip cycle crosses two apply paths in `packages/coding-agent/src/session/session-tools.ts`. The outbound leg to the non-prefix-binding model takes the full-rebuild branch of `#applyActiveToolsByName`, committing the intermediate direct partition to `agent.state.tools` without ever sending it. The return leg to the prefix-binding model takes the frozen branch, so `#notifyToolRosterDelta` diffs against that intermediate set and queues an added-only delta in `#pendingToolRosterDelta`. `syncAfterModelChange` then calls `#refreshBaseSystemPrompt`, which fully rebuilds the base prompt with the complete roster but leaves the queued delta intact — so `takePendingToolRosterNotice` still emits a notice contradicting the freshly rebuilt prompt.

## Fix
- Clear `#pendingToolRosterDelta` in `#refreshBaseSystemPrompt` after the rebuilt prompt is applied — the rebuild already renders the complete current roster, subsuming any queued delta.
- Clear `#pendingToolRosterDelta` in the full-rebuild branch of `#applyActiveToolsByName` for the same invariant.
- Regression test in `test/prefix-binding-tool-roster.test.ts`: a frozen roster change followed by `refreshBaseSystemPrompt()` delivers no notice and the prompt carries the full roster.
- Changelog entry under `[Unreleased]`.

The notice template wording (`prompts/system/tool-roster-notice.md`, the reporter's "problem 2") is a maintainer-owned prompt and is left untouched.

## Verification
`bun test test/prefix-binding-tool-roster.test.ts` → 5 pass / 0 fail (regression case fails before the fix, passes after). Related suites `bun test test/agent-session-tool-rebuild-skip.test.ts test/agent-session-plan-mode-convergence.test.ts test/interactive-mode-default-plan-mode.test.ts` → 67 pass / 0 fail. `bun run fix` + `bun check` gate passed on push.

Fixes #11824