### PR TITLE
fix(utils): tolerate deleted working directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Sessions now stay alive when their working directory is removed instead of crashing while preparing shell tools ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Child-shell environment filtering now tolerates a removed process working directory by retaining the resolved project directory ([#11828](https://github.com/can1357/oh-my-pi/issues/11828)).
+
 ## [18.1.16] - 2026-09-09
 
 ### Fixed

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -110,7 +110,7 @@ function expandDotenvValues(values: Record<string, string>, env: Record<string, 
 /** Filters process env for child shells without launch-cwd dotenv values. */
 export function filterChildShellEnv(
 	env: Record<string, string | undefined>,
-	cwd: string = process.cwd(),
+	cwd: string = getProjectDir(),
 ): Record<string, string> {
 	const runtimeLaunchEnvValues = env === Bun.env || env === process.env ? launchEnvValues : undefined;
 	const result = filterProcessEnv(env);

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -234,6 +234,34 @@ describe("filterChildShellEnv", () => {
 			nodeEnv: "production",
 		});
 	});
+
+	it("keeps filtering after the process working directory is deleted", async () => {
+		const cwd = path.dirname(writeTempEnv(""));
+		const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+		const dirsModulePath = path.join(import.meta.dir, "..", "src", "dirs.ts");
+		const script = [
+			'import * as fs from "node:fs";',
+			`import { filterChildShellEnv } from ${JSON.stringify(envModulePath)};`,
+			`import { getProjectDir } from ${JSON.stringify(dirsModulePath)};`,
+			"getProjectDir();",
+			"fs.rmSync(process.cwd(), { recursive: true });",
+			'const child = filterChildShellEnv({ UNCHANGED: "parent-value" });',
+			"process.stdout.write(JSON.stringify(child));",
+		].join("\n");
+		const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
+	});
 });
 
 describe("isBunTestRuntime", () => {

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -235,33 +235,36 @@ describe("filterChildShellEnv", () => {
 		});
 	});
 
-	it("keeps filtering after the process working directory is deleted", async () => {
-		const cwd = path.dirname(writeTempEnv(""));
-		const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
-		const dirsModulePath = path.join(import.meta.dir, "..", "src", "dirs.ts");
-		const script = [
-			'import * as fs from "node:fs";',
-			`import { filterChildShellEnv } from ${JSON.stringify(envModulePath)};`,
-			`import { getProjectDir } from ${JSON.stringify(dirsModulePath)};`,
-			"getProjectDir();",
-			"fs.rmSync(process.cwd(), { recursive: true });",
-			'const child = filterChildShellEnv({ UNCHANGED: "parent-value" });',
-			"process.stdout.write(JSON.stringify(child));",
-		].join("\n");
-		const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
-			cwd,
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		const [stdout, stderr, exitCode] = await Promise.all([
-			new Response(proc.stdout).text(),
-			new Response(proc.stderr).text(),
-			proc.exited,
-		]);
+	it.skipIf(process.platform === "win32")(
+		"keeps filtering after the process working directory is deleted",
+		async () => {
+			const cwd = path.dirname(writeTempEnv(""));
+			const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+			const dirsModulePath = path.join(import.meta.dir, "..", "src", "dirs.ts");
+			const script = [
+				'import * as fs from "node:fs";',
+				`import { filterChildShellEnv } from ${JSON.stringify(envModulePath)};`,
+				`import { getProjectDir } from ${JSON.stringify(dirsModulePath)};`,
+				"getProjectDir();",
+				"fs.rmSync(process.cwd(), { recursive: true });",
+				'const child = filterChildShellEnv({ UNCHANGED: "parent-value" });',
+				"process.stdout.write(JSON.stringify(child));",
+			].join("\n");
+			const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+				cwd,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
 
-		expect(exitCode, stderr).toBe(0);
-		expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
-	});
+			expect(exitCode, stderr).toBe(0);
+			expect(JSON.parse(stdout)).toEqual({ UNCHANGED: "parent-value" });
+		},
+	);
 });
 
 describe("isBunTestRuntime", () => {


### PR DESCRIPTION
## Repro

The published 18.1.18 Linux standalone binary exits 1 after an extension removes the active `--cwd` during `session_start`; this command reproduces the uncaught `process.cwd()`/`uv_cwd` error before a model request:

```bash
/tmp/omp-18.1.18-linux-x64 --cwd /tmp/omp-11828-binary/worktree --extension /tmp/omp-11828-repro/delete-cwd.ts --no-extensions --no-session --no-rules --no-skills --no-lsp --print "Do nothing"
```

## Cause

`filterChildShellEnv` in `packages/utils/src/env.ts` evaluated `process.cwd()` as its default directory when `packages/utils/src/procmgr.ts` built the shell environment for the tool description. Once the OS working directory had been removed, Bun threw `ENOENT` while evaluating that default parameter and the exception escaped prompt construction.

## Fix

- Resolve the default dotenv directory through the cached `getProjectDir()` value rather than querying process state again.
- Add a subprocess regression test that deletes its own working directory before filtering a child-shell environment.
- Record the user-visible recovery in the coding-agent and utilities changelogs.

## Verification

`bun test packages/utils/test/env.test.ts` passes all 20 tests. `bun run check` passes in `packages/utils`. A standalone binary rebuilt with Bun 1.4.0 runs the reproduction to completion with exit 0 and output `Working...` / `Understood.` after the extension deletes its cwd.

Fixes #11828