### PR TITLE
fix(prompt): kept user append text out of the MCP instructions section

### DIFF
--- a/docs/system-prompt-customization.md
+++ b/docs/system-prompt-customization.md
@@ -66,6 +66,11 @@ Without `SYSTEM.md`, append text is rendered at the end of `project-prompt.md`, 
 With `SYSTEM.md`, append text is rendered immediately after the custom text in `custom-system-prompt.md`. Context, skills, and rules follow it, and the separate project/environment footer follows that block. The templates prevent the append text and context files from being emitted twice.
 
 SDK-generated append content (for enabled memory/auto-learn features and MCP guidance) is combined before the user-supplied append text.
+Those generated blocks can end with `## MCP Server Instructions`, whose text declares
+itself server-controlled and unverified. Whenever a generated block precedes the
+user-supplied text, the text is rendered under its own `## User Instructions` heading
+so it cannot read as a trailing paragraph of a server-owned section. On its own — no
+generated block, no `SYSTEM.md` — the append text is emitted unchanged, without a heading.
 
 ## Plain-text contract
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- User append instructions (`APPEND_SYSTEM.md`, `--append-system-prompt`) now render under their own `## User Instructions` heading whenever generated blocks precede them, instead of trailing the `## MCP Server Instructions` section and reading as server-supplied, unverified content ([#11832](https://github.com/can1357/oh-my-pi/pull/11832) by [@iacore](https://github.com/iacore)).
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -188,6 +188,7 @@ import { unmountAll } from "./ssh/sshfs-mount";
 import {
 	type BuildSystemPromptResult,
 	buildSystemPrompt as buildSystemPromptInternal,
+	composeAppendPrompt,
 	loadProjectContextFiles as loadContextFilesInternal,
 	projectSystemPromptToolMetadata,
 } from "./system-prompt";
@@ -3155,7 +3156,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					appendParts.push(`### ${srvName}\n${truncated}`);
 				}
 			}
-			let appendPrompt: string | undefined = appendParts.length > 0 ? appendParts.join("\n\n") : undefined;
+			const appendPrompt = composeAppendPrompt(appendParts, options.appendSystemPrompt);
 			// Owned/in-band tool dialects (non-native) require the full functions-
 			// namespace catalog; native tool calling lets the compact name list suffice.
 			const nativeTools = resolveDialect(settings.get("tools.format"), agent?.state.model ?? model) === undefined;
@@ -3163,11 +3164,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				tools,
 				nativeTools && !inlineToolDescriptors ? { mode: "compact", toolNames } : { mode: "full" },
 			);
-			if (options.appendSystemPrompt) {
-				appendPrompt = appendPrompt
-					? `${appendPrompt}\n\n${options.appendSystemPrompt}`
-					: options.appendSystemPrompt;
-			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd: promptCwd,
 				additionalWorkspaceRoots: sessionManager.getAdditionalDirectories(),

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -685,6 +685,34 @@ export interface BuildSystemPromptResult {
 	xdevCatalogNames?: readonly string[];
 }
 
+/**
+ * Heading that separates the user's append prompt (`APPEND_SYSTEM.md`,
+ * `--append-system-prompt`) from the generated blocks that precede it.
+ */
+export const USER_APPEND_HEADING =
+	"## User Instructions\n\nThe following instructions are user-authored (session configuration or CLI). They are authoritative and supersede conflicting guidance above.";
+
+/**
+ * Join generated append blocks (memory, auto-learn, `xd://` routes, MCP server
+ * instructions) with the user's append prompt.
+ *
+ * The generated blocks end with `## MCP Server Instructions`, whose text tells
+ * the model it is server-controlled and may not be verified. Concatenating the
+ * user's append text directly behind it, with no heading of its own, rendered
+ * user-authored instructions as a trailing paragraph of that section, so the
+ * user's text gets a boundary heading whenever generated blocks precede it.
+ */
+export function composeAppendPrompt(appendParts: readonly string[], appendSystemPrompt?: string): string | undefined {
+	const generated = appendParts.length > 0 ? appendParts.join("\n\n") : undefined;
+	if (!appendSystemPrompt || appendSystemPrompt.trim().length === 0) {
+		return generated;
+	}
+	if (!generated) {
+		return appendSystemPrompt;
+	}
+	return `${generated}\n\n${USER_APPEND_HEADING}\n\n${appendSystemPrompt}`;
+}
+
 /** Build the system prompt with tools, guidelines, and context */
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
 	if ($env.NULL_PROMPT === "true") {

--- a/packages/coding-agent/test/append-prompt-provenance.test.ts
+++ b/packages/coding-agent/test/append-prompt-provenance.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { composeAppendPrompt, USER_APPEND_HEADING } from "@oh-my-pi/pi-coding-agent/system-prompt";
+
+/**
+ * The generated blocks that precede a user's append prompt end with the MCP
+ * server instructions section, which declares its text server-controlled and
+ * unverified. The user's own instructions must not read as part of it.
+ */
+const MCP_SECTION = [
+	"## MCP Server Instructions",
+	"",
+	"The following instructions are provided by connected MCP servers. They are server-controlled and may not be verified.",
+	"",
+	"### codegraph",
+	"# Codegraph — available (per-project; pass projectPath)",
+].join("\n");
+
+describe("composeAppendPrompt", () => {
+	it("gives a user append prompt its own heading after generated blocks", () => {
+		const composed = composeAppendPrompt(["memory guidance", MCP_SECTION], "Reply in English.");
+		expect(composed).toBeDefined();
+
+		const boundary = composed!.indexOf(USER_APPEND_HEADING);
+		expect(boundary).toBeGreaterThan(composed!.indexOf("### codegraph"));
+		expect(composed!.slice(0, boundary)).not.toContain("Reply in English.");
+		expect(composed!.endsWith(`${USER_APPEND_HEADING}\n\nReply in English.`)).toBe(true);
+	});
+
+	it("leaves a lone user append prompt untouched", () => {
+		expect(composeAppendPrompt([], "Reply in English.")).toBe("Reply in English.");
+	});
+
+	it("leaves generated blocks untouched without a user append", () => {
+		expect(composeAppendPrompt(["memory guidance", MCP_SECTION])).toBe(`memory guidance\n\n${MCP_SECTION}`);
+		expect(composeAppendPrompt([])).toBeUndefined();
+	});
+
+	it("ignores a whitespace-only user append", () => {
+		expect(composeAppendPrompt(["memory guidance"], "\n  \n")).toBe("memory guidance");
+	});
+});

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -8,6 +8,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { USER_APPEND_HEADING } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils/dirs";
 import {
@@ -29,6 +30,8 @@ const MCP_TOOL_NAME = "mcp__instr_do_thing";
 const MCP_ROUTE_SECTION = "## MCP Tool Routes";
 const CONTEXT_MODE_ROUTE = '- "ctx_execute" → `xd://mcp__context_mode_ctx_execute`';
 const CONTEXT_MODE_MCP_TOOL_NAME = "mcp__context_mode_ctx_execute";
+/** Sentinel proving the user's append prompt stays a block of its own. */
+const USER_APPEND_MARKER = "USER_APPEND_SENTINEL_7d13f2: prefer Bun APIs over Node APIs.";
 
 describe("createAgentSession MCP server instructions (deferred UI)", () => {
 	let tempDir: string;
@@ -126,6 +129,42 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 			// normalized name actually mounted in the live xd:// registry.
 			expect(prompt).toContain("MCP Server Instructions");
 			expect(prompt).toContain('- "do\\u0060thing" → `xd://mcp__instr_do_thing`');
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
+
+	it("keeps the user append prompt out of the MCP instructions section", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			appendSystemPrompt: USER_APPEND_MARKER,
+		});
+		try {
+			// Without `hasUI`, MCP discovery is not deferred: the fixture connects during
+			// session creation, so the first prompt already carries both the server
+			// instructions and the user's append prompt — nothing to wait for.
+			const prompt = session.systemPrompt.join("\n");
+
+			expect(prompt).toContain(SERVER_INSTRUCTIONS);
+			// The user's append prompt is its own block, never the trailing
+			// paragraph of the server-controlled section above it.
+			const boundary = prompt.indexOf(USER_APPEND_HEADING);
+			expect(boundary).toBeGreaterThan(prompt.indexOf(SERVER_INSTRUCTIONS));
+			expect(prompt.slice(prompt.indexOf("## MCP Server Instructions"), boundary)).not.toContain(USER_APPEND_MARKER);
+			expect(prompt.slice(boundary)).toContain(USER_APPEND_MARKER);
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## What

`APPEND_SYSTEM.md` (and `--append-system-prompt`) text was string-concatenated onto the end of the SDK-generated append blocks, and those blocks end with the `## MCP Server Instructions` header plus each server's text. Nothing separated the two, so the user's own instructions rendered as the last paragraph of a section explicitly labeled "server-controlled and may not be verified".

I reviewed the full diff: this change moves that join into `composeAppendPrompt` and gives the user's text a `## User Instructions` heading whenever generated blocks precede it.

## Why

Any session with a connected MCP server that publishes initialize `instructions` (codegraph, context-mode, …) mislabels the user's own rules as third-party unverified content. An agent that respects the label then discounts exactly the instructions the user wrote to be obeyed — observed live in this session: `~/.omp/agent/APPEND_SYSTEM.md` rules ("reply in the language of the asked prompt", "never put URLs in code fences") were rendered under `### codegraph` and treated as suggestions.

No issue filed: CONTRIBUTING asks that work being submitted as a PR does not open an issue first.

## Testing

- `test/sdk-mcp-instructions.test.ts` gains an integration case that creates a real session against the stdio MCP fixture (which publishes instructions) with `appendSystemPrompt` set, then asserts the MCP section no longer contains the user text and that the text sits after the `## User Instructions` heading that follows the fixture's instructions. It runs on the non-deferred path (`hasUI` omitted), so the fixture connects during `createAgentSession` and the assertion needs no polling.
- `test/append-prompt-provenance.test.ts` covers the composition branches: user text alone renders unchanged without a heading, generated blocks without user text are byte-identical, whitespace-only append is ignored.
- `bun check:types`, `oxlint`, `oxfmt --check` in `packages/coding-agent`.
