### PR TITLE
fix(natives): reject stale addons during embedding

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Native addon embedding now rejects stale release binaries before standalone builds can package them ([#11831](https://github.com/can1357/oh-my-pi/issues/11831)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Fixed

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -18,12 +18,6 @@ export interface EmbeddedAddon {
 	archive?: EmbeddedAddonArchive;
 }
 
-/** Return the native-addon export expected for a package version. */
-export function versionSentinelFor(packageVersion: string): string;
-
-/** Check whether addon bytes contain the exact expected version sentinel. */
-export function containsVersionSentinel(bytes: Buffer, expected: string): boolean;
-
 export interface DetectCompiledBinaryInput {
 	embeddedAddon: EmbeddedAddon | null | undefined;
 	env: Record<string, string | undefined>;

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -18,6 +18,9 @@ export interface EmbeddedAddon {
 	archive?: EmbeddedAddonArchive;
 }
 
+/** Return the native-addon export expected for a package version. */
+export function versionSentinelFor(packageVersion: string): string;
+
 export interface DetectCompiledBinaryInput {
 	embeddedAddon: EmbeddedAddon | null | undefined;
 	env: Record<string, string | undefined>;

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -21,6 +21,9 @@ export interface EmbeddedAddon {
 /** Return the native-addon export expected for a package version. */
 export function versionSentinelFor(packageVersion: string): string;
 
+/** Check whether addon bytes contain the exact expected version sentinel. */
+export function containsVersionSentinel(bytes: Buffer, expected: string): boolean;
+
 export interface DetectCompiledBinaryInput {
 	embeddedAddon: EmbeddedAddon | null | undefined;
 	env: Record<string, string | undefined>;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -86,6 +86,28 @@ export function versionSentinelFor(packageVersion) {
 }
 
 /**
+ * Check for an exact version sentinel rather than a longer sentinel with the
+ * expected value as its prefix.
+ * @param {Buffer} bytes
+ * @param {string} expected
+ * @returns {boolean}
+ */
+export function containsVersionSentinel(bytes, expected) {
+	if (expected.length === 0) return false;
+	let offset = 0;
+	while (offset < bytes.length) {
+		const index = bytes.indexOf(expected, offset);
+		if (index === -1) return false;
+		const next = bytes[index + expected.length];
+		const isIdentifierByte =
+			next === 95 || (next >= 48 && next <= 57) || (next >= 65 && next <= 90) || (next >= 97 && next <= 122);
+		if (!isIdentifierByte) return true;
+		offset = index + expected.length;
+	}
+	return false;
+}
+
+/**
  * @param {{
  *   embeddedAddon: { platformTag: string; version: string; files: unknown[] } | null | undefined;
  *   env: Record<string, string | undefined>;
@@ -712,7 +734,7 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 	// the current sentinel; otherwise a restart would simply reload stale disk.
 	let diskHasExpectedSentinel = false;
 	try {
-		diskHasExpectedSentinel = fs.readFileSync(candidate).includes(ctx.versionSentinelExport);
+		diskHasExpectedSentinel = containsVersionSentinel(fs.readFileSync(candidate), ctx.versionSentinelExport);
 	} catch {
 		// The successful require above normally guarantees readability. If the
 		// file disappears concurrently, retain the safe reinstall diagnosis.

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import * as zlib from "node:zlib";
 import packageJson from "../package.json" with { type: "json" };
 import { embeddedAddon } from "./embedded-addon.js";
+import { containsVersionSentinel, versionSentinelFor } from "./version-sentinel.js";
 
 /**
  * Native addon loader for `@oh-my-pi/pi-natives`.
@@ -75,37 +76,6 @@ function resolveLeafPackageDir(platformTag) {
 // =========================================================================
 // Pure helpers — re-exported for unit tests in `packages/natives/test/`.
 // =========================================================================
-
-/**
- * Return the version sentinel exported by an addon built for `packageVersion`.
- * @param {string} packageVersion
- * @returns {string}
- */
-export function versionSentinelFor(packageVersion) {
-	return `__piNativesV${packageVersion.replace(/[^A-Za-z0-9]/g, "_")}`;
-}
-
-/**
- * Check for an exact version sentinel rather than a longer sentinel with the
- * expected value as its prefix.
- * @param {Buffer} bytes
- * @param {string} expected
- * @returns {boolean}
- */
-export function containsVersionSentinel(bytes, expected) {
-	if (expected.length === 0) return false;
-	let offset = 0;
-	while (offset < bytes.length) {
-		const index = bytes.indexOf(expected, offset);
-		if (index === -1) return false;
-		const next = bytes[index + expected.length];
-		const isIdentifierByte =
-			next === 95 || (next >= 48 && next <= 57) || (next >= 65 && next <= 90) || (next >= 97 && next <= 122);
-		if (!isIdentifierByte) return true;
-		offset = index + expected.length;
-	}
-	return false;
-}
 
 /**
  * @param {{

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -77,6 +77,15 @@ function resolveLeafPackageDir(platformTag) {
 // =========================================================================
 
 /**
+ * Return the version sentinel exported by an addon built for `packageVersion`.
+ * @param {string} packageVersion
+ * @returns {string}
+ */
+export function versionSentinelFor(packageVersion) {
+	return `__piNativesV${packageVersion.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+
+/**
  * @param {{
  *   embeddedAddon: { platformTag: string; version: string; files: unknown[] } | null | undefined;
  *   env: Record<string, string | undefined>;
@@ -837,7 +846,7 @@ export function initLoaderContext(overrides = {}) {
 	// physically cannot expose the symbol this loader is looking for. That
 	// turns the silent `<sym> is not a function` crash from a Windows
 	// locked-file update into an actionable load-time error.
-	const versionSentinelExport = `__piNativesV${packageVersion.replace(/[^A-Za-z0-9]/g, "_")}`;
+	const versionSentinelExport = versionSentinelFor(packageVersion);
 
 	return {
 		platformTag,

--- a/packages/natives/native/version-sentinel.d.ts
+++ b/packages/natives/native/version-sentinel.d.ts
@@ -1,0 +1,5 @@
+/** Return the native-addon export expected for a package version. */
+export function versionSentinelFor(packageVersion: string): string;
+
+/** Check whether addon bytes contain the exact expected version sentinel. */
+export function containsVersionSentinel(bytes: Buffer, expected: string): boolean;

--- a/packages/natives/native/version-sentinel.js
+++ b/packages/natives/native/version-sentinel.js
@@ -1,0 +1,42 @@
+/**
+ * Version-sentinel helpers shared by the native loader and the embed pipeline.
+ *
+ * Kept in its own module so `scripts/embed-native.ts` can reuse the exact-match
+ * logic without importing `loader-state.js` — which pulls in the generated
+ * `embedded-addon.js` and its `with { type: "file" }` archive import. That
+ * chain fails to resolve when the archive is missing, which would break
+ * `gen:native:reset` on an inconsistent tree (populated manifest, deleted
+ * archive) before it can restore the checked-in null stub.
+ */
+
+/**
+ * Return the version sentinel exported by an addon built for `packageVersion`.
+ * @param {string} packageVersion
+ * @returns {string}
+ */
+export function versionSentinelFor(packageVersion) {
+	return `__piNativesV${packageVersion.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+
+/**
+ * Check for an exact version sentinel rather than a longer sentinel with the
+ * expected value as its prefix (e.g. `__piNativesV18_1_10` must not satisfy a
+ * lookup for `__piNativesV18_1_1`).
+ * @param {Buffer} bytes
+ * @param {string} expected
+ * @returns {boolean}
+ */
+export function containsVersionSentinel(bytes, expected) {
+	if (expected.length === 0) return false;
+	let offset = 0;
+	while (offset < bytes.length) {
+		const index = bytes.indexOf(expected, offset);
+		if (index === -1) return false;
+		const next = bytes[index + expected.length];
+		const isIdentifierByte =
+			next === 95 || (next >= 48 && next <= 57) || (next >= 65 && next <= 90) || (next >= 97 && next <= 122);
+		if (!isIdentifierByte) return true;
+		offset = index + expected.length;
+	}
+	return false;
+}

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { versionSentinelFor } from "../native/loader-state.js";
 
-const reset = process.argv.includes("--reset");
 const outputPath = path.join(import.meta.dir, "../native/embedded-addon.js");
 const packageJsonPath = path.join(import.meta.dir, "../package.json");
 const nativeDir = path.join(import.meta.dir, "../native");
@@ -42,7 +42,7 @@ ${embeddedAddonTypedefs}
 /** @type {EmbeddedAddon|null} */
 export const embeddedAddon = null;
 `;
-if (reset) {
+async function resetEmbeddedAddon(): Promise<void> {
 	await Bun.write(outputPath, stubContent);
 	try {
 		const entries = await fs.readdir(nativeDir);
@@ -54,7 +54,6 @@ if (reset) {
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
 	}
-	process.exit(0);
 }
 
 interface CandidateAddon {
@@ -67,50 +66,71 @@ interface AvailableAddon extends CandidateAddon {
 	size: number;
 }
 
-const targetPlatform = Bun.env.TARGET_PLATFORM || process.platform;
-const targetArch = Bun.env.TARGET_ARCH || process.arch;
-const platformTag = `${targetPlatform}-${targetArch}`;
-const candidates: CandidateAddon[] =
-	targetArch === "x64"
-		? [
-				{ variant: "modern", filename: `pi_natives.${platformTag}-modern.node` },
-				{ variant: "baseline", filename: `pi_natives.${platformTag}-baseline.node` },
-			]
-		: [{ variant: "default", filename: `pi_natives.${platformTag}.node` }];
+/**
+ * Validate and embed native addons for one standalone-binary target.
+ */
+export async function embedNativeAddon({
+	targetPlatform,
+	targetArch,
+	nativeDir,
+	outputPath,
+	version,
+}: {
+	targetPlatform: string;
+	targetArch: string;
+	nativeDir: string;
+	outputPath: string;
+	version: string;
+}): Promise<void> {
+	const platformTag = `${targetPlatform}-${targetArch}`;
+	const candidates: CandidateAddon[] =
+		targetArch === "x64"
+			? [
+					{ variant: "modern", filename: `pi_natives.${platformTag}-modern.node` },
+					{ variant: "baseline", filename: `pi_natives.${platformTag}-baseline.node` },
+				]
+			: [{ variant: "default", filename: `pi_natives.${platformTag}.node` }];
 
-const available: AvailableAddon[] = [];
-for (const candidate of candidates) {
-	const candidatePath = path.join(nativeDir, candidate.filename);
-	try {
-		const stat = await fs.stat(candidatePath);
-		available.push({ ...candidate, path: candidatePath, size: stat.size });
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+	const available: AvailableAddon[] = [];
+	for (const candidate of candidates) {
+		const candidatePath = path.join(nativeDir, candidate.filename);
+		try {
+			const stat = await fs.stat(candidatePath);
+			available.push({ ...candidate, path: candidatePath, size: stat.size });
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+		}
 	}
-}
 
-if (available.length === 0) {
-	const expected = candidates.map(candidate => `  - ${candidate.filename}`).join("\n");
-	throw new Error(`No native addons found for ${platformTag}. Expected one of:\n${expected}`);
-}
-const packageJson = (await Bun.file(packageJsonPath).json()) as { version: string };
+	if (available.length === 0) {
+		const expected = candidates.map(candidate => `  - ${candidate.filename}`).join("\n");
+		throw new Error(`No native addons found for ${platformTag}. Expected one of:\n${expected}`);
+	}
 
-const archiveFilename = `${archivePrefix}${platformTag}${archiveSuffix}`;
-const archivePath = path.join(nativeDir, archiveFilename);
-const archiveEntries: Record<string, Uint8Array> = {};
-for (const addon of available) {
-	archiveEntries[addon.filename] = await fs.readFile(addon.path);
-}
-await Bun.write(archivePath, await new Bun.Archive(archiveEntries, { compress: "gzip", level: 9 }).bytes());
+	const archiveFilename = `${archivePrefix}${platformTag}${archiveSuffix}`;
+	const archivePath = path.join(nativeDir, archiveFilename);
+	const archiveEntries: Record<string, Uint8Array> = {};
+	const versionSentinel = versionSentinelFor(version);
+	for (const addon of available) {
+		const bytes = await fs.readFile(addon.path);
+		if (!bytes.includes(versionSentinel)) {
+			throw new Error(
+				`Native addon ${addon.path} does not contain the @oh-my-pi/pi-natives@${version} version sentinel ` +
+					`\`${versionSentinel}\`. Rebuild it or fetch @oh-my-pi/pi-natives-${platformTag}@${version} before embedding.`,
+			);
+		}
+		archiveEntries[addon.filename] = bytes;
+	}
+	await Bun.write(archivePath, await new Bun.Archive(archiveEntries, { compress: "gzip", level: 9 }).bytes());
 
-const files = available
-	.map(
-		addon =>
-			`\t\t{ variant: ${JSON.stringify(addon.variant)}, filename: ${JSON.stringify(addon.filename)}, size: ${addon.size} },`,
-	)
-	.join("\n");
+	const files = available
+		.map(
+			addon =>
+				`\t\t{ variant: ${JSON.stringify(addon.variant)}, filename: ${JSON.stringify(addon.filename)}, size: ${addon.size} },`,
+		)
+		.join("\n");
 
-const content = `
+	const content = `
 // AUTOGENERATED FILE -- DO NOT EDIT DIRECTLY
 // See scripts/embed-native.ts
 
@@ -120,7 +140,7 @@ import archivePath from ${JSON.stringify(`../native/${archiveFilename}`)} with {
 
 export const embeddedAddon = {
 \tplatformTag: ${JSON.stringify(platformTag)},
-\tversion: ${JSON.stringify(packageJson.version)},
+\tversion: ${JSON.stringify(version)},
 \tarchive: {
 \t\tformat: "tar.gz",
 \t\tfilename: ${JSON.stringify(archiveFilename)},
@@ -132,4 +152,25 @@ ${files}
 };
 `;
 
-await Bun.write(outputPath, content);
+	await Bun.write(outputPath, content);
+}
+
+async function main(): Promise<void> {
+	if (process.argv.includes("--reset")) {
+		await resetEmbeddedAddon();
+		return;
+	}
+
+	const packageJson = (await Bun.file(packageJsonPath).json()) as { version: string };
+	await embedNativeAddon({
+		targetPlatform: Bun.env.TARGET_PLATFORM || process.platform,
+		targetArch: Bun.env.TARGET_ARCH || process.arch,
+		nativeDir,
+		outputPath,
+		version: packageJson.version,
+	});
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { containsVersionSentinel, versionSentinelFor } from "../native/loader-state.js";
+import { containsVersionSentinel, versionSentinelFor } from "../native/version-sentinel.js";
 
 const outputPath = path.join(import.meta.dir, "../native/embedded-addon.js");
 const packageJsonPath = path.join(import.meta.dir, "../package.json");

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { versionSentinelFor } from "../native/loader-state.js";
+import { containsVersionSentinel, versionSentinelFor } from "../native/loader-state.js";
 
 const outputPath = path.join(import.meta.dir, "../native/embedded-addon.js");
 const packageJsonPath = path.join(import.meta.dir, "../package.json");
@@ -113,7 +113,7 @@ export async function embedNativeAddon({
 	const versionSentinel = versionSentinelFor(version);
 	for (const addon of available) {
 		const bytes = await fs.readFile(addon.path);
-		if (!bytes.includes(versionSentinel)) {
+		if (!containsVersionSentinel(bytes, versionSentinel)) {
 			throw new Error(
 				`Native addon ${addon.path} does not contain the @oh-my-pi/pi-natives@${version} version sentinel ` +
 					`\`${versionSentinel}\`. Rebuild it or fetch @oh-my-pi/pi-natives-${platformTag}@${version} before embedding.`,

--- a/packages/natives/test/embed-native.test.ts
+++ b/packages/natives/test/embed-native.test.ts
@@ -5,13 +5,13 @@ import * as path from "node:path";
 import { embedNativeAddon } from "../scripts/embed-native";
 
 describe("native addon embedding", () => {
-	it("rejects an addon from another release before writing build artifacts", async () => {
+	it("rejects a longer release sentinel that starts with the expected version", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-natives-embed-"));
 		const nativeDir = path.join(root, "native");
 		const outputPath = path.join(nativeDir, "embedded-addon.js");
 		try {
 			await fs.mkdir(nativeDir);
-			await Bun.write(path.join(nativeDir, "pi_natives.win32-arm64.node"), "binary__piNativesV18_1_17");
+			await Bun.write(path.join(nativeDir, "pi_natives.win32-arm64.node"), "binary__piNativesV18_1_10");
 
 			await expect(
 				embedNativeAddon({
@@ -19,9 +19,9 @@ describe("native addon embedding", () => {
 					targetArch: "arm64",
 					nativeDir,
 					outputPath,
-					version: "18.1.18",
+					version: "18.1.1",
 				}),
-			).rejects.toThrow("does not contain the @oh-my-pi/pi-natives@18.1.18 version sentinel `__piNativesV18_1_18`");
+			).rejects.toThrow("does not contain the @oh-my-pi/pi-natives@18.1.1 version sentinel `__piNativesV18_1_1`");
 			expect(await Bun.file(outputPath).exists()).toBe(false);
 			expect(await Bun.file(path.join(nativeDir, "embedded-addons.win32-arm64.tar.gz")).exists()).toBe(false);
 		} finally {

--- a/packages/natives/test/embed-native.test.ts
+++ b/packages/natives/test/embed-native.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { embedNativeAddon } from "../scripts/embed-native";
+
+describe("native addon embedding", () => {
+	it("rejects an addon from another release before writing build artifacts", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-natives-embed-"));
+		const nativeDir = path.join(root, "native");
+		const outputPath = path.join(nativeDir, "embedded-addon.js");
+		try {
+			await fs.mkdir(nativeDir);
+			await Bun.write(path.join(nativeDir, "pi_natives.win32-arm64.node"), "binary__piNativesV18_1_17");
+
+			await expect(
+				embedNativeAddon({
+					targetPlatform: "win32",
+					targetArch: "arm64",
+					nativeDir,
+					outputPath,
+					version: "18.1.18",
+				}),
+			).rejects.toThrow("does not contain the @oh-my-pi/pi-natives@18.1.18 version sentinel `__piNativesV18_1_18`");
+			expect(await Bun.file(outputPath).exists()).toBe(false);
+			expect(await Bun.file(path.join(nativeDir, "embedded-addons.win32-arm64.tar.gz")).exists()).toBe(false);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A synthetic `pi_natives.win32-arm64.node` containing only `__piNativesV18_1_17` was placed under `packages/natives/native/`; `TARGET_PLATFORM=win32 TARGET_ARCH=arm64 bun packages/natives/scripts/embed-native.ts` exited 0 and generated an `18.1.18` manifest that archived the stale bytes.

## Cause
`embedNativeAddon` in `packages/natives/scripts/embed-native.ts` selected candidates with `fs.stat()` and copied their bytes into the target archive without enforcing the version-sentinel contract already checked by `packages/natives/native/loader-state.js`.

## Fix
- Share `versionSentinelFor()` between the runtime loader and embed pipeline.
- Reject every mismatched candidate before writing the archive or generated manifest, with a target-specific rebuild/fetch error.
- Cover stale-addon rejection and absence of partial build artifacts; document the fix in the natives changelog.

## Verification
`bun test test/embed-native.test.ts test/windows-staging.test.ts test/issue-4812-repro.test.ts test/issue-823-repro.test.ts` passed 18 tests; `bun run check` passed in `packages/natives`. Re-running the original synthetic stale-addon command now exits 1 with the expected `__piNativesV18_1_18` sentinel and package-fetch hint, while a matching synthetic target addon embeds successfully and resets cleanly.

Fixes #11831