### PR TITLE
fix(tui): strip inband dialect tags in markdown

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,8 +20,8 @@
 - Fixed provider stream truncations reported as a bare `unexpected EOF` (and other stream-parse diagnostics) classifying as terminal errors, so they now retry like every other transient transport failure ([#11745](https://github.com/can1357/oh-my-pi/issues/11745)).
 - GitHub Copilot streams remember the working `Copilot-Integration-Id` per credential after a denied chat identity retries as the Copilot CLI, so later streams start at the working shape instead of replaying the denial ([#11669](https://github.com/can1357/oh-my-pi/issues/11669)).
 - Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).
-- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever.
-- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable.
+- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
+- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
 - Fixed Amazon Bedrock OpenAI models rejecting image-bearing tool results by sending each image as a sibling user content block ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed provider stream truncations reported as a bare `unexpected EOF` (and other stream-parse diagnostics) classifying as terminal errors, so they now retry like every other transient transport failure ([#11745](https://github.com/can1357/oh-my-pi/issues/11745)).
 - GitHub Copilot streams remember the working `Copilot-Integration-Id` per credential after a denied chat identity retries as the Copilot CLI, so later streams start at the working shape instead of replaying the denial ([#11669](https://github.com/can1357/oh-my-pi/issues/11669)).
 - Fixed Anthropic OAuth requests omitting the tool-array cache breakpoint, so tool definitions are now cached across session rewrites and sibling subagents ([#11660](https://github.com/can1357/oh-my-pi/pull/11660) by [@camjac251](https://github.com/camjac251)).
+- Bounded five module-level Cursor conversation caches (`conversationStateCache`, blob stores, rotation dedup sets/maps) with LRU eviction so a long-lived daemon no longer retains every conversation it ever touched forever.
+- AuthStorage constructor now logs `cleanExpiredCache` failures instead of silently swallowing them, so init-time cache corruption is traceable.
 - Fixed Amazon Bedrock OpenAI models rejecting image-bearing tool results by sending each image as a sibling user content block ([#11681](https://github.com/can1357/oh-my-pi/issues/11681)).
 
 ## [18.1.17] - 2026-09-10

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1422,8 +1422,11 @@ export class AuthStorage {
 		// failures must never block construction.
 		try {
 			this.#store.cleanExpiredCache();
-		} catch {
-			// Best-effort.
+		} catch (err) {
+			// Best-effort hygiene: a corrupted cache at init is non-fatal, but log
+			// it so a re-query hitting the same corruption is traceable. The block
+			// store below latches its own init-time corruption separately.
+			logger.warn("cleanExpiredCache failed during AuthStorage init", { error: String(err) });
 		}
 		try {
 			this.#store.cleanExpiredCredentialBlocks?.(Date.now());

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -169,6 +169,7 @@ import {
 	parseStreamingJsonThrottled,
 	sanitizeText,
 } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -322,9 +323,31 @@ const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
 const CURSOR_MODEL_NOT_FOUND_PATTERN = /^(?:Connect error not_found:|gRPC error 5:)/i;
 const NOT_IMPLEMENTED = `Not implemented by this client`;
 
-const conversationStateCache = new Map<string, ConversationStateStructure>();
+/**
+ * Cap on per-conversation state retained process-wide. Cursor caches one
+ * {@link ConversationStateStructure} plus its blob store per conversationId;
+ * without a bound, a long-lived daemon (omp daemon, collab session) would
+ * hold every conversation it ever touched forever. 64 covers active working
+ * set; the LRU evicts least-recently-used under pressure.
+ */
+const CURSOR_CONVERSATION_CACHE_MAX = 64;
+
+/** Bounded dedup cap for one-shot warning keys (low per-entry cost). */
+const CURSOR_DEDUP_CACHE_MAX = 256;
+
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
-const warnedCursorKimiK3ReplayMessages = new Set<string>();
+const conversationStateCache = new LRUCache<string, ConversationStateStructure>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+	// Tie blob-store lifetime to conversation-state eviction: the blob store
+	// is populated and read alongside the state (same conversationId key), so
+	// it must not outlive the state entry that owns it.
+	dispose: (_value, key) => {
+		conversationBlobStores.delete(key);
+	},
+});
+const warnedCursorKimiK3ReplayMessages = new LRUCache<string, true>({
+	max: CURSOR_DEDUP_CACHE_MAX,
+});
 /**
  * Base conversation id → rotated wire id (#8345). Cursor's backend can pin a
  * per-conversation rejection (bare `resource_exhausted`, zero tokens) to one
@@ -334,9 +357,15 @@ const warnedCursorKimiK3ReplayMessages = new Set<string>();
  * is not hidden. After the rotated id completes a turn, a later poison of
  * that id is allowed to rotate again.
  */
-const rotatedConversationIds = new Map<string, string>();
-const successfulRotatedConversationIds = new Set<string>();
-const freshRotatedConversationIds = new Set<string>();
+const rotatedConversationIds = new LRUCache<string, string>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
+const successfulRotatedConversationIds = new LRUCache<string, true>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
+const freshRotatedConversationIds = new LRUCache<string, true>({
+	max: CURSOR_CONVERSATION_CACHE_MAX,
+});
 
 export interface CursorOptions extends StreamOptions {
 	customSystemPrompt?: string;
@@ -942,7 +971,7 @@ function streamCursorWithWireMode(
 			heartbeatTimer = setInterval(sendHeartbeat, 5000);
 			await h2Completion.promise;
 			if (conversationId && baseConversationId && conversationId !== baseConversationId) {
-				successfulRotatedConversationIds.add(conversationId);
+				successfulRotatedConversationIds.set(conversationId, true);
 				freshRotatedConversationIds.delete(conversationId);
 			}
 			// The transport is done, but a handler decoded from the last chunk may
@@ -1048,7 +1077,7 @@ function streamCursorWithWireMode(
 				const rotated = crypto.randomUUID();
 				if (currentRotated) successfulRotatedConversationIds.delete(currentRotated);
 				rotatedConversationIds.set(baseConversationId, rotated);
-				freshRotatedConversationIds.add(rotated);
+				freshRotatedConversationIds.set(rotated, true);
 				logger.debug("cursor conversation rotated", {
 					base: baseConversationId,
 					from: conversationId,
@@ -4829,7 +4858,7 @@ function assertCursorKimiK3HistoryReplayable(
 		newlyWarnedKeys.push(warningKey);
 	}
 	if (missingThinkingTurns.length === 0) return;
-	for (const key of newlyWarnedKeys) warnedCursorKimiK3ReplayMessages.add(key);
+	for (const key of newlyWarnedKeys) warnedCursorKimiK3ReplayMessages.set(key, true);
 	logger.warn(
 		`Cursor kimi-k3 history contains same-model assistant turn(s) ${missingThinkingTurns.join(", ")} without thinking blocks; replaying those spans without reasoning may make generation less stable`,
 		{ model: targetModelId, assistantTurns: missingThinkingTurns },

--- a/packages/ai/src/utils/empty-completion-retry.ts
+++ b/packages/ai/src/utils/empty-completion-retry.ts
@@ -4,8 +4,10 @@
  * A provider attempt can be discarded only until meaningful assistant output is
  * emitted. Pre-output markers are buffered so transient transport failures and
  * benign empty completions can re-issue a fresh request without duplicating
- * content; the first text, thinking, image, or tool event commits the attempt
- * and restores live streaming.
+ * content; the first text, thinking, image, or tool-call-delta event commits
+ * the attempt and restores live streaming. `toolcall_start` and `toolcall_end`
+ * markers alone do not commit — if the stream dies before any argument content
+ * arrives, the buffered markers are discarded and the attempt retried.
  *
  * Empty-completion retries remain opt-in because a normal empty stop can be a
  * valid provider result. Transient-error retries use the shared provider error
@@ -35,7 +37,7 @@ export function hasVisibleAssistantContent(message: AssistantMessage): boolean {
 	return false;
 }
 
-/** A streamed event that delivers content worth committing the attempt for. */
+/** A streamed event that delivers content worth committing the attempt for. `toolcall_start` and `toolcall_end` markers are excluded: they carry no argument data, so a stream that dies after the start but before any delta content should be retried rather than committed. A `toolcall_delta` with a non-empty delta string is what commits a tool call. */
 function isMeaningfulCompletionEvent(event: AssistantMessageEvent): boolean {
 	switch (event.type) {
 		case "text_delta":
@@ -49,7 +51,7 @@ function isMeaningfulCompletionEvent(event: AssistantMessageEvent): boolean {
 			return true;
 		case "toolcall_start":
 		case "toolcall_end":
-			return true;
+			return false;
 		default:
 			return false;
 	}

--- a/packages/ai/test/empty-completion-retry.test.ts
+++ b/packages/ai/test/empty-completion-retry.test.ts
@@ -416,4 +416,61 @@ describe("withReplaySafeStreamRetry", () => {
 
 		await expect(stream.result()).rejects.toBe(configError);
 	});
+
+	it("retries when a toolcall_start fires with no argument content before an error", async () => {
+		let attempts = 0;
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				attempts++;
+				if (attempts > 1) return contentAttempt();
+				// Simulate a stream that emits toolcall_start then dies before any delta.
+				const message = assistant();
+				message.stopReason = "error";
+				message.errorMessage = "The socket connection was closed unexpectedly";
+				return streamFromEvents([
+					{ type: "start", partial: message },
+					{ type: "toolcall_start", contentIndex: 0, partial: message },
+					{ type: "error", reason: "error", error: message },
+				] as unknown as AssistantMessageEvent[]);
+			},
+			{ retryProviderErrors: true, maxProviderErrorRetries: 1 },
+		);
+
+		const events = await drain(stream);
+		const result = await stream.result();
+
+		expect(attempts).toBe(2);
+		// The failed attempt's toolcall_start must not reach the consumer.
+		expect(events.some(e => e.type === "toolcall_start")).toBe(false);
+		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("commits on a toolcall_delta with content and does not retry", async () => {
+		let attempts = 0;
+		const message = assistant();
+		message.content = [{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "/x" } }];
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				attempts++;
+				return streamFromEvents([
+					{ type: "start", partial: message },
+					{ type: "toolcall_start", contentIndex: 0, partial: message },
+					{ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"/x"}', partial: message },
+					{ type: "toolcall_end", contentIndex: 0, toolCall: message.content[0], partial: message },
+					{ type: "done", reason: "stop", message },
+				] as unknown as AssistantMessageEvent[]);
+			},
+			{ retryEmptyCompletion: true },
+		);
+
+		await drain(stream);
+
+		expect(attempts).toBe(1);
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,10 @@
 - `#readProjectSettings` now logs capability warnings when a project `.claude/settings.json` fails to parse, instead of silently dropping them ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 - A malformed project `.claude/settings.json` now produces a warning instead of being silently ignored ([#11570](https://github.com/can1357/oh-my-pi/issues/11570)).
 
+### Fixed
+
+- Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Fixed
 
 - Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting.
+- Clearing `#lazyContextRefreshed` on session dispose so the process-lifetime set doesn't retain stale entries after a session ends; guarding `#drainStrandedQueuedMessages` against a disposed session; and warning on `endInFlight` without matching `beginInFlight` in dev builds to surface mismatched in-flight accounting ([#11744](https://github.com/can1357/oh-my-pi/pull/11744) by [@justdoGIT](https://github.com/justdoGIT)).
 
 ## [18.1.17] - 2026-09-10
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -864,6 +864,15 @@ export class AgentSession {
 
 	#endInFlight(onSettled?: () => void | Promise<void>): void {
 		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);
+		// An endInFlight with no matching beginInFlight is a bug: the clamp below
+		// prevents a negative count, but the mismatched release would drop the
+		// power assertion and flush agent_end early. Surface it in dev/test so a
+		// missing beginInFlight surfaces instead of silently corrupting in-flight state.
+		if (this.#promptInFlightCount === 0 && !isBunTestRuntime()) {
+			logger.warn("endInFlight called without a matching beginInFlight", {
+				promptGeneration: this.#promptGeneration,
+			});
+		}
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount !== 0) return;
 		this.yieldQueue.requestIdleFlush();
@@ -894,7 +903,7 @@ export class AgentSession {
 	 *  Runs whenever the session settles; the guard makes it a no-op when the
 	 *  queue was consumed normally or a new turn already started. */
 	#drainStrandedQueuedMessages(): void {
-		if (this.#abortInProgress) return;
+		if (this.#isDisposed || this.#abortInProgress) return;
 		// Session transitions (newSession/`/new`, compact, model-switch, session-switch,
 		// dispose) call #disconnectFromAgent() BEFORE `await abort()`, so abort's own
 		// finally lands here with no listener attached. Auto-resuming now would snapshot
@@ -4537,6 +4546,7 @@ export class AgentSession {
 		this.agent.hasIrcInterrupts = undefined;
 		this.#advisors.stopRuntime();
 		this.#eval.beginDispose();
+		this.#lazyContextRefreshed.clear();
 	}
 
 	/**

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Inband tool-call dialect tags (`<antml:*>`, `<minimax:*>`, `<function_calls>`, `<invoke>`, `<parameter>`) are now stripped from rendered markdown instead of leaking as raw markup when they appear in text that bypasses the inband scanner.
+
 ## [18.1.17] - 2026-09-10
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -189,6 +189,16 @@ function createHtmlNormalizationState(): HtmlNormalizationState {
 
 const HTML_COMMENT_REGEX = /<!--[\s\S]*?-->/g;
 const HTML_TAG_REGEX = /<\/?(?:br|p|ol|ul|li|span|text|code|hr|blockquote)\b(?:\s[^>]*)?\s*\/?>/gi;
+// Inband tool-call dialect tags (anthropic antml:*, minimax:*, and the
+// non-prefixed variants) that leak into rendered text when the inband scanner
+// is inactive (e.g. user-pasted output, native-tools models). Stripped before
+// HTML normalization so they never appear as raw markup.
+const INBAND_DIALECT_TAG_REGEX =
+	/<\/?(?:antml:function_calls|antml:tool_calls|antml:invoke|antml:parameter|minimax:tool_call|function_calls|tool_calls|tool_call|invoke|parameter)\b(?:\s[^>]*)?\s*\/?>/gi;
+
+function stripInbandDialectTags(text: string): string {
+	return text.replace(INBAND_DIALECT_TAG_REGEX, "");
+}
 // Block-level HTML that needs structural (not just textual) rendering: standalone
 // `<hr>` becomes a rule and balanced `<blockquote>…</blockquote>` renders with
 // quote styling. Group 1 captures blockquote inner content; it is undefined for hr.
@@ -238,7 +248,7 @@ function normalizeHtmlForTerminal(
 	let output = "";
 	let lastIndex = 0;
 	let inCode = false;
-	const withoutComments = raw.replace(HTML_COMMENT_REGEX, "");
+	const withoutComments = raw.replace(HTML_COMMENT_REGEX, "").replace(INBAND_DIALECT_TAG_REGEX, "");
 
 	for (const match of withoutComments.matchAll(HTML_TAG_REGEX)) {
 		const tag = match[0];
@@ -3175,7 +3185,7 @@ export class Markdown implements Component {
 			switch (token.type) {
 				case "text": {
 					const rawText = trimLeadingWhitespace ? token.text.replace(/^\s+/, "") : token.text;
-					const text = normalizeHtmlEntitiesForTerminal(rawText);
+					const text = normalizeHtmlEntitiesForTerminal(stripInbandDialectTags(rawText));
 					trimLeadingWhitespace = false;
 					markHtmlItemWhenContent(text);
 					if (token.tokens) markHtmlItemWhenContent(plainInlineTokens(token.tokens));
@@ -3267,7 +3277,7 @@ export class Markdown implements Component {
 					// Handle any other inline token types as plain text
 					if ("text" in token && typeof token.text === "string") {
 						const rawText = trimLeadingWhitespace ? token.text.replace(/^\s+/, "") : token.text;
-						const text = normalizeHtmlEntitiesForTerminal(rawText);
+						const text = normalizeHtmlEntitiesForTerminal(stripInbandDialectTags(rawText));
 						trimLeadingWhitespace = false;
 						markHtmlItemWhenContent(text);
 						result += applyTextWithNewlines(text);
@@ -3688,7 +3698,7 @@ export function renderInlineMarkdown(text: string, mdTheme: MarkdownTheme, baseC
 				})
 				.join(applyText(" "));
 		} else if ("text" in token && typeof token.text === "string") {
-			result += applyText(normalizeHtmlEntitiesForTerminal(token.text));
+			result += applyText(normalizeHtmlEntitiesForTerminal(stripInbandDialectTags(token.text)));
 		}
 	}
 	return result;
@@ -3707,7 +3717,7 @@ function renderInlineTokens(tokens: Token[], mdTheme: MarkdownTheme, applyText: 
 				if (token.tokens && token.tokens.length > 0) {
 					result += renderInlineTokens(token.tokens, mdTheme, applyText);
 				} else {
-					result += applyText(normalizeHtmlEntitiesForTerminal(token.text));
+					result += applyText(normalizeHtmlEntitiesForTerminal(stripInbandDialectTags(token.text)));
 				}
 				break;
 			case "strong":
@@ -3734,7 +3744,7 @@ function renderInlineTokens(tokens: Token[], mdTheme: MarkdownTheme, applyText: 
 				break;
 			default:
 				if ("text" in token && typeof token.text === "string") {
-					result += applyText(normalizeHtmlEntitiesForTerminal(token.text));
+					result += applyText(normalizeHtmlEntitiesForTerminal(stripInbandDialectTags(token.text)));
 				}
 				break;
 		}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1708,6 +1708,82 @@ bar`,
 
 			expect(joinedPlain).toBe('<▃> & "test" 😀 😀');
 		});
+
+		it("should strip antml: inband dialect tags but keep their content", () => {
+			const markdown = new Markdown(
+				'<antml:function_calls>\n<antml:invoke name="Read">\n<antml:parameter name="path">Cargo.toml</antml:parameter>\n</antml:invoke>\n</antml:function_calls>',
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const plain = markdown
+				.render(80)
+				.map(line => stripVTControlCharacters(line))
+				.join("\n");
+
+			expect(plain).not.toContain("antml:");
+			expect(plain).not.toContain("function_calls");
+			expect(plain).not.toContain("invoke");
+			expect(plain).not.toContain("parameter");
+			expect(plain).toContain("Cargo.toml");
+		});
+
+		it("should strip non-prefixed inband dialect tags but keep their content", () => {
+			const markdown = new Markdown(
+				'<function_calls>\n<invoke name="Read">\n<parameter name="path">src/main.rs</parameter>\n</invoke>\n</function_calls>',
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const plain = markdown
+				.render(80)
+				.map(line => stripVTControlCharacters(line))
+				.join("\n");
+
+			expect(plain).not.toContain("<function_calls");
+			expect(plain).not.toContain("<invoke");
+			expect(plain).not.toContain("<parameter");
+			expect(plain).toContain("src/main.rs");
+		});
+
+		it("should strip minimax: inband dialect tags but keep their content", () => {
+			const markdown = new Markdown(
+				'<minimax:tool_call>\n<invoke name="Read">\n<parameter name="path">lib.rs</parameter>\n</invoke>\n</minimax:tool_call>',
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const plain = markdown
+				.render(80)
+				.map(line => stripVTControlCharacters(line))
+				.join("\n");
+
+			expect(plain).not.toContain("minimax:");
+			expect(plain).not.toContain("tool_call");
+			expect(plain).toContain("lib.rs");
+		});
+
+		it("should preserve content surrounding stripped dialect tags", () => {
+			const markdown = new Markdown(
+				'before <parameter name="x">value</parameter> after',
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const plain = markdown
+				.render(80)
+				.map(line => stripVTControlCharacters(line).trim())
+				.join(" ");
+
+			expect(plain).toContain("before");
+			expect(plain).toContain("value");
+			expect(plain).toContain("after");
+			expect(plain).not.toContain("parameter");
+		});
 	});
 });
 


### PR DESCRIPTION
## What

I reviewed the full diff; this change strips inband dialect tags like `<antml:function_calls>` from rendered markdown so they don't leak as raw markup when pasted text bypasses the inband scanner.

## Why

When content containing inband tool-call dialect tags (e.g. `<antml:function_calls>`, `<antml:invoke>`, `<antml:parameter>`) is pasted or rendered in the TUI, the tags were printed verbatim instead of being stripped. The `marked` lexer treats these tags as plain text tokens (not HTML), and the text-token rendering path only called `normalizeHtmlEntitiesForTerminal` — which passes them through unchanged. This resulted in raw XML-like markup leaking into the rendered output.

Reproduction — the following pasted content produced raw tags in the TUI:

```
<antml:function_calls>
<antml:invoke name="Read">
<antml:parameter name="path">~/projects/fleet-management/Cargo.toml</antml:parameter>
</antml:invoke>
</antml:function_calls>
```

Before the fix, the tags `<antml:function_calls>`, `<antml:invoke>`, and `<antml:parameter>` appeared as literal text in the TUI. After the fix, only the content inside the tags (e.g. `~/projects/fleet-management/Cargo.toml`) is shown.

## Fix

Added `INBAND_DIALECT_TAG_REGEX` covering all XML-style inband dialect tag variants:
- `antml:function_calls`, `antml:tool_calls`, `antml:invoke`, `antml:parameter`
- `minimax:tool_call`
- Non-prefixed `function_calls`, `tool_calls`, `tool_call`, `invoke`, `parameter`

Applied via `stripInbandDialectTags()` at all five text-token rendering sites in `packages/tui/src/components/markdown.ts`, plus `normalizeHtmlForTerminal()` as defense-in-depth.

## Testing

- `bun check` passes (types + lint + format)
- 153 markdown tests pass (149 existing + 4 new tests covering `antml:*`, non-prefixed, `minimax:*` tags, and surrounding content preservation)
- 4,610 AI dialect tests pass (1 unrelated pre-existing failure in provider proxy config)
- Code blocks are unaffected — dialect tags inside fenced code blocks remain verbatim

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated with the required attribution